### PR TITLE
Refine Showood external table fit, pocket visuals, and shooter pose

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -25,10 +25,13 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
+    fitHeightScale: 0.965,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
-    usePoolRoyaleFinish: true
+    usePoolRoyaleFinish: true,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion'],
+    preserveOriginalSurfaceRoles: ['wood', 'trim', 'pocket']
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1251,7 +1251,7 @@ const CHROME_CORNER_POCKET_EDGE_ROUND_SCALE = 0.9; // strongly round the outer c
 const CHROME_SIDE_POCKET_RADIUS_SCALE =
   CORNER_POCKET_INWARD_SCALE *
   CHROME_CORNER_POCKET_RADIUS_SCALE; // match the middle chrome arches to the corner pocket radius
-const WOOD_RAIL_CORNER_RADIUS_SCALE = 0; // keep pocket-adjacent rounded cuts exactly as before
+const WOOD_RAIL_CORNER_RADIUS_SCALE = 0.84; // round the native wooden rail outline so the rail silhouette follows the Showood pocket-jaw style
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0; // disable secondary throat so the side chrome uses a single arch
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // reuse snooker notch height profile
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
@@ -1284,7 +1284,7 @@ const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.958; // shrink the wooden corner round
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_CORNER_POCKET_CUT_CENTER_OUTSET_SCALE = -0.018; // push only the wooden corner rounded cut outward a touch without moving side-pocket cuts
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.008; // keep middle rail rounded cuts just a bit tighter while still matching the chrome arc
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1; // keep middle rail rounded cuts identical to the corner/showood-style pocket arcs
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.068; // move middle wooden relief outward a bit more with the shifted side-pocket geometry
 
 function buildChromePlateGeometry({
@@ -2376,19 +2376,19 @@ const HUMAN_POSE_LAMBDA = 9.0;
 const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
 const HUMAN_EDGE_MARGIN = 1.58; // push the shooter farther outward so the avatar stays behind the cue butt on portrait screens
-const HUMAN_DESIRED_SHOOT_DISTANCE = 1.58; // move the shooter clearly to the cue-butt side so camera no longer sits behind the head
+const HUMAN_DESIRED_SHOOT_DISTANCE = 1.74; // keep the shooter farther back on the cue-butt side like the reference shooting stance
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 4.55; // widen the perimeter walk ring so feet never step onto the table mesh
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
-const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.065; // lock camera nearer to eye line while keeping the cue shaft visible in portrait
+const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.052; // lower the low cue camera slightly closer to the table surface for portrait aiming
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
-const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 1.15; // keep the eye camera on the rear/butt half of the cue instead of drifting toward the tip
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 1.72; // move the low cue camera closer toward the table while staying behind the bridge hand
 const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 0.22; // preserve subtle right-eye bias without exposing too much of the avatar body
 const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
 const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
-const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.235; // push bridge hand slightly farther back from the cue ball so the body stays on the butt side
+const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.285; // set the bridge farther behind the cue ball to match real pool hand placement
 const HUMAN_BRIDGE_HAND_SIDE = -0.008; // match Bilardo Shqip bridge hand lateral placement
-const HUMAN_BRIDGE_CUE_LIFT = 0.026; // match Bilardo Shqip cue elevation above bridge hand
+const HUMAN_BRIDGE_CUE_LIFT = 0.018; // flatten the cue closer to the cloth like the reference shooting photos
 const HUMAN_GRIP_RATIO = 0.9; // anchor right-hand grip much closer to the cue butt so the hand no longer drifts toward the tip
 const HUMAN_CUE_LENGTH = 1.46; // match Bilardo Shqip cue length used for hand/cue alignment
 const HUMAN_BRIDGE_DIST = 0.24; // match Bilardo Shqip bridge-to-tip section used by cue placement
@@ -6609,8 +6609,8 @@ const RAIL_OVERHEAD_DISTANCE_BIAS = 0.94; // pull broadcast rail camera inward f
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
-const CUE_VIEW_RADIUS_RATIO = 0.0178; // move cue camera closer for a tighter portrait aiming view
-const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.08;
+const CUE_VIEW_RADIUS_RATIO = 0.0148; // move cue camera closer for a tighter portrait aiming view
+const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.066;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.26
@@ -9839,6 +9839,7 @@ export function Table3D(
     net.castShadow = false;
     net.receiveShadow = true;
     net.renderOrder = pocket.renderOrder - 0.25;
+    net.userData.externalTableKeepVisible = true;
     table.add(net);
     finishParts.pocketNetMeshes.push(net);
 
@@ -9854,6 +9855,7 @@ export function Table3D(
     ring.rotation.x = Math.PI / 2;
     ring.castShadow = true;
     ring.receiveShadow = true;
+    ring.userData.externalTableKeepVisible = true;
     table.add(ring);
     finishParts.pocketBaseMeshes.push(ring);
     table.userData.pocketHolderAnchors[index] = {
@@ -9887,6 +9889,7 @@ export function Table3D(
       guide.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), delta.clone().normalize());
       guide.castShadow = true;
       guide.receiveShadow = true;
+      guide.userData.externalTableKeepVisible = true;
       table.add(guide);
       finishParts.pocketBaseMeshes.push(guide);
       return guide;
@@ -9950,6 +9953,7 @@ export function Table3D(
       strap.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), strapForward);
       strap.castShadow = true;
       strap.receiveShadow = true;
+      strap.userData.externalTableKeepVisible = true;
       table.add(strap);
       finishParts.pocketJawMeshes.push(strap);
     }
@@ -12546,8 +12550,27 @@ function preparePoolRoyaleExternalTexture(texture, isColor = false) {
   texture.needsUpdate = true;
 }
 
-function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo) {
+function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tableModel = null) {
   if (!material || !finishInfo) return material;
+  const finishRoles = Array.isArray(tableModel?.usePoolRoyaleFinishRoles)
+    ? tableModel.usePoolRoyaleFinishRoles
+    : null;
+  const preserveRoles = Array.isArray(tableModel?.preserveOriginalSurfaceRoles)
+    ? tableModel.preserveOriginalSurfaceRoles
+    : [];
+  const shouldUsePoolRoyaleFinish = !finishRoles || finishRoles.includes(role);
+  if (!shouldUsePoolRoyaleFinish || preserveRoles.includes(role)) {
+    const originalMat = material.clone ? material.clone() : material;
+    preparePoolRoyaleExternalTexture(originalMat.map, true);
+    preparePoolRoyaleExternalTexture(originalMat.emissiveMap, true);
+    preparePoolRoyaleExternalTexture(originalMat.aoMap, false);
+    preparePoolRoyaleExternalTexture(originalMat.normalMap, false);
+    preparePoolRoyaleExternalTexture(originalMat.roughnessMap, false);
+    preparePoolRoyaleExternalTexture(originalMat.metalnessMap, false);
+    preparePoolRoyaleExternalTexture(originalMat.bumpMap, false);
+    originalMat.needsUpdate = true;
+    return originalMat;
+  }
   const mat = material.clone ? material.clone() : material;
   const materials = finishInfo.materials || {};
   const finish = TABLE_FINISHES[finishInfo.id] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
@@ -12626,7 +12649,7 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
       if (tableModel?.usePoolRoyaleFinish && finishInfo) {
-        return applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo);
+        return applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tableModel);
       }
       const mat = material.clone ? material.clone() : material;
       preparePoolRoyaleExternalTexture(mat.map, true);
