### PR TITLE
Fix Pool Royale cloth pattern, shooter pose, and human material fallbacks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4630,8 +4630,8 @@ const ORIGINAL_OUTER_HALF_H =
 const CLOTH_TEXTURE_SIZE = CLOTH_QUALITY.textureSize;
 const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sharper weave
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
-const CLOTH_PATTERN_SCALE = 0.92; // tighten the cloth fibres so the visible felt texture reads smaller in portrait
-const CLOTH_TEXTURE_REPEAT_HINT = 1.72;
+const CLOTH_PATTERN_SCALE = 0.76; // match Snooker Royal's single tighter cloth weave so Pool Royal no longer shows mixed pattern sizes
+const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
 const POLYHAVEN_ANISOTROPY_BOOST = 9;
 const POLYHAVEN_TEXTURE_RESOLUTION =
@@ -25761,7 +25761,7 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            shootBendDirection: 1,
+            shootBendDirection: -1,
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,
             rotLambda: HUMAN_ROT_LAMBDA,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -5,6 +5,64 @@ const Y_AXIS = new THREE.Vector3(0, 1, 0);
 const UP = Y_AXIS;
 const BASIS_MAT = new THREE.Matrix4();
 
+
+const REALISTIC_HUMAN_MATERIALS = Object.freeze({
+  skin: 0xd7a47b,
+  hair: 0x2d1d16,
+  top: 0x2368b8,
+  bottom: 0x25324a,
+  shoes: 0x4a3328,
+  eyes: 0xf5f7fb,
+  teeth: 0xf4eadc,
+  defaultFabric: 0x8b5a3c
+});
+
+function isMostlyGreyColor(color) {
+  if (!color) return true;
+  const max = Math.max(color.r, color.g, color.b);
+  const min = Math.min(color.r, color.g, color.b);
+  return max - min < 0.075;
+}
+
+function pickHumanMaterialColor(obj, mat) {
+  const key = cleanName(`${obj?.name || ''} ${mat?.name || ''}`);
+  if (key.includes('skin') || key.includes('head') || key.includes('face') || key.includes('hand') || key.includes('arm')) {
+    return REALISTIC_HUMAN_MATERIALS.skin;
+  }
+  if (key.includes('hair') || key.includes('beard') || key.includes('brow')) {
+    return REALISTIC_HUMAN_MATERIALS.hair;
+  }
+  if (key.includes('eye')) {
+    return REALISTIC_HUMAN_MATERIALS.eyes;
+  }
+  if (key.includes('teeth') || key.includes('tooth')) {
+    return REALISTIC_HUMAN_MATERIALS.teeth;
+  }
+  if (key.includes('shoe') || key.includes('footwear') || key.includes('boot')) {
+    return REALISTIC_HUMAN_MATERIALS.shoes;
+  }
+  if (key.includes('bottom') || key.includes('pant') || key.includes('trouser') || key.includes('jean') || key.includes('leg')) {
+    return REALISTIC_HUMAN_MATERIALS.bottom;
+  }
+  if (key.includes('top') || key.includes('shirt') || key.includes('hoodie') || key.includes('jacket') || key.includes('torso') || key.includes('outfit')) {
+    return REALISTIC_HUMAN_MATERIALS.top;
+  }
+  return REALISTIC_HUMAN_MATERIALS.defaultFabric;
+}
+
+function applyRealisticHumanMaterialFallback(obj, mat) {
+  if (!mat || !mat.color || mat.userData?.realisticHumanFallbackApplied) return;
+  const shouldTint = !mat.map || isMostlyGreyColor(mat.color);
+  if (!shouldTint) return;
+  mat.color.setHex(pickHumanMaterialColor(obj, mat));
+  if ('roughness' in mat) mat.roughness = Math.max(0.58, mat.roughness ?? 0.72);
+  if ('metalness' in mat) mat.metalness = Math.min(0.04, mat.metalness ?? 0);
+  mat.userData = {
+    ...(mat.userData || {}),
+    realisticHumanFallbackApplied: true
+  };
+}
+
 const BASE_CFG = {
   unit: 1,
   poseLambda: 9,
@@ -268,6 +326,7 @@ export function createHumanRig(scene, opts = {}) {
             mat.map.flipY = false;
             mat.map.needsUpdate = true;
           }
+          applyRealisticHumanMaterialFallback(obj, mat);
           mat.depthWrite = true;
           mat.depthTest = true;
           mat.needsUpdate = true;


### PR DESCRIPTION
### Motivation
- Remove the visible "two cloths / two pattern sizes" artifact by aligning Pool Royale cloth pattern density with Snooker Royal's tighter weave. 
- Correct the shooter stance so the avatar leans forward toward the cue when preparing a shot instead of bending backward. 
- Ensure human character visuals are realistic when GLTF materials are grey or missing by applying sensible color fallbacks.

### Description
- Adjusted Pool Royale cloth sampling constants in `webapp/src/pages/Games/PoolRoyale.jsx` by setting `CLOTH_PATTERN_SCALE = 0.76` and `CLOTH_TEXTURE_REPEAT_HINT = 1.52` to match the snooker cloth density. 
- Reversed the shooting bend direction by changing the rig option `shootBendDirection` to `-1` when creating the Pool Royale human rigs in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Added a realistic human material fallback to `webapp/src/pages/Games/shared/humanRigCore.js` (functions `isMostlyGreyColor`, `pickHumanMaterialColor`, and `applyRealisticHumanMaterialFallback`) and invoked it during GLTF material setup so skin/top/bottom/shoes/eyes/teeth receive plausible colors when textures are absent or grey. 
- Preserved existing texture color-space handling while applying the tint fallback and kept material roughness/metalness tuned for realistic appearance.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the Vite build completed successfully (bundles generated; build finished). 
- Build emitted only chunk-size warnings but finished without errors, indicating the changes integrate with the renderer and material pipeline. 
- No unit tests were modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc19badeb08329b71973217836cd4b)