### PR TITLE
Adjust Showood table fit/materials and tune shooter pose & cameras

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -18,7 +18,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool showroom table matched to the original Pool Royale table footprint, full height, and active finish mapping.',
+      'Open-source Pooltool showroom table matched to the original Pool Royale table footprint, default height, native cloth scale, and Showood base/gold pocket finish.',
     tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
@@ -28,7 +28,16 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
-    usePoolRoyaleFinish: true
+    heightScale: 0.96,
+    usePoolRoyaleFinish: true,
+    materialRolePolicy: Object.freeze({
+      cloth: 'poolRoyale',
+      cushion: 'poolRoyale',
+      wood: 'original',
+      pocket: 'original',
+      trim: 'original'
+    }),
+    keepNativePocketHardware: true
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2375,14 +2375,14 @@ const HUMAN_PLAYER_REACT_LEAN = 0.12;
 const HUMAN_POSE_LAMBDA = 9.0;
 const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
-const HUMAN_EDGE_MARGIN = 1.58; // push the shooter farther outward so the avatar stays behind the cue butt on portrait screens
-const HUMAN_DESIRED_SHOOT_DISTANCE = 1.58; // move the shooter clearly to the cue-butt side so camera no longer sits behind the head
+const HUMAN_EDGE_MARGIN = 1.7; // push the shooter farther outward so the avatar stays behind the cue butt on portrait screens
+const HUMAN_DESIRED_SHOOT_DISTANCE = 1.72; // move the shooter clearly to the cue-butt side so camera no longer sits behind the head
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 4.55; // widen the perimeter walk ring so feet never step onto the table mesh
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
 const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.065; // lock camera nearer to eye line while keeping the cue shaft visible in portrait
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
-const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 1.15; // keep the eye camera on the rear/butt half of the cue instead of drifting toward the tip
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 0.86; // keep the eye camera farther back on the cue butt instead of drifting toward the tip
 const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 0.22; // preserve subtle right-eye bias without exposing too much of the avatar body
 const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
 const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
@@ -6482,7 +6482,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.36; // pull the standing camera a bit closer while keeping the angle unchanged
+const STANDING_VIEW_DISTANCE_SCALE = 0.32; // pull the standing camera closer to the table while keeping the angle unchanged
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -12576,6 +12576,20 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo) {
     mat.bumpMap = clonePoolRoyaleMaterialTexture(source.bumpMap);
   };
 
+  const rolePolicy = tableModel?.materialRolePolicy?.[role] || 'poolRoyale';
+  if (rolePolicy === 'original') {
+    const original = mat.clone ? mat.clone() : mat;
+    preparePoolRoyaleExternalTexture(original.map, true);
+    preparePoolRoyaleExternalTexture(original.emissiveMap, true);
+    preparePoolRoyaleExternalTexture(original.aoMap, false);
+    preparePoolRoyaleExternalTexture(original.normalMap, false);
+    preparePoolRoyaleExternalTexture(original.roughnessMap, false);
+    preparePoolRoyaleExternalTexture(original.metalnessMap, false);
+    preparePoolRoyaleExternalTexture(original.bumpMap, false);
+    original.needsUpdate = true;
+    return original;
+  }
+
   if (role === 'cloth' || role === 'cushion') {
     copyMaterialLook(role === 'cushion' ? finishInfo.cushionMat : finishInfo.clothMat);
     mat.side = THREE.DoubleSide;
@@ -12771,7 +12785,7 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
         : Math.sqrt(exactXScale * exactZScale);
     model.scale.set(
       model.scale.x * exactXScale * fitScaleMultiplier,
-      model.scale.y * exactYScale * fitScaleMultiplier,
+      model.scale.y * exactYScale * fitScaleMultiplier * (tableModel?.heightScale ?? 1),
       model.scale.z * exactZScale * fitScaleMultiplier
     );
   } else {
@@ -13503,8 +13517,20 @@ function mountPoolRoyaleExternalTableModel({
   const generatedVisualSize = generatedVisualBounds.isEmpty()
     ? new THREE.Vector3(TABLE.W, TABLE.THICK, TABLE.H)
     : generatedVisualBounds.getSize(new THREE.Vector3());
+  const nativePocketHardware = new Set([
+    ...finishParts.pocketNetMeshes,
+    ...finishParts.pocketBaseMeshes
+  ]);
   const setGeneratedVisualsVisible = (visible) => {
     generatedVisualObjects.forEach((object) => {
+      if (
+        !visible &&
+        resolvedTableOptions?.tableModel?.keepNativePocketHardware &&
+        nativePocketHardware.has(object)
+      ) {
+        object.visible = true;
+        return;
+      }
       object.visible = visible;
     });
   };
@@ -25515,7 +25541,7 @@ const shotPowerRef = useRef(0);
             bridgeCueLift: HUMAN_BRIDGE_CUE_LIFT,
             cueLength: HUMAN_CUE_LENGTH,
             bridgeDist: HUMAN_BRIDGE_DIST,
-            shootCueGripFromBack: 0.58,
+            shootCueGripFromBack: 0.46,
             rightHandShotExtraBack: 0.18,
             rightHandShotLift: -0.30,
             rightHandForwardClamp: -0.08,
@@ -25528,7 +25554,7 @@ const shotPowerRef = useRef(0);
             rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092),
             rightElbowShotRise: 0.18,
             rightElbowShotSide: -0.46,
-            rightElbowShotBack: -0.78,
+            rightElbowShotBack: -0.92,
             textureAnisotropy: renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
           });
           human.root.position.set(x, floorY, z);
