### PR TITLE
Adjust Showood GLB table integration and human shooting pose

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -12,7 +12,7 @@ describe('Pool Royale table models', () => {
     assert.equal(resolvePoolRoyaleTableModel('unknown').id, 'royal-original');
   });
 
-  test('Showood uses original GLB surface layout with Pool Royale finish textures', () => {
+  test('Showood keeps its own cloth while Pool Royale finishes wood and gold trim', () => {
     const showood = POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
       (option) => option.id === 'showood-seven-foot'
     );
@@ -23,15 +23,11 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.fitScale, 1.035);
     assert.equal(showood.clothRepeatScale, 1.55);
     assert.deepEqual(showood.hideSurfaceRoles, []);
-    assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
-    assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
-      'cloth',
-      'cushion',
-      'wood',
-      'trim',
-      'pocket'
-    ]);
+    assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['cloth', 'cushion', 'pocket']);
+    assert.deepEqual(showood.usePoolRoyaleFinishRoles, ['wood', 'trim']);
+    assert.equal(showood.fitHeightScale, 1.12);
+    assert.equal(showood.externalLowerWoodExpansionScale, 1.08);
+    assert.equal(showood.addGoldLegLevelers, true);
     assert.equal('playfieldVisualLift' in showood, false);
-    assert.equal('fitHeightScale' in showood, false);
   });
 });

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -18,7 +18,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and chrome plates with Pool Royale finish textures.',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping its own cloth/cushion/pocket layout, Pool Royale wood finish only on wooden parts, gold chrome plates, taller base proportions, and rounded gold leg holders.',
     tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
@@ -26,14 +26,17 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     kind: 'gltf',
     fitScale: 1.035,
     clothRepeatScale: 1.55,
+    fitHeightScale: 1.12,
+    externalLowerWoodExpansionScale: 1.08,
+    addGoldLegLevelers: true,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
-    preserveOriginalSurfaceRoles: [],
+    usePoolRoyaleFinishRoles: ['wood', 'trim'],
+    preserveOriginalSurfaceRoles: ['cloth', 'cushion', 'pocket'],
     hideSurfaceRoles: []
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13020,6 +13020,135 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   };
 }
 
