### PR TITLE
Restore Showood table original layout

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_POOL_ROYALE_TABLE_MODEL_ID,
+  POOL_ROYALE_TABLE_MODEL_OPTIONS,
+  resolvePoolRoyaleTableModel
+} from '../webapp/src/config/poolRoyaleTableModels.js';
+
+describe('Pool Royale table models', () => {
+  test('defaults to the native Royal Original table', () => {
+    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'royal-original');
+    assert.equal(resolvePoolRoyaleTableModel(null).id, 'royal-original');
+    assert.equal(resolvePoolRoyaleTableModel('unknown').id, 'royal-original');
+  });
+
+  test('Showood uses original GLB surface layout with Pool Royale finish textures', () => {
+    const showood = POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
+      (option) => option.id === 'showood-seven-foot'
+    );
+
+    assert.ok(showood, 'Showood table model must be configured');
+    assert.equal(showood.kind, 'gltf');
+    assert.equal(showood.useOriginalLayoutSurfaces, true);
+    assert.deepEqual(showood.hideSurfaceRoles, []);
+    assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
+    assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
+      'cloth',
+      'cushion',
+      'wood',
+      'trim',
+      'pocket'
+    ]);
+    assert.equal('playfieldVisualLift' in showood, false);
+    assert.equal('fitHeightScale' in showood, false);
+  });
+});

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -18,22 +18,21 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool showroom table matched to Pool Royale footprint, shortened for default table height, and ready for interchangeable chrome plate styles; generated Pool Royale cloth and cushions are overlaid higher for exact physics-field alignment.',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and chrome plates with Pool Royale finish textures.',
     tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
-    fitHeightScale: 0.88,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
-    playfieldVisualLift: 0.16,
+    useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
     preserveOriginalSurfaceRoles: [],
-    hideSurfaceRoles: ['cloth', 'cushion']
+    hideSurfaceRoles: []
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9034,8 +9034,12 @@ export function Table3D(
     CHROME_PLATE_STYLE_BY_ID[DEFAULT_CHROME_PLATE_STYLE_ID] ??
     CHROME_PLATE_STYLE_OPTIONS[0];
   const usesExternalTableModel = resolvedTableOptions?.tableModel?.kind === 'gltf';
+  const externalTableUsesOriginalLayout =
+    usesExternalTableModel && resolvedTableOptions?.tableModel?.useOriginalLayoutSurfaces === true;
   const externalPlayfieldVisualLift =
-    usesExternalTableModel && Number.isFinite(resolvedTableOptions?.tableModel?.playfieldVisualLift)
+    usesExternalTableModel &&
+    !externalTableUsesOriginalLayout &&
+    Number.isFinite(resolvedTableOptions?.tableModel?.playfieldVisualLift)
       ? Math.max(0, resolvedTableOptions.tableModel.playfieldVisualLift)
       : 0;
   const resolveTablePocketCenters = () => {
@@ -13646,6 +13650,7 @@ function mountPoolRoyaleExternalTableModel({
     generatedVisualObjects.forEach((object) => {
       if (
         !visible &&
+        !externalTableModelForMount?.useOriginalLayoutSurfaces &&
         (object.userData?.externalTableKeepVisible ||
           (object.userData?.isChromePlate && chromePlateStyle.showGeneratedOnExternal))
       ) {


### PR DESCRIPTION
### Motivation
- Allow the Showood GLB table to render with its original cloth, cushions, pockets and chrome plate geometry while still applying Pool Royale finish textures to those roles.
- Prevent the procedural Pool Royale playfield overlay and visual lift from overriding an external GLB that is intended to supply its own visible layout.

### Description
- Added `useOriginalLayoutSurfaces: true` for the `showood-seven-foot` entry in `webapp/src/config/poolRoyaleTableModels.js` and removed the `playfieldVisualLift` / `fitHeightScale` behavior for that option.
- Updated `Table3D` in `webapp/src/pages/Games/PoolRoyale.jsx` to detect `useOriginalLayoutSurfaces` and skip applying the external playfield visual lift when the flag is set.
- Adjusted generated-visuals hiding logic so generated cloth/pocket/chrome overlays remain hidden only when an external model is *not* intended to keep its original surface layout, allowing the GLB to remain authoritative for those surfaces.
- Added a regression test `test/poolRoyaleTableModels.test.js` that verifies the Showood model configuration (GLB kind, `useOriginalLayoutSurfaces`, preserved/hidden roles, Pool Royale finish roles, and absence of `playfieldVisualLift`/`fitHeightScale`).

### Testing
- Ran `npm test -- poolRoyaleTableModels.test.js --runInBand` and the new test suite passed (2 tests, 2 passed). 
- Built the webapp with `npm --prefix webapp run build` and the Vite production build completed successfully. 
- Attempted an automated visual smoke check via Playwright (`npx playwright install chromium` and `npx playwright install-deps chromium` then a headless navigation + screenshot) but the screenshot attempt timed out / encountered headless Chromium environment issues in this runner; this is an environment limitation and not a change failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4ee8d3e88329ae15f61bbbec5d21)