### PR TITLE
Enhance Free Kick Arena controls and animations

### DIFF
--- a/webapp/src/pages/Games/FreeKickArena.tsx
+++ b/webapp/src/pages/Games/FreeKickArena.tsx
@@ -1,16 +1,16 @@
-"use client";
+'use client';
 
-import React, { useEffect, useRef, useState } from "react";
-import * as THREE from "three";
-import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
-import { clone as cloneSkeleton } from "three/examples/jsm/utils/SkeletonUtils.js";
-import { MURLAN_CHARACTER_THEMES } from "../../config/murlanCharacterThemes.js";
+import React, { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js';
+import { MURLAN_CHARACTER_THEMES } from '../../config/murlanCharacterThemes.js';
 
-type AnimName = "Idle" | "Walk" | "Run";
-type ShotState = "aim" | "runup" | "flight" | "var" | "replay" | "result";
-type KickSpot = "left" | "center" | "right" | "near16";
-type ActorKind = "kicker" | "keeper" | "wall";
-type Decision = "GOAL" | "NO GOAL" | "SAVE" | "BLOCKED" | "MISS";
+type AnimName = 'Idle' | 'Walk' | 'Run';
+type ShotState = 'aim' | 'runup' | 'flight' | 'var' | 'replay' | 'result';
+type KickSpot = 'left' | 'center' | 'right' | 'near16';
+type ActorKind = 'kicker' | 'keeper' | 'wall';
+type Decision = 'GOAL' | 'NO GOAL' | 'SAVE' | 'BLOCKED' | 'MISS';
 
 type Bones = {
   hips?: THREE.Bone;
@@ -77,7 +77,7 @@ type SwipeState = {
   startY: number;
   endX: number;
   endY: number;
-  mode?: "shot" | "camera";
+  mode?: 'shot' | 'camera';
 };
 
 type NetRig = {
@@ -90,8 +90,42 @@ type SeatedSpectator = {
   root: THREE.Group;
   fallback: THREE.Group;
   instance: THREE.Object3D | null;
-  bones: Partial<Record<"hips" | "spine" | "head" | "leftUpperArm" | "leftForeArm" | "leftHand" | "rightUpperArm" | "rightForeArm" | "rightHand" | "leftThigh" | "leftCalf" | "rightThigh" | "rightCalf", THREE.Bone>>;
-  base: Partial<Record<"hips" | "spine" | "head" | "leftUpperArm" | "leftForeArm" | "leftHand" | "rightUpperArm" | "rightForeArm" | "rightHand" | "leftThigh" | "leftCalf" | "rightThigh" | "rightCalf", THREE.Euler>>;
+  bones: Partial<
+    Record<
+      | 'hips'
+      | 'spine'
+      | 'head'
+      | 'leftUpperArm'
+      | 'leftForeArm'
+      | 'leftHand'
+      | 'rightUpperArm'
+      | 'rightForeArm'
+      | 'rightHand'
+      | 'leftThigh'
+      | 'leftCalf'
+      | 'rightThigh'
+      | 'rightCalf',
+      THREE.Bone
+    >
+  >;
+  base: Partial<
+    Record<
+      | 'hips'
+      | 'spine'
+      | 'head'
+      | 'leftUpperArm'
+      | 'leftForeArm'
+      | 'leftHand'
+      | 'rightUpperArm'
+      | 'rightForeArm'
+      | 'rightHand'
+      | 'leftThigh'
+      | 'leftCalf'
+      | 'rightThigh'
+      | 'rightCalf',
+      THREE.Euler
+    >
+  >;
   wallIndex: number;
 };
 
@@ -111,24 +145,29 @@ type ReplayFrame = {
   kickerRot: THREE.Euler;
 };
 
-const HUMAN_URL = "https://threejs.org/examples/models/gltf/Soldier.glb";
-const MURLAN_CHARACTER_URLS = MURLAN_CHARACTER_THEMES.map((theme) => theme.modelUrls?.[0] ?? theme.url).filter(Boolean);
-const MURLAN_CHARACTER_COLORS = [0x1d69ff, 0xdc2626, 0x16a34a, 0xfacc15, 0x7c3aed, 0xf97316, 0x0891b2];
+const HUMAN_URL = 'https://threejs.org/examples/models/gltf/Soldier.glb';
+const MURLAN_CHARACTER_URLS = MURLAN_CHARACTER_THEMES.map(
+  (theme) => theme.modelUrls?.[0] ?? theme.url
+).filter(Boolean);
+const MURLAN_CHARACTER_COLORS = [
+  0x1d69ff, 0xdc2626, 0x16a34a, 0xfacc15, 0x7c3aed, 0xf97316, 0x0891b2
+];
 const CAMERA_YAW_STEP = 0.22;
 const CAMERA_YAW_LIMIT = 0.7;
+const CAMERA_HEIGHT_LIMIT = 0.72;
 const SPECTATOR_ROWS_FILLED = 5;
 const SPECTATORS_PER_ROW_TARGET = 18;
-const SPECTATOR_SCALE = 0.38;
-const SPECTATOR_FALLBACK_SCALE = 0.42;
+const SPECTATOR_SCALE = 0.5;
+const SPECTATOR_FALLBACK_SCALE = 0.56;
 const SPECTATOR_SEAT_Y = 0.17;
 const SPECTATOR_SEAT_Z = 0.14;
 const GOAL_RUSH_SOUNDS = {
-  crowd: "/assets/sounds/football-crowd-3-69245.mp3",
-  whistle: "/assets/sounds/metal-whistle-6121.mp3",
-  kick: "/assets/sounds/football-game-sound-effects-359284.mp3",
-  net: "/assets/sounds/a-football-hits-the-net-goal-313216.mp3",
-  post: "/assets/sounds/frying-pan-over-the-head-89303.mp3",
-  victory: "/assets/sounds/11l-victory_sound_with_t-1749487412779-357604.mp3",
+  crowd: '/assets/sounds/football-crowd-3-69245.mp3',
+  whistle: '/assets/sounds/metal-whistle-6121.mp3',
+  kick: '/assets/sounds/football-game-sound-effects-359284.mp3',
+  net: '/assets/sounds/a-football-hits-the-net-goal-313216.mp3',
+  post: '/assets/sounds/frying-pan-over-the-head-89303.mp3',
+  victory: '/assets/sounds/11l-victory_sound_with_t-1749487412779-357604.mp3'
 };
 
 const FIELD_W = 22.0;
@@ -149,15 +188,21 @@ const PLAYER_H = 1.82;
 const GROUND_Y = 0;
 const DT_MAX = 1 / 30;
 const GOAL_LINE_Z = -HALF_H / 2;
-const RUNUP_BACK_STEPS = 2.2;
+const RUNUP_BACK_STEPS = 2.35;
 const TMP = new THREE.Vector3();
 const QTMP = new THREE.Quaternion();
-const SEATED_CHARACTER_TEMPLATE_CACHE = new Map<string, Promise<THREE.Object3D>>();
-
+const SEATED_CHARACTER_TEMPLATE_CACHE = new Map<
+  string,
+  Promise<THREE.Object3D>
+>();
 
 function shuffledCharacterColors() {
   const count = Math.max(7, MURLAN_CHARACTER_THEMES.length || 0);
-  const colors = Array.from({ length: count }, (_, index) => MURLAN_CHARACTER_COLORS[index % MURLAN_CHARACTER_COLORS.length]);
+  const colors = Array.from(
+    { length: count },
+    (_, index) =>
+      MURLAN_CHARACTER_COLORS[index % MURLAN_CHARACTER_COLORS.length]
+  );
   for (let i = colors.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [colors[i], colors[j]] = [colors[j], colors[i]];
@@ -166,7 +211,11 @@ function shuffledCharacterColors() {
 }
 
 function shuffledCharacterUrls() {
-  const urls = [...new Set(MURLAN_CHARACTER_URLS.length ? MURLAN_CHARACTER_URLS : [HUMAN_URL])];
+  const urls = [
+    ...new Set(
+      MURLAN_CHARACTER_URLS.length ? MURLAN_CHARACTER_URLS : [HUMAN_URL]
+    )
+  ];
   for (let i = urls.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [urls[i], urls[j]] = [urls[j], urls[i]];
@@ -209,15 +258,23 @@ function makeGoalRushAudio() {
       }
       playOneShot(GOAL_RUSH_SOUNDS.whistle, 0.9);
     },
-    kick() { playOneShot(GOAL_RUSH_SOUNDS.kick, 0.92); },
-    net() { playOneShot(GOAL_RUSH_SOUNDS.net, 0.95); },
-    save() { playOneShot(GOAL_RUSH_SOUNDS.post, 0.7); },
-    goal() { playOneShot(GOAL_RUSH_SOUNDS.victory, 0.72); },
+    kick() {
+      playOneShot(GOAL_RUSH_SOUNDS.kick, 0.92);
+    },
+    net() {
+      playOneShot(GOAL_RUSH_SOUNDS.net, 0.95);
+    },
+    save() {
+      playOneShot(GOAL_RUSH_SOUNDS.post, 0.7);
+    },
+    goal() {
+      playOneShot(GOAL_RUSH_SOUNDS.victory, 0.72);
+    },
     dispose() {
       enabled = false;
       crowd.pause();
-      crowd.src = "";
-    },
+      crowd.src = '';
+    }
   };
 }
 
@@ -238,7 +295,7 @@ function shadow<T extends THREE.Object3D>(object: T) {
 }
 
 function cleanName(name: string) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
 function findBones(model: THREE.Object3D): Bones {
@@ -247,16 +304,36 @@ function findBones(model: THREE.Object3D): Bones {
     const bone = obj as THREE.Bone;
     if (!bone.isBone) return;
     const n = cleanName(bone.name);
-    if (!bones.hips && n.includes("hips")) bones.hips = bone;
-    if (!bones.spine && n.includes("spine")) bones.spine = bone;
-    if (!bones.leftUpLeg && (n.includes("leftupleg") || n.includes("leftthigh"))) bones.leftUpLeg = bone;
-    if (!bones.leftLeg && !n.includes("foot") && !n.includes("upleg") && n.includes("leftleg")) bones.leftLeg = bone;
-    if (!bones.leftFoot && n.includes("leftfoot")) bones.leftFoot = bone;
-    if (!bones.rightUpLeg && (n.includes("rightupleg") || n.includes("rightthigh"))) bones.rightUpLeg = bone;
-    if (!bones.rightLeg && !n.includes("foot") && !n.includes("upleg") && n.includes("rightleg")) bones.rightLeg = bone;
-    if (!bones.rightFoot && n.includes("rightfoot")) bones.rightFoot = bone;
-    if (!bones.leftArm && n.includes("leftarm")) bones.leftArm = bone;
-    if (!bones.rightArm && n.includes("rightarm")) bones.rightArm = bone;
+    if (!bones.hips && n.includes('hips')) bones.hips = bone;
+    if (!bones.spine && n.includes('spine')) bones.spine = bone;
+    if (
+      !bones.leftUpLeg &&
+      (n.includes('leftupleg') || n.includes('leftthigh'))
+    )
+      bones.leftUpLeg = bone;
+    if (
+      !bones.leftLeg &&
+      !n.includes('foot') &&
+      !n.includes('upleg') &&
+      n.includes('leftleg')
+    )
+      bones.leftLeg = bone;
+    if (!bones.leftFoot && n.includes('leftfoot')) bones.leftFoot = bone;
+    if (
+      !bones.rightUpLeg &&
+      (n.includes('rightupleg') || n.includes('rightthigh'))
+    )
+      bones.rightUpLeg = bone;
+    if (
+      !bones.rightLeg &&
+      !n.includes('foot') &&
+      !n.includes('upleg') &&
+      n.includes('rightleg')
+    )
+      bones.rightLeg = bone;
+    if (!bones.rightFoot && n.includes('rightfoot')) bones.rightFoot = bone;
+    if (!bones.leftArm && n.includes('leftarm')) bones.leftArm = bone;
+    if (!bones.rightArm && n.includes('rightarm')) bones.rightArm = bone;
   });
   return bones;
 }
@@ -272,7 +349,7 @@ function findBoneByHints(root: THREE.Object3D, hints: string[] = []) {
   root.traverse((obj) => {
     const bone = obj as THREE.Bone;
     if (matched || !bone.isBone) return;
-    const name = String(bone.name || "").toLowerCase();
+    const name = String(bone.name || '').toLowerCase();
     if (name && hints.some((hint) => name.includes(hint))) matched = bone;
   });
   return matched;
@@ -282,7 +359,12 @@ function captureBoneRotation(bone: THREE.Bone | null | undefined) {
   return bone ? bone.rotation.clone() : new THREE.Euler();
 }
 
-function applyRotationOffset(bone: THREE.Bone | null | undefined, x = 0, y = 0, z = 0) {
+function applyRotationOffset(
+  bone: THREE.Bone | null | undefined,
+  x = 0,
+  y = 0,
+  z = 0
+) {
   if (!bone) return;
   bone.rotation.x += x;
   bone.rotation.y += y;
@@ -291,19 +373,103 @@ function applyRotationOffset(bone: THREE.Bone | null | undefined, x = 0, y = 0, 
 
 function applyMurlanSeatedPose(instance: THREE.Object3D) {
   const bones = {
-    hips: findBoneByHints(instance, ["hips", "pelvis", "pelvisjoint", "hip_joint"]),
-    spine: findBoneByHints(instance, ["spine", "chest", "torso"]),
-    head: findBoneByHints(instance, ["head", "neck", "headjoint", "head_joint"]),
-    rightUpperArm: findBoneByHints(instance, ["rightarm", "arm.r", "r_upperarm", "rightshoulder", "armjointr", "arm_joint_r_1", "arm_joint_r", "shoulderr"]),
-    rightForeArm: findBoneByHints(instance, ["rightforearm", "r_forearm", "rightlowerarm", "forearmr", "elbowr", "arm_joint_r_2", "arm_joint_r_3"]),
-    rightHand: findBoneByHints(instance, ["righthand", "hand.r", "r_hand", "handjointr", "hand_joint_r"]),
-    leftUpperArm: findBoneByHints(instance, ["leftarm", "arm.l", "l_upperarm", "leftshoulder", "armjointl", "arm_joint_l_1", "arm_joint_l", "shoulderl"]),
-    leftForeArm: findBoneByHints(instance, ["leftforearm", "l_forearm", "leftlowerarm", "forearml", "elbowl", "arm_joint_l_2", "arm_joint_l_3"]),
-    leftHand: findBoneByHints(instance, ["lefthand", "hand.l", "l_hand", "handjointl", "hand_joint_l"]),
-    leftThigh: findBoneByHints(instance, ["leftupleg", "leftthigh", "l_thigh", "legjointl1", "leg_joint_l_1", "leg_joint_l"]),
-    leftCalf: findBoneByHints(instance, ["leftleg", "leftcalf", "l_calf", "legjointl2", "leg_joint_l_2", "leg_joint_l_3"]),
-    rightThigh: findBoneByHints(instance, ["rightupleg", "rightthigh", "r_thigh", "legjointr1", "leg_joint_r_1", "leg_joint_r"]),
-    rightCalf: findBoneByHints(instance, ["rightleg", "rightcalf", "r_calf", "legjointr2", "leg_joint_r_2", "leg_joint_r_3"]),
+    hips: findBoneByHints(instance, [
+      'hips',
+      'pelvis',
+      'pelvisjoint',
+      'hip_joint'
+    ]),
+    spine: findBoneByHints(instance, ['spine', 'chest', 'torso']),
+    head: findBoneByHints(instance, [
+      'head',
+      'neck',
+      'headjoint',
+      'head_joint'
+    ]),
+    rightUpperArm: findBoneByHints(instance, [
+      'rightarm',
+      'arm.r',
+      'r_upperarm',
+      'rightshoulder',
+      'armjointr',
+      'arm_joint_r_1',
+      'arm_joint_r',
+      'shoulderr'
+    ]),
+    rightForeArm: findBoneByHints(instance, [
+      'rightforearm',
+      'r_forearm',
+      'rightlowerarm',
+      'forearmr',
+      'elbowr',
+      'arm_joint_r_2',
+      'arm_joint_r_3'
+    ]),
+    rightHand: findBoneByHints(instance, [
+      'righthand',
+      'hand.r',
+      'r_hand',
+      'handjointr',
+      'hand_joint_r'
+    ]),
+    leftUpperArm: findBoneByHints(instance, [
+      'leftarm',
+      'arm.l',
+      'l_upperarm',
+      'leftshoulder',
+      'armjointl',
+      'arm_joint_l_1',
+      'arm_joint_l',
+      'shoulderl'
+    ]),
+    leftForeArm: findBoneByHints(instance, [
+      'leftforearm',
+      'l_forearm',
+      'leftlowerarm',
+      'forearml',
+      'elbowl',
+      'arm_joint_l_2',
+      'arm_joint_l_3'
+    ]),
+    leftHand: findBoneByHints(instance, [
+      'lefthand',
+      'hand.l',
+      'l_hand',
+      'handjointl',
+      'hand_joint_l'
+    ]),
+    leftThigh: findBoneByHints(instance, [
+      'leftupleg',
+      'leftthigh',
+      'l_thigh',
+      'legjointl1',
+      'leg_joint_l_1',
+      'leg_joint_l'
+    ]),
+    leftCalf: findBoneByHints(instance, [
+      'leftleg',
+      'leftcalf',
+      'l_calf',
+      'legjointl2',
+      'leg_joint_l_2',
+      'leg_joint_l_3'
+    ]),
+    rightThigh: findBoneByHints(instance, [
+      'rightupleg',
+      'rightthigh',
+      'r_thigh',
+      'legjointr1',
+      'leg_joint_r_1',
+      'leg_joint_r'
+    ]),
+    rightCalf: findBoneByHints(instance, [
+      'rightleg',
+      'rightcalf',
+      'r_calf',
+      'legjointr2',
+      'leg_joint_r_2',
+      'leg_joint_r_3'
+    ])
   };
 
   // Exact Murlan Royale seated base pose values so the Free Kick Arena crowd sits
@@ -311,20 +477,75 @@ function applyMurlanSeatedPose(instance: THREE.Object3D) {
   applyRotationOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   applyRotationOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   applyRotationOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  applyRotationOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-53), THREE.MathUtils.degToRad(-6), THREE.MathUtils.degToRad(-2));
-  applyRotationOffset(bones.leftForeArm, THREE.MathUtils.degToRad(40), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
-  applyRotationOffset(bones.leftHand, THREE.MathUtils.degToRad(11), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-2));
-  applyRotationOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-57), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2));
-  applyRotationOffset(bones.rightForeArm, THREE.MathUtils.degToRad(44), THREE.MathUtils.degToRad(3), THREE.MathUtils.degToRad(2));
-  applyRotationOffset(bones.rightHand, THREE.MathUtils.degToRad(13), THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(2));
-  applyRotationOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
-  applyRotationOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
-  applyRotationOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));
-  applyRotationOffset(bones.rightCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(-1.1), THREE.MathUtils.degToRad(-0.6));
+  applyRotationOffset(
+    bones.leftUpperArm,
+    THREE.MathUtils.degToRad(-53),
+    THREE.MathUtils.degToRad(-6),
+    THREE.MathUtils.degToRad(-2)
+  );
+  applyRotationOffset(
+    bones.leftForeArm,
+    THREE.MathUtils.degToRad(40),
+    THREE.MathUtils.degToRad(-3),
+    THREE.MathUtils.degToRad(-2)
+  );
+  applyRotationOffset(
+    bones.leftHand,
+    THREE.MathUtils.degToRad(11),
+    THREE.MathUtils.degToRad(-4),
+    THREE.MathUtils.degToRad(-2)
+  );
+  applyRotationOffset(
+    bones.rightUpperArm,
+    THREE.MathUtils.degToRad(-57),
+    THREE.MathUtils.degToRad(6),
+    THREE.MathUtils.degToRad(2)
+  );
+  applyRotationOffset(
+    bones.rightForeArm,
+    THREE.MathUtils.degToRad(44),
+    THREE.MathUtils.degToRad(3),
+    THREE.MathUtils.degToRad(2)
+  );
+  applyRotationOffset(
+    bones.rightHand,
+    THREE.MathUtils.degToRad(13),
+    THREE.MathUtils.degToRad(4),
+    THREE.MathUtils.degToRad(2)
+  );
+  applyRotationOffset(
+    bones.leftThigh,
+    THREE.MathUtils.degToRad(-90.5),
+    THREE.MathUtils.degToRad(9.2),
+    THREE.MathUtils.degToRad(2.9)
+  );
+  applyRotationOffset(
+    bones.rightThigh,
+    THREE.MathUtils.degToRad(-90.5),
+    THREE.MathUtils.degToRad(1.7),
+    THREE.MathUtils.degToRad(-1.1)
+  );
+  applyRotationOffset(
+    bones.leftCalf,
+    THREE.MathUtils.degToRad(-95.1),
+    THREE.MathUtils.degToRad(1.1),
+    THREE.MathUtils.degToRad(0.6)
+  );
+  applyRotationOffset(
+    bones.rightCalf,
+    THREE.MathUtils.degToRad(-95.1),
+    THREE.MathUtils.degToRad(-1.1),
+    THREE.MathUtils.degToRad(-0.6)
+  );
 
   return {
     bones,
-    base: Object.fromEntries(Object.entries(bones).map(([key, bone]) => [key, captureBoneRotation(bone)])),
+    base: Object.fromEntries(
+      Object.entries(bones).map(([key, bone]) => [
+        key,
+        captureBoneRotation(bone)
+      ])
+    )
   };
 }
 
