### PR TITLE
Lift Snake & Ladder seated human characters

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -100,8 +100,8 @@ const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.28;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_Y = -1.55 * MODEL_SCALE * STOOL_SCALE;
 // Portrait calibration: lift only the loaded human meshes relative to the existing chair ring.
-// This keeps all seating/chair anchors unchanged while moving characters visually higher on screen.
-const SEATED_HUMAN_VISUAL_UPWARD_LIFT = 0.25 * MODEL_SCALE * STOOL_SCALE;
+// Keep all seating/chair anchors unchanged while moving characters visibly higher on portrait screens.
+const SEATED_HUMAN_VISUAL_UPWARD_LIFT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
 const HUMAN_LEG_FRONT_OFFSET = 0;
 const SNAKE_TOKEN_MODEL_URLS = [


### PR DESCRIPTION
### Motivation
- Improve visual composition on portrait/mobile screens by raising the seated human characters so they read higher in the camera frame.
- Keep existing chair and seat anchors unchanged while adjusting only the visible position of loaded human meshes for portrait calibration.

### Description
- Increased the portrait lift constant `SEATED_HUMAN_VISUAL_UPWARD_LIFT` from `0.25 * MODEL_SCALE * STOOL_SCALE` to `0.5 * MODEL_SCALE * STOOL_SCALE` in `webapp/src/components/SnakeBoard3D.jsx` so seated humans appear higher on screen.
- Clarified the calibration comment above the constant to note that seat/chair anchors are preserved and the change affects only the visual lift for portrait screens.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully.
- Ran `git diff --check` to validate whitespace/format issues and it produced no errors.
- Attempted an automated Playwright screenshot to verify the portrait result, but the headless browser capture could not complete in this environment due to Playwright / headless Chromium runtime dependencies, so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5f3f97b88329ab208d7b1369573e)