### PR TITLE
Fix human shooting pose (upper-body counter-lean + planted feet) and reduce Showood cloth pattern scale

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -21,6 +21,7 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.equal(showood.fitScale, 1.035);
+    assert.equal(showood.clothRepeatScale, 1.55);
     assert.deepEqual(showood.hideSurfaceRoles, []);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -25,6 +25,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.035,
+    clothRepeatScale: 1.55,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4633,7 +4633,7 @@ const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.76; // match Snooker Royal's single tighter cloth weave so Pool Royal no longer shows mixed pattern sizes
 const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
-const EXTERNAL_TABLE_CLOTH_REPEAT_SCALE = 2.35; // tighten Showood GLB cloth to the procedural/Snooker Royal weave scale
+const EXTERNAL_TABLE_CLOTH_REPEAT_SCALE = 2.35; // base normalization for external GLB cloth UV spans
 const POLYHAVEN_ANISOTROPY_BOOST = 9;
 const POLYHAVEN_TEXTURE_RESOLUTION =
   CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k';
@@ -12621,6 +12621,31 @@ function clonePoolRoyaleMaterialTexture(texture, { isColor = false } = {}) {
   return clone;
 }
 
+function scalePoolRoyaleExternalClothTextureRepeats(material, repeatScale = 1) {
+  if (
+    !material ||
+    !Number.isFinite(repeatScale) ||
+    repeatScale <= 0 ||
+    Math.abs(repeatScale - 1) < MICRO_EPS
+  ) return;
+  ['map', 'normalMap', 'bumpMap', 'roughnessMap'].forEach((prop) => {
+    const texture = material[prop];
+    if (!texture?.repeat || texture.userData?.poolRoyaleExternalModelRepeatScaled) return;
+    texture.repeat.multiplyScalar(repeatScale);
+    texture.userData = {
+      ...(texture.userData || {}),
+      poolRoyaleExternalModelRepeatScaled: true,
+      poolRoyaleExternalModelRepeatScale: repeatScale
+    };
+    texture.needsUpdate = true;
+  });
+  material.userData = {
+    ...(material.userData || {}),
+    poolRoyaleExternalModelRepeatScale: repeatScale
+  };
+  material.needsUpdate = true;
+}
+
 function preparePoolRoyaleExternalTexture(texture, isColor = false) {
   if (!texture) return;
   if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
@@ -12731,6 +12756,7 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
 
   if (role === 'cloth' || role === 'cushion') {
     copyMaterialLook(role === 'cushion' ? finishInfo.cushionMat : finishInfo.clothMat);
+    scalePoolRoyaleExternalClothTextureRepeats(mat, tableModel?.clothRepeatScale ?? 1);
     mat.side = THREE.DoubleSide;
     mat.userData = {
       ...(mat.userData || {}),
@@ -25766,8 +25792,11 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            // Positive bend keeps the upper body folding toward the table/cue ball.
-            shootBendDirection: 1,
+            // Bend the shooting upper body to the opposite side while the IK feet stay planted.
+            shootBendDirection: -1,
+            shootCounterLeanSide: -1,
+            shootUpperBodyCounterLean: 1.18,
+            plantFeetDuringShot: true,
             forceTableFacingAim: true,
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -238,10 +238,13 @@ const BASE_CFG = {
   groundY: 0,
   perimeterWalk: false,
   perimeterWalkSpeed: 4.0,
-  // Negative bends the cue-side upper body away from the previous over-the-table fold.
-  // Feet remain planted through IK targets while only spine/chest/head targets cross the cue line.
+  // The shooting pose bends the upper body away from the cue-side fold while the
+  // IK feet stay planted on the floor. Pool Royale can override the strength,
+  // but the default keeps spine/chest/head targets on the opposite side.
   shootBendDirection: -1,
   shootCounterLeanSide: -1,
+  shootUpperBodyCounterLean: 1,
+  plantFeetDuringShot: true,
   forceTableFacingAim: true
 };
 
@@ -767,8 +770,12 @@ export function updateHumanPose(human, dt, frameData) {
   const powerLean = (frameData.power || 0) * t;
   const bendDirection = cfg.shootBendDirection >= 0 ? 1 : -1;
   const counterLeanSide = cfg.shootCounterLeanSide >= 0 ? 1 : -1;
+  const upperBodyCounterLean = Number.isFinite(cfg.shootUpperBodyCounterLean)
+    ? Math.max(0, cfg.shootUpperBodyCounterLean)
+    : 1;
+  const plantFeetDuringShot = cfg.plantFeetDuringShot !== false;
   const shotBendZ = (value) => value * bendDirection;
-  const shotCounterLeanX = (value) => value * counterLeanSide;
+  const shotCounterLeanX = (value) => value * counterLeanSide * upperBodyCounterLean;
   const rootWorld = human.root.position.clone();
   rootWorld.y = cfg.groundY;
 
@@ -780,8 +787,27 @@ export function updateHumanPose(human, dt, frameData) {
   const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.058 * t)) * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.unit));
   const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
-  const leftFoot = local(new THREE.Vector3(-0.13 * cfg.unit, cfg.footGroundY, 0.03 * cfg.unit + walk * 0.018 * cfg.unit).lerp(new THREE.Vector3(-cfg.stanceWidth * 0.42, cfg.footGroundY, -0.34 * cfg.unit), t));
-  const rightFoot = local(new THREE.Vector3(0.13 * cfg.unit, cfg.footGroundY, -0.03 * cfg.unit - walk * 0.018 * cfg.unit).lerp(new THREE.Vector3(cfg.stanceWidth * 0.5, cfg.footGroundY, 0.34 * cfg.unit), t));
+  const footWalkBlend = plantFeetDuringShot ? idle : 1;
+  const plantedLeftFootLocal = new THREE.Vector3(
+    -cfg.stanceWidth * 0.42,
+    cfg.footGroundY,
+    -0.34 * cfg.unit
+  );
+  const plantedRightFootLocal = new THREE.Vector3(
+    cfg.stanceWidth * 0.5,
+    cfg.footGroundY,
+    0.34 * cfg.unit
+  );
+  const leftFoot = local(new THREE.Vector3(
+    -0.13 * cfg.unit,
+    cfg.footGroundY,
+    0.03 * cfg.unit + walk * 0.018 * cfg.unit * footWalkBlend
+  ).lerp(plantedLeftFootLocal, t));
+  const rightFoot = local(new THREE.Vector3(
+    0.13 * cfg.unit,
+    cfg.footGroundY,
+    -0.03 * cfg.unit - walk * 0.018 * cfg.unit * footWalkBlend
+  ).lerp(plantedRightFootLocal, t));
 
   const bridgePalmSide = cfg.bridgePoseUsesConfiguredSide
     ? cfg.bridgeHandSide


### PR DESCRIPTION
### Motivation
- Improve the player's shooting animation so the upper body counters (bends) to the opposite side of the cue while feet remain planted, matching reference photos and preventing foot drifting during shots. 
- Make Showood GLB table cloth pattern read smaller so its external cloth textures match Pool Royale procedural cloth texel density.

### Description
- Change shared rig defaults in `shared/humanRigCore.js` to add `shootUpperBodyCounterLean` and `plantFeetDuringShot` and use them when computing torso/chest/neck/head targets so upper body counter-lean is configurable and feet can stay planted during shots. 
- Update the shooting solver to apply the counter-lean scale and to blend foot IK so feet remain on the floor while the upper body bends to the opposite side (`updateHumanPose` adjustments). 
- Apply Pool Royale overrides when creating shooter rigs in `PoolRoyale.jsx` to enable opposite bend, stronger counter-lean and planted feet during aiming/striking. 
- Add `scalePoolRoyaleExternalClothTextureRepeats` and `tableModel.clothRepeatScale` support in `PoolRoyale.jsx` and apply it for external table surfaces so Showood cloth/cushion textures are re-tiled smaller when mounted. 
- Add `clothRepeatScale: 1.55` for the `showood-seven-foot` model in `webapp/src/config/poolRoyaleTableModels.js` and cover it in `test/poolRoyaleTableModels.test.js`.

### Testing
- Ran `npx jest test/poolRoyaleTableModels.test.js --runInBand` and the test suite passed (2 tests). 
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully (Vite build; chunk-size warnings are informational). 
- Downloaded Playwright browsers and OS deps via `npx playwright install chromium` and `npx playwright install-deps chromium` (succeeded). 
- Attempted headless screenshot capture of the running game; environment browser dependencies were installed but a headless capture of the full in-game shot pose timed out in one run (environment/network timings); a lobby screenshot capture succeeded when retried with adjusted launch args.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6605bb8c83299589b1a695c9c6d0)