### PR TITLE
Tune Ludo Battle Royale camera and dice hand pose

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3226,6 +3226,7 @@ const SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET = new Set([
   'carryToken',
   'placeToken'
 ]);
+const SEATED_HUMAN_DICE_CONTACT_MODE_SET = new Set(['reachDice', 'gripDice', 'holdDice']);
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.057 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.112 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_DICE = -0.003 * MODEL_SCALE;
@@ -3251,8 +3252,8 @@ const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.072 * MODEL_SCALE;
 // The bottom-seat gameplay camera is intentionally raised and pushed farther toward the table so
 // portrait players see over the local avatar and closer into the Ludo board/action area.
 const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.31 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.142 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.034 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.19 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.072 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 7;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.3;
 const SEATED_CONTACT_DICE_Y_OFFSET = 0.016;
@@ -6079,6 +6080,14 @@ function applySeatedHumanPose(
     wristZ = THREE.MathUtils.lerp(wristZ, 0.52, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.2, t);
     forearmZ = THREE.MathUtils.lerp(forearmZ, 0.28, t);
+  }
+
+  if (SEATED_HUMAN_DICE_CONTACT_MODE_SET.has(mode)) {
+    wristX = THREE.MathUtils.lerp(wristX, -0.82, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.08, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.18, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.24, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.12, t);
   }
 
   if (bodyLockedMode && !isDiceReachMode) {
@@ -9953,15 +9962,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
       if (!isCamera2d && camera && LUDO_CAMERA_SEAT_LOCK_ENABLED) {
         const bottomActorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === 0);
-        const gameplayTarget = (() => {
-          const dice = diceRef.current;
-          if (dice?.isObject3D) {
-            const target = new THREE.Vector3();
-            dice.getWorldPosition(target);
-            return target;
-          }
-          return boardLookTargetRef.current?.isVector3 ? boardLookTargetRef.current.clone() : null;
-        })();
+        const gameplayTarget = boardLookTargetRef.current?.isVector3
+          ? boardLookTargetRef.current.clone()
+          : null;
         const liveFacePose = resolveSeatedFaceCameraPose(bottomActorEntry, gameplayTarget);
         const hardLockedPosition = liveFacePose?.position?.isVector3
           ? liveFacePose.position
@@ -11635,12 +11638,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
 
   const resolveBottomPlayerGameplayTarget = useCallback(() => {
-    const dice = diceRef.current;
-    if (dice?.isObject3D) {
-      const diceTarget = new THREE.Vector3();
-      dice.getWorldPosition(diceTarget);
-      return diceTarget;
-    }
     return boardLookTargetRef.current?.isVector3 ? boardLookTargetRef.current.clone() : null;
   }, []);
 


### PR DESCRIPTION
### Motivation

- Improve portrait framing by raising the bottom-player camera and making it look slightly downward so players see more of the board at game start.
- Fix the seated human right-hand orientation so the hand visibly turns toward the dice when picking up/gripping/holding.
- Keep the bottom-player camera framing consistent during dice roll/move so the view remains the same as the start of the game.

### Description

- Increased the bottom-seat face-camera offsets by updating `SEATED_FACE_CAMERA_GAMEPLAY_UP` and `SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to raise and lower the camera/look target respectively.  
- Added `SEATED_HUMAN_DICE_CONTACT_MODE_SET` and applied dice-specific wrist/forearm pose adjustments in `applySeatedHumanPose` to turn the hand toward the dice during `reachDice`, `gripDice`, and `holdDice`.  
- Stopped using the dice world position as the live gameplay target for the bottom-locked camera and instead pass `boardLookTarget` into `resolveSeatedFaceCameraPose`, and simplified `resolveBottomPlayerGameplayTarget` to return the board look target so roll/move phases keep the initial framing.  
- Changes are localized to `LudoBattleRoyal.jsx` (camera tuning, seated human IK/pose helpers, and camera-follow logic adjustments).

### Testing

- Ran `npm --prefix webapp run build`, which completed successfully and produced the production build.  
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which completed; the repository-level ESLint ignore produced a warning about the file being ignored.  
- Ran `npx playwright install chromium` which completed to fetch browsers, but an automated Playwright screenshot attempt failed to launch Chromium due to a missing system library (`libatk-1.0.so.0`) in the environment preventing headless Chromium from starting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb13e2a8c83299437d400b299f68f)