### PR TITLE
Adjust Snooker Royal human shooting pose

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -21033,8 +21033,8 @@ const powerRef = useRef(hud.power);
         loader: humanLoader,
         modelUrl: 'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
         unit: humanUnitScale,
-        humanScale: 1.52 * humanUnitScale,
-        shootBendDirection: -1,
+        humanScale: 1.76 * humanUnitScale,
+        shootBendDirection: 1,
         tableTopY: humanTableTopY,
         groundY: humanGroundY,
         tableW: PLAY_W,
@@ -21046,8 +21046,8 @@ const powerRef = useRef(hud.power);
         stanceWidth: 0.52 * humanUnitScale,
         bridgePalmTableLift: 0.006 * humanUnitScale,
         bridgeCueLift: 0.018 * humanUnitScale,
-        bridgeHandBackFromBall: 0.235 * humanUnitScale,
-        bridgeHandSide: -0.012 * humanUnitScale,
+        bridgeHandBackFromBall: 0.18 * humanUnitScale,
+        bridgeHandSide: 0.022 * humanUnitScale,
         chinToCueHeight: 0.11 * humanUnitScale,
         footGroundY: 0.035 * humanUnitScale,
         kneeBendShot: 0.16 * humanUnitScale,
@@ -26651,12 +26651,12 @@ const powerRef = useRef(hud.power);
             }
             const bridgeTarget = cueBallWorld
               .clone()
-              .addScaledVector(aimForward, -0.235 * humanUnitScale)
-              .addScaledVector(aimSide, -0.012 * humanUnitScale)
+              .addScaledVector(aimForward, -0.18 * humanUnitScale)
+              .addScaledVector(aimSide, 0.022 * humanUnitScale)
               .setY(humanTableTopY + 0.006 * humanUnitScale);
             const bridgeCuePoint = bridgeTarget
               .clone()
-              .addScaledVector(aimForward, 0.014 * humanUnitScale)
+              .addScaledVector(aimForward, 0.018 * humanUnitScale)
               .add(new THREE.Vector3(0, 0.018 * humanUnitScale, 0));
             const cueTipShoot = cueBallWorld
               .clone()

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -473,8 +473,8 @@ function driveHuman(human, frame) {
     return;
   }
 
-  const leftHand = frame.leftHandWorld.clone().addScaledVector(frame.forward, 0.032 * cfg.unit * ik).addScaledVector(frame.side, -0.018 * cfg.unit * ik).addScaledVector(UP, -0.018 * cfg.unit * ik);
-  const leftElbow = frame.leftElbow.clone().addScaledVector(frame.forward, 0.045 * cfg.unit * ik).addScaledVector(frame.side, -0.05 * cfg.unit * ik).addScaledVector(UP, -0.01 * cfg.unit * ik);
+  const leftHand = frame.leftHandWorld.clone().addScaledVector(frame.forward, 0.032 * cfg.unit * ik).addScaledVector(frame.side, cfg.bridgeHandSide * ik).addScaledVector(UP, -0.018 * cfg.unit * ik);
+  const leftElbow = frame.leftElbow.clone().addScaledVector(frame.forward, 0.045 * cfg.unit * ik).addScaledVector(frame.side, cfg.bridgeHandSide * 2.8 * ik).addScaledVector(UP, -0.01 * cfg.unit * ik);
   aimTwoBone(b.leftUpperArm, b.leftLowerArm, leftElbow, leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(), 0.98 * ik, 1.0 * ik);
   twistBone(b.leftUpperArm, frame.forward, -0.2 * ik);
   twistBone(b.leftLowerArm, frame.forward, 0.025 * ik);
@@ -548,7 +548,7 @@ export function updateHumanPose(human, dt, frameData) {
 
   const bridgePalmTarget = frameData.bridgeTarget.clone()
     .addScaledVector(forward, -0.006 * cfg.unit * t)
-    .addScaledVector(side, -0.012 * cfg.unit * t)
+    .addScaledVector(side, cfg.bridgeHandSide * t)
     .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
     .addScaledVector(UP, -0.01 * cfg.unit * human.settleT);
   const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);


### PR DESCRIPTION
### Motivation
- Improve shot readability on portrait mobile by making the human character larger and orienting the upper body and bridge hand so the left hand is visible near the cue ball during the shot.

### Description
- Increased Snooker human scale from `1.52` to `1.76` and flipped the shooting bend sign via `shootBendDirection` so the torso leans to the requested side in the snooker pose configuration (`webapp/src/pages/Games/SnookerRoyal.jsx`).
- Moved the bridge hand closer to the cue ball by reducing `bridgeHandBackFromBall` and changing `bridgeHandSide` to a positive offset in the snooker configuration (`webapp/src/pages/Games/SnookerRoyal.jsx`).
- Made the shared human rig respect the configured bridge-hand side by replacing hardcoded side offsets with `cfg.bridgeHandSide` for the palm target, left-hand, and left-elbow calculations and increased left-elbow side influence for a more pronounced bridge (`webapp/src/pages/Games/shared/humanRigCore.js`).

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production bundles. 
- Verified static checks via `git diff --check` with no reported problems. 
- Installed Playwright browsers and system dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium`, which succeeded. 
- Attempted an automated headless screenshot of `/games/snookerroyale` using Playwright, but the WebGL rendering timed out during capture (page rendering hang/timeout), so no final screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc051c2a188329921d1357bfcc6a0e)