### PR TITLE
Adjust Snake & Ladder table layout, dice motion, and weapon parking

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -56,8 +56,8 @@ const AI_CHAIR_GAP = CARD_W * 0.74;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 // Portrait calibration: push the chair ring slightly outward while the human anchors move closer to the table.
-const CHAIR_GLOBAL_PUSHBACK = 0.56 * MODEL_SCALE;
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.58 * MODEL_SCALE;
+const CHAIR_GLOBAL_PUSHBACK = 0.62 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.64 * MODEL_SCALE;
 const TABLE_HEIGHT_LIFT = -0.045 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
@@ -174,9 +174,9 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.82;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
 const SEATED_HUMAN_SEAT_Y_OFFSET = -5.6 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.53;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.58;
 // Portrait calibration: keep all seated humans pulled visibly inward toward the table on phone screens.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.06;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.08;
 const SEATED_HUMAN_WEAPON_RIGHT_HAND_X = SEAT_WIDTH * 0.47;
 const SEATED_HUMAN_WEAPON_SIDE_Z = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
@@ -260,7 +260,7 @@ const DICE_FACE_INSET = DICE_SIZE * 0.064;
 const DICE_ROLL_DURATION = 1100;
 const DICE_SETTLE_DURATION = 240;
 const DICE_RESULT_HOLD_DURATION = 720;
-const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.78;
+const DICE_BOUNCE_HEIGHT = 0.06;
 const DICE_THROW_LANDING_MARGIN = TILE_SIZE * 1.8;
 const DICE_THROW_START_EXTRA = TILE_SIZE * 3.6;
 const DICE_THROW_HEIGHT = DICE_SIZE * 0.78;