@@ -25728,7 +25754,7 @@ const shotPowerRef = useRef(0);
             const cueShootDir = cueTipShoot.clone().sub(cueBackShoot).normalize();
             const shootGripTarget = cueBackShoot
               .clone()
-              .addScaledVector(cueShootDir, 0.58);
+              .addScaledVector(cueShootDir, 0.46);
             if (isHumanShooter && state === 'dragging') {
               activeHumanCueViewRef.current = {
                 cueBack: cueBackShoot.clone(),

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -15,21 +15,22 @@ const BASE_CFG = {
   bridgeCueLift: 0.018,
   bridgeHandBackFromBall: 0.235,
   bridgeHandSide: -0.012,
-  chinToCueHeight: 0.11,
+  bridgeFingerSpread: 0.038,
+  chinToCueHeight: 0.09,
   footGroundY: 0.035,
   footLockStrength: 1.0,
   kneeBendShot: 0.16,
-  rightElbowShotRise: 0.18,
-  rightElbowShotSide: -0.46,
-  rightElbowShotBack: -0.78,
-  rightForearmOutward: 0.36,
-  rightForearmBack: 0.44,
-  rightForearmDown: 0.48,
-  rightForearmLength: 0.34,
+  rightElbowShotRise: 0.28,
+  rightElbowShotSide: -0.48,
+  rightElbowShotBack: -0.92,
+  rightForearmOutward: 0.30,
+  rightForearmBack: 0.54,
+  rightForearmDown: 0.42,
+  rightForearmLength: 0.26,
   rightStrokePull: 0.30,
   rightStrokePush: 0.24,
   rightHandShotLift: -0.30,
-  shootCueGripFromBack: 0.58,
+  shootCueGripFromBack: 0.46,
   idleRightHandY: 0.8,
   idleRightHandX: 0.31,
   idleRightHandZ: -0.015,
@@ -40,7 +41,7 @@ const BASE_CFG = {
   rightHandDownPose: 0.42,
   rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092),
   edgeMargin: 0.58,
-  desiredShootDistance: 1.06,
+  desiredShootDistance: 1.2,
   strikeTime: 0.12,
   holdTime: 0.05,
   tableTopY: 0.84
@@ -95,11 +96,11 @@ function driveHuman(human, frame) { if (!human.activeGlb || !human.model) return
 export function updateHumanPose(human, dt, frameData){ if(!human||!frameData) return; const cfg=human.cfg; const state=frameData.state||'idle'; human.poseT=dampScalar(human.poseT,state==='idle'?0:1,cfg.poseLambda,dt); human.breathT+=dt*(state==='idle'?1.05:0.5); if(state==='striking'){ if(human.strikeClock===0){ human.strikeRoot.copy(human.root.position.lengthSq()>0.001?human.root.position:frameData.rootTarget); human.strikeYaw=human.yaw;} human.strikeClock+=dt;} else human.strikeClock=0;
  const rootGoal=state==='striking'?human.strikeRoot:frameData.rootTarget; dampVector(human.root.position,rootGoal,state==='striking'?12:cfg.moveLambda,dt); const moveAmountRaw=human.root.position.distanceTo(rootGoal); human.walkT+=dt*(2+Math.min(7,moveAmountRaw*10)); human.yaw=dampScalar(human.yaw,state==='striking'?human.strikeYaw:yawFromForward(frameData.aimForward),cfg.rotLambda,dt);
  const t=easeInOut(human.poseT), idle=1-t; const walk=Math.sin(human.walkT*6.2)*Math.min(1,moveAmountRaw*12); const forward = new THREE.Vector3(0,0,-1).applyAxisAngle(Y_AXIS,human.yaw).normalize(); const side = new THREE.Vector3(forward.z,0,-forward.x).normalize(); const local = (v)=>v.clone().applyAxisAngle(Y_AXIS,human.yaw).add(human.root.position);
- const torso = local(new THREE.Vector3(0, lerp(1.3,1.14,t), lerp(0.02,-0.16,t))); const chest=local(new THREE.Vector3(0,lerp(1.52,1.24,t),lerp(0.02,-0.42,t))); const neck=local(new THREE.Vector3(0,lerp(1.68,1.28,t),lerp(0.02,-0.61,t))); const head=local(new THREE.Vector3(0,lerp(1.84,1.37,t),lerp(0.04,-0.72,t))); const leftShoulder=local(new THREE.Vector3(-0.23,lerp(1.58,1.36,t),lerp(0,-0.46,t))); const rightShoulder=local(new THREE.Vector3(0.23,lerp(1.58,1.36,t),lerp(0,-0.34,t)));
+ const torso = local(new THREE.Vector3(0, lerp(1.3,1.08,t), lerp(0.02,-0.22,t))); const chest=local(new THREE.Vector3(0,lerp(1.52,1.16,t),lerp(0.02,-0.5,t))); const neck=local(new THREE.Vector3(0,lerp(1.68,1.2,t),lerp(0.02,-0.7,t))); const head=local(new THREE.Vector3(0,lerp(1.84,1.28,t),lerp(0.04,-0.82,t))); const leftShoulder=local(new THREE.Vector3(-0.23,lerp(1.58,1.3,t),lerp(0,-0.56,t))); const rightShoulder=local(new THREE.Vector3(0.23,lerp(1.58,1.31,t),lerp(0,-0.44,t)));
  const leftHip=local(new THREE.Vector3(-0.13,0.92,0.02)); const rightHip=local(new THREE.Vector3(0.13,0.92,0.02)); const leftFoot=local(new THREE.Vector3(-0.13,cfg.footGroundY,0.03+walk*0.018).lerp(new THREE.Vector3(-cfg.stanceWidth*0.42,cfg.footGroundY,-0.34),t)); const rightFoot=local(new THREE.Vector3(0.13,cfg.footGroundY,-0.03-walk*0.018).lerp(new THREE.Vector3(cfg.stanceWidth*0.5,cfg.footGroundY,0.34),t));
- const bridgePalm = frameData.bridgeTarget.clone().addScaledVector(forward,-0.006*t).addScaledVector(side,-0.012*t).setY(cfg.tableTopY+cfg.bridgePalmTableLift); const leftHand = frameData.idleLeft.clone().lerp(bridgePalm,t); const cueDir = frameData.cueTip.clone().sub(frameData.cueBack).normalize(); const handIk=easeInOut(clamp01(t)); const idleGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,-0.55).addScaledVector(forward,0.16).normalize(); const idleGripUp=UP.clone().multiplyScalar(-1).addScaledVector(side,-0.64).addScaledVector(forward,0.2).normalize(); const liveGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,lerp(-0.55,-0.62,handIk)).addScaledVector(side,0.5*handIk).addScaledVector(forward,lerp(0.16,-0.08,handIk)).normalize(); const liveGripUp=UP.clone().multiplyScalar(lerp(-1.0,0.12,handIk)).addScaledVector(side,lerp(-0.64,-0.04,handIk)).addScaledVector(forward,lerp(0.2,-0.48,handIk)).normalize();
+ const bridgePalm = frameData.bridgeTarget.clone().addScaledVector(forward,-0.016*t).addScaledVector(side,cfg.bridgeHandSide*t).setY(cfg.tableTopY+cfg.bridgePalmTableLift); const leftHand = frameData.idleLeft.clone().lerp(bridgePalm,t); const cueDir = frameData.cueTip.clone().sub(frameData.cueBack).normalize(); const handIk=easeInOut(clamp01(t)); const idleGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,-0.55).addScaledVector(forward,0.16).normalize(); const idleGripUp=UP.clone().multiplyScalar(-1).addScaledVector(side,-0.64).addScaledVector(forward,0.2).normalize(); const liveGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,lerp(-0.55,-0.58,handIk)).addScaledVector(side,0.38*handIk).addScaledVector(forward,lerp(0.16,-0.16,handIk)).normalize(); const liveGripUp=UP.clone().multiplyScalar(lerp(-1.0,0.08,handIk)).addScaledVector(side,lerp(-0.64,-0.02,handIk)).addScaledVector(forward,lerp(0.2,-0.56,handIk)).normalize();
  const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04,cfg.rightElbowShotRise,t)).addScaledVector(side,lerp(-0.18,cfg.rightElbowShotSide,t)).addScaledVector(forward,lerp(-0.04,cfg.rightElbowShotBack,t)); const pullBack = state==='dragging' ? -cfg.rightStrokePull*easeOutCubic(frameData.power||0) : 0; const push = state==='striking' ? cfg.rightStrokePush*Math.sin(clamp01(human.strikeClock/(cfg.strikeTime+cfg.holdTime))*Math.PI):0; const forearmBase = lockedRightElbow.clone().addScaledVector(side,cfg.rightForearmOutward*t).addScaledVector(UP,-cfg.rightForearmDown*t).addScaledVector(UP,cfg.rightHandShotLift*t).addScaledVector(forward,-cfg.rightForearmBack*t).addScaledVector(cueDir,cfg.rightForearmLength); const liveGripPoint = forearmBase.clone().addScaledVector(cueDir,pullBack+push); const idleWrist=frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide,idleGripUp,cueDir,cfg.rightHandRollIdle,cfg.rightHandCueSocketLocal)); const liveWrist=liveGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide,liveGripUp,cueDir,lerp(cfg.rightHandRollIdle,cfg.rightHandRollShoot-cfg.rightHandDownPose,handIk),cfg.rightHandCueSocketLocal));
