### PR TITLE
Rewrite RunMan into `The Maze Battle Royal` — new FPS gameplay, UI, and systems

### DIFF
--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -1,11 +1,11 @@
 const gamesCatalog = [
 
   {
-    name: 'RunMan',
+    name: 'The Maze Battle Royal',
     route: '/games/runman',
     slug: 'runman',
     image: '/assets/icons/runman.svg',
-    description: 'Neon 3D maze runner where two soldiers collect diamonds, grab weapons, and dodge robots.'
+    description: 'Fast portrait FPS maze battle royale with GLTF guns, breakable boxes, pickups, and a minimap.'
   },
 
 

--- a/webapp/src/pages/Games/RunMan.tsx
+++ b/webapp/src/pages/Games/RunMan.tsx
@@ -1,856 +1,896 @@
-"use client";
+'use client';
 
-import React, { useEffect, useRef, useState } from "react";
-import * as THREE from "three";
-import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import React, { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
-type Team = "blue" | "red";
-type ActorKind = Team | "robot";
-type PlayerId = number;
-type WeaponType = "pistol" | "rifle" | "sniper";
+type WeaponId = 'fps' | 'smg' | 'sniper' | 'shotgun';
+type PickupKind = 'health' | 'ammo' | 'weapon' | 'armor';
+type BoxDrop = PickupKind | 'none';
 
-type WeaponEntry = {
-  id: string;
+type WeaponDef = {
+  id: WeaponId;
   name: string;
-  shortName: string;
-  source: "Quaternius" | "Extra";
-  weaponType: WeaponType;
-  urls: string[];
+  slot: string;
   ammo: number;
   damage: number;
   cooldown: number;
-  bulletSpeed: number;
-  bulletLife: number;
-  pickupColor: number;
-};
-type AnimName = "Idle" | "Walk" | "Run";
-type GameState = "playing" | "gameover";
-type PickupKind = "diamond" | "weapon";
-
-type Bones = {
-  hips?: THREE.Bone;
-  spine?: THREE.Bone;
-  leftUpLeg?: THREE.Bone;
-  leftLeg?: THREE.Bone;
-  leftFoot?: THREE.Bone;
-  rightUpLeg?: THREE.Bone;
-  rightLeg?: THREE.Bone;
-  rightFoot?: THREE.Bone;
-  leftArm?: THREE.Bone;
-  rightArm?: THREE.Bone;
+  range: number;
+  color: number;
+  urls: string[];
 };
 
 type Actor = {
-  id: PlayerId;
+  id: number;
   name: string;
-  isUser: boolean;
-  kind: ActorKind;
-  root: THREE.Group;
-  model: THREE.Object3D | null;
-  fallback: THREE.Group;
-  mixer: THREE.AnimationMixer | null;
-  actions: Partial<Record<AnimName, THREE.AnimationAction>>;
-  current: AnimName;
-  bones: Bones;
+  mesh: THREE.Group;
   pos: THREE.Vector3;
   vel: THREE.Vector3;
   dir: THREE.Vector3;
-  targetDir: THREE.Vector3;
-  speed: number;
-  radius: number;
-  stun: number;
-  health: number;
+  hp: number;
+  armor: number;
   ammo: number;
-  weapon: WeaponEntry;
-  fireCooldown: number;
-  loaded: boolean;
+  weapon: WeaponDef;
+  cooldown: number;
+  collapsed: number;
+  bleed: number;
+  aiThink: number;
+  targetCell: { r: number; c: number };
 };
 
-type InputState = {
-  moveX: number;
-  moveY: number;
+type Crate = {
+  mesh: THREE.Mesh;
+  pos: THREE.Vector3;
+  hp: number;
+  alive: boolean;
+  drop: BoxDrop;
 };
 
 type Pickup = {
-  kind: PickupKind;
-  group: THREE.Group;
+  mesh: THREE.Group;
   pos: THREE.Vector3;
-  taken: boolean;
-  value: number;
-  weapon?: WeaponEntry;
+  kind: PickupKind;
+  weapon?: WeaponDef;
+  amount: number;
+  active: boolean;
 };
 
 type Bullet = {
   mesh: THREE.Mesh;
   pos: THREE.Vector3;
   vel: THREE.Vector3;
-  ownerId: PlayerId;
-  ownerName: string;
-  ownerColor: number;
-  weapon: WeaponEntry;
   life: number;
   active: boolean;
 };
 
-type MazeCell = 0 | 1;
-
-declare global {
-  interface Window {
-    __resetRobotMaze?: () => void;
-    __fireRobotMaze?: () => void;
-  }
-}
-
-const SOLDIER_URL = "https://threejs.org/examples/models/gltf/Soldier.glb";
-const ROBOT_URL = "https://threejs.org/examples/models/gltf/RobotExpressive/RobotExpressive.glb";
-
-const CELL = 0.58;
-const ROWS = 17;
-const COLS = 17;
-const MAZE_W = COLS * CELL;
-const MAZE_H = ROWS * CELL;
-const PLAYER_RADIUS = 0.16;
-const ROBOT_RADIUS = 0.17;
-const PICKUP_RADIUS = 0.13;
-const PLAYER_SPEED = 2.12;
-const ROBOT_SPEED = 1.1;
-const MAX_PLAYERS = 8;
-const GROUND_Y = 0;
-const DT_MAX = 1 / 30;
-const GAME_TIME = 180;
-const TMP = new THREE.Vector3();
-
-function polyGlb(uuid: string) {
-  return `https://static.poly.pizza/${uuid}.glb`;
-}
-
-const KNOWN_WORKING_GLB = {
-  awp: "https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb",
-  awpRaw: "https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb",
-  mrtk: "https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb",
-  mrtkRaw: "https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb",
-  mrtkMaster: "https://cdn.jsdelivr.net/gh/Microsoft/MixedRealityToolkit@master/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb",
-  pistolHolster: "https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb",
-  pistolHolsterRaw: "https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb",
-  fps: "https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf",
-  fpsRaw: "https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf",
+type Hud = {
+  hp: number;
+  armor: number;
+  ammo: number;
+  weapon: string;
+  alive: number;
+  fps: number;
+  status: string;
 };
 
-const WEAPONS: WeaponEntry[] = [
-  { id: "poly-shotgun-01", name: "Quaternius Shotgun", shortName: "Shotgun", source: "Quaternius", weaponType: "rifle", urls: [polyGlb("032e6589-3188-41bc-b92b-e25528344275")], ammo: 5, damage: 2, cooldown: 0.52, bulletSpeed: 4.6, bulletLife: 1.05, pickupColor: 0xf59e0b },
-  { id: "poly-assault-rifle-01", name: "Quaternius Assault Rifle", shortName: "Assault", source: "Quaternius", weaponType: "rifle", urls: [polyGlb("b3e6be61-0299-4866-a227-58f5f3fe610b")], ammo: 14, damage: 1, cooldown: 0.18, bulletSpeed: 5.6, bulletLife: 1.15, pickupColor: 0x22c55e },
-  { id: "poly-pistol-01", name: "Quaternius Pistol", shortName: "Pistol", source: "Quaternius", weaponType: "pistol", urls: [polyGlb("3b53f0fe-f86e-451c-816d-6ab9bd265cdc")], ammo: 9, damage: 1, cooldown: 0.34, bulletSpeed: 5.0, bulletLife: 1.0, pickupColor: 0x93c5fd },
-  { id: "poly-revolver-01", name: "Quaternius Heavy Revolver", shortName: "Revolver", source: "Quaternius", weaponType: "pistol", urls: [polyGlb("9e728565-67a3-44db-9567-982320abff09")], ammo: 6, damage: 2, cooldown: 0.46, bulletSpeed: 5.35, bulletLife: 1.05, pickupColor: 0xf97316 },
-  { id: "poly-sawed-off-01", name: "Quaternius Sawed-Off Shotgun", shortName: "Sawed-Off", source: "Quaternius", weaponType: "pistol", urls: [polyGlb("9a6ee0ee-068b-4774-8b0f-679c3cef0b6e")], ammo: 4, damage: 2, cooldown: 0.58, bulletSpeed: 4.4, bulletLife: 0.95, pickupColor: 0xfb923c },
-  { id: "poly-revolver-02", name: "Quaternius Revolver Silver", shortName: "Silver Rev", source: "Quaternius", weaponType: "pistol", urls: [polyGlb("7951b3b9-d3a5-4ec8-81b7-11111f1c8e88")], ammo: 7, damage: 2, cooldown: 0.43, bulletSpeed: 5.25, bulletLife: 1.05, pickupColor: 0xcbd5e1 },
-  { id: "poly-shotgun-02", name: "Quaternius Long Shotgun", shortName: "Long Shot", source: "Quaternius", weaponType: "rifle", urls: [polyGlb("f71d6771-f512-4374-bd23-ba00b564db68")], ammo: 5, damage: 2, cooldown: 0.5, bulletSpeed: 4.75, bulletLife: 1.1, pickupColor: 0xfbbf24 },
-  { id: "poly-shotgun-03", name: "Quaternius Pump Shotgun", shortName: "Pump", source: "Quaternius", weaponType: "rifle", urls: [polyGlb("08f27141-8e64-425a-9161-1bbd6956dfca")], ammo: 6, damage: 2, cooldown: 0.48, bulletSpeed: 4.85, bulletLife: 1.1, pickupColor: 0xeab308 },
-  { id: "poly-smg-01", name: "Quaternius Submachine Gun", shortName: "SMG", source: "Quaternius", weaponType: "rifle", urls: [polyGlb("fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710")], ammo: 18, damage: 1, cooldown: 0.14, bulletSpeed: 5.4, bulletLife: 1.0, pickupColor: 0x38bdf8 },
-  { id: "slot-10-ak47-gltf", name: "AK47 GLTF", shortName: "AK47", source: "Extra", weaponType: "rifle", urls: ["https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf", "https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf", KNOWN_WORKING_GLB.awp, KNOWN_WORKING_GLB.awpRaw], ammo: 16, damage: 1, cooldown: 0.16, bulletSpeed: 5.8, bulletLife: 1.15, pickupColor: 0x16a34a },
-  { id: "slot-11-krsv-gltf", name: "KRSV GLTF", shortName: "KRSV", source: "Extra", weaponType: "rifle", urls: ["https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf", "https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf", KNOWN_WORKING_GLB.mrtk, KNOWN_WORKING_GLB.mrtkRaw], ammo: 15, damage: 1, cooldown: 0.17, bulletSpeed: 5.65, bulletLife: 1.12, pickupColor: 0x14b8a6 },
-  { id: "slot-12-smith-gltf", name: "Smith GLTF", shortName: "Smith", source: "Extra", weaponType: "pistol", urls: ["https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf", "https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf", KNOWN_WORKING_GLB.pistolHolster, KNOWN_WORKING_GLB.pistolHolsterRaw], ammo: 8, damage: 1, cooldown: 0.3, bulletSpeed: 5.1, bulletLife: 1.0, pickupColor: 0xa78bfa },
-  { id: "slot-13-mosin-gltf", name: "Mosin GLTF", shortName: "Mosin", source: "Extra", weaponType: "sniper", urls: ["https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf", "https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf", KNOWN_WORKING_GLB.awp, KNOWN_WORKING_GLB.awpRaw], ammo: 5, damage: 3, cooldown: 0.72, bulletSpeed: 7.0, bulletLife: 1.45, pickupColor: 0x818cf8 },
-  { id: "slot-14-uzi-gltf", name: "Uzi GLTF", shortName: "Uzi", source: "Extra", weaponType: "rifle", urls: ["https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf", "https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf", KNOWN_WORKING_GLB.mrtk, KNOWN_WORKING_GLB.mrtkMaster], ammo: 20, damage: 1, cooldown: 0.12, bulletSpeed: 5.25, bulletLife: 0.95, pickupColor: 0x06b6d4 },
-  { id: "slot-15-sigsauer-gltf", name: "SigSauer GLTF", shortName: "SigSauer", source: "Extra", weaponType: "pistol", urls: ["https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf", "https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf", KNOWN_WORKING_GLB.pistolHolster, KNOWN_WORKING_GLB.pistolHolsterRaw], ammo: 10, damage: 1, cooldown: 0.26, bulletSpeed: 5.25, bulletLife: 1.0, pickupColor: 0xf472b6 },
-  { id: "slot-16-awp-glb", name: "AWP Sniper GLB", shortName: "AWP", source: "Extra", weaponType: "sniper", urls: [KNOWN_WORKING_GLB.awp, KNOWN_WORKING_GLB.awpRaw], ammo: 4, damage: 3, cooldown: 0.82, bulletSpeed: 7.4, bulletLife: 1.55, pickupColor: 0x60a5fa },
-  { id: "slot-17-mrtk-gun-glb", name: "MRTK Gun GLB", shortName: "MRTK", source: "Extra", weaponType: "rifle", urls: [KNOWN_WORKING_GLB.mrtk, KNOWN_WORKING_GLB.mrtkRaw, KNOWN_WORKING_GLB.mrtkMaster], ammo: 12, damage: 1, cooldown: 0.2, bulletSpeed: 5.45, bulletLife: 1.05, pickupColor: 0x2dd4bf },
-  { id: "slot-18-fps-gun-gltf", name: "FPS Gun GLTF", shortName: "FPS Shotgun", source: "Extra", weaponType: "rifle", urls: [KNOWN_WORKING_GLB.fps, KNOWN_WORKING_GLB.fpsRaw, KNOWN_WORKING_GLB.awp, KNOWN_WORKING_GLB.awpRaw], ammo: 5, damage: 2, cooldown: 0.54, bulletSpeed: 4.9, bulletLife: 1.08, pickupColor: 0xfacc15 },
+type MiniDot = {
+  x: number;
+  y: number;
+  color: string;
+  size: number;
+};
+
+const CELL = 0.72;
+const PLAYER_EYE = 0.62;
+const PLAYER_RADIUS = 0.16;
+const WALK_SPEED = 1.75;
+const RUN_SPEED = 3.05;
+const LOOK_SENS = 0.0044;
+const DT_MAX = 1 / 45;
+const BOT_COUNT = 7;
+const START_AMMO = 90;
+const FPS_GUN_URLS = [
+  'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
+  'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf'
+];
+const GLB_URLS = {
+  awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
+  mrtk: 'https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  pistol:
+    'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb'
+};
+
+const WEAPONS: WeaponDef[] = [
+  {
+    id: 'fps',
+    name: 'FPS Rifle',
+    slot: 'FPS',
+    ammo: 90,
+    damage: 22,
+    cooldown: 0.115,
+    range: 5.7,
+    color: 0xfacc15,
+    urls: FPS_GUN_URLS
+  },
+  {
+    id: 'smg',
+    name: 'MRTK SMG',
+    slot: 'SMG',
+    ammo: 70,
+    damage: 14,
+    cooldown: 0.075,
+    range: 4.4,
+    color: 0x22d3ee,
+    urls: [GLB_URLS.mrtk]
+  },
+  {
+    id: 'sniper',
+    name: 'AWP Sniper',
+    slot: 'AWP',
+    ammo: 18,
+    damage: 70,
+    cooldown: 0.52,
+    range: 8.5,
+    color: 0x93c5fd,
+    urls: [GLB_URLS.awp]
+  },
+  {
+    id: 'shotgun',
+    name: 'Short Shotgun',
+    slot: 'SHOT',
+    ammo: 30,
+    damage: 42,
+    cooldown: 0.38,
+    range: 2.8,
+    color: 0xfb923c,
+    urls: [GLB_URLS.pistol]
+  }
 ];
 
-const STARTER_WEAPON = WEAPONS[2];
-
-const MAZE: MazeCell[][] = [
-  [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
-  [1,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,1],
-  [1,0,1,1,1,0,1,0,1,0,1,0,1,1,1,0,1],
-  [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1],
-  [1,1,1,0,1,1,1,0,1,0,1,1,1,0,1,1,1],
-  [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
-  [1,0,1,1,0,1,1,1,0,1,1,1,0,1,1,0,1],
-  [1,0,0,1,0,0,0,0,0,0,0,0,0,1,0,0,1],
-  [1,1,0,1,1,0,1,1,0,1,1,0,1,1,0,1,1],
-  [1,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,1],
-  [1,0,1,1,1,0,1,0,1,0,1,0,1,1,1,0,1],
-  [1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1],
-  [1,1,1,0,1,1,1,0,1,0,1,1,1,0,1,1,1],
-  [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
-  [1,0,1,1,1,0,1,1,1,1,1,0,1,1,1,0,1],
-  [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
-  [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+const START_WEAPON = WEAPONS[0];
+const MAZE = [
+  '111111111111111',
+  '100000100000001',
+  '101110101011101',
+  '101000001000101',
+  '101011111110101',
+  '100010000010001',
+  '111010111010111',
+  '100000101000001',
+  '101110101011101',
+  '100010000010001',
+  '101011111110101',
+  '101000001000101',
+  '101110101011101',
+  '100000100000001',
+  '111111111111111'
 ];
+const ROWS = MAZE.length;
+const COLS = MAZE[0].length;
+const WORLD_W = COLS * CELL;
+const WORLD_H = ROWS * CELL;
+const TMP = new THREE.Vector3();
 
-function mat(color: number, roughness = 0.78, metalness = 0.02) {
-  return new THREE.MeshStandardMaterial({ color, roughness, metalness });
-}
-
-function shadow<T extends THREE.Object3D>(o: T) {
-  o.traverse((c) => {
-    const m = c as THREE.Mesh;
-    if (m.isMesh) {
-      m.castShadow = true;
-      m.receiveShadow = true;
-      m.frustumCulled = false;
-    }
-  });
-  return o;
-}
-
-function clean(name: string) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
-}
-
-function cellToWorld(row: number, col: number) {
-  return new THREE.Vector3((col - COLS / 2 + 0.5) * CELL, GROUND_Y, (row - ROWS / 2 + 0.5) * CELL);
+function cellToWorld(r: number, c: number) {
+  return new THREE.Vector3(
+    (c - COLS / 2 + 0.5) * CELL,
+    0,
+    (r - ROWS / 2 + 0.5) * CELL
+  );
 }
 
 function worldToCell(pos: THREE.Vector3) {
-  const col = Math.floor(pos.x / CELL + COLS / 2);
-  const row = Math.floor(pos.z / CELL + ROWS / 2);
-  return { row, col };
+  return {
+    r: THREE.MathUtils.clamp(Math.floor(pos.z / CELL + ROWS / 2), 0, ROWS - 1),
+    c: THREE.MathUtils.clamp(Math.floor(pos.x / CELL + COLS / 2), 0, COLS - 1)
+  };
 }
 
-function isWallCell(row: number, col: number) {
-  if (row < 0 || col < 0 || row >= ROWS || col >= COLS) return true;
-  return MAZE[row][col] === 1;
+function isWall(r: number, c: number) {
+  return r < 0 || c < 0 || r >= ROWS || c >= COLS || MAZE[r][c] === '1';
 }
 
-function findBones(model: THREE.Object3D): Bones {
-  const b: Bones = {};
-  model.traverse((o) => {
-    const bone = o as THREE.Bone;
-    if (!bone.isBone) return;
-    const n = clean(bone.name);
-    if (!b.hips && n.includes("hips")) b.hips = bone;
-    if (!b.spine && n.includes("spine")) b.spine = bone;
-    if (!b.leftUpLeg && (n.includes("leftupleg") || n.includes("leftthigh") || n.includes("lthigh"))) b.leftUpLeg = bone;
-    if (!b.rightUpLeg && (n.includes("rightupleg") || n.includes("rightthigh") || n.includes("rthigh"))) b.rightUpLeg = bone;
-    if (!b.leftLeg && !n.includes("foot") && !n.includes("upleg") && (n.includes("leftleg") || n.includes("leftcalf") || n.includes("leftshin"))) b.leftLeg = bone;
-    if (!b.rightLeg && !n.includes("foot") && !n.includes("upleg") && (n.includes("rightleg") || n.includes("rightcalf") || n.includes("rightshin"))) b.rightLeg = bone;
-    if (!b.leftFoot && n.includes("leftfoot")) b.leftFoot = bone;
-    if (!b.rightFoot && n.includes("rightfoot")) b.rightFoot = bone;
-    if (!b.leftArm && n.includes("leftarm")) b.leftArm = bone;
-    if (!b.rightArm && n.includes("rightarm")) b.rightArm = bone;
-  });
-  return b;
+function yawForward(yaw: number) {
+  return new THREE.Vector3(Math.sin(yaw), 0, Math.cos(yaw)).normalize();
 }
 
-function normalizeModel(model: THREE.Object3D, height = 0.62, rotateY = Math.PI) {
-  model.rotation.set(0, rotateY, 0);
+function yawRight(yaw: number) {
+  return new THREE.Vector3(Math.cos(yaw), 0, -Math.sin(yaw)).normalize();
+}
+
+function mat(color: number, roughness = 0.8, metalness = 0.04) {
+  return new THREE.MeshStandardMaterial({ color, roughness, metalness });
+}
+
+function makeFallbackGun(weapon: WeaponDef) {
+  const group = new THREE.Group();
+  const skin = mat(0xc58f65, 0.72, 0.02);
+  const dark = mat(0x0f172a, 0.48, 0.35);
+  const metal = mat(weapon.color, 0.34, 0.42);
+  const leftHand = new THREE.Mesh(
+    new THREE.BoxGeometry(0.07, 0.075, 0.2),
+    skin
+  );
+  const rightHand = new THREE.Mesh(
+    new THREE.BoxGeometry(0.075, 0.08, 0.22),
+    skin
+  );
+  const body = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.08, 0.42), metal);
+  const barrel = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.05, 0.34), dark);
+  leftHand.position.set(-0.12, -0.08, -0.2);
+  rightHand.position.set(0.13, -0.1, -0.1);
+  body.position.set(0.04, -0.1, -0.22);
+  barrel.position.set(0.04, -0.08, -0.55);
+  group.add(leftHand, rightHand, body, barrel);
+  return group;
+}
+
+function loadFirstModel(
+  loader: GLTFLoader,
+  urls: string[],
+  onLoad: (model: THREE.Object3D) => void
+) {
+  let i = 0;
+  const load = () => {
+    const url = urls[i++];
+    if (!url) return;
+    loader
+      .setCrossOrigin('anonymous')
+      .load(url, (gltf) => onLoad(gltf.scene), undefined, load);
+  };
+  load();
+}
+
+function fitModel(model: THREE.Object3D, height: number) {
   model.scale.setScalar(1);
+  model.rotation.set(0, Math.PI, 0);
   model.updateMatrixWorld(true);
-  let box = new THREE.Box3().setFromObject(model);
+  const box = new THREE.Box3().setFromObject(model);
   const h = Math.max(0.001, box.max.y - box.min.y);
   model.scale.setScalar(height / h);
   model.updateMatrixWorld(true);
-  box = new THREE.Box3().setFromObject(model);
-  const center = box.getCenter(new THREE.Vector3());
-  model.position.x -= center.x;
-  model.position.z -= center.z;
-  model.position.y -= box.min.y;
-}
-
-function tintModel(model: THREE.Object3D, kind: ActorKind) {
-  const tint = new THREE.Color(kind === "blue" ? 0x1d69ff : kind === "red" ? 0xd92f2f : 0x84fffb);
+  const box2 = new THREE.Box3().setFromObject(model);
+  const center = box2.getCenter(new THREE.Vector3());
+  model.position.sub(center);
+  model.position.y -= box2.min.y - center.y;
   model.traverse((o) => {
     const mesh = o as THREE.Mesh;
-    if (!mesh.isMesh) return;
-    const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-    mats.forEach((raw) => {
-      const m = raw as THREE.MeshStandardMaterial;
-      if (m.color) m.color.lerp(tint, kind === "robot" ? 0.42 : 0.34);
-      if (kind === "robot") {
-        m.emissive = new THREE.Color(0x004d5d);
-        m.emissiveIntensity = 0.22;
-      }
-      m.needsUpdate = true;
-    });
+    if (mesh.isMesh) {
+      mesh.frustumCulled = false;
+      mesh.castShadow = false;
+      mesh.receiveShadow = false;
+    }
   });
+  return model;
 }
 
-function makeFallback(kind: ActorKind) {
+function makeHumanoid(color: number) {
   const group = new THREE.Group();
-  if (kind === "robot") {
-    const body = new THREE.Mesh(new THREE.BoxGeometry(0.18, 0.34, 0.12), mat(0x7dd3fc, 0.48, 0.22));
-    body.position.y = 0.42;
-    const head = new THREE.Mesh(new THREE.BoxGeometry(0.17, 0.13, 0.13), mat(0xd9f99d, 0.4, 0.18));
-    head.position.y = 0.65;
-    const eye = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.025, 0.015), mat(0x00ffcc, 0.25, 0.1));
-    eye.position.set(0, 0.66, -0.068);
-    group.add(shadow(body), shadow(head), shadow(eye));
-    return group;
-  }
-  const color = kind === "blue" ? 0x1d69ff : 0xd92f2f;
-  const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.085, 0.3, 8, 14), mat(color));
-  body.position.y = 0.42;
-  const head = new THREE.Mesh(new THREE.SphereGeometry(0.065, 18, 12), mat(0xf1d6bd));
-  head.position.y = 0.67;
-  const gun = new THREE.Mesh(new THREE.BoxGeometry(0.18, 0.035, 0.045), mat(0x111827, 0.44, 0.26));
-  gun.position.set(0.09, 0.45, -0.09);
-  const leftLeg = new THREE.Mesh(new THREE.CapsuleGeometry(0.024, 0.23, 6, 8), mat(0x171717));
-  const rightLeg = leftLeg.clone();
-  leftLeg.position.set(-0.04, 0.18, 0);
-  rightLeg.position.set(0.04, 0.18, 0);
-  group.add(shadow(body), shadow(head), shadow(gun), shadow(leftLeg), shadow(rightLeg));
+  const body = new THREE.Mesh(
+    new THREE.CapsuleGeometry(0.105, 0.36, 5, 8),
+    mat(color)
+  );
+  const head = new THREE.Mesh(
+    new THREE.SphereGeometry(0.075, 10, 8),
+    mat(0xd1a27a)
+  );
+  const gun = new THREE.Mesh(
+    new THREE.BoxGeometry(0.16, 0.035, 0.28),
+    mat(0x111827, 0.5, 0.25)
+  );
+  body.position.y = 0.34;
+  head.position.y = 0.63;
+  gun.position.set(0.09, 0.42, 0.12);
+  group.add(body, head, gun);
   return group;
 }
 
-function createActor(scene: THREE.Scene, loader: GLTFLoader, id: PlayerId, name: string, kind: ActorKind, start: THREE.Vector3, onLoaded: () => void, isUser = false): Actor {
-  const root = new THREE.Group();
-  root.position.copy(start).setY(GROUND_Y);
-  scene.add(root);
-
-  const fallback = makeFallback(kind);
-  root.add(fallback);
-
-  const actor: Actor = {
-    id,
-    name,
-    isUser,
-    kind,
-    root,
-    model: null,
-    fallback,
-    mixer: null,
-    actions: {},
-    current: "Idle",
-    bones: {},
-    pos: start.clone().setY(GROUND_Y),
-    vel: new THREE.Vector3(),
-    dir: new THREE.Vector3(0, 0, 1),
-    targetDir: new THREE.Vector3(0, 0, 1),
-    speed: 0,
-    radius: kind === "robot" ? ROBOT_RADIUS : PLAYER_RADIUS,
-    stun: 0,
-    health: isUser ? 5 : kind === "robot" ? 2 : 4,
-    ammo: STARTER_WEAPON.ammo,
-    weapon: STARTER_WEAPON,
-    fireCooldown: 0,
-    loaded: false,
-  };
-
-  const url = kind === "robot" ? ROBOT_URL : SOLDIER_URL;
-  loader.setCrossOrigin("anonymous").load(
-    url,
-    (gltf) => {
-      const model = gltf.scene;
-      normalizeModel(model, kind === "robot" ? 0.58 : 0.62, kind === "robot" ? 0 : Math.PI);
-      tintModel(model, kind);
-      shadow(model);
-      root.add(model);
-      fallback.visible = false;
-      actor.model = model;
-      actor.bones = findBones(model);
-      actor.mixer = new THREE.AnimationMixer(model);
-
-      const clipByName = new Map(gltf.animations.map((clip) => [clip.name.toLowerCase(), clip]));
-      const aliases: Record<AnimName, string[]> = kind === "robot"
-        ? { Idle: ["idle"], Walk: ["walking", "walk"], Run: ["running", "run", "walking"] }
-        : { Idle: ["idle"], Walk: ["walk", "walking"], Run: ["run", "running"] };
-
-      (Object.keys(aliases) as AnimName[]).forEach((name) => {
-        const clip = aliases[name].map((a) => clipByName.get(a)).find(Boolean);
-        if (!clip || !actor.mixer) return;
-        const action = actor.mixer.clipAction(clip);
-        action.enabled = true;
-        action.setLoop(THREE.LoopRepeat, Infinity);
-        action.setEffectiveWeight(name === "Idle" ? 1 : 0);
-        action.play();
-        actor.actions[name] = action;
-      });
-      actor.loaded = true;
-      onLoaded();
-    },
-    undefined,
-    () => {
-      actor.loaded = false;
-      fallback.visible = true;
-      onLoaded();
-    }
-  );
-
-  return actor;
-}
-
-function setAction(actor: Actor, next: AnimName, blend = 0.16) {
-  if (actor.current === next || !actor.actions[next]) return;
-  const prev = actor.actions[actor.current];
-  const nextAction = actor.actions[next];
-  if (prev && nextAction) {
-    nextAction.enabled = true;
-    nextAction.reset();
-    nextAction.setEffectiveTimeScale(1);
-    nextAction.setEffectiveWeight(1);
-    prev.crossFadeTo(nextAction, blend, false);
-    nextAction.play();
-  }
-  actor.current = next;
-}
-
-function updateFallbackWalk(actor: Actor) {
-  const meshes = actor.fallback.children.filter((o) => o instanceof THREE.Mesh) as THREE.Mesh[];
-  const t = performance.now() * 0.011;
-  if (actor.kind === "robot") {
-    actor.fallback.rotation.y = Math.sin(t * 0.4) * 0.02;
-    return;
-  }
-  const legs = meshes.slice(-2);
-  const s = Math.sin(t) * Math.min(1.2, actor.speed);
-  if (legs[0]) legs[0].rotation.x = s * 0.75;
-  if (legs[1]) legs[1].rotation.x = -s * 0.75;
-}
-
-function updateActorAnimation(actor: Actor, dt: number) {
-  actor.pos.y = GROUND_Y;
-  actor.root.position.copy(actor.pos);
-  if (actor.targetDir.lengthSq() > 0.001) actor.dir.lerp(actor.targetDir, 1 - Math.pow(0.002, dt)).normalize();
-  actor.root.rotation.y = Math.atan2(actor.dir.x, actor.dir.z);
-
-  const next: AnimName = actor.stun > 0 ? "Idle" : actor.speed > 1.2 ? "Run" : actor.speed > 0.06 ? "Walk" : "Idle";
-  setAction(actor, next);
-  if (actor.actions.Walk) actor.actions.Walk.timeScale = THREE.MathUtils.clamp(actor.speed / 1.0, 0.75, 1.45);
-  if (actor.actions.Run) actor.actions.Run.timeScale = THREE.MathUtils.clamp(actor.speed / 1.7, 0.75, 1.55);
-  actor.mixer?.update(dt);
-
-  if (actor.kind !== "robot" && actor.ammo > 0) {
-    if (actor.bones.spine) actor.bones.spine.rotation.x += -0.04;
-    if (actor.bones.rightArm) actor.bones.rightArm.rotation.x += -0.42;
-    if (actor.bones.leftArm) actor.bones.leftArm.rotation.x += -0.2;
-  }
-
-  updateFallbackWalk(actor);
-  actor.stun = Math.max(0, actor.stun - dt);
-  actor.fireCooldown = Math.max(0, actor.fireCooldown - dt);
-}
-
-function clampToMazeBounds(pos: THREE.Vector3) {
-  const x = MAZE_W / 2 - CELL * 0.5;
-  const z = MAZE_H / 2 - CELL * 0.5;
-  pos.x = THREE.MathUtils.clamp(pos.x, -x, x);
-  pos.z = THREE.MathUtils.clamp(pos.z, -z, z);
-  pos.y = GROUND_Y;
-}
-
-function collidesWithMaze(pos: THREE.Vector3, radius: number) {
-  const points = [
-    [pos.x, pos.z],
-    [pos.x + radius, pos.z],
-    [pos.x - radius, pos.z],
-    [pos.x, pos.z + radius],
-    [pos.x, pos.z - radius],
-    [pos.x + radius * 0.72, pos.z + radius * 0.72],
-    [pos.x - radius * 0.72, pos.z + radius * 0.72],
-    [pos.x + radius * 0.72, pos.z - radius * 0.72],
-    [pos.x - radius * 0.72, pos.z - radius * 0.72],
-  ];
-  return points.some(([x, z]) => {
-    const col = Math.floor(x / CELL + COLS / 2);
-    const row = Math.floor(z / CELL + ROWS / 2);
-    return isWallCell(row, col);
-  });
-}
-
-function tryMoveActor(actor: Actor, dir: THREE.Vector3, speed: number, dt: number) {
-  if (actor.stun > 0 || actor.health <= 0) {
-    actor.vel.multiplyScalar(Math.pow(0.01, dt));
-    actor.speed = 0;
-    return;
-  }
-
-  if (dir.lengthSq() > 0.001) {
-    dir.normalize();
-    actor.targetDir.copy(dir);
-    actor.vel.lerp(dir.clone().multiplyScalar(speed), 1 - Math.pow(0.006, dt));
-  } else {
-    actor.vel.multiplyScalar(Math.pow(0.001, dt));
-  }
-
-  const old = actor.pos.clone();
-  const next = actor.pos.clone().addScaledVector(actor.vel, dt);
-  clampToMazeBounds(next);
-
-  const tryX = actor.pos.clone();
-  tryX.x = next.x;
-  if (!collidesWithMaze(tryX, actor.radius)) actor.pos.x = tryX.x;
-  else actor.vel.x = 0;
-
-  const tryZ = actor.pos.clone();
-  tryZ.z = next.z;
-  if (!collidesWithMaze(tryZ, actor.radius)) actor.pos.z = tryZ.z;
-  else actor.vel.z = 0;
-
-  actor.speed = old.distanceTo(actor.pos) / Math.max(dt, 0.0001);
-}
-
-function cellNeighbors(row: number, col: number) {
-  const dirs = [
-    { row: row - 1, col, dir: new THREE.Vector3(0, 0, -1) },
-    { row: row + 1, col, dir: new THREE.Vector3(0, 0, 1) },
-    { row, col: col - 1, dir: new THREE.Vector3(-1, 0, 0) },
-    { row, col: col + 1, dir: new THREE.Vector3(1, 0, 0) },
-  ];
-  return dirs.filter((d) => !isWallCell(d.row, d.col));
-}
-
-function chooseAiDir(actor: Actor, actors: Actor[]) {
-  const targets = aliveActors(actors).filter((candidate) => candidate.id !== actor.id);
-  if (!targets.length) return new THREE.Vector3();
-  const target = targets.reduce((best, candidate) => (actor.pos.distanceTo(candidate.pos) < actor.pos.distanceTo(best.pos) ? candidate : best), targets[0]);
-  const c = worldToCell(actor.pos);
-  const t = worldToCell(target.pos);
-  const neighbors = cellNeighbors(c.row, c.col);
-  if (!neighbors.length) return new THREE.Vector3();
-
-  let best = neighbors[0];
-  let bestScore = Infinity;
-  for (const n of neighbors) {
-    const dist = Math.abs(n.row - t.row) + Math.abs(n.col - t.col);
-    const world = cellToWorld(n.row, n.col);
-    const score = dist + world.distanceTo(target.pos) * 0.28 + Math.random() * 0.26;
-    if (score < bestScore) {
-      bestScore = score;
-      best = n;
-    }
-  }
-  return best.dir.clone();
-}
-
-function makeMaze(scene: THREE.Scene) {
-  const floor = new THREE.Mesh(new THREE.PlaneGeometry(MAZE_W + 1.1, MAZE_H + 1.1), mat(0x080b16, 0.9, 0));
-  floor.rotation.x = -Math.PI / 2;
-  floor.receiveShadow = true;
-  scene.add(floor);
-
-  const wallMat = new THREE.MeshStandardMaterial({ color: 0x111827, roughness: 0.55, metalness: 0.12, emissive: 0x061122, emissiveIntensity: 0.25 });
-  const topMat = new THREE.MeshStandardMaterial({ color: 0x334155, roughness: 0.45, metalness: 0.1, emissive: 0x0b2344, emissiveIntensity: 0.22 });
-  const pathMat = mat(0x172033, 0.92, 0.02);
-
-  for (let r = 0; r < ROWS; r++) {
-    for (let c = 0; c < COLS; c++) {
-      const p = cellToWorld(r, c);
-      if (MAZE[r][c] === 1) {
-        const wall = new THREE.Mesh(new THREE.BoxGeometry(CELL * 0.96, 0.62, CELL * 0.96), wallMat);
-        wall.position.set(p.x, 0.31, p.z);
-        const cap = new THREE.Mesh(new THREE.BoxGeometry(CELL * 0.98, 0.055, CELL * 0.98), topMat);
-        cap.position.set(p.x, 0.645, p.z);
-        scene.add(shadow(wall), shadow(cap));
-      } else {
-        const tile = new THREE.Mesh(new THREE.BoxGeometry(CELL * 0.9, 0.018, CELL * 0.9), pathMat);
-        tile.position.set(p.x, 0.004, p.z);
-        tile.receiveShadow = true;
-        scene.add(tile);
-      }
-    }
-  }
-
-  const border = new THREE.LineSegments(
-    new THREE.EdgesGeometry(new THREE.BoxGeometry(MAZE_W + 0.2, 0.06, MAZE_H + 0.2)),
-    new THREE.LineBasicMaterial({ color: 0x00e5ff, transparent: true, opacity: 0.35 })
-  );
-  border.position.y = 0.04;
-  scene.add(border);
-}
-
-function makeDiamond(color: number, value = 1) {
+function makePickup(kind: PickupKind, weapon?: WeaponDef) {
   const group = new THREE.Group();
-  const geo = new THREE.OctahedronGeometry(value > 1 ? 0.13 : 0.095, 0);
+  const color =
+    kind === 'health'
+      ? 0x22c55e
+      : kind === 'ammo'
+        ? 0xfacc15
+        : kind === 'armor'
+          ? 0x38bdf8
+          : (weapon?.color ?? 0xe879f9);
+  const geo =
+    kind === 'weapon'
+      ? new THREE.BoxGeometry(0.26, 0.055, 0.12)
+      : new THREE.OctahedronGeometry(0.095, 0);
   const mesh = new THREE.Mesh(
     geo,
-    new THREE.MeshStandardMaterial({ color, roughness: 0.18, metalness: 0.25, emissive: color, emissiveIntensity: 0.28 })
+    new THREE.MeshStandardMaterial({
+      color,
+      emissive: color,
+      emissiveIntensity: 0.22,
+      roughness: 0.38,
+      metalness: 0.18
+    })
   );
-  mesh.rotation.y = Math.PI / 4;
-  group.add(shadow(mesh));
-  const glow = new THREE.PointLight(color, value > 1 ? 0.6 : 0.35, 1.1);
-  glow.position.y = 0.18;
-  group.add(glow);
+  group.add(mesh, new THREE.PointLight(color, 0.45, 1.1));
   return group;
 }
 
-function makeWeaponPickup(weapon: WeaponEntry) {
-  const group = new THREE.Group();
-  const body = new THREE.Mesh(new THREE.BoxGeometry(0.22, 0.055, 0.075), mat(weapon.pickupColor, 0.4, 0.3));
-  const barrel = new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.025, 0.035), mat(0x111827, 0.35, 0.4));
-  barrel.position.x = 0.16;
-  const glow = new THREE.PointLight(weapon.pickupColor, 0.65, 1.1);
-  glow.position.y = 0.2;
-  group.add(shadow(body), shadow(barrel), glow);
-  group.rotation.y = Math.PI / 4;
-  return group;
-}
-
-function createPickups(scene: THREE.Scene) {
-  const pickups: Pickup[] = [];
-  const weaponCells = new Set(["1,3", "1,8", "1,13", "3,3", "3,7", "3,13", "5,1", "5,5", "5,8", "5,11", "5,15", "8,2", "8,8", "8,14", "11,3", "13,7", "13,13", "15,11"]);
-
-  for (let r = 1; r < ROWS - 1; r++) {
-    for (let c = 1; c < COLS - 1; c++) {
-      if (MAZE[r][c] === 1) continue;
-      const startSpot = (r === 1 && c === 1) || (r === 15 && c === 15) || (r === 8 && c === 8);
-      if (startSpot) continue;
-
-      const key = `${r},${c}`;
-      if (weaponCells.has(key)) {
-        const weapon = WEAPONS[pickups.filter((p) => p.kind === "weapon").length % WEAPONS.length];
-        const group = makeWeaponPickup(weapon);
-        const pos = cellToWorld(r, c).setY(0.25);
-        group.position.copy(pos);
-        scene.add(group);
-        pickups.push({ kind: "weapon", group, pos: pos.clone(), taken: false, value: weapon.ammo, weapon });
-      } else {
-        const special = (r + c) % 8 === 0;
-        const group = makeDiamond(special ? 0xffd166 : 0x63e6ff, special ? 3 : 1);
-        const pos = cellToWorld(r, c).setY(special ? 0.25 : 0.2);
-        group.position.copy(pos);
-        scene.add(group);
-        pickups.push({ kind: "diamond", group, pos: pos.clone(), taken: false, value: special ? 3 : 1 });
-      }
-    }
-  }
-  return pickups;
-}
-
-function resetPickups(pickups: Pickup[]) {
-  pickups.forEach((d) => {
-    d.taken = false;
-    d.group.visible = true;
-  });
-}
-
-function collectPickups(actor: Actor, pickups: Pickup[]) {
-  let score = 0;
-  let ammo = 0;
-  let weapon: WeaponEntry | undefined;
-  pickups.forEach((p) => {
-    if (p.taken) return;
-    TMP.copy(p.pos).sub(actor.pos).setY(0);
-    if (TMP.length() < actor.radius + PICKUP_RADIUS) {
-      p.taken = true;
-      p.group.visible = false;
-      if (p.kind === "diamond") score += p.value;
-      else {
-        ammo += p.value;
-        weapon = p.weapon;
-      }
-    }
-  });
-  if (weapon) actor.weapon = weapon;
-  actor.ammo += ammo;
-  return { score, ammo, weapon };
-}
-
-function aliveActors(actors: Actor[]) {
-  return actors.filter((actor) => actor.health > 0 && actor.root.visible);
-}
-
-function resetActors(actors: Actor[]) {
-  const starts = [
-    cellToWorld(15, 1), cellToWorld(1, 15), cellToWorld(15, 15), cellToWorld(1, 1),
-    cellToWorld(8, 8), cellToWorld(1, 8), cellToWorld(15, 8), cellToWorld(8, 1),
-  ];
-  actors.forEach((actor, i) => {
-    actor.pos.copy(starts[i % starts.length]);
-    actor.vel.set(0, 0, 0);
-    actor.dir.set(i % 2 ? -1 : 1, 0, i % 3 ? 0 : -1).normalize();
-    actor.targetDir.copy(actor.dir);
-    actor.stun = 0;
-    actor.health = actor.isUser ? 5 : 4;
-    actor.ammo = STARTER_WEAPON.ammo;
-    actor.weapon = STARTER_WEAPON;
-    actor.root.visible = true;
-  });
-}
-
-function makeMiniMap(scene: THREE.Scene) {
-  const group = new THREE.Group();
-  group.position.set(0, 0.025, 0);
-  const lineMat = new THREE.LineBasicMaterial({ color: 0x00e5ff, transparent: true, opacity: 0.18 });
-  for (let c = 0; c <= COLS; c++) {
-    const x = (c - COLS / 2) * CELL;
-    group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(x, 0, -MAZE_H / 2), new THREE.Vector3(x, 0, MAZE_H / 2)]), lineMat));
-  }
-  for (let r = 0; r <= ROWS; r++) {
-    const z = (r - ROWS / 2) * CELL;
-    group.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(-MAZE_W / 2, 0, z), new THREE.Vector3(MAZE_W / 2, 0, z)]), lineMat));
-  }
-  scene.add(group);
-}
-
-function makePortal(scene: THREE.Scene, row: number, col: number, color: number) {
-  const g = new THREE.Group();
-  const ring = new THREE.Mesh(new THREE.TorusGeometry(0.18, 0.018, 8, 32), new THREE.MeshStandardMaterial({ color, emissive: color, emissiveIntensity: 0.55 }));
-  ring.rotation.x = Math.PI / 2;
-  g.add(ring);
-  const light = new THREE.PointLight(color, 0.8, 1.4);
-  light.position.y = 0.25;
-  g.add(light);
-  g.position.copy(cellToWorld(row, col)).setY(0.08);
-  scene.add(g);
-}
-
-function makeBullet(scene: THREE.Scene, owner: Actor, pos: THREE.Vector3, dir: THREE.Vector3): Bullet {
-  const ownerColor = owner.isUser ? 0x93c5fd : 0xfca5a5;
+function makeCrate(drop: BoxDrop) {
   const mesh = new THREE.Mesh(
-    new THREE.SphereGeometry(owner.weapon.weaponType === "sniper" ? 0.052 : 0.045, 12, 8),
-    new THREE.MeshStandardMaterial({ color: ownerColor, emissive: ownerColor, emissiveIntensity: 0.8 })
+    new THREE.BoxGeometry(0.44, 0.34, 0.44),
+    new THREE.MeshStandardMaterial({
+      color: 0x8b5a2b,
+      roughness: 0.92,
+      metalness: 0.01
+    })
   );
-  mesh.position.copy(pos).setY(0.38);
-  scene.add(mesh);
-  return { mesh, pos: mesh.position.clone(), vel: dir.clone().normalize().multiplyScalar(owner.weapon.bulletSpeed), ownerId: owner.id, ownerName: owner.name, ownerColor, weapon: owner.weapon, life: owner.weapon.bulletLife, active: true };
+  mesh.castShadow = false;
+  mesh.receiveShadow = true;
+  mesh.userData.drop = drop;
+  return mesh;
 }
 
-function updateBullets(bullets: Bullet[], dt: number, actors: Actor[], setStatus: (s: string) => void) {
-  bullets.forEach((b) => {
-    if (!b.active) return;
-    b.life -= dt;
-    b.pos.addScaledVector(b.vel, dt);
-    b.mesh.position.copy(b.pos);
+function openCells() {
+  const cells: { r: number; c: number }[] = [];
+  for (let r = 1; r < ROWS - 1; r += 1) {
+    for (let c = 1; c < COLS - 1; c += 1)
+      if (!isWall(r, c)) cells.push({ r, c });
+  }
+  return cells;
+}
 
-    if (b.life <= 0 || collidesWithMaze(b.pos, 0.035)) {
-      b.active = false;
-      b.mesh.visible = false;
-      return;
-    }
-
-    for (const enemy of actors) {
-      if (enemy.id === b.ownerId || enemy.health <= 0 || !enemy.root.visible) continue;
-      if (b.pos.distanceTo(enemy.pos.clone().setY(0.38)) < enemy.radius + 0.08) {
-        enemy.health = Math.max(0, enemy.health - b.weapon.damage);
-        enemy.stun = 0.75;
-        b.active = false;
-        b.mesh.visible = false;
-        if (enemy.health <= 0) {
-          enemy.root.visible = false;
-          enemy.pos.set(99, 0, 99);
-          setStatus(`${b.ownerName} eliminated ${enemy.name} with ${b.weapon.shortName}!`);
-        } else {
-          const knockback = enemy.pos.clone().sub(b.pos).setY(0).normalize().multiplyScalar(0.18);
-          enemy.pos.add(knockback);
-          setStatus(`${b.ownerName} hit ${enemy.name} with ${b.weapon.shortName}!`);
-        }
-        return;
+function collides(pos: THREE.Vector3, crates: Crate[], radius = PLAYER_RADIUS) {
+  const c = worldToCell(pos);
+  for (let dr = -1; dr <= 1; dr += 1) {
+    for (let dc = -1; dc <= 1; dc += 1) {
+      if (isWall(c.r + dr, c.c + dc)) {
+        const wp = cellToWorld(c.r + dr, c.c + dc);
+        if (
+          Math.abs(pos.x - wp.x) < CELL * 0.5 + radius &&
+          Math.abs(pos.z - wp.z) < CELL * 0.5 + radius
+        )
+          return true;
       }
     }
-  });
+  }
+  return crates.some(
+    (crate) => crate.alive && crate.pos.distanceTo(pos) < 0.34 + radius
+  );
 }
 
 export default function RunMan() {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const moveBase = useRef<HTMLDivElement | null>(null);
-  const moveKnob = useRef<HTMLDivElement | null>(null);
-  const moveTouch = useRef<number | null>(null);
-  const input = useRef<InputState>({ moveX: 0, moveY: 0 });
-  const [hud, setHud] = useState({ alive: MAX_PLAYERS, ammo: STARTER_WEAPON.ammo, hp: 5, weapon: STARTER_WEAPON.shortName, time: GAME_TIME, status: "Loading 8-player last-man-standing arena…" });
+  const moveBaseRef = useRef<HTMLDivElement | null>(null);
+  const moveKnobRef = useRef<HTMLDivElement | null>(null);
+  const fireTouchRef = useRef<number | null>(null);
+  const inputRef = useRef({
+    moveX: 0,
+    moveY: 0,
+    yaw: 0,
+    pitch: -0.03,
+    firing: false,
+    reloading: 0,
+    recoil: 0
+  });
+  const lookRef = useRef<{
+    id: number;
+    x: number;
+    y: number;
+    sx: number;
+    sy: number;
+    moved: boolean;
+  } | null>(null);
+  const moveRef = useRef<number | null>(null);
+  const [hud, setHud] = useState<Hud>({
+    hp: 100,
+    armor: 0,
+    ammo: START_AMMO,
+    weapon: START_WEAPON.slot,
+    alive: BOT_COUNT + 1,
+    fps: 60,
+    status: 'The Maze Battle Royal loading…'
+  });
+  const [slots, setSlots] = useState<WeaponDef[]>([START_WEAPON, WEAPONS[1]]);
+  const [miniDots, setMiniDots] = useState<MiniDot[]>([]);
 
   useEffect(() => {
     const host = hostRef.current;
     const canvas = canvasRef.current;
     if (!host || !canvas) return;
 
-    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-    renderer.setClearColor(0x020617, 1);
-    renderer.shadowMap.enabled = true;
-    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    const renderer = new THREE.WebGLRenderer({
+      canvas,
+      antialias: false,
+      powerPreference: 'high-performance'
+    });
+    renderer.setClearColor(0x060913, 1);
+    renderer.shadowMap.enabled = false;
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
 
     const scene = new THREE.Scene();
-    scene.fog = new THREE.Fog(0x020617, 7, 18);
+    scene.fog = new THREE.Fog(0x060913, 4.8, 11.5);
+    const camera = new THREE.PerspectiveCamera(67, 1, 0.03, 30);
+    scene.add(camera);
 
-    const camera = new THREE.PerspectiveCamera(58, 1, 0.05, 70);
-    camera.position.set(0, 5.2, 4.2);
-    camera.lookAt(0, 0, 0);
+    scene.add(new THREE.HemisphereLight(0xe0f2fe, 0x0f172a, 1.55));
+    const playerLight = new THREE.PointLight(0x8bd3ff, 1.4, 4.5);
+    camera.add(playerLight);
 
-    scene.add(new THREE.AmbientLight(0xffffff, 0.54));
-    const sun = new THREE.DirectionalLight(0xffffff, 1.25);
-    sun.position.set(4, 9, 5);
-    sun.castShadow = true;
-    sun.shadow.mapSize.set(2048, 2048);
-    scene.add(sun);
+    const floor = new THREE.Mesh(
+      new THREE.PlaneGeometry(WORLD_W + 1.2, WORLD_H + 1.2),
+      mat(0x172033, 0.88, 0.02)
+    );
+    floor.rotation.x = -Math.PI / 2;
+    scene.add(floor);
 
-    const cyanLight = new THREE.PointLight(0x00e5ff, 1.4, 11);
-    cyanLight.position.set(0, 2.2, 0);
-    scene.add(cyanLight);
+    const wallGeo = new THREE.BoxGeometry(CELL * 0.98, 0.9, CELL * 0.98);
+    const wallCount = MAZE.join('')
+      .split('')
+      .filter((v) => v === '1').length;
+    const walls = new THREE.InstancedMesh(
+      wallGeo,
+      mat(0x243044, 0.74, 0.03),
+      wallCount
+    );
+    let wallIndex = 0;
+    const wallMatrix = new THREE.Matrix4();
+    for (let r = 0; r < ROWS; r += 1) {
+      for (let c = 0; c < COLS; c += 1) {
+        if (!isWall(r, c)) continue;
+        const p = cellToWorld(r, c);
+        wallMatrix.makeTranslation(p.x, 0.45, p.z);
+        walls.setMatrixAt(wallIndex++, wallMatrix);
+      }
+    }
+    walls.instanceMatrix.needsUpdate = true;
+    scene.add(walls);
 
-    makeMaze(scene);
-    makeMiniMap(scene);
-    makePortal(scene, 1, 1, 0x1d69ff);
-    makePortal(scene, 15, 15, 0xd92f2f);
-    const pickups = createPickups(scene);
-    const bullets: Bullet[] = [];
+    const cells = openCells();
+    const crates: Crate[] = [];
+    const crateDrops: BoxDrop[] = [
+      'health',
+      'ammo',
+      'weapon',
+      'armor',
+      'none',
+      'ammo',
+      'health',
+      'weapon'
+    ];
+    const crateCells = cells
+      .filter(
+        (cell) => (cell.r + cell.c) % 4 === 0 && !(cell.r > 11 && cell.c < 3)
+      )
+      .slice(0, 22);
+    crateCells.forEach((cell, i) => {
+      const pos = cellToWorld(cell.r, cell.c);
+      const mesh = makeCrate(crateDrops[i % crateDrops.length]);
+      mesh.position.set(pos.x, 0.17, pos.z);
+      scene.add(mesh);
+      crates.push({ mesh, pos, hp: 44, alive: true, drop: mesh.userData.drop });
+    });
+
+    const pickups: Pickup[] = [];
+    const spawnPickup = (
+      pos: THREE.Vector3,
+      kind: PickupKind,
+      weapon?: WeaponDef,
+      amount = 1
+    ) => {
+      const mesh = makePickup(kind, weapon);
+      mesh.position.copy(pos).setY(0.24);
+      scene.add(mesh);
+      pickups.push({
+        mesh,
+        pos: pos.clone(),
+        kind,
+        weapon,
+        amount,
+        active: true
+      });
+    };
+    spawnPickup(cellToWorld(1, 3), 'weapon', WEAPONS[2], WEAPONS[2].ammo);
+    spawnPickup(cellToWorld(13, 11), 'weapon', WEAPONS[3], WEAPONS[3].ammo);
+    spawnPickup(cellToWorld(7, 1), 'health', undefined, 35);
+    spawnPickup(cellToWorld(7, 13), 'ammo', undefined, 45);
+
+    const actors: Actor[] = [];
+    const playerMesh = new THREE.Group();
+    scene.add(playerMesh);
+    actors.push({
+      id: 0,
+      name: 'You',
+      mesh: playerMesh,
+      pos: cellToWorld(13, 1),
+      vel: new THREE.Vector3(),
+      dir: new THREE.Vector3(0, 0, -1),
+      hp: 100,
+      armor: 0,
+      ammo: START_AMMO,
+      weapon: START_WEAPON,
+      cooldown: 0,
+      collapsed: 0,
+      bleed: 0,
+      aiThink: 0,
+      targetCell: { r: 1, c: 13 }
+    });
+    const botStarts = [
+      cellToWorld(1, 13),
+      cellToWorld(1, 1),
+      cellToWorld(13, 13),
+      cellToWorld(7, 7),
+      cellToWorld(3, 7),
+      cellToWorld(11, 7),
+      cellToWorld(7, 3)
+    ];
+    botStarts.forEach((pos, i) => {
+      const mesh = makeHumanoid(i % 2 ? 0xd92f2f : 0xf97316);
+      scene.add(mesh);
+      actors.push({
+        id: i + 1,
+        name: `Raider ${i + 1}`,
+        mesh,
+        pos: pos.clone(),
+        vel: new THREE.Vector3(),
+        dir: new THREE.Vector3(0, 0, 1),
+        hp: 68,
+        armor: i % 3 ? 0 : 25,
+        ammo: 60,
+        weapon: WEAPONS[i % WEAPONS.length],
+        cooldown: Math.random() * 0.5,
+        collapsed: 0,
+        bleed: 0,
+        aiThink: 0,
+        targetCell: worldToCell(actors[0].pos)
+      });
+    });
+    const player = actors[0];
+
+    const bullets: Bullet[] = Array.from({ length: 40 }, () => {
+      const mesh = new THREE.Mesh(
+        new THREE.SphereGeometry(0.035, 6, 4),
+        new THREE.MeshBasicMaterial({ color: 0xfef08a })
+      );
+      mesh.visible = false;
+      scene.add(mesh);
+      return {
+        mesh,
+        pos: new THREE.Vector3(),
+        vel: new THREE.Vector3(),
+        life: 0,
+        active: false
+      };
+    });
+    const bloodPool = Array.from({ length: 34 }, () => {
+      const mesh = new THREE.Mesh(
+        new THREE.SphereGeometry(0.025, 5, 4),
+        new THREE.MeshBasicMaterial({ color: 0xb91c1c })
+      );
+      mesh.visible = false;
+      scene.add(mesh);
+      return mesh;
+    });
+    let bloodCursor = 0;
 
     const loader = new GLTFLoader();
-    let loadedCount = 0;
-    const onLoaded = () => {
-      loadedCount += 1;
-      if (loadedCount >= MAX_PLAYERS) setHud((h) => ({ ...h, status: "8 players ready. Last man standing wins." }));
+    const viewModel = new THREE.Group();
+    viewModel.position.set(0.22, -0.19, -0.5);
+    camera.add(viewModel);
+
+    const setViewWeapon = (weapon: WeaponDef) => {
+      viewModel.clear();
+      const fallback = makeFallbackGun(weapon);
+      viewModel.add(fallback);
+      loadFirstModel(loader, weapon.urls, (source) => {
+        if (player.weapon.id !== weapon.id) return;
+        viewModel.clear();
+        const hands = makeFallbackGun(weapon);
+        hands.position.set(0.02, -0.035, 0.07);
+        const model = fitModel(
+          source.clone(true),
+          weapon.id === 'fps' ? 0.31 : 0.24
+        );
+        model.rotation.set(-0.07, Math.PI, 0.02);
+        model.position.set(0.06, -0.13, -0.34);
+        viewModel.add(hands, model);
+      });
     };
+    setViewWeapon(START_WEAPON);
 
-    const starts = [
-      cellToWorld(15, 1), cellToWorld(1, 15), cellToWorld(15, 15), cellToWorld(1, 1),
-      cellToWorld(8, 8), cellToWorld(1, 8), cellToWorld(15, 8), cellToWorld(8, 1),
-    ];
-    const actors: Actor[] = [
-      createActor(scene, loader, 0, "You", "blue", starts[0], onLoaded, true),
-      ...Array.from({ length: MAX_PLAYERS - 1 }, (_, i) => createActor(scene, loader, i + 1, `Runner ${i + 2}`, "red", starts[i + 1], onLoaded)),
-    ];
-    const user = actors[0];
-
-    let gameTime = GAME_TIME;
-    let state: GameState = "playing";
-    let aiThink = 0;
-    let aiFireThink = 0;
-    let frame = 0;
-    let last = performance.now();
-
-    const syncHud = (status?: string) => setHud((h) => ({
-      ...h,
-      alive: aliveActors(actors).length,
-      ammo: user.ammo,
-      hp: Math.max(0, user.health),
-      weapon: user.weapon.shortName,
-      time: Math.ceil(gameTime),
-      status: status ?? h.status,
-    }));
-    const setStatus = (status: string) => syncHud(status);
+    const swapTo = (weapon: WeaponDef) => {
+      player.weapon = weapon;
+      player.ammo = Math.max(player.ammo, Math.min(weapon.ammo, 24));
+      inputRef.current.reloading = 0.28;
+      setViewWeapon(weapon);
+      setHud((h) => ({
+        ...h,
+        weapon: weapon.slot,
+        ammo: player.ammo,
+        status: `Quick swap: ${weapon.name}`
+      }));
+    };
+    (window as unknown as { __mazeSwap?: (id: WeaponId) => void }).__mazeSwap =
+      (id) => {
+        const weapon =
+          slots.find((w) => w.id === id) ?? WEAPONS.find((w) => w.id === id);
+        if (weapon) swapTo(weapon);
+      };
 
     const resize = () => {
       const w = Math.max(1, host.clientWidth);
       const h = Math.max(1, host.clientHeight);
-      renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+      renderer.setPixelRatio(Math.min(1.45, window.devicePixelRatio || 1));
       renderer.setSize(w, h, false);
       camera.aspect = w / h;
       camera.updateProjectionMatrix();
     };
     resize();
-    window.addEventListener("resize", resize);
+    window.addEventListener('resize', resize);
 
-    const resetGame = () => {
-      gameTime = GAME_TIME;
-      state = "playing";
-      resetPickups(pickups);
-      bullets.forEach((b) => { b.active = false; b.mesh.visible = false; });
-      resetActors(actors);
-      input.current = { moveX: 0, moveY: 0 };
-      setHud({ alive: MAX_PLAYERS, ammo: STARTER_WEAPON.ammo, hp: 5, weapon: STARTER_WEAPON.shortName, time: GAME_TIME, status: "New 8-player round. Survive and collect all 18 weapons." });
-    };
-    window.__resetRobotMaze = resetGame;
-    window.__fireRobotMaze = () => {
-      if (state !== "playing") return;
-      if (user.ammo <= 0 || user.fireCooldown > 0 || user.health <= 0) {
-        setStatus("You need weapon ammo!");
-        return;
+    const emitBlood = (pos: THREE.Vector3, count = 4) => {
+      for (let i = 0; i < count; i += 1) {
+        const mesh = bloodPool[bloodCursor++ % bloodPool.length];
+        mesh.position
+          .copy(pos)
+          .add(
+            new THREE.Vector3(
+              (Math.random() - 0.5) * 0.18,
+              0.18 + Math.random() * 0.14,
+              (Math.random() - 0.5) * 0.18
+            )
+          );
+        mesh.visible = true;
       }
-      user.ammo -= 1;
-      user.fireCooldown = user.weapon.cooldown;
-      const muzzle = user.pos.clone().addScaledVector(user.dir, 0.24).setY(0.38);
-      bullets.push(makeBullet(scene, user, muzzle, user.dir));
-      setStatus(`Fired ${user.weapon.shortName}!`);
     };
 
-    const fireActor = (actor: Actor) => {
-      if (state !== "playing" || actor.ammo <= 0 || actor.fireCooldown > 0 || actor.health <= 0) return;
-      actor.ammo -= 1;
-      actor.fireCooldown = actor.weapon.cooldown * 1.18;
-      const muzzle = actor.pos.clone().addScaledVector(actor.dir, 0.24).setY(0.38);
-      bullets.push(makeBullet(scene, actor, muzzle, actor.dir));
+    const breakCrate = (crate: Crate) => {
+      if (!crate.alive) return;
+      crate.alive = false;
+      crate.mesh.visible = false;
+      const pos = crate.pos.clone();
+      if (crate.drop === 'health') spawnPickup(pos, 'health', undefined, 35);
+      if (crate.drop === 'ammo') spawnPickup(pos, 'ammo', undefined, 40);
+      if (crate.drop === 'armor') spawnPickup(pos, 'armor', undefined, 30);
+      if (crate.drop === 'weapon')
+        spawnPickup(
+          pos,
+          'weapon',
+          WEAPONS[1 + Math.floor(Math.random() * (WEAPONS.length - 1))],
+          45
+        );
+      setHud((h) => ({
+        ...h,
+        status:
+          crate.drop === 'none'
+            ? 'Wooden box broken.'
+            : `Wooden box dropped ${crate.drop}!`
+      }));
+    };
+
+    const damageAt = (
+      origin: THREE.Vector3,
+      dir: THREE.Vector3,
+      weapon: WeaponDef,
+      owner: Actor
+    ) => {
+      let hitDistance = weapon.range;
+      let hitActor: Actor | null = null;
+      for (const actor of actors) {
+        if (actor.id === owner.id || actor.hp <= 0) continue;
+        TMP.copy(actor.pos).sub(origin);
+        const forwardDistance = TMP.dot(dir);
+        if (forwardDistance < 0.15 || forwardDistance > hitDistance) continue;
+        const side = TMP.addScaledVector(dir, -forwardDistance).length();
+        if (side < 0.24) {
+          hitDistance = forwardDistance;
+          hitActor = actor;
+        }
+      }
+      let hitCrate: Crate | null = null;
+      for (const crate of crates) {
+        if (!crate.alive) continue;
+        TMP.copy(crate.pos).sub(origin);
+        const forwardDistance = TMP.dot(dir);
+        if (forwardDistance < 0.15 || forwardDistance > hitDistance) continue;
+        const side = TMP.addScaledVector(dir, -forwardDistance).length();
+        if (side < 0.32) {
+          hitDistance = forwardDistance;
+          hitCrate = crate;
+          hitActor = null;
+        }
+      }
+      if (hitActor) {
+        const armorBlock = Math.min(
+          hitActor.armor,
+          Math.ceil(weapon.damage * 0.45)
+        );
+        hitActor.armor -= armorBlock;
+        hitActor.hp = Math.max(0, hitActor.hp - (weapon.damage - armorBlock));
+        hitActor.bleed = 0.5;
+        emitBlood(hitActor.pos.clone().setY(0.36), hitActor.hp <= 0 ? 8 : 4);
+        if (hitActor.hp <= 0) {
+          hitActor.collapsed = 1;
+          hitActor.mesh.rotation.x = -Math.PI / 2;
+          hitActor.mesh.position.y = 0.08;
+          setHud((h) => ({
+            ...h,
+            status: `${owner.name} collapsed ${hitActor.name}.`
+          }));
+        }
+      }
+      if (hitCrate) {
+        hitCrate.hp -= weapon.damage;
+        hitCrate.mesh.rotation.y += 0.18;
+        if (hitCrate.hp <= 0) breakCrate(hitCrate);
+      }
+      const bullet = bullets.find((b) => !b.active);
+      if (bullet) {
+        bullet.active = true;
+        bullet.life = 0.08;
+        bullet.pos
+          .copy(origin)
+          .addScaledVector(dir, Math.min(hitDistance, 0.55));
+        bullet.vel.copy(dir).multiplyScalar(10);
+        bullet.mesh.position.copy(bullet.pos).setY(origin.y);
+        bullet.mesh.visible = true;
+      }
+    };
+
+    const shoot = (owner: Actor, dir: THREE.Vector3) => {
+      if (owner.cooldown > 0 || owner.ammo <= 0 || owner.hp <= 0) return;
+      owner.ammo -= 1;
+      owner.cooldown = owner.weapon.cooldown;
+      if (owner.id === 0) inputRef.current.recoil = 0.12;
+      const muzzle = owner.pos
+        .clone()
+        .add(new THREE.Vector3(0, owner.id === 0 ? PLAYER_EYE : 0.45, 0))
+        .addScaledVector(dir, 0.2);
+      damageAt(muzzle, dir.clone().normalize(), owner.weapon, owner);
+      if (owner.id === 0)
+        setHud((h) => ({
+          ...h,
+          ammo: owner.ammo,
+          weapon: owner.weapon.slot,
+          status: `Fired ${owner.weapon.slot}`
+        }));
+    };
+
+    const melee = (mode: 'punch' | 'kick') => {
+      const dir = yawForward(inputRef.current.yaw);
+      let didHit = false;
+      crates.forEach((crate) => {
+        if (!crate.alive) return;
+        TMP.copy(crate.pos).sub(player.pos);
+        if (
+          TMP.length() < (mode === 'kick' ? 0.72 : 0.55) &&
+          TMP.normalize().dot(dir) > 0.35
+        ) {
+          crate.hp -= mode === 'kick' ? 28 : 18;
+          crate.mesh.rotation.y += mode === 'kick' ? 0.32 : 0.18;
+          didHit = true;
+          if (crate.hp <= 0) breakCrate(crate);
+        }
+      });
+      inputRef.current.recoil = mode === 'kick' ? 0.2 : 0.12;
+      if (didHit)
+        setHud((h) => ({ ...h, status: `Wooden box hit with ${mode}.` }));
+    };
+    (
+      window as unknown as { __mazeMelee?: (mode: 'punch' | 'kick') => void }
+    ).__mazeMelee = melee;
+
+    let frame = 0;
+    let last = performance.now();
+    let hudTimer = 0;
+    let fpsSmooth = 60;
+
+    const moveActor = (
+      actor: Actor,
+      dir: THREE.Vector3,
+      speed: number,
+      dt: number
+    ) => {
+      if (actor.hp <= 0) return;
+      if (dir.lengthSq() > 0.001) {
+        dir.normalize();
+        actor.dir.lerp(dir, 1 - Math.pow(0.004, dt)).normalize();
+        actor.vel.lerp(dir.multiplyScalar(speed), 1 - Math.pow(0.004, dt));
+      } else {
+        actor.vel.multiplyScalar(Math.pow(0.0008, dt));
+      }
+      const next = actor.pos.clone().addScaledVector(actor.vel, dt);
+      const old = actor.pos.clone();
+      const xTry = actor.pos.clone();
+      xTry.x = next.x;
+      if (!collides(xTry, crates)) actor.pos.x = xTry.x;
+      const zTry = actor.pos.clone();
+      zTry.z = next.z;
+      if (!collides(zTry, crates)) actor.pos.z = zTry.z;
+      actor.mesh.position.copy(actor.pos);
+      if (actor.id !== 0) {
+        actor.mesh.rotation.y = Math.atan2(actor.dir.x, actor.dir.z);
+        actor.mesh.position.y = 0;
+        if (actor.pos.distanceTo(old) > 0.002)
+          actor.mesh.position.y +=
+            Math.sin(performance.now() * 0.014 + actor.id) * 0.018;
+      }
+    };
+
+    const updatePickups = (dt: number) => {
+      pickups.forEach((pickup) => {
+        if (!pickup.active) return;
+        pickup.mesh.rotation.y += dt * 2.2;
+        pickup.mesh.position.y =
+          0.24 + Math.sin(performance.now() * 0.004 + pickup.pos.x) * 0.025;
+        if (pickup.pos.distanceTo(player.pos) < 0.44) {
+          pickup.active = false;
+          pickup.mesh.visible = false;
+          if (pickup.kind === 'health')
+            player.hp = Math.min(100, player.hp + pickup.amount);
+          if (pickup.kind === 'armor')
+            player.armor = Math.min(80, player.armor + pickup.amount);
+          if (pickup.kind === 'ammo') player.ammo += pickup.amount;
+          if (pickup.kind === 'weapon' && pickup.weapon) {
+            setSlots((current) =>
+              [
+                pickup.weapon!,
+                ...current.filter((w) => w.id !== pickup.weapon!.id)
+              ].slice(0, 4)
+            );
+            swapTo(pickup.weapon);
+          }
+          setHud((h) => ({
+            ...h,
+            hp: player.hp,
+            armor: player.armor,
+            ammo: player.ammo,
+            weapon: player.weapon.slot,
+            status:
+              pickup.kind === 'weapon'
+                ? `Picked ${pickup.weapon?.name}`
+                : `Picked ${pickup.kind} +${pickup.amount}`
+          }));
+        }
+      });
+    };
+
+    const updateBots = (dt: number) => {
+      const pc = worldToCell(player.pos);
+      actors.slice(1).forEach((bot) => {
+        if (bot.hp <= 0) return;
+        bot.aiThink -= dt;
+        if (bot.aiThink <= 0) {
+          bot.aiThink = 0.28 + Math.random() * 0.18;
+          bot.targetCell =
+            Math.random() < 0.74
+              ? pc
+              : cells[Math.floor(Math.random() * cells.length)];
+        }
+        const bc = worldToCell(bot.pos);
+        const options = [
+          { r: bc.r - 1, c: bc.c },
+          { r: bc.r + 1, c: bc.c },
+          { r: bc.r, c: bc.c - 1 },
+          { r: bc.r, c: bc.c + 1 }
+        ].filter((cell) => !isWall(cell.r, cell.c));
+        const best = options.reduce(
+          (winner, cell) =>
+            Math.abs(cell.r - bot.targetCell.r) +
+              Math.abs(cell.c - bot.targetCell.c) <
+            Math.abs(winner.r - bot.targetCell.r) +
+              Math.abs(winner.c - bot.targetCell.c)
+              ? cell
+              : winner,
+          options[0] ?? bc
+        );
+        const move = cellToWorld(best.r, best.c).sub(bot.pos).setY(0);
+        moveActor(bot, move, 1.55, dt);
+        bot.cooldown = Math.max(0, bot.cooldown - dt);
+        if (
+          bot.pos.distanceTo(player.pos) < bot.weapon.range &&
+          Math.random() < dt * 0.85
+        )
+          shoot(bot, player.pos.clone().sub(bot.pos).setY(0).normalize());
+      });
     };
 
     const loop = () => {
@@ -858,162 +898,527 @@ export default function RunMan() {
       const now = performance.now();
       const dt = Math.min(DT_MAX, (now - last) / 1000);
       last = now;
+      fpsSmooth = fpsSmooth * 0.92 + (1 / Math.max(dt, 0.0001)) * 0.08;
 
-      pickups.forEach((d, i) => {
-        if (!d.taken) {
-          d.group.rotation.y += dt * (1.7 + (i % 5) * 0.12);
-          d.group.position.y = d.pos.y + Math.sin(now * 0.004 + i) * 0.035;
+      const forward = yawForward(inputRef.current.yaw);
+      const right = yawRight(inputRef.current.yaw);
+      const move = forward
+        .multiplyScalar(-inputRef.current.moveY)
+        .add(right.multiplyScalar(inputRef.current.moveX));
+      const movePower = Math.min(
+        1,
+        Math.hypot(inputRef.current.moveX, inputRef.current.moveY)
+      );
+      moveActor(
+        player,
+        move,
+        THREE.MathUtils.lerp(WALK_SPEED, RUN_SPEED, movePower),
+        dt
+      );
+      player.dir.copy(yawForward(inputRef.current.yaw));
+      player.cooldown = Math.max(0, player.cooldown - dt);
+      inputRef.current.reloading = Math.max(0, inputRef.current.reloading - dt);
+      inputRef.current.recoil = Math.max(0, inputRef.current.recoil - dt * 1.8);
+      if (inputRef.current.firing) shoot(player, player.dir.clone());
+
+      updateBots(dt);
+      updatePickups(dt);
+
+      bullets.forEach((bullet) => {
+        if (!bullet.active) return;
+        bullet.life -= dt;
+        bullet.pos.addScaledVector(bullet.vel, dt);
+        bullet.mesh.position.copy(bullet.pos);
+        if (bullet.life <= 0) {
+          bullet.active = false;
+          bullet.mesh.visible = false;
         }
       });
+      bloodPool.forEach((mesh) => {
+        if (!mesh.visible) return;
+        mesh.position.y = Math.max(0.018, mesh.position.y - dt * 0.42);
+      });
 
-      if (state === "playing") {
-        gameTime = Math.max(0, gameTime - dt);
-        const userDir = new THREE.Vector3(input.current.moveX, 0, input.current.moveY);
-        tryMoveActor(user, userDir, PLAYER_SPEED, dt);
+      const camPos = player.pos
+        .clone()
+        .add(new THREE.Vector3(0, PLAYER_EYE, 0));
+      const pitchLift =
+        Math.sin(inputRef.current.pitch) * 1.1 + inputRef.current.recoil * 0.45;
+      camera.position.copy(camPos);
+      camera.lookAt(
+        camPos
+          .clone()
+          .addScaledVector(player.dir, 1.7)
+          .add(new THREE.Vector3(0, pitchLift, 0))
+      );
+      viewModel.position.y =
+        -0.19 -
+        inputRef.current.reloading * 0.22 +
+        Math.sin(now * 0.011) * movePower * 0.012;
+      viewModel.position.z = -0.5 + inputRef.current.recoil * 0.35;
+      viewModel.rotation.x = -0.04 - inputRef.current.recoil * 0.55;
 
-        aiThink -= dt;
-        if (aiThink <= 0) {
-          aiThink = 0.22;
-          actors.slice(1).forEach((actor) => {
-            if (actor.health > 0) actor.targetDir.copy(chooseAiDir(actor, actors));
-          });
-        }
-        actors.slice(1).forEach((actor, i) => {
-          if (actor.health <= 0) return;
-          const speed = ROBOT_SPEED + 0.38 + i * 0.018 + Math.min(0.26, (GAME_TIME - gameTime) / GAME_TIME * 0.26);
-          tryMoveActor(actor, actor.targetDir.clone(), speed, dt);
+      hudTimer -= dt;
+      if (hudTimer <= 0) {
+        hudTimer = 0.22;
+        const alive = actors.filter((actor) => actor.hp > 0).length;
+        setHud((h) => ({
+          ...h,
+          hp: Math.max(0, Math.round(player.hp)),
+          armor: Math.round(player.armor),
+          ammo: player.ammo,
+          weapon: player.weapon.slot,
+          alive,
+          fps: Math.round(fpsSmooth)
+        }));
+        const dots: MiniDot[] = [];
+        dots.push({
+          x: (player.pos.x / WORLD_W + 0.5) * 100,
+          y: (player.pos.z / WORLD_H + 0.5) * 100,
+          color: '#38bdf8',
+          size: 7
         });
-
-        aiFireThink -= dt;
-        if (aiFireThink <= 0) {
-          aiFireThink = 0.42;
-          actors.slice(1).forEach((actor) => {
-            if (actor.health <= 0 || actor.ammo <= 0) return;
-            const targets = aliveActors(actors).filter((candidate) => candidate.id !== actor.id);
-            const target = targets.reduce((best, candidate) => actor.pos.distanceTo(candidate.pos) < actor.pos.distanceTo(best.pos) ? candidate : best, targets[0]);
-            if (target && actor.pos.distanceTo(target.pos) < 2.35 && Math.random() < 0.42) {
-              actor.targetDir.copy(target.pos.clone().sub(actor.pos).setY(0).normalize());
-              fireActor(actor);
-            }
-          });
-        }
-
-        actors.forEach((actor) => {
-          if (actor.health <= 0) return;
-          const gain = collectPickups(actor, pickups);
-          if (gain.score || gain.ammo) {
-            const weaponMsg = gain.weapon ? `${actor.name} picked ${gain.weapon.shortName} +${gain.ammo} ammo` : `${actor.name} +${gain.score}`;
-            setStatus(weaponMsg);
-          }
+        actors.slice(1).forEach((actor) => {
+          if (actor.hp > 0)
+            dots.push({
+              x: (actor.pos.x / WORLD_W + 0.5) * 100,
+              y: (actor.pos.z / WORLD_H + 0.5) * 100,
+              color: '#f87171',
+              size: 5
+            });
         });
-
-        updateBullets(bullets, dt, actors, setStatus);
-
-        actors.forEach((a) => {
-          if (a.health <= 0) return;
-          actors.forEach((b) => {
-            if (a.id >= b.id || b.health <= 0) return;
-            TMP.copy(a.pos).sub(b.pos).setY(0);
-            if (TMP.length() < a.radius + b.radius && a.stun <= 0 && b.stun <= 0) {
-              const push = TMP.lengthSq() > 0.0001 ? TMP.normalize() : new THREE.Vector3(1, 0, 0);
-              a.pos.addScaledVector(push, 0.08);
-              b.pos.addScaledVector(push, -0.08);
-            }
-          });
+        pickups.forEach((pickup) => {
+          if (pickup.active)
+            dots.push({
+              x: (pickup.pos.x / WORLD_W + 0.5) * 100,
+              y: (pickup.pos.z / WORLD_H + 0.5) * 100,
+              color: pickup.kind === 'health' ? '#22c55e' : '#facc15',
+              size: 4
+            });
         });
-
-        const alive = aliveActors(actors);
-        if (alive.length <= 1 || user.health <= 0 || gameTime <= 0) {
-          state = "gameover";
-          const winner = alive.length === 1 ? alive[0] : alive.reduce((best, actor) => actor.health > best.health ? actor : best, alive[0] ?? user);
-          const status = winner?.id === user.id ? "You are the last man standing!" : `${winner?.name ?? "No one"} wins. Last man standing!`;
-          setHud({ alive: alive.length, ammo: user.ammo, hp: Math.max(0, user.health), weapon: user.weapon.shortName, time: Math.ceil(gameTime), status });
-        } else if (Math.ceil(gameTime) % 3 === 0) {
-          syncHud();
-        }
+        setMiniDots(dots);
       }
-
-      actors.forEach((actor) => updateActorAnimation(actor, dt));
-
-      const cameraHeight = 1.12;
-      const behind = user.pos.clone().addScaledVector(user.dir, -0.95).add(new THREE.Vector3(0, cameraHeight, 0));
-      const ahead = user.pos.clone().addScaledVector(user.dir, 1.95).add(new THREE.Vector3(0, 0.45, 0));
-      camera.position.lerp(behind, 1 - Math.pow(0.0015, dt));
-      camera.lookAt(ahead);
 
       renderer.render(scene, camera);
     };
-
     loop();
 
     return () => {
       cancelAnimationFrame(frame);
-      window.removeEventListener("resize", resize);
-      delete window.__resetRobotMaze;
-      delete window.__fireRobotMaze;
+      window.removeEventListener('resize', resize);
+      delete (window as unknown as { __mazeSwap?: unknown }).__mazeSwap;
+      delete (window as unknown as { __mazeMelee?: unknown }).__mazeMelee;
       renderer.dispose();
     };
   }, []);
 
   const updateStick = (clientX: number, clientY: number) => {
-    const base = moveBase.current;
-    const knob = moveKnob.current;
+    const base = moveBaseRef.current;
+    const knob = moveKnobRef.current;
     if (!base || !knob) return;
-    const r = base.getBoundingClientRect();
-    const cx = r.left + r.width / 2;
-    const cy = r.top + r.height / 2;
+    const rect = base.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
     const dx = clientX - cx;
     const dy = clientY - cy;
-    const max = r.width * 0.44;
-    const deadZone = max * 0.08;
-    const rawLen = Math.hypot(dx, dy);
-    const len = Math.min(max, rawLen);
-    const a = Math.atan2(dy, dx);
-    const x = Math.cos(a) * len;
-    const y = Math.sin(a) * len;
+    const max = rect.width * 0.42;
+    const dist = Math.min(max, Math.hypot(dx, dy));
+    const angle = Math.atan2(dy, dx);
+    const x = Math.cos(angle) * dist;
+    const y = Math.sin(angle) * dist;
     knob.style.transform = `translate(${x}px, ${y}px)`;
-    const normalized = rawLen < deadZone ? 0 : Math.min(1, (len - deadZone) / (max - deadZone));
-    input.current.moveX = Math.cos(a) * normalized;
-    input.current.moveY = Math.sin(a) * normalized;
+    const power = dist < max * 0.09 ? 0 : dist / max;
+    inputRef.current.moveX = Math.cos(angle) * power;
+    inputRef.current.moveY = Math.sin(angle) * power;
   };
 
-  const endStick = () => {
-    moveTouch.current = null;
-    input.current.moveX = 0;
-    input.current.moveY = 0;
-    if (moveKnob.current) moveKnob.current.style.transform = "translate(0px,0px)";
+  const stopStick = () => {
+    moveRef.current = null;
+    inputRef.current.moveX = 0;
+    inputRef.current.moveY = 0;
+    if (moveKnobRef.current)
+      moveKnobRef.current.style.transform = 'translate(0px, 0px)';
   };
 
-  const resetGame = () => window.__resetRobotMaze?.();
-  const fire = () => window.__fireRobotMaze?.();
+  const beginLook = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    lookRef.current = {
+      id: e.pointerId,
+      x: e.clientX,
+      y: e.clientY,
+      sx: e.clientX,
+      sy: e.clientY,
+      moved: false
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const moveLook = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const look = lookRef.current;
+    if (!look || look.id !== e.pointerId) return;
+    const dx = e.clientX - look.x;
+    const dy = e.clientY - look.y;
+    look.x = e.clientX;
+    look.y = e.clientY;
+    if (Math.hypot(e.clientX - look.sx, e.clientY - look.sy) > 7)
+      look.moved = true;
+    inputRef.current.yaw -= dx * LOOK_SENS;
+    inputRef.current.pitch = THREE.MathUtils.clamp(
+      inputRef.current.pitch - dy * LOOK_SENS * 0.72,
+      -0.42,
+      0.38
+    );
+  };
+
+  const endLook = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (lookRef.current?.id === e.pointerId) lookRef.current = null;
+  };
+
+  const swapWeapon = (id: WeaponId) =>
+    (
+      window as unknown as { __mazeSwap?: (weaponId: WeaponId) => void }
+    ).__mazeSwap?.(id);
+  const melee = (mode: 'punch' | 'kick') =>
+    (
+      window as unknown as { __mazeMelee?: (mode: 'punch' | 'kick') => void }
+    ).__mazeMelee?.(mode);
 
   return (
-    <div style={{ position: "fixed", inset: 0, background: "#020617", overflow: "hidden", touchAction: "none", userSelect: "none" }}>
-      <div ref={hostRef} style={{ position: "absolute", inset: 0 }}>
-        <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block" }} />
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        overflow: 'hidden',
+        background: '#050816',
+        touchAction: 'none',
+        userSelect: 'none',
+        fontFamily: 'system-ui, sans-serif'
+      }}
+    >
+      <div ref={hostRef} style={{ position: 'absolute', inset: 0 }}>
+        <canvas
+          ref={canvasRef}
+          onPointerDown={beginLook}
+          onPointerMove={moveLook}
+          onPointerUp={endLook}
+          onPointerCancel={() => {
+            lookRef.current = null;
+          }}
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'block',
+            touchAction: 'none'
+          }}
+        />
       </div>
 
-      <div style={{ position: "fixed", left: 0, right: 0, top: 0, padding: "10px 12px", display: "grid", gridTemplateColumns: "1fr auto", alignItems: "center", gap: 8, pointerEvents: "none", color: "white", fontFamily: "system-ui,sans-serif", textShadow: "0 2px 8px #000" }}>
-        <div style={{ fontWeight: 950, fontSize: 12, lineHeight: 1.25 }}>YOU · HP {hud.hp} · AMMO {hud.ammo} · {hud.weapon}</div>
-        <div style={{ fontSize: 12, fontWeight: 900, textAlign: "right" }}>👥 {hud.alive}/8 · ⏱ {hud.time}s</div>
-        <div style={{ gridColumn: "1 / 3", fontSize: 11, textAlign: "center", lineHeight: 1.2 }}>{hud.status}</div>
-      </div>
-
-      <button onClick={resetGame} style={{ position: "fixed", right: 14, top: 64, border: "1px solid rgba(255,255,255,0.28)", color: "white", background: "rgba(15,23,42,0.82)", borderRadius: 14, padding: "8px 12px", fontWeight: 900, pointerEvents: "auto" }}>Reset</button>
-
-      <button onClick={fire} style={{ position: "fixed", right: 28, bottom: 54, width: 104, height: 104, border: "1px solid rgba(252,211,77,0.58)", borderRadius: 999, color: "white", background: "rgba(234,88,12,0.78)", fontWeight: 950, pointerEvents: "auto", boxShadow: "0 18px 34px rgba(0,0,0,0.38)", fontSize: 16 }}>FIRE</button>
-
-      <div style={{ position: "fixed", left: 14, bottom: 14, color: "#93c5fd", fontFamily: "system-ui,sans-serif", fontSize: 11, fontWeight: 900, textShadow: "0 2px 8px #000" }}>MOVE</div>
       <div
-        ref={moveBase}
-        onPointerDown={(e) => { moveTouch.current = e.pointerId; e.currentTarget.setPointerCapture(e.pointerId); updateStick(e.clientX, e.clientY); }}
-        onPointerMove={(e) => { if (moveTouch.current === e.pointerId) updateStick(e.clientX, e.clientY); }}
-        onPointerUp={() => endStick()}
-        onPointerCancel={() => endStick()}
-        style={{ position: "fixed", left: 22, bottom: 34, width: 152, height: 152, borderRadius: 999, background: "rgba(29,105,255,0.18)", border: "1px solid rgba(147,197,253,0.5)", pointerEvents: "auto", display: "grid", placeItems: "center", boxShadow: "0 18px 34px rgba(0,0,0,0.35)" }}
+        style={{
+          position: 'fixed',
+          top: 8,
+          left: 10,
+          right: 10,
+          display: 'grid',
+          gridTemplateColumns: '1fr auto',
+          gap: 8,
+          color: '#fff',
+          pointerEvents: 'none',
+          textShadow: '0 2px 8px #000'
+        }}
       >
-        <div ref={moveKnob} style={{ width: 62, height: 62, borderRadius: 999, background: "rgba(147,197,253,0.96)", boxShadow: "0 8px 18px rgba(0,0,0,0.35)", transition: "transform 45ms linear" }} />
+        <div style={{ fontSize: 12, fontWeight: 950 }}>
+          THE MAZE BATTLE ROYAL
+        </div>
+        <div style={{ fontSize: 11, fontWeight: 900 }}>
+          FPS {hud.fps} · 👥 {hud.alive}/8
+        </div>
+        <div
+          style={{
+            gridColumn: '1 / 3',
+            display: 'flex',
+            gap: 8,
+            alignItems: 'center'
+          }}
+        >
+          <div
+            style={{
+              flex: 1,
+              height: 8,
+              borderRadius: 999,
+              background: 'rgba(239,68,68,0.25)',
+              overflow: 'hidden'
+            }}
+          >
+            <div
+              style={{
+                width: `${hud.hp}%`,
+                height: '100%',
+                background: '#ef4444'
+              }}
+            />
+          </div>
+          <div
+            style={{
+              flex: 0.7,
+              height: 8,
+              borderRadius: 999,
+              background: 'rgba(56,189,248,0.2)',
+              overflow: 'hidden'
+            }}
+          >
+            <div
+              style={{
+                width: `${Math.min(100, hud.armor)}%`,
+                height: '100%',
+                background: '#38bdf8'
+              }}
+            />
+          </div>
+          <div style={{ fontSize: 11, fontWeight: 950 }}>AMMO {hud.ammo}</div>
+        </div>
+        <div
+          style={{
+            gridColumn: '1 / 3',
+            textAlign: 'center',
+            fontSize: 10.5,
+            fontWeight: 800,
+            color: '#dbeafe'
+          }}
+        >
+          {hud.status}
+        </div>
       </div>
+
+      <div
+        style={{
+          position: 'fixed',
+          right: 12,
+          top: 82,
+          width: 116,
+          height: 116,
+          borderRadius: 16,
+          border: '1px solid rgba(147,197,253,0.35)',
+          background: 'rgba(15,23,42,0.68)',
+          overflow: 'hidden',
+          pointerEvents: 'none',
+          boxShadow: '0 10px 26px rgba(0,0,0,0.35)'
+        }}
+      >
+        {MAZE.map((row, r) =>
+          row
+            .split('')
+            .map(
+              (cell, c) =>
+                cell === '1' && (
+                  <div
+                    key={`${r}-${c}`}
+                    style={{
+                      position: 'absolute',
+                      left: `${(c / COLS) * 100}%`,
+                      top: `${(r / ROWS) * 100}%`,
+                      width: `${100 / COLS}%`,
+                      height: `${100 / ROWS}%`,
+                      background: 'rgba(148,163,184,0.42)'
+                    }}
+                  />
+                )
+            )
+        )}
+        {miniDots.map((dot, i) => (
+          <span
+            key={i}
+            style={{
+              position: 'absolute',
+              left: `${dot.x}%`,
+              top: `${dot.y}%`,
+              width: dot.size,
+              height: dot.size,
+              transform: 'translate(-50%, -50%)',
+              borderRadius: 99,
+              background: dot.color,
+              boxShadow: `0 0 8px ${dot.color}`
+            }}
+          />
+        ))}
+      </div>
+
+      <div
+        style={{
+          position: 'fixed',
+          left: '50%',
+          top: '50%',
+          width: 20,
+          height: 20,
+          transform: 'translate(-50%, -50%)',
+          border: '2px solid rgba(255,255,255,0.82)',
+          borderRadius: 999,
+          pointerEvents: 'none',
+          boxShadow: '0 0 18px rgba(250,204,21,0.65)'
+        }}
+      />
+
+      <div
+        style={{
+          position: 'fixed',
+          left: 20,
+          bottom: 28,
+          width: 158,
+          height: 158,
+          borderRadius: 999,
+          background:
+            'radial-gradient(circle, rgba(59,130,246,0.24), rgba(15,23,42,0.38))',
+          border: '1px solid rgba(147,197,253,0.52)',
+          boxShadow: '0 18px 34px rgba(0,0,0,0.36)',
+          pointerEvents: 'auto'
+        }}
+        ref={moveBaseRef}
+        onPointerDown={(e) => {
+          moveRef.current = e.pointerId;
+          e.currentTarget.setPointerCapture(e.pointerId);
+          updateStick(e.clientX, e.clientY);
+        }}
+        onPointerMove={(e) => {
+          if (moveRef.current === e.pointerId)
+            updateStick(e.clientX, e.clientY);
+        }}
+        onPointerUp={stopStick}
+        onPointerCancel={stopStick}
+      >
+        <div
+          ref={moveKnobRef}
+          style={{
+            position: 'absolute',
+            left: 48,
+            top: 48,
+            width: 62,
+            height: 62,
+            borderRadius: 999,
+            background: 'linear-gradient(160deg, #dbeafe, #60a5fa)',
+            boxShadow: '0 8px 18px rgba(0,0,0,0.38)',
+            transition: 'transform 38ms linear'
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            bottom: -18,
+            color: '#bfdbfe',
+            fontSize: 10,
+            fontWeight: 950,
+            textAlign: 'center',
+            textShadow: '0 2px 8px #000'
+          }}
+        >
+          WALK / RUN
+        </div>
+      </div>
+
+      <div
+        style={{
+          position: 'fixed',
+          left: '50%',
+          bottom: 18,
+          transform: 'translateX(-50%)',
+          display: 'flex',
+          gap: 7,
+          pointerEvents: 'auto'
+        }}
+      >
+        {slots.map((weapon) => (
+          <button
+            key={weapon.id}
+            onClick={() => swapWeapon(weapon.id)}
+            style={{
+              border: `1px solid ${hud.weapon === weapon.slot ? 'rgba(250,204,21,0.95)' : 'rgba(255,255,255,0.28)'}`,
+              borderRadius: 13,
+              background:
+                hud.weapon === weapon.slot
+                  ? 'rgba(180,83,9,0.88)'
+                  : 'rgba(15,23,42,0.82)',
+              color: '#fff',
+              minWidth: 50,
+              padding: '8px 7px',
+              fontSize: 10,
+              fontWeight: 950,
+              boxShadow: '0 8px 18px rgba(0,0,0,0.32)'
+            }}
+          >
+            {weapon.slot}
+          </button>
+        ))}
+      </div>
+
+      <button
+        onPointerDown={(e) => {
+          fireTouchRef.current = e.pointerId;
+          inputRef.current.firing = true;
+          e.currentTarget.setPointerCapture(e.pointerId);
+        }}
+        onPointerUp={() => {
+          fireTouchRef.current = null;
+          inputRef.current.firing = false;
+        }}
+        onPointerCancel={() => {
+          fireTouchRef.current = null;
+          inputRef.current.firing = false;
+        }}
+        style={{
+          position: 'fixed',
+          right: 22,
+          bottom: 78,
+          width: 104,
+          height: 104,
+          borderRadius: 999,
+          border: '1px solid rgba(252,211,77,0.7)',
+          color: '#fff',
+          background:
+            'radial-gradient(circle, rgba(248,113,113,0.92), rgba(180,83,9,0.84))',
+          fontWeight: 1000,
+          fontSize: 16,
+          pointerEvents: 'auto',
+          boxShadow: '0 18px 34px rgba(0,0,0,0.4)'
+        }}
+      >
+        FIRE
+      </button>
+      <button
+        onClick={() => melee('punch')}
+        style={{
+          position: 'fixed',
+          right: 18,
+          bottom: 198,
+          width: 58,
+          height: 58,
+          borderRadius: 999,
+          border: '1px solid rgba(255,255,255,0.35)',
+          color: '#fff',
+          background: 'rgba(15,23,42,0.82)',
+          fontWeight: 950,
+          pointerEvents: 'auto'
+        }}
+      >
+        PUNCH
+      </button>
+      <button
+        onClick={() => melee('kick')}
+        style={{
+          position: 'fixed',
+          right: 88,
+          bottom: 196,
+          width: 54,
+          height: 54,
+          borderRadius: 999,
+          border: '1px solid rgba(255,255,255,0.35)',
+          color: '#fff',
+          background: 'rgba(15,23,42,0.82)',
+          fontWeight: 950,
+          pointerEvents: 'auto'
+        }}
+      >
+        KICK
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace the old 8-player maze-runner with a modern portrait-friendly first-person arena called "The Maze Battle Royal" focused on fast FPS mechanics, pickups, and bots.
- Improve visuals, simplify model fallbacks, and reduce runtime overhead by using instanced geometry and streamlined assets.
- Add more interactive world elements (crates, pickups), a basic damage/armor system, and mobile-friendly touch controls and HUD.

### Description
- Update `webapp/src/config/gamesCatalog.js` to rename the game entry to `The Maze Battle Royal` and refresh the `description` and `name` fields.
- Replace and heavily refactor `webapp/src/pages/Games/RunMan.tsx` to implement a first-person arena: new type definitions, weapon definitions (`WEAPONS`), pickup and crate systems, instanced wall geometry, simplified maze representation, and world/cell helpers (`cellToWorld`, `worldToCell`, `isWall`).
- New gameplay systems include bullets, a hitscan-style `damageAt` function, crate breakage and item spawning, bot AI with basic path choice and firing, blood/bullet effects, and player viewmodel loading using `loadFirstModel` with GLTF fallback visuals.
- Input, UI and controls were reworked for touch and pointer: joystick handling, look handling, firing toggle, weapon swap hooks (`__mazeSwap`) and melee hook (`__mazeMelee`), updated HUD, minimap with `miniDots`, and polished styling.
- Renderer and scene changes: camera/projection tuning, fog/lighting adjustments, disabled expensive shadow settings, lowered pixel ratio for performance, and use of `InstancedMesh` for walls to reduce draw cost.

### Testing
- Performed TypeScript type-checking with `yarn tsc` and executed a local production build (`yarn build`), both completed successfully without type or build errors.
- Performed a basic automated smoke check by launching the dev build and verifying the main canvas initializes (no automated unit tests were added or modified).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0acdb23c8329add902f6059598ac)