### PR TITLE
Use GLB snooker table with procedural bases

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10577,9 +10577,22 @@ function Table3D(
     return meshes;
   };
 
-  const setProceduralTableMeshesVisible = (visible) => {
+  const setProceduralTableMeshesVisible = (visible, { keepProceduralBase = false } = {}) => {
+    const parts = finishInfo?.parts || finishParts || {};
+    const proceduralBaseMeshes = new Set([
+      ...(parts.legMeshes || []),
+      ...(parts.baseMeshes || [])
+    ].filter(Boolean));
     collectProceduralTableVisualMeshes().forEach((mesh) => {
       if (!mesh || mesh.userData?.isOpenSourceVisual) return;
+      const isProceduralBase =
+        proceduralBaseMeshes.has(mesh) ||
+        mesh.userData?.__basePart ||
+        mesh.userData?.isSnookerProceduralBase;
+      if (keepProceduralBase && isProceduralBase) {
+        mesh.visible = true;
+        return;
+      }
       mesh.visible = visible || isOpenSourceHardwareKeepMesh(mesh);
     });
   };
@@ -10721,7 +10734,9 @@ function Table3D(
       if (nodeBox.isEmpty()) return;
       const centerY = nodeBox.getCenter(new THREE.Vector3()).y;
       const label = `${node.name || ''} ${node.material?.name || ''}`.toLowerCase();
-      if (centerY >= upperCutoff || /cloth|felt|slate|bed|rail|cushion|frame|table/.test(label)) {
+      const isOriginalBaseLike = /leg|stand|base|foot|pedestal|support/.test(label);
+      if (isOriginalBaseLike) return;
+      if (centerY >= upperCutoff || /cloth|felt|slate|bed|rail|cushion|frame/.test(label)) {
         upperBounds.union(nodeBox);
       }
     });
@@ -10743,6 +10758,40 @@ function Table3D(
       node.userData.openSourceMaterialRole = roles.includes('cloth') ? 'cloth' : roles[0] || 'frame';
       node.material = Array.isArray(node.material) ? resolvedMaterials : resolvedMaterials[0] ?? node.material;
     });
