### PR TITLE
Preserve trim role and sync external cloth texture repeats for Pool Royale tables

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -28,11 +28,13 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
+    // Keep the wooden rail and pocket-jaw stack at the same tall height as
+    // the procedural table so the Showood layout does not get flattened.
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
-    preserveOriginalSurfaceRoles: [],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
+    preserveOriginalSurfaceRoles: ['trim'],
     hideSurfaceRoles: []
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12618,12 +12618,19 @@ const poolRoyaleExternalTableTemplates = new Map();
 const poolRoyaleExternalTablePromises = new Map();
 
 function classifyPoolRoyaleExternalTableSurface(child, material) {
-  const label = `${child?.name || ''} ${material?.name || ''}`.toLowerCase();
+  const childName = `${child?.name || ''}`.toLowerCase();
+  const materialName = `${material?.name || ''}`.toLowerCase();
+  const label = `${childName} ${materialName}`;
+  // Showood uses a shared "cloth" material on the cushion meshes, so mesh names
+  // must win over material names for physics mapping and finish assignment.
+  if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(childName)) return 'cushion';
+  if (/pocket|liner|leather|net|basket|drop|holder/.test(childName)) return 'pocket';
+  if (/diamond|gold|metal|chrome|sight|marker|plate|trim|screw|bolt/.test(childName)) return 'trim';
+  if (/slate|cloth|felt|baize|bed|playfield|playing[_\s-]*surface/.test(childName)) return 'cloth';
   if (/cloth|felt|baize|slate|bed|playfield|playing[_\s-]*surface/.test(label)) return 'cloth';
-  if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(label)) return 'cushion';
   if (/pocket|liner|leather|net|basket|drop/.test(label)) return 'pocket';
   if (/metal|chrome|gold|diamond|sight|marker|plate|trim|screw|bolt/.test(label)) return 'trim';
-  if (/leg|foot|base|support|frame|wood|rail|apron|cabinet|showood/.test(label)) return 'wood';
+  if (/leg|foot|base|support|frame|wood|rail|apron|cabinet|showood|bevel/.test(label)) return 'wood';
   return 'wood';
 }
 
@@ -12639,8 +12646,44 @@ function clonePoolRoyaleMaterialTexture(texture, { isColor = false } = {}) {
 function preparePoolRoyaleExternalTexture(texture, isColor = false) {
   if (!texture) return;
   if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+  texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.anisotropy = resolveTextureAnisotropy(12);
   texture.needsUpdate = true;
+}
+
+function syncPoolRoyaleExternalClothTextureRepeat(material, sourceClothMat) {
+  if (!material || !sourceClothMat) return;
+  const baseRepeat =
+    sourceClothMat.userData?.baseRepeat ??
+    sourceClothMat.map?.repeat?.x ??
+    1;
+  const repeatRatio =
+    sourceClothMat.userData?.repeatRatio ??
+    (sourceClothMat.map?.repeat?.x
+      ? sourceClothMat.map.repeat.y / sourceClothMat.map.repeat.x
+      : 1);
+  const fallbackRepeat = new THREE.Vector2(baseRepeat, baseRepeat * repeatRatio);
+  ['map', 'normalMap', 'bumpMap', 'roughnessMap'].forEach((prop) => {
+    const texture = material[prop];
+    if (!texture) return;
+    const sourceTexture = sourceClothMat[prop];
+    const sourceRepeat = sourceTexture?.repeat?.isVector2
+      ? sourceTexture.repeat
+      : fallbackRepeat;
+    texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+    texture.repeat.copy(sourceRepeat);
+    texture.offset.copy(sourceTexture?.offset?.isVector2 ? sourceTexture.offset : new THREE.Vector2(0, 0));
+    texture.center.copy(sourceTexture?.center?.isVector2 ? sourceTexture.center : new THREE.Vector2(0.5, 0.5));
+    texture.rotation = typeof sourceTexture?.rotation === 'number' ? sourceTexture.rotation : 0;
+    texture.needsUpdate = true;
+  });
+  material.userData = {
+    ...(material.userData || {}),
+    externalClothRepeat: {
+      baseRepeat,
+      repeatRatio
+    }
+  };
 }
 
 function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tableModel = null) {
@@ -12694,6 +12737,9 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
 
   if (role === 'cloth' || role === 'cushion') {
     copyMaterialLook(role === 'cushion' ? finishInfo.cushionMat : finishInfo.clothMat);
+    if (role === 'cloth') {
+      syncPoolRoyaleExternalClothTextureRepeat(mat, finishInfo.clothMat);
+    }
     mat.side = THREE.DoubleSide;
   } else if (role === 'trim') {
     copyMaterialLook(materials.trim);
@@ -12876,6 +12922,7 @@ function resolvePoolRoyaleExternalTableFitBounds(model, tableModel = null) {
 
   return { fullBox, footprintBox };
 }
+
 
 function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   if (!model || !dims) return;


### PR DESCRIPTION
### Motivation

- Keep the Showood GLB layout visually consistent with the native procedural table by preserving trim surfaces and avoiding unintended height/flattening changes. 
- Improve material-role classification so mesh names take precedence over shared material names (e.g. Showood uses a shared "cloth" material on cushions). 
- Ensure external cloth textures tile and align the same way as Pool Royale finishes by copying repeat/offset/center/rotation and enabling proper wrapping.

### Description

- Updated `poolRoyaleTableModels` to preserve the `trim` role for the Showood model and documented keeping upper component height (`matchNativeUpperComponentHeight`).
- Reworked `classifyPoolRoyaleExternalTableSurface` to compute `childName` and `materialName` separately, prioritize `childName` pattern matches for `cushion`, `pocket`, `trim`, and `cloth`, and added `bevel` to wood detection.
- Set texture wrapping to `THREE.RepeatWrapping` in `preparePoolRoyaleExternalTexture` and introduced `syncPoolRoyaleExternalClothTextureRepeat` to copy repeat, offset, center, and rotation from the source cloth material to external cloth textures.
- Applied the cloth-repeat sync inside `applyPoolRoyaleFinishToExternalMaterial` for `cloth` roles and preserved original materials when `preserveOriginalSurfaceRoles` dictates no finish override.

### Testing

- Ran unit tests with `yarn test`, and the test suite completed successfully.
- Built the app with `yarn build`, and the production build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb642efd208329b26118208beacb14)