### PR TITLE
Preserve GLB snooker cloth and cushions

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   applySnookerTableModelParam,
+  preservesOpenSourceSnookerTableOriginalSurface,
   resolveSnookerGlbFitTransform,
   resolveSnookerTableModel,
   usesProceduralSnookerTableRailDecor,
@@ -50,6 +51,13 @@ describe('snooker table model selection', () => {
     assert.equal(usesProceduralSnookerTableRailDecor('classic'), true);
     assert.equal(usesProceduralSnookerTableRailDecor('opensource'), false);
     assert.equal(usesProceduralSnookerTableRailDecor('unknown'), false);
+  });
+
+  test('preserves the original GLB cloth and cushion surface materials', () => {
+    assert.equal(preservesOpenSourceSnookerTableOriginalSurface('cloth'), true);
+    assert.equal(preservesOpenSourceSnookerTableOriginalSurface('cushion'), true);
+    assert.equal(preservesOpenSourceSnookerTableOriginalSurface('rail'), false);
+    assert.equal(preservesOpenSourceSnookerTableOriginalSurface('frame'), false);
   });
 
   test('uses the Pooltool snooker_generic GLB source', () => {

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -18,6 +18,7 @@ import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import {
   resolveSnookerGlbFitTransform,
+  preservesOpenSourceSnookerTableOriginalSurface,
   resolveSnookerTableModel,
   usesProceduralSnookerTableRailDecor,
   TABLE_MODEL_CLASSIC,
@@ -10622,17 +10623,13 @@ function Table3D(
     table.userData.pocketJawSegments = [];
   };
 
-  const resolveOpenSourceClothUvBounds = () => {
-    const bounds = new THREE.Box3();
-    expandBoxByObjectLocalBounds(bounds, cloth);
-    if (bounds.isEmpty()) {
-      bounds.min.set(-PLAY_W / 2, clothPlaneLocal - MICRO_EPS, -PLAY_H / 2);
-      bounds.max.set(PLAY_W / 2, clothPlaneLocal + MICRO_EPS, PLAY_H / 2);
-    }
-    return bounds;
-  };
-
   const cloneFinishMaterialForOpenSource = (role, originalMaterial = null) => {
+    if (preservesOpenSourceSnookerTableOriginalSurface(role)) {
+      if (originalMaterial) {
+        originalMaterial.needsUpdate = true;
+      }
+      return originalMaterial;
+    }
     const materials = finishInfo?.materials || {};
     const sourceByRole = {
       cloth: finishInfo?.clothMat,
@@ -10755,7 +10752,11 @@ function Table3D(
       const resolvedMaterials = materials.map((material, index) =>
         cloneFinishMaterialForOpenSource(roles[index], material)
       );
+      const preservesOriginalSurfaceMaterial = roles.some((role) =>
+        preservesOpenSourceSnookerTableOriginalSurface(role)
+      );
       node.userData.openSourceMaterialRole = roles.includes('cloth') ? 'cloth' : roles[0] || 'frame';
+      node.userData.openSourcePreservesOriginalSurfaceMaterial = preservesOriginalSurfaceMaterial;
       node.material = Array.isArray(node.material) ? resolvedMaterials : resolvedMaterials[0] ?? node.material;
     });
   };
@@ -10792,34 +10793,6 @@ function Table3D(
       usesProceduralTableBase: true
     };
     return removedMeshes.length;
-  };
-
-  const remapOpenSourceClothTextureCoordinates = (root, targetBounds = resolveOpenSourceClothUvBounds()) => {
-    const targetSize = targetBounds.getSize(new THREE.Vector3());
-    if (targetSize.x <= MICRO_EPS || targetSize.z <= MICRO_EPS) return;
-    const localPoint = new THREE.Vector3();
-    const worldPoint = new THREE.Vector3();
-    root.updateMatrixWorld(true);
-    table.updateMatrixWorld(true);
-    root.traverse((node) => {
-      if (!node?.isMesh || node.userData?.openSourceMaterialRole !== 'cloth') return;
-      const geometry = node.geometry;
-      const position = geometry?.attributes?.position;
-      if (!geometry || !position) return;
-      let uv = geometry.attributes.uv;
-      if (!uv || uv.count !== position.count) {
-        uv = new THREE.BufferAttribute(new Float32Array(position.count * 2), 2);
-        geometry.setAttribute('uv', uv);
-      }
-      for (let i = 0; i < position.count; i += 1) {
-        localPoint.fromBufferAttribute(position, i);
-        node.localToWorld(worldPoint.copy(localPoint));
-        table.worldToLocal(worldPoint);
-        uv.setXY(i, worldPoint.x, worldPoint.z);
-      }
-      uv.needsUpdate = true;
-      geometry.computeBoundingBox();
-    });
   };
 
   const applyOpenSourceCushionPhysicsFromModel = (model) => {
@@ -10883,7 +10856,6 @@ function Table3D(
 
   const applyOpenSourceTableVisualOverride = () => {
     const targetBounds = resolveOpenSourceTargetBounds();
-    const clothUvBounds = resolveOpenSourceClothUvBounds();
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     const targetCenter = targetBounds.getCenter(new THREE.Vector3());
     const targetTopY = targetBounds.max.y;
@@ -10925,7 +10897,6 @@ function Table3D(
 
         applyDefaultTableFinishToOpenSourceModel(model);
         const removedOriginalBaseMeshCount = removeOpenSourceOriginalTableBase(model, scaledFitBounds);
-        remapOpenSourceClothTextureCoordinates(model, clothUvBounds);
         applyOpenSourceCushionPhysicsFromModel(model);
         removeOpenSourceProceduralRailDecor();
         setProceduralTableMeshesVisible(false, { keepProceduralBase: true });
@@ -10942,8 +10913,9 @@ function Table3D(
           removedOriginalBaseMeshCount,
           usesProceduralTableBase: true,
           usesGlbCushionShapes: true,
-          clothUvMappedToDefaultPlayfield: true,
-          clothUvUsesProceduralWorldScale: true
+          clothUvMappedToDefaultPlayfield: false,
+          clothUvUsesProceduralWorldScale: false,
+          preservesOriginalGlbClothAndCushionMaterials: true
         };
         table.userData.openSourceVisual = model;
         table.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -2,6 +2,10 @@ export const TABLE_MODEL_CLASSIC = 'classic';
 export const TABLE_MODEL_OPENSOURCE = 'opensource';
 export const TABLE_MODEL_OPENSOURCE_GLB_URL =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
+export const TABLE_MODEL_OPENSOURCE_ORIGINAL_SURFACE_ROLES = Object.freeze([
+  'cloth',
+  'cushion'
+]);
 
 
 const MIN_GLB_FIT_SIZE = 0.0001;
@@ -37,4 +41,8 @@ export function applySnookerTableModelParam(params, tableModel) {
 
 export function usesProceduralSnookerTableRailDecor(tableModel) {
   return resolveSnookerTableModel(tableModel) === TABLE_MODEL_CLASSIC;
+}
+
+export function preservesOpenSourceSnookerTableOriginalSurface(role) {
+  return TABLE_MODEL_OPENSOURCE_ORIGINAL_SURFACE_ROLES.includes(String(role || '').toLowerCase());
 }


### PR DESCRIPTION
### Motivation

- Ensure the Pooltool GLB snooker table keeps its original cloth and cushion surfaces instead of being overwritten by procedural finish materials when the open-source GLB model is used.

### Description

- Add `TABLE_MODEL_OPENSOURCE_ORIGINAL_SURFACE_ROLES` and `preservesOpenSourceSnookerTableOriginalSurface` to `webapp/src/pages/Games/snookerTableModel.js` to mark `cloth` and `cushion` as GLB-owned surfaces.  
- Update `cloneFinishMaterialForOpenSource` in `webapp/src/pages/Games/SnookerRoyal.jsx` to return the GLB's original material for roles preserved by `preservesOpenSourceSnookerTableOriginalSurface` instead of cloning procedural materials.  
- Stop remapping GLB cloth UVs and avoid forcing procedural cloth mapping for the open-source GLB; set `clothUvMappedToDefaultPlayfield: false`, `clothUvUsesProceduralWorldScale: false` and `preservesOriginalGlbClothAndCushionMaterials: true` on the loaded GLB model so original cloth/cushion textures/UVs remain intact.  
- Add a unit test in `test/snookerTableModel.test.js` asserting `preservesOpenSourceSnookerTableOriginalSurface('cloth')` and `('cushion')` are true and other roles are false.

### Testing

- Ran `npm test -- --runInBand test/snookerTableModel.test.js` and the suite passed (`8/8` tests).  
- Ran a production build with `npm --prefix webapp run build` and the build completed successfully.  
- Attempted a Playwright mobile screenshot to visually verify the GLB surfaces, but the headless Chromium failed to launch in this container due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3db02b8883298c77e92c3a5f4451)