### PR TITLE
Introduce reusable human rig and integrate into SnookerRoyal for improved player posing

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -24,6 +24,11 @@ import {
   TABLE_MODEL_OPENSOURCE,
   TABLE_MODEL_OPENSOURCE_GLB_URL
 } from './snookerTableModel.js';
+import {
+  createSnookerHumanRig,
+  chooseHumanEdgePosition as chooseSnookerHumanEdgePosition,
+  updateBilardoHumanPose as updateSnookerHumanPose
+} from './shared/snookerHumanRig.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -10601,6 +10606,8 @@ function Table3D(
     if (keepProceduralRailDecor) return;
     const parts = finishInfo?.parts || finishParts || {};
     const meshesToRemove = new Set([
+      cloth,
+      ...(table.userData?.cushions || []),
       ...(parts.frameMeshes || []),
       ...(parts.railMeshes || []),
       ...(parts.trimMeshes || []),
@@ -10620,6 +10627,11 @@ function Table3D(
     });
 
     table.userData.pocketJawSegments = [];
+    table.userData.proceduralOpenSourceExtrasRemoved = {
+      cloth: true,
+      cushions: table.userData?.cushions?.length || 0,
+      railDecor: true
+    };
   };
 
   const resolveOpenSourceClothUvBounds = () => {
@@ -21013,40 +21025,44 @@ const powerRef = useRef(hud.power);
       };
       const cueTipLocal = new THREE.Vector3(0, 0, -cueLen / 2);
       const cueButtLocal = new THREE.Vector3(0, 0, cueLen / 2);
-      const humanActor = new THREE.Group();
-      const humanModelRoot = new THREE.Group();
-      humanActor.add(humanModelRoot);
-      humanActor.visible = false;
-      table.add(humanActor);
       const humanLoader = new GLTFLoader();
-      humanLoader.setCrossOrigin('anonymous');
-      humanLoader.load(
-        'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
-        (gltf) => {
-          const model = gltf?.scene;
-          if (!model) return;
-          model.traverse((obj) => {
-            if (!obj?.isMesh) return;
-            obj.castShadow = true;
-            obj.receiveShadow = true;
-            obj.frustumCulled = false;
-          });
-          const scaleFactor = SCALE * 1.18;
-          model.scale.setScalar(scaleFactor);
-          model.rotation.set(0, Math.PI, 0);
-          model.position.set(0, 0, 0);
-          model.updateMatrixWorld(true);
-          const box = new THREE.Box3().setFromObject(model);
-          const center = box.getCenter(new THREE.Vector3());
-          model.position.set(-center.x, -box.min.y, -center.z);
-          humanModelRoot.add(model);
-          humanActor.visible = true;
-        },
-        undefined,
-        () => {
-          humanActor.visible = false;
-        }
-      );
+      const humanUnitScale = SCALE;
+      const human = createSnookerHumanRig(table, {
+        loader: humanLoader,
+        modelUrl: 'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
+        unit: humanUnitScale,
+        humanScale: 1.26 * humanUnitScale,
+        tableTopY: CUE_Y,
+        tableW: PLAY_W,
+        tableL: PLAY_H,
+        edgeMargin: 0.68 * humanUnitScale,
+        desiredShootDistance: 1.25 * humanUnitScale,
+        stanceWidth: 0.52 * humanUnitScale,
+        bridgePalmTableLift: 0.006 * humanUnitScale,
+        bridgeCueLift: 0.018 * humanUnitScale,
+        bridgeHandBackFromBall: 0.235 * humanUnitScale,
+        bridgeHandSide: -0.012 * humanUnitScale,
+        chinToCueHeight: 0.11 * humanUnitScale,
+        footGroundY: 0.035 * humanUnitScale,
+        kneeBendShot: 0.16 * humanUnitScale,
+        rightElbowShotRise: 0.18 * humanUnitScale,
+        rightElbowShotSide: -0.46 * humanUnitScale,
+        rightElbowShotBack: -0.78 * humanUnitScale,
+        rightForearmOutward: 0.36 * humanUnitScale,
+        rightForearmBack: 0.44 * humanUnitScale,
+        rightForearmDown: 0.48 * humanUnitScale,
+        rightForearmLength: 0.34 * humanUnitScale,
+        rightStrokePull: 0.30 * humanUnitScale,
+        rightStrokePush: 0.24 * humanUnitScale,
+        rightHandShotLift: -0.30 * humanUnitScale,
+        shootCueGripFromBack: 0.58 * humanUnitScale,
+        idleRightHandY: 0.8 * humanUnitScale,
+        idleRightHandX: 0.31 * humanUnitScale,
+        idleRightHandZ: -0.015 * humanUnitScale,
+        idleCueGripFromBack: 0.24 * humanUnitScale,
+        rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(humanUnitScale)
+      });
+      let lastHumanPoseTime = performance.now();
       const resolveCueButtTiltSign = (group, tilt) => {
         if (!group || !Number.isFinite(tilt) || tilt === 0) return 1;
         const rotY = group.rotation.y;
@@ -26583,18 +26599,55 @@ const powerRef = useRef(hud.power);
             fit(1 + edge * 0.08);
           }
           const frameCamera = updateCamera();
