### PR TITLE
Refine Showood external table finish and human shooting pose

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -18,7 +18,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and chrome plates with Pool Royale finish textures.',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and chrome plates with its own cloth/cushion materials, Pool Royale wood finish only on wood, and gold showroom metal plates.',
     tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
@@ -32,8 +32,12 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
-    preserveOriginalSurfaceRoles: [],
+    usePoolRoyaleFinishRoles: ['wood'],
+    preserveOriginalSurfaceRoles: ['cloth', 'cushion', 'pocket'],
+    forceGoldTrim: true,
+    externalBaseHeightScale: 1.16,
+    externalBaseBottomExpansion: 1.08,
+    addGeneratedGoldLevelers: true,
     hideSurfaceRoles: []
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12716,6 +12716,15 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
   const shouldUsePoolRoyaleFinish = !finishRoles || finishRoles.includes(role);
   if (!shouldUsePoolRoyaleFinish || preserveRoles.includes(role)) {
     const originalMat = material.clone ? material.clone() : material;
+    if (role === 'trim' && tableModel?.forceGoldTrim && originalMat.color) {
+      originalMat.color.set(0xd4af37);
+      originalMat.metalness = Math.max(originalMat.metalness ?? 0, 0.92);
+      originalMat.roughness = Math.min(originalMat.roughness ?? 0.16, 0.16);
+      originalMat.clearcoat = Math.max(originalMat.clearcoat ?? 0, 0.5);
+      originalMat.clearcoatRoughness = Math.min(originalMat.clearcoatRoughness ?? 0.06, 0.06);
+      originalMat.envMapIntensity = Math.max(originalMat.envMapIntensity ?? 0, 0.72);
+      enhanceChromeMaterial(originalMat);
+    }
     preparePoolRoyaleExternalTexture(originalMat.map, true);
     preparePoolRoyaleExternalTexture(originalMat.emissiveMap, true);
     preparePoolRoyaleExternalTexture(originalMat.aoMap, false);
@@ -12764,6 +12773,14 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
     };
   } else if (role === 'trim') {
     copyMaterialLook(materials.trim);
+    if (tableModel?.forceGoldTrim && mat.color) {
+      mat.color.set(0xd4af37);
+      mat.metalness = Math.max(mat.metalness ?? 0, 0.92);
+      mat.roughness = Math.min(mat.roughness ?? 0.16, 0.16);
+      mat.clearcoat = Math.max(mat.clearcoat ?? 0, 0.5);
+      mat.clearcoatRoughness = Math.min(mat.clearcoatRoughness ?? 0.06, 0.06);
+      mat.envMapIntensity = Math.max(mat.envMapIntensity ?? 0, 0.72);
+    }
     enhanceChromeMaterial(mat);
   } else if (role === 'pocket') {
     copyMaterialLook(materials.pocketJaw ?? materials.pocketRim);
@@ -13020,6 +13037,102 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   };
 }
 
