### PR TITLE
Match Showood external table upper-component height to procedural rails/cushions

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -28,6 +28,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
+    matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12903,11 +12903,20 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
     const exactZScale = Math.max(MICRO_EPS, dims.targetLength / Math.max(MICRO_EPS, footprintSize.z));
     const targetHeight = dims.targetHeight ?? dims.nativeVisualHeight;
     const fullSize = fullBox.getSize(new THREE.Vector3());
-    const exactYScale =
-      tableModel?.matchNativeHeight && targetHeight
-        ? Math.max(MICRO_EPS, targetHeight / Math.max(MICRO_EPS, fullSize.y)) *
-          (tableModel?.fitHeightScale ?? 1)
-        : Math.sqrt(exactXScale * exactZScale);
+    const upperComponentHeight = Math.max(MICRO_EPS, footprintSize.y);
+    const targetUpperComponentHeight = Number.isFinite(dims.targetUpperComponentHeight)
+      ? Math.max(MICRO_EPS, dims.targetUpperComponentHeight)
+      : null;
+    const heightMatchSource =
+      tableModel?.matchNativeUpperComponentHeight && targetUpperComponentHeight
+        ? { target: targetUpperComponentHeight, source: upperComponentHeight }
+        : tableModel?.matchNativeHeight && targetHeight
+          ? { target: targetHeight, source: fullSize.y }
+          : null;
+    const exactYScale = heightMatchSource
+      ? Math.max(MICRO_EPS, heightMatchSource.target / Math.max(MICRO_EPS, heightMatchSource.source)) *
+        (tableModel?.fitHeightScale ?? 1)
+      : Math.sqrt(exactXScale * exactZScale);
     model.scale.set(
       model.scale.x * exactXScale * fitScaleMultiplier,
       model.scale.y * exactYScale * fitScaleMultiplier,
@@ -13646,6 +13655,18 @@ function mountPoolRoyaleExternalTableModel({
   const generatedVisualSize = generatedVisualBounds.isEmpty()
     ? new THREE.Vector3(TABLE.W, TABLE.THICK, TABLE.H)
     : generatedVisualBounds.getSize(new THREE.Vector3());
+  const generatedUpperComponentObjects = [
+    ...finishParts.railMeshes,
+    ...finishParts.pocketJawMeshes,
+    ...finishParts.pocketRimMeshes,
+    ...(Array.isArray(table.userData.cushions) ? table.userData.cushions : [])
+  ].filter(Boolean);
+  const generatedUpperComponentBounds = expandPoolRoyaleBoundsByObjects(
+    generatedUpperComponentObjects.length ? generatedUpperComponentObjects : generatedStructuralObjects
+  );
+  const generatedUpperComponentSize = generatedUpperComponentBounds.isEmpty()
+    ? new THREE.Vector3(TABLE.W, TABLE.THICK, TABLE.H)
+    : generatedUpperComponentBounds.getSize(new THREE.Vector3());
   const setGeneratedVisualsVisible = (visible) => {
     generatedVisualObjects.forEach((object) => {
       if (
@@ -13681,7 +13702,12 @@ function mountPoolRoyaleExternalTableModel({
             targetWidth: generatedVisualBounds.isEmpty() ? TABLE.W : generatedVisualSize.x,
             targetLength: generatedVisualBounds.isEmpty() ? TABLE.H : generatedVisualSize.z,
             targetHeight: generatedVisualBounds.isEmpty() ? TABLE.THICK + LEG_ROOM_HEIGHT : generatedVisualSize.y,
-            targetTopLocal: generatedVisualBounds.isEmpty() ? cushionTopLocal : generatedVisualBounds.max.y,
+            targetUpperComponentHeight: generatedUpperComponentBounds.isEmpty()
+              ? RAIL_HEIGHT
+              : generatedUpperComponentSize.y,
+            targetTopLocal: generatedUpperComponentBounds.isEmpty()
+              ? (generatedVisualBounds.isEmpty() ? cushionTopLocal : generatedVisualBounds.max.y)
+              : generatedUpperComponentBounds.max.y,
             cushionTopLocal
           },
           finishInfo,


### PR DESCRIPTION
### Motivation
- Ensure Showood GLB wooden frame/rails, cushions, and pocket jaws line up vertically with the procedural Pool Royale table so their visible tops share the same height and avoid appearing too short.

### Description
- Added a new table model flag `matchNativeUpperComponentHeight` in `webapp/src/config/poolRoyaleTableModels.js` to opt into matching upper-component height for external GLB models.
- When fitting an external model, `fitPoolRoyaleExternalTableModel` now computes an `upperComponentHeight` from the external footprint and prefers `dims.targetUpperComponentHeight` when `matchNativeUpperComponentHeight` is enabled to compute the exact Y scale used for vertical fitting.
- Collected the procedural upper components (rails, pocket jaw/rim meshes and cushions) into `generatedUpperComponentBounds` inside `mountPoolRoyaleExternalTableModel` and passed `targetUpperComponentHeight` and an adjusted `targetTopLocal` into the external-mount `dims` so the external model aligns to the native rail/cushion/jaw top when requested.
- Kept the original full-model height matching behavior as a fallback when the new upper-component match is not available or not requested.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build produced assets without errors).
- Ran `git diff --check` and repository checks passed with no reported issues after the change.
- Attempted an end-to-end visual verification by launching the dev site and capturing a screenshot via Playwright, but `page.screenshot` timed out in the headless WebGL environment after installing Chromium and dependencies; browser install succeeded but the screenshot capture timed out (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5b12b5688329a732aa33d77c36f7)