### PR TITLE
Lift Showood external table visuals to raise cloth/cushions/balls

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -29,6 +29,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
+    playfieldVisualLift: 0.08,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
     preserveOriginalSurfaceRoles: [],

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12876,7 +12876,9 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   model.position.x -= footprintCenter.x;
   model.position.z -= footprintCenter.z;
   const targetTopLocal = dims.targetTopLocal ?? dims.cushionTopLocal;
-  model.position.y += targetTopLocal - fullBox.max.y + (tableModel?.verticalOffset ?? 0);
+  const playfieldVisualLift = tableModel?.playfieldVisualLift ?? 0;
+  model.position.y +=
+    targetTopLocal - fullBox.max.y + (tableModel?.verticalOffset ?? 0) - playfieldVisualLift;
   model.updateMatrixWorld(true);
   model.userData = {
     ...(model.userData || {}),


### PR DESCRIPTION
### Motivation
- Make the Pool Royale playfield (cloth, cushions, and balls) appear visually higher when using the Showood external GLB so the portrait/mobile framing matches the requested look.

### Description
- Add a `playfieldVisualLift` numeric option to the Showood table entry in `webapp/src/config/poolRoyaleTableModels.js` (value `0.08`).
- Apply the new value during external GLB fitting in `fitPoolRoyaleExternalTableModel` so the external model is lowered by `playfieldVisualLift` and the generated Pool Royale playfield stays visually higher and aligned with the physics field (`model.position.y += ... - playfieldVisualLift`).

### Testing
- Ran `npm --prefix webapp run build` which completed successfully. 
- Installed Playwright browser and runtime deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, both succeeded. 
- Attempted an automated Playwright screenshot to verify the lift but the headless capture timed out in this environment (screenshot attempt failed due to timeout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4361c61483299e9ec06f58813658)