### PR TITLE
Refine Pool Royale showroom table: remove extra GLBs, exact-fit Showood model, and remap GLB materials to Pool Royale finishes

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -17,37 +17,16 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
-    description: 'Open-source Pooltool seven-foot table with original GLB textures.',
-    tableSizeId: '8ft',
+    description:
+      'Open-source Pooltool showroom table fitted exactly to the original Pool Royale table footprint and remapped to the active table finish.',
+    tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
-    fitStrategy: 'cover'
-  },
-  {
-    id: 'pooltool-null-pbr',
-    label: 'Pooltool PBR GLB',
-    description: 'Pooltool PBR pool table normalized to Pool Royale proportions.',
-    tableSizeId: '9ft',
-    assetUrl: `${POOLTOOL_RAW_BASE}/null/null_pbr.glb`,
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/null/null.glb`,
-    icon: '🟩',
-    kind: 'gltf',
-    fitScale: 1,
-    fitStrategy: 'cover'
-  },
-  {
-    id: 'snooker-generic',
-    label: 'Snooker GLB',
-    description: 'Open-source snooker-style table fitted to the 9 ft Pool Royale arena.',
-    tableSizeId: '9ft',
-    assetUrl: `${POOLTOOL_RAW_BASE}/snooker_generic/snooker_generic.glb`,
-    icon: '🟦',
-    kind: 'gltf',
-    fitScale: 1,
-    fitStrategy: 'cover'
+    fitStrategy: 'exact',
+    usePoolRoyaleFinish: true
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12520,29 +12520,121 @@ export function Table3D(
 const poolRoyaleExternalTableTemplates = new Map();
 const poolRoyaleExternalTablePromises = new Map();
 
-function preparePoolRoyaleExternalTableMaterials(root) {
+function classifyPoolRoyaleExternalTableSurface(child, material) {
+  const label = `${child?.name || ''} ${material?.name || ''}`.toLowerCase();
+  if (/cloth|felt|baize|slate|bed|playfield|playing[_\s-]*surface/.test(label)) return 'cloth';
+  if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(label)) return 'cushion';
+  if (/pocket|liner|leather|net|basket|drop/.test(label)) return 'pocket';
+  if (/metal|chrome|gold|diamond|sight|marker|plate|trim|screw|bolt/.test(label)) return 'trim';
+  if (/leg|foot|base|support|frame|wood|rail|apron|cabinet|showood/.test(label)) return 'wood';
+  return 'wood';
+}
+
+function clonePoolRoyaleMaterialTexture(texture, { isColor = false } = {}) {
+  if (!texture) return null;
+  const clone = texture.clone ? texture.clone() : texture;
+  if (isColor) clone.colorSpace = THREE.SRGBColorSpace;
+  clone.anisotropy = resolveTextureAnisotropy(12);
+  clone.needsUpdate = true;
+  return clone;
+}
+
+function preparePoolRoyaleExternalTexture(texture, isColor = false) {
+  if (!texture) return;
+  if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = resolveTextureAnisotropy(12);
+  texture.needsUpdate = true;
+}
+
+function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo) {
+  if (!material || !finishInfo) return material;
+  const mat = material.clone ? material.clone() : material;
+  const materials = finishInfo.materials || {};
+  const finish = TABLE_FINISHES[finishInfo.id] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
+
+  const copyMaterialLook = (source) => {
+    if (!source) return;
+    if (source.color && mat.color) mat.color.copy(source.color);
+    [
+      'roughness',
+      'metalness',
+      'clearcoat',
+      'clearcoatRoughness',
+      'sheen',
+      'sheenRoughness',
+      'reflectivity',
+      'envMapIntensity',
+      'bumpScale'
+    ].forEach((key) => {
+      if (typeof source[key] === 'number' && key in mat) mat[key] = source[key];
+    });
+    mat.map = clonePoolRoyaleMaterialTexture(source.map, { isColor: true });
+    mat.normalMap = clonePoolRoyaleMaterialTexture(source.normalMap);
+    mat.roughnessMap = clonePoolRoyaleMaterialTexture(source.roughnessMap);
+    mat.aoMap = clonePoolRoyaleMaterialTexture(source.aoMap);
+    mat.metalnessMap = clonePoolRoyaleMaterialTexture(source.metalnessMap);
+    mat.bumpMap = clonePoolRoyaleMaterialTexture(source.bumpMap);
+  };
+
+  if (role === 'cloth' || role === 'cushion') {
+    copyMaterialLook(role === 'cushion' ? finishInfo.cushionMat : finishInfo.clothMat);
+    mat.side = THREE.DoubleSide;
+  } else if (role === 'trim') {
+    copyMaterialLook(materials.trim);
+    enhanceChromeMaterial(mat);
+  } else if (role === 'pocket') {
+    copyMaterialLook(materials.pocketJaw ?? materials.pocketRim);
+  } else {
+    const surface =
+      role === 'wood'
+        ? finishInfo.parts?.woodSurfaces?.rail || finishInfo.parts?.woodSurfaces?.frame
+        : finishInfo.parts?.woodSurfaces?.frame;
+    if (materials.rail?.color && mat.color) mat.color.copy(materials.rail.color);
+    if (mat.color) {
+      mat.userData = mat.userData || {};
+      mat.userData.baseTintHex = mat.color.getHex();
+    }
+    applyWoodTextureToMaterial(mat, surface || { woodRepeatScale: finishInfo.woodRepeatScale });
+    applyTableFinishDulling(mat);
+    applyTableWoodVisibilityTuning(mat);
+    if (finish?.surfaceStyle === 'matte') {
+      if (finish?.preserveFinishTintOnWood) applyMatteSurfacePropsOnly(mat);
+      else applyMonoMattePlasticSurface(mat);
+    }
+    applyFinishWoodTint(mat, finish);
+  }
+
+  preparePoolRoyaleExternalTexture(mat.map, true);
+  preparePoolRoyaleExternalTexture(mat.emissiveMap, true);
+  preparePoolRoyaleExternalTexture(mat.aoMap, false);
+  preparePoolRoyaleExternalTexture(mat.normalMap, false);
+  preparePoolRoyaleExternalTexture(mat.roughnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.metalnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.bumpMap, false);
+  mat.needsUpdate = true;
+  return mat;
+}
+
+function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finishInfo = null) {
   root?.traverse?.((child) => {
     if (!child?.isMesh) return;
     child.castShadow = true;
     child.receiveShadow = true;
     child.frustumCulled = false;
 
-    const prepareTexture = (texture, isColor = false) => {
-      if (!texture) return;
-      if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
-      texture.anisotropy = resolveTextureAnisotropy(12);
-      texture.needsUpdate = true;
-    };
-
     const prepareMaterial = (material) => {
       if (!material) return material;
+      const role = classifyPoolRoyaleExternalTableSurface(child, material);
+      if (tableModel?.usePoolRoyaleFinish && finishInfo) {
+        return applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo);
+      }
       const mat = material.clone ? material.clone() : material;
-      prepareTexture(mat.map, true);
-      prepareTexture(mat.emissiveMap, true);
-      prepareTexture(mat.aoMap, false);
-      prepareTexture(mat.normalMap, false);
-      prepareTexture(mat.roughnessMap, false);
-      prepareTexture(mat.metalnessMap, false);
+      preparePoolRoyaleExternalTexture(mat.map, true);
+      preparePoolRoyaleExternalTexture(mat.emissiveMap, true);
+      preparePoolRoyaleExternalTexture(mat.aoMap, false);
+      preparePoolRoyaleExternalTexture(mat.normalMap, false);
+      preparePoolRoyaleExternalTexture(mat.roughnessMap, false);
+      preparePoolRoyaleExternalTexture(mat.metalnessMap, false);
       mat.needsUpdate = true;
       return mat;
     };
@@ -12555,9 +12647,9 @@ function preparePoolRoyaleExternalTableMaterials(root) {
   });
 }
 
-function clonePoolRoyaleExternalTableTemplate(template) {
+function clonePoolRoyaleExternalTableTemplate(template, tableModel = null, finishInfo = null) {
   const clone = template.clone(true);
-  preparePoolRoyaleExternalTableMaterials(clone);
+  preparePoolRoyaleExternalTableMaterials(clone, tableModel, finishInfo);
   return clone;
 }
 
@@ -12612,12 +12704,23 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   const modelLength = Math.max(MICRO_EPS, Math.max(size.x, size.z));
   const widthScale = dims.targetWidth / modelWidth;
   const lengthScale = dims.targetLength / modelLength;
-  const baseFitScale =
-    tableModel?.fitStrategy === 'contain'
-      ? Math.min(widthScale, lengthScale)
-      : Math.max(widthScale, lengthScale);
-  const fitScale = baseFitScale * (tableModel?.fitScale ?? 1);
-  model.scale.multiplyScalar(fitScale);
+  const fitScaleMultiplier = tableModel?.fitScale ?? 1;
+  if (tableModel?.fitStrategy === 'exact') {
+    const exactXScale = Math.max(MICRO_EPS, dims.targetWidth / Math.max(MICRO_EPS, size.x));
+    const exactZScale = Math.max(MICRO_EPS, dims.targetLength / Math.max(MICRO_EPS, size.z));
+    const exactYScale = Math.sqrt(exactXScale * exactZScale);
+    model.scale.set(
+      model.scale.x * exactXScale * fitScaleMultiplier,
+      model.scale.y * exactYScale * fitScaleMultiplier,
+      model.scale.z * exactZScale * fitScaleMultiplier
+    );
+  } else {
+    const baseFitScale =
+      tableModel?.fitStrategy === 'contain'
+        ? Math.min(widthScale, lengthScale)
+        : Math.max(widthScale, lengthScale);
+    model.scale.multiplyScalar(baseFitScale * fitScaleMultiplier);
+  }
   model.updateMatrixWorld(true);
 
   box = new THREE.Box3().setFromObject(model);
@@ -12643,6 +12746,7 @@ function mountPoolRoyaleExternalTableModel({
   tableModel,
   renderer,
   dims,
+  finishInfo,
   setGeneratedVisualsVisible
 }) {
   if (!table || !tableModel?.assetUrl) return null;
@@ -12659,7 +12763,7 @@ function mountPoolRoyaleExternalTableModel({
   loadPoolRoyaleExternalTableTemplate(tableModel, renderer)
     .then((template) => {
       if (disposed || !template) return;
-      const model = clonePoolRoyaleExternalTableTemplate(template);
+      const model = clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo);
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
       externalRoot.clear();
       externalRoot.add(model);
@@ -13347,10 +13451,11 @@ function mountPoolRoyaleExternalTableModel({
           tableModel: resolvedTableOptions.tableModel,
           renderer,
           dims: {
-            targetWidth: Math.max(TABLE.W, generatedVisualSize.x),
-            targetLength: Math.max(TABLE.H, generatedVisualSize.z),
+            targetWidth: generatedVisualBounds.isEmpty() ? TABLE.W : generatedVisualSize.x,
+            targetLength: generatedVisualBounds.isEmpty() ? TABLE.H : generatedVisualSize.z,
             cushionTopLocal
           },
+          finishInfo,
           setGeneratedVisualsVisible
         })
       : null;


### PR DESCRIPTION
### Motivation
- Remove unused external GLB options (Pooltool PBR and Snooker GLB) from the Pool Royale lobby to simplify showroom choices and avoid visual/size mismatches. 
- Make the Showood 7 ft showroom GLB match the live Pool Royale table footprint precisely so its geometry aligns with gameplay and camera framing. 
- Allow showroom GLB materials to inherit the active Pool Royale finish/cloth/trim/pocket materials so textures and UVs read consistently with the original table.

### Description
- Adjusted `POOL_ROYALE_TABLE_MODEL_OPTIONS` to drop the `pooltool-null-pbr` and `snooker-generic` entries and reconfigured the `showood-seven-foot` option to use `tableSizeId: '9ft'`, `fitStrategy: 'exact'`, and a `usePoolRoyaleFinish` flag (`webapp/src/config/poolRoyaleTableModels.js`).
- Added GLB material pipeline utilities and finish remapping in the Pool Royale renderer: `classifyPoolRoyaleExternalTableSurface`, texture cloning/prep helpers, and `applyPoolRoyaleFinishToExternalMaterial` to copy/look-match Pool Royale finish materials onto external GLB meshes while preserving UVs (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Plumbed the finish info through the external-template flow by extending `clonePoolRoyaleExternalTableTemplate` and `mountPoolRoyaleExternalTableModel` to accept `tableModel` and `finishInfo`, and to apply prepared materials when `usePoolRoyaleFinish` is set (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Implemented an `exact` fit strategy for external GLBs that applies non-uniform X/Z scaling (and a Y scale derived from X/Z) to match the target playfield dimensions precisely, and switched mounting to use the generated visual bounds when available for higher precision (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran a small sanity check script to validate available model IDs and the Showood option configuration, which passed (`node --input-type=module ...` returned expected model list). 
- Performed type/syntax checks and a monorepo TypeScript build with `npm run build`, which completed successfully. 
- Built the webapp with `npm --prefix webapp run build`, which succeeded (Vite build completed; standard chunk-size warnings were reported). 
- Attempted a headless screenshot of the lobby via Playwright to visually confirm the lobby options, but that run failed due to missing native Chromium shared libraries in the environment (Playwright browser launch error); the build and code-paths used by the lobby were still verified by static checks and local dev server run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad96b54908329b28fb8e2a9d6240c)