### PR TITLE
Disable procedural wooden frame/rails & chrome plates for open-source GLB snooker table

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -3,16 +3,17 @@ import {
   applySnookerTableModelParam,
   resolveSnookerGlbFitTransform,
   resolveSnookerTableModel,
+  usesProceduralSnookerTableRailDecor,
   TABLE_MODEL_CLASSIC,
   TABLE_MODEL_OPENSOURCE,
   TABLE_MODEL_OPENSOURCE_GLB_URL
 } from '../webapp/src/pages/Games/snookerTableModel.js';
 
 describe('snooker table model selection', () => {
-  test('resolveSnookerTableModel defaults to classic', () => {
-    assert.equal(resolveSnookerTableModel(null), TABLE_MODEL_CLASSIC);
-    assert.equal(resolveSnookerTableModel(''), TABLE_MODEL_CLASSIC);
-    assert.equal(resolveSnookerTableModel('invalid'), TABLE_MODEL_CLASSIC);
+  test('resolveSnookerTableModel defaults to the open-source GLB table', () => {
+    assert.equal(resolveSnookerTableModel(null), TABLE_MODEL_OPENSOURCE);
+    assert.equal(resolveSnookerTableModel(''), TABLE_MODEL_OPENSOURCE);
+    assert.equal(resolveSnookerTableModel('invalid'), TABLE_MODEL_OPENSOURCE);
   });
 
   test('resolveSnookerTableModel accepts opensource value case-insensitively', () => {
@@ -26,7 +27,7 @@ describe('snooker table model selection', () => {
     assert.equal(params.get('tableModel'), TABLE_MODEL_OPENSOURCE);
 
     applySnookerTableModelParam(params, 'unknown');
-    assert.equal(params.get('tableModel'), TABLE_MODEL_CLASSIC);
+    assert.equal(params.get('tableModel'), TABLE_MODEL_OPENSOURCE);
   });
 
   test('resolveSnookerGlbFitTransform maps GLB bounds exactly onto the procedural table', () => {
@@ -43,6 +44,12 @@ describe('snooker table model selection', () => {
       { x: 12, y: 1, z: 20 }
     );
     assert.deepEqual(transform.scale, { x: 6, y: 1, z: 4 });
+  });
+
+  test('uses procedural rail decor only for the classic table model', () => {
+    assert.equal(usesProceduralSnookerTableRailDecor('classic'), true);
+    assert.equal(usesProceduralSnookerTableRailDecor('opensource'), false);
+    assert.equal(usesProceduralSnookerTableRailDecor('unknown'), false);
   });
 
   test('uses the Pooltool snooker_generic GLB source', () => {

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -19,6 +19,7 @@ import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.j
 import {
   resolveSnookerGlbFitTransform,
   resolveSnookerTableModel,
+  usesProceduralSnookerTableRailDecor,
   TABLE_MODEL_CLASSIC,
   TABLE_MODEL_OPENSOURCE,
   TABLE_MODEL_OPENSOURCE_GLB_URL
@@ -7003,6 +7004,9 @@ function Table3D(
   const tableSizeMeta =
     tableSpecMeta && typeof tableSpecMeta === 'object' ? tableSpecMeta : null;
   const resolvedTableVisualModel = resolveSnookerTableModel(tableVisualModel);
+  const keepProceduralRailDecor = usesProceduralSnookerTableRailDecor(
+    resolvedTableVisualModel
+  );
   applyTablePhysicsSpec(tableSizeMeta);
 
   const table = new THREE.Group();
@@ -10580,6 +10584,31 @@ function Table3D(
     });
   };
 
+  const removeOpenSourceProceduralRailDecor = () => {
+    if (keepProceduralRailDecor) return;
+    const parts = finishInfo?.parts || finishParts || {};
+    const meshesToRemove = new Set([
+      ...(parts.frameMeshes || []),
+      ...(parts.railMeshes || []),
+      ...(parts.trimMeshes || []),
+      ...(parts.pocketJawMeshes || []),
+      ...(parts.pocketRimMeshes || []),
+      ...(parts.gapFillMeshes || []),
+      ...(parts.underlayMeshes || []),
+      ...(parts.clothEdgeMeshes || [])
+    ].filter(Boolean));
+
+    meshesToRemove.forEach((mesh) => {
+      if (!mesh || mesh.userData?.isOpenSourceVisual || isOpenSourceHardwareKeepMesh(mesh)) {
+        return;
+      }
+      mesh.visible = false;
+      mesh.parent?.remove?.(mesh);
+    });
+
+    table.userData.pocketJawSegments = [];
+  };
+
   const resolveOpenSourceClothUvBounds = () => {
     const bounds = new THREE.Box3();
     expandBoxByObjectLocalBounds(bounds, cloth);
@@ -10785,13 +10814,18 @@ function Table3D(
     });
 
     if (segments.length >= 4) {
-      const jaws = Array.isArray(table.userData?.cushionSegments)
-        ? table.userData.cushionSegments.filter((segment) => segment?.type === 'jaw')
-        : [];
+      const jaws =
+        keepProceduralRailDecor && Array.isArray(table.userData?.cushionSegments)
+          ? table.userData.cushionSegments.filter((segment) => segment?.type === 'jaw')
+          : [];
       const nextSegments = [...segments, ...jaws];
       table.userData.cushionSegments = nextSegments;
       CUSHION_SEGMENTS = nextSegments;
-      table.userData.openSourcePhysics = { source: 'glb-cushion-bounds', segmentCount: segments.length };
+      table.userData.openSourcePhysics = {
+        source: 'glb-cushion-bounds',
+        segmentCount: segments.length,
+        proceduralJawSegmentCount: jaws.length
+      };
       return true;
     }
     table.userData.openSourcePhysics = { source: 'procedural-fallback', segmentCount: 0 };
@@ -10844,6 +10878,7 @@ function Table3D(
         applyDefaultTableFinishToOpenSourceModel(model);
         remapOpenSourceClothTextureCoordinates(model, clothUvBounds);
         applyOpenSourceCushionPhysicsFromModel(model);
+        removeOpenSourceProceduralRailDecor();
         setProceduralTableMeshesVisible(false);
         model.name = 'pooltool-snooker-generic-table';
         model.userData = {
@@ -10853,6 +10888,7 @@ function Table3D(
           fitToProceduralMapping: true,
           keepsDefaultPocketDropHardware: true,
           preservesProceduralChromeHoldersLeatherStrapsAndNets: true,
+          removesProceduralFrameRailsChromePlatesAndJaws: !keepProceduralRailDecor,
           preservesOriginalTableBase: true,
           usesGlbCushionShapes: true,
           clothUvMappedToDefaultPlayfield: true,

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -34,3 +34,7 @@ export function applySnookerTableModelParam(params, tableModel) {
   params.set('tableModel', resolved);
   return resolved;
 }
+
+export function usesProceduralSnookerTableRailDecor(tableModel) {
+  return resolveSnookerTableModel(tableModel) === TABLE_MODEL_CLASSIC;
+}


### PR DESCRIPTION
### Motivation
- The open-source GLB snooker table should render as the authoritative visual; procedural wooden frame rails, chrome plates and pocket jaws from the procedural generator must be removed when using the GLB model to avoid duplicate/incorrect geometry.
- Preserve the procedural decor only for the classic procedural table model so custom rail decor remains available where intended.
- Ensure cushion/jaw collision segments and physics do not incorrectly merge procedural jaw segments into the GLB-derived cushion data.

### Description
- Added `usesProceduralSnookerTableRailDecor(tableModel)` helper in `snookerTableModel.js` to centralize whether procedural rail decor should be kept. 
- In `SnookerRoyal.jsx` the GLB load path now calls `removeOpenSourceProceduralRailDecor()` after applying the GLB visual override to hide/remove procedural `frame/rail`, `trim/chrome` plates, `pocketJaw/pocketRim`, `gap/underlay` and `clothEdge` meshes and clears procedural jaw segment lists when the GLB model is used.
- Open-source cushion physics merging was gated by the new flag (procedural jaw segments are only merged back when keeping procedural decor), and `table.userData.openSourcePhysics` now includes `proceduralJawSegmentCount` metadata; tests were updated to reflect the GLB-as-default behavior and to assert the classic-only procedural-decor policy.

### Testing
- Ran the unit tests for the snooker table model: `npm test -- --runInBand test/snookerTableModel.test.js`, and the suite passed (all tests in that file succeeded).
- Built the webapp production bundle: `npm --prefix webapp run build`, and the Vite build completed successfully (production build emitted bundles with usual chunk warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb237564948329891c5611a6db39d8)