### PR TITLE
Adjust Domino Royal seated character placement

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7917,9 +7917,10 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.42;
-const DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.95;
-const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 0.56;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 2.72;
+// Positive local Z moves the seated character away from the table because each chair wrapper faces inward.
+const DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.42;
+const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 0.74;
 const DOMINO_CHARACTER_CACHE = new Map();
 const DOMINO_CHARACTER_TEXTURE_CACHE = new Map();
 let dominoCharacterThemeOrder = DOMINO_CHARACTER_THEMES.map((_, index) => index);
@@ -8316,7 +8317,7 @@ function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   seatRoot.position.set(
     0,
     visibleSeatLift + (theme.seatOffsetY ?? -0.4) - 0.22 - scaleDelta * 0.08 - DOMINO_CHARACTER_EXTRA_LOWER_OFFSET,
-    (theme.seatOffsetZ ?? 0.52) - 0.03 - DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET
+    (theme.seatOffsetZ ?? 0.52) - 0.03 + DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET
   );
   seatRoot.add(instance);
   const rig = createDominoCharacterRig(instance, seatRoot, seatIndex, player);

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-07-domino-seated-humans-v4';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-07-domino-seated-humans-v5';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Make Domino Royal seated human characters appear larger, sit lower, and move farther outward from the table for improved visual balance and readability on portrait screens.
- Force clients to pick up the updated arena script by incrementing the script version cache key.

### Description
- Increased shared character scale by changing `DOMINO_CHARACTER_PROPORTION_SCALE` from `2.42` to `2.72` to make avatars bigger in the scene.
- Adjusted offsets by updating `DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET` from `0.95` to `0.42` and `DOMINO_CHARACTER_EXTRA_LOWER_OFFSET` from `0.56` to `0.74`, and flipped the Z application so the seat root now uses `+ DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET` to push characters outward relative to the chair orientation; these changes are in `webapp/public/domino-royal-game.js`.
- Bumped the arena script cache token by changing `DOMINO_ROYAL_SCRIPT_VERSION` to `'2026-05-07-domino-seated-humans-v5'` in `webapp/src/pages/Games/DominoRoyalArena.jsx` so updated clients reload the modified game bundle.
- Added an inline clarifying comment explaining that positive local Z moves the seated character away from the table because each chair wrapper faces inward.

### Testing
- Ran `npm --prefix webapp run build`, which completed successfully (Vite build finished and produced `dist/`), with existing chunk-size/dynamic-import warnings reported but no build failure.
- No additional automated tests were changed or required for this visual/positioning tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4ca927fc832987146114d6ca153b)