@@ -12767,7 +12790,8 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
     const fullSize = fullBox.getSize(new THREE.Vector3());
     const exactYScale =
       tableModel?.matchNativeHeight && targetHeight
-        ? Math.max(MICRO_EPS, targetHeight / Math.max(MICRO_EPS, fullSize.y))
+        ? Math.max(MICRO_EPS, targetHeight / Math.max(MICRO_EPS, fullSize.y)) *
+          (tableModel?.fitHeightScale ?? 1)
         : Math.sqrt(exactXScale * exactZScale);
     model.scale.set(
       model.scale.x * exactXScale * fitScaleMultiplier,
@@ -13505,6 +13529,10 @@ function mountPoolRoyaleExternalTableModel({
     : generatedVisualBounds.getSize(new THREE.Vector3());
   const setGeneratedVisualsVisible = (visible) => {
     generatedVisualObjects.forEach((object) => {
+      if (!visible && object.userData?.externalTableKeepVisible) {
+        object.visible = true;
+        return;
+      }
       object.visible = visible;
     });
   };
@@ -25504,8 +25532,8 @@ const shotPowerRef = useRef(0);
             rotLambda: HUMAN_ROT_LAMBDA,
             strikeTime: 0.11,
             holdTime: 0.05,
-            stanceWidth: 0.52,
-            bridgePalmTableLift: 0.006,
+            stanceWidth: 0.58,
+            bridgePalmTableLift: 0.004,
             chinToCueHeight: 0.11,
             cueArmElbowRise: 0.18,
             tableTopY: TABLE_Y + TABLE.THICK,
@@ -25515,20 +25543,24 @@ const shotPowerRef = useRef(0);
             bridgeCueLift: HUMAN_BRIDGE_CUE_LIFT,
             cueLength: HUMAN_CUE_LENGTH,
             bridgeDist: HUMAN_BRIDGE_DIST,
-            shootCueGripFromBack: 0.58,
-            rightHandShotExtraBack: 0.18,
-            rightHandShotLift: -0.30,
+            shootCueGripFromBack: 0.42,
+            rightHandShotExtraBack: 0.26,
+            rightHandShotLift: -0.36,
             rightHandForwardClamp: -0.08,
-            rightHandOutward: 0.14,
+            rightHandOutward: 0.1,
+            rightForearmOutward: 0.26,
+            rightForearmBack: 0.62,
+            rightForearmDown: 0.54,
+            rightForearmLength: 0.28,
             idleRightHandX: 0.31,
             idleRightHandY: 0.8,
             idleRightHandZ: -0.015,
             rightHandRollIdle: -2.2,
             rightHandRollShoot: -2.05,
             rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092),
-            rightElbowShotRise: 0.18,
-            rightElbowShotSide: -0.46,
-            rightElbowShotBack: -0.78,
+            rightElbowShotRise: 0.34,
+            rightElbowShotSide: -0.38,
+            rightElbowShotBack: -0.96,
             textureAnisotropy: renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
           });
           human.root.position.set(x, floorY, z);
