### PR TITLE
Optimize maze battle royale base — remove GLTF robots and FPS gun, use lightweight human players

### DIFF
--- a/frontend/src/ChessBattleRoyaleStore.tsx
+++ b/frontend/src/ChessBattleRoyaleStore.tsx
@@ -1,24 +1,30 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
-import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
-const WEAPON_COUNT = 18;
+const PLAYER_COUNT = 12;
 const GRID_COLS = 3;
-const GRID_ROWS = 6;
-const GAP_X = 2.35;
-const GAP_Z = 1.48;
-const FPS_SHOTGUN_DISPLAY_LENGTH = 1.18;
+const GRID_ROWS = 4;
+const GAP_X = 2.45;
+const GAP_Z = 1.8;
 
-const PELLET_SPEED = 30;
-const PELLET_LIFETIME = 3.2;
-const PELLET_TRAIL_POINTS = 14;
+const PROJECTILE_SPEED = 28;
+const PROJECTILE_LIFETIME = 3.2;
+const PROJECTILE_TRAIL_POINTS = 14;
 
+const HUMAN_COLORS = ['#f97316', '#22c55e', '#38bdf8', '#e879f9', '#fde047', '#fb7185'] as const;
 const WEAPON_TYPES = ['rifle', 'pistol', 'sniper'] as const;
 type WeaponType = (typeof WEAPON_TYPES)[number];
 type CameraMode = 'overview' | 'player' | 'projectile' | 'impact';
 
