### PR TITLE
Adjust Showood GLB model settings, chrome-plate visibility, and human bridge pose

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -20,15 +20,15 @@ describe('Pool Royale table models', () => {
     assert.ok(showood, 'Showood table model must be configured');
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
-    assert.equal(showood.fitScale, 1.035);
-    assert.equal(showood.clothRepeatScale, 1.55);
-    assert.deepEqual(showood.hideSurfaceRoles, []);
+    assert.equal(showood.fitScale, 1.055);
+    assert.equal(showood.clothRepeatScale, 5.25);
+    assert.deepEqual(showood.hideSurfaceRoles, ['trim']);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
+    assert.equal(showood.forceGeneratedChromePlates, true);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',
       'wood',
-      'trim',
       'pocket'
     ]);
     assert.equal('playfieldVisualLift' in showood, false);

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -24,17 +24,18 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
-    fitScale: 1.035,
-    clothRepeatScale: 3.2,
+    fitScale: 1.055,
+    clothRepeatScale: 5.25,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
-    preserveOriginalSurfaceRoles: ['trim'],
-    hideSurfaceRoles: []
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
+    preserveOriginalSurfaceRoles: [],
+    forceGeneratedChromePlates: true,
+    hideSurfaceRoles: ['trim']
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13738,11 +13738,13 @@ function mountPoolRoyaleExternalTableModel({
     : generatedUpperComponentBounds.getSize(new THREE.Vector3());
   const setGeneratedVisualsVisible = (visible) => {
     generatedVisualObjects.forEach((object) => {
+      const forceGeneratedChrome = Boolean(externalTableModelForMount?.forceGeneratedChromePlates);
       if (
         !visible &&
-        !externalTableModelForMount?.useOriginalLayoutSurfaces &&
-        (object.userData?.externalTableKeepVisible ||
-          (object.userData?.isChromePlate && chromePlateStyle.showGeneratedOnExternal))
+        (
+          (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
+          (object.userData?.isChromePlate && (chromePlateStyle.showGeneratedOnExternal || forceGeneratedChrome))
+        )
       ) {
         object.visible = true;
         return;
@@ -25792,11 +25794,13 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
-            // Bend the shooting upper body to the opposite side while the IK feet stay planted.
+            // Drop the bridge hand to the cloth while keeping the cue aligned with the aim line
+            // as the portrait camera lowers into the ready-to-shoot view.
             shootBendDirection: -1,
             shootCounterLeanSide: -1,
-            shootUpperBodyCounterLean: 1.18,
+            shootUpperBodyCounterLean: 0.72,
             plantFeetDuringShot: true,
+            bridgeArmStraightDown: true,
             forceTableFacingAim: true,
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,
@@ -26018,8 +26022,8 @@ const shotPowerRef = useRef(0);
             }
             const bridgeTarget = cueWorld
               .clone()
-              .addScaledVector(aimForward, -0.145 * humanUnitScale)
-              .addScaledVector(side, -0.012 * humanUnitScale)
+              .addScaledVector(aimForward, -0.105 * humanUnitScale)
+              .addScaledVector(side, -0.038 * humanUnitScale)
               .setY(TABLE_Y + TABLE.THICK + 0.006 * humanUnitScale);
             const bridgeCuePoint = bridgeTarget
               .clone()

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -245,6 +245,7 @@ const BASE_CFG = {
   shootCounterLeanSide: -1,
   shootUpperBodyCounterLean: 1,
   plantFeetDuringShot: true,
+  bridgeArmStraightDown: false,
   forceTableFacingAim: true
 };
 
@@ -843,7 +844,16 @@ export function updateHumanPose(human, dt, frameData) {
   const idleWristTarget = frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal));
   const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - cfg.rightHandDownPose, handIk), cfg.rightHandCueSocketLocal));
   const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
-  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * cfg.unit * t).addScaledVector(side, -0.044 * cfg.unit * t).addScaledVector(forward, 0.065 * cfg.unit * t);
+  const bridgeArmDownElbow = leftHand.clone()
+    .addScaledVector(UP, 0.34 * cfg.unit)
+    .addScaledVector(side, -0.01 * cfg.unit)
+    .addScaledVector(forward, 0.012 * cfg.unit);
+  const leftElbow = leftShoulder.clone()
+    .lerp(leftHand, 0.62)
+    .addScaledVector(UP, 0.006 * cfg.unit * t)
+    .addScaledVector(side, -0.044 * cfg.unit * t)
+    .addScaledVector(forward, 0.065 * cfg.unit * t)
+    .lerp(bridgeArmDownElbow, cfg.bridgeArmStraightDown ? t : 0);
   const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * cfg.unit * t).addScaledVector(side, -0.012 * cfg.unit * t);
   const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * cfg.unit * t).addScaledVector(side, 0.014 * cfg.unit * t);
 


### PR DESCRIPTION
### Motivation
- Update the Showood GLB table model to better match visual scale and material mapping used by Pool Royale and ensure chrome plates render consistently. 
- Improve the player bridge pose so the bridge hand drops to the cloth and the cue stays aligned for the lowered portrait camera pose. 

### Description
- Updated `POOL_ROYALE_TABLE_MODEL_OPTIONS` for `showood-seven-foot` to change `fitScale` from `1.035` to `1.055` and `clothRepeatScale` from `3.2` to `5.25`, remove `trim` from `usePoolRoyaleFinishRoles`, clear `preserveOriginalSurfaceRoles`, add `forceGeneratedChromePlates: true`, and move `trim` into `hideSurfaceRoles` (file `webapp/src/config/poolRoyaleTableModels.js`).
- Adjusted the table-model resolution test expectations in `test/poolRoyaleTableModels.test.js` to match the new model fields and values.
- Modified external GLB mount visibility logic in `webapp/src/pages/Games/PoolRoyale.jsx` so generated chrome-plate objects can be forced visible when a table model sets `forceGeneratedChromePlates`, and updated condition ordering to preserve `externalTableKeepVisible` behavior.
- Tuned human rig parameters in `webapp/src/pages/Games/PoolRoyale.jsx` by lowering `shootUpperBodyCounterLean` and enabling `bridgeArmStraightDown` for Pool Royale rigs, and adjusted bridge target offsets to bring the bridge hand closer to the cloth.
- Added `bridgeArmStraightDown` to the human rig base config in `webapp/src/pages/Games/shared/humanRigCore.js` and implemented a blending path for the left elbow (`bridgeArmDownElbow`) so the bridge arm can be straight down when `cfg.bridgeArmStraightDown` is true.

### Testing
- Ran the unit test file `test/poolRoyaleTableModels.test.js` which was updated to reflect the new model configuration and succeeded. 
- Ran the project test suite via `npm test` and observed no failing tests related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcac49cce8832988a4513b4e976e13)