### PR TITLE
Make GLB Snooker table the default with procedural fallback; preserve hardware, remap cloth UVs, derive cushion physics, and tighten human pose

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10550,6 +10550,16 @@ function Table3D(
     });
   };
 
+  const resolveOpenSourceClothUvBounds = () => {
+    const bounds = new THREE.Box3();
+    expandBoxByObjectLocalBounds(bounds, cloth);
+    if (bounds.isEmpty()) {
+      bounds.min.set(-PLAY_W / 2, clothPlaneLocal - MICRO_EPS, -PLAY_H / 2);
+      bounds.max.set(PLAY_W / 2, clothPlaneLocal + MICRO_EPS, PLAY_H / 2);
+    }
+    return bounds;
+  };
+
   const cloneFinishMaterialForOpenSource = (role, originalMaterial = null) => {
     const materials = finishInfo?.materials || {};
     const sourceByRole = {
@@ -10676,7 +10686,7 @@ function Table3D(
     });
   };
 
-  const remapOpenSourceClothTextureCoordinates = (root, targetBounds) => {
+  const remapOpenSourceClothTextureCoordinates = (root, targetBounds = resolveOpenSourceClothUvBounds()) => {
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     if (targetSize.x <= MICRO_EPS || targetSize.z <= MICRO_EPS) return;
     const localPoint = new THREE.Vector3();
@@ -10708,13 +10718,67 @@ function Table3D(
     });
   };
 
