### PR TITLE
Make Pooltool GLB the default Snooker table and share finishes/cloths

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -5,14 +5,22 @@ import {
   resolveSnookerTableModel,
   TABLE_MODEL_CLASSIC,
   TABLE_MODEL_OPENSOURCE,
-  TABLE_MODEL_OPENSOURCE_GLB_URL
+  TABLE_MODEL_OPENSOURCE_GLB_URL,
+  TABLE_MODEL_DEFAULT,
+  TABLE_MODEL_PROCEDURAL_FALLBACK
 } from '../webapp/src/pages/Games/snookerTableModel.js';
 
 describe('snooker table model selection', () => {
-  test('resolveSnookerTableModel defaults to classic', () => {
-    assert.equal(resolveSnookerTableModel(null), TABLE_MODEL_CLASSIC);
-    assert.equal(resolveSnookerTableModel(''), TABLE_MODEL_CLASSIC);
-    assert.equal(resolveSnookerTableModel('invalid'), TABLE_MODEL_CLASSIC);
+  test('resolveSnookerTableModel defaults to the GLB table', () => {
+    assert.equal(TABLE_MODEL_DEFAULT, TABLE_MODEL_OPENSOURCE);
+    assert.equal(TABLE_MODEL_PROCEDURAL_FALLBACK, TABLE_MODEL_CLASSIC);
+    assert.equal(resolveSnookerTableModel(null), TABLE_MODEL_OPENSOURCE);
+    assert.equal(resolveSnookerTableModel(''), TABLE_MODEL_OPENSOURCE);
+    assert.equal(resolveSnookerTableModel('invalid'), TABLE_MODEL_OPENSOURCE);
+  });
+
+  test('resolveSnookerTableModel keeps classic available as procedural fallback', () => {
+    assert.equal(resolveSnookerTableModel('classic'), TABLE_MODEL_CLASSIC);
   });
 
   test('resolveSnookerTableModel accepts opensource value case-insensitively', () => {
@@ -26,7 +34,7 @@ describe('snooker table model selection', () => {
     assert.equal(params.get('tableModel'), TABLE_MODEL_OPENSOURCE);
 
     applySnookerTableModelParam(params, 'unknown');
-    assert.equal(params.get('tableModel'), TABLE_MODEL_CLASSIC);
+    assert.equal(params.get('tableModel'), TABLE_MODEL_OPENSOURCE);
   });
 
   test('resolveSnookerGlbFitTransform maps GLB bounds exactly onto the procedural table', () => {

--- a/webapp/src/config/snookerRoyalClothPresets.js
+++ b/webapp/src/config/snookerRoyalClothPresets.js
@@ -1,4 +1,5 @@
 import { polyHavenThumb } from './storeThumbnails.js';
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 
 const normalizeHex = (value) => {
   const asString = typeof value === 'number' ? value.toString(16).padStart(6, '0') : String(value || '').replace('#', '');
@@ -183,6 +184,17 @@ const createVariantsForMaterial = (material) => {
   ];
 };
 
-export const SNOOKER_ROYALE_CLOTH_VARIANTS = Object.freeze(
-  MATERIAL_SERIES.flatMap((material) => createVariantsForMaterial(material))
+const SNOOKER_NATIVE_CLOTH_VARIANTS = MATERIAL_SERIES.flatMap((material) =>
+  createVariantsForMaterial(material)
 );
+
+export const SNOOKER_ROYALE_CLOTH_VARIANTS = Object.freeze([
+  ...SNOOKER_NATIVE_CLOTH_VARIANTS,
+  ...POOL_ROYALE_CLOTH_VARIANTS.map((variant) => ({
+    ...variant,
+    sharedWithDefaultTable: true,
+    description:
+      variant.description ||
+      'Shared cloth preset from the default Pool Royale table library.'
+  }))
+]);

--- a/webapp/src/config/snookerRoyalInventoryConfig.js
+++ b/webapp/src/config/snookerRoyalInventoryConfig.js
@@ -1,4 +1,8 @@
 import { SNOOKER_ROYALE_CLOTH_VARIANTS } from './snookerRoyalClothPresets.js';
+import {
+  POOL_ROYALE_OPTION_LABELS,
+  POOL_ROYALE_STORE_ITEMS
+} from './poolRoyaleInventoryConfig.js';
 import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 const SNOOKER_ROYALE_HDRI_PLACEMENTS = Object.freeze({
@@ -290,13 +294,17 @@ export const SNOOKER_ROYALE_HDRI_VARIANTS = Object.freeze(
   }))
 );
 
-const TABLE_FINISH_THUMBNAILS = Object.freeze({
-  peelingPaintWeathered: polyHavenThumb('wood_peeling_paint_weathered'),
-  oakVeneer01: polyHavenThumb('oak_veneer_01'),
-  woodTable001: polyHavenThumb('wood_table_001'),
-  darkWood: polyHavenThumb('dark_wood'),
-  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
-});
+
+const SNOOKER_ROYALE_SHARED_TABLE_FINISH_ITEMS = Object.freeze(
+  POOL_ROYALE_STORE_ITEMS.filter((item) => item?.type === 'tableFinish').map((item) => ({
+    ...item,
+    id: `shared-${item.id}`,
+    name: item.name?.includes('Finish') ? item.name : `${item.name} Finish`,
+    description:
+      item.description ||
+      'Shared table finish from the default Pool Royale table library.'
+  }))
+);
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
   'plastic-black': swatchThumbnail(['#0b0d10', '#1f2937', '#4b5563']),
@@ -378,10 +386,10 @@ export const SNOOKER_ROYALE_BASE_VARIANTS = Object.freeze([
 export const SNOOKER_ROYALE_DEFAULT_HDRI_ID = 'colorfulStudio';
 
 export const SNOOKER_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
-  tableFinish: ['peelingPaintWeathered'],
+  tableFinish: Object.keys(POOL_ROYALE_OPTION_LABELS.tableFinish || {}),
   chromeColor: ['gold'],
   railMarkerColor: ['gold'],
-  clothColor: [SNOOKER_ROYALE_CLOTH_VARIANTS[0].id],
+  clothColor: SNOOKER_ROYALE_CLOTH_VARIANTS.map((variant) => variant.id),
   cueStyle: ['birch-frost'],
   pocketLiner: ['plastic-black'],
   environmentHdri: [SNOOKER_ROYALE_DEFAULT_HDRI_ID],
@@ -396,11 +404,7 @@ export const SNOOKER_ROYALE_OPTION_LABELS = Object.freeze({
     }, {})
   ),
   tableFinish: Object.freeze({
-    peelingPaintWeathered: 'Wood Peeling Paint Weathered',
-    oakVeneer01: 'Oak Veneer 01',
-    woodTable001: 'Wood Table 001',
-    darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    ...POOL_ROYALE_OPTION_LABELS.tableFinish
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -443,51 +447,7 @@ export const SNOOKER_ROYALE_OPTION_LABELS = Object.freeze({
 });
 
 export const SNOOKER_ROYALE_STORE_ITEMS = [
-  {
-    id: 'finish-peelingPaintWeathered',
-    type: 'tableFinish',
-    optionId: 'peelingPaintWeathered',
-    name: 'Wood Peeling Paint Weathered Finish',
-    price: 980,
-    description: 'Weathered peeling paint wood rails with a reclaimed finish.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.peelingPaintWeathered
-  },
-  {
-    id: 'finish-oakVeneer01',
-    type: 'tableFinish',
-    optionId: 'oakVeneer01',
-    name: 'Oak Veneer 01 Finish',
-    price: 990,
-    description: 'Warm oak veneer rails with smooth satin polish.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01
-  },
-  {
-    id: 'finish-woodTable001',
-    type: 'tableFinish',
-    optionId: 'woodTable001',
-    name: 'Wood Table 001 Finish',
-    price: 1000,
-    description: 'Balanced walnut-brown rails inspired by classic table slabs.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.woodTable001
-  },
-  {
-    id: 'finish-darkWood',
-    type: 'tableFinish',
-    optionId: 'darkWood',
-    name: 'Dark Wood Finish',
-    price: 1010,
-    description: 'Deep espresso rails with strong grain contrast.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.darkWood
-  },
-  {
-    id: 'finish-rosewoodVeneer01',
-    type: 'tableFinish',
-    optionId: 'rosewoodVeneer01',
-    name: 'Rosewood Veneer 01 Finish',
-    price: 1020,
-    description: 'Rosewood veneer rails with rich, reddish undertones.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
-  },
+  ...SNOOKER_ROYALE_SHARED_TABLE_FINISH_ITEMS,
   {
     id: 'chrome-chrome',
     type: 'chromeColor',

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -2694,6 +2694,16 @@ const createStandardWoodFinish = ({
   }
 });
 
+const POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE = Object.freeze({
+  wood_peeling_paint_weathered: 0.8,
+  oak_veneer_01: 1.8,
+  wood_table_001: 1.5,
+  dark_wood: 2,
+  rosewood_veneer_01: 2.4
+});
+const LT_TABLE_WOOD_TEXTURE_ID = 'rosewood_veneer_01';
+const LT_TABLE_WOOD_REPEAT_SCALE = POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01;
+
 const TABLE_FINISHES = Object.freeze({
   peelingPaintWeathered: createStandardWoodFinish({
     id: 'peelingPaintWeathered',
@@ -2702,7 +2712,7 @@ const TABLE_FINISHES = Object.freeze({
     base: 0xa89f95,
     trim: 0xd6d0c7,
     woodTextureId: 'wood_peeling_paint_weathered',
-    woodRepeatScale: 1
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.wood_peeling_paint_weathered
   }),
   oakVeneer01: createStandardWoodFinish({
     id: 'oakVeneer01',
@@ -2711,7 +2721,7 @@ const TABLE_FINISHES = Object.freeze({
     base: 0xb9854e,
     trim: 0xe0bb7a,
     woodTextureId: 'oak_veneer_01',
-    woodRepeatScale: 1
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.oak_veneer_01
   }),
   woodTable001: createStandardWoodFinish({
     id: 'woodTable001',
@@ -2720,7 +2730,7 @@ const TABLE_FINISHES = Object.freeze({
     base: 0x8f6243,
     trim: 0xc89a64,
     woodTextureId: 'wood_table_001',
-    woodRepeatScale: 1
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.wood_table_001
   }),
   darkWood: createStandardWoodFinish({
     id: 'darkWood',
@@ -2729,7 +2739,7 @@ const TABLE_FINISHES = Object.freeze({
     base: 0x2f241f,
     trim: 0x6a5a52,
     woodTextureId: 'dark_wood',
-    woodRepeatScale: 1
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.dark_wood
   }),
   rosewoodVeneer01: createStandardWoodFinish({
     id: 'rosewoodVeneer01',
@@ -2738,7 +2748,142 @@ const TABLE_FINISHES = Object.freeze({
     base: 0x5b2f26,
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
-    woodRepeatScale: 1
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01
+  }),
+  carbonFiberChalk: createStandardWoodFinish({
+    id: 'carbonFiberChalk',
+    label: 'LT Black',
+    rail: 0x2a313d,
+    base: 0x2a313d,
+    trim: 0x2a313d,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberChalkGrey: createStandardWoodFinish({
+    id: 'carbonFiberChalkGrey',
+    label: 'LT Grey',
+    rail: 0xc8d0da,
+    base: 0xc8d0da,
+    trim: 0xc8d0da,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberChalkBeige: createStandardWoodFinish({
+    id: 'carbonFiberChalkBeige',
+    label: 'LT Dark Grey',
+    rail: 0x727d8b,
+    base: 0x727d8b,
+    trim: 0x727d8b,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberChalkDarkBlue: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkBlue',
+    label: 'LT Burgundy',
+    rail: 0xc17276,
+    base: 0xc17276,
+    trim: 0xc17276,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberChalkWhite: createStandardWoodFinish({
+    id: 'carbonFiberChalkWhite',
+    label: 'LT Milk Cream',
+    rail: 0xf8eedf,
+    base: 0xf8eedf,
+    trim: 0xf8eedf,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberChalkDarkGreen: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkGreen',
+    label: 'LT Dark Green',
+    rail: 0x548460,
+    base: 0x548460,
+    trim: 0x548460,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberChalkDarkYellow: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkYellow',
+    label: 'LT Dark Yellow',
+    rail: 0xd1a652,
+    base: 0xd1a652,
+    trim: 0xd1a652,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberChalkDarkBrown: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkBrown',
+    label: 'LT Dark Brown',
+    rail: 0x956b4f,
+    base: 0x956b4f,
+    trim: 0x956b4f,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberChalkDarkRed: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkRed',
+    label: 'LT Dark Red',
+    rail: 0xaa5151,
+    base: 0xaa5151,
+    trim: 0xaa5151,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberAlligatorOlive: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorOlive',
+    label: 'LT Olive Alligator',
+    rail: 0x556b3f,
+    base: 0x556b3f,
+    trim: 0x556b3f,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberAlligatorSwamp: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorSwamp',
+    label: 'LT Swamp Alligator',
+    rail: 0x3f5a3c,
+    base: 0x3f5a3c,
+    trim: 0x3f5a3c,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberAlligatorClay: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorClay',
+    label: 'LT Clay Alligator',
+    rail: 0x6f5b45,
+    base: 0x6f5b45,
+    trim: 0x6f5b45,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberAlligatorSand: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorSand',
+    label: 'LT Sand Alligator',
+    rail: 0x8a7b5e,
+    base: 0x8a7b5e,
+    trim: 0x8a7b5e,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberAlligatorMoss: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorMoss',
+    label: 'LT Moss Alligator',
+    rail: 0x4f6048,
+    base: 0x4f6048,
+    trim: 0x4f6048,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
+  }),
+  carbonFiberAlligatorNight: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorNight',
+    label: 'LT Night Alligator',
+    rail: 0x2f3c32,
+    base: 0x2f3c32,
+    trim: 0x2f3c32,
+    woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
+    woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE
   })
 });
 
@@ -2748,7 +2893,22 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.carbonFiberChalk,
+    TABLE_FINISHES.carbonFiberChalkGrey,
+    TABLE_FINISHES.carbonFiberChalkBeige,
+    TABLE_FINISHES.carbonFiberChalkDarkBlue,
+    TABLE_FINISHES.carbonFiberChalkWhite,
+    TABLE_FINISHES.carbonFiberChalkDarkGreen,
+    TABLE_FINISHES.carbonFiberChalkDarkYellow,
+    TABLE_FINISHES.carbonFiberChalkDarkBrown,
+    TABLE_FINISHES.carbonFiberChalkDarkRed,
+    TABLE_FINISHES.carbonFiberAlligatorOlive,
+    TABLE_FINISHES.carbonFiberAlligatorSwamp,
+    TABLE_FINISHES.carbonFiberAlligatorClay,
+    TABLE_FINISHES.carbonFiberAlligatorSand,
+    TABLE_FINISHES.carbonFiberAlligatorMoss,
+    TABLE_FINISHES.carbonFiberAlligatorNight
   ].filter(Boolean)
 );
 
@@ -10488,58 +10648,6 @@ function Table3D(
     return builder;
   };
 
-  const applyPooltoolTableVisualOverride = () => {
-    const loader = createConfiguredGLTFLoader(renderer);
-    loader
-      .loadAsync(POOLTOOL_SNOOKER_TABLE_URL)
-      .then((gltf) => {
-        const model = gltf?.scene || gltf?.scenes?.[0];
-        if (!model) return;
-
-        const tableBounds = new THREE.Box3().setFromObject(table);
-        const targetSize = tableBounds.getSize(new THREE.Vector3());
-        const targetCenter = tableBounds.getCenter(new THREE.Vector3());
-
-        const modelBounds = new THREE.Box3().setFromObject(model);
-        const modelSize = modelBounds.getSize(new THREE.Vector3());
-        const scaleX = modelSize.x > MICRO_EPS ? targetSize.x / modelSize.x : 1;
-        const scaleZ = modelSize.z > MICRO_EPS ? targetSize.z / modelSize.z : 1;
-        const uniformScale = Math.min(scaleX, scaleZ);
-        if (Number.isFinite(uniformScale) && uniformScale > 0) {
-          model.scale.setScalar(uniformScale);
-        }
-
-        model.updateMatrixWorld(true);
-        const scaledBounds = new THREE.Box3().setFromObject(model);
-        const scaledCenter = scaledBounds.getCenter(new THREE.Vector3());
-        model.position.set(
-          targetCenter.x - scaledCenter.x,
-          tableBounds.min.y - scaledBounds.min.y,
-          targetCenter.z - scaledCenter.z
-        );
-        model.updateMatrixWorld(true);
-
-        table.traverse((child) => {
-          if (!child?.isMesh) return;
-          if (child.userData?.__basePart) return;
-          child.visible = false;
-        });
-
-        model.traverse((child) => {
-          if (!child?.isMesh) return;
-          child.castShadow = true;
-          child.receiveShadow = true;
-          child.renderOrder = 2;
-        });
-
-        table.add(model);
-        table.userData.visualOverrideModel = model;
-      })
-      .catch((error) => {
-        console.warn('Snooker Royal failed to load Pooltool table override; using procedural table.', error);
-      });
-  };
-
   const isOpenSourceHardwareKeepMesh = (mesh) => Boolean(mesh?.userData?.isPocketDropHardware);
 
   const setProceduralTableMeshesVisible = (visible) => {
@@ -10708,6 +10816,35 @@ function Table3D(
     });
   };
 
+
+  const resolveOpenSourceGameplayMapping = (model, targetBounds) => {
+    const mapping = {
+      source: 'pooltool-snooker-generic-glb',
+      hasEmbeddedPhysics: false,
+      usesProceduralFallbackPhysics: true,
+      clothBounds: null,
+      cushionBounds: [],
+      pocketBounds: [],
+      targetBounds: targetBounds?.clone?.() ?? null
+    };
+    if (!model) return mapping;
+    model.updateMatrixWorld(true);
+    model.traverse((node) => {
+      if (!node?.isMesh) return;
+      const role = node.userData?.openSourceMaterialRole || resolveOpenSourceMaterialRole(node, node.material);
+      const box = new THREE.Box3().setFromObject(node);
+      if (box.isEmpty()) return;
+      if (role === 'cloth') {
+        mapping.clothBounds = mapping.clothBounds ? mapping.clothBounds.union(box) : box.clone();
+      } else if (role === 'cushion') {
+        mapping.cushionBounds.push(box.clone());
+      } else if (role === 'pocket') {
+        mapping.pocketBounds.push(box.clone());
+      }
+    });
+    return mapping;
+  };
+
   const applyOpenSourceTableVisualOverride = () => {
     const targetBounds = resolveOpenSourceTargetBounds();
     const targetSize = targetBounds.getSize(new THREE.Vector3());
@@ -10720,7 +10857,11 @@ function Table3D(
       .loadAsync(TABLE_MODEL_OPENSOURCE_GLB_URL)
       .then((gltf) => {
         const model = gltf?.scene || gltf?.scenes?.[0];
-        if (!model) return;
+        if (!model) {
+          setProceduralTableMeshesVisible(true);
+          table.userData.openSourceVisualLoadFailed = true;
+          return;
+        }
 
         model.updateMatrixWorld(true);
         const fullSourceBounds = new THREE.Box3().setFromObject(model);
@@ -10753,6 +10894,7 @@ function Table3D(
 
         applyDefaultTableFinishToOpenSourceModel(model);
         remapOpenSourceClothTextureCoordinates(model, targetBounds);
+        const sourceGameplayMapping = resolveOpenSourceGameplayMapping(model, targetBounds);
         model.name = 'pooltool-snooker-generic-table';
         model.userData = {
           ...(model.userData || {}),
@@ -10761,15 +10903,19 @@ function Table3D(
           fitToProceduralMapping: true,
           keepsDefaultPocketDropHardware: true,
           preservesOriginalTableBase: true,
-          usesGlbCushionShapes: true
+          usesGlbCushionShapes: true,
+          sourceGameplayMapping
         };
         table.userData.openSourceVisual = model;
         table.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;
         table.userData.openSourceVisualFit = fit;
         table.userData.openSourceVisualTargetBounds = targetBounds;
+        table.userData.openSourceGameplayMapping = sourceGameplayMapping;
       })
       .catch((error) => {
-        console.warn('Failed to load Pooltool snooker_generic table model', error);
+        setProceduralTableMeshesVisible(true);
+        table.userData.openSourceVisualLoadFailed = true;
+        console.warn('Failed to load Pooltool snooker_generic table model; restored procedural fallback table.', error);
       });
   };
 
@@ -11185,7 +11331,7 @@ function Table3D(
   if (resolvedTableVisualModel === TABLE_MODEL_OPENSOURCE) {
     applyOpenSourceTableVisualOverride();
   } else {
-    applyPooltoolTableVisualOverride();
+    table.userData.visualModel = 'proceduralFallback';
   }
 
   const baulkZ = baulkLineZ;
@@ -11529,6 +11675,8 @@ function applyTableFinishToTable(table, finish) {
     }
     mat.needsUpdate = true;
   });
+
+
   if (typeof finishInfo.applyClothDetail === 'function') {
     finishInfo.applyClothDetail(resolvedFinish?.clothDetail ?? null);
   }
@@ -11545,6 +11693,38 @@ function applyTableFinishToTable(table, finish) {
     accent: accentConfig
   };
   finishInfo.clothDetail = resolvedFinish?.clothDetail ?? null;
+  const openSourceVisual = table.userData?.openSourceVisual;
+  if (openSourceVisual) {
+    openSourceVisual.traverse((node) => {
+      if (!node?.isMesh || !node.userData?.isOpenSourceVisual) return;
+      const role = node.userData.openSourceMaterialRole || 'frame';
+      const sourceByRole = {
+        cloth: finishInfo.clothMat,
+        cushion: finishInfo.cushionMat,
+        rail: finishInfo.materials.rail || finishInfo.materials.frame,
+        frame: finishInfo.materials.frame || finishInfo.materials.rail,
+        leg: finishInfo.materials.leg || finishInfo.materials.frame || finishInfo.materials.rail,
+        trim: finishInfo.materials.trim || finishInfo.materials.pocketRim,
+        pocket: finishInfo.materials.pocketJaw || finishInfo.materials.pocketRim,
+        pocketRim: finishInfo.materials.pocketRim || finishInfo.materials.trim
+      };
+      const sourceMaterial = sourceByRole[role] || sourceByRole.frame;
+      if (!sourceMaterial?.clone) return;
+      const currentMaterials = Array.isArray(node.material) ? node.material : [node.material];
+      const nextMaterials = currentMaterials.map((current) => {
+        const next = sourceMaterial.clone();
+        next.name = `${current?.name || role || 'snooker-glb'}-${resolvedFinish.id}`;
+        next.side = current?.side ?? next.side;
+        next.transparent = current?.transparent || next.transparent;
+        next.opacity = current?.opacity ?? next.opacity;
+        next.alphaTest = current?.alphaTest ?? next.alphaTest;
+        next.needsUpdate = true;
+        return next;
+      });
+      node.material = Array.isArray(node.material) ? nextMaterials : nextMaterials[0] ?? node.material;
+    });
+  }
+
 }
 
 // --------------------------------------------------
@@ -26408,10 +26588,16 @@ const powerRef = useRef(hud.power);
             const forwardZ = Math.cos(yaw - Math.PI);
             const sideX = forwardZ;
             const sideZ = -forwardX;
+            // Anchor the player to the cue butt instead of the cue group center so, on portrait
+            // mobile, the hands/body stay close to the bottom end of the cue at the table edge.
+            const actorBackOffset = SCALE * 1.05;
+            const actorSideOffset = SCALE * 0.28;
+            const buttX = Number.isFinite(TMP_VEC3_BUTT.x) ? TMP_VEC3_BUTT.x : cueStick.position.x;
+            const buttZ = Number.isFinite(TMP_VEC3_BUTT.z) ? TMP_VEC3_BUTT.z : cueStick.position.z;
             humanActor.position.set(
-              cueStick.position.x - forwardX * (SCALE * 3.6) - sideX * (SCALE * 0.7),
+              buttX - forwardX * actorBackOffset - sideX * actorSideOffset,
               0,
-              cueStick.position.z - forwardZ * (SCALE * 3.6) - sideZ * (SCALE * 0.7)
+              buttZ - forwardZ * actorBackOffset - sideZ * actorSideOffset
             );
             humanActor.rotation.y = yaw;
           }

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -1,5 +1,7 @@
 export const TABLE_MODEL_CLASSIC = 'classic';
 export const TABLE_MODEL_OPENSOURCE = 'opensource';
+export const TABLE_MODEL_DEFAULT = TABLE_MODEL_OPENSOURCE;
+export const TABLE_MODEL_PROCEDURAL_FALLBACK = TABLE_MODEL_CLASSIC;
 export const TABLE_MODEL_OPENSOURCE_GLB_URL =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
 
@@ -26,7 +28,8 @@ export function resolveSnookerGlbFitTransform(sourceSize = {}, targetSize = {}) 
 
 export function resolveSnookerTableModel(value) {
   const requested = String(value || '').toLowerCase();
-  return requested === TABLE_MODEL_OPENSOURCE ? TABLE_MODEL_OPENSOURCE : TABLE_MODEL_CLASSIC;
+  if (requested === TABLE_MODEL_CLASSIC) return TABLE_MODEL_CLASSIC;
+  return TABLE_MODEL_DEFAULT;
 }
 
 export function applySnookerTableModelParam(params, tableModel) {


### PR DESCRIPTION
### Motivation
- Use the higher‑fidelity open‑source GLB Snooker table as the default playable visual while preserving the procedural table as a reliable fallback.
- Preserve original GLB visuals (cloth mapping, pocket hardware, base) so the GLB looks and behaves like its source where possible.
- Reuse the existing Pool Royale/Default table finishes and cloth presets to allow users to apply the same materials to the GLB model.
- Improve mobile portrait UX by moving the human actor anchor closer to the cue butt so the character appears near the table edge.

### Description
- Made the open‑source Pooltool GLB the default table model and introduced `TABLE_MODEL_DEFAULT` / `TABLE_MODEL_PROCEDURAL_FALLBACK`; `resolveSnookerTableModel` now returns the GLB by default and keeps `classic` as an explicit procedural fallback. (`webapp/src/pages/Games/snookerTableModel.js`)
- Load/fit the GLB into the procedural table footprint, remap GLB cloth UVs to the table texture space, preserve GLB base and pocket hardware, and produce a `sourceGameplayMapping` describing cloth/cushion/pocket bounds for use at runtime; if GLB loading fails the procedural table is restored. (`webapp/src/pages/Games/SnookerRoyal.jsx`)
- Share Pool Royale cloth variants and table finishes with Snooker Royal by merging preset lists and adding shared store entries so Pool Royale finishes/cloths are available to the GLB table and the Snooker inventory. (`webapp/src/config/snookerRoyalClothPresets.js`, `webapp/src/config/snookerRoyalInventoryConfig.js`)
- Ensure runtime finish application updates open‑source model materials when the player changes finishes/cloths and wire up cloth texture consumer plumbing so repeat/tiling and normal/roughness maps are applied consistently. (`webapp/src/pages/Games/SnookerRoyal.jsx`)
- Added a number of LT/default table finishes and repeat scales for PolyHaven wood textures and included them in the Snooker finish options so users can reuse the same table finishes. (`webapp/src/pages/Games/SnookerRoyal.jsx`, inventory config)
- Adjusted the human actor placement logic to anchor to the cue butt so the character sits closer to the bottom end of the cue on portrait screens. (`webapp/src/pages/Games/SnookerRoyal.jsx`)
- Updated unit tests to reflect the new default behavior and added constants for clarity. (`test/snookerTableModel.test.js`)

### Testing
- Ran unit tests: `npm test -- --runInBand test/snookerTableModel.test.js test/inventoryCrossGameConfig.test.js` — both suites passed (all tests green).
- Built the web app: `npm --prefix webapp run build` — production build completed successfully; Vite emitted existing chunking/warning notes about large chunks but build artifacts produced.
- Lint: `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx webapp/src/pages/Games/snookerTableModel.js webapp/src/config/snookerRoyalClothPresets.js webapp/src/config/snookerRoyalInventoryConfig.js test/snookerTableModel.test.js` — ran, reported ignore warnings but no blocking errors.
- Verified that table finish/cloth inventory and mapping tests (inventory cross‑game config) still pass after sharing Pool Royale variants (tests above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0ed7bcc48329971bfede0ba91b8c)