### PR TITLE
Preserve Showood chrome plates, shrink external cloth, and keep shooter upright in Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -26,6 +26,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     kind: 'gltf',
     fitScale: 1.035,
     clothRepeatScale: 3.2,
+    clothVisualScale: 0.9,
+    forcePreserveExternalTrim: true,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12808,6 +12808,10 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const prepareMaterial = (material) => {
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
+      child.userData = {
+        ...(child.userData || {}),
+        poolRoyaleExternalSurfaceRole: role
+      };
       if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
         child.visible = false;
       }
@@ -12915,6 +12919,38 @@ function applyPoolRoyaleExternalPlayfieldVisualLift(table, lift = 0) {
     liftedRoots.push(object);
   });
   return liftedRoots.length;
+}
+
+
+function shrinkPoolRoyaleExternalClothSurfaces(root, tableModel = null) {
+  const scale = tableModel?.clothVisualScale;
+  if (!root || !Number.isFinite(scale) || scale <= 0 || Math.abs(scale - 1) < MICRO_EPS) return 0;
+  let changed = 0;
+  root.traverse?.((child) => {
+    if (!child?.isMesh || child.userData?.poolRoyaleExternalSurfaceRole !== 'cloth') return;
+    if (child.userData.poolRoyaleExternalClothVisualScaleApplied) return;
+    const sourceGeometry = child.geometry;
+    const position = sourceGeometry?.attributes?.position;
+    if (!position) return;
+    const geometry = sourceGeometry.clone();
+    geometry.computeBoundingBox();
+    const center = geometry.boundingBox?.getCenter(new THREE.Vector3()) ?? new THREE.Vector3();
+    const scaledPosition = geometry.attributes.position;
+    for (let i = 0; i < scaledPosition.count; i += 1) {
+      scaledPosition.setX(i, center.x + (scaledPosition.getX(i) - center.x) * scale);
+      scaledPosition.setZ(i, center.z + (scaledPosition.getZ(i) - center.z) * scale);
+    }
+    scaledPosition.needsUpdate = true;
+    geometry.computeBoundingBox();
+    geometry.computeBoundingSphere();
+    child.geometry = geometry;
+    child.userData = {
+      ...(child.userData || {}),
+      poolRoyaleExternalClothVisualScaleApplied: scale
+    };
+    changed += 1;
+  });
+  return changed;
 }
 
 function resolvePoolRoyaleExternalTableFitBounds(model, tableModel = null) {
@@ -13044,6 +13080,7 @@ function mountPoolRoyaleExternalTableModel({
       if (disposed || !template) return;
       const model = clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo);
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
+      shrinkPoolRoyaleExternalClothSurfaces(model, tableModel);
       externalRoot.clear();
       externalRoot.add(model);
       setGeneratedVisualsVisible?.(false);
@@ -13754,11 +13791,12 @@ function mountPoolRoyaleExternalTableModel({
     resolvedTableOptions?.tableModel?.kind === 'gltf'
       ? {
           ...resolvedTableOptions.tableModel,
-          preserveOriginalSurfaceRoles: chromePlateStyle.preserveExternalTrim
-            ? resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles
-            : resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles?.filter(
-                (role) => role !== 'trim'
-              )
+          preserveOriginalSurfaceRoles:
+            chromePlateStyle.preserveExternalTrim || resolvedTableOptions.tableModel.forcePreserveExternalTrim
+              ? resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles
+              : resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles?.filter(
+                  (role) => role !== 'trim'
+                )
         }
       : null;
   const externalTable =
@@ -25792,7 +25830,8 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            // Bend the shooting upper body to the opposite side while the IK feet stay planted.
+            // Keep the shooter upright in the same relaxed stance used at game start.
+            keepUprightWhileShooting: true,
             shootBendDirection: -1,
             shootCounterLeanSide: -1,
             shootUpperBodyCounterLean: 1.18,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -245,7 +245,8 @@ const BASE_CFG = {
   shootCounterLeanSide: -1,
   shootUpperBodyCounterLean: 1,
   plantFeetDuringShot: true,
-  forceTableFacingAim: true
+  forceTableFacingAim: true,
+  keepUprightWhileShooting: false
 };
 
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
@@ -732,9 +733,10 @@ export function updateHumanPose(human, dt, frameData) {
   const cfg = human.cfg;
   const state = frameData.state || 'idle';
   const activeState = state === 'rolling' || state === 'turnEnd' || state === 'gameOver' ? 'idle' : state;
-  human.poseT = dampScalar(human.poseT, activeState === 'idle' ? 0 : 1, cfg.poseLambda, dt);
-  human.breathT += dt * (activeState === 'idle' ? 1.05 : 0.5);
-  human.settleT = dampScalar(human.settleT, activeState === 'dragging' ? 1 : 0, 5.5, dt);
+  const keepUprightWhileShooting = cfg.keepUprightWhileShooting === true;
+  human.poseT = dampScalar(human.poseT, activeState === 'idle' || keepUprightWhileShooting ? 0 : 1, cfg.poseLambda, dt);
+  human.breathT += dt * (activeState === 'idle' || keepUprightWhileShooting ? 1.05 : 0.5);
+  human.settleT = dampScalar(human.settleT, activeState === 'dragging' && !keepUprightWhileShooting ? 1 : 0, 5.5, dt);
   if (activeState === 'striking') {
     if (human.strikeClock === 0) {
       human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : frameData.rootTarget);


### PR DESCRIPTION
### Motivation
- Ensure the Showood GLB keeps its original chrome/trim plates visible and not overwritten by the table finish when the external model is used. 
- Reduce the visual footprint of external GLB cloth surfaces to better match the native Pool Royale playfield scale and avoid finish overlaps. 
- Prevent the shooter avatar from bending into an exaggerated shooting stance during initial capture/aiming so the human remains in the relaxed start pose while holding the cue. 

### Description
- Added `clothVisualScale` (0.9) and `forcePreserveExternalTrim` to the Showood table model entry in `webapp/src/config/poolRoyaleTableModels.js` to drive cloth shrinking and trim-preservation behavior. 
- Tagged external table meshes with `poolRoyaleExternalSurfaceRole` in `preparePoolRoyaleExternalTableMaterials` and added `shrinkPoolRoyaleExternalClothSurfaces` to scale cloth geometry vertices for external GLB tables, then call this pass after the external model is fitted (all in `webapp/src/pages/Games/PoolRoyale.jsx`). 
- Adjusted external finish application logic to respect either the chrome-plate style preference or the table model `forcePreserveExternalTrim` flag so original trim/plates remain preserved. 
- Added `keepUprightWhileShooting` to the human rig config and used it in `updateHumanPose` to keep pose blending at idle when enabled, and enabled this option for Pool Royale player rigs so the human holds the cue while remaining straight (changes in `webapp/src/pages/Games/shared/humanRigCore.js` and the Pool Royale rig instantiation). 

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully. 
- Installed Playwright browsers and dependencies via `npx playwright install chromium` and `npx playwright install-deps chromium` which completed successfully in the environment. 
- Attempted an automated visual check using Playwright to open the mobile Pool Royale route and capture a screenshot, but headless Chromium captures timed out/hung in this CI-like environment (missing/host-dependent headless libraries and headless renderer issues caused the screenshot attempt to fail). 
- Manual verification note: the build artifacts and dev server started during the run and the updated code paths are in place for runtime inspection in a full desktop/browser environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcac49cce8832988a4513b4e976e13)