### PR TITLE
Tune Snake & Ladder table seating, dice roll, and weapon parking

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -56,8 +56,8 @@ const AI_CHAIR_GAP = CARD_W * 0.74;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 // Portrait calibration: push the chair ring slightly outward while the human anchors move closer to the table.
-const CHAIR_GLOBAL_PUSHBACK = 0.56 * MODEL_SCALE;
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.58 * MODEL_SCALE;
+const CHAIR_GLOBAL_PUSHBACK = 0.64 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.66 * MODEL_SCALE;
 const TABLE_HEIGHT_LIFT = -0.045 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
@@ -174,9 +174,9 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.82;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
 const SEATED_HUMAN_SEAT_Y_OFFSET = -5.6 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.53;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.58;
 // Portrait calibration: keep all seated humans pulled visibly inward toward the table on phone screens.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.06;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.08;
 const SEATED_HUMAN_WEAPON_RIGHT_HAND_X = SEAT_WIDTH * 0.47;
 const SEATED_HUMAN_WEAPON_SIDE_Z = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
@@ -257,10 +257,10 @@ const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
 // Keep Snake dice motion aligned with Ludo Battle Royal's single-arc spinDice roll.
-const DICE_ROLL_DURATION = 1100;
+const DICE_ROLL_DURATION = 900;
 const DICE_SETTLE_DURATION = 240;
 const DICE_RESULT_HOLD_DURATION = 720;
-const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.78;
+const DICE_BOUNCE_HEIGHT = 0.06;
 const DICE_THROW_LANDING_MARGIN = TILE_SIZE * 1.8;
 const DICE_THROW_START_EXTRA = TILE_SIZE * 3.6;
 const DICE_THROW_HEIGHT = DICE_SIZE * 0.78;
@@ -459,13 +459,13 @@ const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
   'slot-16-awp-glb': 3,
   'slot-13-mosin-gltf': 3
 });
-const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.88;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.4,
-  TILE_SIZE * 0.38,
-  TILE_SIZE * 0.46,
-  TILE_SIZE * 0.38
+  0,
+  0,
+  0,
+  0
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -503,11 +503,11 @@ const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
-const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
-const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
+const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.38;
+const WEAPON_PARKING_SIDE_EXTRA_RADIUS = -TILE_SIZE * 0.08;
 const WEAPON_PARKING_Y_FROM_GROUND_FLOOR = TOKEN_HEIGHT * 1.02;
-const PARKING_TOP_SCREEN_WORLD_SHIFT = TILE_SIZE * 1.32;
-const PARKING_VERTICAL_LIFT = TILE_SIZE * 0.2;
+const PARKING_TOP_SCREEN_WORLD_SHIFT = TILE_SIZE * 0.78;
+const PARKING_VERTICAL_LIFT = TILE_SIZE * 0.08;
 const WEAPON_MIN_BOARD_CLEARANCE = TILE_SIZE * 0.52;
 const WEAPON_RIGHT_HAND_SIDE_OFFSET = TOKEN_RADIUS * 0.85;
 
