### PR TITLE
Raise Pool Royale playfield visuals for Showood external table

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -29,6 +29,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
+    playfieldVisualLift: 0.16,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
     preserveOriginalSurfaceRoles: [],

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8646,7 +8646,30 @@ function calcTarget(cue, dir, balls) {
   return { impact, targetDir, cueDir, targetBall, railNormal, tHit: travel };
 }
 
+
+function getPoolRoyaleBallParent(parent) {
+  if (!parent?.userData) return parent;
+  const lift = parent.userData.playfieldVisualLift ?? 0;
+  if (!Number.isFinite(lift) || Math.abs(lift) <= MICRO_EPS) return parent;
+  if (!parent.userData.playfieldBallRoot) {
+    const root = new THREE.Group();
+    root.name = 'pool-royale-lifted-ball-root';
+    root.position.y = lift;
+    root.userData = {
+      ...(root.userData || {}),
+      poolRoyaleLiftedPlayfieldBalls: true,
+      playfieldVisualLift: lift
+    };
+    parent.add(root);
+    parent.userData.playfieldBallRoot = root;
+  } else if (Math.abs((parent.userData.playfieldBallRoot.position.y ?? 0) - lift) > MICRO_EPS) {
+    parent.userData.playfieldBallRoot.position.y = lift;
+  }
+  return parent.userData.playfieldBallRoot;
+}
+
 function Guret(parent, id, color, x, y, options = {}) {
+  const ballParent = getPoolRoyaleBallParent(parent);
   const pattern = options.pattern || (id === 'cue' ? 'cue' : 'solid');
   const number = options.number ?? null;
   const material = getBilliardBallMaterial({
@@ -8675,8 +8698,8 @@ function Guret(parent, id, color, x, y, options = {}) {
     node.userData = node.userData || {};
     node.userData.ballId = id;
   });
-  parent.add(mesh);
-  if (shadow) parent.add(shadow);
+  ballParent.add(mesh);
+  if (shadow) ballParent.add(shadow);
   return {
     id,
     color,
@@ -9011,6 +9034,10 @@ export function Table3D(
     CHROME_PLATE_STYLE_BY_ID[DEFAULT_CHROME_PLATE_STYLE_ID] ??
     CHROME_PLATE_STYLE_OPTIONS[0];
   const usesExternalTableModel = resolvedTableOptions?.tableModel?.kind === 'gltf';
+  const externalPlayfieldVisualLift =
+    usesExternalTableModel && Number.isFinite(resolvedTableOptions?.tableModel?.playfieldVisualLift)
+      ? Math.max(0, resolvedTableOptions.tableModel.playfieldVisualLift)
+      : 0;
   const resolveTablePocketCenters = () => {
     const centers = pocketCenters();
     return enableSidePockets ? centers : centers.slice(0, 4);
@@ -9020,6 +9047,7 @@ export function Table3D(
   table.userData = table.userData || {};
   table.userData.cushions = [];
   table.userData.pocketJaws = [];
+  table.userData.playfieldVisualLift = externalPlayfieldVisualLift;
   table.userData.componentPreset = tableSizeMeta?.componentPreset || 'pool';
 
   const finishParts = {
@@ -12797,6 +12825,25 @@ function expandPoolRoyaleUpperMeshBounds(targetBox, mesh, minWorldY) {
   return expanded;
 }
 
+
+function applyPoolRoyaleExternalPlayfieldVisualLift(table, lift = 0) {
+  if (!table || !Number.isFinite(lift) || Math.abs(lift) <= MICRO_EPS) return 0;
+  const liftedRoots = [];
+  table.traverse((object) => {
+    if (!object || object === table || !object.userData?.externalTableKeepVisible) return;
+    let ancestor = object.parent;
+    while (ancestor && ancestor !== table) {
+      if (ancestor.userData?.externalTableKeepVisible) return;
+      ancestor = ancestor.parent;
+    }
+    if (object.userData.poolRoyaleExternalPlayfieldLiftApplied) return;
+    object.position.y += lift;
+    object.userData.poolRoyaleExternalPlayfieldLiftApplied = lift;
+    liftedRoots.push(object);
+  });
+  return liftedRoots.length;
+}
+
 function resolvePoolRoyaleExternalTableFitBounds(model, tableModel = null) {
   const fullBox = new THREE.Box3().setFromObject(model);
   const fullSize = fullBox.getSize(new THREE.Vector3());
@@ -13369,6 +13416,10 @@ function mountPoolRoyaleExternalTableModel({
     finishParts.baseVariantId = variantId;
     table.userData.baseVariantId = variantId;
   };
+
+  if (externalPlayfieldVisualLift > 0) {
+    applyPoolRoyaleExternalPlayfieldVisualLift(table, externalPlayfieldVisualLift);
+  }
 
   applyBaseVariant(baseVariant || DEFAULT_TABLE_BASE_ID);
 


### PR DESCRIPTION
### Motivation
- Align the visual cloth/cushion overlay and balls when using the Showood GLB table by raising the generated playfield so it sits visibly higher on the external model.
- Keep playfield visuals, cushions and ball placement consistent when external table models are mounted, avoiding clipping or apparent sinking under chrome/rails.

### Description
- Added a per-model `playfieldVisualLift` option to the Showood table entry in `webapp/src/config/poolRoyaleTableModels.js` to declare the desired upward visual offset.
- Plumbed the lift into `Table3D` by storing `playfieldVisualLift` on `table.userData` and using an `externalPlayfieldVisualLift` value when the table model is GLTF-based (PoolRoyale.jsx).
- Added `getPoolRoyaleBallParent` and updated `Guret` so balls and their shadows are parented under a lifted group when a playfield lift is active, keeping balls visually matched to the raised cloth.
- Implemented `applyPoolRoyaleExternalPlayfieldVisualLift` which nudges generated overlay meshes (cloth, cushions, pocket nets/cradles marked `externalTableKeepVisible`) upward when mounting an external table model, and applied it during external-table mount/fitting.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build completed). (success)
- Installed Playwright browsers with `npx playwright install chromium` and system deps with `npx playwright install-deps chromium`. (success)
- Attempted an automated Playwright screenshot of the Pool Royale page with the Showood table to validate the lift visually, but the headless capture timed out / the page screenshot step hung in the CI-like headless environment (fonts / WebGL rendering issues), so a screenshot could not be produced in this run (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4361c61483299e9ec06f58813658)