-          if (humanActor.visible && cueStick) {
-            const yaw = cueStick.rotation.y;
-            const forwardX = Math.sin(yaw - Math.PI);
-            const forwardZ = Math.cos(yaw - Math.PI);
-            const sideX = forwardZ;
-            const sideZ = -forwardX;
-            humanActor.position.set(
-              cueStick.position.x - forwardX * (SCALE * 2.35) - sideX * (SCALE * 0.35),
-              0,
-              cueStick.position.z - forwardZ * (SCALE * 2.35) - sideZ * (SCALE * 0.35)
-            );
-            humanActor.rotation.y = yaw;
+          if (human && cueStick && cue?.active) {
+            const nowHumanPose = performance.now();
+            const humanDt = Math.min(0.033, Math.max(0, (nowHumanPose - lastHumanPoseTime) / 1000));
+            lastHumanPoseTime = nowHumanPose;
+            TMP_VEC3_CUE_TIP_OFFSET.copy(cueTipLocal).applyEuler(cueStick.rotation);
+            TMP_VEC3_CUE_BUTT_OFFSET.copy(cueButtLocal).applyEuler(cueStick.rotation);
+            const cueTipWorld = cueStick.position.clone().add(TMP_VEC3_CUE_TIP_OFFSET);
+            const cueBackWorld = cueStick.position.clone().add(TMP_VEC3_CUE_BUTT_OFFSET);
+            const aim2DForHuman = aimDirRef.current?.clone?.() || new THREE.Vector2(0, 1);
+            if (aim2DForHuman.lengthSq() < 1e-8) aim2DForHuman.set(0, 1);
+            aim2DForHuman.normalize();
+            const aimForward = new THREE.Vector3(aim2DForHuman.x, 0, aim2DForHuman.y).normalize();
+            const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+            const cueBallWorld = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
+            const rootTarget = chooseSnookerHumanEdgePosition(cueBallWorld, aimForward, {
+              tableW: PLAY_W,
+              tableL: PLAY_H,
+              edgeMargin: 0.68 * humanUnitScale,
+              desiredShootDistance: 1.25 * humanUnitScale
+            });
+            const bridgeTarget = cueBallWorld
+              .clone()
+              .addScaledVector(aimForward, -0.235 * humanUnitScale)
+              .addScaledVector(aimSide, -0.012 * humanUnitScale)
+              .setY(CUE_Y + 0.006 * humanUnitScale);
+            const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
+            const idleRight = rootTarget
+              .clone()
+              .add(new THREE.Vector3(0.31, 0.8, -0.015).multiplyScalar(humanUnitScale).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+            const idleLeft = rootTarget
+              .clone()
+              .add(new THREE.Vector3(-0.18, 1.08, 0.03).multiplyScalar(humanUnitScale).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+            const shootingViewActive = (cameraBlendRef.current ?? 1) < 0.55;
+            const humanState = shooting
+              ? 'striking'
+              : sliderInstanceRef.current?.dragging || shootingViewActive
+                ? 'dragging'
+                : 'idle';
+            updateSnookerHumanPose(human, humanDt, {
+              state: humanState,
+              rootTarget,
+              aimForward,
+              bridgeTarget,
+              idleRight,
+              idleLeft,
+              cueBack: cueBackWorld,
+              cueTip: cueTipWorld,
+              power: powerRef.current ?? 0
+            });
           }
           renderer.render(scene, frameCamera ?? camera);
           const shouldStreamAim =

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -1,17 +1,19 @@
 import * as THREE from 'three';
 
+const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const Y_AXIS = new THREE.Vector3(0, 1, 0);
 const UP = Y_AXIS;
 const BASIS_MAT = new THREE.Matrix4();
 
 const BASE_CFG = {
+  unit: 1,
   poseLambda: 9,
   moveLambda: 5.6,
   rotLambda: 8.5,
-  humanScale: 1.18,
+  humanScale: 1.26,
   humanVisualYawFix: Math.PI,
-  stanceWidth: 0.58,
-  bridgePalmTableLift: 0.004,
+  stanceWidth: 0.52,
+  bridgePalmTableLift: 0.006,
   bridgeCueLift: 0.018,
   bridgeHandBackFromBall: 0.235,
   bridgeHandSide: -0.012,
@@ -19,16 +21,16 @@ const BASE_CFG = {
   footGroundY: 0.035,
   footLockStrength: 1.0,
   kneeBendShot: 0.16,
-  rightElbowShotRise: 0.34,
-  rightElbowShotSide: -0.38,
-  rightElbowShotBack: -0.96,
-  rightForearmOutward: 0.26,
-  rightForearmBack: 0.62,
-  rightForearmDown: 0.54,
-  rightForearmLength: 0.28,
+  rightElbowShotRise: 0.18,
+  rightElbowShotSide: -0.46,
+  rightElbowShotBack: -0.78,
+  rightForearmOutward: 0.36,
+  rightForearmBack: 0.44,
+  rightForearmDown: 0.48,
+  rightForearmLength: 0.34,
   rightStrokePull: 0.30,
   rightStrokePush: 0.24,
-  rightHandShotLift: -0.36,
+  rightHandShotLift: -0.30,
   shootCueGripFromBack: 0.58,
   idleRightHandY: 0.8,
   idleRightHandX: 0.31,
@@ -39,68 +41,505 @@ const BASE_CFG = {
   rightHandRollShoot: -2.05,
   rightHandDownPose: 0.42,
   rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092),
-  edgeMargin: 0.58,
-  desiredShootDistance: 1.06,
+  edgeMargin: 0.68,
+  desiredShootDistance: 1.25,
   strikeTime: 0.12,
   holdTime: 0.05,
   tableTopY: 0.84
 };
+
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
 const clamp01 = (v) => clamp(v, 0, 1);
 const lerp = (a, b, t) => a + (b - a) * t;
-const easeOutCubic = (t) => 1 - ((1 - t) ** 3);
+const easeOutCubic = (t) => 1 - (1 - t) ** 3;
 const easeInOut = (t) => t * t * (3 - 2 * t);
-const dampScalar = (c, t, l, dt) => THREE.MathUtils.lerp(c, t, 1 - Math.exp(-l * dt));
-const dampVector = (c, t, l, dt) => c.lerp(t, 1 - Math.exp(-l * dt));
-const yawFromForward = (f) => Math.atan2(-f.x, -f.z);
+const dampScalar = (current, target, lambda, dt) =>
+  THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+const dampVector = (current, target, lambda, dt) =>
+  current.lerp(target, 1 - Math.exp(-lambda * dt));
+const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
 const cleanName = (name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
 
+function scaleVectorConfig(cfg) {
+  const next = { ...BASE_CFG, ...cfg };
+  if (!(next.rightHandCueSocketLocal instanceof THREE.Vector3)) {
+    const socket = next.rightHandCueSocketLocal || BASE_CFG.rightHandCueSocketLocal;
+    next.rightHandCueSocketLocal = new THREE.Vector3(socket.x, socket.y, socket.z);
+  } else {
+    next.rightHandCueSocketLocal = next.rightHandCueSocketLocal.clone();
+  }
+  if (!(next.idleCueDir instanceof THREE.Vector3)) {
+    const dir = next.idleCueDir || BASE_CFG.idleCueDir;
+    next.idleCueDir = new THREE.Vector3(dir.x, dir.y, dir.z);
+  } else {
+    next.idleCueDir = next.idleCueDir.clone();
+  }
+  return next;
+}
+
 function makeBasisQuaternion(side, up, forward) {
-  BASIS_MAT.makeBasis(side.clone().normalize(), up.clone().normalize(), forward.clone().normalize());
+  BASIS_MAT.makeBasis(
+    side.clone().normalize(),
+    up.clone().normalize(),
+    forward.clone().normalize()
+  );
   return new THREE.Quaternion().setFromRotationMatrix(BASIS_MAT);
 }
-function findBone(all, aliases) { const list = all.map((bone) => ({ bone, name: cleanName(bone.name) })); for (const alias of aliases.map(cleanName)) { const m = list.find((x) => x.name === alias || x.name.endsWith(alias) || x.name.includes(alias)); if (m) return m.bone; } return undefined; }
-function buildAvatarBones(model) { const all = []; model.traverse((o) => o?.isBone && all.push(o)); const f = (...n) => findBone(all, n); return { hips: f('hips','pelvis','mixamorigHips'), spine: f('spine','spine01','mixamorigSpine'), chest: f('spine2','chest','upperchest','mixamorigSpine2','mixamorigSpine1'), neck: f('neck','mixamorigNeck'), head: f('head','mixamorigHead'), leftUpperArm: f('leftupperarm','leftarm','upperarml','mixamorigLeftArm'), leftLowerArm: f('leftforearm','leftlowerarm','forearml','mixamorigLeftForeArm'), leftHand: f('lefthand','handl','mixamorigLeftHand'), rightUpperArm: f('rightupperarm','rightarm','upperarmr','mixamorigRightArm'), rightLowerArm: f('rightforearm','rightlowerarm','forearmr','mixamorigRightForeArm'), rightHand: f('righthand','handr','mixamorigRightHand'), leftUpperLeg: f('leftupleg','leftupperleg','leftthigh','mixamorigLeftUpLeg'), leftLowerLeg: f('leftleg','leftlowerleg','leftcalf','mixamorigLeftLeg'), leftFoot: f('leftfoot','footl','mixamorigLeftFoot'), rightUpperLeg: f('rightupleg','rightupperleg','rightthigh','mixamorigRightUpLeg'), rightLowerLeg: f('rightleg','rightlowerleg','rightcalf','mixamorigRightLeg'), rightFoot: f('rightfoot','footr','mixamorigRightFoot') }; }
-const collectFingerBones = (hand) => { const out = []; hand?.traverse((o) => { if (!o?.isBone || o === hand) return; const n = cleanName(o.name); if (['thumb','index','middle','ring','pinky','little','finger'].some((s) => n.includes(s))) out.push(o); }); return out; };
-function normalizeHuman(model, cfg) { model.scale.setScalar(cfg.humanScale); model.rotation.set(0, cfg.humanVisualYawFix, 0); model.position.set(0,0,0); model.updateMatrixWorld(true); const box = new THREE.Box3().setFromObject(model); const c = box.getCenter(new THREE.Vector3()); model.position.set(-c.x, -box.min.y, -c.z); }
-function setBoneWorldQuaternion(bone, q) { if (!bone || !q) return; const p = new THREE.Quaternion(); bone.parent?.getWorldQuaternion(p); bone.quaternion.copy(p.invert().multiply(q)); bone.updateMatrixWorld(true); }
-function firstBoneChild(bone) { return bone?.children.find((c) => c?.isBone); }
-function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) { if (!bone || strength <= 0) return; const bp = bone.getWorldPosition(new THREE.Vector3()); const cp = firstBoneChild(bone)?.getWorldPosition(new THREE.Vector3()) || bp.clone().addScaledVector(fallbackDir, 0.25); const current = cp.sub(bp).normalize(); const desired = target.clone().sub(bp); if (desired.lengthSq() < 1e-6) return; const delta = new THREE.Quaternion().slerpQuaternions(new THREE.Quaternion(), new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()), clamp01(strength)); setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion()))); }
-const twistBone = (bone, axis, amount) => bone && Math.abs(amount) > 1e-5 && setBoneWorldQuaternion(bone, new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount).multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
-const aimTwoBone = (u,l,e,h,p,us=0.96,ls=0.98) => { for(let i=0;i<4;i+=1){ rotateBoneToward(u,e,us,p); rotateBoneToward(l,h,ls,p);} };
-function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) { if (!bone) return; const q = makeBasisQuaternion(side, up, forward); if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll)); setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength))); }
-function cueSocketOffsetWorld(side, up, forward, roll, socketLocal) { const q = makeBasisQuaternion(side, up, forward); if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll)); return socketLocal.clone().applyQuaternion(q); }
-function poseFingers(fingers, mode, weight) { const w = clamp01(weight); fingers.forEach((f) => { if (mode === 'idle') { f.rotation.x += 0.018 * w; return; } f.rotation.x += (mode === 'grip' ? 0.5 : 0.2) * w; }); }
+
+function findBone(all, aliases) {
+  const list = all.map((bone) => ({ bone, name: cleanName(bone.name) }));
+  const names = aliases.map(cleanName);
+  for (const alias of names) {
+    const exact = list.find((x) => x.name === alias || x.name.endsWith(alias));
+    if (exact) return exact.bone;
+  }
+  for (const alias of names) {
+    const loose = list.find((x) => x.name.includes(alias));
+    if (loose) return loose.bone;
+  }
+  return undefined;
+}
+
+function buildAvatarBones(model) {
+  const all = [];
+  model.traverse((obj) => {
+    if (obj?.isBone) all.push(obj);
+  });
+  const f = (...names) => findBone(all, names);
+  return {
+    hips: f('hips', 'pelvis', 'mixamorigHips'),
+    spine: f('spine', 'spine01', 'mixamorigSpine'),
+    chest: f('spine2', 'chest', 'upperchest', 'mixamorigSpine2', 'mixamorigSpine1'),
+    neck: f('neck', 'mixamorigNeck'),
+    head: f('head', 'mixamorigHead'),
+    leftUpperArm: f('leftupperarm', 'leftarm', 'upperarml', 'mixamorigLeftArm'),
+    leftLowerArm: f('leftforearm', 'leftlowerarm', 'forearml', 'mixamorigLeftForeArm'),
+    leftHand: f('lefthand', 'handl', 'mixamorigLeftHand'),
+    rightUpperArm: f('rightupperarm', 'rightarm', 'upperarmr', 'mixamorigRightArm'),
+    rightLowerArm: f('rightforearm', 'rightlowerarm', 'forearmr', 'mixamorigRightForeArm'),
+    rightHand: f('righthand', 'handr', 'mixamorigRightHand'),
+    leftUpperLeg: f('leftupleg', 'leftupperleg', 'leftthigh', 'mixamorigLeftUpLeg'),
+    leftLowerLeg: f('leftleg', 'leftlowerleg', 'leftcalf', 'mixamorigLeftLeg'),
+    leftFoot: f('leftfoot', 'footl', 'mixamorigLeftFoot'),
+    rightUpperLeg: f('rightupleg', 'rightupperleg', 'rightthigh', 'mixamorigRightUpLeg'),
+    rightLowerLeg: f('rightleg', 'rightlowerleg', 'rightcalf', 'mixamorigRightLeg'),
+    rightFoot: f('rightfoot', 'footr', 'mixamorigRightFoot')
+  };
+}
+
+function collectFingerBones(hand) {
+  const out = [];
+  hand?.traverse((obj) => {
+    if (!obj?.isBone || obj === hand) return;
+    const n = cleanName(obj.name);
+    if (['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((s) => n.includes(s))) {
+      out.push(obj);
+    }
+  });
+  return out;
+}
+
+function normalizeHuman(model, cfg) {
+  model.scale.setScalar(cfg.humanScale);
+  model.rotation.set(0, cfg.humanVisualYawFix, 0);
+  model.position.set(0, 0, 0);
+  model.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const center = box.getCenter(new THREE.Vector3());
+  model.position.set(-center.x, -box.min.y, -center.z);
+}
 
 export function createHumanRig(scene, opts = {}) {
-  const cfg = { ...BASE_CFG, ...opts };
-  const human = { root: new THREE.Group(), modelRoot: new THREE.Group(), model: null, bones: {}, leftFingers: [], rightFingers: [], restQuats: new Map(), activeGlb: false, poseT:0, walkT:0, yaw:0, breathT:0, settleT:0, strikeRoot:new THREE.Vector3(), strikeYaw:0, strikeClock:0, cfg };
-  human.root.visible = false; human.modelRoot.visible = false; scene.add(human.root, human.modelRoot);
-  const { loader, modelUrl } = opts;
-  if (!loader || !modelUrl) return human;
+  const cfg = scaleVectorConfig(opts);
+  const human = {
+    root: new THREE.Group(),
+    modelRoot: new THREE.Group(),
+    model: null,
+    bones: {},
+    leftFingers: [],
+    rightFingers: [],
+    restQuats: new Map(),
+    activeGlb: false,
+    poseT: 0,
+    walkT: 0,
+    yaw: 0,
+    breathT: 0,
+    settleT: 0,
+    strikeRoot: new THREE.Vector3(),
+    strikeYaw: 0,
+    strikeClock: 0,
+    cfg
+  };
+  human.root.visible = false;
+  human.modelRoot.visible = false;
+  scene.add(human.root, human.modelRoot);
+
+  const { loader, modelUrl = HUMAN_URL, onStatus } = opts;
+  if (!loader) return human;
   loader.setCrossOrigin?.('anonymous');
-  loader.load(modelUrl, (gltf) => { const model = gltf?.scene; if (!model) return; normalizeHuman(model, cfg); model.traverse((o)=>{ if(!o?.isMesh) return; o.castShadow=true;o.receiveShadow=true;o.frustumCulled=false;}); human.bones=buildAvatarBones(model); human.leftFingers=collectFingerBones(human.bones.leftHand); human.rightFingers=collectFingerBones(human.bones.rightHand); [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((b)=>b&&human.restQuats.set(b,b.quaternion.clone())); human.activeGlb=Boolean(human.bones.hips&&human.bones.spine&&human.bones.head&&human.bones.rightUpperArm&&human.bones.rightLowerArm&&human.bones.rightHand); human.model=model; human.modelRoot.add(model); human.modelRoot.visible=human.activeGlb; });
+  onStatus?.('Loading original skeleton human logic…');
+  loader.load(
+    modelUrl,
+    (gltf) => {
+      const model = gltf?.scene;
+      if (!model) return;
+      normalizeHuman(model, cfg);
+      model.traverse((obj) => {
+        if (!obj?.isMesh) return;
+        obj.castShadow = true;
+        obj.receiveShadow = true;
+        obj.frustumCulled = false;
+        const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+        mats.forEach((mat) => {
+          if (mat.map) {
+            mat.map.colorSpace = THREE.SRGBColorSpace;
+            mat.map.flipY = false;
+            mat.map.needsUpdate = true;
+          }
+          mat.depthWrite = true;
+          mat.depthTest = true;
+          mat.needsUpdate = true;
+        });
+      });
+      human.bones = buildAvatarBones(model);
+      human.leftFingers = collectFingerBones(human.bones.leftHand);
+      human.rightFingers = collectFingerBones(human.bones.rightHand);
+      [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((bone) => {
+        if (bone) human.restQuats.set(bone, bone.quaternion.clone());
+      });
+      const b = human.bones;
+      human.activeGlb = Boolean(
+        b.hips && b.spine && b.head && b.rightUpperArm && b.rightLowerArm && b.rightHand &&
+        b.leftUpperLeg && b.leftLowerLeg && b.leftFoot && b.rightUpperLeg && b.rightLowerLeg && b.rightFoot
+      );
+      human.model = model;
+      human.modelRoot.add(model);
+      human.modelRoot.visible = human.activeGlb;
+      onStatus?.(human.activeGlb ? 'Original human skeleton logic restored' : 'Human loaded, skeleton aliases incomplete');
+    },
+    undefined,
+    (error) => {
+      console.warn('ReadyPlayer human failed', error);
+      onStatus?.('ReadyPlayer GLTF human failed');
+    }
+  );
   return human;
 }
 
-function driveHuman(human, frame) { if (!human.activeGlb || !human.model) return; const cfg = human.cfg; human.modelRoot.visible=true; human.modelRoot.position.copy(frame.rootWorld); human.modelRoot.rotation.y=human.yaw; human.modelRoot.updateMatrixWorld(true); human.restQuats.forEach((q,b)=>b.quaternion.copy(q));
-  const b = human.bones; const ik = easeInOut(clamp01(frame.t)); const idle=1-ik; const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize(); const standingCueDir = cfg.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
-  const rightGrip = frame.rightHandWorld.clone(); const rightIdleElbow = rightGrip.clone().addScaledVector(UP,0.04+0.14*ik).addScaledVector(frame.side,-0.2).addScaledVector(frame.forward,-0.03*idle); const rightElbow=frame.rightElbow.clone().lerp(rightIdleElbow,idle*0.5); const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(UP,0.32).addScaledVector(frame.forward,-0.55).normalize(); aimTwoBone(b.rightUpperArm,b.rightLowerArm,rightElbow,rightGrip,pole,0.9+0.1*ik,1.0);
-  const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP,-0.55).addScaledVector(frame.forward,0.16).normalize(); const standingHandUp = UP.clone().multiplyScalar(-1).addScaledVector(frame.side,-0.64).addScaledVector(frame.forward,0.2).normalize(); const handForward = ik>=0.025 ? standingCueDir : cueDir; const roll = ik>=0.025 ? cfg.rightHandRollIdle : cfg.rightHandRollIdle + 0.02*frame.stroke; setHandBasis(b.rightHand, standingHandSide, standingHandUp, handForward, roll, 1.0); poseFingers(human.rightFingers,'grip',0.95);
-  if (ik < 0.025) { poseFingers(human.leftFingers,'idle',1); return; }
-  const leftHand = frame.leftHandWorld.clone(); const leftElbow = frame.leftElbow.clone(); aimTwoBone(b.leftUpperArm,b.leftLowerArm,leftElbow,leftHand,frame.side.clone().multiplyScalar(-1).addScaledVector(UP,0.1).normalize(),0.98*ik,1.0*ik);
-  const bridgeSide = frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward,-0.52).normalize(); const bridgeUp = UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward,-0.28).addScaledVector(frame.side,-0.16).normalize(); setHandBasis(b.leftHand, bridgeSide, bridgeUp, cueDir, -0.68*ik, 1.0*ik); poseFingers(human.leftFingers,'bridge',ik);
+function setBoneWorldQuaternion(bone, q) {
+  if (!bone || !q) return;
+  const parentQ = new THREE.Quaternion();
+  bone.parent?.getWorldQuaternion(parentQ);
+  bone.quaternion.copy(parentQ.invert().multiply(q));
+  bone.updateMatrixWorld(true);
+}
+function firstBoneChild(bone) {
+  return bone?.children.find((child) => child?.isBone);
+}
+function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) {
+  if (!bone || strength <= 0) return;
+  const bonePos = bone.getWorldPosition(new THREE.Vector3());
+  const childPos = firstBoneChild(bone)?.getWorldPosition(new THREE.Vector3()) ||
+    bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25);
+  const current = childPos.sub(bonePos).normalize();
+  const desired = target.clone().sub(bonePos);
+  if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return;
+  const delta = new THREE.Quaternion().slerpQuaternions(
+    new THREE.Quaternion(),
+    new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()),
+    clamp01(strength)
+  );
+  setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+function twistBone(bone, axis, amount) {
+  if (!bone || Math.abs(amount) < 1e-5) return;
+  setBoneWorldQuaternion(
+    bone,
+    new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount)
+      .multiply(bone.getWorldQuaternion(new THREE.Quaternion()))
+  );
+}
+function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) {
+  for (let i = 0; i < 4; i += 1) {
+    rotateBoneToward(upper, elbow, upperStrength, pole);
+    rotateBoneToward(lower, hand, lowerStrength, pole);
+  }
+}
+function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) {
+  if (!bone || strength <= 0) return;
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-4) {
+    q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  }
+  setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength)));
+}
+function cueSocketOffsetWorld(side, up, forward, roll, socketLocal) {
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  return socketLocal.clone().applyQuaternion(q);
+}
+function poseFingers(fingers, mode, weight) {
+  const w = clamp01(weight);
+  fingers.forEach((finger, i) => {
+    const n = cleanName(finger.name);
+    const thumb = n.includes('thumb');
+    const index = n.includes('index');
+    const middle = n.includes('middle');
+    const ring = n.includes('ring');
+    const pinky = n.includes('pinky') || n.includes('little');
+    const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal'));
+    const mid = n.includes('2') || n.includes('intermediate');
+    const tip = n.includes('3') || n.includes('distal');
+    if (mode === 'idle') {
+      finger.rotation.x += 0.018 * w;
+      finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1);
+      return;
+    }
+    if (mode === 'grip') {
+      if (thumb) {
+        finger.rotation.x += 0.48 * w;
+        finger.rotation.y += -0.82 * w;
+        finger.rotation.z += 0.54 * w;
+        return;
+      }
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0;
+      finger.rotation.x += curl * w;
+      finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w;
+      finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w;
+      return;
+    }
+    if (thumb) {
+      finger.rotation.x += -0.18 * w;
+      finger.rotation.y += 0.95 * w;
+      finger.rotation.z += -0.95 * w;
+    } else if (index) {
+      finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w;
+      finger.rotation.y += -0.46 * w;
+      finger.rotation.z += -0.42 * w;
+    } else if (middle) {
+      finger.rotation.x += (base ? 0.18 : mid ? 0.32 : 0.22) * w;
+      finger.rotation.y += -0.12 * w;
+      finger.rotation.z += -0.14 * w;
+    } else if (ring || pinky) {
+      finger.rotation.x += (base ? (ring ? 0.08 : 0.05) : mid ? (ring ? 0.18 : 0.16) : tip ? (ring ? 0.12 : 0.1) : 0.1) * w;
+      finger.rotation.y += (ring ? 0.18 : 0.34) * w;
+      finger.rotation.z += (ring ? 0.28 : 0.46) * w;
+    }
+  });
 }
 