+  };
+
+  const removeOpenSourceOriginalTableBase = (model, upperBounds) => {
+    if (!model) return 0;
+    model.updateMatrixWorld(true);
+    const upperMinY = upperBounds && !upperBounds.isEmpty?.() ? upperBounds.min.y : null;
+    const removedMeshes = [];
+    model.traverse((node) => {
+      if (!node?.isMesh) return;
+      const role = node.userData?.openSourceMaterialRole;
+      const label = `${node.name || ''} ${node.material?.name || ''}`.toLowerCase();
+      const nodeBox = new THREE.Box3().setFromObject(node);
+      const belowUpperTable =
+        Number.isFinite(upperMinY) && !nodeBox.isEmpty() && nodeBox.max.y < upperMinY + MICRO_EPS;
+      const isOriginalBaseMesh =
+        role === 'leg' ||
+        /leg|stand|base|foot|pedestal|support/.test(label) ||
+        (role === 'frame' && belowUpperTable);
+      if (!isOriginalBaseMesh) return;
+      node.visible = false;
+      node.castShadow = false;
+      node.receiveShadow = false;
+      node.userData = {
+        ...(node.userData || {}),
+        isOpenSourceOriginalBaseRemoved: true
+      };
+      removedMeshes.push(node);
+    });
+    model.userData = {
+      ...(model.userData || {}),
+      removedOriginalBaseMeshCount: removedMeshes.length,
+      usesProceduralTableBase: true
+    };
+    return removedMeshes.length;
   };
 
   const remapOpenSourceClothTextureCoordinates = (root, targetBounds = resolveOpenSourceClothUvBounds()) => {
@@ -10838,7 +10887,6 @@ function Table3D(
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     const targetCenter = targetBounds.getCenter(new THREE.Vector3());
     const targetTopY = targetBounds.max.y;
-    const targetHeight = Math.max(targetTopY - FLOOR_Y, targetSize.y, MICRO_EPS);
     const loader = createConfiguredGLTFLoader(renderer);
     loader
       .loadAsync(TABLE_MODEL_OPENSOURCE_GLB_URL)
@@ -10852,13 +10900,13 @@ function Table3D(
         const fullSourceSize = fullSourceBounds.getSize(new THREE.Vector3());
         const sourceFitSize = sourceFitBounds.getSize(new THREE.Vector3());
         const fit = resolveSnookerGlbFitTransform(
-          { x: sourceFitSize.x, y: fullSourceSize.y, z: sourceFitSize.z },
-          { x: targetSize.x, y: targetHeight, z: targetSize.z }
+          { x: sourceFitSize.x, y: sourceFitSize.y, z: sourceFitSize.z },
+          { x: targetSize.x, y: targetSize.y, z: targetSize.z }
         );
-        const originalBaseScale = Math.min(fit.scale.x, fit.scale.z);
-        if (Number.isFinite(originalBaseScale) && originalBaseScale > MICRO_EPS) {
-          fit.scale.y = originalBaseScale;
-          fit.preserveOriginalBaseScale = true;
+        const upperTableScale = Math.min(fit.scale.x, fit.scale.z);
+        if (Number.isFinite(upperTableScale) && upperTableScale > MICRO_EPS) {
+          fit.scale.y = upperTableScale;
+          fit.preservesOriginalUpperTableProportions = true;
         }
         model.scale.set(fit.scale.x, fit.scale.y, fit.scale.z);
 
@@ -10876,10 +10924,11 @@ function Table3D(
         model.updateMatrixWorld(true);
 
         applyDefaultTableFinishToOpenSourceModel(model);
+        const removedOriginalBaseMeshCount = removeOpenSourceOriginalTableBase(model, scaledFitBounds);
         remapOpenSourceClothTextureCoordinates(model, clothUvBounds);
         applyOpenSourceCushionPhysicsFromModel(model);
         removeOpenSourceProceduralRailDecor();
-        setProceduralTableMeshesVisible(false);
+        setProceduralTableMeshesVisible(false, { keepProceduralBase: true });
         model.name = 'pooltool-snooker-generic-table';
         model.userData = {
           ...(model.userData || {}),
@@ -10889,7 +10938,9 @@ function Table3D(
           keepsDefaultPocketDropHardware: true,
           preservesProceduralChromeHoldersLeatherStrapsAndNets: true,
           removesProceduralFrameRailsChromePlatesAndJaws: !keepProceduralRailDecor,
-          preservesOriginalTableBase: true,
+          preservesOriginalTableBase: false,
+          removedOriginalBaseMeshCount,
+          usesProceduralTableBase: true,
           usesGlbCushionShapes: true,
           clothUvMappedToDefaultPlayfield: true,
           clothUvUsesProceduralWorldScale: true

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -16,8 +16,6 @@ import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
 import {
   applySnookerTableModelParam,
-  resolveSnookerTableModel,
-  TABLE_MODEL_CLASSIC,
   TABLE_MODEL_OPENSOURCE
 } from './snookerTableModel.js';
 
@@ -45,10 +43,7 @@ export default function SnookerRoyalLobby() {
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
-  const initialTableModel = (() => {
-    return resolveSnookerTableModel(searchParams.get('tableModel'));
-  })();
-  const [tableModel, setTableModel] = useState(initialTableModel);
+  const tableModel = TABLE_MODEL_OPENSOURCE;
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -443,35 +438,15 @@ export default function SnookerRoyalLobby() {
 
         <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Choose Table</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Layout</span>
+            <h3 className="font-semibold text-white">Table</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">GLB</span>
           </div>
-          <div className="grid grid-cols-2 gap-3">
-            {[
-              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Default GLB table with procedural fallback' },
-              { id: TABLE_MODEL_CLASSIC, label: 'Procedural Table', desc: 'Original generated fallback table' }
-            ].map(({ id, label, desc }) => {
-              const active = tableModel === id;
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => setTableModel(id)}
-                  className={`lobby-option-card ${
-                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
-                  }`}
-                >
-                  <div className="text-center">
-                    <p className="lobby-option-label">{label}</p>
-                    <p className="lobby-option-subtitle">{desc}</p>
-                  </div>
-                </button>
-              );
-            })}
+          <div className="lobby-option-card lobby-option-card-active cursor-default">
+            <div className="text-center">
+              <p className="lobby-option-label">GLB Snooker Table</p>
+              <p className="lobby-option-subtitle">Default table with original GLB cushions and procedural bases.</p>
+            </div>
           </div>
-          <p className="text-xs text-white/60 text-center">
-            You can switch between the existing table and the new snooker model before match start.
-          </p>
         </div>
 
         <div className="space-y-3">


### PR DESCRIPTION
### Motivation
- Make the GLB snooker table the default visual in the Snooker Royal lobby and remove the procedural table selector to simplify UX.
- Preserve the original GLB cushions (visuals and cushion-derived physics) while replacing the GLB table base with procedural bases so bases can be themed/variant-driven.
- Ensure the GLB visual still fits the procedural playfield correctly but the GLB base meshes are removed to allow procedural bases to remain visible.

### Description
- Lobby: removed the table-choice UI and force the lobby to use the GLB table by default with `tableModel = TABLE_MODEL_OPENSOURCE`, and replaced the selector block with a static GLB table card (file: `webapp/src/pages/Games/SnookerRoyalLobby.jsx`).
- Table loading/visuals: added `removeOpenSourceOriginalTableBase(model, upperBounds)` to hide original GLB base/leg meshes and mark `model.userData` with `removedOriginalBaseMeshCount` and `usesProceduralTableBase` (file: `webapp/src/pages/Games/SnookerRoyal.jsx`).
- Fit and mapping changes: updated `resolveOpenSourceUpperBounds` to ignore base-like mesh labels when computing the upper-table fit area and adjusted the GLB fit transform inputs so the GLB upper table maps to the procedural playfield correctly (file: `webapp/src/pages/Games/SnookerRoyal.jsx`).
- Procedural visibility control: extended `setProceduralTableMeshesVisible` to accept `keepProceduralBase` so procedural leg/base meshes remain visible while procedural upper visuals are hidden; callsites updated to hide procedural visuals but keep procedural bases when the GLB model is active (file: `webapp/src/pages/Games/SnookerRoyal.jsx`).
- GLB material/physics handling: preserved GLB cushion meshes and used `applyOpenSourceCushionPhysicsFromModel` so cushion shapes/physics remain functional while original GLB bases are removed.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it completed without reported problems.
- Built the webapp with `npm --prefix webapp run build` and the Vite production build completed successfully.
- Installed Playwright and its deps with `npx --prefix webapp playwright install chromium` and `npx --prefix webapp playwright install-deps chromium`, both completed successfully.
- Launched a dev server and captured a mobile lobby screenshot via Playwright; screenshot produced at `/tmp/tonplaygram-screenshots/snooker-royal-lobby-glb-table.png` indicating the lobby now shows the GLB table card.
- No automated unit/test-suite changes were required for these visual/loader updates and the above automated steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3731ba0c8329bed217e05473f1c2)