### PR TITLE
Tune Snake & Ladder seating, dice roll, and weapon parking

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -58,6 +58,7 @@ const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 // Portrait calibration: push the chair ring slightly outward while the human anchors move closer to the table.
 const CHAIR_GLOBAL_PUSHBACK = 0.56 * MODEL_SCALE;
 const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.58 * MODEL_SCALE;
+const CHAIR_MODEL_AWAY_FROM_TABLE_OFFSET = SEAT_DEPTH * 0.1;
 const TABLE_HEIGHT_LIFT = -0.045 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
@@ -174,9 +175,9 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.82;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
 const SEATED_HUMAN_SEAT_Y_OFFSET = -5.6 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.53;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.59;
 // Portrait calibration: keep all seated humans pulled visibly inward toward the table on phone screens.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.06;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.08;
 const SEATED_HUMAN_WEAPON_RIGHT_HAND_X = SEAT_WIDTH * 0.47;
 const SEATED_HUMAN_WEAPON_SIDE_Z = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
@@ -257,10 +258,10 @@ const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
 // Keep Snake dice motion aligned with Ludo Battle Royal's single-arc spinDice roll.
-const DICE_ROLL_DURATION = 1100;
+const DICE_ROLL_DURATION = 900;
 const DICE_SETTLE_DURATION = 240;
 const DICE_RESULT_HOLD_DURATION = 720;
-const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.78;
+const DICE_BOUNCE_HEIGHT = 0.06;
 const DICE_THROW_LANDING_MARGIN = TILE_SIZE * 1.8;
 const DICE_THROW_START_EXTRA = TILE_SIZE * 3.6;
 const DICE_THROW_HEIGHT = DICE_SIZE * 0.78;
