### PR TITLE
Align Showood GLB mapping, cloth tiling, and physics to Pool Royale

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -21,14 +21,22 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.deepEqual(showood.hideSurfaceRoles, []);
-    assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
+    assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['trim']);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',
       'wood',
-      'trim',
       'pocket'
     ]);
+    assert.equal(showood.matchNativeHeight, true);
+    assert.equal(showood.matchNativeUpperComponentHeight, false);
+    assert.equal(showood.matchProceduralClothTextureScale, true);
+    assert.equal(showood.useModelPhysicsMapping, true);
+    assert.equal(showood.physicsMapping.source, 'showood-visual-profile');
+    assert.equal(showood.physicsMapping.fallback, 'pool-royale-procedural');
+    assert.equal(showood.physicsMapping.cushionSegmentSource, 'generated-showood-jaws');
+    assert.equal(showood.physicsMapping.jawMappingRadiusScale, 1);
+    assert.equal(showood.physicsMapping.railCutInsetScale, 1);
     assert.equal('playfieldVisualLift' in showood, false);
     assert.equal('fitHeightScale' in showood, false);
   });

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -28,11 +28,22 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
-    matchNativeUpperComponentHeight: true,
+    matchNativeUpperComponentHeight: false,
     useOriginalLayoutSurfaces: true,
+    useModelPhysicsMapping: true,
+    physicsMapping: Object.freeze({
+      source: 'showood-visual-profile',
+      fallback: 'pool-royale-procedural',
+      cushionSegmentSource: 'generated-showood-jaws',
+      pocketCenterSource: 'pool-royale-native-centers',
+      jawMappingRadiusScale: 1,
+      jawCaptureRadiusScale: 1,
+      railCutInsetScale: 1
+    }),
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
-    preserveOriginalSurfaceRoles: [],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
+    preserveOriginalSurfaceRoles: ['trim'],
+    matchProceduralClothTextureScale: true,
     hideSurfaceRoles: []
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8832,7 +8832,11 @@ function updateCushionSegmentsFromTable(table) {
     const cutTypes = data.cutTypes || {};
     const minTypeScale = cutTypes.min === 'side' ? 0.2 : 1;
     const maxTypeScale = cutTypes.max === 'side' ? 0.2 : 1;
-    const cutInsetBase = RAIL_CONTACT_RADIUS * 0.12;
+    const physicsMapping = table.userData?.tableModelPhysicsMapping || null;
+    const railCutInsetScale = Number.isFinite(physicsMapping?.railCutInsetScale)
+      ? Math.max(0, physicsMapping.railCutInsetScale)
+      : 1;
+    const cutInsetBase = RAIL_CONTACT_RADIUS * 0.12 * railCutInsetScale;
     const minInset = Math.min(minCut, cutInsetBase * minTypeScale);
     const maxInset = Math.min(maxCut, cutInsetBase * maxTypeScale);
     const cutAngles = data.cutAngles || {};
@@ -8879,10 +8883,14 @@ function updateCushionSegmentsFromTable(table) {
     if (!(jaw?.center instanceof THREE.Vector2)) return;
     if (!Number.isFinite(jaw?.outerRadius) || jaw.outerRadius <= MICRO_EPS) return;
     if (!Number.isFinite(jaw?.jawAngle) || jaw.jawAngle <= MICRO_EPS) return;
-    const mappingOuterRadius = Math.max(
-      MICRO_EPS,
-      jaw.outerRadius * POCKET_JAW_MAPPING_RADIUS_SCALE
-    );
+    const physicsMapping = table.userData?.tableModelPhysicsMapping || null;
+    const jawMappingRadiusScale = Number.isFinite(physicsMapping?.jawMappingRadiusScale)
+      ? Math.max(MICRO_EPS, physicsMapping.jawMappingRadiusScale)
+      : POCKET_JAW_MAPPING_RADIUS_SCALE;
+    const jawCaptureRadiusScale = Number.isFinite(physicsMapping?.jawCaptureRadiusScale)
+      ? Math.max(MICRO_EPS, physicsMapping.jawCaptureRadiusScale)
+      : 1;
+    const mappingOuterRadius = Math.max(MICRO_EPS, jaw.outerRadius * jawMappingRadiusScale);
     const steps = Math.max(16, Math.ceil((jaw.jawAngle / Math.PI) * 48));
     const startAngle = jaw.orientationAngle - jaw.jawAngle / 2;
     const endAngle = jaw.orientationAngle + jaw.jawAngle / 2;
@@ -8906,7 +8914,9 @@ function updateCushionSegmentsFromTable(table) {
           type: 'jaw',
           normal,
           center: jaw.center.clone(),
-          captureRadius: jaw.captureRadius
+          captureRadius: Number.isFinite(jaw.captureRadius)
+            ? jaw.captureRadius * jawCaptureRadiusScale
+            : jaw.captureRadius
         });
       }
       prev = point;