+
+function createPoolRoyaleGoldLegLevelerMaterial() {
+  return new THREE.MeshPhysicalMaterial({
+    color: 0xe5b84a,
+    metalness: 0.92,
+    roughness: 0.22,
+    clearcoat: 0.85,
+    clearcoatRoughness: 0.18,
+    envMapIntensity: 1.25
+  });
+}
+
+function expandPoolRoyaleExternalLowerWood(model, tableModel = null) {
+  const expansion = tableModel?.externalLowerWoodExpansionScale ?? 1;
+  if (!model || !Number.isFinite(expansion) || expansion <= 1 + MICRO_EPS) return 0;
+  model.updateMatrixWorld(true);
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return 0;
+  const fullSize = fullBox.getSize(new THREE.Vector3());
+  const lowerLimitY = fullBox.min.y + fullSize.y * 0.46;
+  const center = fullBox.getCenter(new THREE.Vector3());
+  let expanded = 0;
+  model.traverse((child) => {
+    if (!child?.isMesh || child.userData?.poolRoyaleLowerWoodExpanded) return;
+    const material = Array.isArray(child.material) ? child.material[0] : child.material;
+    const role = classifyPoolRoyaleExternalTableSurface(child, material);
+    if (role !== 'wood') return;
+    const name = `${child.name || ''} ${material?.name || ''}`.toLowerCase();
+    if (!/leg|foot|base|support|pedestal|cabinet|frame|apron/.test(name)) return;
+    const childBox = new THREE.Box3().setFromObject(child);
+    if (childBox.isEmpty() || childBox.max.y > lowerLimitY) return;
+    child.scale.x *= expansion;
+    child.scale.z *= expansion;
+    child.position.x = center.x + (child.position.x - center.x) * expansion;
+    child.position.z = center.z + (child.position.z - center.z) * expansion;
+    child.userData = {
+      ...(child.userData || {}),
+      poolRoyaleLowerWoodExpanded: true,
+      poolRoyaleLowerWoodExpansionScale: expansion
+    };
+    expanded += 1;
+  });
+  if (expanded) model.updateMatrixWorld(true);
+  return expanded;
+}
+
+function resolvePoolRoyaleExternalLegLevelerCenters(model) {
+  if (!model) return [];
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return [];
+  const fullSize = fullBox.getSize(new THREE.Vector3());
+  const center = fullBox.getCenter(new THREE.Vector3());
+  const legBoxes = [];
+  const lowLimitY = fullBox.min.y + fullSize.y * 0.5;
+  model.traverse((child) => {
+    if (!child?.isMesh) return;
+    const material = Array.isArray(child.material) ? child.material[0] : child.material;
+    const role = classifyPoolRoyaleExternalTableSurface(child, material);
+    if (role !== 'wood') return;
+    const name = `${child.name || ''} ${material?.name || ''}`.toLowerCase();
+    if (!/leg|foot|base|support|pedestal/.test(name)) return;
+    const box = new THREE.Box3().setFromObject(child);
+    if (box.isEmpty() || box.min.y > lowLimitY) return;
+    legBoxes.push(box);
+  });
+  if (legBoxes.length >= 4) {
+    return legBoxes
+      .map((box) => {
+        const c = box.getCenter(new THREE.Vector3());
+        return { x: c.x, z: c.z, y: box.min.y };
+      })
+      .sort((a, b) => a.y - b.y)
+      .slice(0, 4);
+  }
+  const insetX = Math.max(fullSize.x * 0.32, BALL_R * 4.5);
+  const insetZ = Math.max(fullSize.z * 0.32, BALL_R * 4.5);
+  return [
+    { x: center.x - insetX, z: center.z - insetZ, y: fullBox.min.y },
+    { x: center.x + insetX, z: center.z - insetZ, y: fullBox.min.y },
+    { x: center.x - insetX, z: center.z + insetZ, y: fullBox.min.y },
+    { x: center.x + insetX, z: center.z + insetZ, y: fullBox.min.y }
+  ];
+}
+
+function addPoolRoyaleExternalGoldLegLevelers(model, tableModel = null) {
+  if (!model || !tableModel?.addGoldLegLevelers || model.userData?.poolRoyaleGoldLegLevelersAdded) return 0;
+  model.updateMatrixWorld(true);
+  const centers = resolvePoolRoyaleExternalLegLevelerCenters(model);
+  if (!centers.length) return 0;
+  const bounds = new THREE.Box3().setFromObject(model);
+  const size = bounds.getSize(new THREE.Vector3());
+  const mat = createPoolRoyaleGoldLegLevelerMaterial();
+  const radius = Math.max(BALL_R * 0.42, Math.min(size.x, size.z) * 0.026);
+  const discHeight = Math.max(BALL_R * 0.18, radius * 0.28);
+  const stemHeight = Math.max(BALL_R * 0.28, radius * 0.48);
+  const rubberHeight = Math.max(BALL_R * 0.07, radius * 0.12);
+  const discGeom = new THREE.CylinderGeometry(radius * 0.86, radius, discHeight, 42);
+  const stemGeom = new THREE.CylinderGeometry(radius * 0.36, radius * 0.4, stemHeight, 32);
+  const rubberGeom = new THREE.CylinderGeometry(radius * 0.92, radius * 0.92, rubberHeight, 36);
+  const rubberMat = new THREE.MeshStandardMaterial({ color: 0x090807, roughness: 0.86, metalness: 0.04 });
+  const group = new THREE.Group();
+  group.name = 'PoolRoyale_Showood_GoldLegLevelers';
+  centers.forEach((center, idx) => {
+    const foot = new THREE.Group();
+    foot.name = `PoolRoyale_Showood_GoldLegLeveler_${idx + 1}`;
+    const rubber = new THREE.Mesh(rubberGeom, rubberMat);
+    rubber.position.y = rubberHeight * 0.5;
+    const disc = new THREE.Mesh(discGeom, mat);
+    disc.position.y = rubberHeight + discHeight * 0.5;
+    const stem = new THREE.Mesh(stemGeom, mat);
+    stem.position.y = rubberHeight + discHeight + stemHeight * 0.5 - MICRO_EPS;
+    [rubber, disc, stem].forEach((mesh) => {
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      mesh.userData = { ...(mesh.userData || {}), externalTableKeepVisible: true };
+    });
+    foot.add(rubber, disc, stem);
+    foot.position.set(center.x, center.y - (rubberHeight + discHeight * 0.5), center.z);
+    group.add(foot);
+  });
+  group.userData = { ...(group.userData || {}), externalTableKeepVisible: true };
+  model.add(group);
+  model.userData = {
+    ...(model.userData || {}),
+    poolRoyaleGoldLegLevelersAdded: true
+  };
+  return centers.length;
+}
+
 function mountPoolRoyaleExternalTableModel({
   table,
   tableModel,
@@ -13044,6 +13173,8 @@ function mountPoolRoyaleExternalTableModel({
       if (disposed || !template) return;
       const model = clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo);
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
+      expandPoolRoyaleExternalLowerWood(model, tableModel);
+      addPoolRoyaleExternalGoldLegLevelers(model, tableModel);
       externalRoot.clear();
       externalRoot.add(model);
       setGeneratedVisualsVisible?.(false);
@@ -25573,7 +25704,7 @@ const shotPowerRef = useRef(0);
             rig.group.parent.remove(rig.group);
           }
           if (rig?.human) {
-            [rig.human.root, rig.human.modelRoot, rig.human.fallback].forEach((node) => {
+            [rig.human.root, rig.human.modelRoot, rig.human.bodyPositionHelper, rig.human.fallback].forEach((node) => {
               if (node?.parent) node.parent.remove(node);
             });
           }
@@ -25792,10 +25923,12 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            // Bend the shooting upper body to the opposite side while the IK feet stay planted.
-            shootBendDirection: -1,
+            // Bend the shooting upper body gently toward the cue ball while the IK feet stay planted.
+            shootBendDirection: 1,
             shootCounterLeanSide: -1,
-            shootUpperBodyCounterLean: 1.18,
+            shootUpperBodyCounterLean: 0.92,
+            shootForwardBendScale: 0.58,
+            shootBodyHelperYOffset: 0.018,
             plantFeetDuringShot: true,
             forceTableFacingAim: true,
             poseLambda: HUMAN_POSE_LAMBDA,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -244,6 +244,8 @@ const BASE_CFG = {
   shootBendDirection: -1,
   shootCounterLeanSide: -1,
   shootUpperBodyCounterLean: 1,
+  shootForwardBendScale: 0.72,
+  shootBodyHelperYOffset: 0.02,
   plantFeetDuringShot: true,
   forceTableFacingAim: true
 };
@@ -458,11 +460,14 @@ export function createHumanRig(scene, opts = {}) {
     strikeRoot: new THREE.Vector3(),
     strikeYaw: 0,
     strikeClock: 0,
+    bodyPositionHelper: new THREE.Object3D(),
     cfg
   };
   human.root.visible = false;
   human.modelRoot.visible = false;
-  scene.add(human.root, human.modelRoot);
+  human.bodyPositionHelper.name = 'PoolRoyale_Human_BodyPositionHelper';
+  human.bodyPositionHelper.visible = false;
+  scene.add(human.root, human.modelRoot, human.bodyPositionHelper);
 
   const { loader, modelUrl = HUMAN_URL, onStatus } = opts;
   if (!loader) return human;
@@ -774,7 +779,10 @@ export function updateHumanPose(human, dt, frameData) {
     ? Math.max(0, cfg.shootUpperBodyCounterLean)
     : 1;
   const plantFeetDuringShot = cfg.plantFeetDuringShot !== false;
-  const shotBendZ = (value) => value * bendDirection;
+  const forwardBendScale = Number.isFinite(cfg.shootForwardBendScale)
+    ? Math.max(0.35, Math.min(1.15, cfg.shootForwardBendScale))
+    : 0.72;
+  const shotBendZ = (value) => value * bendDirection * forwardBendScale;
   const shotCounterLeanX = (value) => value * counterLeanSide * upperBodyCounterLean;
   const rootWorld = human.root.position.clone();
   rootWorld.y = cfg.groundY;
@@ -783,6 +791,16 @@ export function updateHumanPose(human, dt, frameData) {
   const chest = local(new THREE.Vector3(shotCounterLeanX(0.07 * t + 0.012 * powerLean) * cfg.unit, lerp(1.52, 1.24, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.42, t) - 0.024 * powerLean) * cfg.unit));
   const neck = local(new THREE.Vector3(shotCounterLeanX(0.105 * t + 0.016 * powerLean) * cfg.unit, lerp(1.68, 1.28, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.61, t) - 0.028 * powerLean) * cfg.unit));
   const head = local(new THREE.Vector3(shotCounterLeanX(0.12 * t + 0.018 * powerLean) * cfg.unit, lerp(1.84, 1.37, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.16 * t, shotBendZ(lerp(0.04, -0.72, t) - 0.028 * powerLean) * cfg.unit));
+  if (human.bodyPositionHelper) {
+    const helperTarget = chest.clone()
+      .lerp(neck, 0.42)
+      .addScaledVector(side, shotCounterLeanX(0.018 * t) * cfg.unit)
+      .addScaledVector(UP, (cfg.shootBodyHelperYOffset ?? 0.02) * cfg.unit * t);
+    human.bodyPositionHelper.position.copy(helperTarget);
+    human.bodyPositionHelper.quaternion.setFromRotationMatrix(
+      new THREE.Matrix4().lookAt(helperTarget, helperTarget.clone().add(forward), UP)
+    );
+  }
   const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.075 * t)) * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.46, t) - 0.018 * human.settleT) * cfg.unit));
   const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.058 * t)) * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.unit));
   const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));


