### PR TITLE
Adjust Domino Royal human character layout

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7918,8 +7918,11 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
   }
 ]);
 const DOMINO_CHARACTER_PROPORTION_SCALE = 2.0;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.22;
 const DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET = 1.0;
+const DOMINO_HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.3;
 const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 1.0;
+const ENABLE_DOMINO_CHARACTER_HELD_RACKS = false;
 const DOMINO_CHARACTER_CACHE = new Map();
 const DOMINO_CHARACTER_TEXTURE_CACHE = new Map();
 let dominoCharacterThemeOrder = DOMINO_CHARACTER_THEMES.map((_, index) => index);
@@ -8275,6 +8278,12 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
 
 function refreshDominoRigRack(rig, handTiles = []) {
   if (!rig) return;
+  if (!ENABLE_DOMINO_CHARACTER_HELD_RACKS) {
+    rig.heldRack?.userData?.dispose?.();
+    rig.heldRack?.parent?.remove(rig.heldRack);
+    rig.heldRack = null;
+    return;
+  }
   const signature = (Array.isArray(handTiles) ? handTiles.slice(0, 5) : []).map((tile) => `${tile.a}:${tile.b}`).join('|');
   if (rig.heldRack?.userData?.signature === signature) return;
   const parent = rig.heldRack?.parent || rig.instance;
@@ -8307,8 +8316,11 @@ function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   enhanceDominoCharacterMaterials(instance, theme, seatIndex);
   normalizeDominoCharacterRoot(instance);
   const seatRoot = new THREE.Group();
-  const seatScale = (theme.scale || 1) * DOMINO_CHARACTER_PROPORTION_SCALE;
-  const scaleDelta = Math.max(0, DOMINO_CHARACTER_PROPORTION_SCALE - 1);
+  const isHumanSeat = seatIndex === HUMAN_SEAT_INDEX;
+  const characterScale = DOMINO_CHARACTER_PROPORTION_SCALE +
+    (isHumanSeat ? DOMINO_HUMAN_CHARACTER_SCALE_BOOST : 0);
+  const seatScale = (theme.scale || 1) * characterScale;
+  const scaleDelta = Math.max(0, characterScale - 1);
   seatRoot.scale.setScalar(seatScale);
   const visibleSeatLift = Number.isFinite(chair?.userData?.dominoCharacterSeatLift)
     ? chair.userData.dominoCharacterSeatLift
@@ -8316,7 +8328,8 @@ function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   seatRoot.position.set(
     0,
     visibleSeatLift + (theme.seatOffsetY ?? -0.4) - 0.22 - scaleDelta * 0.08 - DOMINO_CHARACTER_EXTRA_LOWER_OFFSET,
-    (theme.seatOffsetZ ?? 0.52) - 0.03 + DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET
+    (theme.seatOffsetZ ?? 0.52) - 0.03 + DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET +
+      (isHumanSeat ? DOMINO_HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET : 0)
   );
   seatRoot.add(instance);
   const rig = createDominoCharacterRig(instance, seatRoot, seatIndex, player);

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-07-domino-seated-humans-v7';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-07-domino-human-layout-v8';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Make the bottom (human) seated character visually larger and pushed farther out from the table to match the previous seating adjustment while leaving other seated characters unchanged.  
- Remove the oversized decorative domino rack that was rendering at the top of the portrait page while keeping player hand dominoes and table dominoes untouched.

### Description
- Added human-specific layout controls: `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` and `DOMINO_HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET`, and a feature flag `ENABLE_DOMINO_CHARACTER_HELD_RACKS = false` to disable decorative held racks.  
- Updated `refreshDominoRigRack` to early-remove the held/domino rack when `ENABLE_DOMINO_CHARACTER_HELD_RACKS` is `false`, preventing the large top-of-page dominos from being created.  
- Changed `attachDominoCharacterToChair` so the bottom/human seat gets an increased `seatScale` and additional outward `z` offset while other seats keep existing scaling and offsets.  
- Bumped the Domino Royal arena script version in `webapp/src/pages/Games/DominoRoyalArena.jsx` so clients will load the updated `webapp/public/domino-royal-game.js` layout changes.

### Testing
- Ran `npm run build` (production Vite build) and the build completed successfully though the build reported chunk-size warnings for large bundles.  
- Ran `git diff --check -- webapp/public/domino-royal-game.js webapp/src/pages/Games/DominoRoyalArena.jsx` which returned clean results.  
- Attempted an automated Playwright portrait screenshot to visually verify layout, but browser verification was blocked in this environment due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc62f88f388329a8528f1a43cebe9f)