### PR TITLE
Preserve Showood chrome plates, tighten cloth scale, and keep shooter upright

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -21,14 +21,14 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.equal(showood.fitScale, 1.035);
-    assert.equal(showood.clothRepeatScale, 1.55);
+    assert.equal(showood.clothRepeatScale, 4.25);
     assert.deepEqual(showood.hideSurfaceRoles, []);
-    assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
+    assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['trim']);
+    assert.deepEqual(showood.alwaysPreserveOriginalSurfaceRoles, ['trim']);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',
       'wood',
-      'trim',
       'pocket'
     ]);
     assert.equal('playfieldVisualLift' in showood, false);

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -25,15 +25,16 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.035,
-    clothRepeatScale: 3.2,
+    clothRepeatScale: 4.25,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
     preserveOriginalSurfaceRoles: ['trim'],
+    alwaysPreserveOriginalSurfaceRoles: ['trim'],
     hideSurfaceRoles: []
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13754,11 +13754,14 @@ function mountPoolRoyaleExternalTableModel({
     resolvedTableOptions?.tableModel?.kind === 'gltf'
       ? {
           ...resolvedTableOptions.tableModel,
-          preserveOriginalSurfaceRoles: chromePlateStyle.preserveExternalTrim
-            ? resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles
-            : resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles?.filter(
-                (role) => role !== 'trim'
-              )
+          preserveOriginalSurfaceRoles: Array.from(new Set([
+            ...(chromePlateStyle.preserveExternalTrim
+              ? resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles ?? []
+              : resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles?.filter(
+                  (role) => role !== 'trim'
+                ) ?? []),
+            ...(resolvedTableOptions.tableModel.alwaysPreserveOriginalSurfaceRoles ?? [])
+          ]))
         }
       : null;
   const externalTable =
@@ -25792,11 +25795,13 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            // Bend the shooting upper body to the opposite side while the IK feet stay planted.
+            // Keep Pool Royal avatars upright during shots; the player holds the cue
+            // in the same standing pose used at the start instead of bending
+            // into the table-facing shooting stance.
             shootBendDirection: -1,
             shootCounterLeanSide: -1,
-            shootUpperBodyCounterLean: 1.18,
-            plantFeetDuringShot: true,
+            shootUpperBodyCounterLean: 0,
+            plantFeetDuringShot: false,
             forceTableFacingAim: true,
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,
@@ -26056,9 +26061,11 @@ const shotPowerRef = useRef(0);
               .normalize();
             const idleCueBack = idleRight.clone().addScaledVector(idleCueDir, -0.24 * humanUnitScale);
             const idleCueTip = idleRight.clone().addScaledVector(idleCueDir, cueLen - 0.24 * humanUnitScale);
-            const cueBack = state === 'idle' ? idleCueBack : cueBackShoot;
-            const cueTip = state === 'idle' ? idleCueTip : cueTipShoot;
-            const gripTarget = state === 'idle' ? idleRight : shootGripTarget;
+            const forceStandingCuePose = true;
+            const cueBack = forceStandingCuePose || state === 'idle' ? idleCueBack : cueBackShoot;
+            const cueTip = forceStandingCuePose || state === 'idle' ? idleCueTip : cueTipShoot;
+            const gripTarget = forceStandingCuePose || state === 'idle' ? idleRight : shootGripTarget;
+            const humanPoseState = forceStandingCuePose ? 'idle' : state;
             const isFiniteVec3 = (v) =>
               Number.isFinite(v?.x) && Number.isFinite(v?.y) && Number.isFinite(v?.z);
             if (
@@ -26074,7 +26081,7 @@ const shotPowerRef = useRef(0);
               return;
             }
             updateBilardoHumanPose(human, dtSeconds, {
-              state,
+              state: humanPoseState,
               rootTarget: walkRoot,
               aimForward,
               bridgeTarget,


### PR DESCRIPTION
### Motivation
- Keep Showood GLB chrome/trim plates visible and prevent table finishes from repainting them. 
- Make the Showood cloth pattern visually smaller/tighter to match prior visual tweaks. 
- Ensure the human shooter remains in the same upright standing cue-hold pose during aiming/striking instead of bending into a shooting stance.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to increase `clothRepeatScale` for the Showood model to `4.25`, remove `trim` from `usePoolRoyaleFinishRoles`, and add `alwaysPreserveOriginalSurfaceRoles: ['trim']` so chrome plates stay original.
- Modified external table mounting in `webapp/src/pages/Games/PoolRoyale.jsx` to merge any `alwaysPreserveOriginalSurfaceRoles` into the resolved `preserveOriginalSurfaceRoles` set used when mounting GLTF tables.
- Changed the Pool Royale human rig setup in `webapp/src/pages/Games/PoolRoyale.jsx` to keep avatars upright during shots by setting `shootUpperBodyCounterLean: 0`, `plantFeetDuringShot: false`, forcing a standing cue pose during aim/strike, and passing that pose state into `updateBilardoHumanPose` so the human holds the cue straight.
- Updated `test/poolRoyaleTableModels.test.js` to assert the new `clothRepeatScale` and that Showood preserves `trim` in the model options.

### Testing
- Ran unit tests with `npm test -- --runInBand test/poolRoyaleTableModels.test.js test/poolRoyaleCueStrokeTimeline.test.js` and both test suites passed. 
- Built the web app with `npm --prefix webapp run build` and the production build completed (with standard Vite warnings about large chunks). 
- Attempted an automated Playwright portrait screenshot to visually verify the upright pose, but Chromium could not launch in the container due to a missing system library (`libatk-1.0.so.0`), so the screenshot step failed outside of the unit/build checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcac49cce8832988a4513b4e976e13)