+
+function tunePoolRoyaleExternalShowoodBase(model, tableModel = null) {
+  if (!model) return;
+  const baseHeightScale = Number.isFinite(tableModel?.externalBaseHeightScale)
+    ? Math.max(1, tableModel.externalBaseHeightScale)
+    : 1;
+  const bottomExpansion = Number.isFinite(tableModel?.externalBaseBottomExpansion)
+    ? Math.max(1, tableModel.externalBaseBottomExpansion)
+    : 1;
+  if (baseHeightScale <= 1 + MICRO_EPS && bottomExpansion <= 1 + MICRO_EPS) return;
+
+  model.updateMatrixWorld(true);
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return;
+  const fullHeight = Math.max(MICRO_EPS, fullBox.max.y - fullBox.min.y);
+  const lowerCutoff = fullBox.min.y + fullHeight * 0.42;
+  const center = fullBox.getCenter(new THREE.Vector3());
+
+  model.traverse((child) => {
+    if (!child?.isMesh) return;
+    const material = Array.isArray(child.material) ? child.material[0] : child.material;
+    const role = classifyPoolRoyaleExternalTableSurface(child, material);
+    if (role !== 'wood') return;
+    const childBox = new THREE.Box3().setFromObject(child);
+    if (childBox.isEmpty() || childBox.min.y > lowerCutoff) return;
+    child.position.y = fullBox.min.y + (child.position.y - fullBox.min.y) * baseHeightScale;
+    if (bottomExpansion > 1 + MICRO_EPS) {
+      const lowFactor = THREE.MathUtils.clamp((lowerCutoff - childBox.min.y) / (fullHeight * 0.42), 0, 1);
+      const expansion = THREE.MathUtils.lerp(1, bottomExpansion, lowFactor);
+      child.position.x = center.x + (child.position.x - center.x) * expansion;
+      child.position.z = center.z + (child.position.z - center.z) * expansion;
+      child.scale.x *= expansion;
+      child.scale.z *= expansion;
+    }
+    child.updateMatrixWorld(true);
+  });
+}
+
+function addPoolRoyaleExternalGoldLevelers(model, tableModel = null) {
+  if (!model || !tableModel?.addGeneratedGoldLevelers) return;
+  model.updateMatrixWorld(true);
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return;
+  const size = fullBox.getSize(new THREE.Vector3());
+  const radius = Math.max(Math.min(size.x, size.z) * 0.035, BALL_R * 0.42);
+  const height = Math.max(radius * 0.22, BALL_R * 0.18);
+  const stemRadius = radius * 0.38;
+  const stemHeight = height * 1.45;
+  const rubberHeight = height * 0.26;
+  const insetX = size.x * 0.18;
+  const insetZ = size.z * 0.18;
+  const centers = [
+    [fullBox.min.x + insetX, fullBox.min.z + insetZ],
+    [fullBox.max.x - insetX, fullBox.min.z + insetZ],
+    [fullBox.min.x + insetX, fullBox.max.z - insetZ],
+    [fullBox.max.x - insetX, fullBox.max.z - insetZ]
+  ];
+  const goldMat = new THREE.MeshPhysicalMaterial({
+    color: 0xd4af37,
+    metalness: 0.92,
+    roughness: 0.16,
+    clearcoat: 0.62,
+    clearcoatRoughness: 0.08,
+    envMapIntensity: 0.88
+  });
+  enhanceChromeMaterial(goldMat);
+  const rubberMat = new THREE.MeshStandardMaterial({
+    color: 0x090909,
+    roughness: 0.85,
+    metalness: 0.08,
+    envMapIntensity: 0.05
+  });
+  const discGeo = new THREE.CylinderGeometry(radius * 0.84, radius, height, 42);
+  const stemGeo = new THREE.CylinderGeometry(stemRadius, stemRadius * 1.02, stemHeight, 26);
+  const rubberGeo = new THREE.CylinderGeometry(radius * 1.03, radius * 1.03, rubberHeight, 34);
+  const levelerGroup = new THREE.Group();
+  levelerGroup.name = 'pool-royale-showood-gold-leg-levelers';
+  centers.forEach(([x, z]) => {
+    const group = new THREE.Group();
+    group.position.set(x, fullBox.min.y - height * 0.5, z);
+    const rubber = new THREE.Mesh(rubberGeo, rubberMat);
+    rubber.position.y = rubberHeight * 0.5 - height * 0.5 - rubberHeight;
+    const disc = new THREE.Mesh(discGeo, goldMat);
+    disc.position.y = 0;
+    const stem = new THREE.Mesh(stemGeo, goldMat);
+    stem.position.y = height * 0.5 + stemHeight * 0.5 - MICRO_EPS;
+    [rubber, disc, stem].forEach((mesh) => {
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+    });
+    group.add(rubber, disc, stem);
+    levelerGroup.add(group);
+  });
+  model.add(levelerGroup);
+}
+
 function mountPoolRoyaleExternalTableModel({
   table,
   tableModel,
@@ -13044,6 +13157,8 @@ function mountPoolRoyaleExternalTableModel({
       if (disposed || !template) return;
       const model = clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo);
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
+      tunePoolRoyaleExternalShowoodBase(model, tableModel);
+      addPoolRoyaleExternalGoldLevelers(model, tableModel);
       externalRoot.clear();
       externalRoot.add(model);
       setGeneratedVisualsVisible?.(false);
@@ -25792,10 +25907,13 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            // Bend the shooting upper body to the opposite side while the IK feet stay planted.
-            shootBendDirection: -1,
+            // Keep the shooting upper body controlled while the IK feet stay planted.
+            // Use a small body-position helper in the shared rig so the player leans
+            // toward the cue ball (not backward) and keeps the bend subtle in portrait aim view.
+            shootBendDirection: 1,
             shootCounterLeanSide: -1,
-            shootUpperBodyCounterLean: 1.18,
+            shootUpperBodyCounterLean: 0.72,
+            shootForwardBendScale: 0.56,
             plantFeetDuringShot: true,
             forceTableFacingAim: true,
             poseLambda: HUMAN_POSE_LAMBDA,
@@ -25810,9 +25928,9 @@ const shotPowerRef = useRef(0);
             perimeterWalk: true,
             perimeterWalkSpeed: 4.0 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             stanceWidth: 0.52 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            bridgePalmTableLift: 0.006 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            bridgePalmTableLift: 0.002 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             chinToCueHeight: 0.11 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            footGroundY: 0.02 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            footGroundY: 0,
             footLockStrength: 1.25,
             kneeBendShot: 0.16 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             desiredShootDistance: 1.32 * POOL_ROYALE_HUMAN_UNIT_SCALE,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -244,6 +244,7 @@ const BASE_CFG = {
   shootBendDirection: -1,
   shootCounterLeanSide: -1,
   shootUpperBodyCounterLean: 1,
+  shootForwardBendScale: 1,
   plantFeetDuringShot: true,
   forceTableFacingAim: true
 };
@@ -774,7 +775,10 @@ export function updateHumanPose(human, dt, frameData) {
     ? Math.max(0, cfg.shootUpperBodyCounterLean)
     : 1;
   const plantFeetDuringShot = cfg.plantFeetDuringShot !== false;
-  const shotBendZ = (value) => value * bendDirection;
+  const forwardBendScale = Number.isFinite(cfg.shootForwardBendScale)
+    ? THREE.MathUtils.clamp(cfg.shootForwardBendScale, 0.25, 1.25)
+    : 1;
+  const shotBendZ = (value) => value * bendDirection * forwardBendScale;
   const shotCounterLeanX = (value) => value * counterLeanSide * upperBodyCounterLean;
   const rootWorld = human.root.position.clone();
   rootWorld.y = cfg.groundY;
@@ -812,7 +816,10 @@ export function updateHumanPose(human, dt, frameData) {
   const bridgePalmSide = cfg.bridgePoseUsesConfiguredSide
     ? cfg.bridgeHandSide
     : -0.012 * cfg.unit;
-  const bridgePalmTarget = frameData.bridgeTarget.clone()
+  const bridgeAimHelper = frameData.bridgeTarget.clone()
+    .lerp(frameData.cueTip || frameData.bridgeTarget, 0.18 * t);
+  bridgeAimHelper.y = cfg.tableTopY + cfg.bridgePalmTableLift;
+  const bridgePalmTarget = bridgeAimHelper
     .addScaledVector(forward, -0.006 * cfg.unit * t)
     .addScaledVector(side, bridgePalmSide * t)
     .setY(cfg.tableTopY + cfg.bridgePalmTableLift)


### PR DESCRIPTION
### Motivation
- Improve player pose and bridge hand placement during low/portrait cue-camera shots so the avatar bends less and leans toward the cue ball while keeping feet planted.  
- Allow the Showood GLTF table model to keep its own cloth/cushion materials while applying Pool Royale wood finish only to wooden parts and ensuring showroom gold trim and taller base/rounded leg holders match the procedural table look.  

### Description
- Added a new rig parameter `shootForwardBendScale` and applied it in the shared human pose solver so the forward/backward bend strength can be tuned per-table or per-rig (`webapp/src/pages/Games/shared/humanRigCore.js`).  
- Introduced a bridge-hand helper target that lerps the bridge palm toward the cue line/cue tip and pins its Y to `tableTopY + bridgePalmTableLift` so the left hand sits on the table closer to the cue ball (`humanRigCore.js`).  
- Updated Pool Royale local rig defaults to reduce backward bend, lower the bridge palm, and place feet at ground level by changing `shootBendDirection`, `shootUpperBodyCounterLean`, `shootForwardBendScale`, `bridgePalmTableLift`, and `footGroundY` in the Pool Royale rig instantiation (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- Added Showood table model options to preserve external cloth/cushion/pocket materials while applying Pool Royale finish only to wood and forcing gold trim, and added configuration flags for scaling/expanding the external base and generating gold leg levelers (`webapp/src/config/poolRoyaleTableModels.js`).  
- Implemented external-table post-processing helpers `tunePoolRoyaleExternalShowoodBase` and `addPoolRoyaleExternalGoldLevelers` and wired them into the external model mounting flow so a Showood GLTF receives the base height/footprint tuning and gold rounded leg holders on load (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- When preserving original external roles, trim materials are optionally coerced to a gold showroom look (color + physical params) so chrome plates on the Showood model appear gold while wood stays under Pool Royale finish (`PoolRoyale.jsx`).  

### Testing
- Built the web app with `npm --prefix webapp run build` and the Vite production build completed successfully (only existing chunking warnings reported).  
- Ran the repository linter command but it surfaced many pre-existing lint issues across the repo and therefore reported failures; the changes themselves target the game code and are syntactically valid (lint failures were due to global/ignored/generated files).  
- Attempted an automated headless screenshot via Playwright to validate the human + Showood table scene, but the run failed because Playwright Chromium could not launch in this environment due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc80f964548329aa977331a3235495)