### PR TITLE
Adjust seated character scale/offsets and bump Domino script version

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7917,9 +7917,9 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.42;
-const DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.95;
-const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 0.56;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 2.86;
+const DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET = 1.18;
+const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 0.82;
 const DOMINO_CHARACTER_CACHE = new Map();
 const DOMINO_CHARACTER_TEXTURE_CACHE = new Map();
 let dominoCharacterThemeOrder = DOMINO_CHARACTER_THEMES.map((_, index) => index);
@@ -8316,7 +8316,7 @@ function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   seatRoot.position.set(
     0,
     visibleSeatLift + (theme.seatOffsetY ?? -0.4) - 0.22 - scaleDelta * 0.08 - DOMINO_CHARACTER_EXTRA_LOWER_OFFSET,
-    (theme.seatOffsetZ ?? 0.52) - 0.03 - DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET
+    (theme.seatOffsetZ ?? 0.52) - 0.03 + DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET
   );
   seatRoot.add(instance);
   const rig = createDominoCharacterRig(instance, seatRoot, seatIndex, player);

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-07-domino-seated-humans-v4';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-07-domino-seated-humans-v6';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Improve visual alignment and positioning of seated human characters by tuning proportion and offset constants to reduce clipping and better match chair geometry.
- Force client reload of updated runtime assets by bumping the embedded script version string so changes propagate to active pages.

### Description
- Increased `DOMINO_CHARACTER_PROPORTION_SCALE` from `2.42` to `2.86` to scale seated characters larger. 
- Adjusted `DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET` from `0.95` to `1.18` and `DOMINO_CHARACTER_EXTRA_LOWER_OFFSET` from `0.56` to `0.82` to change character placement relative to chairs. 
- Changed seat root X/Z positioning to apply the outward offset with a positive addition instead of subtraction so characters sit further outward: the position expression now uses `+ DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET`.
- Bumped the inline script version identifier `DOMINO_ROYAL_SCRIPT_VERSION` in `DominoRoyalArena.jsx` from `2026-05-07-domino-seated-humans-v4` to `2026-05-07-domino-seated-humans-v6` to invalidate caches.

### Testing
- Ran the project build with `npm run build` and it completed successfully. 
- Ran the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4ca927fc832987146114d6ca153b)