-export function updateHumanPose(human, dt, frameData){ if(!human||!frameData) return; const cfg=human.cfg; const state=frameData.state||'idle'; human.poseT=dampScalar(human.poseT,state==='idle'?0:1,cfg.poseLambda,dt); human.breathT+=dt*(state==='idle'?1.05:0.5); if(state==='striking'){ if(human.strikeClock===0){ human.strikeRoot.copy(human.root.position.lengthSq()>0.001?human.root.position:frameData.rootTarget); human.strikeYaw=human.yaw;} human.strikeClock+=dt;} else human.strikeClock=0;
- const rootGoal=state==='striking'?human.strikeRoot:frameData.rootTarget; dampVector(human.root.position,rootGoal,state==='striking'?12:cfg.moveLambda,dt); const moveAmountRaw=human.root.position.distanceTo(rootGoal); human.walkT+=dt*(2+Math.min(7,moveAmountRaw*10)); human.yaw=dampScalar(human.yaw,state==='striking'?human.strikeYaw:yawFromForward(frameData.aimForward),cfg.rotLambda,dt);
- const t=easeInOut(human.poseT), idle=1-t; const walk=Math.sin(human.walkT*6.2)*Math.min(1,moveAmountRaw*12); const forward = new THREE.Vector3(0,0,-1).applyAxisAngle(Y_AXIS,human.yaw).normalize(); const side = new THREE.Vector3(forward.z,0,-forward.x).normalize(); const local = (v)=>v.clone().applyAxisAngle(Y_AXIS,human.yaw).add(human.root.position);
- const torso = local(new THREE.Vector3(0, lerp(1.3,1.08,t), lerp(0.02,-0.22,t))); const chest=local(new THREE.Vector3(0,lerp(1.52,1.16,t),lerp(0.02,-0.52,t))); const neck=local(new THREE.Vector3(0,lerp(1.68,1.18,t),lerp(0.02,-0.74,t))); const head=local(new THREE.Vector3(0,lerp(1.84,1.25,t),lerp(0.04,-0.88,t))); const leftShoulder=local(new THREE.Vector3(-0.23,lerp(1.58,1.24,t),lerp(0,-0.6,t))); const rightShoulder=local(new THREE.Vector3(0.23,lerp(1.58,1.26,t),lerp(0,-0.45,t)));
- const leftHip=local(new THREE.Vector3(-0.13,0.92,0.02)); const rightHip=local(new THREE.Vector3(0.13,0.92,0.02)); const leftFoot=local(new THREE.Vector3(-0.13,cfg.footGroundY,0.03+walk*0.018).lerp(new THREE.Vector3(-cfg.stanceWidth*0.42,cfg.footGroundY,-0.34),t)); const rightFoot=local(new THREE.Vector3(0.13,cfg.footGroundY,-0.03-walk*0.018).lerp(new THREE.Vector3(cfg.stanceWidth*0.5,cfg.footGroundY,0.34),t));
- const bridgePalm = frameData.bridgeTarget.clone().addScaledVector(forward,-0.006*t).addScaledVector(side,-0.012*t).setY(cfg.tableTopY+cfg.bridgePalmTableLift); const leftHand = frameData.idleLeft.clone().lerp(bridgePalm,t); const cueDir = frameData.cueTip.clone().sub(frameData.cueBack).normalize(); const handIk=easeInOut(clamp01(t)); const idleGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,-0.55).addScaledVector(forward,0.16).normalize(); const idleGripUp=UP.clone().multiplyScalar(-1).addScaledVector(side,-0.64).addScaledVector(forward,0.2).normalize(); const liveGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,lerp(-0.55,-0.62,handIk)).addScaledVector(side,0.5*handIk).addScaledVector(forward,lerp(0.16,-0.08,handIk)).normalize(); const liveGripUp=UP.clone().multiplyScalar(lerp(-1.0,0.12,handIk)).addScaledVector(side,lerp(-0.64,-0.04,handIk)).addScaledVector(forward,lerp(0.2,-0.48,handIk)).normalize();
- const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04,cfg.rightElbowShotRise,t)).addScaledVector(side,lerp(-0.18,cfg.rightElbowShotSide,t)).addScaledVector(forward,lerp(-0.04,cfg.rightElbowShotBack,t)); const pullBack = state==='dragging' ? -cfg.rightStrokePull*easeOutCubic(frameData.power||0) : 0; const push = state==='striking' ? cfg.rightStrokePush*Math.sin(clamp01(human.strikeClock/(cfg.strikeTime+cfg.holdTime))*Math.PI):0; const forearmBase = lockedRightElbow.clone().addScaledVector(side,cfg.rightForearmOutward*t).addScaledVector(UP,-cfg.rightForearmDown*t).addScaledVector(UP,cfg.rightHandShotLift*t).addScaledVector(forward,-cfg.rightForearmBack*t).addScaledVector(cueDir,cfg.rightForearmLength); const liveGripPoint = forearmBase.clone().addScaledVector(cueDir,pullBack+push); if (frameData.gripTarget) liveGripPoint.lerp(frameData.gripTarget, 0.72*t); const idleWrist=frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide,idleGripUp,cueDir,cfg.rightHandRollIdle,cfg.rightHandCueSocketLocal)); const liveWrist=liveGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide,liveGripUp,cueDir,lerp(cfg.rightHandRollIdle,cfg.rightHandRollShoot-cfg.rightHandDownPose,handIk),cfg.rightHandCueSocketLocal));
- const rightHand = idleWrist.clone().lerp(liveWrist,t); const leftElbow = leftShoulder.clone().lerp(leftHand,0.62); const leftKnee = leftHip.clone().lerp(leftFoot,0.53).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot,t)); const rightKnee = rightHip.clone().lerp(rightFoot,0.52).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot*0.88,t));
- human.root.visible=true; driveHuman(human,{t,stroke:pullBack+push,forward,side,up:UP,rootWorld:human.root.position.clone(),torsoCenterWorld:torso,chestCenterWorld:chest,neckWorld:neck,headCenterWorld:head,leftElbow,rightElbow:lockedRightElbow,leftHandWorld:leftHand,rightHandWorld:rightHand,leftKnee,rightKnee,leftFootWorld:leftFoot,rightFootWorld:rightFoot,cueBackWorld:frameData.cueBack,cueTipWorld:frameData.cueTip});
+function driveHuman(human, frame) {
+  if (!human.activeGlb || !human.model) return;
+  const cfg = human.cfg;
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(frame.rootWorld);
+  human.modelRoot.rotation.y = human.yaw;
+  human.modelRoot.updateMatrixWorld(true);
+  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
+  human.modelRoot.updateMatrixWorld(true);
+  const b = human.bones;
+  const ik = easeInOut(clamp01(frame.t));
+  const idle = 1 - ik;
+  const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
+  const standingCueDir = cfg.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
+
+  if (frame.walkAmount * idle > 0.001) {
+    const s = Math.sin(human.walkT * 6.2);
+    const c = Math.cos(human.walkT * 6.2);
+    const w = frame.walkAmount * idle;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+  }
+
+  if (ik >= 0.025) {
+    rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
+    twistBone(b.hips, frame.side, -0.045 * ik);
+    twistBone(b.hips, frame.forward, -0.025 * ik);
+    rotateBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
+    twistBone(b.spine, frame.side, -0.2 * ik);
+    twistBone(b.spine, frame.forward, -0.04 * ik);
+    rotateBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
+    twistBone(b.chest, frame.side, -0.32 * ik);
+    twistBone(b.chest, frame.forward, -0.025 * ik);
+    rotateBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
+    twistBone(b.neck, frame.side, -0.12 * ik);
+    if (b.head) {
+      setBoneWorldQuaternion(
+        b.head,
+        b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(
+          shotQ.clone()
+            .multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik))
+            .multiply(new THREE.Quaternion().setFromAxisAngle(frame.forward, -0.025 * ik)),
+          0.74 * ik
+        )
+      );
+    }
+    human.modelRoot.updateMatrixWorld(true);
+  }
+
+  const rightGrip = frame.rightHandWorld.clone();
+  const rightIdleElbow = rightGrip.clone()
+    .addScaledVector(UP, 0.04 * cfg.unit + 0.14 * cfg.unit * ik)
+    .addScaledVector(frame.side, -0.2 * cfg.unit)
+    .addScaledVector(frame.forward, -0.03 * cfg.unit * idle);
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
+  const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.32).addScaledVector(frame.forward, -0.55).normalize();
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, pole, 0.9 + 0.1 * ik, 1.0);
+  const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
+  const standingHandUp = UP.clone().multiplyScalar(-1.0).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
+  const handForwardForOrientation = ik >= 0.025 ? standingCueDir : cueDir;
+  setHandBasis(b.rightHand, standingHandSide, standingHandUp, handForwardForOrientation, cfg.rightHandRollIdle, 1.0);
+  poseFingers(human.rightFingers, 'grip', 0.95);
+  if (ik < 0.025) {
+    poseFingers(human.leftFingers, 'idle', 1);
+    return;
+  }
+
+  const leftHand = frame.leftHandWorld.clone().addScaledVector(frame.forward, 0.032 * cfg.unit * ik).addScaledVector(frame.side, -0.018 * cfg.unit * ik).addScaledVector(UP, -0.018 * cfg.unit * ik);
+  const leftElbow = frame.leftElbow.clone().addScaledVector(frame.forward, 0.045 * cfg.unit * ik).addScaledVector(frame.side, -0.05 * cfg.unit * ik).addScaledVector(UP, -0.01 * cfg.unit * ik);
+  aimTwoBone(b.leftUpperArm, b.leftLowerArm, leftElbow, leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(), 0.98 * ik, 1.0 * ik);
+  twistBone(b.leftUpperArm, frame.forward, -0.2 * ik);
+  twistBone(b.leftLowerArm, frame.forward, 0.025 * ik);
+  const bridgeSide = frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize();
+  const bridgeUp = UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize();
+  setHandBasis(b.leftHand, bridgeSide, bridgeUp, cueDir, -0.68 * ik, 1.0 * ik);
+  poseFingers(human.leftFingers, 'bridge', ik);
+  aimTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
+  twistBone(b.leftUpperLeg, frame.forward, -0.035 * ik);
+  setHandBasis(b.leftFoot, frame.side, frame.up, frame.forward, -0.02 * ik, cfg.footLockStrength * ik);
+  aimTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
+  twistBone(b.rightUpperLeg, frame.forward, 0.03 * ik);
+  setHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, cfg.footLockStrength * ik);
 }
 
