### PR TITLE
Preserve GLB snooker cloth and cushions

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10622,21 +10622,23 @@ function Table3D(
     table.userData.pocketJawSegments = [];
   };
 
-  const resolveOpenSourceClothUvBounds = () => {
-    const bounds = new THREE.Box3();
-    expandBoxByObjectLocalBounds(bounds, cloth);
-    if (bounds.isEmpty()) {
-      bounds.min.set(-PLAY_W / 2, clothPlaneLocal - MICRO_EPS, -PLAY_H / 2);
-      bounds.max.set(PLAY_W / 2, clothPlaneLocal + MICRO_EPS, PLAY_H / 2);
-    }
-    return bounds;
-  };
+  const OPEN_SOURCE_ORIGINAL_SURFACE_ROLES = new Set(['cloth', 'cushion']);
 
   const cloneFinishMaterialForOpenSource = (role, originalMaterial = null) => {
+    if (OPEN_SOURCE_ORIGINAL_SURFACE_ROLES.has(role) && originalMaterial) {
+      const originalSurface = sharpenGltfMaterial(originalMaterial);
+      originalSurface.name = `${originalMaterial.name || role || 'snooker-glb'}-original-glb`;
+      originalSurface.userData = {
+        ...(originalSurface.userData || {}),
+        preservesOriginalGlbSnookerSurface: true,
+        openSourceSurfaceRole: role
+      };
+      originalSurface.needsUpdate = true;
+      return originalSurface;
+    }
+
     const materials = finishInfo?.materials || {};
     const sourceByRole = {
-      cloth: finishInfo?.clothMat,
-      cushion: finishInfo?.cushionMat,
       rail: materials.rail || materials.frame,
       frame: materials.frame || materials.rail,
       leg: materials.leg || materials.frame || materials.rail,
@@ -10794,34 +10796,6 @@ function Table3D(
     return removedMeshes.length;
   };
 
-  const remapOpenSourceClothTextureCoordinates = (root, targetBounds = resolveOpenSourceClothUvBounds()) => {
-    const targetSize = targetBounds.getSize(new THREE.Vector3());
-    if (targetSize.x <= MICRO_EPS || targetSize.z <= MICRO_EPS) return;
-    const localPoint = new THREE.Vector3();
-    const worldPoint = new THREE.Vector3();
-    root.updateMatrixWorld(true);
-    table.updateMatrixWorld(true);
-    root.traverse((node) => {
-      if (!node?.isMesh || node.userData?.openSourceMaterialRole !== 'cloth') return;
-      const geometry = node.geometry;
-      const position = geometry?.attributes?.position;
-      if (!geometry || !position) return;
-      let uv = geometry.attributes.uv;
-      if (!uv || uv.count !== position.count) {
-        uv = new THREE.BufferAttribute(new Float32Array(position.count * 2), 2);
-        geometry.setAttribute('uv', uv);
-      }
-      for (let i = 0; i < position.count; i += 1) {
-        localPoint.fromBufferAttribute(position, i);
-        node.localToWorld(worldPoint.copy(localPoint));
-        table.worldToLocal(worldPoint);
-        uv.setXY(i, worldPoint.x, worldPoint.z);
-      }
-      uv.needsUpdate = true;
-      geometry.computeBoundingBox();
-    });
-  };
-
   const applyOpenSourceCushionPhysicsFromModel = (model) => {
     const segments = [];
     const addSegment = (start, end, type = 'glb-cushion') => {
@@ -10883,7 +10857,6 @@ function Table3D(
 
   const applyOpenSourceTableVisualOverride = () => {
     const targetBounds = resolveOpenSourceTargetBounds();
-    const clothUvBounds = resolveOpenSourceClothUvBounds();
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     const targetCenter = targetBounds.getCenter(new THREE.Vector3());
     const targetTopY = targetBounds.max.y;
@@ -10925,7 +10898,6 @@ function Table3D(
 
         applyDefaultTableFinishToOpenSourceModel(model);
         const removedOriginalBaseMeshCount = removeOpenSourceOriginalTableBase(model, scaledFitBounds);
-        remapOpenSourceClothTextureCoordinates(model, clothUvBounds);
         applyOpenSourceCushionPhysicsFromModel(model);
         removeOpenSourceProceduralRailDecor();
         setProceduralTableMeshesVisible(false, { keepProceduralBase: true });
@@ -10942,8 +10914,10 @@ function Table3D(
           removedOriginalBaseMeshCount,
           usesProceduralTableBase: true,
           usesGlbCushionShapes: true,
-          clothUvMappedToDefaultPlayfield: true,
-          clothUvUsesProceduralWorldScale: true
+          hidesProceduralClothAndCushions: true,
+          preservesOriginalGlbClothAndCushions: true,
+          clothUvMappedToDefaultPlayfield: false,
+          clothUvUsesProceduralWorldScale: false
         };
         table.userData.openSourceVisual = model;
         table.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;


### PR DESCRIPTION
### Motivation
- Keep original cloth and cushion visuals/UVs when loading the open-source GLB snooker table instead of overwriting them with procedural materials and UV remaps.
- Ensure physics/cushion segments still derive from GLB geometry while leaving GLB cloth/cushions visually intact.

### Description
- When importing an open-source GLB table, detect `cloth` and `cushion` material roles and preserve the original GLB materials by sharpening/cloning the GLB materials instead of replacing them with procedural finish materials (`cloneFinishMaterialForOpenSource` respects `cloth`/`cushion`).
- Stop remapping GLB cloth UVs to the procedural world mapping and remove the UV-remap call in the open-source visual override flow so the imported cloth preserves its original texture coordinates.
- Keep applying cushion physics from the GLB (`applyOpenSourceCushionPhysicsFromModel`) and mark the loaded GLB with metadata flags (`hidesProceduralClothAndCushions`, `preservesOriginalGlbClothAndCushions`, `clothUvMappedToDefaultPlayfield: false`, `clothUvUsesProceduralWorldScale: false`) to document that procedural cloth/cushion geometry is hidden while original GLB surfaces are preserved.

### Testing
- Ran `npm --prefix webapp run build` to confirm the webapp builds; the build completed (Vite output) with chunking warnings but succeeded.
- Ran `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx`; ESLint ran but the file is ignored by project ignore rules (warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3db02b8883298c77e92c3a5f4451)