### PR TITLE
Fix Snooker Royal shooting stance bend

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -21036,7 +21036,9 @@ const powerRef = useRef(hud.power);
         modelUrl: 'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
         unit: humanUnitScale,
         humanScale: 1.82 * humanUnitScale,
-        shootBendDirection: 1,
+        // Snooker Royal uses the opposite shooting-side bend so the avatar drops
+        // into position on the visually correct side of the cue in portrait view.
+        shootBendDirection: -1,
         tableTopY: humanTableTopY,
         groundY: humanGroundY,
         tableW: PLAY_W,


### PR DESCRIPTION
### Motivation
- Ensure the human avatar bends to the visually correct side when taking a shot in portrait-mode Snooker Royal so the stance matches the requested behavior.

### Description
- Flip `shootBendDirection` from `1` to `-1` in `webapp/src/pages/Games/SnookerRoyal.jsx` and add a brief comment documenting the portrait-view stance calibration.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Installed browser tooling with `npx playwright install chromium` and `npx playwright install-deps chromium` which completed successfully.
- Attempted an automated Playwright portrait screenshot of `/games/snookerroyale?offline=1&mode=offline`, but screenshot capture timed out in the WebGL scene, so visual verification is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1a1ad3e48329a8b96d89bc9af62e)