### PR TITLE
Retarget FPS gun hands onto visible human character hands

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -77,6 +77,7 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Transform weaponSwapIcon;
         [SerializeField] private Transform rightHandGrip;
         [SerializeField] private Transform leftHandGrip;
+        [SerializeField] private FpsGunHumanHandRetargeter humanHandRetargeter;
 
         [Header("Weapon presets")]
         [SerializeField] private List<WeaponBallisticsProfile> weaponProfiles = new List<WeaponBallisticsProfile>();
@@ -127,6 +128,11 @@ namespace TonPlaygram.Gameplay.Weapons
             if (sfxSource == null)
             {
                 sfxSource = GetComponent<AudioSource>();
+            }
+
+            if (humanHandRetargeter == null)
+            {
+                humanHandRetargeter = GetComponentInChildren<FpsGunHumanHandRetargeter>(true);
             }
 
             if (playerCamera != null)
@@ -397,6 +403,11 @@ namespace TonPlaygram.Gameplay.Weapons
                 leftHandGrip.position = muzzle.position - (shotDirection * 0.06f) - leftOffset;
                 leftHandGrip.rotation = Quaternion.LookRotation(shotDirection, Vector3.up);
             }
+
+            if (humanHandRetargeter != null)
+            {
+                humanHandRetargeter.SnapToMappedPose();
+            }
         }
 
         private IEnumerator AimViewRoutine(WeaponBallisticsProfile weapon)
@@ -574,6 +585,10 @@ namespace TonPlaygram.Gameplay.Weapons
         private void LateUpdate()
         {
             MaintainStaticPresentationAnchors();
+            if (humanHandRetargeter != null)
+            {
+                humanHandRetargeter.SnapToMappedPose();
+            }
         }
 
         private void CacheStaticAnchors()