@@ -346,8 +567,16 @@ function normalizeHuman(model: THREE.Object3D, height = PLAYER_H) {
   model.position.y -= box2.min.y;
 }
 
-function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0, kitColor?: number) {
-  const color = kind === "keeper" ? new THREE.Color(0x111111) : new THREE.Color(kitColor ?? (kind === "kicker" ? 0x1d69ff : 0xfacc15));
+function tintModel(
+  model: THREE.Object3D,
+  kind: ActorKind,
+  index = 0,
+  kitColor?: number
+) {
+  const color =
+    kind === 'keeper'
+      ? new THREE.Color(0x111111)
+      : new THREE.Color(kitColor ?? (kind === 'kicker' ? 0x1d69ff : 0xfacc15));
   model.traverse((obj) => {
     const mesh = obj as THREE.Mesh;
     if (!mesh.isMesh) return;
@@ -356,7 +585,8 @@ function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0, kitColor?:
       const m = raw as THREE.MeshStandardMaterial;
       if (m.color) {
         m.color.lerp(color, 0.36);
-        if (kind === "wall") m.color.lerp(new THREE.Color(index % 2 ? 0x174ea6 : 0xfacc15), 0.18);
+        if (kind === 'wall')
+          m.color.lerp(new THREE.Color(index % 2 ? 0x174ea6 : 0xfacc15), 0.18);
       }
       m.needsUpdate = true;
     });
@@ -365,33 +595,67 @@ function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0, kitColor?:
 
 function makeFallback(kind: ActorKind, index = 0, kitColor?: number) {
   const group = new THREE.Group();
-  const kit = kind === "keeper" ? 0x111111 : kitColor ?? (kind === "kicker" ? 0x1d69ff : 0xfacc15);
-  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.19, 0.72, 8, 14), material(kit));
-  torso.name = "torso";
+  const kit =
+    kind === 'keeper'
+      ? 0x111111
+      : (kitColor ?? (kind === 'kicker' ? 0x1d69ff : 0xfacc15));
+  const torso = new THREE.Mesh(
+    new THREE.CapsuleGeometry(0.19, 0.72, 8, 14),
+    material(kit)
+  );
+  torso.name = 'torso';
   torso.position.y = 1.05;
-  const stripe = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.06, 0.02), material(kind === "wall" ? 0x174ea6 : 0xffffff));
-  stripe.name = "stripe";
+  const stripe = new THREE.Mesh(
+    new THREE.BoxGeometry(0.28, 0.06, 0.02),
+    material(kind === 'wall' ? 0x174ea6 : 0xffffff)
+  );
+  stripe.name = 'stripe';
   stripe.position.set(0, 1.25, -0.16);
-  const head = new THREE.Mesh(new THREE.SphereGeometry(0.13, 18, 12), material(0xf1d6bd));
-  head.name = "head";
+  const head = new THREE.Mesh(
+    new THREE.SphereGeometry(0.13, 18, 12),
+    material(0xf1d6bd)
+  );
+  head.name = 'head';
   head.position.y = 1.62;
-  const leftLeg = new THREE.Mesh(new THREE.CapsuleGeometry(0.06, 0.64, 6, 10), material(0x202020));
-  leftLeg.name = "leftLeg";
+  const leftLeg = new THREE.Mesh(
+    new THREE.CapsuleGeometry(0.06, 0.64, 6, 10),
+    material(0x202020)
+  );
+  leftLeg.name = 'leftLeg';
   const rightLeg = leftLeg.clone();
-  rightLeg.name = "rightLeg";
+  rightLeg.name = 'rightLeg';
   leftLeg.position.set(-0.09, 0.42, 0);
   rightLeg.position.set(0.09, 0.42, 0);
-  const leftArm = new THREE.Mesh(new THREE.CapsuleGeometry(0.045, 0.52, 6, 10), material(0xdddddd));
-  leftArm.name = "leftArm";
+  const leftArm = new THREE.Mesh(
+    new THREE.CapsuleGeometry(0.045, 0.52, 6, 10),
+    material(0xdddddd)
+  );
+  leftArm.name = 'leftArm';
   const rightArm = leftArm.clone();
-  rightArm.name = "rightArm";
+  rightArm.name = 'rightArm';
   leftArm.position.set(-0.25, 1.05, 0.01);
   rightArm.position.set(0.25, 1.05, 0.01);
-  group.add(shadow(torso), shadow(stripe), shadow(head), shadow(leftLeg), shadow(rightLeg), shadow(leftArm), shadow(rightArm));
+  group.add(
+    shadow(torso),
+    shadow(stripe),
+    shadow(head),
+    shadow(leftLeg),
+    shadow(rightLeg),
+    shadow(leftArm),
+    shadow(rightArm)
+  );
   return group;
 }
 
-function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, pos: THREE.Vector3, index = 0, kitColor?: number, modelUrl = HUMAN_URL): Actor {
+function createActor(
+  scene: THREE.Scene,
+  loader: GLTFLoader,
+  kind: ActorKind,
+  pos: THREE.Vector3,
+  index = 0,
+  kitColor?: number,
+  modelUrl = HUMAN_URL
+): Actor {
   const root = new THREE.Group();
   root.position.copy(pos).setY(GROUND_Y);
   scene.add(root);
@@ -406,7 +670,7 @@ function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, po
     fallback,
     mixer: null,
     actions: {},
-    current: "Idle",
+    current: 'Idle',
     bones: {},
     pos: pos.clone().setY(GROUND_Y),
     vel: new THREE.Vector3(),
@@ -422,38 +686,14 @@ function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, po
     saveTargetY: 1.15,
     wallIndex: index,
     loaded: false,
-    celebrateTime: 0,
+    celebrateTime: 0
   };
 
-  loader.setCrossOrigin("anonymous").load(modelUrl, (gltf) => {
-    const model = gltf.scene;
-    normalizeHuman(model, kind === "keeper" ? 1.9 : PLAYER_H);
-    tintModel(model, kind, index, kitColor);
-    shadow(model);
-    root.add(model);
-    fallback.visible = false;
-    actor.model = model;
-    actor.bones = findBones(model);
-    actor.mixer = new THREE.AnimationMixer(model);
-
-    const clips = new Map(gltf.animations.map((clip) => [clip.name.toLowerCase(), clip]));
-    const aliases: Record<AnimName, string[]> = { Idle: ["idle"], Walk: ["walk"], Run: ["run"] };
-    (Object.keys(aliases) as AnimName[]).forEach((name) => {
-      const clip = aliases[name].map((key) => clips.get(key)).find(Boolean);
-      if (!clip || !actor.mixer) return;
-      const action = actor.mixer.clipAction(clip);
-      action.enabled = true;
-      action.setLoop(THREE.LoopRepeat, Infinity);
-      action.setEffectiveWeight(name === "Idle" ? 1 : 0);
-      action.play();
-      actor.actions[name] = action;
-    });
-    actor.loaded = true;
-  }, undefined, () => {
-    if (modelUrl === HUMAN_URL) return;
-    loader.setCrossOrigin("anonymous").load(HUMAN_URL, (gltf) => {
+  loader.setCrossOrigin('anonymous').load(
+    modelUrl,
+    (gltf) => {
       const model = gltf.scene;
-      normalizeHuman(model, kind === "keeper" ? 1.9 : PLAYER_H);
+      normalizeHuman(model, kind === 'keeper' ? 1.9 : PLAYER_H);
       tintModel(model, kind, index, kitColor);
       shadow(model);
       root.add(model);
@@ -461,21 +701,62 @@ function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, po
       actor.model = model;
       actor.bones = findBones(model);
       actor.mixer = new THREE.AnimationMixer(model);
-      const clips = new Map(gltf.animations.map((clip) => [clip.name.toLowerCase(), clip]));
-      const aliases: Record<AnimName, string[]> = { Idle: ["idle"], Walk: ["walk"], Run: ["run"] };
+
+      const clips = new Map(
+        gltf.animations.map((clip) => [clip.name.toLowerCase(), clip])
+      );
+      const aliases: Record<AnimName, string[]> = {
+        Idle: ['idle'],
+        Walk: ['walk'],
+        Run: ['run']
+      };
       (Object.keys(aliases) as AnimName[]).forEach((name) => {
         const clip = aliases[name].map((key) => clips.get(key)).find(Boolean);
         if (!clip || !actor.mixer) return;
         const action = actor.mixer.clipAction(clip);
         action.enabled = true;
         action.setLoop(THREE.LoopRepeat, Infinity);
-        action.setEffectiveWeight(name === "Idle" ? 1 : 0);
+        action.setEffectiveWeight(name === 'Idle' ? 1 : 0);
         action.play();
         actor.actions[name] = action;
       });
       actor.loaded = true;
-    });
-  });
+    },
+    undefined,
+    () => {
+      if (modelUrl === HUMAN_URL) return;
+      loader.setCrossOrigin('anonymous').load(HUMAN_URL, (gltf) => {
+        const model = gltf.scene;
+        normalizeHuman(model, kind === 'keeper' ? 1.9 : PLAYER_H);
+        tintModel(model, kind, index, kitColor);
+        shadow(model);
+        root.add(model);
+        fallback.visible = false;
+        actor.model = model;
+        actor.bones = findBones(model);
+        actor.mixer = new THREE.AnimationMixer(model);
+        const clips = new Map(
+          gltf.animations.map((clip) => [clip.name.toLowerCase(), clip])
+        );
+        const aliases: Record<AnimName, string[]> = {
+          Idle: ['idle'],
+          Walk: ['walk'],
+          Run: ['run']
+        };
+        (Object.keys(aliases) as AnimName[]).forEach((name) => {
+          const clip = aliases[name].map((key) => clips.get(key)).find(Boolean);
+          if (!clip || !actor.mixer) return;
+          const action = actor.mixer.clipAction(clip);
+          action.enabled = true;
+          action.setLoop(THREE.LoopRepeat, Infinity);
+          action.setEffectiveWeight(name === 'Idle' ? 1 : 0);
+          action.play();
+          actor.actions[name] = action;
+        });
+        actor.loaded = true;
+      });
+    }
+  );
 
   return actor;
 }
@@ -497,11 +778,23 @@ function updateActorBase(actor: Actor, dt: number) {
   actor.root.position.copy(actor.pos);
   actor.root.rotation.x = 0;
   actor.root.rotation.z = 0;
-  if (actor.dir.lengthSq() > 0.001) actor.root.rotation.y = Math.atan2(actor.dir.x, actor.dir.z);
-  const wanted: AnimName = actor.speed > 2.45 ? "Run" : actor.speed > 0.08 ? "Walk" : "Idle";
+  if (actor.dir.lengthSq() > 0.001)
+    actor.root.rotation.y = Math.atan2(actor.dir.x, actor.dir.z);
+  const wanted: AnimName =
+    actor.speed > 2.45 ? 'Run' : actor.speed > 0.08 ? 'Walk' : 'Idle';
   setAction(actor, wanted);
-  if (actor.actions.Walk) actor.actions.Walk.timeScale = THREE.MathUtils.clamp(actor.speed / 1.45, 0.95, 1.65);
-  if (actor.actions.Run) actor.actions.Run.timeScale = THREE.MathUtils.clamp(actor.speed / 2.9, 0.9, 1.45);
+  if (actor.actions.Walk)
+    actor.actions.Walk.timeScale = THREE.MathUtils.clamp(
+      actor.speed / 1.45,
+      0.95,
+      1.65
+    );
+  if (actor.actions.Run)
+    actor.actions.Run.timeScale = THREE.MathUtils.clamp(
+      actor.speed / 2.9,
+      0.9,
+      1.45
+    );
   actor.mixer?.update(dt);
 }
 