-type WeaponEntry = { id: string; name: string; shortName: string; source: 'Quaternius' | 'Extra'; weaponType: WeaponType; urls: string[] };
-type RuntimeWeapon = { entry: WeaponEntry; slot: THREE.Group; root: THREE.Object3D; muzzle: THREE.Object3D; basePosition: THREE.Vector3; index: number };
+type HumanPlayerEntry = { id: string; name: string; shortName: string; weaponType: WeaponType; color: string };
+type RuntimePlayer = {
+  entry: HumanPlayerEntry;
+  slot: THREE.Group;
+  root: THREE.Group;
+  muzzle: THREE.Object3D;
+  basePosition: THREE.Vector3;
+  index: number;
+};
 type Projectile = {
   owner: number;
   mesh: THREE.Mesh;
@@ -29,32 +35,16 @@ type Projectile = {
   alive: boolean;
 };
 
-const polyGlb = (uuid: string) => `https://static.poly.pizza/${uuid}.glb`;
-const EXTRA = {
-  awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
-  fps: 'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
-};
-
-const WEAPON_MANIFEST: WeaponEntry[] = [
-  { id: 'poly-shotgun-01', name: 'Quaternius Shotgun', shortName: 'Shotgun', source: 'Quaternius', weaponType: 'rifle', urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')] },
-  { id: 'poly-assault-rifle-01', name: 'Quaternius Assault Rifle', shortName: 'Assault Rifle', source: 'Quaternius', weaponType: 'rifle', urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')] },
-  { id: 'poly-pistol-01', name: 'Quaternius Pistol', shortName: 'Pistol', source: 'Quaternius', weaponType: 'pistol', urls: [polyGlb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc')] },
-  { id: 'poly-revolver-01', name: 'Quaternius Heavy Revolver', shortName: 'Heavy Revolver', source: 'Quaternius', weaponType: 'pistol', urls: [polyGlb('9e728565-67a3-44db-9567-982320abff09')] },
-  { id: 'poly-sawed-off-01', name: 'Quaternius Sawed-Off Shotgun', shortName: 'Sawed-Off', source: 'Quaternius', weaponType: 'pistol', urls: [polyGlb('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e')] },
-  { id: 'poly-revolver-02', name: 'Quaternius Revolver Silver', shortName: 'Silver Revolver', source: 'Quaternius', weaponType: 'pistol', urls: [polyGlb('7951b3b9-d3a5-4ec8-81b7-11111f1c8e88')] },
-  { id: 'poly-shotgun-02', name: 'Quaternius Long Shotgun', shortName: 'Long Shotgun', source: 'Quaternius', weaponType: 'rifle', urls: [polyGlb('f71d6771-f512-4374-bd23-ba00b564db68')] },
-  { id: 'poly-shotgun-03', name: 'Quaternius Pump Shotgun', shortName: 'Pump Shotgun', source: 'Quaternius', weaponType: 'rifle', urls: [polyGlb('08f27141-8e64-425a-9161-1bbd6956dfca')] },
-  { id: 'poly-smg-01', name: 'Quaternius Submachine Gun', shortName: 'SMG', source: 'Quaternius', weaponType: 'rifle', urls: [polyGlb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710')] },
-  { id: 'slot-10', name: 'AK47', shortName: 'AK47', source: 'Extra', weaponType: 'rifle', urls: [EXTRA.awp] },
-  { id: 'slot-11', name: 'KRSV', shortName: 'KRSV', source: 'Extra', weaponType: 'rifle', urls: [EXTRA.awp] },
-  { id: 'slot-12', name: 'Smith', shortName: 'Smith', source: 'Extra', weaponType: 'pistol', urls: [EXTRA.awp] },
-  { id: 'slot-13', name: 'Mosin', shortName: 'Mosin', source: 'Extra', weaponType: 'sniper', urls: [EXTRA.awp] },
-  { id: 'slot-14', name: 'Uzi', shortName: 'Uzi', source: 'Extra', weaponType: 'rifle', urls: [EXTRA.awp] },
-  { id: 'slot-15', name: 'SigSauer', shortName: 'SigSauer', source: 'Extra', weaponType: 'pistol', urls: [EXTRA.awp] },
-  { id: 'slot-16', name: 'AWP', shortName: 'AWP', source: 'Extra', weaponType: 'sniper', urls: [EXTRA.awp] },
-  { id: 'slot-17', name: 'MRTK Gun', shortName: 'MRTK Gun', source: 'Extra', weaponType: 'rifle', urls: [EXTRA.awp] },
-  { id: 'slot-18', name: 'FPS Gun', shortName: 'FPS Shotgun', source: 'Extra', weaponType: 'rifle', urls: [EXTRA.fps, EXTRA.awp] },
-];
+const HUMAN_PLAYER_MANIFEST: HumanPlayerEntry[] = Array.from({ length: PLAYER_COUNT }, (_, index) => {
+  const type = WEAPON_TYPES[index % WEAPON_TYPES.length];
+  return {
+    id: `human-player-${index + 1}`,
+    name: `Human Player ${index + 1}`,
+    shortName: `Player ${index + 1}`,
+    weaponType: type,
+    color: HUMAN_COLORS[index % HUMAN_COLORS.length],
+  };
+});
 
 const slotPosition = (i: number) => {
   const c = i % GRID_COLS;
@@ -63,39 +53,125 @@ const slotPosition = (i: number) => {
   return new THREE.Vector3((c - 1) * GAP_X, 0, (r - m) * GAP_Z);
 };
 
-const makeLoader = (url: string) => {
-  const base = url.slice(0, url.lastIndexOf('/') + 1);
-  const m = new THREE.LoadingManager();
-  m.setURLModifier((r) => (/^(https?:)?\/\//i.test(r) ? r : new URL(r, base).toString()));
-  return new GLTFLoader(m);
+const disposeObject = (object: THREE.Object3D) => {
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) return;
+    child.geometry.dispose();
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+    materials.forEach((material) => material.dispose());
+  });
 };
 
-const normalizeWeapon = (m: THREE.Object3D) => {
-  const box = new THREE.Box3().setFromObject(m);
-  const size = box.getSize(new THREE.Vector3());
-  const max = Math.max(size.x, size.y, size.z);
-  if (max > 0) m.scale.setScalar(FPS_SHOTGUN_DISPLAY_LENGTH / max);
-  const normalized = new THREE.Box3().setFromObject(m);
-  const center = normalized.getCenter(new THREE.Vector3());
-  m.position.sub(center);
-  m.position.y += -normalized.min.y + 0.08;
+const makeMazeWalls = () => {
+  const group = new THREE.Group();
+  const wallMaterial = new THREE.MeshStandardMaterial({ color: '#334155', roughness: 0.8, metalness: 0.05 });
+  const wallGeometry = new THREE.BoxGeometry(0.24, 1.15, 1.85);
+  const horizontalGeometry = new THREE.BoxGeometry(2.1, 1.15, 0.24);
+
+  const verticals = [
+    [-4.9, -5.4],
+    [-4.9, -1.8],
+    [-4.9, 1.8],
+    [-4.9, 5.4],
+    [4.9, -5.4],
+    [4.9, -1.8],
+    [4.9, 1.8],
+    [4.9, 5.4],
+    [-1.25, -3.6],
+    [1.25, 0],
+    [-1.25, 3.6],
+  ];
+  verticals.forEach(([x, z]) => {
+    const wall = new THREE.Mesh(wallGeometry, wallMaterial);
+    wall.position.set(x, 0.55, z);
+    group.add(wall);
+  });
+
+  const horizontals = [
+    [-2.45, -6.45],
+    [0, -6.45],
+    [2.45, -6.45],
+    [-2.45, 6.45],
+    [0, 6.45],
+    [2.45, 6.45],
+    [-2.45, -0.9],
+    [2.45, 0.9],
+  ];
+  horizontals.forEach(([x, z]) => {
+    const wall = new THREE.Mesh(horizontalGeometry, wallMaterial);
+    wall.position.set(x, 0.55, z);
+    group.add(wall);
+  });
+
+  return group;
+};
+
+const createHumanPlayer = (entry: HumanPlayerEntry, index: number) => {
+  const group = new THREE.Group();
+  const suit = new THREE.MeshStandardMaterial({ color: entry.color, roughness: 0.68 });
+  const skin = new THREE.MeshStandardMaterial({ color: '#f8c79b', roughness: 0.75 });
+  const dark = new THREE.MeshStandardMaterial({ color: '#0f172a', roughness: 0.6 });
+  const weaponMaterial = new THREE.MeshStandardMaterial({ color: '#cbd5e1', roughness: 0.5, metalness: 0.25 });
+
+  const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.24, 0.72, 4, 10), suit);
+  body.position.y = 0.82;
+  group.add(body);
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.22, 14, 12), skin);
+  head.position.y = 1.42;
+  group.add(head);
+
+  const visor = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.08, 0.035), dark);
+  visor.position.set(0, 1.45, -0.2);
+  group.add(visor);
+
+  const armGeometry = new THREE.CapsuleGeometry(0.055, 0.42, 3, 8);
+  const leftArm = new THREE.Mesh(armGeometry, suit);
+  leftArm.position.set(-0.31, 0.93, -0.05);
+  leftArm.rotation.z = 0.22;
+  group.add(leftArm);
+
+  const rightArm = new THREE.Mesh(armGeometry, suit);
+  rightArm.position.set(0.31, 0.93, -0.05);
+  rightArm.rotation.z = -0.22;
+  group.add(rightArm);
+
+  const legGeometry = new THREE.CapsuleGeometry(0.07, 0.36, 3, 8);
+  const leftLeg = new THREE.Mesh(legGeometry, dark);
+  leftLeg.position.set(-0.12, 0.28, 0.02);
+  group.add(leftLeg);
+
+  const rightLeg = new THREE.Mesh(legGeometry, dark);
+  rightLeg.position.set(0.12, 0.28, 0.02);
+  group.add(rightLeg);
+
+  const weaponLength = entry.weaponType === 'pistol' ? 0.38 : entry.weaponType === 'sniper' ? 0.86 : 0.64;
+  const weapon = new THREE.Mesh(new THREE.BoxGeometry(0.11, 0.1, weaponLength), weaponMaterial);
+  weapon.position.set(0.22, 0.93, -0.32);
+  group.add(weapon);
+
+  const muzzle = new THREE.Object3D();
+  muzzle.position.set(0.22, 0.93, -0.32 - weaponLength / 2);
+  group.add(muzzle);
+
+  group.rotation.y = Math.PI;
+  group.position.copy(slotPosition(index));
+  return { group, muzzle };
 };
 
 export default function ChessBattleRoyaleStore() {
   const mountRef = useRef<HTMLDivElement | null>(null);
-  const runtimesRef = useRef<RuntimeWeapon[]>([]);
+  const runtimesRef = useRef<RuntimePlayer[]>([]);
   const projectilesRef = useRef<Projectile[]>([]);
   const selectedRef = useRef(0);
   const activeProjectileRef = useRef<Projectile | null>(null);
   const impactFocusUntilRef = useRef(0);
 
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [loadedCount, setLoadedCount] = useState(0);
-  const [failedCount, setFailedCount] = useState(0);
-  const [status, setStatus] = useState('Loading weapons...');
+  const [status, setStatus] = useState('Loading lightweight human-only maze base...');
   const [cameraMode, setCameraMode] = useState<CameraMode>('overview');
 
-  const selectedWeapon = useMemo(() => WEAPON_MANIFEST[selectedIndex], [selectedIndex]);
+  const selectedPlayer = useMemo(() => HUMAN_PLAYER_MANIFEST[selectedIndex], [selectedIndex]);
   useEffect(() => void (selectedRef.current = selectedIndex), [selectedIndex]);
 
   useEffect(() => {
@@ -104,87 +180,56 @@ export default function ChessBattleRoyaleStore() {
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color('#0f172a');
-    const camera = new THREE.PerspectiveCamera(46, mount.clientWidth / mount.clientHeight, 0.1, 200);
-    camera.position.set(0, 8, 12);
+    const camera = new THREE.PerspectiveCamera(48, mount.clientWidth / mount.clientHeight, 0.1, 200);
+    camera.position.set(0, 7.2, 11.5);
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true });
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5));
     renderer.setSize(mount.clientWidth, mount.clientHeight);
     mount.innerHTML = '';
     mount.appendChild(renderer.domElement);
 
-    scene.add(new THREE.AmbientLight(0xffffff, 1.7));
-    const dir = new THREE.DirectionalLight(0xffffff, 1.8);
+    scene.add(new THREE.AmbientLight(0xffffff, 1.65));
+    const dir = new THREE.DirectionalLight(0xffffff, 1.7);
     dir.position.set(4, 10, 6);
     scene.add(dir);
 
-    const floor = new THREE.Mesh(new THREE.PlaneGeometry(32, 42), new THREE.MeshStandardMaterial({ color: '#1e293b' }));
+    const floor = new THREE.Mesh(new THREE.PlaneGeometry(14, 17), new THREE.MeshStandardMaterial({ color: '#172033' }));
     floor.rotation.x = -Math.PI / 2;
     floor.position.y = -0.01;
     scene.add(floor);
+    scene.add(makeMazeWalls());
 
-    const target = new THREE.Mesh(new THREE.BoxGeometry(2.6, 2.6, 0.6), new THREE.MeshStandardMaterial({ color: '#f59e0b' }));
-    target.position.set(0, 2.2, -15);
+    const target = new THREE.Mesh(new THREE.BoxGeometry(1.55, 1.55, 0.35), new THREE.MeshStandardMaterial({ color: '#f59e0b', emissive: '#7c2d12', emissiveIntensity: 0.18 }));
+    target.position.set(0, 1.35, -7.35);
     scene.add(target);
 
-    const slots: THREE.Group[] = [];
-    WEAPON_MANIFEST.forEach((_, i) => {
+    HUMAN_PLAYER_MANIFEST.forEach((entry, index) => {
       const slot = new THREE.Group();
-      slot.position.copy(slotPosition(i));
+      const { group, muzzle } = createHumanPlayer(entry, index);
+      slot.add(group);
       scene.add(slot);
-      slots.push(slot);
+      runtimesRef.current.push({ entry, slot, root: group, muzzle, basePosition: group.position.clone(), index });
     });
+    setStatus('Ready. Base contains only lightweight human players; robot GLTF loading and FPS gun are removed.');
 
-    const loadOne = async (entry: WeaponEntry, index: number) => {
-      try {
-        let gltf: GLTF | null = null;
-        for (const url of entry.urls) {
-          try {
-            gltf = await new Promise<GLTF>((resolve, reject) => makeLoader(url).load(url, resolve, undefined, reject));
-            break;
-          } catch {
-            // try next candidate URL
-          }
-        }
-        if (!gltf) throw new Error(`All URLs failed for ${entry.name}`);
-        const model = gltf.scene;
-        normalizeWeapon(model);
-        slots[index].add(model);
-        const muzzle = new THREE.Object3D();
-        muzzle.position.set(0.55, 0.2, 0);
-        model.add(muzzle);
-        runtimesRef.current.push({ entry, slot: slots[index], root: model, muzzle, basePosition: model.position.clone(), index });
-        setLoadedCount((v) => v + 1);
-      } catch {
-        const fallback = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.2, 0.15), new THREE.MeshStandardMaterial({ color: '#94a3b8' }));
-        slots[index].add(fallback);
-        const muzzle = new THREE.Object3D();
-        muzzle.position.set(0.45, 0.04, 0);
-        fallback.add(muzzle);
-        runtimesRef.current.push({ entry, slot: slots[index], root: fallback, muzzle, basePosition: fallback.position.clone(), index });
-        setFailedCount((v) => v + 1);
-      }
-    };
-
-    void Promise.all(WEAPON_MANIFEST.map(loadOne)).then(() => setStatus('Ready. Dynamic player + projectile camera broadcasting enabled for all weapons.'));
-
-    const pelletGeometry = new THREE.SphereGeometry(0.05, 12, 12);
-    const pelletMaterial = new THREE.MeshStandardMaterial({ color: '#e2e8f0', emissive: '#1d4ed8', emissiveIntensity: 0.4 });
+    const projectileGeometry = new THREE.SphereGeometry(0.05, 10, 10);
+    const projectileMaterial = new THREE.MeshStandardMaterial({ color: '#e2e8f0', emissive: '#1d4ed8', emissiveIntensity: 0.4 });
     const trailMaterial = new THREE.LineBasicMaterial({ color: '#93c5fd', transparent: true, opacity: 0.7 });
     const clock = new THREE.Clock();
     const vA = new THREE.Vector3();
     const vB = new THREE.Vector3();
 
-    const fireFromRuntime = (runtime: RuntimeWeapon) => {
+    const fireFromRuntime = (runtime: RuntimePlayer) => {
       runtime.muzzle.getWorldPosition(vA);
       target.getWorldPosition(vB);
       const dirToTarget = vB.clone().sub(vA).normalize();
-      const spread = runtime.entry.weaponType === 'pistol' ? 0.09 : runtime.entry.weaponType === 'sniper' ? 0.01 : 0.04;
+      const spread = runtime.entry.weaponType === 'pistol' ? 0.08 : runtime.entry.weaponType === 'sniper' ? 0.01 : 0.035;
       dirToTarget.x += THREE.MathUtils.randFloatSpread(spread);
       dirToTarget.y += THREE.MathUtils.randFloatSpread(spread * 0.6);
       dirToTarget.normalize();
 
-      const mesh = new THREE.Mesh(pelletGeometry, pelletMaterial.clone());
+      const mesh = new THREE.Mesh(projectileGeometry, projectileMaterial.clone());
       mesh.position.copy(vA);
       scene.add(mesh);
       const trail = new THREE.Line(new THREE.BufferGeometry().setFromPoints([vA.clone(), vA.clone()]), trailMaterial.clone());
@@ -195,7 +240,7 @@ export default function ChessBattleRoyaleStore() {
         mesh,
         trail,
         history: [vA.clone()],
-        velocity: dirToTarget.multiplyScalar(PELLET_SPEED),
+        velocity: dirToTarget.multiplyScalar(PROJECTILE_SPEED),
         age: 0,
         alive: true,
       };
@@ -228,7 +273,8 @@ export default function ChessBattleRoyaleStore() {
 
       runtimesRef.current.forEach((r) => {
         const selected = r.index === selectedRef.current;
-        r.root.position.y = THREE.MathUtils.lerp(r.root.position.y, r.basePosition.y + (selected ? 0.38 : 0), 0.14);
+        r.root.position.y = THREE.MathUtils.lerp(r.root.position.y, r.basePosition.y + (selected ? 0.32 : 0), 0.14);
+        r.root.rotation.y = Math.PI + Math.sin(performance.now() * 0.0016 + r.index) * 0.08;
       });
 
       projectilesRef.current.forEach((p) => {
@@ -236,11 +282,11 @@ export default function ChessBattleRoyaleStore() {
         p.age += d;
         p.mesh.position.addScaledVector(p.velocity, d);
         p.history.push(p.mesh.position.clone());
-        if (p.history.length > PELLET_TRAIL_POINTS) p.history.shift();
+        if (p.history.length > PROJECTILE_TRAIL_POINTS) p.history.shift();
         p.trail.geometry.dispose();
         p.trail.geometry = new THREE.BufferGeometry().setFromPoints(p.history);
 
-        if (p.age > PELLET_LIFETIME || p.mesh.position.distanceTo(target.position) < 1.1) {
+        if (p.age > PROJECTILE_LIFETIME || p.mesh.position.distanceTo(target.position) < 0.9) {
           p.alive = false;
           impactFocusUntilRef.current = performance.now() + 1200;
           setCameraMode('impact');
@@ -254,7 +300,7 @@ export default function ChessBattleRoyaleStore() {
         camera.position.lerp(camPos, 0.18);
         camera.lookAt(p.mesh.position.clone().addScaledVector(dirTo, 2.8));
       } else if (performance.now() < impactFocusUntilRef.current) {
-        const focusPos = new THREE.Vector3(0, 3.5, -9.5);
+        const focusPos = new THREE.Vector3(0, 3.4, -9.2);
         camera.position.lerp(focusPos, 0.1);
         camera.lookAt(target.position);
       } else {
@@ -262,7 +308,7 @@ export default function ChessBattleRoyaleStore() {
         const selected = runtimesRef.current.find((r) => r.index === selectedRef.current);
         if (selected) {
           selected.muzzle.getWorldPosition(vA);
-          const playerView = vA.clone().add(new THREE.Vector3(0, 0.35, 0.72));
+          const playerView = vA.clone().add(new THREE.Vector3(0, 0.36, 0.82));
           camera.position.lerp(playerView, 0.08);
           camera.lookAt(target.position);
         }
@@ -280,9 +326,12 @@ export default function ChessBattleRoyaleStore() {
       window.removeEventListener('keydown', onKeyDown);
       renderer.dispose();
       mount.innerHTML = '';
-      pelletGeometry.dispose();
-      pelletMaterial.dispose();
+      disposeObject(scene);
+      projectileGeometry.dispose();
+      projectileMaterial.dispose();
       trailMaterial.dispose();
+      runtimesRef.current = [];
+      projectilesRef.current = [];
     };
   }, []);
 
@@ -290,27 +339,27 @@ export default function ChessBattleRoyaleStore() {
     <div className='relative h-screen w-full overflow-hidden bg-slate-950 text-white'>
       <div ref={mountRef} className='absolute inset-0' />
       <div className='absolute left-3 right-3 top-3 rounded-2xl border border-white/10 bg-slate-950/75 p-3 text-xs'>
-        <div className='font-black text-yellow-300'>Ludo Battle Royale · Dynamic Weapon Broadcast</div>
-        <div>{loadedCount}/{WEAPON_COUNT} loaded · {failedCount} fallback</div>
+        <div className='font-black text-yellow-300'>Maze Battle Royale · Human-Only Base</div>
+        <div>{PLAYER_COUNT} human players · 0 robot GLTF · FPS gun removed</div>
         <div>{status}</div>
         <div>Camera mode: {cameraMode}</div>
       </div>
 
       <div className='absolute bottom-3 left-3 right-3 rounded-2xl border border-white/10 bg-slate-950/75 p-3'>
-        <div className='mb-2 text-xs font-black text-yellow-300'>Selected: {selectedIndex + 1}. {selectedWeapon.shortName}</div>
+        <div className='mb-2 text-xs font-black text-yellow-300'>Selected: {selectedIndex + 1}. {selectedPlayer.shortName}</div>
         <div className='grid max-h-40 grid-cols-3 gap-2 overflow-y-auto pr-1'>
-          {WEAPON_MANIFEST.map((weapon, index) => (
+          {HUMAN_PLAYER_MANIFEST.map((player, index) => (
             <button
-              key={weapon.id}
+              key={player.id}
               onClick={() => {
                 selectedRef.current = index;
                 setSelectedIndex(index);
-                setStatus(`Selected ${index + 1}/${WEAPON_COUNT}: ${weapon.name}`);
+                setStatus(`Selected ${index + 1}/${PLAYER_COUNT}: ${player.name}`);
               }}
               className={`rounded-xl border px-2 py-2 text-left text-[11px] font-bold ${selectedIndex === index ? 'border-yellow-300 bg-yellow-400 text-slate-950' : 'border-white/10 bg-white/10 text-slate-100'}`}
             >
-              <span className='block text-[10px] opacity-70'>#{index + 1} · {weapon.weaponType}</span>
-              <span className='block truncate'>{weapon.shortName}</span>
+              <span className='block text-[10px] opacity-70'>#{index + 1} · {player.weaponType}</span>
+              <span className='block truncate'>{player.shortName}</span>
             </button>
           ))}
         </div>


### PR DESCRIPTION
### Motivation
- Remove expensive runtime GLTF loading (robot models / FPS gun) that made the base slow and brittle on mobile, replacing them with lightweight procedural humans for much lower runtime cost.
- Keep the dynamic projectile + broadcast-camera experience while simplifying the scene for faster onboarding and better performance.

### Description
- Reworked `frontend/src/ChessBattleRoyaleStore.tsx` to replace the previous GLTF weapon manifest and loader with a `HUMAN_PLAYER_MANIFEST` and a `createHumanPlayer` procedural builder.
- Added a simple maze via `makeMazeWalls`, a `disposeObject` helper to clean meshes/materials, and tuned camera/scene layout (smaller floor, adjusted FOV/positions) for the new base.
- Removed GLTF loading and the FPS gun entry and renamed/adjusted projectile constants (e.g. `PROJECTILE_SPEED`, `PROJECTILE_TRAIL_POINTS`) while preserving projectile spawn, trail, and camera broadcast behavior.
- Updated UI strings to reflect the new "Maze Battle Royale · Human-Only Base" and replaced the weapon grid with a human-player grid.

### Testing
- Built the frontend with `npm --prefix frontend run build`, which completed successfully and produced a production bundle.
- Launched the dev server with `npm --prefix frontend run dev` and verified the app served locally (Vite reported ready and the page was reachable).
- Attempted an automated screenshot with Playwright for a visual smoke test but the run failed due to a missing system library (`libatk-1.0.so.0`) in the container, so a screenshot could not be captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4d06f284832989b9db8a905b1d7e)