@@ -12731,6 +12741,62 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
   return mat;
 }
 
+function applyPoolRoyaleProceduralTextureRepeat(material, baseRepeat, repeatRatio = 1) {
+  if (!material || !Number.isFinite(baseRepeat) || baseRepeat <= 0) return;
+  const repeatY = baseRepeat * (Number.isFinite(repeatRatio) && repeatRatio > 0 ? repeatRatio : 1);
+  ['map', 'normalMap', 'bumpMap', 'roughnessMap', 'aoMap'].forEach((slot) => {
+    const texture = material[slot];
+    if (!texture?.repeat) return;
+    texture.repeat.set(baseRepeat, repeatY);
+    texture.needsUpdate = true;
+  });
+  if (Number.isFinite(material.userData?.bumpScale)) {
+    material.bumpScale = material.userData.bumpScale;
+  }
+  material.needsUpdate = true;
+}
+
+function applyPoolRoyaleExternalClothTextureScale(root, tableModel = null, finishInfo = null, dims = null) {
+  if (!root || !tableModel?.matchProceduralClothTextureScale || !finishInfo?.clothMat) return 0;
+  const baseRepeat = finishInfo.clothMat.userData?.baseRepeat ?? finishInfo.clothMat.map?.repeat?.x;
+  const repeatRatio =
+    finishInfo.clothMat.userData?.repeatRatio ??
+    (finishInfo.clothMat.map?.repeat?.x
+      ? finishInfo.clothMat.map.repeat.y / finishInfo.clothMat.map.repeat.x
+      : 1);
+  if (!Number.isFinite(baseRepeat) || baseRepeat <= 0) return 0;
+  const targetWidth = Math.max(MICRO_EPS, dims?.targetClothWidth ?? dims?.targetWidth ?? PLAY_W);
+  const targetLength = Math.max(MICRO_EPS, dims?.targetClothLength ?? dims?.targetLength ?? PLAY_H);
+  let updated = 0;
+  root.updateMatrixWorld?.(true);
+  root.traverse?.((child) => {
+    if (!child?.isMesh) return;
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+    const childBox = new THREE.Box3().setFromObject(child);
+    const childSize = childBox.getSize(new THREE.Vector3());
+    const childWidth = Math.max(MICRO_EPS, Math.min(childSize.x, childSize.z));
+    const childLength = Math.max(MICRO_EPS, Math.max(childSize.x, childSize.z));
+    materials.forEach((material) => {
+      if (!material) return;
+      const role = classifyPoolRoyaleExternalTableSurface(child, material);
+      if (role !== 'cloth') return;
+      const worldScale = Math.sqrt(
+        Math.max(MICRO_EPS, childWidth / targetWidth) *
+          Math.max(MICRO_EPS, childLength / targetLength)
+      );
+      applyPoolRoyaleProceduralTextureRepeat(material, baseRepeat * worldScale, repeatRatio);
+      material.userData = {
+        ...(material.userData || {}),
+        poolRoyaleProceduralClothRepeat: baseRepeat,
+        poolRoyaleProceduralClothRepeatRatio: repeatRatio,
+        poolRoyaleExternalClothWorldScale: worldScale
+      };
+      updated += 1;
+    });
+  });
+  return updated;
+}
+
 function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finishInfo = null) {
   root?.traverse?.((child) => {
     if (!child?.isMesh) return;
@@ -12975,6 +13041,7 @@ function mountPoolRoyaleExternalTableModel({
       if (disposed || !template) return;
       const model = clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo);
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
+      applyPoolRoyaleExternalClothTextureScale(model, tableModel, finishInfo, dims);
       externalRoot.clear();
       externalRoot.add(model);
       setGeneratedVisualsVisible?.(false);
@@ -13626,6 +13693,11 @@ function mountPoolRoyaleExternalTableModel({
     mesh.position.y = pocketTopY - TABLE.THICK / 2 + lift;
   });
 
+  table.userData.tableModelPhysicsMapping = resolvedTableOptions?.tableModel?.useModelPhysicsMapping
+    ? resolvedTableOptions.tableModel.physicsMapping || null
+    : null;
+  table.userData.tableModelPhysicsMappingSource = table.userData.tableModelPhysicsMapping?.source || null;
+
   alignRailsToCushions(table, railsGroup, finishParts.railMeshes);
   table.updateMatrixWorld(true);
   updateRailLimitsFromTable(table);
@@ -13705,6 +13777,8 @@ function mountPoolRoyaleExternalTableModel({
             targetUpperComponentHeight: generatedUpperComponentBounds.isEmpty()
               ? RAIL_HEIGHT
               : generatedUpperComponentSize.y,
+            targetClothWidth: halfWext * 2,
+            targetClothLength: halfHext * 2,
             targetTopLocal: generatedUpperComponentBounds.isEmpty()
               ? (generatedVisualBounds.isEmpty() ? cushionTopLocal : generatedVisualBounds.max.y)
               : generatedUpperComponentBounds.max.y,


### PR DESCRIPTION
### Motivation
- Make the open-source Showood GLB usable as a Pool Royale table by reusing its original cushions/pockets while ensuring gameplay geometry, physics mapping, and cloth texel density match the procedural/native Pool Royale table.
- Preserve the GLB trim (gold/chrome) visuals while letting Pool Royale finishes drive cloth, cushion and pocket materials where appropriate.

### Description
- Added a Showood table configuration and flags in `webapp/src/config/poolRoyaleTableModels.js` to enable native-height fitting, preserve trim, enable a Showood physics mapping profile, and request procedural cloth texture scale matching (`matchProceduralClothTextureScale` and `physicsMapping`).
- Implemented external-table cloth retile helpers (`applyPoolRoyaleProceduralTextureRepeat` and `applyPoolRoyaleExternalClothTextureScale`) and invoke them after the GLB is fitted so the external cloth materials are re-tiled to match Pool Royale cloth density; these live in `webapp/src/pages/Games/PoolRoyale.jsx` and are applied during `mountPoolRoyaleExternalTableModel`.
- Plumbed `table.userData.tableModelPhysicsMapping` into the table build pipeline and used mapping values to adjust cushion/rail cut insets, pocket-jaw mapping radius, and capture radius with fallbacks to native procedural values in `updateCushionSegmentsFromTable` and related logic in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Kept original GLB trim surfaces visible by preserving `trim` role and restricted Pool Royale finish roles to the intended surfaces; updated the unit test expectations in `test/poolRoyaleTableModels.test.js` to cover the new configuration.

### Testing
- Ran the unit test `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and it passed.
- Built the web app with `npm --prefix webapp run build` and the production bundle completed successfully (vite build completed). 
- Attempted an automated visual smoke check using Playwright (started Vite then tried a headless Chromium screenshot), but the Playwright-run browser failed to launch due to a missing container dependency (`libatk-1.0.so.0`), so the screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb642efd208329b26118208beacb14)