@@ -3403,7 +3403,8 @@ function createDiceRollAnimation(
     )
   );
   const wobbleVectors = diceArray.map(
-    () => new THREE.Vector3((Math.random() - 0.5) * DICE_SIZE * 1.25, 0, (Math.random() - 0.5) * DICE_SIZE * 1.25)
+    // Match Ludo Battle Royal's spinDice wobble magnitude exactly.
+    () => new THREE.Vector3((Math.random() - 0.5) * 0.16, 0, (Math.random() - 0.5) * 0.16)
   );
 
   return {
@@ -5954,62 +5955,53 @@ function updateSeatWeaponDisplays(board, players = []) {
       holder.add(createSeatWeaponMesh(parkedWeaponType, { parkingPose: isVehicleWeapon ? 'flat' : 'vertical' }));
       holder.userData.weaponType = parkedWeaponType;
     }
-    const weaponAnchor = !isVehicleWeapon ? board.weaponAnchors?.[seatIndex] : null;
-    const weaponParent = board.weaponDisplayGroup.parent || board.boardRoot || null;
-    if (weaponAnchor && weaponParent) {
-      const chairSideWorld = new THREE.Vector3();
-      weaponAnchor.getWorldPosition(chairSideWorld);
-      chairSideWorld.y = SEATED_HUMAN_GROUND_Y;
-      weaponParent.worldToLocal(chairSideWorld);
-      holder.position.copy(chairSideWorld);
-    } else {
-      const railLayout = getSeatSideParkingLayout(board, seatIndex, board.weaponDisplayGroup);
-      if (railLayout) {
-        const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
-        const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
-        const portraitShift = WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? null;
+    // Keep every parked weapon on the tabletop parking slots instead of attaching firearms to chair-side hands.
+    const railLayout = getSeatSideParkingLayout(board, seatIndex, board.weaponDisplayGroup);
+    if (railLayout) {
+      const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
+      const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
+      const portraitShift = WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? null;
+      holder.position
+        .copy(railLayout.railLocal)
+        .addScaledVector(
+          railLayout.lateral,
+          sideSign * SEAT_RAIL_SLOT_OFFSET * WEAPON_SLOT_CLUSTER_SCALE +
+            lateralNudge +
+            WEAPON_RIGHT_HAND_SIDE_OFFSET
+        )
+        .addScaledVector(
+          railLayout.seatDirection,
+          WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)
+        );
+      if (portraitShift) {
         holder.position
-          .copy(railLayout.railLocal)
-          .addScaledVector(
-            railLayout.lateral,
-            sideSign * SEAT_RAIL_SLOT_OFFSET * WEAPON_SLOT_CLUSTER_SCALE +
-              lateralNudge +
-              WEAPON_RIGHT_HAND_SIDE_OFFSET
-          )
-          .addScaledVector(
-            railLayout.seatDirection,
-            WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)
-          );
-        if (portraitShift) {
-          holder.position
-            .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
-            .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
-        }
-        holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
-        holder.position.y += PARKING_VERTICAL_LIFT;
-        const radialFromCenter = holder.position.clone().sub(boardLookTarget).setY(0);
-        const minClearance = BOARD_RADIUS + WEAPON_MIN_BOARD_CLEARANCE;
-        if (radialFromCenter.length() < minClearance) {
-          radialFromCenter.normalize().multiplyScalar(minClearance);
-          holder.position.x = boardLookTarget.x + radialFromCenter.x;
-          holder.position.z = boardLookTarget.z + radialFromCenter.z;
-        }
-      } else {
-        const seatWorld = new THREE.Vector3();
-        anchor.getWorldPosition(seatWorld);
-        const seatDirection = seatWorld.clone().sub(boardLookTarget).setY(0);
-        if (seatDirection.lengthSq() < 1e-6) continue;
-        seatDirection.normalize();
-        const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
-        const radius = TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.16;
-        const markerPos = boardLookTarget
-          .clone()
-          .addScaledVector(seatDirection, radius)
-          .addScaledVector(lateral, (seatIndex % 2 === 0 ? 1 : -1) * TOKEN_RADIUS * 0.22);
-        holder.position.copy(markerPos);
-        holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
-        holder.position.y = (board.baseLevelTop ?? 0) + WEAPON_PARKING_Y_FROM_GROUND_FLOOR + PARKING_VERTICAL_LIFT;
+          .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
+          .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
       }
+      holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
+      holder.position.y += PARKING_VERTICAL_LIFT;
+      const radialFromCenter = holder.position.clone().sub(boardLookTarget).setY(0);
+      const minClearance = BOARD_RADIUS + WEAPON_MIN_BOARD_CLEARANCE;
+      if (radialFromCenter.length() < minClearance) {
+        radialFromCenter.normalize().multiplyScalar(minClearance);
+        holder.position.x = boardLookTarget.x + radialFromCenter.x;
+        holder.position.z = boardLookTarget.z + radialFromCenter.z;
+      }
+    } else {
+      const seatWorld = new THREE.Vector3();
+      anchor.getWorldPosition(seatWorld);
+      const seatDirection = seatWorld.clone().sub(boardLookTarget).setY(0);
+      if (seatDirection.lengthSq() < 1e-6) continue;
+      seatDirection.normalize();
+      const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
+      const radius = TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.16;
+      const markerPos = boardLookTarget
+        .clone()
+        .addScaledVector(seatDirection, radius)
+        .addScaledVector(lateral, (seatIndex % 2 === 0 ? 1 : -1) * TOKEN_RADIUS * 0.22);
+      holder.position.copy(markerPos);
+      holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
+      holder.position.y = (board.baseLevelTop ?? 0) + WEAPON_PARKING_Y_FROM_GROUND_FLOOR + PARKING_VERTICAL_LIFT;
     }
     const lookAwayDirection = holder.position.clone().sub(boardLookTarget).setY(0);
     if (lookAwayDirection.lengthSq() < 1e-6) lookAwayDirection.set(0, 0, 1);


### PR DESCRIPTION
### Motivation

- Improve portrait-screen composition by bringing seated humans visually closer to the table while moving chairs slightly outward so characters read better on phone screens.
- Make the Snake dice roll match the feel used in Ludo Battle Royal for consistent UX by reusing the same single-arc spin/wobble behaviour.
- Restore parked weapons to fixed tabletop parking slots so weapon models appear in their original table locations instead of being attached to chair-side hand anchors.

### Description

- Adjusted portrait calibration constants in `webapp/src/components/SnakeBoard3D.jsx` by increasing `CHAIR_GLOBAL_PUSHBACK` and `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` and pulling seated humans inward via `SEATED_HUMAN_SEAT_Z_OFFSET` and `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` to visually move characters closer to the table.
- Aligned dice motion with Ludo Battle Royal by lowering/standardizing the dice bounce to `DICE_BOUNCE_HEIGHT = 0.06` and replacing large size-based wobble vectors with the same fixed-wobble magnitude used by Ludo (`0.16`) inside the dice roll animation helpers in `SnakeBoard3D.jsx`.
- Updated `updateSeatWeaponDisplays` in `SnakeBoard3D.jsx` so parked weapons are placed on tabletop parking slots (`getSeatSideParkingLayout`) instead of being positioned from chair-side `weaponAnchor` world positions, keeping weapons visually on the table.
- Removed an accidental duplicate local variable initialization and cleaned up layout/indentation in the affected block to keep the function flow clearer.

### Testing

- Ran `npm --prefix webapp run build` which completed successfully and produced the production `dist/` output.
- Started the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1` which came up (Vite served at `http://127.0.0.1:5173/`).
- Installed Playwright browsers with `npx playwright install chromium` and system deps with `npx playwright install-deps chromium`, both of which completed successfully.
- Attempted an automated headless WebGL screenshot; full WebGL rendering in headless Chromium had environment-related issues/timeouts (native headless libs and headless rendering in CI), but a UI smoke screenshot with the canvas hidden was captured as a fallback to verify UI placement.
- Ran `git diff --check` to verify no trailing whitespace or basic diff issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9e5cd5488329b6fc979c43eceaa0)