### PR TITLE
Pool Royale: unify cloth weave, fix procedural bump, correct human pose and tint human materials

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -81,7 +81,7 @@ export const POOL_ROYALE_CLOTH_VARIANTS = Object.freeze(
     group.hex.map((hex, index) => ({
       id: `${group.idPrefix}${group.tones[index]}`,
       name: `${group.label} ${group.tones[index]}`,
-      sourceId: `${group.idPrefix}-${group.tones[index].toLowerCase()}`,
+      sourceId: 'caban',
       tone: group.label.toLowerCase(),
       baseColor: toNumber(hex),
       palette: buildPalette(hex),
@@ -91,7 +91,7 @@ export const POOL_ROYALE_CLOTH_VARIANTS = Object.freeze(
       thumbnail: polyHavenThumb('caban'),
       price: BASE_PRICE + PRICE_STEP * index,
       swatches: createSwatches(hex),
-      description: `Original Poly Haven caban cloth texture with a ${group.label.toLowerCase()} ${group.tones[index].toLowerCase()} tint.`
+      description: `Original Poly Haven caban cloth texture with a ${group.label.toLowerCase()} ${group.tones[index].toLowerCase()} tint and the same single small-weave source used by Snooker Royal.`
     }))
   )
 )

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4632,6 +4632,7 @@ const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sh
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.92; // tighten the cloth fibres so the visible felt texture reads smaller in portrait
 const CLOTH_TEXTURE_REPEAT_HINT = 1.72;
+const POOL_ROYALE_SINGLE_CLOTH_REPEAT_SCALE = 1.45;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
 const POLYHAVEN_ANISOTROPY_BOOST = 9;
 const POLYHAVEN_TEXTURE_RESOLUTION =