-export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) { const cfg = { ...BASE_CFG, ...opts }; const desired = cueBallWorld.clone().addScaledVector(aimForward, -cfg.desiredShootDistance); const xEdge = (opts.tableW ?? 2.0)/2 + cfg.edgeMargin; const zEdge = (opts.tableL ?? 3.6)/2 + cfg.edgeMargin; const c=[new THREE.Vector3(-xEdge,0,clamp(desired.z,-zEdge,zEdge)),new THREE.Vector3(xEdge,0,clamp(desired.z,-zEdge,zEdge)),new THREE.Vector3(clamp(desired.x,-xEdge,xEdge),0,-zEdge),new THREE.Vector3(clamp(desired.x,-xEdge,xEdge),0,zEdge)]; return c.sort((a,b)=>a.distanceToSquared(desired)-b.distanceToSquared(desired))[0].clone(); }
+export function updateHumanPose(human, dt, frameData) {
+  if (!human || !frameData || !Number.isFinite(dt) || dt < 0 || !frameData.rootTarget || !frameData.aimForward) return;
+  const cfg = human.cfg;
+  const state = frameData.state || 'idle';
+  const activeState = state === 'rolling' || state === 'turnEnd' || state === 'gameOver' ? 'idle' : state;
+  human.poseT = dampScalar(human.poseT, activeState === 'idle' ? 0 : 1, cfg.poseLambda, dt);
+  human.breathT += dt * (activeState === 'idle' ? 1.05 : 0.5);
+  human.settleT = dampScalar(human.settleT, activeState === 'dragging' ? 1 : 0, 5.5, dt);
+  if (activeState === 'striking') {
+    if (human.strikeClock === 0) {
+      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : frameData.rootTarget);
+      human.strikeYaw = human.yaw;
+    }
+    human.strikeClock += dt;
+  } else {
+    human.strikeClock = 0;
+  }
+
+  const rootGoal = activeState === 'striking' ? human.strikeRoot : frameData.rootTarget;
+  dampVector(human.root.position, rootGoal, activeState === 'striking' ? 12 : cfg.moveLambda, dt);
+  const moveAmountRaw = human.root.position.distanceTo(rootGoal);
+  human.walkT += dt * (2 + Math.min(7, (moveAmountRaw * 10) / cfg.unit));
+  human.yaw = dampScalar(human.yaw, activeState === 'striking' ? human.strikeYaw : yawFromForward(frameData.aimForward), cfg.rotLambda, dt);
+
+  const t = easeInOut(human.poseT);
+  const idle = 1 - t;
+  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * cfg.unit);
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, (moveAmountRaw * 12) / cfg.unit);
+  const walkAmount = clamp01((moveAmountRaw * 18) / cfg.unit) * idle;
+  const dragStroke = activeState === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + (frameData.power || 0) * 0.75) : 0;
+  const strikeFollow = activeState === 'striking' ? Math.sin(clamp01(human.strikeClock / (cfg.strikeTime + cfg.holdTime)) * Math.PI) : 0;
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
+  const powerLean = (frameData.power || 0) * t;
+  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * cfg.unit);
+  rootWorld.y = 0;
+
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) * cfg.unit + breath, (lerp(0.02, -0.16, t) - 0.014 * powerLean) * cfg.unit));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) * cfg.unit + breath, (lerp(0.02, -0.42, t) - 0.024 * powerLean) * cfg.unit));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) * cfg.unit + breath, (lerp(0.02, -0.61, t) - 0.028 * powerLean) * cfg.unit));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.72, t) - 0.028 * powerLean) * cfg.unit));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * cfg.unit));
+  const rightShoulder = local(new THREE.Vector3(0.23 * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.unit));
+  const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
+  const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
+  const leftFoot = local(new THREE.Vector3(-0.13 * cfg.unit, cfg.footGroundY, 0.03 * cfg.unit + walk * 0.018 * cfg.unit).lerp(new THREE.Vector3(-cfg.stanceWidth * 0.42, cfg.footGroundY, -0.34 * cfg.unit), t));
+  const rightFoot = local(new THREE.Vector3(0.13 * cfg.unit, cfg.footGroundY, -0.03 * cfg.unit - walk * 0.018 * cfg.unit).lerp(new THREE.Vector3(cfg.stanceWidth * 0.5, cfg.footGroundY, 0.34 * cfg.unit), t));
+
+  const bridgePalmTarget = frameData.bridgeTarget.clone()
+    .addScaledVector(forward, -0.006 * cfg.unit * t)
+    .addScaledVector(side, -0.012 * cfg.unit * t)
+    .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
+    .addScaledVector(UP, -0.01 * cfg.unit * human.settleT);
+  const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);
+  const cueDirForHand = frameData.cueTip.clone().sub(frameData.cueBack).normalize();
+  const handIk = easeInOut(clamp01(t));
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = UP.clone().multiplyScalar(-1.0).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
+  const lockedRightElbow = rightShoulder.clone()
+    .addScaledVector(UP, lerp(0.04 * cfg.unit, cfg.rightElbowShotRise, t))
+    .addScaledVector(side, lerp(-0.18 * cfg.unit, cfg.rightElbowShotSide, t))
+    .addScaledVector(forward, lerp(-0.04 * cfg.unit, cfg.rightElbowShotBack, t));
+  const pullBack = activeState === 'dragging' ? -cfg.rightStrokePull * easeOutCubic(frameData.power || 0) : 0;
+  const pushForward = activeState === 'striking' ? cfg.rightStrokePush * strikeFollow : 0;
+  const smallPractice = activeState === 'dragging' ? dragStroke * 0.035 * cfg.unit : 0;
+  const forearmStroke = pullBack + pushForward + smallPractice;
+  const forearmBase = lockedRightElbow.clone()
+    .addScaledVector(side, cfg.rightForearmOutward * t)
+    .addScaledVector(UP, -cfg.rightForearmDown * t)
+    .addScaledVector(UP, cfg.rightHandShotLift * t)
+    .addScaledVector(forward, -cfg.rightForearmBack * t)
+    .addScaledVector(cueDirForHand, cfg.rightForearmLength);
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
+  if (frameData.gripTarget) liveCueGripPoint.lerp(frameData.gripTarget, 0.72 * t);
+  const idleWristTarget = frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal));
+  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - cfg.rightHandDownPose, handIk), cfg.rightHandCueSocketLocal));
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * cfg.unit * t).addScaledVector(side, -0.044 * cfg.unit * t).addScaledVector(forward, 0.065 * cfg.unit * t);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * cfg.unit * t).addScaledVector(side, -0.012 * cfg.unit * t);
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * cfg.unit * t).addScaledVector(side, 0.014 * cfg.unit * t);
+
+  human.root.visible = true;
+  driveHuman(human, {
+    t,
+    stroke: forearmStroke / cfg.unit,
+    follow: strikeFollow,
+    walkAmount,
+    forward,
+    side,
+    up: UP,
+    rootWorld,
+    torsoCenterWorld: torso,
+    chestCenterWorld: chest,
+    neckWorld: neck,
+    headCenterWorld: head,
+    leftElbow,
+    rightElbow: lockedRightElbow,
+    leftHandWorld: leftHand,
+    rightHandWorld: rightHand,
+    leftKnee,
+    rightKnee,
+    leftFootWorld: leftFoot,
+    rightFootWorld: rightFoot,
+    cueBackWorld: frameData.cueBack,
+    cueTipWorld: frameData.cueTip
+  });
+}
+
+export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
+  const cfg = scaleVectorConfig(opts);
+  const desired = cueBallWorld.clone().addScaledVector(aimForward, -cfg.desiredShootDistance);
+  const xEdge = (opts.tableW ?? 2.0) / 2 + cfg.edgeMargin;
+  const zEdge = (opts.tableL ?? 3.6) / 2 + cfg.edgeMargin;
+  const candidates = [
+    new THREE.Vector3(-xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
+    new THREE.Vector3(xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
+    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, -zEdge),
+    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, zEdge)
+  ];
+  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+}


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc ReadyPlayer GLTF loader and static model handling with a reusable, configurable human rig to produce more natural snooker poses and animations.
- Centralize bone detection, finger posing, IK and pose damping logic so other tables/games can reuse consistent human behavior.
- Improve handling of open-source procedural table assets removal state to avoid leaving inconsistent flags on the table object.

