### PR TITLE
Snooker Royal: prefer GLB table in lobby, hide GLB base and use procedural bases

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10580,7 +10580,7 @@ function Table3D(
   const setProceduralTableMeshesVisible = (visible) => {
     collectProceduralTableVisualMeshes().forEach((mesh) => {
       if (!mesh || mesh.userData?.isOpenSourceVisual) return;
-      mesh.visible = visible || isOpenSourceHardwareKeepMesh(mesh);
+      mesh.visible = visible || isOpenSourceHardwareKeepMesh(mesh) || Boolean(mesh.userData?.__basePart);
     });
   };
 
@@ -10745,6 +10745,55 @@ function Table3D(
     });
   };
 
+  const hideOpenSourceOriginalTableBase = (root) => {
+    if (!root) return 0;
+    root.updateMatrixWorld(true);
+    const rootBounds = new THREE.Box3().setFromObject(root);
+    if (rootBounds.isEmpty()) return 0;
+    const rootSize = rootBounds.getSize(new THREE.Vector3());
+    const lowerBaseCutoff = rootBounds.min.y + rootSize.y * 0.45;
+    const topSurfaceRoles = new Set(['cloth', 'cushion', 'pocket', 'trim', 'rail']);
+    let hiddenCount = 0;
+
+    root.traverse((node) => {
+      if (!node?.isMesh) return;
+      const role = node.userData?.openSourceMaterialRole || 'frame';
+      const nodeLabel = `${node.name || ''}`.toLowerCase();
+      const materialLabel = (Array.isArray(node.material) ? node.material : [node.material])
+        .map((material) => material?.name || '')
+        .join(' ')
+        .toLowerCase();
+      const label = `${nodeLabel} ${materialLabel}`;
+      const nodeBounds = new THREE.Box3().setFromObject(node);
+      if (nodeBounds.isEmpty()) return;
+      const centerY = nodeBounds.getCenter(new THREE.Vector3()).y;
+      const namedBasePart = /\b(leg|stand|foot|feet|plinth|pedestal|support|trestle)\b/.test(label)
+        || /\bbase\b/.test(nodeLabel);
+      const lowerCabinetPart =
+        !topSurfaceRoles.has(role) &&
+        centerY < lowerBaseCutoff &&
+        /\b(frame|body|cabinet|table|wood|panel|side|apron|base)\b/.test(label);
+
+      if (role === 'leg' || namedBasePart || lowerCabinetPart) {
+        node.visible = false;
+        node.castShadow = false;
+        node.userData = {
+          ...(node.userData || {}),
+          isOpenSourceOriginalBase: true,
+          replacedByProceduralBase: true
+        };
+        hiddenCount += 1;
+      }
+    });
+
+    root.userData = {
+      ...(root.userData || {}),
+      hiddenOriginalBaseMeshCount: hiddenCount,
+      usesProceduralTableBase: true
+    };
+    return hiddenCount;
+  };
+
   const remapOpenSourceClothTextureCoordinates = (root, targetBounds = resolveOpenSourceClothUvBounds()) => {
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     if (targetSize.x <= MICRO_EPS || targetSize.z <= MICRO_EPS) return;
@@ -10876,6 +10925,7 @@ function Table3D(
         model.updateMatrixWorld(true);
 
         applyDefaultTableFinishToOpenSourceModel(model);
+        const hiddenOriginalBaseMeshCount = hideOpenSourceOriginalTableBase(model);
         remapOpenSourceClothTextureCoordinates(model, clothUvBounds);
         applyOpenSourceCushionPhysicsFromModel(model);
         removeOpenSourceProceduralRailDecor();
@@ -10889,7 +10939,9 @@ function Table3D(
           keepsDefaultPocketDropHardware: true,
           preservesProceduralChromeHoldersLeatherStrapsAndNets: true,
           removesProceduralFrameRailsChromePlatesAndJaws: !keepProceduralRailDecor,
-          preservesOriginalTableBase: true,
+          preservesOriginalTableBase: false,
+          usesProceduralTableBase: true,
+          hiddenOriginalBaseMeshCount,
           usesGlbCushionShapes: true,
           clothUvMappedToDefaultPlayfield: true,
           clothUvUsesProceduralWorldScale: true

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -16,9 +16,7 @@ import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
 import {
   applySnookerTableModelParam,
-  resolveSnookerTableModel,
-  TABLE_MODEL_CLASSIC,
-  TABLE_MODEL_OPENSOURCE
+  resolveSnookerTableModel
 } from './snookerTableModel.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'snookerRoyalPlayerFlag';
@@ -45,10 +43,7 @@ export default function SnookerRoyalLobby() {
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
-  const initialTableModel = (() => {
-    return resolveSnookerTableModel(searchParams.get('tableModel'));
-  })();
-  const [tableModel, setTableModel] = useState(initialTableModel);
+  const tableModel = resolveSnookerTableModel();
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -441,38 +436,6 @@ export default function SnookerRoyalLobby() {
           </p>
         </div>
 
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Choose Table</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Layout</span>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            {[
-              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Default GLB table with procedural fallback' },
-              { id: TABLE_MODEL_CLASSIC, label: 'Procedural Table', desc: 'Original generated fallback table' }
-            ].map(({ id, label, desc }) => {
-              const active = tableModel === id;
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => setTableModel(id)}
-                  className={`lobby-option-card ${
-                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
-                  }`}
-                >
-                  <div className="text-center">
-                    <p className="lobby-option-label">{label}</p>
-                    <p className="lobby-option-subtitle">{desc}</p>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-          <p className="text-xs text-white/60 text-center">
-            You can switch between the existing table and the new snooker model before match start.
-          </p>
-        </div>
 
         <div className="space-y-3">
           <div className="flex items-center justify-between">


### PR DESCRIPTION
### Motivation
- Make the GLB snooker table the default visual in the lobby and remove the procedural table selector so matches open with the authored GLB by default. 
- Preserve the GLB table's original cushion geometry/physics while replacing its lower/base geometry with the procedural base assets so visual/physics fidelity for cushions is retained but table bases use procedural variants. 
- Avoid double rendering / visual conflicts between the GLB model's base and the procedural base parts by detecting and hiding the GLB lower/base meshes when an open-source GLB is used.

### Description
- Added `hideOpenSourceOriginalTableBase(root)` which traverses a loaded GLB model, detects lower/base/leg/cabinet meshes (heuristics on names/roles/vertical position), hides them and marks them with `userData.isOpenSourceOriginalBase` and `replacedByProceduralBase`, and returns a `hiddenOriginalBaseMeshCount` for telemetry. 
- During GLB load (`applyOpenSourceTableVisualOverride`) the new function is invoked and its result is stored in `model.userData.hiddenOriginalBaseMeshCount` and `table.userData.openSourceVisual.*`; metadata flags `preservesOriginalTableBase` (now `false`) and `usesProceduralTableBase` (now `true`) are written. 
- Updated procedural-visibility logic in `setProceduralTableMeshesVisible` so procedural base meshes (those tagged with `userData.__basePart`) remain visible when the GLB visual is active, avoiding removal of the intended procedural bases. 
- Removed the lobby table selector UI and state so the lobby always resolves to the GLB table model by default; simplified the lobby to no longer offer switching between `classic` (procedural) and `opensource` options before match start and removed the `tableModel` setter/state from the lobby component. 

### Testing
- Ran `npm run build` in `webapp/` and the production build completed successfully with Vite; the output included only standard chunking/warning messages but the build artifacts were produced. 
- The code changes were exercised by the same `npm run build` run which validated module transforms and bundling without runtime syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3731ba0c8329bed217e05473f1c2)