### PR TITLE
Tune Showood table fit, cloth tiling and pocket trim for Pool Royale parity

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -20,6 +20,7 @@ describe('Pool Royale table models', () => {
     assert.ok(showood, 'Showood table model must be configured');
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
+    assert.equal(showood.fitScale, 1.035);
     assert.deepEqual(showood.hideSurfaceRoles, []);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -24,15 +24,15 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
-    fitScale: 1,
+    fitScale: 1.035,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
-    preserveOriginalSurfaceRoles: ['trim'],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
+    preserveOriginalSurfaceRoles: [],
     hideSurfaceRoles: []
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5387,26 +5387,13 @@ function updateClothTexturesForFinish (
   if (Number.isFinite(finishInfo.clothBase?.baseBumpScale)) {
     finishInfo.clothMat.bumpScale = finishInfo.clothBase.baseBumpScale;
   }
-  if (isPolyHavenTexture) {
-    ['map', 'normalMap', 'bumpMap', 'roughnessMap'].forEach((prop) => {
-      const tex = finishInfo.clothMat?.[prop];
-      if (!tex) return;
-      tex.wrapS = THREE.ClampToEdgeWrapping;
-      tex.wrapT = THREE.ClampToEdgeWrapping;
-      tex.repeat.set(1, 1);
-      tex.offset.set(0, 0);
-      tex.rotation = 0;
-      tex.center.set(0, 0);
-      tex.needsUpdate = true;
-    });
-  }
   if (finishInfo.clothMat.userData) {
     finishInfo.clothMat.userData.polyRepeatScale = textureScale;
     finishInfo.clothMat.userData.baseRepeat = baseRepeatValue;
     finishInfo.clothMat.userData.baseRepeatRaw = baseRepeatRaw;
-    finishInfo.clothMat.userData.nearRepeat = isPolyHavenTexture ? 1 : baseRepeatValue * 1.12;
-    finishInfo.clothMat.userData.farRepeat = isPolyHavenTexture ? 1 : baseRepeatValue * 0.44;
-    finishInfo.clothMat.userData.preserveOriginalUvMapping = Boolean(isPolyHavenTexture);
+    finishInfo.clothMat.userData.nearRepeat = baseRepeatValue * 1.12;
+    finishInfo.clothMat.userData.farRepeat = baseRepeatValue * 0.44;
+    finishInfo.clothMat.userData.preserveOriginalUvMapping = false;
   }
   if (finishInfo.cushionMat) {
     replaceMaterialTexture(finishInfo.cushionMat, 'map', textures.map, fallbackRepeat, {
@@ -9280,10 +9267,7 @@ export function Table3D(
   const clothPatternUpscale = isPolyHavenCloth
     ? 1
     : (1 / 1.3) * 0.5 * 1.25 * 1.5 * CLOTH_PATTERN_SCALE; // double the thread pattern size for a looser, woollier weave
-  const patternOverride =
-    clothMapSource === 'polyhaven'
-      ? null
-      : resolveClothPatternOverride(clothTextureKey);
+  const patternOverride = resolveClothPatternOverride(clothTextureKey);
   const clothTextureScale =
     0.032 * 1.35 * 1.56 * 1.12 * clothPatternUpscale; // keep Pool Royale cloth texel density aligned with Snooker Royal
   let baseRepeat =
@@ -9298,7 +9282,7 @@ export function Table3D(
     patternOverride?.repeatRatioScale && patternOverride.repeatRatioScale > 0
       ? patternOverride.repeatRatioScale
       : 1;
-  const repeatRatio = 1 * repeatRatioScale;
+  const repeatRatio = 3.45 * repeatRatioScale;
   const polyRepeatScale =
     clothMapSource === 'polyhaven' ? POLYHAVEN_PATTERN_REPEAT_SCALE : 1;
   const baseRepeatApplied = baseRepeat * polyRepeatScale;
@@ -9309,25 +9293,19 @@ export function Table3D(
   const flattenedBumpScale = baseBumpScale * 0.48;
   if (clothMap) {
     clothMat.map = clothMap;
-    if (!isPolyHavenCloth) {
-      clothMat.map.repeat.set(baseRepeatApplied, baseRepeatApplied * repeatRatio);
-    }
+    clothMat.map.repeat.set(baseRepeatApplied, baseRepeatApplied * repeatRatio);
     clothMat.map.needsUpdate = true;
   }
   if (clothNormal) {
     clothMat.normalMap = clothNormal;
-    if (!isPolyHavenCloth) {
-      clothMat.normalMap.repeat.set(baseRepeatApplied, baseRepeatApplied * repeatRatio);
-    }
+    clothMat.normalMap.repeat.set(baseRepeatApplied, baseRepeatApplied * repeatRatio);
     clothMat.normalScale = clothNormalScale.clone();
     clothMat.normalMap.needsUpdate = true;
     clothMat.bumpScale = flattenedBumpScale;
     clothMat.bumpMap = null;
   } else if (clothBump) {
     clothMat.bumpMap = clothBump;
-    if (!isPolyHavenCloth) {
-      clothMat.bumpMap.repeat.set(baseRepeatApplied, baseRepeatApplied * repeatRatio);
-    }
+    clothMat.bumpMap.repeat.set(baseRepeatApplied, baseRepeatApplied * repeatRatio);
     clothMat.bumpScale = flattenedBumpScale;
     clothMat.bumpMap.needsUpdate = true;
   } else {
@@ -9335,9 +9313,7 @@ export function Table3D(
   }
   if (clothRoughness) {
     clothMat.roughnessMap = clothRoughness;
-    if (!isPolyHavenCloth) {
-      clothMat.roughnessMap.repeat.set(baseRepeatApplied, baseRepeatApplied * repeatRatio);
-    }
+    clothMat.roughnessMap.repeat.set(baseRepeatApplied, baseRepeatApplied * repeatRatio);
     clothMat.roughness = CLOTH_ROUGHNESS_TARGET;
     clothMat.roughnessMap.needsUpdate = true;
   }
@@ -9347,12 +9323,12 @@ export function Table3D(
     baseRepeat: baseRepeatApplied,
     repeatRatio,
     polyRepeatScale,
-    nearRepeat: isPolyHavenCloth ? 1 : baseRepeatApplied * 1.12,
-    farRepeat: isPolyHavenCloth ? 1 : baseRepeatApplied * 0.44,
+    nearRepeat: baseRepeatApplied * 1.12,
+    farRepeat: baseRepeatApplied * 0.44,
     bumpScale: clothMat.bumpScale,
     baseBumpScale: clothMat.bumpScale,
     quality: CLOTH_QUALITY,
-    preserveOriginalUvMapping: Boolean(isPolyHavenCloth)
+    preserveOriginalUvMapping: false
   };
 
   const cushionMat = clothMat.clone();


### PR DESCRIPTION
### Motivation
- Align the Showood GLB external table visuals and finishes to Pool Royale gameplay so cushions/pockets map precisely to existing physics and UI mappings.
- Make the Pool Royale cloth pattern match Snooker Royal texel density so weave/pattern size is visually identical between modes.
- Ensure pocket fascia on the Showood table uses the Pool Royale chrome/gold finish instead of preserving source GLB chrome so metals match selected options.

### Description
- Increase Showood external model fit scale from `1` to `1.035` and stop preserving the original `trim` material so Pool Royale finishes apply to pocket fascia; changes in `webapp/src/config/poolRoyaleTableModels.js`.
- Add `trim` to the `usePoolRoyaleFinishRoles` and clear `preserveOriginalSurfaceRoles` so external table chrome/metal parts receive the selected Pool Royale chrome/gold materials; change in `webapp/src/config/poolRoyaleTableModels.js`.
- Unify cloth pattern handling with Snooker Royal by applying `resolveClothPatternOverride` for all cloth types, setting `repeatRatio = 3.45 * repeatRatioScale`, and always setting `map/normal/bump/roughness` repeats to the computed values; changes in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Disable the previous PolyHaven UV-clamp behavior and force the finish metadata to record `nearRepeat`, `farRepeat` and `preserveOriginalUvMapping: false` so Pool Royale uses the calibrated repeat metadata for all cloth textures; changes in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Update test `test/poolRoyaleTableModels.test.js` to assert the Showood model `fitScale` and finish role adjustments.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and the suite passed (2 tests, 0 failures). ✅
- Ran `npm run build` (TypeScript build) which completed without errors. ✅
- Ran `git diff --check` to validate whitespace/format issues and none were reported. ✅
- Attempted an automated mobile screenshot using Playwright against a running Vite dev server to visually validate the Showood table, but the headless browser capture timed out in this environment despite installing Playwright browsers and dependencies (capture not completed). ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9200ae2c8329a355a72d5fd1740a)