### PR TITLE
Snooker: stop cue follow-through, enlarge human, and reverse shot bend

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -21033,7 +21033,8 @@ const powerRef = useRef(hud.power);
         loader: humanLoader,
         modelUrl: 'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
         unit: humanUnitScale,
-        humanScale: 1.26 * humanUnitScale,
+        humanScale: 1.52 * humanUnitScale,
+        shootBendDirection: -1,
         tableTopY: humanTableTopY,
         groundY: humanGroundY,
         tableW: PLAY_W,
@@ -21058,7 +21059,7 @@ const powerRef = useRef(hud.power);
         rightForearmDown: 0.48 * humanUnitScale,
         rightForearmLength: 0.34 * humanUnitScale,
         rightStrokePull: 0.30 * humanUnitScale,
-        rightStrokePush: 0.24 * humanUnitScale,
+        rightStrokePush: 0.08 * humanUnitScale,
         rightHandShotLift: -0.30 * humanUnitScale,
         shootCueGripFromBack: 0.58 * humanUnitScale,
         idleRightHandY: 0.8 * humanUnitScale,
@@ -22653,7 +22654,6 @@ const powerRef = useRef(hud.power);
           cueStick.position.copy(idlePos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          const powerStrength = THREE.MathUtils.clamp(clampedPower ?? 0, 0, 1);
           const pullbackDuration = 0;
           const strikeDuration = 110;
           const holdDuration = 45;
@@ -22664,19 +22664,8 @@ const powerRef = useRef(hud.power);
             BALL_R * 0.3
           );
           const impactPos = buildCuePosition(-impactPush);
-          // Match the reference cue-stick behavior for spin:
-          // topspin adds a tiny forward follow-through after contact,
-          // while backspin keeps a clean stop at impact.
-          const topspinFactor = THREE.MathUtils.clamp(
-            Math.max(0, appliedSpin?.y ?? 0) * powerStrength,
-            0,
-            1
-          );
-          const followExtra = THREE.MathUtils.clamp(
-            topspinFactor * BALL_R * 0.32,
-            0,
-            BALL_R * 0.34
-          );
+          // Stop the visible cue at contact so it never chases the cue ball.
+          const followExtra = 0;
           TMP_VEC3_FOLLOW_DIR.copy(impactPos).sub(pullPos);
           if (TMP_VEC3_FOLLOW_DIR.lengthSq() > 1e-8) {
             TMP_VEC3_FOLLOW_DIR.normalize();
@@ -26631,7 +26620,10 @@ const powerRef = useRef(hud.power);
                 ? 'striking'
                 : 'idle';
             const activePower = THREE.MathUtils.clamp(powerRef.current ?? 0, 0, 1);
-            const cueBallWorld = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
+            const strokeAnchor = cueStickAnchorRef.current;
+            const cueBallWorld = humanState === 'striking' && strokeAnchor
+              ? new THREE.Vector3(strokeAnchor.x, BALL_CENTER_Y, strokeAnchor.z)
+              : new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
             const aimForward = new THREE.Vector3(aimDir.x, 0, aimDir.y);
             if (aimForward.lengthSq() < 1e-8) aimForward.set(0, 0, 1);
             else aimForward.normalize();

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -48,7 +48,8 @@ const BASE_CFG = {
   tableTopY: 0.84,
   groundY: 0,
   perimeterWalk: false,
-  perimeterWalkSpeed: 4.0
+  perimeterWalkSpeed: 4.0,
+  shootBendDirection: 1
 };
 
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
@@ -529,15 +530,17 @@ export function updateHumanPose(human, dt, frameData) {
   const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
   const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
   const powerLean = (frameData.power || 0) * t;
-  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * cfg.unit);
+  const bendDirection = cfg.shootBendDirection >= 0 ? 1 : -1;
+  const shotBendZ = (value) => value * bendDirection;
+  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * cfg.unit * bendDirection);
   rootWorld.y = cfg.groundY;
 
-  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) * cfg.unit + breath, (lerp(0.02, -0.16, t) - 0.014 * powerLean) * cfg.unit));
-  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) * cfg.unit + breath, (lerp(0.02, -0.42, t) - 0.024 * powerLean) * cfg.unit));
-  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) * cfg.unit + breath, (lerp(0.02, -0.61, t) - 0.028 * powerLean) * cfg.unit));
-  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.72, t) - 0.028 * powerLean) * cfg.unit));
-  const leftShoulder = local(new THREE.Vector3(-0.23 * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * cfg.unit));
-  const rightShoulder = local(new THREE.Vector3(0.23 * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.unit));
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.16, t) - 0.014 * powerLean) * cfg.unit));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.42, t) - 0.024 * powerLean) * cfg.unit));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.61, t) - 0.028 * powerLean) * cfg.unit));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.16 * t, shotBendZ(lerp(0.04, -0.72, t) - 0.028 * powerLean) * cfg.unit));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.46, t) - 0.018 * human.settleT) * cfg.unit));
+  const rightShoulder = local(new THREE.Vector3(0.23 * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.unit));
   const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const leftFoot = local(new THREE.Vector3(-0.13 * cfg.unit, cfg.footGroundY, 0.03 * cfg.unit + walk * 0.018 * cfg.unit).lerp(new THREE.Vector3(-cfg.stanceWidth * 0.42, cfg.footGroundY, -0.34 * cfg.unit), t));


### PR DESCRIPTION
### Motivation
- Make the visual shot feel more realistic by preventing the cue stick from chasing the cue ball after impact, make the human shooter visually larger, and let Snooker shots bend in the opposite direction to match design intent.

### Description
- In `webapp/src/pages/Games/SnookerRoyal.jsx` increase shooter size by changing `humanScale` from `1.26` to `1.52` and pass `shootBendDirection: -1` into the snooker human rig configuration.
- Reduce visible forward follow by lowering the player's stroke push (`rightStrokePush` reduced) and lock the shot anchor during striking by using the cue-stick anchor for the pose (`cueBallWorld` now uses `cueStickAnchorRef` while `humanState === 'striking'`).
- Stop visible cue follow-through by removing the follow-through offset and forcing `followExtra = 0` so the visible cue stops at contact instead of chasing the ball.
- In `webapp/src/pages/Games/shared/humanRigCore.js` add a new rig option `shootBendDirection` (default `1`) and use it to compute `bendDirection`/`shotBendZ` so torso/chest/neck/head/shoulder bend values are multiplied by the direction, enabling per-game reversal of bend without changing shared defaults.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build messages and chunk warnings were produced but build finished).
- Attempted an automated mobile portrait screenshot with Playwright but the headless Chromium process could not run in this container due to missing system library `libatk-1.0.so.0`, so the visual verification screenshot step failed; `npx playwright install chromium` succeeded in downloading browsers but launching failed at runtime.
- Changes were committed (`Adjust Snooker Royal cue and human shot pose`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb90ec6e7483298c992cc66a00f95d)