### PR TITLE
Tune Snake & Ladder seating and dice roll

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -56,8 +56,8 @@ const AI_CHAIR_GAP = CARD_W * 0.74;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 // Portrait calibration: push the chair ring slightly outward while the human anchors move closer to the table.
-const CHAIR_GLOBAL_PUSHBACK = 0.48 * MODEL_SCALE;
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.5 * MODEL_SCALE;
+const CHAIR_GLOBAL_PUSHBACK = 0.56 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.58 * MODEL_SCALE;
 const TABLE_HEIGHT_LIFT = -0.045 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
@@ -174,9 +174,9 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.82;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
 const SEATED_HUMAN_SEAT_Y_OFFSET = -5.6 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.48;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.54;
 // Portrait calibration: keep all seated humans pulled visibly inward toward the table on phone screens.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.03;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.05;
 const SEATED_HUMAN_WEAPON_RIGHT_HAND_X = SEAT_WIDTH * 0.47;
 const SEATED_HUMAN_WEAPON_SIDE_Z = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
@@ -256,8 +256,8 @@ const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
-// Keep Snake dice pacing and bounce aligned with Pool Royale's break-dice roll configuration.
-const DICE_ROLL_DURATION = 940;
+// Keep Snake dice pacing and bounce aligned with Ludo Battle Royal's dice roll configuration.
+const DICE_ROLL_DURATION = 900;
 const DICE_SETTLE_DURATION = 240;
 const DICE_RESULT_HOLD_DURATION = 720;
 const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.78;