### Description
- Added a new/refactored human rig core implementation in `webapp/src/pages/Games/shared/humanRigCore.js` that provides `createHumanRig`, `updateHumanPose`, and `chooseHumanEdgePosition`-style functionality with unit scaling, improved bone aliasing, finger posing, IK, damping and material fixes for loaded meshes.
- Integrated the new rig into `SnookerRoyal.jsx` by replacing the simple GLTF model load with `createSnookerHumanRig(...)` and using `updateSnookerHumanPose(...)` each frame to drive the human actor; introduced `lastHumanPoseTime` for stable timestep handling.
- Updated open-source procedural table cleanup to include `cloth` and `cushions` in the removal set and to set `table.userData.proceduralOpenSourceExtrasRemoved` with details so downstream logic can detect the removal state.
- Small API/behavior tweaks: default human GLB URL constant, material color-space/flip fixes for meshes, enhanced configuration via a scaled config helper, and more robust bone-finding heuristics.

### Testing
- Performed a local frontend build validation with `yarn build` which completed successfully.
- Ran the existing frontend unit test suite with `yarn test` and observed no regressions in the tested units.
- Performed a quick in-app smoke test of the Snooker scene to confirm the human model loads and the pose updates run during aim/drag/strike scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb456a5d748329bcacc7b6e9e1b713)