@@ -25728,7 +25760,7 @@ const shotPowerRef = useRef(0);
             const cueShootDir = cueTipShoot.clone().sub(cueBackShoot).normalize();
             const shootGripTarget = cueBackShoot
               .clone()
-              .addScaledVector(cueShootDir, 0.58);
+              .addScaledVector(cueShootDir, 0.42);
             if (isHumanShooter && state === 'dragging') {
               activeHumanCueViewRef.current = {
                 cueBack: cueBackShoot.clone(),

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -10,8 +10,8 @@ const BASE_CFG = {
   rotLambda: 8.5,
   humanScale: 1.18,
   humanVisualYawFix: Math.PI,
-  stanceWidth: 0.52,
-  bridgePalmTableLift: 0.006,
+  stanceWidth: 0.58,
+  bridgePalmTableLift: 0.004,
   bridgeCueLift: 0.018,
   bridgeHandBackFromBall: 0.235,
   bridgeHandSide: -0.012,
@@ -19,16 +19,16 @@ const BASE_CFG = {
   footGroundY: 0.035,
   footLockStrength: 1.0,
   kneeBendShot: 0.16,
-  rightElbowShotRise: 0.18,
-  rightElbowShotSide: -0.46,
-  rightElbowShotBack: -0.78,
-  rightForearmOutward: 0.36,
-  rightForearmBack: 0.44,
-  rightForearmDown: 0.48,
-  rightForearmLength: 0.34,
+  rightElbowShotRise: 0.34,
+  rightElbowShotSide: -0.38,
+  rightElbowShotBack: -0.96,
+  rightForearmOutward: 0.26,
+  rightForearmBack: 0.62,
+  rightForearmDown: 0.54,
+  rightForearmLength: 0.28,
   rightStrokePull: 0.30,
   rightStrokePush: 0.24,
-  rightHandShotLift: -0.30,
+  rightHandShotLift: -0.36,
   shootCueGripFromBack: 0.58,
   idleRightHandY: 0.8,
   idleRightHandX: 0.31,
@@ -95,10 +95,10 @@ function driveHuman(human, frame) { if (!human.activeGlb || !human.model) return
 export function updateHumanPose(human, dt, frameData){ if(!human||!frameData) return; const cfg=human.cfg; const state=frameData.state||'idle'; human.poseT=dampScalar(human.poseT,state==='idle'?0:1,cfg.poseLambda,dt); human.breathT+=dt*(state==='idle'?1.05:0.5); if(state==='striking'){ if(human.strikeClock===0){ human.strikeRoot.copy(human.root.position.lengthSq()>0.001?human.root.position:frameData.rootTarget); human.strikeYaw=human.yaw;} human.strikeClock+=dt;} else human.strikeClock=0;
  const rootGoal=state==='striking'?human.strikeRoot:frameData.rootTarget; dampVector(human.root.position,rootGoal,state==='striking'?12:cfg.moveLambda,dt); const moveAmountRaw=human.root.position.distanceTo(rootGoal); human.walkT+=dt*(2+Math.min(7,moveAmountRaw*10)); human.yaw=dampScalar(human.yaw,state==='striking'?human.strikeYaw:yawFromForward(frameData.aimForward),cfg.rotLambda,dt);
  const t=easeInOut(human.poseT), idle=1-t; const walk=Math.sin(human.walkT*6.2)*Math.min(1,moveAmountRaw*12); const forward = new THREE.Vector3(0,0,-1).applyAxisAngle(Y_AXIS,human.yaw).normalize(); const side = new THREE.Vector3(forward.z,0,-forward.x).normalize(); const local = (v)=>v.clone().applyAxisAngle(Y_AXIS,human.yaw).add(human.root.position);
- const torso = local(new THREE.Vector3(0, lerp(1.3,1.14,t), lerp(0.02,-0.16,t))); const chest=local(new THREE.Vector3(0,lerp(1.52,1.24,t),lerp(0.02,-0.42,t))); const neck=local(new THREE.Vector3(0,lerp(1.68,1.28,t),lerp(0.02,-0.61,t))); const head=local(new THREE.Vector3(0,lerp(1.84,1.37,t),lerp(0.04,-0.72,t))); const leftShoulder=local(new THREE.Vector3(-0.23,lerp(1.58,1.36,t),lerp(0,-0.46,t))); const rightShoulder=local(new THREE.Vector3(0.23,lerp(1.58,1.36,t),lerp(0,-0.34,t)));
+ const torso = local(new THREE.Vector3(0, lerp(1.3,1.08,t), lerp(0.02,-0.22,t))); const chest=local(new THREE.Vector3(0,lerp(1.52,1.16,t),lerp(0.02,-0.52,t))); const neck=local(new THREE.Vector3(0,lerp(1.68,1.18,t),lerp(0.02,-0.74,t))); const head=local(new THREE.Vector3(0,lerp(1.84,1.25,t),lerp(0.04,-0.88,t))); const leftShoulder=local(new THREE.Vector3(-0.23,lerp(1.58,1.24,t),lerp(0,-0.6,t))); const rightShoulder=local(new THREE.Vector3(0.23,lerp(1.58,1.26,t),lerp(0,-0.45,t)));
  const leftHip=local(new THREE.Vector3(-0.13,0.92,0.02)); const rightHip=local(new THREE.Vector3(0.13,0.92,0.02)); const leftFoot=local(new THREE.Vector3(-0.13,cfg.footGroundY,0.03+walk*0.018).lerp(new THREE.Vector3(-cfg.stanceWidth*0.42,cfg.footGroundY,-0.34),t)); const rightFoot=local(new THREE.Vector3(0.13,cfg.footGroundY,-0.03-walk*0.018).lerp(new THREE.Vector3(cfg.stanceWidth*0.5,cfg.footGroundY,0.34),t));
  const bridgePalm = frameData.bridgeTarget.clone().addScaledVector(forward,-0.006*t).addScaledVector(side,-0.012*t).setY(cfg.tableTopY+cfg.bridgePalmTableLift); const leftHand = frameData.idleLeft.clone().lerp(bridgePalm,t); const cueDir = frameData.cueTip.clone().sub(frameData.cueBack).normalize(); const handIk=easeInOut(clamp01(t)); const idleGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,-0.55).addScaledVector(forward,0.16).normalize(); const idleGripUp=UP.clone().multiplyScalar(-1).addScaledVector(side,-0.64).addScaledVector(forward,0.2).normalize(); const liveGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,lerp(-0.55,-0.62,handIk)).addScaledVector(side,0.5*handIk).addScaledVector(forward,lerp(0.16,-0.08,handIk)).normalize(); const liveGripUp=UP.clone().multiplyScalar(lerp(-1.0,0.12,handIk)).addScaledVector(side,lerp(-0.64,-0.04,handIk)).addScaledVector(forward,lerp(0.2,-0.48,handIk)).normalize();
- const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04,cfg.rightElbowShotRise,t)).addScaledVector(side,lerp(-0.18,cfg.rightElbowShotSide,t)).addScaledVector(forward,lerp(-0.04,cfg.rightElbowShotBack,t)); const pullBack = state==='dragging' ? -cfg.rightStrokePull*easeOutCubic(frameData.power||0) : 0; const push = state==='striking' ? cfg.rightStrokePush*Math.sin(clamp01(human.strikeClock/(cfg.strikeTime+cfg.holdTime))*Math.PI):0; const forearmBase = lockedRightElbow.clone().addScaledVector(side,cfg.rightForearmOutward*t).addScaledVector(UP,-cfg.rightForearmDown*t).addScaledVector(UP,cfg.rightHandShotLift*t).addScaledVector(forward,-cfg.rightForearmBack*t).addScaledVector(cueDir,cfg.rightForearmLength); const liveGripPoint = forearmBase.clone().addScaledVector(cueDir,pullBack+push); const idleWrist=frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide,idleGripUp,cueDir,cfg.rightHandRollIdle,cfg.rightHandCueSocketLocal)); const liveWrist=liveGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide,liveGripUp,cueDir,lerp(cfg.rightHandRollIdle,cfg.rightHandRollShoot-cfg.rightHandDownPose,handIk),cfg.rightHandCueSocketLocal));
+ const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04,cfg.rightElbowShotRise,t)).addScaledVector(side,lerp(-0.18,cfg.rightElbowShotSide,t)).addScaledVector(forward,lerp(-0.04,cfg.rightElbowShotBack,t)); const pullBack = state==='dragging' ? -cfg.rightStrokePull*easeOutCubic(frameData.power||0) : 0; const push = state==='striking' ? cfg.rightStrokePush*Math.sin(clamp01(human.strikeClock/(cfg.strikeTime+cfg.holdTime))*Math.PI):0; const forearmBase = lockedRightElbow.clone().addScaledVector(side,cfg.rightForearmOutward*t).addScaledVector(UP,-cfg.rightForearmDown*t).addScaledVector(UP,cfg.rightHandShotLift*t).addScaledVector(forward,-cfg.rightForearmBack*t).addScaledVector(cueDir,cfg.rightForearmLength); const liveGripPoint = forearmBase.clone().addScaledVector(cueDir,pullBack+push); if (frameData.gripTarget) liveGripPoint.lerp(frameData.gripTarget, 0.72*t); const idleWrist=frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide,idleGripUp,cueDir,cfg.rightHandRollIdle,cfg.rightHandCueSocketLocal)); const liveWrist=liveGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide,liveGripUp,cueDir,lerp(cfg.rightHandRollIdle,cfg.rightHandRollShoot-cfg.rightHandDownPose,handIk),cfg.rightHandCueSocketLocal));
  const rightHand = idleWrist.clone().lerp(liveWrist,t); const leftElbow = leftShoulder.clone().lerp(leftHand,0.62); const leftKnee = leftHip.clone().lerp(leftFoot,0.53).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot,t)); const rightKnee = rightHip.clone().lerp(rightFoot,0.52).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot*0.88,t));
  human.root.visible=true; driveHuman(human,{t,stroke:pullBack+push,forward,side,up:UP,rootWorld:human.root.position.clone(),torsoCenterWorld:torso,chestCenterWorld:chest,neckWorld:neck,headCenterWorld:head,leftElbow,rightElbow:lockedRightElbow,leftHandWorld:leftHand,rightHandWorld:rightHand,leftKnee,rightKnee,leftFootWorld:leftFoot,rightFootWorld:rightFoot,cueBackWorld:frameData.cueBack,cueTipWorld:frameData.cueTip});
 }


