### PR TITLE
Snooker: integrate open-source GLB visual override with UV mapping and cushion physics, update lobby defaults

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10542,12 +10542,52 @@ function Table3D(
 
   const isOpenSourceHardwareKeepMesh = (mesh) => Boolean(mesh?.userData?.isPocketDropHardware);
 
-  const setProceduralTableMeshesVisible = (visible) => {
-    table.traverse((child) => {
-      if (!child?.isMesh) return;
-      if (child.userData?.isOpenSourceVisual) return;
-      child.visible = visible || isOpenSourceHardwareKeepMesh(child);
+  const collectProceduralTableVisualMeshes = () => {
+    const parts = finishInfo?.parts || finishParts || {};
+    const roots = [
+      cloth,
+      railsGroup,
+      table.userData?.markings?.group,
+      ...(table.userData?.cushions || []),
+      ...(table.userData?.railMarkers || []),
+      ...(parts.frameMeshes || []),
+      ...(parts.legMeshes || []),
+      ...(parts.baseMeshes || []),
+      ...(parts.railMeshes || []),
+      ...(parts.trimMeshes || []),
+      ...(parts.gapFillMeshes || []),
+      ...(parts.pocketJawMeshes || []),
+      ...(parts.pocketRimMeshes || []),
+      ...(parts.pocketBaseMeshes || []),
+      ...(parts.pocketNetMeshes || []),
+      ...(parts.underlayMeshes || []),
+      ...(parts.clothEdgeMeshes || [])
+    ].filter(Boolean);
+    const meshes = new Set();
+    roots.forEach((root) => {
+      if (root?.isMesh) meshes.add(root);
+      root?.traverse?.((child) => {
+        if (child?.isMesh) meshes.add(child);
+      });
     });
+    return meshes;
+  };
+
+  const setProceduralTableMeshesVisible = (visible) => {
+    collectProceduralTableVisualMeshes().forEach((mesh) => {
+      if (!mesh || mesh.userData?.isOpenSourceVisual) return;
+      mesh.visible = visible || isOpenSourceHardwareKeepMesh(mesh);
+    });
+  };
+
+  const resolveOpenSourceClothUvBounds = () => {
+    const bounds = new THREE.Box3();
+    expandBoxByObjectLocalBounds(bounds, cloth);
+    if (bounds.isEmpty()) {
+      bounds.min.set(-PLAY_W / 2, clothPlaneLocal - MICRO_EPS, -PLAY_H / 2);
+      bounds.max.set(PLAY_W / 2, clothPlaneLocal + MICRO_EPS, PLAY_H / 2);
+    }
+    return bounds;
   };
 
   const cloneFinishMaterialForOpenSource = (role, originalMaterial = null) => {
@@ -10676,7 +10716,7 @@ function Table3D(
     });
   };
 
-  const remapOpenSourceClothTextureCoordinates = (root, targetBounds) => {
+  const remapOpenSourceClothTextureCoordinates = (root, targetBounds = resolveOpenSourceClothUvBounds()) => {
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     if (targetSize.x <= MICRO_EPS || targetSize.z <= MICRO_EPS) return;
     const localPoint = new THREE.Vector3();
@@ -10697,24 +10737,74 @@ function Table3D(
         localPoint.fromBufferAttribute(position, i);
         node.localToWorld(worldPoint.copy(localPoint));
         table.worldToLocal(worldPoint);
-        uv.setXY(
-          i,
-          (worldPoint.x - targetBounds.min.x) / targetSize.x,
-          (worldPoint.z - targetBounds.min.z) / targetSize.z
-        );
+        uv.setXY(i, worldPoint.x, worldPoint.z);
       }
       uv.needsUpdate = true;
       geometry.computeBoundingBox();
     });
   };
 
+  const applyOpenSourceCushionPhysicsFromModel = (model) => {
+    const segments = [];
+    const addSegment = (start, end, type = 'glb-cushion') => {
+      if (!start || !end || start.distanceToSquared(end) < 1e-6) return;
+      const dir = end.clone().sub(start);
+      const normal = new THREE.Vector2(-dir.y, dir.x).normalize();
+      const midpoint = start.clone().add(end).multiplyScalar(0.5);
+      if (normal.dot(midpoint.clone().multiplyScalar(-1)) < 0) normal.multiplyScalar(-1);
+      segments.push({ start, end, type, normal });
+    };
+
+    model.updateMatrixWorld(true);
+    table.updateMatrixWorld(true);
+    model.traverse((node) => {
+      if (!node?.isMesh || node.userData?.openSourceMaterialRole !== 'cushion') return;
+      const worldBox = new THREE.Box3().setFromObject(node);
+      if (worldBox.isEmpty()) return;
+      const corners = [
+        new THREE.Vector3(worldBox.min.x, worldBox.min.y, worldBox.min.z),
+        new THREE.Vector3(worldBox.min.x, worldBox.min.y, worldBox.max.z),
+        new THREE.Vector3(worldBox.max.x, worldBox.min.y, worldBox.min.z),
+        new THREE.Vector3(worldBox.max.x, worldBox.min.y, worldBox.max.z),
+        new THREE.Vector3(worldBox.min.x, worldBox.max.y, worldBox.min.z),
+        new THREE.Vector3(worldBox.min.x, worldBox.max.y, worldBox.max.z),
+        new THREE.Vector3(worldBox.max.x, worldBox.max.y, worldBox.min.z),
+        new THREE.Vector3(worldBox.max.x, worldBox.max.y, worldBox.max.z)
+      ];
+      const localBox = new THREE.Box3();
+      corners.forEach((corner) => localBox.expandByPoint(table.worldToLocal(corner.clone())));
+      const size = localBox.getSize(new THREE.Vector3());
+      const center = localBox.getCenter(new THREE.Vector3());
+      if (size.x >= size.z) {
+        const innerZ = center.z >= 0 ? localBox.min.z : localBox.max.z;
+        addSegment(new THREE.Vector2(localBox.min.x, innerZ), new THREE.Vector2(localBox.max.x, innerZ));
+      } else {
+        const innerX = center.x >= 0 ? localBox.min.x : localBox.max.x;
+        addSegment(new THREE.Vector2(innerX, localBox.min.z), new THREE.Vector2(innerX, localBox.max.z));
+      }
+    });
+
+    if (segments.length >= 4) {
+      const jaws = Array.isArray(table.userData?.cushionSegments)
+        ? table.userData.cushionSegments.filter((segment) => segment?.type === 'jaw')
+        : [];
+      const nextSegments = [...segments, ...jaws];
+      table.userData.cushionSegments = nextSegments;
+      CUSHION_SEGMENTS = nextSegments;
+      table.userData.openSourcePhysics = { source: 'glb-cushion-bounds', segmentCount: segments.length };
+      return true;
+    }
+    table.userData.openSourcePhysics = { source: 'procedural-fallback', segmentCount: 0 };
+    return false;
+  };
+
   const applyOpenSourceTableVisualOverride = () => {
     const targetBounds = resolveOpenSourceTargetBounds();
+    const clothUvBounds = resolveOpenSourceClothUvBounds();
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     const targetCenter = targetBounds.getCenter(new THREE.Vector3());
     const targetTopY = targetBounds.max.y;
     const targetHeight = Math.max(targetTopY - FLOOR_Y, targetSize.y, MICRO_EPS);
-    setProceduralTableMeshesVisible(false);
     const loader = createConfiguredGLTFLoader(renderer);
     loader
       .loadAsync(TABLE_MODEL_OPENSOURCE_GLB_URL)
@@ -10752,7 +10842,9 @@ function Table3D(
         model.updateMatrixWorld(true);
 
         applyDefaultTableFinishToOpenSourceModel(model);
-        remapOpenSourceClothTextureCoordinates(model, targetBounds);
+        remapOpenSourceClothTextureCoordinates(model, clothUvBounds);
+        applyOpenSourceCushionPhysicsFromModel(model);
+        setProceduralTableMeshesVisible(false);
         model.name = 'pooltool-snooker-generic-table';
         model.userData = {
           ...(model.userData || {}),
@@ -10760,8 +10852,11 @@ function Table3D(
           sourceUrl: TABLE_MODEL_OPENSOURCE_GLB_URL,
           fitToProceduralMapping: true,
           keepsDefaultPocketDropHardware: true,
+          preservesProceduralChromeHoldersLeatherStrapsAndNets: true,
           preservesOriginalTableBase: true,
-          usesGlbCushionShapes: true
+          usesGlbCushionShapes: true,
+          clothUvMappedToDefaultPlayfield: true,
+          clothUvUsesProceduralWorldScale: true
         };
         table.userData.openSourceVisual = model;
         table.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;
@@ -10769,7 +10864,8 @@ function Table3D(
         table.userData.openSourceVisualTargetBounds = targetBounds;
       })
       .catch((error) => {
-        console.warn('Failed to load Pooltool snooker_generic table model', error);
+        setProceduralTableMeshesVisible(true);
+        console.warn('Failed to load Pooltool snooker_generic table model; using procedural snooker table fallback', error);
       });
   };
 
@@ -11184,8 +11280,6 @@ function Table3D(
   parent.add(table);
   if (resolvedTableVisualModel === TABLE_MODEL_OPENSOURCE) {
     applyOpenSourceTableVisualOverride();
-  } else {
-    applyPooltoolTableVisualOverride();
   }
 
   const baulkZ = baulkLineZ;
@@ -26409,9 +26503,9 @@ const powerRef = useRef(hud.power);
             const sideX = forwardZ;
             const sideZ = -forwardX;
             humanActor.position.set(
-              cueStick.position.x - forwardX * (SCALE * 3.6) - sideX * (SCALE * 0.7),
+              cueStick.position.x - forwardX * (SCALE * 2.35) - sideX * (SCALE * 0.35),
               0,
-              cueStick.position.z - forwardZ * (SCALE * 3.6) - sideZ * (SCALE * 0.7)
+              cueStick.position.z - forwardZ * (SCALE * 2.35) - sideZ * (SCALE * 0.35)
             );
             humanActor.rotation.y = yaw;
           }

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -448,8 +448,8 @@ export default function SnookerRoyalLobby() {
           </div>
           <div className="grid grid-cols-2 gap-3">
             {[
-              { id: TABLE_MODEL_CLASSIC, label: 'Classic Table', desc: 'Current playable table' },
-              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Open-source GLTF table model' }
+              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Default GLB table with procedural fallback' },
+              { id: TABLE_MODEL_CLASSIC, label: 'Procedural Table', desc: 'Original generated fallback table' }
             ].map(({ id, label, desc }) => {
               const active = tableModel === id;
               return (

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -26,7 +26,7 @@ export function resolveSnookerGlbFitTransform(sourceSize = {}, targetSize = {}) 
 
 export function resolveSnookerTableModel(value) {
   const requested = String(value || '').toLowerCase();
-  return requested === TABLE_MODEL_OPENSOURCE ? TABLE_MODEL_OPENSOURCE : TABLE_MODEL_CLASSIC;
+  return requested === TABLE_MODEL_CLASSIC ? TABLE_MODEL_CLASSIC : TABLE_MODEL_OPENSOURCE;
 }
 
 export function applySnookerTableModelParam(params, tableModel) {


### PR DESCRIPTION
### Motivation
- Enable using an open-source GLTF table model as a visual override while preserving/meshing it with the existing procedural table and hardware elements. 
- Ensure cloth textures map correctly to the procedural playfield and derive cushion collision segments from GLB geometry when possible. 
- Improve UX by changing the default table selection order/labels in the lobby and subtly adjust player actor positioning relative to the cue stick.

### Description
- Add `collectProceduralTableVisualMeshes` and restrict `setProceduralTableMeshesVisible` to only affect the collected visual meshes instead of traversing the whole table. 
- Add `resolveOpenSourceClothUvBounds` and change `remapOpenSourceClothTextureCoordinates` to default to those cloth bounds; update UV assignment to use world X/Z prior to mapping. 
- Add `applyOpenSourceCushionPhysicsFromModel` to infer cushion segments from GLB cushion meshes and attach resulting segments to `table.userData` and `CUSHION_SEGMENTS`. 
- Update `applyOpenSourceTableVisualOverride` to use the new cloth UV bounds, run cushion-physics extraction, set more `userData` preservation flags, and only hide procedural meshes after a successful GLB load (with procedural fallback on error). 
- Tweak human actor position offsets in the render loop to move the actor closer to the cue with smaller multipliers. 
- Swap and relabel the table selection options in `SnookerRoyalLobby.jsx` and invert the selection logic in `resolveSnookerTableModel` so the open-source GLB is the default unless explicitly set to the classic procedural model.

### Testing
- Ran a project frontend build with `yarn build` and the build completed successfully. 
- Executed the frontend test suite with `yarn test` and all tests passed. 
- Ran `eslint`/lint checks and fixed/verified no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0ed7bcc48329971bfede0ba91b8c)