@@ -3403,7 +3403,7 @@ function createDiceRollAnimation(
     )
   );
   const wobbleVectors = diceArray.map(
-    () => new THREE.Vector3((Math.random() - 0.5) * DICE_SIZE * 1.25, 0, (Math.random() - 0.5) * DICE_SIZE * 1.25)
+    () => new THREE.Vector3((Math.random() - 0.5) * 0.16, 0, (Math.random() - 0.5) * 0.16)
   );
 
   return {
@@ -5954,62 +5954,53 @@ function updateSeatWeaponDisplays(board, players = []) {
       holder.add(createSeatWeaponMesh(parkedWeaponType, { parkingPose: isVehicleWeapon ? 'flat' : 'vertical' }));
       holder.userData.weaponType = parkedWeaponType;
     }
-    const weaponAnchor = !isVehicleWeapon ? board.weaponAnchors?.[seatIndex] : null;
-    const weaponParent = board.weaponDisplayGroup.parent || board.boardRoot || null;
-    if (weaponAnchor && weaponParent) {
-      const chairSideWorld = new THREE.Vector3();
-      weaponAnchor.getWorldPosition(chairSideWorld);
-      chairSideWorld.y = SEATED_HUMAN_GROUND_Y;
-      weaponParent.worldToLocal(chairSideWorld);
-      holder.position.copy(chairSideWorld);
-    } else {
-      const railLayout = getSeatSideParkingLayout(board, seatIndex, board.weaponDisplayGroup);
-      if (railLayout) {
-        const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
-        const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
-        const portraitShift = WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? null;
+    // Park every weapon back on the shared table-side slots instead of drifting to the chair/hand anchors.
+    const railLayout = getSeatSideParkingLayout(board, seatIndex, board.weaponDisplayGroup);
+    if (railLayout) {
+      const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
+      const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
+      const portraitShift = WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? null;
+      holder.position
+        .copy(railLayout.railLocal)
+        .addScaledVector(
+          railLayout.lateral,
+          sideSign * SEAT_RAIL_SLOT_OFFSET * WEAPON_SLOT_CLUSTER_SCALE +
+            lateralNudge +
+            WEAPON_RIGHT_HAND_SIDE_OFFSET
+        )
+        .addScaledVector(
+          railLayout.seatDirection,
+          WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)
+        );
+      if (portraitShift) {
         holder.position
-          .copy(railLayout.railLocal)
-          .addScaledVector(
-            railLayout.lateral,
-            sideSign * SEAT_RAIL_SLOT_OFFSET * WEAPON_SLOT_CLUSTER_SCALE +
-              lateralNudge +
-              WEAPON_RIGHT_HAND_SIDE_OFFSET
-          )
-          .addScaledVector(
-            railLayout.seatDirection,
-            WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)
-          );
-        if (portraitShift) {
-          holder.position
-            .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
-            .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
-        }
-        holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
-        holder.position.y += PARKING_VERTICAL_LIFT;
-        const radialFromCenter = holder.position.clone().sub(boardLookTarget).setY(0);
-        const minClearance = BOARD_RADIUS + WEAPON_MIN_BOARD_CLEARANCE;
-        if (radialFromCenter.length() < minClearance) {
-          radialFromCenter.normalize().multiplyScalar(minClearance);
-          holder.position.x = boardLookTarget.x + radialFromCenter.x;
-          holder.position.z = boardLookTarget.z + radialFromCenter.z;
-        }
-      } else {
-        const seatWorld = new THREE.Vector3();
-        anchor.getWorldPosition(seatWorld);
-        const seatDirection = seatWorld.clone().sub(boardLookTarget).setY(0);
-        if (seatDirection.lengthSq() < 1e-6) continue;
-        seatDirection.normalize();
-        const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
-        const radius = TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.16;
-        const markerPos = boardLookTarget
-          .clone()
-          .addScaledVector(seatDirection, radius)
-          .addScaledVector(lateral, (seatIndex % 2 === 0 ? 1 : -1) * TOKEN_RADIUS * 0.22);
-        holder.position.copy(markerPos);
-        holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
-        holder.position.y = (board.baseLevelTop ?? 0) + WEAPON_PARKING_Y_FROM_GROUND_FLOOR + PARKING_VERTICAL_LIFT;
+          .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
+          .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
       }
+      holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
+      holder.position.y += PARKING_VERTICAL_LIFT;
+      const radialFromCenter = holder.position.clone().sub(boardLookTarget).setY(0);
+      const minClearance = BOARD_RADIUS + WEAPON_MIN_BOARD_CLEARANCE;
+      if (radialFromCenter.length() < minClearance) {
+        radialFromCenter.normalize().multiplyScalar(minClearance);
+        holder.position.x = boardLookTarget.x + radialFromCenter.x;
+        holder.position.z = boardLookTarget.z + radialFromCenter.z;
+      }
+    } else {
+      const seatWorld = new THREE.Vector3();
+      anchor.getWorldPosition(seatWorld);
+      const seatDirection = seatWorld.clone().sub(boardLookTarget).setY(0);
+      if (seatDirection.lengthSq() < 1e-6) continue;
+      seatDirection.normalize();
+      const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
+      const radius = TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.16;
+      const markerPos = boardLookTarget
+        .clone()
+        .addScaledVector(seatDirection, radius)
+        .addScaledVector(lateral, (seatIndex % 2 === 0 ? 1 : -1) * TOKEN_RADIUS * 0.22);
+      holder.position.copy(markerPos);
+      holder.position.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
+      holder.position.y = (board.baseLevelTop ?? 0) + WEAPON_PARKING_Y_FROM_GROUND_FLOOR + PARKING_VERTICAL_LIFT;
     }
     const lookAwayDirection = holder.position.clone().sub(boardLookTarget).setY(0);
     if (lookAwayDirection.lengthSq() < 1e-6) lookAwayDirection.set(0, 0, 1);


### PR DESCRIPTION
### Motivation
- Improve portrait/mobile composition by bringing seated human characters visually closer to the table while moving chairs slightly outward for clearer spacing. 
- Replace the Snake & Ladder dice motion with the same single-arc / spin cadence used by Ludo Battle Royal so rolls feel consistent across games. 
- Restore parked weapons to fixed table-side parking slots so weapons return to stable, predictable locations on the table instead of drifting toward chairs or hand anchors.

### Description
- Adjusted seating and avatar offsets by changing `CHAIR_GLOBAL_PUSHBACK`, `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK`, `SEATED_HUMAN_SEAT_Z_OFFSET`, and `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` in `webapp/src/components/SnakeBoard3D.jsx` to pull humans slightly inward and push chairs outward. 
- Re-tuned dice rollout by setting `DICE_ROLL_DURATION` to `900`, reducing `DICE_BOUNCE_HEIGHT`, tightening wobble vectors, and using the same spin/wobble cadence used by Ludo (updates in `createDiceRollAnimation` and related helpers). 
- Returned parked weapons to table-side parking: reduced outward offsets and per-seat cluster offsets, lowered parking lift, and always prefer the shared table-side `railLayout` when placing parked weapons (changes in `updateSeatWeaponDisplays` constants and logic). 
- All changes are concentrated in `webapp/src/components/SnakeBoard3D.jsx` and preserve existing APIs and data flows.

### Testing
- Ran the production build with `npm run build` which completed successfully. 
- Verified the file diffs with `git diff --check` and confirmed no whitespace/parse issues for the modified file. 
- Installed Playwright browsers and system deps with `npx playwright install chromium` and `npx playwright install-deps chromium` and then captured a portrait screenshot via a headless Playwright script (output saved to `/tmp/snake-ladder-calibration.png`). 
- Dev server `npm run dev` was started to exercise runtime behavior while capturing the screenshot and inspect console output for resource load fallbacks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9e5cd5488329b6fc979c43eceaa0)