- const rightHand = idleWrist.clone().lerp(liveWrist,t); const leftElbow = leftShoulder.clone().lerp(leftHand,0.62); const leftKnee = leftHip.clone().lerp(leftFoot,0.53).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot,t)); const rightKnee = rightHip.clone().lerp(rightFoot,0.52).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot*0.88,t));
+ const rightHand = idleWrist.clone().lerp(liveWrist,t); const leftElbow = leftShoulder.clone().lerp(leftHand,0.64).addScaledVector(side,-cfg.bridgeFingerSpread*t).addScaledVector(forward,0.06*t); const leftKnee = leftHip.clone().lerp(leftFoot,0.53).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot,t)); const rightKnee = rightHip.clone().lerp(rightFoot,0.52).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot*0.88,t));
  human.root.visible=true; driveHuman(human,{t,stroke:pullBack+push,forward,side,up:UP,rootWorld:human.root.position.clone(),torsoCenterWorld:torso,chestCenterWorld:chest,neckWorld:neck,headCenterWorld:head,leftElbow,rightElbow:lockedRightElbow,leftHandWorld:leftHand,rightHandWorld:rightHand,leftKnee,rightKnee,leftFootWorld:leftFoot,rightFootWorld:rightFoot,cueBackWorld:frameData.cueBack,cueTipWorld:frameData.cueTip});
 }
 