@@ -4992,6 +4993,7 @@ const createClothTextures = (() => {
 
     const image = ctx.createImageData(SIZE, SIZE);
     const data = image.data;
+    const bumpData = new Uint8Array(SIZE * SIZE * 4);
     const hashNoise = (x, y, seedX, seedY, phase = 0) =>
       Math.sin((x * seedX + y * seedY + phase) * 0.02454369260617026) * 0.5 + 0.5;
     const fiberNoise = (x, y) =>
@@ -5124,10 +5126,10 @@ const createClothTextures = (() => {
         data[idx + 1] = g;
         data[idx + 2] = b;
         data[idx + 3] = a;
-        data[idx + 4] = bumpValue;
-        data[idx + 5] = bumpValue;
-        data[idx + 6] = bumpValue;
-        data[idx + 7] = a;
+        bumpData[idx] = bumpValue;
+        bumpData[idx + 1] = bumpValue;
+        bumpData[idx + 2] = bumpValue;
+        bumpData[idx + 3] = a;
       }
     }
 
@@ -5135,7 +5137,7 @@ const createClothTextures = (() => {
     applySRGBColorSpace(colorMap);
     applyTextureDefaults(colorMap);
 
-    const bumpMap = new THREE.DataTexture(image.data, SIZE, SIZE, THREE.RGBAFormat);
+    const bumpMap = new THREE.DataTexture(bumpData, SIZE, SIZE, THREE.RGBAFormat);
     applyTextureDefaults(bumpMap);
 
     return { map: colorMap, bump: bumpMap, mapSource: 'procedural' };
@@ -9266,8 +9268,8 @@ export function Table3D(
   const ballsAcrossWidth = PLAY_W / ballDiameter;
   const threadsPerBallTarget = 12; // base density before global scaling adjustments
   const clothPatternUpscale = isPolyHavenCloth
-    ? 1
-    : (1 / 1.3) * 0.5 * 1.25 * 1.5 * CLOTH_PATTERN_SCALE; // double the thread pattern size for a looser, woollier weave
+    ? POOL_ROYALE_SINGLE_CLOTH_REPEAT_SCALE
+    : (1 / 1.3) * 0.5 * 1.25 * 1.5 * CLOTH_PATTERN_SCALE * POOL_ROYALE_SINGLE_CLOTH_REPEAT_SCALE; // use one denser small-weave cloth instead of mixing visible pattern sizes
   const patternOverride = resolveClothPatternOverride(clothTextureKey);
   const clothTextureScale =
     0.032 * 1.35 * 1.56 * 1.12 * clothPatternUpscale; // keep Pool Royale cloth texel density aligned with Snooker Royal
@@ -25761,7 +25763,7 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            shootBendDirection: 1,
+            shootBendDirection: -1,
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,
             rotLambda: HUMAN_ROT_LAMBDA,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -221,6 +221,67 @@ function normalizeHuman(model, cfg) {
   model.position.set(-center.x, -box.min.y, -center.z);
 }
 
+
+function isNearlyNeutralMaterial(mat) {
+  if (!mat?.color || mat.map) return false;
+  const { r, g, b } = mat.color;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  return max - min < 0.08;
+}
+
+function classifyHumanMaterial(meshName, matName) {
+  const name = `${meshName || ''} ${matName || ''}`.toLowerCase();
+  if (/(skin|face|head|neck|hand|arm|body)/.test(name) && !/(shirt|top|hood|jacket|pant|trouser|shoe|hair)/.test(name)) {
+    return 'skin';
+  }
+  if (/(hair|beard|brow)/.test(name)) return 'hair';
+  if (/(shoe|sneaker|boot|foot)/.test(name)) return 'shoes';
+  if (/(pant|trouser|jean|leg|bottom)/.test(name)) return 'pants';
+  if (/(shirt|top|hood|jacket|torso|chest|sleeve)/.test(name)) return 'shirt';
+  return 'accent';
+}
+
+function applyRealisticHumanMaterials(model) {
+  const palette = {
+    skin: new THREE.Color(0xd7a47d),
+    hair: new THREE.Color(0x2b1a12),
+    shirt: new THREE.Color(0x155fd3),
+    pants: new THREE.Color(0x202a44),
+    shoes: new THREE.Color(0x141414),
+    accent: new THREE.Color(0xb8c7df)
+  };
+  model.traverse((obj) => {
+    if (!obj?.isMesh) return;
+    const sourceMaterials = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+    const nextMaterials = sourceMaterials.map((sourceMat) => {
+      if (!sourceMat) return sourceMat;
+      const mat = sourceMat.clone?.() ?? sourceMat;
+      const role = classifyHumanMaterial(obj.name, mat.name);
+      if (isNearlyNeutralMaterial(mat)) {
+        mat.color.copy(palette[role] || palette.accent);
+      }
+      if (role === 'skin') {
+        mat.roughness = Math.min(0.86, Math.max(mat.roughness ?? 0.72, 0.68));
+        mat.metalness = 0;
+      } else if (role === 'shirt') {
+        mat.roughness = Math.min(0.82, Math.max(mat.roughness ?? 0.7, 0.58));
+        mat.metalness = 0;
+      } else if (role === 'pants' || role === 'shoes') {
+        mat.roughness = Math.min(0.78, Math.max(mat.roughness ?? 0.64, 0.54));
+        mat.metalness = role === 'shoes' ? 0.02 : 0;
+      }
+      if (mat.emissive?.isColor) {
+        mat.emissive.copy((palette[role] || palette.accent).clone().multiplyScalar(role === 'skin' ? 0.015 : 0.01));
+        mat.emissiveIntensity = Math.max(mat.emissiveIntensity ?? 0, 0.02);
+      }
+      mat.needsUpdate = true;
+      return mat;
+    });
+    obj.material = Array.isArray(obj.material) ? nextMaterials : nextMaterials[0] ?? obj.material;
+  });
+}
+
 export function createHumanRig(scene, opts = {}) {
   const cfg = scaleVectorConfig(opts);
   const human = {
@@ -256,6 +317,7 @@ export function createHumanRig(scene, opts = {}) {
       const model = gltf?.scene;
       if (!model) return;
       normalizeHuman(model, cfg);
+      applyRealisticHumanMaterials(model);
       model.traverse((obj) => {
         if (!obj?.isMesh) return;
         obj.castShadow = true;


### PR DESCRIPTION
### Motivation
- Fix visible double-pattern artifact on Pool Royale tables by using a single small-weave cloth source and consistent repeat scaling. 
- Make shooter animation lean forward toward the cue (matching Snooker behavior) instead of bending backward. 
- Improve human fallback visuals by giving neutral/gray avatar materials realistic colors and material properties so characters look less flat.

### Description
- Use the same PolyHaven `caban` source for all Pool Royale cloth variants and update their descriptions so the table uses a single small-weave source (`webapp/src/config/poolRoyaleClothPresets.js`).
- Add a Pool Royale cloth repeat scale and apply it to pattern calculation so the weave density matches Snooker Royal in portrait (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Split procedural cloth generation into separate color and bump buffers (generate `bumpData` and create `DataTexture` from it) to avoid mixing bump into the color canvas and eliminate the appearance of two different cloth pattern sizes (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Make the procedural cloth pattern/upscale logic use the new single-cloth repeat scale so procedural and PolyHaven cloths read consistently on the table (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Reverse the human `shootBendDirection` for Pool Royale so the upper body leans forward toward the cue (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Add `applyRealisticHumanMaterials` helper that classifies neutral materials (skin/hair/shirt/pants/shoes/accent) and tints/adjusts roughness/metalness/emissive for loaded GLTF fallback materials, and call it after normalizing the human model (`webapp/src/pages/Games/shared/humanRigCore.js`).

### Testing
- Ran the production webapp build with `npm --prefix webapp run build` which completed successfully. (✅)
- Ran static checks with `git diff --check` which reported no issues. (✅)
- Started a preview server with `npm --prefix webapp run preview` and the app served at `http://127.0.0.1:4173/`. (✅)
- Installed Playwright browsers with `npx playwright install chromium` successfully, but an automated headless screenshot attempt failed because Chromium could not start due to a missing system library (`libatk-1.0.so.0`) in the environment (manual preview succeeded). (⚠️)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc19badeb08329b71973217836cd4b)