### PR TITLE
Adjust Showood table cloth tiling and preserve original chrome plates

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -18,14 +18,14 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and chrome plates with Pool Royale finish textures.',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and preserved Showood chrome plates.',
     tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.035,
-    clothRepeatScale: 1.55,
+    clothRepeatScale: 3.2,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
@@ -33,7 +33,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
-    preserveOriginalSurfaceRoles: [],
+    preserveOriginalSurfaceRoles: ['trim'],
     hideSurfaceRoles: []
   }
 ]);


### PR DESCRIPTION
### Motivation
- Make the Showood GLB look correct in Pool Royale by shrinking the visible cloth pattern and keeping the model's original chrome trim instead of replacing it with Pool Royale chrome.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to increase `clothRepeatScale` from `1.55` to `3.2`, add `preserveOriginalSurfaceRoles: ['trim']` and tweak the description to document preserved Showood chrome plates.

### Testing
- Ran `git diff --check`, `npm run build`, `npx playwright install chromium`, `npx playwright install-deps chromium` and captured a Playwright screenshot of the Pool Royale lobby (saved as `/workspace/pool-royale-showood-lobby.png`), all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8df0297083299902fd93bb167bc0)