### PR DESCRIPTION
### Motivation
- Keep the Showood GLB's original cloth/cushion/pocket materials instead of forcing procedural cloth, while applying Pool Royale finishes only to the wooden and trim parts for correct visuals. 
- Improve Showood base visuals by slightly increasing base height/footprint and adding rounded gold leg holders so the external model reads consistently with Pool Royale styling. 
- Reduce and redirect the human shooting bend so the avatar leans a bit toward the cue ball (not backward), keeps feet planted, and provides a helper target for accurate torso alignment when the cue camera is lowered.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to change the `showood-seven-foot` table options to preserve GLB `cloth/cushion/pocket`, apply Pool Royale finishes only to `wood` and `trim`, and add `fitHeightScale`, `externalLowerWoodExpansionScale`, and `addGoldLegLevelers` flags. 
- Added external-table helpers in `webapp/src/pages/Games/PoolRoyale.jsx`: `expandPoolRoyaleExternalLowerWood`, `resolvePoolRoyaleExternalLegLevelerCenters`, `addPoolRoyaleExternalGoldLegLevelers`, and a gold `createPoolRoyaleGoldLegLevelerMaterial`, and invoked them during external GLTF mount so the base expands and rounded gold leg levelers are generated. 
- Modified `webapp/src/pages/Games/shared/humanRigCore.js` to add a `bodyPositionHelper`, expose `shootForwardBendScale` and `shootBodyHelperYOffset` in the human config, and use the helper to position a torso target; this file also lowers the strength and reverses the shooting bend so the upper body leans slightly toward the cue ball. 
- Integrated the human helper into the Pool Royale scene lifecycle by adding the helper to player character creation and ensuring it is removed in `disposePlayerCharacters` in `PoolRoyale.jsx`. 
- Updated the unit test `test/poolRoyaleTableModels.test.js` to assert the new `showood-seven-foot` configuration (preserved cloth, finish roles limited to `wood`/`trim`, and new fit/leveler flags). 

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and the modified test suite passed. 
- Built the web client with `npm run build --prefix webapp` and the Vite production build completed successfully. 
- Ran a repository consistency check (`git diff --check`) with no issues; an attempted Playwright portrait screenshot to verify the runtime visual failed due to environment/browser timeout so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc80f964548329aa977331a3235495)