### PR TITLE
Flip Snooker Royal shooting bend direction

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -21036,7 +21036,7 @@ const powerRef = useRef(hud.power);
         modelUrl: 'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
         unit: humanUnitScale,
         humanScale: 1.82 * humanUnitScale,
-        shootBendDirection: 1,
+        shootBendDirection: -1,
         tableTopY: humanTableTopY,
         groundY: humanGroundY,
         tableW: PLAY_W,


### PR DESCRIPTION
### Motivation
- Make the player avatar bend to the opposite side when taking a shot in Snooker Royal so the pose matches the requested visual direction change.

### Description
- Change the human rig configuration value `shootBendDirection` from `1` to `-1` in `webapp/src/pages/Games/SnookerRoyal.jsx` so the shot pose bends the other way.

### Testing
- Successfully ran the production build with `npm --prefix webapp run build` and installed Playwright browsers with `npx playwright install chromium` and `npx playwright install-deps chromium`.
- Attempted an automated headless screenshot of `/games/snookerroyale` (Playwright) but the capture timed out due to the heavy WebGL scene rendering, so visual verification should be done in a local/dev environment if needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1a1ad3e48329a8b96d89bc9af62e)