### PR DESCRIPTION
### Motivation
- Make the Showood 7ft external table visually match the native Pool Royale table height and cloth scale while keeping the Showood wood/base and gold pocket materials and native pocket hardware intact. 
- Ensure external GLTF table materials map correctly to Pool Royale surfaces so cloth and cushions keep Pool Royale appearance while wood/trim/pocket hardware can remain original. 
- Move the human shooter slightly rearward relative to the cue butt, bring the camera closer to the table for portrait framing, and retune the shooting rig so the body, hands, and bridge match photographic references more precisely. 

### Description
- Adjusted Showood table model configuration (`webapp/src/config/poolRoyaleTableModels.js`) to apply `heightScale: 0.96`, expose `materialRolePolicy` to choose which surface roles use original vs Pool Royale finishes, and added `keepNativePocketHardware` to preserve under-pocket nets/holders. 
- Added role-aware material handling and height-scale application in the external-table pipeline (`webapp/src/pages/Games/PoolRoyale.jsx`) so external models can keep original wood/trim/pocket materials while sharing Pool Royale cloth/cushion style, and the exact-fit path now respects `heightScale`. 
- When hiding generated visuals for external tables, keep native pocket hardware visible when `keepNativePocketHardware` is set by filtering `finishParts.pocketNetMeshes` and `finishParts.pocketBaseMeshes`. 
- Tuned camera and shooter framing constants in `PoolRoyale.jsx` (`HUMAN_EDGE_MARGIN`, `HUMAN_DESIRED_SHOOT_DISTANCE`, `HUMAN_EYE_CAMERA_FORWARD_OFFSET`, `STANDING_VIEW_DISTANCE_SCALE`) to move the avatar back and pull the camera closer for portrait play. 
- Retuned human rig parameters and pose math across the shared rig (`webapp/src/pages/Games/shared/humanRigCore.js`) and PoolRoyale rig usage to change elbow/back offsets, rear-grip distance (`shootCueGripFromBack`), bridge hand placement/spread, torso/head targets and left-hand bridge behaviour so animations align more closely with the supplied photo reference. 

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully (Vite produced build output with standard warnings about chunk size). 
- Ran a static check with `git diff --check` which reported no style errors. 
- Attempted an automated Playwright screenshot of the running dev site to visually verify the Showood table and human pose, but the headless Chromium process failed to start in this environment due to a missing system library (`libatk-1.0.so.0`), so the screenshot step could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf32acd6c8329807cd0aa4b569aca)