### PR TITLE
Keep human avatar facing table during shots and correct upper-body bend

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25761,7 +25761,8 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            shootBendDirection: -1,
+            shootBendDirection: 1,
+            tableFacingDotGuard: 0.18,
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,
             rotLambda: HUMAN_ROT_LAMBDA,
@@ -25776,7 +25777,7 @@ const shotPowerRef = useRef(0);
             stanceWidth: 0.52 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             bridgePalmTableLift: 0.006 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             chinToCueHeight: 0.11 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            footGroundY: 0.02 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            footGroundY: 0.005 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             footLockStrength: 1.25,
             kneeBendShot: 0.16 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             desiredShootDistance: 1.32 * POOL_ROYALE_HUMAN_UNIT_SCALE,
@@ -25959,6 +25960,9 @@ const shotPowerRef = useRef(0);
               1
             );
             const walkRoot = perimeterTToPoint(human.walkPerimeterT);
+            const bodyForward = cueWorld.clone().sub(walkRoot).setY(0);
+            if (bodyForward.lengthSq() > 1e-6) bodyForward.normalize();
+            else bodyForward.copy(aimForward);
             const state =
               mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
             const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
@@ -26041,6 +26045,8 @@ const shotPowerRef = useRef(0);
               state,
               rootTarget: walkRoot,
               aimForward,
+              bodyForward,
+              tableFocus: cueWorld,
               bridgeTarget,
               gripTarget,
               idleRight,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -108,7 +108,8 @@ const BASE_CFG = {
   groundY: 0,
   perimeterWalk: false,
   perimeterWalkSpeed: 4.0,
-  shootBendDirection: 1
+  shootBendDirection: 1,
+  tableFacingDotGuard: 0.18
 };
 
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
@@ -121,6 +122,19 @@ const dampScalar = (current, target, lambda, dt) =>
 const dampVector = (current, target, lambda, dt) =>
   current.lerp(target, 1 - Math.exp(-lambda * dt));
 const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
+
+function resolveTableFacingForward(root, aimForward, tableFocus, cfg) {
+  const safeAim = aimForward?.clone?.() || new THREE.Vector3(0, 0, -1);
+  safeAim.y = 0;
+  if (safeAim.lengthSq() < 1e-6) safeAim.set(0, 0, -1);
+  safeAim.normalize();
+  const towardTable = tableFocus?.clone?.().sub(root) || safeAim.clone();
+  towardTable.y = 0;
+  if (towardTable.lengthSq() < 1e-6) return safeAim;
+  towardTable.normalize();
+  const minDot = Number.isFinite(cfg?.tableFacingDotGuard) ? cfg.tableFacingDotGuard : 0.18;
+  return safeAim.dot(towardTable) >= minDot ? safeAim : towardTable;
+}
 const cleanName = (name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
 
 function scaleVectorConfig(cfg) {
@@ -589,7 +603,13 @@ export function updateHumanPose(human, dt, frameData) {
       })()
     : moveRootAroundPerimeter(human, rootGoal, cfg, dt);
   human.walkT += dt * (2 + Math.min(7, (moveAmountRaw * 10) / cfg.unit));
-  human.yaw = dampScalar(human.yaw, activeState === 'striking' ? human.strikeYaw : yawFromForward(frameData.aimForward), cfg.rotLambda, dt);
+  const facingForward = resolveTableFacingForward(
+    human.root.position,
+    frameData.bodyForward || frameData.aimForward,
+    frameData.tableFocus || frameData.bridgeTarget || frameData.cueTip || frameData.rootTarget,
+    cfg
+  );
+  human.yaw = dampScalar(human.yaw, activeState === 'striking' ? human.strikeYaw : yawFromForward(facingForward), cfg.rotLambda, dt);
 
   const t = easeInOut(human.poseT);
   const idle = 1 - t;
@@ -602,7 +622,13 @@ export function updateHumanPose(human, dt, frameData) {
   const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
   const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
   const powerLean = (frameData.power || 0) * t;
-  const bendDirection = cfg.shootBendDirection >= 0 ? 1 : -1;
+  const leanFocus = frameData.tableFocus || frameData.bridgeTarget || frameData.cueTip;
+  const leanTowardTable = leanFocus?.clone?.().sub(human.root.position) || forward.clone();
+  leanTowardTable.y = 0;
+  const configuredBendDirection = cfg.shootBendDirection >= 0 ? 1 : -1;
+  const bendDirection = leanTowardTable.lengthSq() > 1e-6
+    ? (forward.dot(leanTowardTable.normalize()) < -0.05 ? -1 : 1)
+    : configuredBendDirection;
   const shotBendZ = (value) => value * bendDirection;
   const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * cfg.unit * bendDirection);
   rootWorld.y = cfg.groundY;


### PR DESCRIPTION
### Motivation
- Prevent the human avatar from turning away from the table when moving around the rail so aiming/IK helpers remain stable and the pose pipeline yields realistic bridge/grip orientation. 
- Ensure the upper body always bends toward the table/cue focus (not away) during setup and stroke so the right-hand pull/push and bridge stay visually correct.
- Provide small tuning helpers to make the pose solver choose a safe forward vector when aim vectors are unreliable.

### Description
- Added a table-facing resolver `resolveTableFacingForward` and a `tableFacingDotGuard` config to `webapp/src/pages/Games/shared/humanRigCore.js` to pick a safe forward used for yaw instead of blindly using `aimForward`. 
- Switched yaw driving in `updateHumanPose` to use the resolved `facingForward` and damp toward `yawFromForward(facingForward)` when not striking. 
- Updated shooting bend logic in `updateHumanPose` to decide `bendDirection` by comparing the local forward vs a `tableFocus`/lean direction so the torso leans toward the table when appropriate and falls back to the configured `shootBendDirection`. 
- Exposed the new helpers through Pool Royale setup by passing `tableFacingDotGuard` and flipping `shootBendDirection` to prefer forward-table bend, lowering `footGroundY` for a flatter foot posture, computing `bodyForward` from the walking root to the cue world, and passing `bodyForward` + `tableFocus` into `updateBilardoHumanPose` in `webapp/src/pages/Games/PoolRoyale.jsx` so the shared rig can use the extra context.
- Files changed: `webapp/src/pages/Games/shared/humanRigCore.js` and `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Built the web app with `npm --prefix webapp run build`, which completed successfully. 
- Ran `npx eslint` against the changed files; the default invocation skipped the files due to repo ignore rules while `npx eslint --no-ignore` reported many existing style issues in the large shared file (these are baseline/style problems, not syntax regressions). 
- Verified `git diff --check` produced no blocking diff-check issues. 
- Attempted an automated visual smoke test with Playwright to capture a screenshot at `/games/poolroyale?mode=training`; Playwright browser install/deps were applied but headless WebGL rendering timed out when taking the screenshot in this CI-like environment, so an automated image artifact was not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3d82eb20832991856aae710ff593)