@@ -510,10 +803,15 @@ function applyKickerPose(kicker: Actor) {
 
   const t = 1 - kicker.kickTime / 0.72;
   const plant = THREE.MathUtils.smoothstep(t, 0.18, 0.38);
-  const backswing = Math.sin(THREE.MathUtils.clamp((t - 0.16) / 0.26, 0, 1) * Math.PI) * 0.72;
-  const strike = Math.sin(THREE.MathUtils.clamp((t - 0.38) / 0.26, 0, 1) * Math.PI) * 2.45;
-  const follow = Math.sin(THREE.MathUtils.clamp((t - 0.60) / 0.40, 0, 1) * Math.PI) * 0.9;
-  const chestBalance = Math.sin(THREE.MathUtils.clamp((t - 0.20) / 0.55, 0, 1) * Math.PI);
+  const backswing =
+    Math.sin(THREE.MathUtils.clamp((t - 0.16) / 0.26, 0, 1) * Math.PI) * 0.72;
+  const strike =
+    Math.sin(THREE.MathUtils.clamp((t - 0.38) / 0.26, 0, 1) * Math.PI) * 2.45;
+  const follow =
+    Math.sin(THREE.MathUtils.clamp((t - 0.6) / 0.4, 0, 1) * Math.PI) * 0.9;
+  const chestBalance = Math.sin(
+    THREE.MathUtils.clamp((t - 0.2) / 0.55, 0, 1) * Math.PI
+  );
 
   const upLeg = kicker.bones.rightUpLeg;
   const lowLeg = kicker.bones.rightLeg;
@@ -524,8 +822,10 @@ function applyKickerPose(kicker: Actor) {
     kicker.bones.spine.rotation.x += -0.035 * strike + 0.02 * chestBalance;
     kicker.bones.spine.rotation.y += 0.055 * chestBalance;
   }
-  if (kicker.bones.leftArm) kicker.bones.leftArm.rotation.z += -0.22 * chestBalance;
-  if (kicker.bones.rightArm) kicker.bones.rightArm.rotation.z += 0.20 * chestBalance;
+  if (kicker.bones.leftArm)
+    kicker.bones.leftArm.rotation.z += -0.22 * chestBalance;
+  if (kicker.bones.rightArm)
+    kicker.bones.rightArm.rotation.z += 0.2 * chestBalance;
   if (kicker.bones.leftUpLeg) kicker.bones.leftUpLeg.rotation.x += 0.18 * plant;
   if (kicker.bones.leftLeg) kicker.bones.leftLeg.rotation.x += -0.08 * plant;
   if (upLeg) upLeg.rotation.x += -backswing + strike + follow;
@@ -543,26 +843,78 @@ function applyWallPose(actor: Actor) {
 }
 
 function applyKeeperPose(keeper: Actor) {
+  const side = keeper.diveDir || 0;
   if (keeper.diveTime <= 0) {
-    if (keeper.bones.leftArm) keeper.bones.leftArm.rotation.z += -0.18;
-    if (keeper.bones.rightArm) keeper.bones.rightArm.rotation.z += 0.18;
+    if (keeper.bones.spine)
+      keeper.bones.spine.rotation.x += THREE.MathUtils.degToRad(5);
+    if (keeper.bones.hips)
+      keeper.bones.hips.rotation.x += THREE.MathUtils.degToRad(-4);
+    if (keeper.bones.leftArm) {
+      keeper.bones.leftArm.rotation.x += THREE.MathUtils.degToRad(-28);
+      keeper.bones.leftArm.rotation.z += THREE.MathUtils.degToRad(-16);
+    }
+    if (keeper.bones.rightArm) {
+      keeper.bones.rightArm.rotation.x += THREE.MathUtils.degToRad(-28);
+      keeper.bones.rightArm.rotation.z += THREE.MathUtils.degToRad(16);
+    }
+    if (keeper.bones.leftUpLeg)
+      keeper.bones.leftUpLeg.rotation.x += THREE.MathUtils.degToRad(-10);
+    if (keeper.bones.rightUpLeg)
+      keeper.bones.rightUpLeg.rotation.x += THREE.MathUtils.degToRad(-10);
     return;
   }
-  const t = 1 - keeper.diveTime / 0.9;
-  const dive = THREE.MathUtils.smoothstep(t, 0.02, 0.64);
-  const recover = THREE.MathUtils.smoothstep(t, 0.84, 1);
-  const a = dive * (1 - recover);
-  keeper.root.rotation.z = -keeper.diveDir * 1.32 * a;
-  keeper.root.rotation.x = -0.34 * a;
-  keeper.root.position.x += keeper.diveDir * 2.55 * a;
-  keeper.root.position.y += keeper.diveHeight * 0.54 * Math.sin(t * Math.PI) * (1 - recover);
-  if (keeper.bones.leftArm) keeper.bones.leftArm.rotation.z += -keeper.diveDir * 1.65 * a;
-  if (keeper.bones.rightArm) keeper.bones.rightArm.rotation.z += -keeper.diveDir * 1.65 * a;
+
+  // Built from goalkeeper technique references: set stance, weight forward, first step
+  // toward the ball, hands leading, then catch/parry with extended gloves.
+  const t = 1 - keeper.diveTime / 0.95;
+  const load = Math.sin(THREE.MathUtils.clamp(t / 0.22, 0, 1) * Math.PI);
+  const spring = THREE.MathUtils.smoothstep(t, 0.12, 0.58);
+  const recover = THREE.MathUtils.smoothstep(t, 0.82, 1);
+  const a = spring * (1 - recover);
+  const high = THREE.MathUtils.clamp((keeper.diveHeight - 0.7) / 1.15, 0, 1);
+  const low = 1 - high;
+  keeper.root.rotation.z = -side * THREE.MathUtils.lerp(1.02, 1.48, high) * a;
+  keeper.root.rotation.x =
+    -0.18 * load - THREE.MathUtils.lerp(0.28, 0.14, high) * a;
+  keeper.root.position.x += side * THREE.MathUtils.lerp(2.05, 2.95, high) * a;
+  keeper.root.position.y +=
+    (0.1 * load + keeper.diveHeight * 0.68 * Math.sin(t * Math.PI)) *
+    (1 - recover);
+
+  if (keeper.bones.spine) {
+    keeper.bones.spine.rotation.x += -0.12 * load + 0.18 * a;
+    keeper.bones.spine.rotation.z += -side * 0.28 * a;
+  }
+  if (keeper.bones.hips) keeper.bones.hips.rotation.z += side * 0.18 * a;
+  if (keeper.bones.leftUpLeg)
+    keeper.bones.leftUpLeg.rotation.x +=
+      -0.22 * load + (side > 0 ? -0.1 : 0.22) * a;
+  if (keeper.bones.rightUpLeg)
+    keeper.bones.rightUpLeg.rotation.x +=
+      -0.22 * load + (side < 0 ? -0.1 : 0.22) * a;
+  if (keeper.bones.leftLeg)
+    keeper.bones.leftLeg.rotation.x += 0.24 * load + low * 0.18 * a;
+  if (keeper.bones.rightLeg)
+    keeper.bones.rightLeg.rotation.x += 0.24 * load + low * 0.18 * a;
+
+  const leadLeft = side <= 0;
+  const reachX = THREE.MathUtils.degToRad(-118 - high * 22);
+  const reachZ = THREE.MathUtils.degToRad(leadLeft ? -72 : 72);
+  if (keeper.bones.leftArm) {
+    keeper.bones.leftArm.rotation.x += reachX * a - 0.42 * load;
+    keeper.bones.leftArm.rotation.z +=
+      (leadLeft ? reachZ : reachZ * 0.58) * a - 0.2 * load;
+  }
+  if (keeper.bones.rightArm) {
+    keeper.bones.rightArm.rotation.x += reachX * a - 0.42 * load;
+    keeper.bones.rightArm.rotation.z +=
+      (leadLeft ? reachZ * 0.58 : reachZ) * a + 0.2 * load;
+  }
 }
 
 function createSeatedFallbackSpectator(color: number) {
   const group = new THREE.Group();
-  group.name = "murlan-seated-fallback";
+  group.name = 'murlan-seated-fallback';
   group.scale.setScalar(SPECTATOR_FALLBACK_SCALE);
   group.position.set(0, SPECTATOR_SEAT_Y, SPECTATOR_SEAT_Z);
 
@@ -570,37 +922,66 @@ function createSeatedFallbackSpectator(color: number) {
   const skin = material(0xf1d6bd, 0.7, 0.02);
   const dark = material(0x171717, 0.68, 0.03);
   const sleeve = material(0xe5e7eb, 0.68, 0.02);
-  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.18, 0.54, 8, 12), shirt);
+  const torso = new THREE.Mesh(
+    new THREE.CapsuleGeometry(0.18, 0.54, 8, 12),
+    shirt
+  );
   torso.position.set(0, 0.78, -0.05);
   torso.rotation.x = THREE.MathUtils.degToRad(-9);
   const head = new THREE.Mesh(new THREE.SphereGeometry(0.13, 18, 12), skin);
   head.position.set(0, 1.22, -0.1);
-  const leftThigh = new THREE.Mesh(new THREE.CapsuleGeometry(0.055, 0.42, 6, 10), dark);
+  const leftThigh = new THREE.Mesh(
+    new THREE.CapsuleGeometry(0.055, 0.42, 6, 10),
+    dark
+  );
   const rightThigh = leftThigh.clone();
   leftThigh.position.set(-0.085, 0.45, 0.14);
   rightThigh.position.set(0.085, 0.45, 0.14);
   leftThigh.rotation.x = THREE.MathUtils.degToRad(88);
   rightThigh.rotation.x = THREE.MathUtils.degToRad(88);
-  const leftCalf = new THREE.Mesh(new THREE.CapsuleGeometry(0.052, 0.46, 6, 10), dark);
+  const leftCalf = new THREE.Mesh(
+    new THREE.CapsuleGeometry(0.052, 0.46, 6, 10),
+    dark
+  );
   const rightCalf = leftCalf.clone();
   leftCalf.position.set(-0.085, 0.22, 0.34);
   rightCalf.position.set(0.085, 0.22, 0.34);
   leftCalf.rotation.x = THREE.MathUtils.degToRad(8);
   rightCalf.rotation.x = THREE.MathUtils.degToRad(8);
-  const leftArm = new THREE.Mesh(new THREE.CapsuleGeometry(0.04, 0.4, 6, 10), sleeve);
+  const leftArm = new THREE.Mesh(
+    new THREE.CapsuleGeometry(0.04, 0.4, 6, 10),
+    sleeve
+  );
   const rightArm = leftArm.clone();
   leftArm.position.set(-0.22, 0.72, 0.02);
   rightArm.position.set(0.22, 0.72, 0.02);
-  leftArm.rotation.set(THREE.MathUtils.degToRad(-53), THREE.MathUtils.degToRad(-6), THREE.MathUtils.degToRad(-8));
-  rightArm.rotation.set(THREE.MathUtils.degToRad(-57), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(8));
-  group.add(shadow(torso), shadow(head), shadow(leftThigh), shadow(rightThigh), shadow(leftCalf), shadow(rightCalf), shadow(leftArm), shadow(rightArm));
+  leftArm.rotation.set(
+    THREE.MathUtils.degToRad(-53),
+    THREE.MathUtils.degToRad(-6),
+    THREE.MathUtils.degToRad(-8)
+  );
+  rightArm.rotation.set(
+    THREE.MathUtils.degToRad(-57),
+    THREE.MathUtils.degToRad(6),
+    THREE.MathUtils.degToRad(8)
+  );
+  group.add(
+    shadow(torso),
+    shadow(head),
+    shadow(leftThigh),
+    shadow(rightThigh),
+    shadow(leftCalf),
+    shadow(rightCalf),
+    shadow(leftArm),
+    shadow(rightArm)
+  );
   return group;
 }
 
 function loadSeatedCharacterTemplate(loader: GLTFLoader, modelUrl: string) {
   const cached = SEATED_CHARACTER_TEMPLATE_CACHE.get(modelUrl);
   if (cached) return cached;
-  loader.setCrossOrigin("anonymous");
+  loader.setCrossOrigin('anonymous');
   const promise = new Promise<THREE.Object3D>((resolve, reject) => {
     loader.load(modelUrl, (gltf) => resolve(gltf.scene), undefined, reject);
   });
@@ -608,18 +989,36 @@ function loadSeatedCharacterTemplate(loader: GLTFLoader, modelUrl: string) {
   return promise;
 }
 
-function attachMurlanSeatedSpectator(chair: THREE.Group, loader: GLTFLoader, characterTheme: any, index: number, kitColor: number): SeatedSpectator {
+function attachMurlanSeatedSpectator(
+  chair: THREE.Group,
+  loader: GLTFLoader,
+  characterTheme: any,
+  index: number,
+  kitColor: number
+): SeatedSpectator {
   const root = new THREE.Group();
   root.name = `murlan-seated-spectator-${index}`;
   root.position.set(0, SPECTATOR_SEAT_Y, SPECTATOR_SEAT_Z);
   root.scale.setScalar((characterTheme?.scale ?? 1) * SPECTATOR_SCALE);
-  root.rotation.set(characterTheme?.seatPitch ?? 0, characterTheme?.seatYaw ?? 0, 0);
+  root.rotation.set(
+    characterTheme?.seatPitch ?? 0,
+    characterTheme?.seatYaw ?? 0,
+    0
+  );
 
   const fallback = createSeatedFallbackSpectator(kitColor);
-  const spectator: SeatedSpectator = { root, fallback, instance: null, bones: {}, base: {}, wallIndex: index };
+  const spectator: SeatedSpectator = {
+    root,
+    fallback,
+    instance: null,
+    bones: {},
+    base: {},
+    wallIndex: index
+  };
   chair.add(root, fallback);
 
-  const modelUrl = characterTheme?.modelUrls?.[0] ?? characterTheme?.url ?? HUMAN_URL;
+  const modelUrl =
+    characterTheme?.modelUrls?.[0] ?? characterTheme?.url ?? HUMAN_URL;
   loadSeatedCharacterTemplate(loader, modelUrl)
     .then((template) => {
       const instance = cloneSkeleton(template);
@@ -629,7 +1028,9 @@ function attachMurlanSeatedSpectator(chair: THREE.Group, loader: GLTFLoader, cha
         mesh.castShadow = true;
         mesh.receiveShadow = true;
         mesh.frustumCulled = false;
-        const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+        const mats = Array.isArray(mesh.material)
+          ? mesh.material
+          : [mesh.material];
         mats.forEach((raw) => {
           const matRef = raw as THREE.MeshStandardMaterial;
           if (matRef?.map) matRef.map.colorSpace = THREE.SRGBColorSpace;
@@ -655,18 +1056,42 @@ function attachMurlanSeatedSpectator(chair: THREE.Group, loader: GLTFLoader, cha
 function applySeatedSpectatorPose(spectator: SeatedSpectator, cheerTime = 0) {
   const cheer = cheerTime > 0;
   const phase = performance.now() * 0.006 + spectator.wallIndex * 0.73;
-  const wave = Math.sin(phase) * (cheer ? 0.08 : 0.02);
-  spectator.root.position.y = SPECTATOR_SEAT_Y + Math.abs(wave) * 0.015;
-  spectator.fallback.position.y = SPECTATOR_SEAT_Y + Math.abs(wave) * 0.015;
+  const wave = Math.sin(phase) * (cheer ? 1 : 0.25);
+  const stand = cheer ? THREE.MathUtils.smoothstep(cheerTime, 0.35, 1.1) : 0;
+  const bounce = Math.abs(wave) * (cheer ? 0.035 : 0.015);
+  spectator.root.position.y = SPECTATOR_SEAT_Y + stand * 0.42 + bounce;
+  spectator.fallback.position.y = SPECTATOR_SEAT_Y + stand * 0.42 + bounce;
+  spectator.root.rotation.x = (1 - stand) * 0.02;
+  spectator.fallback.rotation.x = -stand * 0.08;
 
-  const leftUpperArm = spectator.bones.leftUpperArm;
-  const rightUpperArm = spectator.bones.rightUpperArm;
-  const leftBase = spectator.base.leftUpperArm;
-  const rightBase = spectator.base.rightUpperArm;
-  if (leftUpperArm && leftBase) leftUpperArm.rotation.z = leftBase.z - Math.abs(wave) * 0.45;
-  if (rightUpperArm && rightBase) rightUpperArm.rotation.z = rightBase.z + Math.abs(wave) * 0.45;
+  const setBone = (
+    key: keyof SeatedSpectator['bones'],
+    x = 0,
+    y = 0,
+    z = 0
+  ) => {
+    const bone = spectator.bones[key];
+    const base = spectator.base[key];
+    if (!bone || !base) return;
+    bone.rotation.set(base.x + x, base.y + y, base.z + z);
+  };
+
+  const armLift = stand * THREE.MathUtils.degToRad(-128);
+  const armSpread = stand * THREE.MathUtils.degToRad(24);
+  const foreWave = stand * Math.sin(phase * 2.6) * 0.42;
+  setBone('leftUpperArm', armLift, 0, -Math.abs(wave) * 0.28 - armSpread);
+  setBone('rightUpperArm', armLift, 0, Math.abs(wave) * 0.28 + armSpread);
+  setBone('leftForeArm', stand * THREE.MathUtils.degToRad(-32), 0, foreWave);
+  setBone('rightForeArm', stand * THREE.MathUtils.degToRad(-32), 0, -foreWave);
+  setBone('leftHand', 0, 0, foreWave * 0.5);
+  setBone('rightHand', 0, 0, -foreWave * 0.5);
+  setBone('spine', stand * THREE.MathUtils.degToRad(10), 0, wave * 0.045);
+  setBone('hips', stand * THREE.MathUtils.degToRad(8), 0, 0);
+  setBone('leftThigh', stand * THREE.MathUtils.degToRad(82), 0, 0);
+  setBone('rightThigh', stand * THREE.MathUtils.degToRad(82), 0, 0);
+  setBone('leftCalf', stand * THREE.MathUtils.degToRad(74), 0, 0);
+  setBone('rightCalf', stand * THREE.MathUtils.degToRad(74), 0, 0);
 }
-
 
 function applyGoalDancePose(kicker: Actor) {
   if (kicker.celebrateTime <= 0) return;
@@ -691,31 +1116,36 @@ function applyGoalDancePose(kicker: Actor) {
     kicker.bones.rightArm.rotation.x += -1.85 - beat * 0.2;
     kicker.bones.rightArm.rotation.z += 0.74 + sway * 0.28;
   }
-  if (kicker.bones.leftUpLeg) kicker.bones.leftUpLeg.rotation.x += -0.16 + Math.max(0, beat) * 0.32;
-  if (kicker.bones.rightUpLeg) kicker.bones.rightUpLeg.rotation.x += -0.16 + Math.max(0, -beat) * 0.32;
+  if (kicker.bones.leftUpLeg)
+    kicker.bones.leftUpLeg.rotation.x += -0.16 + Math.max(0, beat) * 0.32;
+  if (kicker.bones.rightUpLeg)
+    kicker.bones.rightUpLeg.rotation.x += -0.16 + Math.max(0, -beat) * 0.32;
   if (kicker.bones.leftLeg) kicker.bones.leftLeg.rotation.x += 0.18;
   if (kicker.bones.rightLeg) kicker.bones.rightLeg.rotation.x += 0.18;
 }
 
 function triggerCrowdCheer(stadium: StadiumRig) {
-  stadium.cheerTime = 3.0;
+  stadium.cheerTime = 3.8;
 }
 
 function updateStadiumCrowd(stadium: StadiumRig, dt: number) {
-  if (stadium.cheerTime > 0) stadium.cheerTime = Math.max(0, stadium.cheerTime - dt);
-  stadium.spectators.forEach((spectator) => applySeatedSpectatorPose(spectator, stadium.cheerTime));
+  if (stadium.cheerTime > 0)
+    stadium.cheerTime = Math.max(0, stadium.cheerTime - dt);
+  stadium.spectators.forEach((spectator) =>
+    applySeatedSpectatorPose(spectator, stadium.cheerTime)
+  );
 }
 
 function createSoccerBallTexture() {
-  const canvas = document.createElement("canvas");
+  const canvas = document.createElement('canvas');
   canvas.width = 512;
   canvas.height = 256;
-  const ctx = canvas.getContext("2d")!;
-  ctx.fillStyle = "#f8fafc";
+  const ctx = canvas.getContext('2d')!;
+  ctx.fillStyle = '#f8fafc';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
-  ctx.strokeStyle = "#111827";
+  ctx.strokeStyle = '#111827';
   ctx.lineWidth = 5;
-  ctx.fillStyle = "#111827";
+  ctx.fillStyle = '#111827';
   for (let y = 34; y < 256; y += 64) {
     for (let x = (y / 64) % 2 ? 32 : 76; x < 512; x += 96) {
       ctx.beginPath();
@@ -748,8 +1178,15 @@ function createSoccerBallTexture() {
 
 function makeBall(scene: THREE.Scene): BallState {
   const object = new THREE.Group();
-  const ballMat = new THREE.MeshStandardMaterial({ map: createSoccerBallTexture(), roughness: 0.42, metalness: 0.02 });
-  const ball = new THREE.Mesh(new THREE.SphereGeometry(BALL_R, 48, 32), ballMat);
+  const ballMat = new THREE.MeshStandardMaterial({
+    map: createSoccerBallTexture(),
+    roughness: 0.42,
+    metalness: 0.02
+  });
+  const ball = new THREE.Mesh(
+    new THREE.SphereGeometry(BALL_R, 48, 32),
+    ballMat
+  );
   object.add(shadow(ball));
   scene.add(object);
   return {
@@ -769,17 +1206,30 @@ function makeBall(scene: THREE.Scene): BallState {
     netAge: 0,
     netVel: new THREE.Vector3(),
     crossedGoalLine: false,
-    hitFrame: false,
+    hitFrame: false
   };
 }
 
-function netPoint(a: THREE.Vector3, b: THREE.Vector3, c: THREE.Vector3, d: THREE.Vector3, u: number, v: number) {
+function netPoint(
+  a: THREE.Vector3,
+  b: THREE.Vector3,
+  c: THREE.Vector3,
+  d: THREE.Vector3,
+  u: number,
+  v: number
+) {
   const bottom = a.clone().lerp(b, u);
   const top = d.clone().lerp(c, u);
   return bottom.lerp(top, v);
 }
 
-function addNetLine(group: THREE.Group, rig: NetRig, p1: THREE.Vector3, p2: THREE.Vector3, lineMat: THREE.LineBasicMaterial) {
+function addNetLine(
+  group: THREE.Group,
+  rig: NetRig,
+  p1: THREE.Vector3,
+  p2: THREE.Vector3,
+  lineMat: THREE.LineBasicMaterial
+) {
   const geometry = new THREE.BufferGeometry().setFromPoints([p1, p2]);
   const line = new THREE.Line(geometry, lineMat);
   line.userData.base = [p1.clone(), p2.clone()];
@@ -787,16 +1237,40 @@ function addNetLine(group: THREE.Group, rig: NetRig, p1: THREE.Vector3, p2: THRE
   group.add(line);
 }
 
-function makeNetSurface(rig: NetRig, a: THREE.Vector3, b: THREE.Vector3, c: THREE.Vector3, d: THREE.Vector3, cols: number, rows: number) {
+function makeNetSurface(
+  rig: NetRig,
+  a: THREE.Vector3,
+  b: THREE.Vector3,
+  c: THREE.Vector3,
+  d: THREE.Vector3,
+  cols: number,
+  rows: number
+) {
   const group = new THREE.Group();
-  const lineMat = new THREE.LineBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.58 });
+  const lineMat = new THREE.LineBasicMaterial({
+    color: 0xffffff,
+    transparent: true,
+    opacity: 0.58
+  });
   for (let i = 0; i <= cols; i++) {
     const u = i / cols;
-    addNetLine(group, rig, netPoint(a, b, c, d, u, 0), netPoint(a, b, c, d, u, 1), lineMat);
+    addNetLine(
+      group,
+      rig,
+      netPoint(a, b, c, d, u, 0),
+      netPoint(a, b, c, d, u, 1),
+      lineMat
+    );
   }
   for (let j = 0; j <= rows; j++) {
     const v = j / rows;
-    addNetLine(group, rig, netPoint(a, b, c, d, 0, v), netPoint(a, b, c, d, 1, v), lineMat);
+    addNetLine(
+      group,
+      rig,
+      netPoint(a, b, c, d, 0, v),
+      netPoint(a, b, c, d, 1, v),
+      lineMat
+    );
   }
   for (let j = 0; j < rows; j++) {
     for (let i = 0; i < cols; i++) {
@@ -804,18 +1278,125 @@ function makeNetSurface(rig: NetRig, a: THREE.Vector3, b: THREE.Vector3, c: THRE
       const u1 = (i + 1) / cols;
       const v0 = j / rows;
       const v1 = (j + 1) / rows;
-      addNetLine(group, rig, netPoint(a, b, c, d, (u0 + u1) / 2, v0), netPoint(a, b, c, d, u1, (v0 + v1) / 2), lineMat);
-      addNetLine(group, rig, netPoint(a, b, c, d, u1, (v0 + v1) / 2), netPoint(a, b, c, d, (u0 + u1) / 2, v1), lineMat);
-      addNetLine(group, rig, netPoint(a, b, c, d, (u0 + u1) / 2, v1), netPoint(a, b, c, d, u0, (v0 + v1) / 2), lineMat);
-      addNetLine(group, rig, netPoint(a, b, c, d, u0, (v0 + v1) / 2), netPoint(a, b, c, d, (u0 + u1) / 2, v0), lineMat);
+      addNetLine(
+        group,
+        rig,
+        netPoint(a, b, c, d, (u0 + u1) / 2, v0),
+        netPoint(a, b, c, d, u1, (v0 + v1) / 2),
+        lineMat
+      );
+      addNetLine(
+        group,
+        rig,
+        netPoint(a, b, c, d, u1, (v0 + v1) / 2),
+        netPoint(a, b, c, d, (u0 + u1) / 2, v1),
+        lineMat
+      );
+      addNetLine(
+        group,
+        rig,
+        netPoint(a, b, c, d, (u0 + u1) / 2, v1),
+        netPoint(a, b, c, d, u0, (v0 + v1) / 2),
+        lineMat
+      );
+      addNetLine(
+        group,
+        rig,
+        netPoint(a, b, c, d, u0, (v0 + v1) / 2),
+        netPoint(a, b, c, d, (u0 + u1) / 2, v0),
+        lineMat
+      );
     }
   }
   return group;
 }
-function makeCylinderBetween(a: THREE.Vector3, b: THREE.Vector3, radius: number, matRef: THREE.Material) { const dir = b.clone().sub(a); const mesh = new THREE.Mesh(new THREE.CylinderGeometry(radius, radius, Math.max(0.001, dir.length()), 18), matRef); mesh.position.copy(a).addScaledVector(dir, 0.5); mesh.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.normalize()); return shadow(mesh); }
-function makeGoal(scene: THREE.Scene, netRig: NetRig) { const root = new THREE.Group(); root.position.z = GOAL_LINE_Z; const white = material(0xffffff, 0.4, 0.18); const rear = material(0xcbd5e1, 0.46, 0.28); const backScale = 0.82; const backW = GOAL_W * backScale; const backH = GOAL_H * backScale; const FL = new THREE.Vector3(-GOAL_W / 2, 0, 0); const FR = new THREE.Vector3(GOAL_W / 2, 0, 0); const FLT = new THREE.Vector3(-GOAL_W / 2, GOAL_H, 0); const FRT = new THREE.Vector3(GOAL_W / 2, GOAL_H, 0); const BL = new THREE.Vector3(-backW / 2, 0.03, -GOAL_D); const BR = new THREE.Vector3(backW / 2, 0.03, -GOAL_D); const BLT = new THREE.Vector3(-backW / 2, backH, -GOAL_D); const BRT = new THREE.Vector3(backW / 2, backH, -GOAL_D); root.add(makeCylinderBetween(FL, FLT, POST_R, white), makeCylinderBetween(FR, FRT, POST_R, white), makeCylinderBetween(FLT, FRT, POST_R, white), makeCylinderBetween(BL, BLT, POST_R * 0.48, rear), makeCylinderBetween(BR, BRT, POST_R * 0.48, rear), makeCylinderBetween(BLT, BRT, POST_R * 0.48, rear), makeCylinderBetween(FLT, BLT, POST_R * 0.42, rear), makeCylinderBetween(FRT, BRT, POST_R * 0.42, rear), makeCylinderBetween(FL, BL, POST_R * 0.36, rear), makeCylinderBetween(FR, BR, POST_R * 0.36, rear)); root.add(makeNetSurface(netRig, BL, BR, BRT, BLT, 18, 10)); root.add(makeNetSurface(netRig, FLT, FRT, BRT, BLT, 18, 8)); root.add(makeNetSurface(netRig, FL, BL, BLT, FLT, 8, 10)); root.add(makeNetSurface(netRig, FR, BR, BRT, FRT, 8, 10)); scene.add(root); }
-function triggerNetShake(netRig: NetRig, impact: THREE.Vector3) { netRig.shake = 1.35; netRig.impact.copy(impact).sub(new THREE.Vector3(0, 0, GOAL_LINE_Z)); }
-function updateNetShake(netRig: NetRig, dt: number) { if (netRig.shake <= 0) return; const time = performance.now() * 0.02; const strength = netRig.shake; netRig.lines.forEach((line, idx) => { const base = line.userData.base as THREE.Vector3[]; const attr = line.geometry.getAttribute("position") as THREE.BufferAttribute; for (let i = 0; i < 2; i++) { const p = base[i]; const distance = Math.max(0.28, p.distanceTo(netRig.impact)); const falloff = THREE.MathUtils.clamp(1.65 / distance, 0, 1.4); const wave = Math.sin(time + idx * 0.37 + i * 1.7) * 0.24 * strength * falloff; attr.setXYZ(i, p.x + wave * 0.36, p.y + Math.abs(wave) * 0.28, p.z - Math.abs(wave) * 1.45); } attr.needsUpdate = true; }); netRig.shake = Math.max(0, netRig.shake - dt * 1.65); }
+function makeCylinderBetween(
+  a: THREE.Vector3,
+  b: THREE.Vector3,
+  radius: number,
+  matRef: THREE.Material
+) {
+  const dir = b.clone().sub(a);
+  const mesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(
+      radius,
+      radius,
+      Math.max(0.001, dir.length()),
+      18
+    ),
+    matRef
+  );
+  mesh.position.copy(a).addScaledVector(dir, 0.5);
+  mesh.quaternion.setFromUnitVectors(
+    new THREE.Vector3(0, 1, 0),
+    dir.normalize()
+  );
+  return shadow(mesh);
+}
+function makeGoal(scene: THREE.Scene, netRig: NetRig) {
+  const root = new THREE.Group();
+  root.position.z = GOAL_LINE_Z;
+  const white = material(0xffffff, 0.4, 0.18);
+  const rear = material(0xcbd5e1, 0.46, 0.28);
+  const backScale = 0.82;
+  const backW = GOAL_W * backScale;
+  const backH = GOAL_H * backScale;
+  const FL = new THREE.Vector3(-GOAL_W / 2, 0, 0);
+  const FR = new THREE.Vector3(GOAL_W / 2, 0, 0);
+  const FLT = new THREE.Vector3(-GOAL_W / 2, GOAL_H, 0);
+  const FRT = new THREE.Vector3(GOAL_W / 2, GOAL_H, 0);
+  const BL = new THREE.Vector3(-backW / 2, 0.03, -GOAL_D);
+  const BR = new THREE.Vector3(backW / 2, 0.03, -GOAL_D);
+  const BLT = new THREE.Vector3(-backW / 2, backH, -GOAL_D);
+  const BRT = new THREE.Vector3(backW / 2, backH, -GOAL_D);
+  root.add(
+    makeCylinderBetween(FL, FLT, POST_R, white),
+    makeCylinderBetween(FR, FRT, POST_R, white),
+    makeCylinderBetween(FLT, FRT, POST_R, white),
+    makeCylinderBetween(BL, BLT, POST_R * 0.48, rear),
+    makeCylinderBetween(BR, BRT, POST_R * 0.48, rear),
+    makeCylinderBetween(BLT, BRT, POST_R * 0.48, rear),
+    makeCylinderBetween(FLT, BLT, POST_R * 0.42, rear),
+    makeCylinderBetween(FRT, BRT, POST_R * 0.42, rear),
+    makeCylinderBetween(FL, BL, POST_R * 0.36, rear),
+    makeCylinderBetween(FR, BR, POST_R * 0.36, rear)
+  );
+  root.add(makeNetSurface(netRig, BL, BR, BRT, BLT, 18, 10));
+  root.add(makeNetSurface(netRig, FLT, FRT, BRT, BLT, 18, 8));
+  root.add(makeNetSurface(netRig, FL, BL, BLT, FLT, 8, 10));
+  root.add(makeNetSurface(netRig, FR, BR, BRT, FRT, 8, 10));
+  scene.add(root);
+}
+function triggerNetShake(netRig: NetRig, impact: THREE.Vector3) {
+  netRig.shake = 1.35;
+  netRig.impact.copy(impact).sub(new THREE.Vector3(0, 0, GOAL_LINE_Z));
+}
+function updateNetShake(netRig: NetRig, dt: number) {
+  if (netRig.shake <= 0) return;
+  const time = performance.now() * 0.02;
+  const strength = netRig.shake;
+  netRig.lines.forEach((line, idx) => {
+    const base = line.userData.base as THREE.Vector3[];
+    const attr = line.geometry.getAttribute(
+      'position'
+    ) as THREE.BufferAttribute;
+    for (let i = 0; i < 2; i++) {
+      const p = base[i];
+      const distance = Math.max(0.28, p.distanceTo(netRig.impact));
+      const falloff = THREE.MathUtils.clamp(1.65 / distance, 0, 1.4);
+      const wave =
+        Math.sin(time + idx * 0.37 + i * 1.7) * 0.24 * strength * falloff;
+      attr.setXYZ(
+        i,
+        p.x + wave * 0.36,
+        p.y + Math.abs(wave) * 0.28,
+        p.z - Math.abs(wave) * 1.45
+      );
+    }
+    attr.needsUpdate = true;
+  });
+  netRig.shake = Math.max(0, netRig.shake - dt * 1.65);
+}
 function makeChair(color: number) {
   const chair = new THREE.Group();
   const plastic = material(color, 0.62, 0.02);
@@ -825,7 +1406,10 @@ function makeChair(color: number) {
   back.position.set(0, 0.55, -0.16);
   const legMat = material(0x334155, 0.45, 0.18);
   const legs = [
-    [-0.16, 0.13, -0.12], [0.16, 0.13, -0.12], [-0.16, 0.13, 0.14], [0.16, 0.13, 0.14],
+    [-0.16, 0.13, -0.12],
+    [0.16, 0.13, -0.12],
+    [-0.16, 0.13, 0.14],
+    [0.16, 0.13, 0.14]
   ].map(([x, y, z]) => {
     const leg = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.28, 0.04), legMat);
     leg.position.set(x, y, z);
@@ -835,17 +1419,31 @@ function makeChair(color: number) {
   return chair;
 }
 
-function makeBillboardsAndStands(scene: THREE.Scene, loader: GLTFLoader): StadiumRig {
+function makeBillboardsAndStands(
+  scene: THREE.Scene,
+  loader: GLTFLoader
+): StadiumRig {
   const boardGroup = new THREE.Group();
   const zBoard = GOAL_LINE_Z - GOAL_D - 0.75;
-  const boardColors = [0x2563eb, 0xef4444, 0x16a34a, 0xfacc15, 0x7c3aed, 0x0ea5e9];
+  const boardColors = [
+    0x2563eb, 0xef4444, 0x16a34a, 0xfacc15, 0x7c3aed, 0x0ea5e9
+  ];
   for (let i = 0; i < 6; i++) {
     const x = (i - 2.5) * 3.15;
-    const board = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.82, 0.08), material(boardColors[i], 0.5, 0.02));
+    const board = new THREE.Mesh(
+      new THREE.BoxGeometry(2.95, 0.82, 0.08),
+      material(boardColors[i], 0.5, 0.02)
+    );
     board.position.set(x, 0.55, zBoard);
-    const top = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.08, 0.1), material(0xffffff, 0.55, 0.02));
+    const top = new THREE.Mesh(
+      new THREE.BoxGeometry(2.95, 0.08, 0.1),
+      material(0xffffff, 0.55, 0.02)
+    );
     top.position.set(x, 1.0, zBoard + 0.01);
-    const textBar = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.12, 0.105), material(0xffffff, 0.55, 0.02));
+    const textBar = new THREE.Mesh(
+      new THREE.BoxGeometry(1.7, 0.12, 0.105),
+      material(0xffffff, 0.55, 0.02)
+    );
     textBar.position.set(x, 0.55, zBoard + 0.015);
     boardGroup.add(shadow(board), shadow(top), shadow(textBar));
   }
@@ -866,22 +1464,41 @@ function makeBillboardsAndStands(scene: THREE.Scene, loader: GLTFLoader): Stadiu
   for (let row = 0; row < rows; row++) {
     const z = -row * rowDepth;
     const y = 0.18 + row * rowRise;
-    const tread = new THREE.Mesh(new THREE.BoxGeometry(width, 0.16, rowDepth), concrete);
+    const tread = new THREE.Mesh(
+      new THREE.BoxGeometry(width, 0.16, rowDepth),
+      concrete
+    );
     tread.position.set(0, y, z);
-    const riser = new THREE.Mesh(new THREE.BoxGeometry(width, rowRise, 0.08), riserMat);
+    const riser = new THREE.Mesh(
+      new THREE.BoxGeometry(width, rowRise, 0.08),
+      riserMat
+    );
     riser.position.set(0, y - 0.03, z + rowDepth * 0.46);
-    const lip = new THREE.Mesh(new THREE.BoxGeometry(width, 0.045, 0.07), railMat);
+    const lip = new THREE.Mesh(
+      new THREE.BoxGeometry(width, 0.045, 0.07),
+      railMat
+    );
     lip.position.set(0, y + 0.12, z + rowDepth * 0.46);
     stands.add(shadow(tread), shadow(riser), shadow(lip));
   }
 
   stairXs.forEach((x) => {
     for (let row = 0; row < rows; row++) {
-      const stair = new THREE.Mesh(new THREE.BoxGeometry(0.78, 0.11, rowDepth * 0.78), aisleMat);
+      const stair = new THREE.Mesh(
+        new THREE.BoxGeometry(0.78, 0.11, rowDepth * 0.78),
+        aisleMat
+      );
       stair.position.set(x, 0.32 + row * rowRise, -row * rowDepth + 0.02);
       stands.add(shadow(stair));
-      const nose = new THREE.Mesh(new THREE.BoxGeometry(0.78, 0.035, 0.05), material(0xffffff, 0.72, 0.01));
-      nose.position.set(x, 0.4 + row * rowRise, -row * rowDepth + rowDepth * 0.38);
+      const nose = new THREE.Mesh(
+        new THREE.BoxGeometry(0.78, 0.035, 0.05),
+        material(0xffffff, 0.72, 0.01)
+      );
+      nose.position.set(
+        x,
+        0.4 + row * rowRise,
+        -row * rowDepth + rowDepth * 0.38
+      );
       stands.add(shadow(nose));
     }
     const railPostCount = rows + 1;
@@ -889,7 +1506,10 @@ function makeBillboardsAndStands(scene: THREE.Scene, loader: GLTFLoader): Stadiu
       const postZ = -i * rowDepth + rowDepth * 0.28;
       const postY = 0.65 + i * rowRise;
       [-0.46, 0.46].forEach((side) => {
-        const post = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.025, 0.62, 10), railMat);
+        const post = new THREE.Mesh(
+          new THREE.CylinderGeometry(0.025, 0.025, 0.62, 10),
+          railMat
+        );
         post.position.set(x + side, postY, postZ);
         stands.add(shadow(post));
       });
@@ -897,7 +1517,11 @@ function makeBillboardsAndStands(scene: THREE.Scene, loader: GLTFLoader): Stadiu
     [-0.46, 0.46].forEach((side) => {
       const rail = makeCylinderBetween(
         new THREE.Vector3(x + side, 0.86, rowDepth * 0.3),
-        new THREE.Vector3(x + side, 0.86 + rows * rowRise, -(rows - 1) * rowDepth + rowDepth * 0.25),
+        new THREE.Vector3(
+          x + side,
+          0.86 + rows * rowRise,
+          -(rows - 1) * rowDepth + rowDepth * 0.25
+        ),
         0.022,
         railMat
       );
@@ -921,27 +1545,59 @@ function makeBillboardsAndStands(scene: THREE.Scene, loader: GLTFLoader): Stadiu
       chair.rotation.y = 0;
       stands.add(chair);
 
-      const shouldSeatHuman = row < SPECTATOR_ROWS_FILLED && rowSpectators < SPECTATORS_PER_ROW_TARGET;
+      const shouldSeatHuman =
+        row < SPECTATOR_ROWS_FILLED &&
+        rowSpectators < SPECTATORS_PER_ROW_TARGET;
       if (shouldSeatHuman) {
-        const kit = MURLAN_CHARACTER_COLORS[characterIndex % MURLAN_CHARACTER_COLORS.length];
-        const characterTheme = MURLAN_CHARACTER_THEMES[characterIndex % Math.max(1, MURLAN_CHARACTER_THEMES.length)] ?? { url: HUMAN_URL, scale: 1 };
-        spectators.push(attachMurlanSeatedSpectator(chair, loader, characterTheme, characterIndex, kit));
+        const kit =
+          MURLAN_CHARACTER_COLORS[
+            characterIndex % MURLAN_CHARACTER_COLORS.length
+          ];
+        const characterTheme = MURLAN_CHARACTER_THEMES[
+          characterIndex % Math.max(1, MURLAN_CHARACTER_THEMES.length)
+        ] ?? { url: HUMAN_URL, scale: 1 };
+        spectators.push(
+          attachMurlanSeatedSpectator(
+            chair,
+            loader,
+            characterTheme,
+            characterIndex,
+            kit
+          )
+        );
         characterIndex += 1;
         rowSpectators += 1;
       }
     }
   }
 
-  const backWall = new THREE.Mesh(new THREE.BoxGeometry(width + 0.9, rows * rowRise + 1.2, 0.28), material(0x475569, 0.72, 0.06));
-  backWall.position.set(0, 1.08 + rows * rowRise, -(rows - 1) * rowDepth - 0.62);
+  const backWall = new THREE.Mesh(
+    new THREE.BoxGeometry(width + 0.9, rows * rowRise + 1.2, 0.28),
+    material(0x475569, 0.72, 0.06)
+  );
+  backWall.position.set(
+    0,
+    1.08 + rows * rowRise,
+    -(rows - 1) * rowDepth - 0.62
+  );
   stands.add(shadow(backWall));
 
-  const frontRail = new THREE.Mesh(new THREE.BoxGeometry(width + 0.4, 0.08, 0.08), railMat);
+  const frontRail = new THREE.Mesh(
+    new THREE.BoxGeometry(width + 0.4, 0.08, 0.08),
+    railMat
+  );
   frontRail.position.set(0, 1.05, 0.62);
   stands.add(shadow(frontRail));
   [-width / 2 - 0.22, width / 2 + 0.22].forEach((x) => {
-    const sideWall = new THREE.Mesh(new THREE.BoxGeometry(0.18, rows * rowRise + 0.7, rows * rowDepth + 0.8), material(0x5b6472, 0.82, 0.04));
-    sideWall.position.set(x, 0.72 + rows * rowRise * 0.5, -((rows - 1) * rowDepth) / 2);
+    const sideWall = new THREE.Mesh(
+      new THREE.BoxGeometry(0.18, rows * rowRise + 0.7, rows * rowDepth + 0.8),
+      material(0x5b6472, 0.82, 0.04)
+    );
+    sideWall.position.set(
+      x,
+      0.72 + rows * rowRise * 0.5,
+      -((rows - 1) * rowDepth) / 2
+    );
     stands.add(shadow(sideWall));
   });
 
@@ -949,14 +1605,47 @@ function makeBillboardsAndStands(scene: THREE.Scene, loader: GLTFLoader): Stadiu
   return { spectators, cheerTime: 0 };
 }
 
-
-function addLine(scene: THREE.Scene, points: THREE.Vector3[], color = 0xffffff, opacity = 0.9) { const line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(points.map((p) => new THREE.Vector3(p.x, 0.018, p.z))), new THREE.LineBasicMaterial({ color, transparent: true, opacity })); scene.add(line); return line; }
-function addRect(scene: THREE.Scene, left: number, right: number, frontZ: number, backZ: number) { addLine(scene, [new THREE.Vector3(left, 0, frontZ), new THREE.Vector3(left, 0, backZ), new THREE.Vector3(right, 0, backZ), new THREE.Vector3(right, 0, frontZ)]); }
-function makeHalfField(scene: THREE.Scene, netRig: NetRig, loader: GLTFLoader): StadiumRig {
+function addLine(
+  scene: THREE.Scene,
+  points: THREE.Vector3[],
+  color = 0xffffff,
+  opacity = 0.9
+) {
+  const line = new THREE.Line(
+    new THREE.BufferGeometry().setFromPoints(
+      points.map((p) => new THREE.Vector3(p.x, 0.018, p.z))
+    ),
+    new THREE.LineBasicMaterial({ color, transparent: true, opacity })
+  );
+  scene.add(line);
+  return line;
+}
+function addRect(
+  scene: THREE.Scene,
+  left: number,
+  right: number,
+  frontZ: number,
+  backZ: number
+) {
+  addLine(scene, [
+    new THREE.Vector3(left, 0, frontZ),
+    new THREE.Vector3(left, 0, backZ),
+    new THREE.Vector3(right, 0, backZ),
+    new THREE.Vector3(right, 0, frontZ)
+  ]);
+}
+function makeHalfField(
+  scene: THREE.Scene,
+  netRig: NetRig,
+  loader: GLTFLoader
+): StadiumRig {
   const grassA = material(0x1d7d39, 0.95, 0);
   const grassB = material(0x16692e, 0.95, 0);
   for (let i = 0; i < 10; i++) {
-    const stripe = new THREE.Mesh(new THREE.PlaneGeometry(FIELD_W, HALF_H / 10), i % 2 ? grassA : grassB);
+    const stripe = new THREE.Mesh(
+      new THREE.PlaneGeometry(FIELD_W, HALF_H / 10),
+      i % 2 ? grassA : grassB
+    );
     stripe.rotation.x = -Math.PI / 2;
     stripe.position.z = -HALF_H / 2 + HALF_H / 20 + (i * HALF_H) / 10;
     stripe.receiveShadow = true;
@@ -964,48 +1653,167 @@ function makeHalfField(scene: THREE.Scene, netRig: NetRig, loader: GLTFLoader): 
   }
   const w = FIELD_W / 2;
   const h = HALF_H / 2;
-  addLine(scene, [new THREE.Vector3(-w, 0, -h), new THREE.Vector3(w, 0, -h), new THREE.Vector3(w, 0, h), new THREE.Vector3(-w, 0, h), new THREE.Vector3(-w, 0, -h)]);
+  addLine(scene, [
+    new THREE.Vector3(-w, 0, -h),
+    new THREE.Vector3(w, 0, -h),
+    new THREE.Vector3(w, 0, h),
+    new THREE.Vector3(-w, 0, h),
+    new THREE.Vector3(-w, 0, -h)
+  ]);
   addLine(scene, [new THREE.Vector3(-w, 0, h), new THREE.Vector3(w, 0, h)]);
   addRect(scene, -PENALTY_W / 2, PENALTY_W / 2, -h, -h + PENALTY_D);
   addRect(scene, -GOAL_AREA_W / 2, GOAL_AREA_W / 2, -h, -h + GOAL_AREA_D);
-  const penaltySpot = new THREE.Mesh(new THREE.CircleGeometry(0.08, 28), new THREE.MeshBasicMaterial({ color: 0xffffff }));
+  const penaltySpot = new THREE.Mesh(
+    new THREE.CircleGeometry(0.08, 28),
+    new THREE.MeshBasicMaterial({ color: 0xffffff })
+  );
   penaltySpot.rotation.x = -Math.PI / 2;
   penaltySpot.position.set(0, 0.022, -h + PENALTY_SPOT_D);
   scene.add(penaltySpot);
   const boxTopZ = -h + PENALTY_D;
   const spotZ = -h + PENALTY_SPOT_D;
   const theta = Math.acos((boxTopZ - spotZ) / ARC_R);
-  const arcPts = new THREE.EllipseCurve(0, spotZ, ARC_R, ARC_R, theta, Math.PI - theta).getPoints(96).map((p) => new THREE.Vector3(p.x, 0, p.y));
+  const arcPts = new THREE.EllipseCurve(
+    0,
+    spotZ,
+    ARC_R,
+    ARC_R,
+    theta,
+    Math.PI - theta
+  )
+    .getPoints(96)
+    .map((p) => new THREE.Vector3(p.x, 0, p.y));
   addLine(scene, arcPts);
   makeGoal(scene, netRig);
   return makeBillboardsAndStands(scene, loader);
 }
 
-function makeAimLine(scene: THREE.Scene) { const geometry = new THREE.BufferGeometry(); geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(34 * 3), 3)); const line = new THREE.Line(geometry, new THREE.LineBasicMaterial({ color: 0xfff200, transparent: true, opacity: 0.95 })); scene.add(line); return line; }
-function shotPoint(start: THREE.Vector3, target: THREE.Vector3, curve: number, lift: number, t: number) { const p = start.clone().lerp(target, t); p.x += curve * Math.sin(t * Math.PI); p.y = BALL_R + lift * Math.sin(t * Math.PI) + (target.y - BALL_R) * t; return p; }
+function makeAimLine(scene: THREE.Scene) {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute(
+    'position',
+    new THREE.BufferAttribute(new Float32Array(34 * 3), 3)
+  );
+  const line = new THREE.Line(
+    geometry,
+    new THREE.LineBasicMaterial({
+      color: 0xfff200,
+      transparent: true,
+      opacity: 0.95
+    })
+  );
+  scene.add(line);
+  return line;
+}
+function shotPoint(
+  start: THREE.Vector3,
+  target: THREE.Vector3,
+  curve: number,
+  lift: number,
+  t: number
+) {
+  const p = start.clone().lerp(target, t);
+  p.x += curve * Math.sin(t * Math.PI);
+  p.y = BALL_R + lift * Math.sin(t * Math.PI) + (target.y - BALL_R) * t;
+  return p;
+}
 function swipeToShot(ballPos: THREE.Vector3, swipe: SwipeState) {
   const dx = swipe.endX - swipe.startX;
   const dy = swipe.startY - swipe.endY;
-  const targetX = THREE.MathUtils.clamp(dx / 34, -GOAL_W / 2 + 0.2, GOAL_W / 2 - 0.2);
-  const targetY = THREE.MathUtils.clamp(0.45 + dy / 82, 0.22, GOAL_H + 1.3);
-  const onFrame = Math.abs(targetX) > GOAL_W / 2 - 0.34 || targetY > GOAL_H - 0.08;
-  const inMouth = Math.abs(targetX) <= GOAL_W / 2 - BALL_R * 1.4 && targetY >= BALL_R && targetY <= GOAL_H - BALL_R * 0.3;
-  const targetDepth = inMouth && !onFrame ? GOAL_LINE_Z - GOAL_D + 0.32 : GOAL_LINE_Z - 0.12;
+  const targetX = THREE.MathUtils.clamp(
+    dx / 50,
+    -GOAL_W / 2 + 0.2,
+    GOAL_W / 2 - 0.2
+  );
+  const targetY = THREE.MathUtils.clamp(0.45 + dy / 115, 0.22, GOAL_H + 1.3);
+  const onFrame =
+    Math.abs(targetX) > GOAL_W / 2 - 0.34 || targetY > GOAL_H - 0.08;
+  const inMouth =
+    Math.abs(targetX) <= GOAL_W / 2 - BALL_R * 1.4 &&
+    targetY >= BALL_R &&
+    targetY <= GOAL_H - BALL_R * 0.3;
+  const targetDepth =
+    inMouth && !onFrame ? GOAL_LINE_Z - GOAL_D + 0.32 : GOAL_LINE_Z - 0.12;
   const target = new THREE.Vector3(targetX, targetY, targetDepth);
-  const curve = THREE.MathUtils.clamp(dx / 58, -6.0, 6.0);
-  const lift = THREE.MathUtils.clamp(dy / 65, 0.35, GOAL_H + 2.4);
-  const power = THREE.MathUtils.clamp(Math.hypot(dx, dy) / 123, 0.48, 1.72);
+  const curve = THREE.MathUtils.clamp(dx / 80, -6.0, 6.0);
+  const lift = THREE.MathUtils.clamp(dy / 90, 0.35, GOAL_H + 2.4);
+  const power = THREE.MathUtils.clamp(Math.hypot(dx, dy) / 150, 0.48, 1.72);
   const distance = ballPos.distanceTo(target);
-  const duration = THREE.MathUtils.clamp(distance / (18.7 + power * 10.4), 0.72, 1.34);
+  const duration = THREE.MathUtils.clamp(
+    distance / (18.7 + power * 10.4),
+    0.72,
+    1.34
+  );
   return { target, curve, lift, power, duration };
 }
-function setAimCurve(line: THREE.Line, ballPos: THREE.Vector3, swipe: SwipeState) { const attr = (line.geometry as THREE.BufferGeometry).getAttribute("position") as THREE.BufferAttribute; const shot = swipeToShot(ballPos, swipe); for (let i = 0; i < attr.count; i++) { const t = i / (attr.count - 1); const p = shotPoint(ballPos, shot.target, shot.curve, shot.lift, t); attr.setXYZ(i, p.x, p.y + 0.08, p.z); } attr.needsUpdate = true; line.geometry.computeBoundingSphere(); }
-function hideAimLine(line: THREE.Line) { const attr = (line.geometry as THREE.BufferGeometry).getAttribute("position") as THREE.BufferAttribute; for (let i = 0; i < attr.count; i++) attr.setXYZ(i, 99, 99, 99); attr.needsUpdate = true; }
-function freeKickPosition(spot: KickSpot) { if (spot === "left") return new THREE.Vector3(-4.6, BALL_R, GOAL_LINE_Z + 24.5); if (spot === "right") return new THREE.Vector3(4.6, BALL_R, GOAL_LINE_Z + 24.5); if (spot === "near16") return new THREE.Vector3(0.7, BALL_R, GOAL_LINE_Z + 18.8); return new THREE.Vector3(0, BALL_R, GOAL_LINE_Z + 23.0); }
-function wallCountForSpot(spot: KickSpot) { if (spot === "left" || spot === "right") return 3; if (spot === "near16") return 5; return 4; }
-function wallCenterForBall(ballPos: THREE.Vector3) { const goalCenter = new THREE.Vector3(0, 0, GOAL_LINE_Z); const toGoal = goalCenter.sub(ballPos).setY(0).normalize(); return ballPos.clone().addScaledVector(toGoal, WALL_DISTANCE).setY(0); }
-function placeWall(wall: Actor[], spot: KickSpot, ballPos: THREE.Vector3) { const count = wallCountForSpot(spot); const center = wallCenterForBall(ballPos); const toBall = ballPos.clone().sub(center).setY(0).normalize(); const side = new THREE.Vector3(toBall.z, 0, -toBall.x).normalize(); wall.forEach((actor, i) => { actor.root.visible = i < count; const offset = i - (count - 1) / 2; actor.pos.copy(center).addScaledVector(side, offset * 0.62).setY(0); actor.dir.copy(ballPos.clone().sub(actor.pos).setY(0).normalize()); actor.vel.set(0, 0, 0); actor.speed = 0; actor.jumpTime = 0; }); }
-function resetShot(ball: BallState, kicker: Actor, keeper: Actor, wall: Actor[], spot: KickSpot) {
+function setAimCurve(
+  line: THREE.Line,
+  ballPos: THREE.Vector3,
+  swipe: SwipeState
+) {
+  const attr = (line.geometry as THREE.BufferGeometry).getAttribute(
+    'position'
+  ) as THREE.BufferAttribute;
+  const shot = swipeToShot(ballPos, swipe);
+  for (let i = 0; i < attr.count; i++) {
+    const t = i / (attr.count - 1);
+    const p = shotPoint(ballPos, shot.target, shot.curve, shot.lift, t);
+    attr.setXYZ(i, p.x, p.y + 0.08, p.z);
+  }
+  attr.needsUpdate = true;
+  line.geometry.computeBoundingSphere();
+}
+function hideAimLine(line: THREE.Line) {
+  const attr = (line.geometry as THREE.BufferGeometry).getAttribute(
+    'position'
+  ) as THREE.BufferAttribute;
+  for (let i = 0; i < attr.count; i++) attr.setXYZ(i, 99, 99, 99);
+  attr.needsUpdate = true;
+}
+function freeKickPosition(spot: KickSpot) {
+  if (spot === 'left')
+    return new THREE.Vector3(-4.6, BALL_R, GOAL_LINE_Z + 24.5);
+  if (spot === 'right')
+    return new THREE.Vector3(4.6, BALL_R, GOAL_LINE_Z + 24.5);
+  if (spot === 'near16')
+    return new THREE.Vector3(0.7, BALL_R, GOAL_LINE_Z + 18.8);
+  return new THREE.Vector3(0, BALL_R, GOAL_LINE_Z + 23.0);
+}
+function wallCountForSpot(spot: KickSpot) {
+  if (spot === 'left' || spot === 'right') return 3;
+  if (spot === 'near16') return 5;
+  return 4;
+}
+function wallCenterForBall(ballPos: THREE.Vector3) {
+  const goalCenter = new THREE.Vector3(0, 0, GOAL_LINE_Z);
+  const toGoal = goalCenter.sub(ballPos).setY(0).normalize();
+  return ballPos.clone().addScaledVector(toGoal, WALL_DISTANCE).setY(0);
+}
+function placeWall(wall: Actor[], spot: KickSpot, ballPos: THREE.Vector3) {
+  const count = wallCountForSpot(spot);
+  const center = wallCenterForBall(ballPos);
+  const toBall = ballPos.clone().sub(center).setY(0).normalize();
+  const side = new THREE.Vector3(toBall.z, 0, -toBall.x).normalize();
+  wall.forEach((actor, i) => {
+    actor.root.visible = i < count;
+    const offset = i - (count - 1) / 2;
+    actor.pos
+      .copy(center)
+      .addScaledVector(side, offset * 0.62)
+      .setY(0);
+    actor.dir.copy(ballPos.clone().sub(actor.pos).setY(0).normalize());
+    actor.vel.set(0, 0, 0);
+    actor.speed = 0;
+    actor.jumpTime = 0;
+  });
+}
+function resetShot(
+  ball: BallState,
+  kicker: Actor,
+  keeper: Actor,
+  wall: Actor[],
+  spot: KickSpot
+) {
   const ballPos = freeKickPosition(spot);
   ball.object.position.copy(ballPos);
   ball.vel.set(0, 0, 0);
@@ -1025,8 +1833,15 @@ function resetShot(ball: BallState, kicker: Actor, keeper: Actor, wall: Actor[],
   ball.lastPos.copy(ballPos);
   ball.knuckleSeed = Math.random() * 100;
 
-  const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ballPos).setY(0).normalize();
-  const runupStart = ballPos.clone().addScaledVector(toGoal, -RUNUP_BACK_STEPS).add(new THREE.Vector3(-0.42, -BALL_R, 0)).setY(0);
+  const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z)
+    .sub(ballPos)
+    .setY(0)
+    .normalize();
+  const runupStart = ballPos
+    .clone()
+    .addScaledVector(toGoal, -RUNUP_BACK_STEPS)
+    .add(new THREE.Vector3(-0.42, -BALL_R, 0))
+    .setY(0);
   kicker.pos.copy(runupStart);
   kicker.dir.copy(ballPos.clone().sub(kicker.pos).setY(0).normalize());
   kicker.vel.set(0, 0, 0);
@@ -1062,19 +1877,32 @@ function predictShotResult(ballPos: THREE.Vector3, swipe: SwipeState) {
   return { shot, final, goalLine };
 }
 
-function beginRunup(kicker: Actor, wall: Actor[], keeper: Actor, ball: BallState, swipe: SwipeState) {
-  kicker.kickTime = 0.72;
+function beginRunup(
+  kicker: Actor,
+  wall: Actor[],
+  keeper: Actor,
+  ball: BallState,
+  swipe: SwipeState
+) {
+  kicker.kickTime = 0;
   wall.forEach((w) => (w.jumpTime = 0.42));
 
   const { goalLine } = predictShotResult(ball.object.position, swipe);
-  keeper.saveTargetX = THREE.MathUtils.clamp(goalLine.x, -GOAL_W / 2 + 0.28, GOAL_W / 2 - 0.28);
+  keeper.saveTargetX = THREE.MathUtils.clamp(
+    goalLine.x,
+    -GOAL_W / 2 + 0.28,
+    GOAL_W / 2 - 0.28
+  );
   keeper.saveTargetY = THREE.MathUtils.clamp(goalLine.y, 0.35, GOAL_H + 0.15);
 
-  const targetSide = keeper.saveTargetX < -0.28 ? -1 : keeper.saveTargetX > 0.28 ? 1 : 0;
+  const targetSide =
+    keeper.saveTargetX < -0.28 ? -1 : keeper.saveTargetX > 0.28 ? 1 : 0;
   const quality = Math.random();
-  keeper.diveDir = quality < 0.08 ? -targetSide || (Math.random() > 0.5 ? 1 : -1) : targetSide;
-  keeper.diveHeight = keeper.saveTargetY < 0.8 ? 0.62 : keeper.saveTargetY > 1.7 ? 1.78 : 1.18;
-  keeper.diveDelay = quality > 0.7 ? 0.06 : quality > 0.25 ? 0.12 : 0.18;
+  keeper.diveDir =
+    quality < 0.08 ? -targetSide || (Math.random() > 0.5 ? 1 : -1) : targetSide;
+  keeper.diveHeight =
+    keeper.saveTargetY < 0.8 ? 0.62 : keeper.saveTargetY > 1.7 ? 1.78 : 1.18;
+  keeper.diveDelay = quality > 0.7 ? 0.035 : quality > 0.25 ? 0.085 : 0.135;
   keeper.diveTime = 0;
 }
 
@@ -1105,7 +1933,10 @@ function rollBall(ball: BallState, move: THREE.Vector3, dt: number) {
     ball.object.quaternion.premultiply(QTMP);
   }
   const curveSpin = Math.abs(ball.curve) * 0.08 + 0.04;
-  QTMP.setFromAxisAngle(new THREE.Vector3(0, Math.sign(ball.curve || 1), 0), curveSpin * Math.max(1, dt * 60));
+  QTMP.setFromAxisAngle(
+    new THREE.Vector3(0, Math.sign(ball.curve || 1), 0),
+    curveSpin * Math.max(1, dt * 60)
+  );
   ball.object.quaternion.premultiply(QTMP);
 }
 
@@ -1116,7 +1947,11 @@ function updateBall(ball: BallState, dt: number) {
     ball.netVel.multiplyScalar(Math.pow(0.82, dt * 60));
     const prev = ball.object.position.clone();
     ball.object.position.addScaledVector(ball.netVel, dt);
-    ball.object.position.z = THREE.MathUtils.clamp(ball.object.position.z, GOAL_LINE_Z - GOAL_D + 0.18, GOAL_LINE_Z - 0.18);
+    ball.object.position.z = THREE.MathUtils.clamp(
+      ball.object.position.z,
+      GOAL_LINE_Z - GOAL_D + 0.18,
+      GOAL_LINE_Z - 0.18
+    );
     ball.object.position.y = Math.max(BALL_R, ball.object.position.y);
     rollBall(ball, ball.object.position.clone().sub(prev), dt);
     if (ball.netAge > 1.15 || ball.netVel.length() < 0.04) ball.flying = false;
@@ -1131,11 +1966,20 @@ function updateBall(ball: BallState, dt: number) {
   if (ball.shotAge <= ball.shotDuration) {
     const t = THREE.MathUtils.clamp(ball.shotAge / ball.shotDuration, 0, 1);
     const eased = 1 - Math.pow(1 - t, 1.25);
-    const next = shotPoint(ball.shotStart, ball.shotTarget, ball.curve, ball.lift, eased);
+    const next = shotPoint(
+      ball.shotStart,
+      ball.shotTarget,
+      ball.curve,
+      ball.lift,
+      eased
+    );
     ball.vel.copy(next).sub(prev).divideScalar(Math.max(0.0001, dt));
     ball.object.position.copy(next);
   } else {
-    const knuckle = Math.sin(ball.shotAge * 12 + ball.knuckleSeed) * Math.abs(ball.curve) * 0.22;
+    const knuckle =
+      Math.sin(ball.shotAge * 12 + ball.knuckleSeed) *
+      Math.abs(ball.curve) *
+      0.22;
     ball.vel.x += (knuckle - ball.vel.x * 0.025) * dt;
     ball.vel.y -= 8.6 * dt;
     ball.vel.multiplyScalar(Math.pow(0.992, dt * 60));
@@ -1145,21 +1989,35 @@ function updateBall(ball: BallState, dt: number) {
       ball.object.position.y = BALL_R;
       if (Math.abs(ball.vel.y) > 0.9) ball.vel.y = -ball.vel.y * 0.34;
       else ball.vel.y = 0;
-      ball.vel.x *= Math.pow(0.90, dt * 60);
-      ball.vel.z *= Math.pow(0.90, dt * 60);
+      ball.vel.x *= Math.pow(0.9, dt * 60);
+      ball.vel.z *= Math.pow(0.9, dt * 60);
     }
   }
 
   rollBall(ball, ball.object.position.clone().sub(prev), dt);
   ball.lastPos.copy(prev);
 
-  if (ball.object.position.y <= BALL_R + 0.01 && ball.vel.length() < 0.18) ball.flying = false;
-  if (ball.object.position.z < GOAL_LINE_Z - GOAL_D - 5.5 || Math.abs(ball.object.position.x) > FIELD_W * 0.85 || ball.object.position.y > GOAL_H + 8) ball.flying = false;
+  if (ball.object.position.y <= BALL_R + 0.01 && ball.vel.length() < 0.18)
+    ball.flying = false;
+  if (
+    ball.object.position.z < GOAL_LINE_Z - GOAL_D - 5.5 ||
+    Math.abs(ball.object.position.x) > FIELD_W * 0.85 ||
+    ball.object.position.y > GOAL_H + 8
+  )
+    ball.flying = false;
 }
 
-function segmentDistanceToBall(a: THREE.Vector3, b: THREE.Vector3, p: THREE.Vector3) {
+function segmentDistanceToBall(
+  a: THREE.Vector3,
+  b: THREE.Vector3,
+  p: THREE.Vector3
+) {
   const ab = b.clone().sub(a);
-  const t = THREE.MathUtils.clamp(p.clone().sub(a).dot(ab) / Math.max(0.0001, ab.lengthSq()), 0, 1);
+  const t = THREE.MathUtils.clamp(
+    p.clone().sub(a).dot(ab) / Math.max(0.0001, ab.lengthSq()),
+    0,
+    1
+  );
   return a.clone().addScaledVector(ab, t).distanceTo(p);
 }
 
@@ -1167,26 +2025,68 @@ function keeperSaveCheck(keeper: Actor, ball: BallState, dt: number) {
   if (!ball.flying || ball.netCaught) return false;
   if (keeper.diveDelay > 0) {
     keeper.diveDelay = Math.max(0, keeper.diveDelay - dt);
-    if (keeper.diveDelay <= 0) keeper.diveTime = 0.9;
+    if (keeper.diveDelay <= 0) keeper.diveTime = 0.95;
   }
 
   const reaction = Math.max(0, 1 - keeper.diveDelay * 5.2);
-  const targetStep = THREE.MathUtils.clamp(keeper.saveTargetX * 0.42 + keeper.diveDir * 0.65, -1.55, 1.55);
-  keeper.pos.x = THREE.MathUtils.lerp(keeper.pos.x, targetStep, 0.12 * reaction + 0.035);
+  const targetStep = THREE.MathUtils.clamp(
+    keeper.saveTargetX * 0.5 + keeper.diveDir * 0.82,
+    -1.82,
+    1.82
+  );
+  keeper.pos.x = THREE.MathUtils.lerp(
+    keeper.pos.x,
+    targetStep,
+    0.18 * reaction + 0.055
+  );
 
-  const nearGoal = ball.object.position.z < GOAL_LINE_Z + 1.85 && ball.object.position.z > GOAL_LINE_Z - 0.75;
+  const nearGoal =
+    ball.object.position.z < GOAL_LINE_Z + 1.85 &&
+    ball.object.position.z > GOAL_LINE_Z - 0.75;
   if (!nearGoal) return false;
 
+  const side =
+    keeper.diveDir || (ball.object.position.x < keeper.pos.x ? -1 : 1);
   const bodyCenter = keeper.pos.clone().add(new THREE.Vector3(0, 1.05, 0));
-  const gloveCenter = keeper.pos.clone().add(new THREE.Vector3(keeper.diveDir * 1.48, keeper.diveHeight, 0));
-  const highGlove = keeper.pos.clone().add(new THREE.Vector3(keeper.diveDir * 1.92, keeper.diveHeight + 0.22, 0));
-  const bodyReach = 0.64;
-  const gloveReach = keeper.diveDir === 0 ? 1.08 : 1.5;
+  const gloveCenter = keeper.pos
+    .clone()
+    .add(new THREE.Vector3(side * 1.62, keeper.diveHeight, -0.04));
+  const secondGlove = keeper.pos
+    .clone()
+    .add(
+      new THREE.Vector3(
+        side * 1.18,
+        THREE.MathUtils.lerp(0.78, keeper.diveHeight + 0.2, 0.65),
+        -0.02
+      )
+    );
+  const highGlove = keeper.pos
+    .clone()
+    .add(new THREE.Vector3(side * 2.08, keeper.diveHeight + 0.28, -0.04));
+  const bodyReach = 0.66;
+  const gloveReach = keeper.diveDir === 0 ? 1.1 : 1.62;
 
-  if (bodyCenter.distanceTo(ball.object.position) < bodyReach || gloveCenter.distanceTo(ball.object.position) < gloveReach || segmentDistanceToBall(gloveCenter, highGlove, ball.object.position) < BALL_R + 0.32) {
-    const push = ball.object.position.clone().sub(gloveCenter).setY(0).normalize();
-    if (push.lengthSq() < 0.001) push.set(keeper.diveDir || (ball.object.position.x < 0 ? -1 : 1), 0, 0.25).normalize();
-    ball.vel.set(push.x * 5.2, Math.max(1.4, ball.vel.y * 0.2 + 1.8), Math.max(1.2, Math.abs(ball.vel.z) * 0.28));
+  if (
+    bodyCenter.distanceTo(ball.object.position) < bodyReach ||
+    gloveCenter.distanceTo(ball.object.position) < gloveReach ||
+    secondGlove.distanceTo(ball.object.position) < 1.08 ||
+    segmentDistanceToBall(gloveCenter, highGlove, ball.object.position) <
+      BALL_R + 0.42
+  ) {
+    const push = ball.object.position
+      .clone()
+      .sub(gloveCenter)
+      .setY(0)
+      .normalize();
+    if (push.lengthSq() < 0.001)
+      push
+        .set(keeper.diveDir || (ball.object.position.x < 0 ? -1 : 1), 0, 0.25)
+        .normalize();
+    ball.vel.set(
+      push.x * 5.6,
+      Math.max(1.25, ball.vel.y * 0.18 + 1.7),
+      Math.max(1.35, Math.abs(ball.vel.z) * 0.24)
+    );
     ball.object.position.addScaledVector(push, BALL_R * 1.2);
     ball.shotAge = ball.shotDuration + 0.01;
     return true;
@@ -1194,7 +2094,18 @@ function keeperSaveCheck(keeper: Actor, ball: BallState, dt: number) {
   return false;
 }
 
-function wallBlockCheck(wall: Actor[], ball: BallState) { if (!ball.flying || ball.netCaught) return false; for (const actor of wall) { if (!actor.root.visible) continue; const chest = actor.pos.clone().setY(actor.jumpTime > 0 ? 1.55 : 1.15); if (chest.distanceTo(ball.object.position) < 0.55) { ball.flying = false; return true; } } return false; }
+function wallBlockCheck(wall: Actor[], ball: BallState) {
+  if (!ball.flying || ball.netCaught) return false;
+  for (const actor of wall) {
+    if (!actor.root.visible) continue;
+    const chest = actor.pos.clone().setY(actor.jumpTime > 0 ? 1.55 : 1.15);
+    if (chest.distanceTo(ball.object.position) < 0.55) {
+      ball.flying = false;
+      return true;
+    }
+  }
+  return false;
+}
 
 function markGoalCrossing(ball: BallState) {
   if (ball.crossedGoalLine || ball.hitFrame) return false;
@@ -1205,7 +2116,10 @@ function markGoalCrossing(ball: BallState) {
   const ratio = (prev.z - GOAL_LINE_Z) / Math.max(0.0001, prev.z - curr.z);
   const x = THREE.MathUtils.lerp(prev.x, curr.x, ratio);
   const y = THREE.MathUtils.lerp(prev.y, curr.y, ratio);
-  ball.crossedGoalLine = Math.abs(x) <= GOAL_W / 2 - BALL_R && y >= BALL_R && y <= GOAL_H - BALL_R * 0.25;
+  ball.crossedGoalLine =
+    Math.abs(x) <= GOAL_W / 2 - BALL_R &&
+    y >= BALL_R &&
+    y <= GOAL_H - BALL_R * 0.25;
   return ball.crossedGoalLine;
 }
 
@@ -1215,18 +2129,33 @@ function reflectFromGoalFrame(ball: BallState) {
   if (p.z > GOAL_LINE_Z + 0.22 || p.z < GOAL_LINE_Z - 0.35) return false;
   const radius = BALL_R + POST_R * 1.25;
   const candidates = [
-    [new THREE.Vector3(-GOAL_W / 2, 0, GOAL_LINE_Z), new THREE.Vector3(-GOAL_W / 2, GOAL_H, GOAL_LINE_Z)],
-    [new THREE.Vector3(GOAL_W / 2, 0, GOAL_LINE_Z), new THREE.Vector3(GOAL_W / 2, GOAL_H, GOAL_LINE_Z)],
-    [new THREE.Vector3(-GOAL_W / 2, GOAL_H, GOAL_LINE_Z), new THREE.Vector3(GOAL_W / 2, GOAL_H, GOAL_LINE_Z)],
+    [
+      new THREE.Vector3(-GOAL_W / 2, 0, GOAL_LINE_Z),
+      new THREE.Vector3(-GOAL_W / 2, GOAL_H, GOAL_LINE_Z)
+    ],
+    [
+      new THREE.Vector3(GOAL_W / 2, 0, GOAL_LINE_Z),
+      new THREE.Vector3(GOAL_W / 2, GOAL_H, GOAL_LINE_Z)
+    ],
+    [
+      new THREE.Vector3(-GOAL_W / 2, GOAL_H, GOAL_LINE_Z),
+      new THREE.Vector3(GOAL_W / 2, GOAL_H, GOAL_LINE_Z)
+    ]
   ];
   for (const [a, b] of candidates) {
     const ab = b.clone().sub(a);
-    const t = THREE.MathUtils.clamp(p.clone().sub(a).dot(ab) / Math.max(0.0001, ab.lengthSq()), 0, 1);
+    const t = THREE.MathUtils.clamp(
+      p.clone().sub(a).dot(ab) / Math.max(0.0001, ab.lengthSq()),
+      0,
+      1
+    );
     const closest = a.clone().addScaledVector(ab, t);
     if (closest.distanceTo(p) <= radius) {
       const normal = p.clone().sub(closest).normalize();
       if (normal.lengthSq() < 0.001) normal.set(0, 0, 1);
-      ball.object.position.copy(closest).addScaledVector(normal, radius + 0.015);
+      ball.object.position
+        .copy(closest)
+        .addScaledVector(normal, radius + 0.015);
       ball.vel.reflect(normal).multiplyScalar(0.72);
       ball.vel.z = Math.max(ball.vel.z, 1.1);
       ball.hitFrame = true;
@@ -1241,7 +2170,8 @@ function netCatchCheck(ball: BallState, netRig: NetRig) {
   if (!ball.flying || ball.netCaught || !ball.crossedGoalLine) return false;
   const p = ball.object.position;
   const inGoalDepth = p.z <= GOAL_LINE_Z - GOAL_D + 0.2;
-  const stillInsideGoal = Math.abs(p.x) <= GOAL_W / 2 + 0.35 && p.y <= GOAL_H + 0.32;
+  const stillInsideGoal =
+    Math.abs(p.x) <= GOAL_W / 2 + 0.35 && p.y <= GOAL_H + 0.32;
   if (inGoalDepth && stillInsideGoal) {
     catchBallInNet(ball, netRig);
     return true;
@@ -1249,10 +2179,14 @@ function netCatchCheck(ball: BallState, netRig: NetRig) {
   return false;
 }
 
-function decideShot(ball: BallState, blocked: boolean, saved: boolean): Decision {
-  if (blocked) return "BLOCKED";
-  if (saved) return "SAVE";
-  return ball.crossedGoalLine || ball.netCaught ? "GOAL" : "NO GOAL";
+function decideShot(
+  ball: BallState,
+  blocked: boolean,
+  saved: boolean
+): Decision {
+  if (blocked) return 'BLOCKED';
+  if (saved) return 'SAVE';
+  return ball.crossedGoalLine || ball.netCaught ? 'GOAL' : 'NO GOAL';
 }
 
 function catchBallInNet(ball: BallState, netRig: NetRig) {
@@ -1265,20 +2199,53 @@ function catchBallInNet(ball: BallState, netRig: NetRig) {
   triggerNetShake(netRig, ball.object.position.clone());
 }
 
-function placeCameraForNextShot(camera: THREE.PerspectiveCamera, kicker: Actor, cameraYaw = 0) {
-  const lookPoint = new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25);
-  const behindOffset = new THREE.Vector3(kicker.pos.x * 0.45, 0, kicker.pos.z + 2.85)
+function randomKickSpot(): KickSpot {
+  const spots: KickSpot[] = ['left', 'center', 'right', 'near16'];
+  return spots[Math.floor(Math.random() * spots.length)];
+}
+
+function placeCameraForNextShot(
+  camera: THREE.PerspectiveCamera,
+  kicker: Actor,
+  cameraYaw = 0,
+  cameraHeight = 0
+) {
+  const lookPoint = new THREE.Vector3(
+    0,
+    1.22 + cameraHeight * 0.35,
+    GOAL_LINE_Z + 0.25
+  );
+  const behindOffset = new THREE.Vector3(
+    kicker.pos.x * 0.45,
+    0,
+    kicker.pos.z + 2.85
+  )
     .sub(new THREE.Vector3(lookPoint.x, 0, lookPoint.z))
     .applyAxisAngle(new THREE.Vector3(0, 1, 0), cameraYaw);
-  camera.position.set(lookPoint.x + behindOffset.x, 1.22, lookPoint.z + behindOffset.z);
+  camera.position.set(
+    lookPoint.x + behindOffset.x,
+    1.22 + cameraHeight,
+    lookPoint.z + behindOffset.z
+  );
   camera.lookAt(lookPoint);
 }
 
 export default function FreeKickGame() {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const swipeRef = useRef<SwipeState>({ active: false, startX: 0, startY: 0, endX: 0, endY: 0 });
-  const [hud, setHud] = useState({ goals: 0, saves: 0, spot: "center" as KickSpot, state: "Swipe to aim and shoot" });
+  const swipeRef = useRef<SwipeState>({
+    active: false,
+    startX: 0,
+    startY: 0,
+    endX: 0,
+    endY: 0
+  });
+  const [hud, setHud] = useState({
+    goals: 0,
+    saves: 0,
+    spot: 'center' as KickSpot,
+    state: 'Swipe to aim and shoot'
+  });
   useEffect(() => {
     const host = hostRef.current;
     const canvas = canvasRef.current;
@@ -1293,7 +2260,10 @@ export default function FreeKickGame() {
     const camera = new THREE.PerspectiveCamera(62, 1, 0.05, 140);
     scene.add(new THREE.AmbientLight(0xffffff, 0.68));
     const sun = new THREE.DirectionalLight(0xffffff, 1.35);
-    sun.position.set(8, 16, 10); sun.castShadow = true; sun.shadow.mapSize.set(2048, 2048); scene.add(sun);
+    sun.position.set(8, 16, 10);
+    sun.castShadow = true;
+    sun.shadow.mapSize.set(2048, 2048);
+    scene.add(sun);
     const netRig: NetRig = { lines: [], shake: 0, impact: new THREE.Vector3() };
     const loader = new GLTFLoader();
     const stadium = makeHalfField(scene, netRig, loader);
@@ -1303,39 +2273,112 @@ export default function FreeKickGame() {
     const audio = makeGoalRushAudio();
     const characterColors = shuffledCharacterColors();
     const characterUrls = shuffledCharacterUrls();
-    const actorKitColor = (index: number) => characterColors[index % characterColors.length];
-    const actorModelUrl = (index: number) => characterUrls[index % characterUrls.length] ?? HUMAN_URL;
-    const kicker = createActor(scene, loader, "kicker", new THREE.Vector3(0, 0, 6), 0, actorKitColor(0), actorModelUrl(0));
-    const keeper = createActor(scene, loader, "keeper", new THREE.Vector3(0, 0, GOAL_LINE_Z + 0.36), 0, actorKitColor(1), actorModelUrl(1));
-    const wall = Array.from({ length: 5 }, (_, i) => createActor(scene, loader, "wall", new THREE.Vector3(0, 0, 0), i, actorKitColor(i + 2), actorModelUrl(i + 2)));
-    let spot: KickSpot = "center"; let state: ShotState = "aim"; let resultTimer = 0; let varTimer = 0; let replayIndex = 0; let replayClock = 0; let pendingDecision: Decision = "NO GOAL"; let shotBlocked = false; let shotSaved = false; let shotFinalized = false; let netTriggered = false; let cameraYaw = 0; const replayFrames: ReplayFrame[] = []; let score = { goals: 0, saves: 0 }; resetShot(ball, kicker, keeper, wall, spot);
-    placeCameraForNextShot(camera, kicker, cameraYaw);
-    const resize = () => { const w = Math.max(1, host.clientWidth); const h = Math.max(1, host.clientHeight); renderer.setSize(w, h, false); renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1)); camera.aspect = w / h; camera.updateProjectionMatrix(); };
-    resize(); window.addEventListener("resize", resize);
+    const actorKitColor = (index: number) =>
+      characterColors[index % characterColors.length];
+    const actorModelUrl = (index: number) =>
+      characterUrls[index % characterUrls.length] ?? HUMAN_URL;
+    const kicker = createActor(
+      scene,
+      loader,
+      'kicker',
+      new THREE.Vector3(0, 0, 6),
+      0,
+      actorKitColor(0),
+      actorModelUrl(0)
+    );
+    const keeper = createActor(
+      scene,
+      loader,
+      'keeper',
+      new THREE.Vector3(0, 0, GOAL_LINE_Z + 0.36),
+      0,
+      actorKitColor(1),
+      actorModelUrl(1)
+    );
+    const wall = Array.from({ length: 5 }, (_, i) =>
+      createActor(
+        scene,
+        loader,
+        'wall',
+        new THREE.Vector3(0, 0, 0),
+        i,
+        actorKitColor(i + 2),
+        actorModelUrl(i + 2)
+      )
+    );
+    let spot: KickSpot = randomKickSpot();
+    let state: ShotState = 'aim';
+    let resultTimer = 0;
+    let varTimer = 0;
+    let replayIndex = 0;
+    let replayClock = 0;
+    let pendingDecision: Decision = 'NO GOAL';
+    let shotBlocked = false;
+    let shotSaved = false;
+    let shotFinalized = false;
+    let netTriggered = false;
+    let strikeCommitted = false;
+    let cameraYaw = 0;
+    let cameraHeight = 0;
+    const replayFrames: ReplayFrame[] = [];
+    let score = { goals: 0, saves: 0 };
+    resetShot(ball, kicker, keeper, wall, spot);
+    placeCameraForNextShot(camera, kicker, cameraYaw, cameraHeight);
+    const resize = () => {
+      const w = Math.max(1, host.clientWidth);
+      const h = Math.max(1, host.clientHeight);
+      renderer.setSize(w, h, false);
+      renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    };
+    resize();
+    window.addEventListener('resize', resize);
     const onDown = (e: PointerEvent) => {
       audio.start();
       const rect = host.getBoundingClientRect();
-      const cameraZone = state !== "aim" || e.clientY - rect.top < rect.height * 0.42;
-      swipeRef.current = { active: true, startX: e.clientX, startY: e.clientY, endX: e.clientX, endY: e.clientY, mode: cameraZone ? "camera" : "shot" };
-      if (!cameraZone && state === "aim") setAimCurve(aimLine, ball.object.position, swipeRef.current);
+      const cameraZone =
+        state !== 'aim' ||
+        e.clientY - rect.top < rect.height * 0.5 ||
+        e.clientX - rect.left > rect.width * 0.72;
+      swipeRef.current = {
+        active: true,
+        startX: e.clientX,
+        startY: e.clientY,
+        endX: e.clientX,
+        endY: e.clientY,
+        mode: cameraZone ? 'camera' : 'shot'
+      };
+      if (!cameraZone && state === 'aim')
+        setAimCurve(aimLine, ball.object.position, swipeRef.current);
     };
     const onMove = (e: PointerEvent) => {
       if (!swipeRef.current.active) return;
-      if (swipeRef.current.mode === "camera") {
+      if (swipeRef.current.mode === 'camera') {
         const dx = e.clientX - swipeRef.current.endX;
-        cameraYaw = THREE.MathUtils.clamp(cameraYaw + dx / 260, -CAMERA_YAW_LIMIT, CAMERA_YAW_LIMIT);
+        const dy = e.clientY - swipeRef.current.endY;
+        cameraYaw = THREE.MathUtils.clamp(
+          cameraYaw + dx / 420,
+          -CAMERA_YAW_LIMIT,
+          CAMERA_YAW_LIMIT
+        );
+        cameraHeight = THREE.MathUtils.clamp(
+          cameraHeight - dy / 520,
+          -CAMERA_HEIGHT_LIMIT * 0.55,
+          CAMERA_HEIGHT_LIMIT
+        );
         swipeRef.current.endX = e.clientX;
         swipeRef.current.endY = e.clientY;
         return;
       }
-      if (state !== "aim") return;
+      if (state !== 'aim') return;
       swipeRef.current.endX = e.clientX;
       swipeRef.current.endY = e.clientY;
       setAimCurve(aimLine, ball.object.position, swipeRef.current);
     };
     const onUp = (e: PointerEvent) => {
       if (!swipeRef.current.active) return;
-      if (swipeRef.current.mode === "camera" || state !== "aim") {
+      if (swipeRef.current.mode === 'camera' || state !== 'aim') {
         swipeRef.current.active = false;
         return;
       }
@@ -1348,134 +2391,396 @@ export default function FreeKickGame() {
       shotSaved = false;
       shotFinalized = false;
       netTriggered = false;
+      strikeCommitted = false;
       replayFrames.length = 0;
-      state = "runup";
-      setHud((h) => ({ ...h, state: "2-step run-up..." }));
+      state = 'runup';
+      setHud((h) => ({ ...h, state: '2-step run-up...' }));
     };
-    canvas.addEventListener("pointerdown", onDown); canvas.addEventListener("pointermove", onMove); canvas.addEventListener("pointerup", onUp); canvas.addEventListener("pointercancel", onUp);
-    const recordReplayFrame = (look: THREE.Vector3) => { if (replayFrames.length > 220) replayFrames.shift(); replayFrames.push({ ball: ball.object.position.clone(), quat: ball.object.quaternion.clone(), cam: camera.position.clone(), look: look.clone(), keeper: keeper.root.position.clone(), keeperRot: keeper.root.rotation.clone(), kicker: kicker.root.position.clone(), kickerRot: kicker.root.rotation.clone() }); };
-    let last = performance.now(); let frame = 0;
+    canvas.addEventListener('pointerdown', onDown);
+    canvas.addEventListener('pointermove', onMove);
+    canvas.addEventListener('pointerup', onUp);
+    canvas.addEventListener('pointercancel', onUp);
+    const recordReplayFrame = (look: THREE.Vector3) => {
+      if (replayFrames.length > 220) replayFrames.shift();
+      replayFrames.push({
+        ball: ball.object.position.clone(),
+        quat: ball.object.quaternion.clone(),
+        cam: camera.position.clone(),
+        look: look.clone(),
+        keeper: keeper.root.position.clone(),
+        keeperRot: keeper.root.rotation.clone(),
+        kicker: kicker.root.position.clone(),
+        kickerRot: kicker.root.rotation.clone()
+      });
+    };
+    let last = performance.now();
+    let frame = 0;
     const loop = () => {
       frame = requestAnimationFrame(loop);
-      const now = performance.now(); const dt = Math.min(DT_MAX, (now - last) / 1000); last = now;
-      if (state === "aim" && swipeRef.current.active && swipeRef.current.mode === "shot") setAimCurve(aimLine, ball.object.position, swipeRef.current);
-      if (state === "runup") {
-        const strikeSpot = ball.object.position.clone().add(new THREE.Vector3(-0.24, -BALL_R, 0.42)).setY(0);
+      const now = performance.now();
+      const dt = Math.min(DT_MAX, (now - last) / 1000);
+      last = now;
+      if (
+        state === 'aim' &&
+        swipeRef.current.active &&
+        swipeRef.current.mode === 'shot'
+      )
+        setAimCurve(aimLine, ball.object.position, swipeRef.current);
+      if (state === 'runup') {
+        const strikeSpot = ball.object.position
+          .clone()
+          .add(new THREE.Vector3(-0.24, -BALL_R, 0.42))
+          .setY(0);
         TMP.copy(strikeSpot).sub(kicker.pos).setY(0);
-        if (TMP.length() > 0.055) { kicker.dir.copy(TMP.clone().normalize()); kicker.vel.copy(kicker.dir).multiplyScalar(4.05); kicker.pos.addScaledVector(kicker.vel, dt); kicker.speed = kicker.vel.length(); } else { kicker.speed = 0; }
-        if (kicker.kickTime < 0.34 && !ball.flying) { replayFrames.length = 0; recordReplayFrame(new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25)); shootBall(ball, swipeRef.current); audio.kick(); state = "flight"; setHud((h) => ({ ...h, state: "Right-foot strike · recording replay" })); }
-      } else { kicker.speed = 0; }
-      updateBall(ball, dt); updateNetShake(netRig, dt);
-      if (state === "flight") {
+        if (!strikeCommitted && TMP.length() > 0.055) {
+          kicker.dir.copy(TMP.clone().normalize());
+          kicker.vel.copy(kicker.dir).multiplyScalar(3.15);
+          kicker.pos.addScaledVector(kicker.vel, dt);
+          kicker.speed = kicker.vel.length();
+        } else {
+          kicker.speed = 0;
+          if (!strikeCommitted) {
+            strikeCommitted = true;
+            kicker.kickTime = 0.72;
+          }
+        }
+        if (strikeCommitted && kicker.kickTime < 0.34 && !ball.flying) {
+          replayFrames.length = 0;
+          recordReplayFrame(new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25));
+          shootBall(ball, swipeRef.current);
+          audio.kick();
+          state = 'flight';
+          setHud((h) => ({
+            ...h,
+            state: 'Right-foot strike · recording replay'
+          }));
+        }
+      } else {
+        kicker.speed = 0;
+      }
+      updateBall(ball, dt);
+      updateNetShake(netRig, dt);
+      if (state === 'flight') {
         if (!shotBlocked && wallBlockCheck(wall, ball)) {
           shotBlocked = true;
           shotFinalized = true;
-          pendingDecision = "BLOCKED";
+          pendingDecision = 'BLOCKED';
           audio.save();
-          state = "result";
+          state = 'result';
           resultTimer = 0.38;
           score.saves += 1;
-          setHud((h) => ({ ...h, saves: score.saves, state: "BLOCKED · next free kick" }));
+          setHud((h) => ({
+            ...h,
+            saves: score.saves,
+            state: 'BLOCKED · next free kick'
+          }));
         }
         if (!shotFinalized && !shotSaved && keeperSaveCheck(keeper, ball, dt)) {
           shotSaved = true;
           shotFinalized = true;
-          pendingDecision = "SAVE";
+          pendingDecision = 'SAVE';
           ball.flying = false;
           audio.save();
-          state = "result";
+          state = 'result';
           resultTimer = 0.42;
           score.saves += 1;
-          setHud((h) => ({ ...h, saves: score.saves, state: "SAVE · next free kick" }));
+          setHud((h) => ({
+            ...h,
+            saves: score.saves,
+            state: 'SAVE · next free kick'
+          }));
         }
-        if (!shotFinalized && markGoalCrossing(ball)) setHud((h) => ({ ...h, state: "Ball crossed line · still travelling" }));
-        if (!shotFinalized && !shotBlocked && !shotSaved && reflectFromGoalFrame(ball)) { audio.save(); setHud((h) => ({ ...h, state: "Off the frame · ball still live" })); }
-        if (!shotFinalized && !netTriggered && !shotBlocked && !shotSaved && netCatchCheck(ball, netRig)) { netTriggered = true; audio.net(); setHud((h) => ({ ...h, state: "Net contact · checking VAR" })); }
+        if (!shotFinalized && markGoalCrossing(ball))
+          setHud((h) => ({
+            ...h,
+            state: 'Ball crossed line · still travelling'
+          }));
+        if (
+          !shotFinalized &&
+          !shotBlocked &&
+          !shotSaved &&
+          reflectFromGoalFrame(ball)
+        ) {
+          audio.save();
+          setHud((h) => ({ ...h, state: 'Off the frame · ball still live' }));
+        }
+        if (
+          !shotFinalized &&
+          !netTriggered &&
+          !shotBlocked &&
+          !shotSaved &&
+          netCatchCheck(ball, netRig)
+        ) {
+          netTriggered = true;
+          audio.net();
+          setHud((h) => ({ ...h, state: 'Net contact · checking VAR' }));
+        }
         if (!ball.flying && !shotFinalized) {
           shotFinalized = true;
           pendingDecision = decideShot(ball, shotBlocked, shotSaved);
-          if (pendingDecision === "GOAL") {
+          if (pendingDecision === 'GOAL') {
             varTimer = 1.05;
-            state = "var";
-            setHud((h) => ({ ...h, state: "VAR CHECK: ball crossed line" }));
+            state = 'var';
+            setHud((h) => ({ ...h, state: 'VAR CHECK: ball crossed line' }));
           } else {
-            state = "result";
+            state = 'result';
             resultTimer = 0.45;
             score.saves += 1;
-            setHud((h) => ({ ...h, saves: score.saves, state: `${pendingDecision} · next free kick` }));
+            setHud((h) => ({
+              ...h,
+              saves: score.saves,
+              state: `${pendingDecision} · next free kick`
+            }));
           }
         }
       }
-      if (state === "var") { varTimer -= dt; if (varTimer <= 0) { state = "replay"; replayIndex = 0; replayClock = 0; setHud((h) => ({ ...h, state: `SLOW REPLAY: ${pendingDecision}` })); } }
-      if (state === "replay") {
-        replayClock += dt * 0.48; replayIndex = Math.floor(replayClock * 30);
-        const frameData = replayFrames[Math.min(replayFrames.length - 1, replayIndex)];
-        if (frameData) {
-          ball.object.position.copy(frameData.ball); ball.object.quaternion.copy(frameData.quat); keeper.root.position.copy(frameData.keeper); keeper.root.rotation.copy(frameData.keeperRot); kicker.root.position.copy(frameData.kicker); kicker.root.rotation.copy(frameData.kickerRot);
-          const orbitPhase = replayIndex * 0.045;
-          const dynamicOffset = new THREE.Vector3(Math.sin(orbitPhase) * 0.85, 0.25 + Math.sin(orbitPhase * 0.7) * 0.18, Math.cos(orbitPhase) * 0.65);
-          const replayCam = frameData.cam.clone().lerp(frameData.ball.clone().add(new THREE.Vector3(0, 1.25, 3.9)).add(dynamicOffset), 0.42);
-          const replayLook = frameData.look.clone().lerp(frameData.ball.clone().add(new THREE.Vector3(0, 0.28, 0)), 0.52);
-          camera.position.copy(replayCam); camera.lookAt(replayLook);
+      if (state === 'var') {
+        varTimer -= dt;
+        if (varTimer <= 0) {
+          state = 'replay';
+          replayIndex = 0;
+          replayClock = 0;
+          setHud((h) => ({ ...h, state: `SLOW REPLAY: ${pendingDecision}` }));
         }
-        if (replayIndex >= replayFrames.length - 1 || replayFrames.length === 0) { state = "result"; resultTimer = pendingDecision === "GOAL" ? 2.65 : 1.05; if (pendingDecision === "GOAL") { audio.goal(); triggerCrowdCheer(stadium); kicker.celebrateTime = 2.45; score.goals += 1; setHud((h) => ({ ...h, goals: score.goals, state: "VAR: GOAL confirmed" })); } else { score.saves += 1; setHud((h) => ({ ...h, saves: score.saves, state: `VAR: ${pendingDecision}` })); } }
       }
-      if (state === "result") { resultTimer -= dt; if (resultTimer <= 0) { state = "aim"; shotBlocked = false; shotSaved = false; shotFinalized = false; netTriggered = false; replayFrames.length = 0; resetShot(ball, kicker, keeper, wall, spot); placeCameraForNextShot(camera, kicker, cameraYaw); setHud((h) => ({ ...h, state: "Swipe to aim and shoot" })); } }
-      if (state !== "replay") {
-        updateActorBase(kicker, dt); applyKickerPose(kicker); applyGoalDancePose(kicker); updateActorBase(keeper, dt); applyKeeperPose(keeper);
-        wall.forEach((w) => { updateActorBase(w, dt); applyWallPose(w); if (w.jumpTime > 0) w.jumpTime = Math.max(0, w.jumpTime - dt); });
-        if (kicker.kickTime > 0) kicker.kickTime = Math.max(0, kicker.kickTime - dt);
-        if (keeper.diveTime > 0) keeper.diveTime = Math.max(0, keeper.diveTime - dt);
-        if (kicker.celebrateTime > 0) kicker.celebrateTime = Math.max(0, kicker.celebrateTime - dt);
+      if (state === 'replay') {
+        replayClock += dt * 0.48;
+        replayIndex = Math.floor(replayClock * 30);
+        const frameData =
+          replayFrames[Math.min(replayFrames.length - 1, replayIndex)];
+        if (frameData) {
+          ball.object.position.copy(frameData.ball);
+          ball.object.quaternion.copy(frameData.quat);
+          keeper.root.position.copy(frameData.keeper);
+          keeper.root.rotation.copy(frameData.keeperRot);
+          kicker.root.position.copy(frameData.kicker);
+          kicker.root.rotation.copy(frameData.kickerRot);
+          const orbitPhase = replayIndex * 0.045;
+          const dynamicOffset = new THREE.Vector3(
+            Math.sin(orbitPhase) * 0.85,
+            0.25 + Math.sin(orbitPhase * 0.7) * 0.18,
+            Math.cos(orbitPhase) * 0.65
+          );
+          const replayCam = frameData.cam.clone().lerp(
+            frameData.ball
+              .clone()
+              .add(new THREE.Vector3(0, 1.25, 3.9))
+              .add(dynamicOffset),
+            0.42
+          );
+          const replayLook = frameData.look
+            .clone()
+            .lerp(
+              frameData.ball.clone().add(new THREE.Vector3(0, 0.28, 0)),
+              0.52
+            );
+          camera.position.copy(replayCam);
+          camera.lookAt(replayLook);
+        }
+        if (
+          replayIndex >= replayFrames.length - 1 ||
+          replayFrames.length === 0
+        ) {
+          state = 'result';
+          resultTimer = pendingDecision === 'GOAL' ? 2.65 : 1.05;
+          if (pendingDecision === 'GOAL') {
+            audio.goal();
+            triggerCrowdCheer(stadium);
+            kicker.celebrateTime = 2.45;
+            score.goals += 1;
+            setHud((h) => ({
+              ...h,
+              goals: score.goals,
+              state: 'VAR: GOAL confirmed'
+            }));
+          } else {
+            score.saves += 1;
+            setHud((h) => ({
+              ...h,
+              saves: score.saves,
+              state: `VAR: ${pendingDecision}`
+            }));
+          }
+        }
+      }
+      if (state === 'result') {
+        resultTimer -= dt;
+        if (resultTimer <= 0) {
+          state = 'aim';
+          shotBlocked = false;
+          shotSaved = false;
+          shotFinalized = false;
+          netTriggered = false;
+          strikeCommitted = false;
+          replayFrames.length = 0;
+          spot = randomKickSpot();
+          resetShot(ball, kicker, keeper, wall, spot);
+          placeCameraForNextShot(camera, kicker, cameraYaw, cameraHeight);
+          setHud((h) => ({
+            ...h,
+            spot,
+            state: `Random free kick ${spot} · swipe lower screen to shoot`
+          }));
+        }
+      }
+      if (state !== 'replay') {
+        updateActorBase(kicker, dt);
+        applyKickerPose(kicker);
+        applyGoalDancePose(kicker);
+        updateActorBase(keeper, dt);
+        applyKeeperPose(keeper);
+        wall.forEach((w) => {
+          updateActorBase(w, dt);
+          applyWallPose(w);
+          if (w.jumpTime > 0) w.jumpTime = Math.max(0, w.jumpTime - dt);
+        });
+        if (kicker.kickTime > 0)
+          kicker.kickTime = Math.max(0, kicker.kickTime - dt);
+        if (keeper.diveTime > 0)
+          keeper.diveTime = Math.max(0, keeper.diveTime - dt);
+        if (kicker.celebrateTime > 0)
+          kicker.celebrateTime = Math.max(0, kicker.celebrateTime - dt);
         updateStadiumCrowd(stadium, dt);
       }
       let lookPoint = new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25);
-      if (state !== "replay") {
-        if (ball.flying || state === "var") { const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ball.object.position).setY(0).normalize(); const followOffset = toGoal.clone().multiplyScalar(-4.3).applyAxisAngle(new THREE.Vector3(0, 1, 0), cameraYaw * 0.55); const followPos = ball.object.position.clone().add(followOffset).add(new THREE.Vector3(0, 1.55, 0)); camera.position.lerp(followPos, 0.11); lookPoint = ball.object.position.clone().addScaledVector(toGoal, 6.0).add(new THREE.Vector3(0, 0.55, 0)); camera.lookAt(lookPoint); } else { lookPoint.set(0, 1.22, GOAL_LINE_Z + 0.25); const behindOffset = new THREE.Vector3(kicker.pos.x * 0.45, 0, kicker.pos.z + 2.85).sub(new THREE.Vector3(lookPoint.x, 0, lookPoint.z)).applyAxisAngle(new THREE.Vector3(0, 1, 0), cameraYaw); const behind = new THREE.Vector3(lookPoint.x + behindOffset.x, 1.22, lookPoint.z + behindOffset.z); camera.position.lerp(behind, 0.18); camera.lookAt(lookPoint); }
-        if (state === "flight" || state === "var") recordReplayFrame(lookPoint);
+      if (state !== 'replay') {
+        if (ball.flying || state === 'var') {
+          const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z)
+            .sub(ball.object.position)
+            .setY(0)
+            .normalize();
+          const followOffset = toGoal
+            .clone()
+            .multiplyScalar(-4.3)
+            .applyAxisAngle(new THREE.Vector3(0, 1, 0), cameraYaw * 0.55);
+          const followPos = ball.object.position
+            .clone()
+            .add(followOffset)
+            .add(new THREE.Vector3(0, 1.55, 0));
+          camera.position.lerp(followPos, 0.11);
+          lookPoint = ball.object.position
+            .clone()
+            .addScaledVector(toGoal, 6.0)
+            .add(new THREE.Vector3(0, 0.55, 0));
+          camera.lookAt(lookPoint);
+        } else {
+          lookPoint.set(0, 1.22, GOAL_LINE_Z + 0.25);
+          const behindOffset = new THREE.Vector3(
+            kicker.pos.x * 0.45,
+            0,
+            kicker.pos.z + 2.85
+          )
+            .sub(new THREE.Vector3(lookPoint.x, 0, lookPoint.z))
+            .applyAxisAngle(new THREE.Vector3(0, 1, 0), cameraYaw);
+          const behind = new THREE.Vector3(
+            lookPoint.x + behindOffset.x,
+            1.22 + cameraHeight,
+            lookPoint.z + behindOffset.z
+          );
+          camera.position.lerp(behind, 0.18);
+          camera.lookAt(lookPoint);
+        }
+        if (state === 'flight' || state === 'var') recordReplayFrame(lookPoint);
       }
       renderer.render(scene, camera);
     };
     loop();
-    (window as any).__setFreeKickSpot = (next: KickSpot) => { audio.whistle(); spot = next; state = "aim"; hideAimLine(aimLine); replayFrames.length = 0; resetShot(ball, kicker, keeper, wall, spot); placeCameraForNextShot(camera, kicker, cameraYaw); setHud((h) => ({ ...h, spot, state: `Free kick ${next}: wall ${wallCountForSpot(next)} at 9.15m` })); };
-    return () => { cancelAnimationFrame(frame); window.removeEventListener("resize", resize); canvas.removeEventListener("pointerdown", onDown); canvas.removeEventListener("pointermove", onMove); canvas.removeEventListener("pointerup", onUp); canvas.removeEventListener("pointercancel", onUp); audio.dispose(); renderer.dispose(); };
+    (window as any).__setFreeKickSpot = (next: KickSpot) => {
+      audio.whistle();
+      spot = next;
+      state = 'aim';
+      hideAimLine(aimLine);
+      replayFrames.length = 0;
+      resetShot(ball, kicker, keeper, wall, spot);
+      placeCameraForNextShot(camera, kicker, cameraYaw, cameraHeight);
+      setHud((h) => ({
+        ...h,
+        spot,
+        state: `Free kick ${next}: wall ${wallCountForSpot(next)} at 9.15m`
+      }));
+    };
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('resize', resize);
+      canvas.removeEventListener('pointerdown', onDown);
+      canvas.removeEventListener('pointermove', onMove);
+      canvas.removeEventListener('pointerup', onUp);
+      canvas.removeEventListener('pointercancel', onUp);
+      audio.dispose();
+      renderer.dispose();
+    };
   }, []);
 
-  const setSpot = (spot: KickSpot) => {
-    (window as any).__setFreeKickSpot?.(spot);
-  };
-
-
   return (
-    <div style={{ position: "fixed", inset: 0, background: "#07110b", overflow: "hidden", touchAction: "none", userSelect: "none" }}>
-      <div ref={hostRef} style={{ position: "absolute", inset: 0 }}>
-        <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block", touchAction: "none" }} />
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: '#07110b',
+        overflow: 'hidden',
+        touchAction: 'none',
+        userSelect: 'none'
+      }}
+    >
+      <div ref={hostRef} style={{ position: 'absolute', inset: 0 }}>
+        <canvas
+          ref={canvasRef}
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'block',
+            touchAction: 'none'
+          }}
+        />
       </div>
-      <div style={{ position: "fixed", left: 0, right: 0, top: 0, padding: "12px 14px", display: "flex", justifyContent: "space-between", alignItems: "center", pointerEvents: "none", color: "white", fontFamily: "system-ui,sans-serif", textShadow: "0 2px 8px #000" }}>
-        <div style={{ fontWeight: 900, fontSize: 18 }}>GOALS {hud.goals} · SAVES {hud.saves}</div>
-        <div style={{ fontSize: 11, maxWidth: 220, textAlign: "right", lineHeight: 1.25 }}>{hud.state}</div>
+      <div
+        style={{
+          position: 'fixed',
+          left: 0,
+          right: 0,
+          top: 0,
+          padding: '12px 14px',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          pointerEvents: 'none',
+          color: 'white',
+          fontFamily: 'system-ui,sans-serif',
+          textShadow: '0 2px 8px #000'
+        }}
+      >
+        <div style={{ fontWeight: 900, fontSize: 18 }}>
+          GOALS {hud.goals} · SAVES {hud.saves}
+        </div>
+        <div
+          style={{
+            fontSize: 11,
+            maxWidth: 220,
+            textAlign: 'right',
+            lineHeight: 1.25
+          }}
+        >
+          {hud.state}
+        </div>
       </div>
 
-      <div style={{ position: "fixed", left: 12, bottom: 14, right: 12, display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 8, pointerEvents: "auto" }}>
-        <button onClick={() => setSpot("left")} style={buttonStyle}>Left<br />3 wall</button>
-        <button onClick={() => setSpot("center")} style={buttonStyle}>Center<br />4 wall</button>
-        <button onClick={() => setSpot("right")} style={buttonStyle}>Right<br />3 wall</button>
-        <button onClick={() => setSpot("near16")} style={buttonStyle}>Near 16<br />5 wall</button>
-      </div>
-      <div style={{ position: "fixed", left: 14, top: 54, color: "white", fontFamily: "system-ui,sans-serif", fontSize: 11, lineHeight: 1.3, maxWidth: 300, pointerEvents: "none", textShadow: "0 2px 8px #000" }}>
-        Natural shoulder movement, slower replay from the strike, and dynamic replay camera.
+      <div
+        style={{
+          position: 'fixed',
+          left: 14,
+          top: 54,
+          color: 'white',
+          fontFamily: 'system-ui,sans-serif',
+          fontSize: 11,
+          lineHeight: 1.3,
+          maxWidth: 300,
+          pointerEvents: 'none',
+          textShadow: '0 2px 8px #000'
+        }}
+      >
+        Lower screen: precise shot swipe. Top/right screen: precise camera
+        pan/height. Spots rotate randomly.
       </div>
     </div>
   );
 }
-
-const buttonStyle: React.CSSProperties = {
-  minHeight: 48,
-  border: "1px solid rgba(255,255,255,0.28)",
-  borderRadius: 14,
-  color: "white",
-  background: "rgba(15,23,42,0.86)",
-  fontWeight: 900,
-  fontSize: 11,
-  boxShadow: "0 12px 24px rgba(0,0,0,0.35)",
-};


### PR DESCRIPTION
### Motivation
- Make the free-kick experience feel more natural and precise by adding a two-step run-up, improving touch aiming/camera controls, enhancing goalkeeper saves, and raising spectator realism. 
- Replace bottom-UI spot buttons with randomized kick placement to streamline the mobile portrait UX and encourage variety.

### Description
- Reworked free-kick flow and input: implemented a two-step run-up (player starts ~2.35 units back, advances to plant, then triggers strike), reduced swipe sensitivity for target/curve/lift/power, and split touch zones so lower screen controls shooting while top/right control camera pan and vertical height. (File: `webapp/src/pages/Games/FreeKickArena.tsx`)
- Randomized kick spots: removed bottom spot-selection buttons and added `randomKickSpot()` that picks a new spot each attempt and updates camera placement accordingly; camera placement now accepts a height offset for top-right vertical control.
- Spectator and celebration changes: increased seated spectator scale and fallback sizes, added a cheered/stand animation where spectators stand, lift both arms, wave, then sit down, and increased crowd cheer duration and stadium updates.
- Goalkeeper & save improvements: rewritten keeper stance and dive timing to lead with hands, added side-aware glove positions and a second glove check, widened reach and refined dive timing/height/reaction calculations for more natural catches and parry behavior.

### Testing
- Ran production build with `npm --prefix webapp run build` which completed successfully. 
- Installed Playwright and browsers with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully. 
- Launched the dev server `npm --prefix webapp run dev -- --host 127.0.0.1` and verified the FreeKick page loads locally. 
- Automated visual check: used Playwright (Pixel 5 device emulation) to capture a mobile portrait screenshot of `/games/freekickarena`, which produced an image during the run (used to validate camera / UI layout and touch zones).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf4be8fac83298b1332ff59b9aed3)