--- a/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
+++ b/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Weapons
+{
+    /// <summary>
+    /// Retargets the original first-person weapon hand pose onto the visible human character hands.
+    ///
+    /// Setup notes:
+    /// 1. Keep the original FPS weapon rig active so its authored gun/hand animation, recoil, and grip sockets still play.
+    /// 2. Assign only the original FPS hand visual roots to originalFpsHandVisualRoots so their meshes are hidden.
+    /// 3. Map every important original FPS hand bone/socket to the matching human hand bone in boneMappings.
+    /// 4. Leave weaponRoot visible; this script aligns it to the chosen human grip while the hidden FPS hands drive pose fidelity.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class FpsGunHumanHandRetargeter : MonoBehaviour
+    {
+        [Serializable]
+        public sealed class HandBoneMapping
+        {
+            [Tooltip("Animated source bone/socket from the original first-person gun hand rig.")]
+            public Transform originalFpsBone;
+
+            [Tooltip("Visible human-character hand/finger bone that must copy the source pose.")]
+            public Transform humanBone;
+
+            [Tooltip("Per-bone position correction in the source bone's local space. Keep zero after exact rig matching.")]
+            public Vector3 localPositionOffset;
+
+            [Tooltip("Per-bone rotation correction after copying the source world rotation. Use for rig-axis differences only.")]
+            public Vector3 localEulerOffset;
+
+            [Tooltip("Copy source world position. Disable only for twist/helper bones that should rotate in place.")]
+            public bool copyPosition = true;
+
+            [Tooltip("Copy source world rotation.")]
+            public bool copyRotation = true;
+
+            [Tooltip("Copy source lossy scale into the human bone. Off by default to avoid deforming character hands.")]
+            public bool copyScale;
+
+            private Quaternion _localRotationOffset;
+
+            public void CacheOffsets()
+            {
+                _localRotationOffset = Quaternion.Euler(localEulerOffset);
+            }
+
+            public void Apply()
+            {
+                if (originalFpsBone == null || humanBone == null)
+                    return;
+
+                if (copyPosition)
+                {
+                    humanBone.position = originalFpsBone.TransformPoint(localPositionOffset);
+                }
+
+                if (copyRotation)
+                {
+                    humanBone.rotation = originalFpsBone.rotation * _localRotationOffset;
+                }
+
+                if (copyScale)
+                {
+                    humanBone.localScale = originalFpsBone.lossyScale;
+                }
+            }
+        }
+
+        [Header("Original FPS rig visibility")]
+        [SerializeField] private Transform[] originalFpsHandVisualRoots = Array.Empty<Transform>();
+        [SerializeField] private Renderer[] extraOriginalHandRenderers = Array.Empty<Renderer>();
+        [SerializeField] private bool hideOriginalFpsHandsOnAwake = true;
+        [SerializeField] private bool includeInactiveHandRenderers = true;
+
+        [Header("Visible human hand retarget")]
+        [SerializeField] private List<HandBoneMapping> boneMappings = new List<HandBoneMapping>();
+        [SerializeField] private bool retargetEveryLateUpdate = true;
+
+        [Header("Weapon grip")]
+        [SerializeField] private Transform weaponRoot;
+        [SerializeField] private Transform originalFpsRightGrip;
+        [SerializeField] private Transform humanRightGrip;
+        [SerializeField] private bool keepWeaponOnHumanRightGrip = true;
+        [SerializeField] private Vector3 weaponGripPositionOffset;
+        [SerializeField] private Vector3 weaponGripEulerOffset;
+
+        private readonly List<Renderer> _hiddenOriginalHandRenderers = new List<Renderer>();
+        private Quaternion _weaponGripRotationOffset;
+        private Quaternion _originalGripToWeaponRotation = Quaternion.identity;
+        private Vector3 _originalGripToWeaponPosition;
+        private bool _hasOriginalGripToWeapon;
+
+        private void Awake()
+        {
+            CacheRuntimeOffsets();
+
+            if (hideOriginalFpsHandsOnAwake)
+            {
+                HideOriginalFpsHands();
+            }
+
+            SnapToMappedPose();
+        }
+
+        private void LateUpdate()
+        {
+            if (!retargetEveryLateUpdate)
+                return;
+
+            SnapToMappedPose();
+        }
+
+        [ContextMenu("Snap Human Hands To FPS Gun Rig")]
+        public void SnapToMappedPose()
+        {
+            for (int i = 0; i < boneMappings.Count; i++)
+            {
+                HandBoneMapping mapping = boneMappings[i];
+                if (mapping == null)
+                    continue;
+
+                mapping.Apply();
+            }
+
+            SnapWeaponToHumanGrip();
+        }
+
+        [ContextMenu("Hide Original FPS Hands")]
+        public void HideOriginalFpsHands()
+        {
+            _hiddenOriginalHandRenderers.Clear();
+            AddExtraOriginalHandRenderers();
+            AddRenderersFromOriginalHandRoots();
+
+            for (int i = 0; i < _hiddenOriginalHandRenderers.Count; i++)
+            {
+                Renderer rendererToHide = _hiddenOriginalHandRenderers[i];
+                if (rendererToHide != null)
+                {
+                    rendererToHide.enabled = false;
+                }
+            }
+        }
+
+        [ContextMenu("Show Original FPS Hands")]
+        public void ShowOriginalFpsHands()
+        {
+            for (int i = 0; i < _hiddenOriginalHandRenderers.Count; i++)
+            {
+                Renderer rendererToShow = _hiddenOriginalHandRenderers[i];
+                if (rendererToShow != null)
+                {
+                    rendererToShow.enabled = true;
+                }
+            }
+        }
+
+        private void CacheRuntimeOffsets()
+        {
+            _weaponGripRotationOffset = Quaternion.Euler(weaponGripEulerOffset);
+            if (weaponRoot != null && originalFpsRightGrip != null)
+            {
+                _originalGripToWeaponRotation = Quaternion.Inverse(originalFpsRightGrip.rotation) * weaponRoot.rotation;
+                _originalGripToWeaponPosition = Quaternion.Inverse(originalFpsRightGrip.rotation) * (weaponRoot.position - originalFpsRightGrip.position);
+                _hasOriginalGripToWeapon = true;
+            }
+
+            for (int i = 0; i < boneMappings.Count; i++)
+            {
+                HandBoneMapping mapping = boneMappings[i];
+                if (mapping != null)
+                {
+                    mapping.CacheOffsets();
+                }
+            }
+        }
+
+        private void SnapWeaponToHumanGrip()
+        {
+            if (!keepWeaponOnHumanRightGrip || weaponRoot == null || humanRightGrip == null)
+                return;
+
+            if (_hasOriginalGripToWeapon)
+            {
+                weaponRoot.rotation = humanRightGrip.rotation * _originalGripToWeaponRotation * _weaponGripRotationOffset;
+                weaponRoot.position = humanRightGrip.position + (humanRightGrip.rotation * (_originalGripToWeaponPosition + weaponGripPositionOffset));
+                return;
+            }
+
+            weaponRoot.position = humanRightGrip.TransformPoint(weaponGripPositionOffset);
+            weaponRoot.rotation = humanRightGrip.rotation * _weaponGripRotationOffset;
+        }
+
+        private void AddExtraOriginalHandRenderers()
+        {
+            for (int i = 0; i < extraOriginalHandRenderers.Length; i++)
+            {
+                AddHiddenRenderer(extraOriginalHandRenderers[i]);
+            }
+        }
+
+        private void AddRenderersFromOriginalHandRoots()
+        {
+            for (int i = 0; i < originalFpsHandVisualRoots.Length; i++)
+            {
+                Transform handRoot = originalFpsHandVisualRoots[i];
+                if (handRoot == null)
+                    continue;
+
+                Renderer[] renderers = handRoot.GetComponentsInChildren<Renderer>(includeInactiveHandRenderers);
+                for (int rendererIndex = 0; rendererIndex < renderers.Length; rendererIndex++)
+                {
+                    AddHiddenRenderer(renderers[rendererIndex]);
+                }
+            }
+        }
+
+        private void AddHiddenRenderer(Renderer rendererToHide)
+        {
+            if (rendererToHide == null || _hiddenOriginalHandRenderers.Contains(rendererToHide))
+                return;
+
+            _hiddenOriginalHandRenderers.Add(rendererToHide);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Make the FPS gun appear held by the visible human character while preserving the original FPS rig animation and pose fidelity. 
- Allow the human-character hands to match the authored FPS hand/grip mapping precisely so recoil, aim and IK-driven motion remain identical visually. 
- Provide a reusable, inspector-configurable component to hide original FPS hand meshes while driving visible hands from the original rig. 

### Description
- Added `FpsGunHumanHandRetargeter` (new file `Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs`) which exposes per-bone `HandBoneMapping` entries, supports per-bone position/rotation offsets, optional scale copying, and runtime caching of offsets via `CacheRuntimeOffsets` and `SnapToMappedPose` methods. 
- The retargeter hides original FPS hand renderers (configurable via `originalFpsHandVisualRoots` and `extraOriginalHandRenderers`) while keeping the original FPS rig active as the animation source so authored gun animations and recoil remain intact. 
- The component caches the original FPS right-grip → weapon transform and keeps `weaponRoot` aligned to the chosen `humanRightGrip`, including a fallback when authored grip data is missing. 
- Wired the existing `BattleRoyaleWeaponDirector` (`Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs`) to discover a `FpsGunHumanHandRetargeter` via `GetComponentInChildren` and call `SnapToMappedPose()` during `RefreshWeaponPose` and `LateUpdate` so human hands stay synchronized with weapon pose updates. 

### Testing
- Ran `git diff --check -- Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs` which produced no diff-check errors. 
- Unity editor / playmode validation could not be executed in this environment because a Unity executable was not available, so runtime verification should be performed in-editor (recommend testing grip alignment, per-bone offsets and hiding behavior in Play mode).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2244e5b08329b1dc8caa5b5574ce)