@@ -3391,12 +3391,10 @@ function createDiceRollAnimation(
   {
     basePositions,
     baseY,
-    startPositions = [],
-    bouncePoints = []
+    startPositions = []
   }
 ) {
   const start = performance.now();
-  const rollSplit = 0.58;
   const spinVectors = diceArray.map(() =>
     new THREE.Vector3(
       1.2 + Math.random() * 0.7,
@@ -3405,37 +3403,30 @@ function createDiceRollAnimation(
     )
   );
   const wobbleVectors = diceArray.map(
-    () => new THREE.Vector3((Math.random() - 0.5) * DICE_SIZE * 1.35, 0, (Math.random() - 0.5) * DICE_SIZE * 1.35)
+    () => new THREE.Vector3((Math.random() - 0.5) * DICE_SIZE * 2.2, 0, (Math.random() - 0.5) * DICE_SIZE * 2.2)
   );
 
   return {
     type: 'diceRoll',
     update: (now) => {
-      const t = Math.min((now - start) / Math.max(1, DICE_ROLL_DURATION), 1);
+      const t = Math.min(1, (now - start) / Math.max(1, DICE_ROLL_DURATION));
       const eased = easeOutCubic(t);
       diceArray.forEach((die, index) => {
         const base = basePositions[index];
         if (!base) return;
         const startPos = startPositions[index] ?? base;
-        const bouncePos = bouncePoints[index] ?? startPos.clone().lerp(base, 0.58);
-        const firstLeg = eased < rollSplit;
-        const legT = firstLeg ? smootherstep01(eased / rollSplit) : smootherstep01((eased - rollSplit) / (1 - rollSplit));
-        const from = firstLeg ? startPos : bouncePos;
-        const to = firstLeg ? bouncePos : base;
-        const position = from.clone().lerp(to, legT);
+        const endPos = new THREE.Vector3(base.x, baseY, base.z);
+        const position = startPos.clone().lerp(endPos, eased);
         const wobbleStrength = Math.sin(eased * Math.PI);
-        position.addScaledVector(wobbleVectors[index], wobbleStrength * 0.32);
-        const hopArc = Math.sin(legT * Math.PI);
-        const hopHeight = firstLeg ? DICE_THROW_HEIGHT * 0.34 : DICE_BOUNCE_HEIGHT * 0.9;
-        position.y = THREE.MathUtils.lerp(from.y, firstLeg ? bouncePos.y : baseY, legT) + hopArc * hopHeight * (1 - eased * 0.34);
+        position.addScaledVector(wobbleVectors[index], wobbleStrength * 0.45);
+        const bounce = Math.sin(Math.min(1, eased * 1.25) * Math.PI) * DICE_BOUNCE_HEIGHT * (1 - eased * 0.45);
+        position.y = THREE.MathUtils.lerp(startPos.y, endPos.y, eased) + bounce;
         die.position.copy(position);
 
-        const travelDistance = Math.max(DICE_SIZE, from.distanceTo(to));
-        const rollAmount = (travelDistance / Math.max(DICE_SIZE * 0.5, 0.001)) * (firstLeg ? 0.17 : 0.13);
         const spinFactor = 1 - eased * 0.28;
-        die.rotation.x += spinVectors[index].x * spinFactor * rollAmount;
-        die.rotation.y += spinVectors[index].y * spinFactor * rollAmount;
-        die.rotation.z += spinVectors[index].z * spinFactor * rollAmount;
+        die.rotation.x += spinVectors[index].x * spinFactor * 0.22;
+        die.rotation.y += spinVectors[index].y * spinFactor * 0.22;
+        die.rotation.z += spinVectors[index].z * spinFactor * 0.22;
       });
       if (t >= 1) {
         diceArray.forEach((die, index) => {
@@ -7114,10 +7105,6 @@ export default function SnakeBoard3D({
       const centerOffset = (count - 1) / 2;
       const basePositions = [];
       const startPositions = [];
-      const travelVectors = [];
-      const bouncePoints = [];
-      const retreatVectors = [];
-      const edgeNormals = [];
       let visibleIndex = 0;
       diceSet.forEach((die, index) => {
         const visible = index < count;
@@ -7126,20 +7113,10 @@ export default function SnakeBoard3D({
         const fallbackBase = new THREE.Vector3((index - centerOffset) * spacing, diceBaseY, diceAnchorZ);
         const base = layout.basePositions?.[visibleIndex] ?? fallbackBase;
         const start = layout.startPositions?.[visibleIndex] ?? base.clone();
-        const travel = layout.travelVectors?.[visibleIndex] ?? base.clone().sub(start);
-        const bounce = layout.bouncePoints?.[visibleIndex] ?? base.clone();
-        const retreat = layout.retreatVectors?.[visibleIndex] ?? base.clone().sub(bounce);
-        const normal = layout.edgeNormals?.[visibleIndex]
-          ? layout.edgeNormals[visibleIndex].clone()
-          : new THREE.Vector3(0, 0, 0);
         die.position.copy(start);
         die.rotation.set(Math.random() * Math.PI, Math.random() * Math.PI, Math.random() * Math.PI);
         basePositions.push(base.clone());
         startPositions.push(start.clone());
-        travelVectors.push(travel.clone());
-        bouncePoints.push(bounce.clone());
-        retreatVectors.push(retreat.clone());
-        edgeNormals.push(normal);
         visibleIndex += 1;
       });
       diceStateRef.current = {
@@ -7175,8 +7152,7 @@ export default function SnakeBoard3D({
         const rollAnimation = createDiceRollAnimation(active, {
           basePositions,
           baseY: diceBaseY,
-          startPositions,
-          bouncePoints
+          startPositions
         });
         if (rollAnimation) animationsRef.current.push(rollAnimation);
       }


### PR DESCRIPTION
### Motivation
- Improve portrait UX by moving human characters visually closer to the table while pushing chairs slightly outward so the scene reads better on phone screens.
- Make the Snake & Ladder dice feel consistent with the Ludo Battle Royal roll behavior used elsewhere in the app.
- Reduce unused two-stage dice path plumbing and simplify the dice start/roll flow for more predictable animation logic.

### Description
- Increased chair radial pushback via `CHAIR_GLOBAL_PUSHBACK` and `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` to move the chair ring farther from the table in portrait contexts in `webapp/src/components/SnakeBoard3D.jsx`.
- Pulled seated humans inward by adjusting `SEATED_HUMAN_SEAT_Z_OFFSET` and `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` so characters appear closer to the table on portrait screens.
- Aligned dice timing and motion to the Ludo roll by changing `DICE_ROLL_DURATION` and replacing the prior two-stage roll path with a simpler eased travel + wobble + bounce + spin implementation inside `createDiceRollAnimation`.
- Removed unused travel/bounce/retreat arrays from the dice start setup and simplified the roll invocation so only `basePositions` and `startPositions` are passed to the roll animation.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite chunk-size warnings only).
- Ran `npx playwright install chromium` and `npx playwright install-deps chromium` to prepare browser automation, both completed successfully.
- Attempted an automated Playwright screenshot of the running `/games/snake` page to visually validate portrait layout, but the screenshot capture timed out when rendering the WebGL scene (page/font timing), so visual confirmation was not captured by the script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9589667c8329b022f5ddecc630f3)