### PR TITLE
Add Showood 7ft external Snooker table model and mount external GLBs in SnookerRoyal

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -4,7 +4,9 @@ import {
   resolveSnookerTableModel,
   TABLE_MODEL_CLASSIC,
   TABLE_MODEL_OPENSOURCE,
-  TABLE_MODEL_OPENSOURCE_GLB_URL
+  TABLE_MODEL_OPENSOURCE_GLB_URL,
+  TABLE_MODEL_SHOWOOD,
+  TABLE_MODEL_SHOWOOD_ASSET_URL
 } from '../webapp/src/pages/Games/snookerTableModel.js';
 
 describe('snooker table model selection', () => {
@@ -19,19 +21,31 @@ describe('snooker table model selection', () => {
     assert.equal(resolveSnookerTableModel('OpenSource'), TABLE_MODEL_OPENSOURCE);
   });
 
+  test('resolveSnookerTableModel accepts showood aliases case-insensitively', () => {
+    assert.equal(resolveSnookerTableModel('showood'), TABLE_MODEL_SHOWOOD);
+    assert.equal(resolveSnookerTableModel('Showood-Seven-Foot'), TABLE_MODEL_SHOWOOD);
+  });
+
   test('applySnookerTableModelParam always writes a safe tableModel param', () => {
     const params = new URLSearchParams();
     applySnookerTableModelParam(params, 'opensource');
     assert.equal(params.get('tableModel'), TABLE_MODEL_OPENSOURCE);
 
+    applySnookerTableModelParam(params, 'showood');
+    assert.equal(params.get('tableModel'), TABLE_MODEL_SHOWOOD);
+
     applySnookerTableModelParam(params, 'unknown');
     assert.equal(params.get('tableModel'), TABLE_MODEL_CLASSIC);
   });
 
-  test('uses the Pooltool snooker_generic GLB source', () => {
+  test('uses the Pooltool snooker_generic and Showood GLB sources', () => {
     assert.match(
       TABLE_MODEL_OPENSOURCE_GLB_URL,
       /pooltool\/models\/table\/snooker_generic\/snooker_generic\.glb$/
+    );
+    assert.match(
+      TABLE_MODEL_SHOWOOD_ASSET_URL,
+      /pooltool\/models\/table\/seven_foot_showood\/seven_foot_showood_pbr\.glb$/
     );
   });
 });

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -18,9 +18,9 @@ import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import {
   resolveSnookerTableModel,
+  resolveSnookerTableModelOption,
   TABLE_MODEL_CLASSIC,
-  TABLE_MODEL_OPENSOURCE,
-  TABLE_MODEL_OPENSOURCE_GLB_URL
+  TABLE_MODEL_OPENSOURCE
 } from './snookerTableModel.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
@@ -6996,11 +6996,16 @@ function Table3D(
   tableSpecMeta = null,
   railMarkerStyle = null,
   baseVariant = null,
-  renderer = null
+  renderer = null,
+  tableOptions = null
 ) {
   const tableSizeMeta =
     tableSpecMeta && typeof tableSpecMeta === 'object' ? tableSpecMeta : null;
   applyTablePhysicsSpec(tableSizeMeta);
+  const resolvedTableOptions =
+    tableOptions && typeof tableOptions === 'object' ? tableOptions : null;
+  const selectedTableModel = resolvedTableOptions?.tableModel ?? null;
+  const usesExternalTableModel = selectedTableModel?.kind === 'gltf';
 
   const table = new THREE.Group();
   table.userData = table.userData || {};
@@ -10475,58 +10480,6 @@ function Table3D(
     return builder;
   };
 
-  const applyPooltoolTableVisualOverride = () => {
-    const loader = createConfiguredGLTFLoader(renderer);
-    loader
-      .loadAsync(POOLTOOL_SNOOKER_TABLE_URL)
-      .then((gltf) => {
-        const model = gltf?.scene || gltf?.scenes?.[0];
-        if (!model) return;
-
-        const tableBounds = new THREE.Box3().setFromObject(table);
-        const targetSize = tableBounds.getSize(new THREE.Vector3());
-        const targetCenter = tableBounds.getCenter(new THREE.Vector3());
-
-        const modelBounds = new THREE.Box3().setFromObject(model);
-        const modelSize = modelBounds.getSize(new THREE.Vector3());
-        const scaleX = modelSize.x > MICRO_EPS ? targetSize.x / modelSize.x : 1;
-        const scaleZ = modelSize.z > MICRO_EPS ? targetSize.z / modelSize.z : 1;
-        const uniformScale = Math.min(scaleX, scaleZ);
-        if (Number.isFinite(uniformScale) && uniformScale > 0) {
-          model.scale.setScalar(uniformScale);
-        }
-
-        model.updateMatrixWorld(true);
-        const scaledBounds = new THREE.Box3().setFromObject(model);
-        const scaledCenter = scaledBounds.getCenter(new THREE.Vector3());
-        model.position.set(
-          targetCenter.x - scaledCenter.x,
-          tableBounds.min.y - scaledBounds.min.y,
-          targetCenter.z - scaledCenter.z
-        );
-        model.updateMatrixWorld(true);
-
-        table.traverse((child) => {
-          if (!child?.isMesh) return;
-          if (child.userData?.__basePart) return;
-          child.visible = false;
-        });
-
-        model.traverse((child) => {
-          if (!child?.isMesh) return;
-          child.castShadow = true;
-          child.receiveShadow = true;
-          child.renderOrder = 2;
-        });
-
-        table.add(model);
-        table.userData.visualOverrideModel = model;
-      })
-      .catch((error) => {
-        console.warn('Snooker Royal failed to load Pooltool table override; using procedural table.', error);
-      });
-  };
-
   const createPolyhavenTableBaseBuilder = (
     assetId,
     {
@@ -10935,8 +10888,41 @@ function Table3D(
   table.userData.cushionLipClearance = clothPlaneWorld;
   table.userData.clothPlaneLocal = clothPlaneLocal;
   table.userData.finish = finishInfo;
+  const generatedVisualObjects = [];
+  table.traverse((child) => {
+    if (child !== table && (child.isMesh || child.isLine || child.isSprite)) {
+      generatedVisualObjects.push(child);
+    }
+  });
+  const generatedVisualBounds = new THREE.Box3();
+  generatedVisualObjects.forEach((object) => {
+    object.updateMatrixWorld(true);
+    generatedVisualBounds.expandByObject(object);
+  });
+  const generatedVisualSize = generatedVisualBounds.isEmpty()
+    ? new THREE.Vector3(TABLE.W, TABLE.THICK, TABLE.H)
+    : generatedVisualBounds.getSize(new THREE.Vector3());
+  const setGeneratedVisualsVisible = (visible) => {
+    generatedVisualObjects.forEach((object) => {
+      object.visible = visible;
+    });
+  };
+  const externalTable = usesExternalTableModel
+    ? mountSnookerRoyalExternalTableModel({
+        table,
+        tableModel: selectedTableModel,
+        renderer,
+        dims: {
+          targetWidth: generatedVisualBounds.isEmpty() ? TABLE.W : generatedVisualSize.x,
+          targetLength: generatedVisualBounds.isEmpty() ? TABLE.H : generatedVisualSize.z,
+          cushionTopLocal
+        },
+        finishInfo,
+        setGeneratedVisualsVisible
+      })
+    : null;
+  table.userData.externalTable = externalTable;
   parent.add(table);
-  applyPooltoolTableVisualOverride();
 
   const baulkZ = baulkLineZ;
 
@@ -11295,6 +11281,285 @@ function applyTableFinishToTable(table, finish) {
     accent: accentConfig
   };
   finishInfo.clothDetail = resolvedFinish?.clothDetail ?? null;
+}
+
+
+const snookerRoyalExternalTableTemplates = new Map();
+const snookerRoyalExternalTablePromises = new Map();
+
+function classifySnookerRoyalExternalTableSurface(child, material) {
+  const label = `${child?.name || ''} ${material?.name || ''}`.toLowerCase();
+  if (/cloth|felt|baize|slate|bed|playfield|playing[_\s-]*surface/.test(label)) return 'cloth';
+  if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(label)) return 'cushion';
+  if (/pocket|liner|leather|net|basket|drop/.test(label)) return 'pocket';
+  if (/metal|chrome|gold|diamond|sight|marker|plate|trim|screw|bolt/.test(label)) return 'trim';
+  if (/leg|foot|base|support|frame|wood|rail|apron|cabinet|showood/.test(label)) return 'wood';
+  return 'wood';
+}
+
+function cloneSnookerRoyalMaterialTexture(texture, { isColor = false } = {}) {
+  if (!texture) return null;
+  const clone = texture.clone ? texture.clone() : texture;
+  if (isColor) clone.colorSpace = THREE.SRGBColorSpace;
+  clone.generateMipmaps = true;
+  clone.minFilter = THREE.LinearMipmapLinearFilter;
+  clone.magFilter = THREE.LinearFilter;
+  clone.anisotropy = 12;
+  clone.needsUpdate = true;
+  return clone;
+}
+
+function prepareSnookerRoyalExternalTexture(texture, isColor = false) {
+  if (!texture) return;
+  if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+  texture.flipY = false;
+  texture.generateMipmaps = true;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.anisotropy = Math.max(texture.anisotropy ?? 1, 12);
+  texture.needsUpdate = true;
+}
+
+function applySnookerRoyalFinishToExternalMaterial(material, role, finishInfo) {
+  if (!material || !finishInfo) return material;
+  const mat = material.clone ? material.clone() : material;
+  const materials = finishInfo.materials || {};
+  const copyMaterialLook = (source) => {
+    if (!source) return;
+    if (source.color && mat.color) mat.color.copy(source.color);
+    [
+      'roughness',
+      'metalness',
+      'clearcoat',
+      'clearcoatRoughness',
+      'sheen',
+      'sheenRoughness',
+      'reflectivity',
+      'envMapIntensity',
+      'bumpScale'
+    ].forEach((key) => {
+      if (typeof source[key] === 'number' && key in mat) mat[key] = source[key];
+    });
+    mat.map = cloneSnookerRoyalMaterialTexture(source.map, { isColor: true });
+    mat.normalMap = cloneSnookerRoyalMaterialTexture(source.normalMap);
+    mat.roughnessMap = cloneSnookerRoyalMaterialTexture(source.roughnessMap);
+    mat.aoMap = cloneSnookerRoyalMaterialTexture(source.aoMap);
+    mat.metalnessMap = cloneSnookerRoyalMaterialTexture(source.metalnessMap);
+    mat.bumpMap = cloneSnookerRoyalMaterialTexture(source.bumpMap);
+  };
+
+  if (role === 'cloth' || role === 'cushion') {
+    copyMaterialLook(role === 'cushion' ? finishInfo.cushionMat : finishInfo.clothMat);
+    mat.side = THREE.DoubleSide;
+  } else if (role === 'trim') {
+    copyMaterialLook(materials.trim);
+    enhanceChromeMaterial(mat);
+  } else if (role === 'pocket') {
+    copyMaterialLook(materials.pocketJaw ?? materials.pocketRim);
+  } else {
+    const surface = finishInfo.parts?.woodSurfaces?.rail || finishInfo.parts?.woodSurfaces?.frame;
+    if (materials.rail?.color && mat.color) mat.color.copy(materials.rail.color);
+    if (mat.color) {
+      mat.userData = mat.userData || {};
+      mat.userData.baseTintHex = mat.color.getHex();
+    }
+    applyWoodTextureToMaterial(mat, surface || { woodRepeatScale: finishInfo.woodRepeatScale });
+    applyTableFinishDulling(mat);
+    applyTableWoodVisibilityTuning(mat);
+  }
+
+  prepareSnookerRoyalExternalTexture(mat.map, true);
+  prepareSnookerRoyalExternalTexture(mat.emissiveMap, true);
+  prepareSnookerRoyalExternalTexture(mat.aoMap, false);
+  prepareSnookerRoyalExternalTexture(mat.normalMap, false);
+  prepareSnookerRoyalExternalTexture(mat.roughnessMap, false);
+  prepareSnookerRoyalExternalTexture(mat.metalnessMap, false);
+  prepareSnookerRoyalExternalTexture(mat.bumpMap, false);
+  mat.needsUpdate = true;
+  return mat;
+}
+
+function prepareSnookerRoyalExternalTableMaterials(root, tableModel = null, finishInfo = null) {
+  root?.traverse?.((child) => {
+    if (!child?.isMesh) return;
+    child.castShadow = true;
+    child.receiveShadow = true;
+    child.frustumCulled = false;
+    const prepareMaterial = (material) => {
+      if (!material) return material;
+      const role = classifySnookerRoyalExternalTableSurface(child, material);
+      if (tableModel?.useSnookerRoyalFinish && finishInfo) {
+        return applySnookerRoyalFinishToExternalMaterial(material, role, finishInfo);
+      }
+      const mat = material.clone ? material.clone() : material;
+      prepareSnookerRoyalExternalTexture(mat.map, true);
+      prepareSnookerRoyalExternalTexture(mat.emissiveMap, true);
+      prepareSnookerRoyalExternalTexture(mat.aoMap, false);
+      prepareSnookerRoyalExternalTexture(mat.normalMap, false);
+      prepareSnookerRoyalExternalTexture(mat.roughnessMap, false);
+      prepareSnookerRoyalExternalTexture(mat.metalnessMap, false);
+      mat.needsUpdate = true;
+      return mat;
+    };
+    child.material = Array.isArray(child.material)
+      ? child.material.map(prepareMaterial)
+      : prepareMaterial(child.material);
+  });
+}
+
+function cloneSnookerRoyalExternalTableTemplate(template, tableModel = null, finishInfo = null) {
+  const clone = template.clone(true);
+  prepareSnookerRoyalExternalTableMaterials(clone, tableModel, finishInfo);
+  return clone;
+}
+
+async function loadSnookerRoyalExternalTableTemplate(tableModel, renderer = null) {
+  if (!tableModel?.assetUrl) return null;
+  if (snookerRoyalExternalTableTemplates.has(tableModel.id)) {
+    return snookerRoyalExternalTableTemplates.get(tableModel.id);
+  }
+  if (snookerRoyalExternalTablePromises.has(tableModel.id)) {
+    return snookerRoyalExternalTablePromises.get(tableModel.id);
+  }
+  const promise = (async () => {
+    const loader = new GLTFLoader();
+    loader.setCrossOrigin('anonymous');
+    const draco = new DRACOLoader();
+    draco.setDecoderPath(DRACO_DECODER_PATH);
+    loader.setDRACOLoader(draco);
+    const ktx2 = new KTX2Loader();
+    ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
+    if (renderer) {
+      try {
+        ktx2.detectSupport(renderer);
+      } catch (error) {
+        console.warn('Snooker Royal external table KTX2 support detection failed', error);
+      }
+    }
+    loader.setKTX2Loader(ktx2);
+    loader.setMeshoptDecoder(MeshoptDecoder);
+    let lastError = null;
+    const urls = [tableModel.assetUrl, tableModel.fallbackAssetUrl].filter(Boolean);
+    for (const url of urls) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const gltf = await loader.loadAsync(url);
+        const scene = gltf?.scene || gltf?.scenes?.[0];
+        if (!scene) throw new Error(`Missing GLTF scene for ${tableModel.id}`);
+        snookerRoyalExternalTableTemplates.set(tableModel.id, scene);
+        return scene;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error(`Failed to load Snooker Royal table model: ${tableModel.id}`);
+  })();
+  snookerRoyalExternalTablePromises.set(tableModel.id, promise);
+  promise.catch(() => snookerRoyalExternalTablePromises.delete(tableModel.id));
+  return promise;
+}
+
+function fitSnookerRoyalExternalTableModel(model, tableModel, dims) {
+  if (!model || !dims) return;
+  model.position.set(0, 0, 0);
+  model.rotation.set(0, 0, 0);
+  model.scale.setScalar(1);
+  model.updateMatrixWorld(true);
+  let box = new THREE.Box3().setFromObject(model);
+  let size = box.getSize(new THREE.Vector3());
+  if (size.x > size.z && dims.targetLength > dims.targetWidth) {
+    model.rotation.y = Math.PI / 2;
+    model.updateMatrixWorld(true);
+    box = new THREE.Box3().setFromObject(model);
+    size = box.getSize(new THREE.Vector3());
+  }
+  const fitScaleMultiplier = tableModel?.fitScale ?? 1;
+  if (tableModel?.fitStrategy === 'exact') {
+    const exactXScale = dims.targetWidth / Math.max(MICRO_EPS, size.x);
+    const exactZScale = dims.targetLength / Math.max(MICRO_EPS, size.z);
+    const exactYScale = Math.sqrt(exactXScale * exactZScale);
+    model.scale.set(
+      model.scale.x * exactXScale * fitScaleMultiplier,
+      model.scale.y * exactYScale * fitScaleMultiplier,
+      model.scale.z * exactZScale * fitScaleMultiplier
+    );
+  } else {
+    const modelWidth = Math.max(MICRO_EPS, Math.min(size.x, size.z));
+    const modelLength = Math.max(MICRO_EPS, Math.max(size.x, size.z));
+    const widthScale = dims.targetWidth / modelWidth;
+    const lengthScale = dims.targetLength / modelLength;
+    const baseFitScale = tableModel?.fitStrategy === 'contain'
+      ? Math.min(widthScale, lengthScale)
+      : Math.max(widthScale, lengthScale);
+    model.scale.multiplyScalar(baseFitScale * fitScaleMultiplier);
+  }
+  model.updateMatrixWorld(true);
+  box = new THREE.Box3().setFromObject(model);
+  const center = box.getCenter(new THREE.Vector3());
+  model.position.x -= center.x;
+  model.position.z -= center.z;
+  model.position.y += dims.cushionTopLocal - box.max.y + (tableModel?.verticalOffset ?? 0);
+  model.updateMatrixWorld(true);
+  model.userData = {
+    ...(model.userData || {}),
+    snookerRoyalExternalTable: true,
+    tableModelId: tableModel?.id,
+    fittedToPlayfield: {
+      width: dims.targetWidth,
+      length: dims.targetLength,
+      physics: 'Snooker Royal playfield, pockets, cushions, and ball simulation'
+    }
+  };
+}
+
+function mountSnookerRoyalExternalTableModel({
+  table,
+  tableModel,
+  renderer,
+  dims,
+  finishInfo,
+  setGeneratedVisualsVisible
+}) {
+  if (!table || !tableModel?.assetUrl) return null;
+  const externalRoot = new THREE.Group();
+  externalRoot.name = `snooker-royal-external-table-${tableModel.id}`;
+  externalRoot.userData = {
+    ...(externalRoot.userData || {}),
+    snookerRoyalExternalTableRoot: true,
+    tableModelId: tableModel.id
+  };
+  table.add(externalRoot);
+  let disposed = false;
+  loadSnookerRoyalExternalTableTemplate(tableModel, renderer)
+    .then((template) => {
+      if (disposed || !template) return;
+      const model = cloneSnookerRoyalExternalTableTemplate(template, tableModel, finishInfo);
+      fitSnookerRoyalExternalTableModel(model, tableModel, dims);
+      externalRoot.clear();
+      externalRoot.add(model);
+      setGeneratedVisualsVisible?.(false);
+    })
+    .catch((error) => {
+      console.warn('Snooker Royal external table failed to load; keeping native table', {
+        tableModelId: tableModel.id,
+        error
+      });
+      if (!disposed) setGeneratedVisualsVisible?.(true);
+    });
+  return {
+    group: externalRoot,
+    dispose: () => {
+      disposed = true;
+      if (externalRoot.parent) externalRoot.parent.remove(externalRoot);
+      externalRoot.traverse((child) => {
+        if (!child?.isMesh) return;
+        child.geometry?.dispose?.();
+        const material = child.material;
+        if (Array.isArray(material)) material.forEach((mat) => mat?.dispose?.());
+        else material?.dispose?.();
+      });
+    }
+  };
 }
 
 // --------------------------------------------------
@@ -11900,6 +12165,10 @@ function SnookerRoyalGame({
       availableTableBases[0] ??
       SNOOKER_ROYALE_BASE_VARIANTS[0],
     [availableTableBases, tableBaseId]
+  );
+  const activeTableModel = useMemo(
+    () => resolveSnookerTableModelOption(tableModel),
+    [tableModel]
   );
   const resolvedHdriResolution =
     activeHdriResolutionOption.id === 'auto'
@@ -19809,7 +20078,8 @@ const powerRef = useRef(hud.power);
         tableSizeMeta,
         railMarkerStyleRef.current,
         activeTableBase,
-        rendererRef.current
+        rendererRef.current,
+        { tableModel: activeTableModel }
       );
       const SPOTS = spotPositions(baulkZ);
       snookerSpotsRef.current = SPOTS;
@@ -19828,10 +20098,12 @@ const powerRef = useRef(hud.power);
         tableSizeMeta,
         railMarkerStyleRef.current,
         activeTableBase,
-        rendererRef.current
+        rendererRef.current,
+        { tableModel: activeTableModel }
       );
       secondaryTableRef.current = secondaryTableEntry?.group ?? null;
       secondaryBaseSetterRef.current = secondaryTableEntry?.setBaseVariant ?? null;
+      const activeExternalTableModel = resolveSnookerTableModelOption(tableModel);
       const resolveSnookerScale = () => {
         const poolWidth = tableSizeMeta?.playfield?.widthMm ?? 2540;
         const snookerWidth = resolveTableSize()?.playfield?.widthMm ?? 3556;
@@ -19839,107 +20111,14 @@ const powerRef = useRef(hud.power);
         return Math.max(1.15, snookerWidth / poolWidth);
       };
       const snookerDecorScale = resolveSnookerScale();
-      const attachOpenSourceTableModel = (tableGroup) => {
-        if (tableModel !== TABLE_MODEL_OPENSOURCE || !tableGroup) return;
-        tableGroup.updateMatrixWorld(true);
-        const targetBox = new THREE.Box3().setFromObject(tableGroup);
-        const targetSize = targetBox.getSize(new THREE.Vector3());
-        const proceduralMeshes = new Set();
-        tableGroup.traverse((node) => {
-          if (node?.isMesh) proceduralMeshes.add(node.uuid);
-        });
-        const loader = new GLTFLoader();
-        loader.setCrossOrigin('anonymous');
-        const draco = new DRACOLoader();
-        draco.setDecoderPath(DRACO_DECODER_PATH);
-        loader.setDRACOLoader(draco);
-        const ktx2 = new KTX2Loader();
-        ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
-        if (rendererRef.current) {
-          try {
-            ktx2.detectSupport(rendererRef.current);
-          } catch (error) {
-            console.warn('Snooker Royal table KTX2 support detection failed', error);
-          }
+      // External table models are mounted by Table3D so the native generated table
+      // is hidden only after the selected GLB is ready.
+      if (activeExternalTableModel?.id === TABLE_MODEL_OPENSOURCE) {
+        table.userData.openSourceVisualUrl = activeExternalTableModel.assetUrl;
+        if (secondaryTableEntry?.group) {
+          secondaryTableEntry.group.userData.openSourceVisualUrl = activeExternalTableModel.assetUrl;
         }
-        loader.setKTX2Loader(ktx2);
-        loader.setMeshoptDecoder(MeshoptDecoder);
-        const tuneOriginalPooltoolTextures = (root) => {
-          root.traverse((node) => {
-            if (!node?.isMesh) return;
-            node.castShadow = true;
-            node.receiveShadow = true;
-            const materials = Array.isArray(node.material) ? node.material : [node.material];
-            materials.forEach((material) => {
-              if (!material) return;
-              ['map', 'emissiveMap'].forEach((key) => {
-                if (material[key]) {
-                  material[key].colorSpace = THREE.SRGBColorSpace;
-                }
-              });
-              [
-                'map',
-                'emissiveMap',
-                'aoMap',
-                'normalMap',
-                'roughnessMap',
-                'metalnessMap'
-              ].forEach((key) => {
-                const texture = material[key];
-                if (!texture) return;
-                texture.flipY = false;
-                texture.generateMipmaps = true;
-                texture.minFilter = THREE.LinearMipmapLinearFilter;
-                texture.magFilter = THREE.LinearFilter;
-                texture.anisotropy = 8;
-                texture.needsUpdate = true;
-              });
-              material.needsUpdate = true;
-            });
-          });
-        };
-        loader.load(
-          TABLE_MODEL_OPENSOURCE_GLB_URL,
-          (gltf) => {
-            const visual = gltf?.scene;
-            if (!visual) return;
-            visual.updateMatrixWorld(true);
-            const sourceBox = new THREE.Box3().setFromObject(visual);
-            const sourceSize = sourceBox.getSize(new THREE.Vector3());
-            const scaleXZ = Math.min(
-              targetSize.x / Math.max(sourceSize.x, 0.0001),
-              targetSize.z / Math.max(sourceSize.z, 0.0001)
-            );
-            const scaleY = targetSize.y / Math.max(sourceSize.y, 0.0001);
-            visual.scale.set(scaleXZ, scaleY, scaleXZ);
-            visual.updateMatrixWorld(true);
-            const scaledBox = new THREE.Box3().setFromObject(visual);
-            const scaledCenter = scaledBox.getCenter(new THREE.Vector3());
-            const targetCenter = targetBox.getCenter(new THREE.Vector3());
-            visual.position.set(
-              targetCenter.x - scaledCenter.x,
-              targetBox.min.y - scaledBox.min.y,
-              targetCenter.z - scaledCenter.z
-            );
-            tuneOriginalPooltoolTextures(visual);
-            visual.name = 'pooltool-snooker-generic-table';
-            tableGroup.traverse((node) => {
-              if (node?.isMesh && proceduralMeshes.has(node.uuid)) {
-                node.visible = false;
-              }
-            });
-            tableGroup.add(visual);
-            tableGroup.userData.openSourceVisual = visual;
-            tableGroup.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;
-          },
-          undefined,
-          (error) => {
-            console.warn('Failed to load Pooltool snooker_generic table model', error);
-          }
-        );
-      };
-      attachOpenSourceTableModel(table);
-      attachOpenSourceTableModel(secondaryTableEntry?.group);
+      }
       const disposeSecondaryDecor = () => {
         const currentDecor = secondaryTableDecorRef.current;
         if (currentDecor?.group?.parent) {
@@ -20131,7 +20310,8 @@ const powerRef = useRef(hud.power);
           tableSizeMeta,
           railMarkerStyleRef.current,
           activeTableBase,
-          rendererRef.current
+          rendererRef.current,
+          { tableModel: activeTableModel }
         );
         const tableGroup = entry?.group;
         if (!tableGroup) return null;

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -18,7 +18,8 @@ import {
   applySnookerTableModelParam,
   resolveSnookerTableModel,
   TABLE_MODEL_CLASSIC,
-  TABLE_MODEL_OPENSOURCE
+  TABLE_MODEL_OPENSOURCE,
+  TABLE_MODEL_SHOWOOD
 } from './snookerTableModel.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'snookerRoyalPlayerFlag';
@@ -446,10 +447,11 @@ export default function SnookerRoyalLobby() {
             <h3 className="font-semibold text-white">Choose Table</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Layout</span>
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
             {[
               { id: TABLE_MODEL_CLASSIC, label: 'Classic Table', desc: 'Current playable table' },
-              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Open-source GLTF table model' }
+              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Open-source GLTF table model' },
+              { id: TABLE_MODEL_SHOWOOD, label: 'Showood Table', desc: 'Exact-fit GLB with selected textures' }
             ].map(({ id, label, desc }) => {
               const active = tableModel === id;
               return (

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -1,11 +1,60 @@
 export const TABLE_MODEL_CLASSIC = 'classic';
 export const TABLE_MODEL_OPENSOURCE = 'opensource';
+export const TABLE_MODEL_SHOWOOD = 'showood-seven-foot';
 export const TABLE_MODEL_OPENSOURCE_GLB_URL =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
 
-export function resolveSnookerTableModel(value) {
+const POOLTOOL_TABLE_RAW_BASE =
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+
+export const TABLE_MODEL_SHOWOOD_ASSET_URL =
+  `${POOLTOOL_TABLE_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`;
+export const TABLE_MODEL_SHOWOOD_FALLBACK_ASSET_URL =
+  `${POOLTOOL_TABLE_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`;
+
+export const SNOOKER_TABLE_MODEL_OPTIONS = Object.freeze([
+  {
+    id: TABLE_MODEL_CLASSIC,
+    label: 'Classic Table',
+    description: 'Current playable procedural Snooker Royal table.',
+    kind: 'native'
+  },
+  {
+    id: TABLE_MODEL_OPENSOURCE,
+    label: 'New Snooker Table',
+    description: 'Open-source Pooltool snooker_generic GLB visual fitted to the playable table.',
+    kind: 'gltf',
+    assetUrl: TABLE_MODEL_OPENSOURCE_GLB_URL,
+    fitStrategy: 'contain',
+    useSnookerRoyalFinish: false
+  },
+  {
+    id: TABLE_MODEL_SHOWOOD,
+    aliases: ['showood', 'showood7', 'showood-7ft', 'showood-seven-foot'],
+    label: 'Showood 7 ft Table',
+    description: 'Pooltool Showood GLB fitted exactly to the Snooker Royal table and remapped to the selected finish.',
+    kind: 'gltf',
+    assetUrl: TABLE_MODEL_SHOWOOD_ASSET_URL,
+    fallbackAssetUrl: TABLE_MODEL_SHOWOOD_FALLBACK_ASSET_URL,
+    fitStrategy: 'exact',
+    fitScale: 1,
+    useSnookerRoyalFinish: true
+  }
+]);
+
+export function resolveSnookerTableModelOption(value) {
   const requested = String(value || '').toLowerCase();
-  return requested === TABLE_MODEL_OPENSOURCE ? TABLE_MODEL_OPENSOURCE : TABLE_MODEL_CLASSIC;
+  return (
+    SNOOKER_TABLE_MODEL_OPTIONS.find(
+      (option) =>
+        option.id.toLowerCase() === requested ||
+        option.aliases?.some((alias) => alias.toLowerCase() === requested)
+    ) || SNOOKER_TABLE_MODEL_OPTIONS[0]
+  );
+}
+
+export function resolveSnookerTableModel(value) {
+  return resolveSnookerTableModelOption(value).id;
 }
 
 export function applySnookerTableModelParam(params, tableModel) {


### PR DESCRIPTION
### Motivation

- Provide a selectable, exact-fit Showood 7 ft table model (Pooltool GLB) for Snooker Royal so players can switch between the built-in procedural table and an open-source GLB that reuses the same playfield mapping and can accept the Snooker Royal finishes.
- Make external GLB table visuals mountable through the existing Table3D pipeline and ensure only the selected table visual is shown (native vs external) once the external GLB is ready.

### Description

- Added a table-model options module and constants in `webapp/src/pages/Games/snookerTableModel.js` including `showood-seven-foot` with asset and fallback URLs and alias-safe resolution via `resolveSnookerTableModelOption` and `resolveSnookerTableModel`.
- Extended the Snooker lobby UI to expose three table choices: Classic, New Snooker (snooker_generic), and Showood (exact-fit GLB). (`webapp/src/pages/Games/SnookerRoyalLobby.jsx`).
- Plumbed external table selection into `Table3D` so a selected external model is mounted via a new external-template loader/clone/fit pipeline and the generated/default table visuals are hidden only after the GLB is loaded; added `mountSnookerRoyalExternalTableModel`, `loadSnookerRoyalExternalTableTemplate`, `fitSnookerRoyalExternalTableModel`, and material remapping helpers to remap cloth, cushions, wood, trim and pocket materials for external tables. (`webapp/src/pages/Games/SnookerRoyal.jsx`).
- Kept playfield/physics mapping unchanged by fitting the external model to the generated table footprint (exact/contain strategies) and added helpers to apply Snooker Royal finishes to external GLB materials when requested.
- Tests: extended `test/snookerTableModel.test.js` to verify Showood aliases, safe query param writing, and both Showood & snooker_generic asset URL patterns.

### Testing

- Ran unit tests with `npm test -- --runInBand test/snookerTableModel.test.js`, and all tests passed (5/5).
- Performed TypeScript project build with `npm run build` which completed successfully.
- Built the webapp with `npm --prefix webapp run build` (Vite production build) which completed successfully (build artifacts produced and noted chunk-size warnings from Vite).
- Ran ESLint; default run (repo ignore) printed ignored-file warnings, and an explicit `npx eslint --no-ignore ...` run flagged issues in some edited files (these are reported and left for follow-up fixes).
- Attempted an automated Playwright screenshot to validate lobby UI, but Chromium failed to launch in the container due to a missing system library (`libatk-1.0.so.0`); the Playwright-based visual check did not complete for that reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae23ebed88329996798d95cb0528f)