### PR TITLE
Align Pool Royale Showood table surfaces

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -32,7 +32,9 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
     preserveOriginalSurfaceRoles: [],
-    hideSurfaceRoles: ['cloth']
+    // Showood supplies the cabinet/legs, while Pool Royale renders the lifted native
+    // playfield, cushions, and jaws so those surfaces share one exact gameplay layout.
+    hideSurfaceRoles: ['cloth', 'cushion', 'pocket']
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9011,6 +9011,8 @@ export function Table3D(
     CHROME_PLATE_STYLE_BY_ID[DEFAULT_CHROME_PLATE_STYLE_ID] ??
     CHROME_PLATE_STYLE_OPTIONS[0];
   const usesExternalTableModel = resolvedTableOptions?.tableModel?.kind === 'gltf';
+  const usesShowoodTableModel = resolvedTableOptions?.tableModel?.id === 'showood-seven-foot';
+  const showoodSurfaceLift = usesShowoodTableModel ? TABLE.THICK * 0.18 : 0;
   const resolveTablePocketCenters = () => {
     const centers = pocketCenters();
     return enableSidePockets ? centers : centers.slice(0, 4);
@@ -9048,7 +9050,7 @@ export function Table3D(
   const halfH = PLAY_H / 2;
   const baulkLineZ = -PLAY_H / 2 + BAULK_FROM_BAULK;
   const frameTopY = FRAME_TOP_Y;
-  const clothPlaneLocal = CLOTH_TOP_LOCAL + CLOTH_LIFT;
+  const clothPlaneLocal = CLOTH_TOP_LOCAL + CLOTH_LIFT + showoodSurfaceLift;
   const clothSurfaceY = clothPlaneLocal - CLOTH_DROP;
 
   const resolvedFinish =
@@ -11337,6 +11339,19 @@ export function Table3D(
   const addPocketJaw = (config) => {
     const assembly = createPocketJawAssembly(config);
     if (!assembly) return;
+    if (usesExternalTableModel) {
+      assembly.group.userData = {
+        ...(assembly.group.userData || {}),
+        externalTableKeepVisible: true
+      };
+      [assembly.jawMesh, assembly.rimMesh].forEach((mesh) => {
+        if (!mesh) return;
+        mesh.userData = {
+          ...(mesh.userData || {}),
+          externalTableKeepVisible: true
+        };
+      });
+    }
     scalePocketJawUvs(assembly.jawMesh?.geometry);
     pocketJawGroup.add(assembly.group);
     finishParts.pocketJawMeshes.push(assembly.jawMesh);
@@ -12008,6 +12023,7 @@ export function Table3D(
   const CUSHION_NOSE_FRONT_PULL_SCALE = 0.11; // extend only the exposed nose + undercut toward the playfield without moving the cushion base
   const CUSHION_FRONT_FIELD_EXPANSION = BALL_R * 0.5; // grow the exposed triangular faces toward the playfield without touching the rail side
   const cushionBaseY = CLOTH_TOP_LOCAL - MICRO_EPS + CUSHION_EXTRA_LIFT;
+  const cushionVisualLift = showoodSurfaceLift;
   const rawCushionHeight = Math.max(0, railsTopY - cushionBaseY);
   const cushionDrop = Math.min(CUSHION_HEIGHT_DROP, rawCushionHeight);
   const cushionHeightTarget = rawCushionHeight - cushionDrop;
@@ -12197,16 +12213,29 @@ export function Table3D(
     const geo = cushionProfileAdvanced(len, horizontal, resolvedCutAngles);
     const mesh = new THREE.Mesh(geo, cushionMat);
     mesh.rotation.x = -Math.PI / 2;
+    if (usesExternalTableModel) {
+      mesh.userData = {
+        ...(mesh.userData || {}),
+        externalTableKeepVisible: true
+      };
+    }
     const orientationScale = horizontal ? SHORT_CUSHION_HEIGHT_SCALE : 1;
     const heightScale = Math.max(0.001, cushionScaleBase / orientationScale);
     mesh.scale.y = heightScale * orientationScale;
     mesh.renderOrder = 2;
     const group = new THREE.Group();
+    if (usesExternalTableModel) {
+      group.userData = {
+        ...(group.userData || {}),
+        externalTableKeepVisible: true
+      };
+    }
     group.add(mesh);
     group.position.set(
       x,
       cushionBaseY +
-        (horizontal ? SHORT_RAIL_CUSHION_VERTICAL_LIFT : LONG_RAIL_CUSHION_VERTICAL_LIFT),
+        (horizontal ? SHORT_RAIL_CUSHION_VERTICAL_LIFT : LONG_RAIL_CUSHION_VERTICAL_LIFT) +
+        cushionVisualLift,
       z
     );
     if (!horizontal) group.rotation.y = Math.PI / 2;
@@ -12244,7 +12273,7 @@ export function Table3D(
       stripe.receiveShadow = false;
       stripe.position.set(
         group.position.x,
-        cushionBaseY + gapStripeHeight / 2 + gapStripeLift,
+        cushionBaseY + gapStripeHeight / 2 + gapStripeLift + cushionVisualLift,
         group.position.z
       );
       if (!horizontal) {


### PR DESCRIPTION
### Motivation
- Ensure the Showood GLB (external table model) visually matches Pool Royale by lifting the cloth/cushions and reusing the native playfield/cushion/jaw geometry so gameplay layout and pocket/jaw behavior remain identical.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to hide external `cloth`, `cushion`, and `pocket` surface roles for the `showood-seven-foot` model so Pool Royale renders those surfaces itself with consistent gameplay geometry.
- Added `usesShowoodTableModel` and a `showoodSurfaceLift` offset in `webapp/src/pages/Games/PoolRoyale.jsx` and applied the lift to the cloth plane and cushion visuals so the Showood cabinet/legs sit while the playfield/cushions read slightly higher.
- Marked generated pocket jaw and cushion meshes as visible when an external table is mounted by setting `userData.externalTableKeepVisible` for those assemblies so pocket jaws/cushions remain the authoritative Pool Royale pieces.
- Kept existing external-table finish application logic intact while only swapping which surface roles are hidden/preserved for the Showood model.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npx vite build` and the Vite build completed successfully (warnings about large chunks but no errors).
- Ran `git diff --check` with no issues reported.
- Attempted an automated Playwright portrait screenshot of the Showood table at `/games/poolroyale?tableModel=showood-seven-foot`; browser dependencies were installed but capturing the WebGL page timed out in this environment, so visual verification via screenshot failed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb26ba2b5c83299055db4cd765ab99)