@@ -355,6 +356,11 @@ function measureMinYRelativeToParent(object) {
   const box = new THREE.Box3().setFromObject(object);
   if (!Number.isFinite(box.min.y)) return null;
   return box.min.y - parent.getWorldPosition(new THREE.Vector3()).y;
+}
+
+function pushChairModelAwayFromTable(model) {
+  if (!model?.isObject3D) return;
+  model.position.z = CHAIR_MODEL_AWAY_FROM_TABLE_OFFSET;
 }
 
 function alignChairLegsToHumanGround(chair) {
@@ -3403,7 +3409,7 @@ function createDiceRollAnimation(
     )
   );
   const wobbleVectors = diceArray.map(
-    () => new THREE.Vector3((Math.random() - 0.5) * DICE_SIZE * 1.25, 0, (Math.random() - 0.5) * DICE_SIZE * 1.25)
+    () => new THREE.Vector3((Math.random() - 0.5) * 0.16, 0, (Math.random() - 0.5) * 0.16)
   );
 
   return {
@@ -4095,6 +4101,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
       }
       if (chairTemplate) {
         const model = chairTemplate.clone(true);
+        pushChairModelAwayFromTable(model);
         chair.group.add(model);
         chair.model = model;
         alignChairLegsToHumanGround(chair);
@@ -4130,6 +4137,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
 
     const chairModel = chairTemplate ? chairTemplate.clone(true) : null;
     if (chairModel) {
+      pushChairModelAwayFromTable(chairModel);
       group.add(chairModel);
     }
 
@@ -5954,62 +5962,52 @@ function updateSeatWeaponDisplays(board, players = []) {
       holder.add(createSeatWeaponMesh(parkedWeaponType, { parkingPose: isVehicleWeapon ? 'flat' : 'vertical' }));
       holder.userData.weaponType = parkedWeaponType;
     }
-    const weaponAnchor = !isVehicleWeapon ? board.weaponAnchors?.[seatIndex] : null;
-    const weaponParent = board.weaponDisplayGroup.parent || board.boardRoot || null;
-    if (weaponAnchor && weaponParent) {
-      const chairSideWorld = new THREE.Vector3();
-      weaponAnchor.getWorldPosition(chairSideWorld);
-      chairSideWorld.y = SEATED_HUMAN_GROUND_Y;
-      weaponParent.worldToLocal(chairSideWorld);
-      holder.position.copy(chairSideWorld);
-    } else {
-      const railLayout = getSeatSideParkingLayout(board, seatIndex, board.weaponDisplayGroup);
-      if (railLayout) {
-        const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
-        const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
-        const portraitShift = WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? null;
+    const railLayout = getSeatSideParkingLayout(board, seatIndex, board.weaponDisplayGroup);
+    if (railLayout) {
+      const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
+      const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
+      const portraitShift = WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? null;
+      holder.position
+        .copy(railLayout.railLocal)
+        .addScaledVector(
+          railLayout.lateral,
+          sideSign * SEAT_RAIL_SLOT_OFFSET * WEAPON_SLOT_CLUSTER_SCALE +
+            lateralNudge +
+            WEAPON_RIGHT_HAND_SIDE_OFFSET
+        )
+        .addScaledVector(
+          railLayout.seatDirection,
+          WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)
+        );
+      if (portraitShift) {
         holder.position
-          .copy(railLayout.railLocal)
-          .addScaledVector(
-            railLayout.lateral,
-            sideSign * SEAT_RAIL_SLOT_OFFSET * WEAPON_SLOT_CLUSTER_SCALE +
-              lateralNudge +
-              WEAPON_RIGHT_HAND_SIDE_OFFSET
-          )
-          .addScaledVector(
-            railLayout.seatDirection,
-            WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)
-          );
-        if (portraitShift) {
-          holder.position
-            .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
-            .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
-        }
-        holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
-        holder.position.y += PARKING_VERTICAL_LIFT;
-        const radialFromCenter = holder.position.clone().sub(boardLookTarget).setY(0);
-        const minClearance = BOARD_RADIUS + WEAPON_MIN_BOARD_CLEARANCE;
-        if (radialFromCenter.length() < minClearance) {
-          radialFromCenter.normalize().multiplyScalar(minClearance);
-          holder.position.x = boardLookTarget.x + radialFromCenter.x;
-          holder.position.z = boardLookTarget.z + radialFromCenter.z;
-        }
-      } else {
-        const seatWorld = new THREE.Vector3();
-        anchor.getWorldPosition(seatWorld);
-        const seatDirection = seatWorld.clone().sub(boardLookTarget).setY(0);
-        if (seatDirection.lengthSq() < 1e-6) continue;
-        seatDirection.normalize();
-        const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
-        const radius = TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.16;
-        const markerPos = boardLookTarget
-          .clone()
-          .addScaledVector(seatDirection, radius)
-          .addScaledVector(lateral, (seatIndex % 2 === 0 ? 1 : -1) * TOKEN_RADIUS * 0.22);
-        holder.position.copy(markerPos);
-        holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
-        holder.position.y = (board.baseLevelTop ?? 0) + WEAPON_PARKING_Y_FROM_GROUND_FLOOR + PARKING_VERTICAL_LIFT;
+          .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
+          .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
       }
+      holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
+      holder.position.y += PARKING_VERTICAL_LIFT;
+      const radialFromCenter = holder.position.clone().sub(boardLookTarget).setY(0);
+      const minClearance = BOARD_RADIUS + WEAPON_MIN_BOARD_CLEARANCE;
+      if (radialFromCenter.length() < minClearance) {
+        radialFromCenter.normalize().multiplyScalar(minClearance);
+        holder.position.x = boardLookTarget.x + radialFromCenter.x;
+        holder.position.z = boardLookTarget.z + radialFromCenter.z;
+      }
+    } else {
+      const seatWorld = new THREE.Vector3();
+      anchor.getWorldPosition(seatWorld);
+      const seatDirection = seatWorld.clone().sub(boardLookTarget).setY(0);
+      if (seatDirection.lengthSq() < 1e-6) continue;
+      seatDirection.normalize();
+      const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
+      const radius = TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.16;
+      const markerPos = boardLookTarget
+        .clone()
+        .addScaledVector(seatDirection, radius)
+        .addScaledVector(lateral, (seatIndex % 2 === 0 ? 1 : -1) * TOKEN_RADIUS * 0.22);
+      holder.position.copy(markerPos);
+      holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
+      holder.position.y = (board.baseLevelTop ?? 0) + WEAPON_PARKING_Y_FROM_GROUND_FLOOR + PARKING_VERTICAL_LIFT;
     }
     const lookAwayDirection = holder.position.clone().sub(boardLookTarget).setY(0);
     if (lookAwayDirection.lengthSq() < 1e-6) lookAwayDirection.set(0, 0, 1);


### PR DESCRIPTION
### Motivation
- Improve portrait UX for Snake & Ladder by visually bringing seated human characters closer to the table while moving chairs outward so characters read better on mobile screens.
- Standardize dice motion so Snake roll uses the same single-arc feel as Ludo Battle Royal for consistency and improved feedback.
- Restore parked weapons to table-side parking slots so weapon models remain in predictable positions around the board.

### Description
- Adjusted seated human and chair placement constants: increased inward human offsets (`SEATED_HUMAN_SEAT_Z_OFFSET`, `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET`) and added `CHAIR_MODEL_AWAY_FROM_TABLE_OFFSET` plus `pushChairModelAwayFromTable()` to push chair models outward when instantiated/refreshed. (file: `webapp/src/components/SnakeBoard3D.jsx`)
- Aligned dice behavior with Ludo: reduced `DICE_ROLL_DURATION` to `900`, set `DICE_BOUNCE_HEIGHT` to `0.06`, and reduced per-die wobble magnitude so the roll animation follows the single-arc cadence used in Ludo. (file: `webapp/src/components/SnakeBoard3D.jsx`)
- Kept parked weapons on table-side parking layout by using seat-side parking layout logic for weapon holders (removed reliance on per-seat weaponAnchor hand/chair positions), ensuring weapons remain on the table rim/parking slots. (file: `webapp/src/components/SnakeBoard3D.jsx`)
- Minor refactors: applied chair offset during initial chair creation and refresh flows; tightened dice wobble vectors to match Ludo implementation.

### Testing
- `npm run build` for the webapp completed successfully and produced the production bundles (build warnings about large chunks were reported but build finished). — succeeded.
- Ran the dev server (`vite`) and attempted an automated headless render with Playwright to verify mobile portrait layout; Playwright browser download and system deps were installed during testing but the screenshot attempt timed out / had resource-loading issues in CI environment (no final screenshot artifact). — screenshot attempt inconclusive.
- Verified code changes were staged and committed locally (`Tune snake ladder arena seating and dice`). — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9e5cd5488329b6fc979c43eceaa0)