### PR TITLE
Fix Pool Royale human shooting orientation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -125,6 +125,7 @@ import { polyHavenThumb } from '../../config/storeThumbnails.js';
 import {
   createBilardoHumanRig as sharedCreateBilardoHumanRig,
   chooseHumanEdgePosition as sharedChooseBilardoHumanEdgePosition,
+  resolveHumanShotOrientation as sharedResolveHumanShotOrientation,
   updateBilardoHumanPose as sharedUpdateBilardoHumanPose
 } from './shared/bilardoHumanRig.js';
 
@@ -558,6 +559,7 @@ function updateBilardoHumanPose(human, dt, frameData) {
 // Use stable shared GLTF rig pipeline (known-good loading), while keeping local rig code available for reference.
 const createBilardoHumanRig = sharedCreateBilardoHumanRig;
 const chooseBilardoHumanEdgePosition = sharedChooseBilardoHumanEdgePosition;
+const resolveBilardoHumanShotOrientation = sharedResolveHumanShotOrientation;
 const updateBilardoHumanPose = sharedUpdateBilardoHumanPose;
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
@@ -25761,7 +25763,8 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            shootBendDirection: -1,
+            // Positive bend keeps the upper body folding toward the table/cue ball.
+            shootBendDirection: 1,
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,
             rotLambda: HUMAN_ROT_LAMBDA,
@@ -25793,7 +25796,7 @@ const shotPowerRef = useRef(0);
             rightForearmDown: 0.48 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightForearmLength: 0.34 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightStrokePull: 0.30 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            rightStrokePush: 0.08 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            rightStrokePush: 0.20 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightHandShotLift: -0.30 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             idleRightHandX: 0.31 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             idleRightHandY: 0.8 * POOL_ROYALE_HUMAN_UNIT_SCALE,
@@ -25933,15 +25936,27 @@ const shotPowerRef = useRef(0);
           if (anim) anim.mode = mode;
 
           if (human) {
-            const aimForward = new THREE.Vector3(normalizedAim.x, 0, normalizedAim.y).normalize();
-            const side = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
-            const desiredRoot = chooseBilardoHumanEdgePosition(cueWorld, aimForward, {
+            const rawAimForward = new THREE.Vector3(normalizedAim.x, 0, normalizedAim.y).normalize();
+            let desiredRoot = chooseBilardoHumanEdgePosition(cueWorld, rawAimForward, {
               tableW: TABLE.W,
               tableL: TABLE.H,
               edgeMargin: HUMAN_EDGE_MARGIN,
               desiredShootDistance: HUMAN_DESIRED_SHOOT_DISTANCE
             }).setY(floorY);
-            const perimeterRoot = clampToWalkPerimeter(desiredRoot);
+            let perimeterRoot = clampToWalkPerimeter(desiredRoot);
+            const aimForward = resolveBilardoHumanShotOrientation(rawAimForward, cueWorld, perimeterRoot, {
+              faceTableDotTolerance: 0.02
+            });
+            if (aimForward.dot(rawAimForward) < 0.999) {
+              desiredRoot = chooseBilardoHumanEdgePosition(cueWorld, aimForward, {
+                tableW: TABLE.W,
+                tableL: TABLE.H,
+                edgeMargin: HUMAN_EDGE_MARGIN,
+                desiredShootDistance: HUMAN_DESIRED_SHOOT_DISTANCE
+              }).setY(floorY);
+              perimeterRoot = clampToWalkPerimeter(desiredRoot);
+            }
+            const side = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
             if (isInsideTableBlocker(perimeterRoot)) {
               perimeterRoot.copy(clampToWalkPerimeter(perimeterRoot));
             }

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -1,10 +1,10 @@
-import { createHumanRig, chooseHumanEdgePosition, updateHumanPose } from './humanRigCore';
+import { createHumanRig, chooseHumanEdgePosition, resolveHumanShotOrientation, updateHumanPose } from './humanRigCore';
 
 export function createBilardoHumanRig(scene, opts = {}) {
   return createHumanRig(scene, opts);
 }
 
-export { chooseHumanEdgePosition };
+export { chooseHumanEdgePosition, resolveHumanShotOrientation };
 
 export function updateBilardoHumanPose(human, dt, frameData) {
   return updateHumanPose(human, dt, frameData);

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -108,7 +108,8 @@ const BASE_CFG = {
   groundY: 0,
   perimeterWalk: false,
   perimeterWalkSpeed: 4.0,
-  shootBendDirection: 1
+  shootBendDirection: 1,
+  faceTableDotTolerance: 0.035
 };
 
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
@@ -560,6 +561,29 @@ function driveHuman(human, frame) {
   aimTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
   twistBone(b.rightUpperLeg, frame.forward, 0.03 * ik);
   setHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, cfg.footLockStrength * ik);
+}
+
+
+export function resolveHumanShotOrientation(rawAimForward, cueBallWorld, rootTarget, opts = {}) {
+  const cfg = scaleVectorConfig(opts);
+  const fallback = new THREE.Vector3(0, 0, -1);
+  const aim = rawAimForward?.clone?.() ?? fallback.clone();
+  aim.y = 0;
+  if (!Number.isFinite(aim.x) || !Number.isFinite(aim.z) || aim.lengthSq() < 1e-8) {
+    aim.copy(fallback);
+  }
+  aim.normalize();
+
+  const toCueBall = cueBallWorld?.clone?.().sub(rootTarget ?? new THREE.Vector3()) ?? aim.clone();
+  toCueBall.y = 0;
+  if (Number.isFinite(toCueBall.x) && Number.isFinite(toCueBall.z) && toCueBall.lengthSq() > 1e-8) {
+    toCueBall.normalize();
+    const tolerance = Math.max(0, cfg.faceTableDotTolerance ?? 0);
+    if (aim.dot(toCueBall) < -tolerance) {
+      aim.multiplyScalar(-1);
+    }
+  }
+  return aim;
 }
 
 export function updateHumanPose(human, dt, frameData) {


### PR DESCRIPTION
### Motivation
- Prevent the seated human avatar from facing away from the table/ cue ball during aiming and shooting which breaks pose and animation fidelity. 
- Ensure the upper body bends toward the table and the hands/feet remain grounded for a realistic cue stroke and readable visual feedback.

### Description
- Added `resolveHumanShotOrientation` in `webapp/src/pages/Games/shared/humanRigCore.js` to validate/correct the raw aim direction so the avatar faces the cue ball (with configurable dot-tolerance). 
- Exported the new helper via `webapp/src/pages/Games/shared/bilardoHumanRig.js` and wired it into Pool Royale so the edge/perimeter root is recomputed when orientation is corrected (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Updated Pool Royale human config to fold the upper body toward the table (`shootBendDirection: 1`) and increased right-hand forward push (`rightStrokePush` raised from `0.08` to `0.20`) to improve follow-through realism.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully. 
- Executed a small orientation assertion using Node + `three` that imports and exercises `resolveHumanShotOrientation`, and the assertions passed. 
- Attempted an automated Playwright mobile screenshot of the Pool Royale route (Chromium and dependencies were installed), but capturing the WebGL frame timed out in this environment; the browser launched and the page loaded during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3d82eb20832991856aae710ff593)