### PR TITLE
Adjust Snooker Royal human shooting stance

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -21029,12 +21029,14 @@ const powerRef = useRef(hud.power);
       const humanUnitScale = SCALE;
       const humanTableTopY = BALL_CENTER_Y - BALL_R;
       const humanGroundY = FLOOR_Y - TABLE_Y;
+      const humanBridgeBackFromBall = 0.18 * humanUnitScale;
+      const humanBridgeSideOffset = 0.045 * humanUnitScale;
       const human = createSnookerHumanRig(table, {
         loader: humanLoader,
         modelUrl: 'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
         unit: humanUnitScale,
-        humanScale: 1.52 * humanUnitScale,
-        shootBendDirection: -1,
+        humanScale: 1.82 * humanUnitScale,
+        shootBendDirection: 1,
         tableTopY: humanTableTopY,
         groundY: humanGroundY,
         tableW: PLAY_W,
@@ -21044,10 +21046,11 @@ const powerRef = useRef(hud.power);
         edgeMargin: 0.68 * humanUnitScale,
         desiredShootDistance: 1.25 * humanUnitScale,
         stanceWidth: 0.52 * humanUnitScale,
-        bridgePalmTableLift: 0.006 * humanUnitScale,
-        bridgeCueLift: 0.018 * humanUnitScale,
-        bridgeHandBackFromBall: 0.235 * humanUnitScale,
-        bridgeHandSide: -0.012 * humanUnitScale,
+        bridgePalmTableLift: 0.004 * humanUnitScale,
+        bridgeCueLift: 0.014 * humanUnitScale,
+        bridgeHandBackFromBall: humanBridgeBackFromBall,
+        bridgeHandSide: humanBridgeSideOffset,
+        bridgePoseUsesConfiguredSide: true,
         chinToCueHeight: 0.11 * humanUnitScale,
         footGroundY: 0.035 * humanUnitScale,
         kneeBendShot: 0.16 * humanUnitScale,
@@ -26651,13 +26654,13 @@ const powerRef = useRef(hud.power);
             }
             const bridgeTarget = cueBallWorld
               .clone()
-              .addScaledVector(aimForward, -0.235 * humanUnitScale)
-              .addScaledVector(aimSide, -0.012 * humanUnitScale)
-              .setY(humanTableTopY + 0.006 * humanUnitScale);
+              .addScaledVector(aimForward, -humanBridgeBackFromBall)
+              .addScaledVector(aimSide, humanBridgeSideOffset)
+              .setY(humanTableTopY + 0.004 * humanUnitScale);
             const bridgeCuePoint = bridgeTarget
               .clone()
-              .addScaledVector(aimForward, 0.014 * humanUnitScale)
-              .add(new THREE.Vector3(0, 0.018 * humanUnitScale, 0));
+              .addScaledVector(aimForward, 0.018 * humanUnitScale)
+              .add(new THREE.Vector3(0, 0.014 * humanUnitScale, 0));
             const cueTipShoot = cueBallWorld
               .clone()
               .addScaledVector(aimForward, -(BALL_R + gap));

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -17,6 +17,7 @@ const BASE_CFG = {
   bridgeCueLift: 0.018,
   bridgeHandBackFromBall: 0.235,
   bridgeHandSide: -0.012,
+  bridgePoseUsesConfiguredSide: false,
   chinToCueHeight: 0.11,
   footGroundY: 0.035,
   footLockStrength: 1.0,
@@ -473,8 +474,20 @@ function driveHuman(human, frame) {
     return;
   }
 
-  const leftHand = frame.leftHandWorld.clone().addScaledVector(frame.forward, 0.032 * cfg.unit * ik).addScaledVector(frame.side, -0.018 * cfg.unit * ik).addScaledVector(UP, -0.018 * cfg.unit * ik);
-  const leftElbow = frame.leftElbow.clone().addScaledVector(frame.forward, 0.045 * cfg.unit * ik).addScaledVector(frame.side, -0.05 * cfg.unit * ik).addScaledVector(UP, -0.01 * cfg.unit * ik);
+  const bridgeIkHandSide = cfg.bridgePoseUsesConfiguredSide
+    ? cfg.bridgeHandSide * 0.8
+    : -0.018 * cfg.unit;
+  const bridgeIkElbowSide = cfg.bridgePoseUsesConfiguredSide
+    ? cfg.bridgeHandSide * 1.15
+    : -0.05 * cfg.unit;
+  const leftHand = frame.leftHandWorld.clone()
+    .addScaledVector(frame.forward, 0.032 * cfg.unit * ik)
+    .addScaledVector(frame.side, bridgeIkHandSide * ik)
+    .addScaledVector(UP, -0.018 * cfg.unit * ik);
+  const leftElbow = frame.leftElbow.clone()
+    .addScaledVector(frame.forward, 0.045 * cfg.unit * ik)
+    .addScaledVector(frame.side, bridgeIkElbowSide * ik)
+    .addScaledVector(UP, -0.01 * cfg.unit * ik);
   aimTwoBone(b.leftUpperArm, b.leftLowerArm, leftElbow, leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(), 0.98 * ik, 1.0 * ik);
   twistBone(b.leftUpperArm, frame.forward, -0.2 * ik);
   twistBone(b.leftLowerArm, frame.forward, 0.025 * ik);
@@ -546,9 +559,12 @@ export function updateHumanPose(human, dt, frameData) {
   const leftFoot = local(new THREE.Vector3(-0.13 * cfg.unit, cfg.footGroundY, 0.03 * cfg.unit + walk * 0.018 * cfg.unit).lerp(new THREE.Vector3(-cfg.stanceWidth * 0.42, cfg.footGroundY, -0.34 * cfg.unit), t));
   const rightFoot = local(new THREE.Vector3(0.13 * cfg.unit, cfg.footGroundY, -0.03 * cfg.unit - walk * 0.018 * cfg.unit).lerp(new THREE.Vector3(cfg.stanceWidth * 0.5, cfg.footGroundY, 0.34 * cfg.unit), t));
 
+  const bridgePalmSide = cfg.bridgePoseUsesConfiguredSide
+    ? cfg.bridgeHandSide
+    : -0.012 * cfg.unit;
   const bridgePalmTarget = frameData.bridgeTarget.clone()
     .addScaledVector(forward, -0.006 * cfg.unit * t)
-    .addScaledVector(side, -0.012 * cfg.unit * t)
+    .addScaledVector(side, bridgePalmSide * t)
     .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
     .addScaledVector(UP, -0.01 * cfg.unit * human.settleT);
   const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal player character read better on portrait phones by increasing the rig size and changing the shooting posture so the upper body bends to the opposite side of the cue line.
- Move the bridge hand/left-hand IK to sit closer to and alongside the cue ball (visible on the table) so the player’s left hand appears as a real bridge near the cue tip.
- Keep the new bridge behavior opt-in so other games that reuse the shared rig keep their existing default bridge computation.

### Description
- Increased the Snooker human rig scale and flipped the shot bend direction by changing `humanScale` and `shootBendDirection` in `webapp/src/pages/Games/SnookerRoyal.jsx` and added `humanBridgeBackFromBall` / `humanBridgeSideOffset` parameters used for bridge placement.
- Reduced `bridgePalmTableLift` / `bridgeCueLift` and wired the new bridge offsets into the local shot computation so `bridgeTarget`/`bridgeCuePoint` place the bridge nearer the cue and on the configured side in `SnookerRoyal.jsx`.
- Added an opt-in flag `bridgePoseUsesConfiguredSide` to `BASE_CFG` in `webapp/src/pages/Games/shared/humanRigCore.js` and changed the left-hand/elbow IK to use `cfg.bridgeHandSide` when that flag is enabled, otherwise fallback to the previous defaults.
- Cleaned up left-hand/bridge math to lerp/compose targets with the configured offsets and preserved backwards compatibility for other games using the shared rig.

### Testing
- Ran `git diff --check` which passed with no whitespace or check-errors reported.
- Built the web client with `npm --prefix webapp run build` and the Vite production build completed successfully (the build log includes normal chunk-size and dynamic-vs-static import warnings from Vite).
- Attempted an automated visual capture using Playwright after installing browsers and OS deps; the environment required additional system libraries and the screenshot attempt timed out in this container, so the headless screenshot step did not produce a verified image (installation and attempts are recorded in the rollout logs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc051c2a188329921d1357bfcc6a0e)