### PR DESCRIPTION
### Motivation
- Bring the Showood external table visuals and shooter pose into parity with the built-in Pool Royale look by shortening the Showood model to match tabletop height, preserve its original base/wood/gold assets, and align cloth/pocket visuals and the player stance for portrait mobile framing.

### Description
- Apply a vertical fit tweak and per-role finish control for the Showood GLB by adding `fitHeightScale`, `usePoolRoyaleFinishRoles`, and `preserveOriginalSurfaceRoles` so only cloth/cushion use Pool Royale finishes while `wood`, `trim`, and `pocket` keep the original model assets (`webapp/src/config/poolRoyaleTableModels.js`).
- Keep Pool Royale pocket nets, chrome holder rings/rails and leather straps visible when an external GLB is mounted by tagging pocket helper meshes with `userData.externalTableKeepVisible` and making `setGeneratedVisualsVisible` respect that flag (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Adjust wooden rail outline, cloth/camera framing, and cue view limits to tighten cue-camera framing and better match the Showood pocket/jaw silhouette (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Tune the human rig and shooter pose (stance width, bridge distance/lift, cue grip offsets, right-elbow/forearm/grip parameters, and cue camera offsets) so the avatar sits farther back on the cue butt with a lower, flatter cue and modified grip to reproduce the reference shooting posture (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/pages/Games/shared/humanRigCore.js`).

### Testing
- Built the webapp production bundle with `npm --prefix webapp run build`, which completed successfully (build warnings about large chunks only).
- Ran unit tests with `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js test/poolRoyalePocketAim.test.js test/poolRoyaleRules.test.ts`, and all three test suites passed (`3 passed, 3 total`).
- Attempted an automated Playwright screenshot of the updated scene after installing Chromium and system deps, but headless WebGL page/canvas capture timed out in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf32acd6c8329807cd0aa4b569aca)