### PR TITLE
Map Showood GLB to Snooker table footprint and apply table finishes

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -20,7 +20,8 @@ import {
   resolveSnookerTableModel,
   TABLE_MODEL_CLASSIC,
   TABLE_MODEL_OPENSOURCE,
-  TABLE_MODEL_OPENSOURCE_GLB_URL
+  TABLE_MODEL_OPENSOURCE_GLB_URL,
+  TABLE_MODEL_OPENSOURCE_FALLBACK_GLB_URL
 } from './snookerTableModel.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
@@ -10951,6 +10952,126 @@ function Table3D(
   };
 }
 
+
+function classifySnookerExternalTableSurface(child, material) {
+  const label = `${child?.name || ''} ${material?.name || ''}`.toLowerCase();
+  if (/cloth|felt|baize|slate|bed|playfield|playing[_\s-]*surface/.test(label)) return 'cloth';
+  if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(label)) return 'cushion';
+  if (/pocket|liner|leather|net|basket|drop/.test(label)) return 'pocket';
+  if (/metal|chrome|gold|diamond|sight|marker|plate|trim|screw|bolt/.test(label)) return 'trim';
+  if (/leg|foot|base|support|frame|wood|rail|apron|cabinet|showood/.test(label)) return 'wood';
+  return 'wood';
+}
+
+function cloneSnookerExternalMaterialTexture(texture, { isColor = false } = {}) {
+  if (!texture) return null;
+  const clone = texture.clone ? texture.clone() : texture;
+  if (isColor) clone.colorSpace = THREE.SRGBColorSpace;
+  clone.anisotropy = resolveTextureAnisotropy(12);
+  clone.needsUpdate = true;
+  return clone;
+}
+
+function prepareSnookerExternalTexture(texture, isColor = false) {
+  if (!texture) return;
+  if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = resolveTextureAnisotropy(12);
+  texture.generateMipmaps = true;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.needsUpdate = true;
+}
+
+function copySnookerMaterialLook(target, source) {
+  if (!target || !source) return;
+  if (source.color && target.color) target.color.copy(source.color);
+  if (source.emissive && target.emissive) target.emissive.copy(source.emissive);
+  [
+    'roughness',
+    'metalness',
+    'clearcoat',
+    'clearcoatRoughness',
+    'sheen',
+    'sheenRoughness',
+    'reflectivity',
+    'envMapIntensity',
+    'emissiveIntensity',
+    'bumpScale'
+  ].forEach((key) => {
+    if (typeof source[key] === 'number' && key in target) target[key] = source[key];
+  });
+  target.map = cloneSnookerExternalMaterialTexture(source.map, { isColor: true });
+  target.emissiveMap = cloneSnookerExternalMaterialTexture(source.emissiveMap, { isColor: true });
+  target.normalMap = cloneSnookerExternalMaterialTexture(source.normalMap);
+  target.roughnessMap = cloneSnookerExternalMaterialTexture(source.roughnessMap);
+  target.aoMap = cloneSnookerExternalMaterialTexture(source.aoMap);
+  target.metalnessMap = cloneSnookerExternalMaterialTexture(source.metalnessMap);
+  target.bumpMap = cloneSnookerExternalMaterialTexture(source.bumpMap);
+}
+
+function applySnookerFinishToExternalMaterial(material, role, finishInfo) {
+  if (!material || !finishInfo) return material;
+  const mat = material.clone ? material.clone() : material;
+  const materials = finishInfo.materials || {};
+  if (role === 'cloth' || role === 'cushion') {
+    copySnookerMaterialLook(mat, role === 'cushion' ? finishInfo.cushionMat : finishInfo.clothMat);
+    mat.side = THREE.DoubleSide;
+  } else if (role === 'trim') {
+    copySnookerMaterialLook(mat, materials.trim);
+    enhanceChromeMaterial(mat);
+  } else if (role === 'pocket') {
+    copySnookerMaterialLook(mat, materials.pocketJaw ?? materials.pocketRim);
+  } else {
+    const surface =
+      finishInfo.parts?.woodSurfaces?.rail ||
+      finishInfo.parts?.woodSurfaces?.frame ||
+      { woodRepeatScale: finishInfo.woodRepeatScale };
+    if (materials.rail?.color && mat.color) mat.color.copy(materials.rail.color);
+    if (mat.color) {
+      mat.userData = mat.userData || {};
+      mat.userData.baseTintHex = mat.color.getHex();
+    }
+    applyWoodTextureToMaterial(mat, surface);
+    applyTableFinishDulling(mat);
+    applyTableWoodVisibilityTuning(mat);
+  }
+  prepareSnookerExternalTexture(mat.map, true);
+  prepareSnookerExternalTexture(mat.emissiveMap, true);
+  prepareSnookerExternalTexture(mat.aoMap, false);
+  prepareSnookerExternalTexture(mat.normalMap, false);
+  prepareSnookerExternalTexture(mat.roughnessMap, false);
+  prepareSnookerExternalTexture(mat.metalnessMap, false);
+  prepareSnookerExternalTexture(mat.bumpMap, false);
+  mat.needsUpdate = true;
+  return mat;
+}
+
+function applySnookerFinishToExternalTable(root, finishInfo) {
+  if (!root || !finishInfo) return;
+  root.traverse((child) => {
+    if (!child?.isMesh) return;
+    child.castShadow = true;
+    child.receiveShadow = true;
+    child.frustumCulled = false;
+    const applyMaterial = (material) => {
+      const role = classifySnookerExternalTableSurface(child, material);
+      return applySnookerFinishToExternalMaterial(material, role, finishInfo);
+    };
+    child.material = Array.isArray(child.material)
+      ? child.material.map(applyMaterial)
+      : applyMaterial(child.material);
+  });
+}
+
+function setGeneratedSnookerTableVisualsVisible(tableGroup, proceduralMeshes, visible) {
+  if (!tableGroup || !proceduralMeshes) return;
+  tableGroup.traverse((node) => {
+    if (node?.isMesh && proceduralMeshes.has(node.uuid)) {
+      node.visible = visible;
+    }
+  });
+}
+
 function applyTableFinishToTable(table, finish) {
   if (!table || !finish) return;
   const finishInfo = table.userData?.finish;
@@ -11295,6 +11416,9 @@ function applyTableFinishToTable(table, finish) {
     accent: accentConfig
   };
   finishInfo.clothDetail = resolvedFinish?.clothDetail ?? null;
+  if (table.userData?.openSourceVisual) {
+    applySnookerFinishToExternalTable(table.userData.openSourceVisual, finishInfo);
+  }
 }
 
 // --------------------------------------------------