+  const applyOpenSourceCushionPhysicsFromModel = (model) => {
+    const segments = [];
+    const addSegment = (start, end, type = 'glb-cushion') => {
+      if (!start || !end || start.distanceToSquared(end) < 1e-6) return;
+      const dir = end.clone().sub(start);
+      const normal = new THREE.Vector2(-dir.y, dir.x).normalize();
+      const midpoint = start.clone().add(end).multiplyScalar(0.5);
+      if (normal.dot(midpoint.clone().multiplyScalar(-1)) < 0) normal.multiplyScalar(-1);
+      segments.push({ start, end, type, normal });
+    };
+
+    model.updateMatrixWorld(true);
+    table.updateMatrixWorld(true);
+    model.traverse((node) => {
+      if (!node?.isMesh || node.userData?.openSourceMaterialRole !== 'cushion') return;
+      const worldBox = new THREE.Box3().setFromObject(node);
+      if (worldBox.isEmpty()) return;
+      const corners = [
+        new THREE.Vector3(worldBox.min.x, worldBox.min.y, worldBox.min.z),
+        new THREE.Vector3(worldBox.min.x, worldBox.min.y, worldBox.max.z),
+        new THREE.Vector3(worldBox.max.x, worldBox.min.y, worldBox.min.z),
+        new THREE.Vector3(worldBox.max.x, worldBox.min.y, worldBox.max.z),
+        new THREE.Vector3(worldBox.min.x, worldBox.max.y, worldBox.min.z),
+        new THREE.Vector3(worldBox.min.x, worldBox.max.y, worldBox.max.z),
+        new THREE.Vector3(worldBox.max.x, worldBox.max.y, worldBox.min.z),
+        new THREE.Vector3(worldBox.max.x, worldBox.max.y, worldBox.max.z)
+      ];
+      const localBox = new THREE.Box3();
+      corners.forEach((corner) => localBox.expandByPoint(table.worldToLocal(corner.clone())));
+      const size = localBox.getSize(new THREE.Vector3());
+      const center = localBox.getCenter(new THREE.Vector3());
+      if (size.x >= size.z) {
+        const innerZ = center.z >= 0 ? localBox.min.z : localBox.max.z;
+        addSegment(new THREE.Vector2(localBox.min.x, innerZ), new THREE.Vector2(localBox.max.x, innerZ));
+      } else {
+        const innerX = center.x >= 0 ? localBox.min.x : localBox.max.x;
+        addSegment(new THREE.Vector2(innerX, localBox.min.z), new THREE.Vector2(innerX, localBox.max.z));
+      }
+    });
+
+    if (segments.length >= 4) {
+      const jaws = Array.isArray(table.userData?.cushionSegments)
+        ? table.userData.cushionSegments.filter((segment) => segment?.type === 'jaw')
+        : [];
+      const nextSegments = [...segments, ...jaws];
+      table.userData.cushionSegments = nextSegments;
+      CUSHION_SEGMENTS = nextSegments;
+      table.userData.openSourcePhysics = { source: 'glb-cushion-bounds', segmentCount: segments.length };
+      return true;
+    }
+    table.userData.openSourcePhysics = { source: 'procedural-fallback', segmentCount: 0 };
+    return false;
+  };
+
   const applyOpenSourceTableVisualOverride = () => {
     const targetBounds = resolveOpenSourceTargetBounds();
+    const clothUvBounds = resolveOpenSourceClothUvBounds();
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     const targetCenter = targetBounds.getCenter(new THREE.Vector3());
     const targetTopY = targetBounds.max.y;
     const targetHeight = Math.max(targetTopY - FLOOR_Y, targetSize.y, MICRO_EPS);
-    setProceduralTableMeshesVisible(false);
     const loader = createConfiguredGLTFLoader(renderer);
     loader
       .loadAsync(TABLE_MODEL_OPENSOURCE_GLB_URL)
@@ -10752,7 +10816,9 @@ function Table3D(
         model.updateMatrixWorld(true);
 
         applyDefaultTableFinishToOpenSourceModel(model);
-        remapOpenSourceClothTextureCoordinates(model, targetBounds);
+        remapOpenSourceClothTextureCoordinates(model, clothUvBounds);
+        applyOpenSourceCushionPhysicsFromModel(model);
+        setProceduralTableMeshesVisible(false);
         model.name = 'pooltool-snooker-generic-table';
         model.userData = {
           ...(model.userData || {}),
@@ -10760,8 +10826,10 @@ function Table3D(
           sourceUrl: TABLE_MODEL_OPENSOURCE_GLB_URL,
           fitToProceduralMapping: true,
           keepsDefaultPocketDropHardware: true,
+          preservesProceduralChromeHoldersLeatherStrapsAndNets: true,
           preservesOriginalTableBase: true,
-          usesGlbCushionShapes: true
+          usesGlbCushionShapes: true,
+          clothUvMappedToDefaultPlayfield: true
         };
         table.userData.openSourceVisual = model;
         table.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;
@@ -10769,7 +10837,8 @@ function Table3D(
         table.userData.openSourceVisualTargetBounds = targetBounds;
       })
       .catch((error) => {
-        console.warn('Failed to load Pooltool snooker_generic table model', error);
+        setProceduralTableMeshesVisible(true);
+        console.warn('Failed to load Pooltool snooker_generic table model; using procedural snooker table fallback', error);
       });
   };
 
@@ -11184,8 +11253,6 @@ function Table3D(
   parent.add(table);
   if (resolvedTableVisualModel === TABLE_MODEL_OPENSOURCE) {
     applyOpenSourceTableVisualOverride();
-  } else {
-    applyPooltoolTableVisualOverride();
   }
 
   const baulkZ = baulkLineZ;
@@ -26409,9 +26476,9 @@ const powerRef = useRef(hud.power);
             const sideX = forwardZ;
             const sideZ = -forwardX;
             humanActor.position.set(
-              cueStick.position.x - forwardX * (SCALE * 3.6) - sideX * (SCALE * 0.7),
+              cueStick.position.x - forwardX * (SCALE * 2.35) - sideX * (SCALE * 0.35),
               0,
-              cueStick.position.z - forwardZ * (SCALE * 3.6) - sideZ * (SCALE * 0.7)
+              cueStick.position.z - forwardZ * (SCALE * 2.35) - sideZ * (SCALE * 0.35)
             );
             humanActor.rotation.y = yaw;
           }

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -448,8 +448,8 @@ export default function SnookerRoyalLobby() {
           </div>
           <div className="grid grid-cols-2 gap-3">
             {[
-              { id: TABLE_MODEL_CLASSIC, label: 'Classic Table', desc: 'Current playable table' },
-              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Open-source GLTF table model' }
+              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Default GLB table with procedural fallback' },
+              { id: TABLE_MODEL_CLASSIC, label: 'Procedural Table', desc: 'Original generated fallback table' }
             ].map(({ id, label, desc }) => {
               const active = tableModel === id;
               return (

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -26,7 +26,7 @@ export function resolveSnookerGlbFitTransform(sourceSize = {}, targetSize = {}) 
 
 export function resolveSnookerTableModel(value) {
   const requested = String(value || '').toLowerCase();
-  return requested === TABLE_MODEL_OPENSOURCE ? TABLE_MODEL_OPENSOURCE : TABLE_MODEL_CLASSIC;
+  return requested === TABLE_MODEL_CLASSIC ? TABLE_MODEL_CLASSIC : TABLE_MODEL_OPENSOURCE;
 }
 
 export function applySnookerTableModelParam(params, tableModel) {


### PR DESCRIPTION
### Motivation
- Ship the Pooltool GLB snooker model as the default playable Snooker Royal table while keeping the procedural/table-base as a robust fallback if the GLB fails to load. 
- Ensure GLB cloth textures match the existing table cloth scale and let players use the same table finishes/cloths as the procedural table. 
- Preserve the procedural chrome pocket holders, leather straps and nets (pocket hardware) when rendering the GLB and derive cushion mapping/physics from the GLB where available. 
- Improve player framing by moving the human character closer to the cue butt so the cue is visually nearer the table on portrait phones.

### Description
- Default table selection: `resolveSnookerTableModel` now treats the open-source GLB as the default when no explicit `tableModel` is provided; the previous `classic` procedural table remains available as the fallback option in the lobby UI. (changes in `snookerTableModel.js` and `SnookerRoyalLobby.jsx`).
- Cloth UV mapping: added `resolveOpenSourceClothUvBounds` and changed `remapOpenSourceClothTextureCoordinates` to default to the procedural cloth bounds so external GLB cloth UVs are remapped to the game's playfield, keeping cloth texture scale consistent with the default table. (`SnookerRoyal.jsx`).
- Preserve pocket hardware and visuals: procedural pocket hardware (chrome rings, leather straps, nets) are kept visible when a GLB visual is mounted; the GLB visual is tagged with flags (e.g. `preservesProceduralChromeHoldersLeatherStrapsAndNets`, `clothUvMappedToDefaultPlayfield`) so the renderer and UI can treat these cases accordingly. (`SnookerRoyal.jsx`).
- Cushion physics from GLB: added `applyOpenSourceCushionPhysicsFromModel` which extracts cushion segments from GLB cushion meshes and populates `table.userData.cushionSegments`/`CUSHION_SEGMENTS`; if insufficient GLB data exists the code falls back to procedural cushion segments. (`SnookerRoyal.jsx`).
- GLB load visibility / fallback behavior: procedural meshes remain visible until GLB success; on GLB failure the procedural table is restored automatically. (`SnookerRoyal.jsx`).
- Human character placement: tightened the human actor offsets relative to the cue butt to move the character closer to the cue/table for better portrait framing on phones (tuned scale offsets). (`SnookerRoyal.jsx`).
- Lobby wording: swapped table option order and labels to surface the GLB option as the default and label the procedural option as the fallback in the UI. (`SnookerRoyalLobby.jsx`).

### Testing
- Built the web app with `npm --prefix webapp run build` and the production bundle completed successfully (Vite build output shown). (Succeeded)
- Ran a repository sanity check `git diff --check` to ensure no trailing whitespace or obvious diffs remain. (Succeeded)
- Started the dev server with `npm --prefix webapp run dev` to smoke-test the UI locally; server came up and the lobby page was reachable. (Succeeded)
- Attempted an automated Playwright screenshot of the lobby page to verify the default selection visually, but Playwright’s browser binary is not installed in this environment so the screenshot step failed (Playwright error). (Failed due to missing browser binary)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0ed7bcc48329971bfede0ba91b8c)