@@ -19844,10 +19968,13 @@ const powerRef = useRef(hud.power);
         tableGroup.updateMatrixWorld(true);
         const targetBox = new THREE.Box3().setFromObject(tableGroup);
         const targetSize = targetBox.getSize(new THREE.Vector3());
+        const targetCenter = targetBox.getCenter(new THREE.Vector3());
         const proceduralMeshes = new Set();
         tableGroup.traverse((node) => {
           if (node?.isMesh) proceduralMeshes.add(node.uuid);
         });
+        setGeneratedSnookerTableVisualsVisible(tableGroup, proceduralMeshes, false);
+
         const loader = new GLTFLoader();
         loader.setCrossOrigin('anonymous');
         const draco = new DRACOLoader();
@@ -19859,84 +19986,79 @@ const powerRef = useRef(hud.power);
           try {
             ktx2.detectSupport(rendererRef.current);
           } catch (error) {
-            console.warn('Snooker Royal table KTX2 support detection failed', error);
+            console.warn('Snooker Royal Showood table KTX2 support detection failed', error);
           }
         }
         loader.setKTX2Loader(ktx2);
         loader.setMeshoptDecoder(MeshoptDecoder);
-        const tuneOriginalPooltoolTextures = (root) => {
-          root.traverse((node) => {
-            if (!node?.isMesh) return;
-            node.castShadow = true;
-            node.receiveShadow = true;
-            const materials = Array.isArray(node.material) ? node.material : [node.material];
-            materials.forEach((material) => {
-              if (!material) return;
-              ['map', 'emissiveMap'].forEach((key) => {
-                if (material[key]) {
-                  material[key].colorSpace = THREE.SRGBColorSpace;
-                }
-              });
-              [
-                'map',
-                'emissiveMap',
-                'aoMap',
-                'normalMap',
-                'roughnessMap',
-                'metalnessMap'
-              ].forEach((key) => {
-                const texture = material[key];
-                if (!texture) return;
-                texture.flipY = false;
-                texture.generateMipmaps = true;
-                texture.minFilter = THREE.LinearMipmapLinearFilter;
-                texture.magFilter = THREE.LinearFilter;
-                texture.anisotropy = 8;
-                texture.needsUpdate = true;
-              });
-              material.needsUpdate = true;
-            });
-          });
-        };
-        loader.load(
-          TABLE_MODEL_OPENSOURCE_GLB_URL,
-          (gltf) => {
-            const visual = gltf?.scene;
-            if (!visual) return;
+
+        const fitShowoodVisualToNativeMapping = (visual) => {
+          visual.position.set(0, 0, 0);
+          visual.rotation.set(0, 0, 0);
+          visual.scale.setScalar(1);
+          visual.updateMatrixWorld(true);
+
+          let sourceBox = new THREE.Box3().setFromObject(visual);
+          let sourceSize = sourceBox.getSize(new THREE.Vector3());
+          if (sourceSize.x > sourceSize.z && targetSize.z > targetSize.x) {
+            visual.rotation.y = Math.PI / 2;
             visual.updateMatrixWorld(true);
-            const sourceBox = new THREE.Box3().setFromObject(visual);
-            const sourceSize = sourceBox.getSize(new THREE.Vector3());
-            const scaleXZ = Math.min(
-              targetSize.x / Math.max(sourceSize.x, 0.0001),
-              targetSize.z / Math.max(sourceSize.z, 0.0001)
-            );
-            const scaleY = targetSize.y / Math.max(sourceSize.y, 0.0001);
-            visual.scale.set(scaleXZ, scaleY, scaleXZ);
-            visual.updateMatrixWorld(true);
-            const scaledBox = new THREE.Box3().setFromObject(visual);
-            const scaledCenter = scaledBox.getCenter(new THREE.Vector3());
-            const targetCenter = targetBox.getCenter(new THREE.Vector3());
-            visual.position.set(
-              targetCenter.x - scaledCenter.x,
-              targetBox.min.y - scaledBox.min.y,
-              targetCenter.z - scaledCenter.z
-            );
-            tuneOriginalPooltoolTextures(visual);
-            visual.name = 'pooltool-snooker-generic-table';
-            tableGroup.traverse((node) => {
-              if (node?.isMesh && proceduralMeshes.has(node.uuid)) {
-                node.visible = false;
-              }
-            });
-            tableGroup.add(visual);
-            tableGroup.userData.openSourceVisual = visual;
-            tableGroup.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;
-          },
-          undefined,
-          (error) => {
-            console.warn('Failed to load Pooltool snooker_generic table model', error);
+            sourceBox = new THREE.Box3().setFromObject(visual);
+            sourceSize = sourceBox.getSize(new THREE.Vector3());
           }
-        );
+
+          const scaleX = targetSize.x / Math.max(sourceSize.x, MICRO_EPS);
+          const scaleZ = targetSize.z / Math.max(sourceSize.z, MICRO_EPS);
+          const scaleY = Math.sqrt(Math.max(MICRO_EPS, scaleX * scaleZ));
+          visual.scale.set(scaleX, scaleY, scaleZ);
+          visual.updateMatrixWorld(true);
+
+          const scaledBox = new THREE.Box3().setFromObject(visual);
+          const scaledCenter = scaledBox.getCenter(new THREE.Vector3());
+          visual.position.set(
+            targetCenter.x - scaledCenter.x,
+            targetBox.min.y - scaledBox.min.y,
+            targetCenter.z - scaledCenter.z
+          );
+          visual.updateMatrixWorld(true);
+          visual.userData = {
+            ...(visual.userData || {}),
+            snookerRoyalExternalTable: true,
+            tableModelId: TABLE_MODEL_OPENSOURCE,
+            fittedToPlayfield: {
+              width: targetSize.x,
+              length: targetSize.z,
+              physics: 'Snooker Royal native pockets, cushions, and ball mapping'
+            }
+          };
+        };
+
+        (async () => {
+          let lastError = null;
+          const urls = [
+            TABLE_MODEL_OPENSOURCE_GLB_URL,
+            TABLE_MODEL_OPENSOURCE_FALLBACK_GLB_URL
+          ].filter(Boolean);
+          for (const url of urls) {
+            try {
+              // eslint-disable-next-line no-await-in-loop
+              const gltf = await loader.loadAsync(url);
+              const visual = gltf?.scene || gltf?.scenes?.[0];
+              if (!visual) throw new Error('Missing Showood table scene');
+              fitShowoodVisualToNativeMapping(visual);
+              applySnookerFinishToExternalTable(visual, tableGroup.userData?.finish);
+              visual.name = 'pooltool-showood-seven-foot-table';
+              tableGroup.add(visual);
+              tableGroup.userData.openSourceVisual = visual;
+              tableGroup.userData.openSourceVisualUrl = url;
+              return;
+            } catch (error) {
+              lastError = error;
+            }
+          }
+          console.warn('Failed to load Pooltool Showood table model', lastError);
+          setGeneratedSnookerTableVisualsVisible(tableGroup, proceduralMeshes, true);
+        })();
       };
       attachOpenSourceTableModel(table);
       attachOpenSourceTableModel(secondaryTableEntry?.group);

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -449,7 +449,7 @@ export default function SnookerRoyalLobby() {
           <div className="grid grid-cols-2 gap-3">
             {[
               { id: TABLE_MODEL_CLASSIC, label: 'Classic Table', desc: 'Current playable table' },
-              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Open-source GLTF table model' }
+              { id: TABLE_MODEL_OPENSOURCE, label: 'Showood Table', desc: 'Showood GLB mapped to the same playable table' }
             ].map(({ id, label, desc }) => {
               const active = tableModel === id;
               return (

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -1,11 +1,18 @@
 export const TABLE_MODEL_CLASSIC = 'classic';
 export const TABLE_MODEL_OPENSOURCE = 'opensource';
+const POOLTOOL_TABLE_RAW_BASE =
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+
 export const TABLE_MODEL_OPENSOURCE_GLB_URL =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
+  `${POOLTOOL_TABLE_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`;
+export const TABLE_MODEL_OPENSOURCE_FALLBACK_GLB_URL =
+  `${POOLTOOL_TABLE_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`;
 
 export function resolveSnookerTableModel(value) {
   const requested = String(value || '').toLowerCase();
-  return requested === TABLE_MODEL_OPENSOURCE ? TABLE_MODEL_OPENSOURCE : TABLE_MODEL_CLASSIC;
+  return requested === TABLE_MODEL_OPENSOURCE || requested === 'showood'
+    ? TABLE_MODEL_OPENSOURCE
+    : TABLE_MODEL_CLASSIC;
 }
 
 export function applySnookerTableModelParam(params, tableModel) {


### PR DESCRIPTION
### Motivation
- Provide an alternative open-source Snooker table (Showood GLB) that uses the exact Snooker Royal playfield footprint and pocket/cushion mapping while allowing the active Snooker table finishes/textures to be applied to the external model. 
- Keep only one visible table at a time so selecting the Showood model hides the default procedural table visuals.

### Description
- Added `POOLTOOL_TABLE_RAW_BASE`, `TABLE_MODEL_OPENSOURCE_GLB_URL`, and `TABLE_MODEL_OPENSOURCE_FALLBACK_GLB_URL` and made `resolveSnookerTableModel` accept `showood` as an alias in `webapp/src/pages/Games/snookerTableModel.js`.
- Implemented external-model material remapping utilities in `webapp/src/pages/Games/SnookerRoyal.jsx` (`classifySnookerExternalTableSurface`, `applySnookerFinishToExternalMaterial`, `applySnookerFinishToExternalTable`, and helpers) to copy cloth/cushion/trim/pocket/wood look from the active `finishInfo` onto the Showood GLB.
- Hooked external table mounting to: hide generated native table meshes while loading, fit the Showood GLB exactly to the native table footprint (scale/rotation/translation), attach the Showood visual to the scene, and store `openSourceVisual` on the table group for later updates.
- Ensure the active finish is re-applied to the Showood visual when finishes change by calling `applySnookerFinishToExternalTable` when the local `finishInfo` is created/updated.
- Added `setGeneratedSnookerTableVisualsVisible` so procedural meshes are shown/hidden depending on whether the Showood model loaded successfully.
- Renamed the lobby option label to `Showood Table` and updated its description in `webapp/src/pages/Games/SnookerRoyalLobby.jsx` so the choice is clear to users.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build finished without errors). 
- Ran `git diff --check` on modified files and there were no diff-check errors.
- Attempted an automated mobile screenshot using Playwright, but Chromium could not launch in this environment due to the container missing the native `libatk-1.0.so.0` library, so the Playwright screenshot step failed (environment issue, not code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae23ebed88329996798d95cb0528f)