### PR TITLE
Tune Pool Royale table visuals and match Goal Rush walk/pose

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2366,7 +2366,7 @@ const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.9; // keep low-power shots visibly pus
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so powerful shots visibly punch forward
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.96; // increase player size so body/table proportions match Bilardo-like framing
-const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/Soldier.glb';
 const POOL_ROYALE_HUMAN_UNIT_SCALE = BALL_R / 0.0525;
 const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.85 * POOL_ROYALE_HUMAN_UNIT_SCALE; // make the shooter larger again without returning to the oversized direct scale
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
@@ -4152,7 +4152,8 @@ const CHROME_PLATE_STYLE_OPTIONS = Object.freeze([
     sideWidthScale: 1.05,
     sideHeightScale: 0.86,
     sideRadiusScale: 3.4,
-    sideCutScale: 1.12
+    sideCutScale: 1.12,
+    hideGeneratedPlates: true
   },
   {
     id: 'royal-classic',
@@ -10929,7 +10930,9 @@ export function Table3D(
       finishParts.trimMeshes.push(plate);
     });
   }
-  railsGroup.add(chromePlates);
+  if (!chromePlateStyle.hideGeneratedPlates) {
+    railsGroup.add(chromePlates);
+  }
 
   const pocketJawGroup = new THREE.Group();
 
@@ -25795,8 +25798,9 @@ const shotPowerRef = useRef(0);
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
             // Drop the bridge hand to the cloth while keeping the cue aligned with the aim line
-            // as the portrait camera lowers into the ready-to-shoot view.
-            shootBendDirection: -1,
+            // as the portrait camera lowers into the ready-to-shoot view. Positive bend keeps
+            // the shooter folding toward the table instead of bending backward away from it.
+            shootBendDirection: 1,
             shootCounterLeanSide: -1,
             shootUpperBodyCounterLean: 0.72,
             plantFeetDuringShot: true,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -459,6 +459,9 @@ export function createHumanRig(scene, opts = {}) {
     strikeRoot: new THREE.Vector3(),
     strikeYaw: 0,
     strikeClock: 0,
+    mixer: null,
+    actions: {},
+    currentAction: 'Idle',
     cfg
   };
   human.root.visible = false;
@@ -496,6 +499,24 @@ export function createHumanRig(scene, opts = {}) {
           mat.depthTest = true;
           mat.needsUpdate = true;
         });
+      });
+      human.mixer = new THREE.AnimationMixer(model);
+      const clipByName = new Map((gltf.animations || []).map((clip) => [String(clip.name || '').toLowerCase(), clip]));
+      const aliases = {
+        Idle: ['idle'],
+        Walk: ['walk', 'walking'],
+        Run: ['run', 'running']
+      };
+      Object.entries(aliases).forEach(([name, names]) => {
+        const clip = names.map((alias) => clipByName.get(alias)).find(Boolean);
+        if (!clip) return;
+        const action = human.mixer.clipAction(clip);
+        action.enabled = true;
+        action.setLoop(THREE.LoopRepeat, Infinity);
+        action.clampWhenFinished = false;
+        action.setEffectiveWeight(name === 'Idle' ? 1 : 0);
+        action.play();
+        human.actions[name] = action;
       });
       human.bones = buildAvatarBones(model);
       human.leftFingers = collectFingerBones(human.bones.leftHand);
@@ -625,6 +646,36 @@ function poseFingers(fingers, mode, weight) {
   });
 }
 
+function setHumanAction(human, next, blend = 0.18) {
+  if (!human?.actions?.[next] || human.currentAction === next) return;
+  const previous = human.actions[human.currentAction];
+  const nextAction = human.actions[next];
+  if (previous && nextAction) {
+    nextAction.enabled = true;
+    nextAction.reset();
+    nextAction.setEffectiveTimeScale(1);
+    nextAction.setEffectiveWeight(1);
+    previous.crossFadeTo(nextAction, blend, false);
+    nextAction.play();
+  }
+  human.currentAction = next;
+}
+
+function updateGoalRushWalkAnimation(human, dt, frame) {
+  if (!human?.mixer || !human.actions?.Walk) return false;
+  const walkWeight = frame.walkAmount * (1 - easeInOut(clamp01(frame.t)));
+  const next = walkWeight > 0.05 ? 'Walk' : 'Idle';
+  setHumanAction(human, next);
+  const walk = human.actions.Walk;
+  if (walk) {
+    const ref = human.cfg?.perimeterWalkSpeed || human.cfg?.unit || 1;
+    const normalizedSpeed = Math.max(0, Math.min(2, (human.lastMoveAmountRaw || 0) * 60 / Math.max(0.001, ref)));
+    walk.timeScale = THREE.MathUtils.clamp(normalizedSpeed || walkWeight, 0.7, 1.35);
+  }
+  human.mixer.update(dt);
+  return walkWeight > 0.05 && frame.t < 0.025;
+}
+
 function driveHuman(human, frame) {
   if (!human.activeGlb || !human.model) return;
   const cfg = human.cfg;
@@ -632,6 +683,8 @@ function driveHuman(human, frame) {
   human.modelRoot.position.copy(frame.rootWorld);
   human.modelRoot.rotation.y = human.yaw;
   human.modelRoot.updateMatrixWorld(true);
+  const usingGoalRushWalk = updateGoalRushWalkAnimation(human, frame.dt || 0, frame);
+  if (usingGoalRushWalk) return;
   human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
   human.modelRoot.updateMatrixWorld(true);
   const b = human.bones;
@@ -762,6 +815,7 @@ export function updateHumanPose(human, dt, frameData) {
   const idle = 1 - t;
   const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * cfg.unit);
   const walk = Math.sin(human.walkT * 6.2) * Math.min(1, (moveAmountRaw * 12) / cfg.unit);
+  human.lastMoveAmountRaw = moveAmountRaw;
   const walkAmount = clamp01((moveAmountRaw * 18) / cfg.unit) * idle;
   const dragStroke = activeState === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + (frameData.power || 0) * 0.75) : 0;
   const strikeFollow = activeState === 'striking' ? Math.sin(clamp01(human.strikeClock / (cfg.strikeTime + cfg.holdTime)) * Math.PI) : 0;
@@ -860,6 +914,7 @@ export function updateHumanPose(human, dt, frameData) {
   human.root.visible = true;
   driveHuman(human, {
     t,
+    dt,
     stroke: forearmStroke / cfg.unit,
     follow: strikeFollow,
     walkAmount,


### PR DESCRIPTION
### Motivation
- Remove the procedurally-generated chrome fascia plates that were overlaying the Showood table so the Showood table renders its original trim cleanly.
- Make the Pool Royale shooter walk exactly like the Goal Rush character by reusing the same animated GLTF and animation blending, and correct the shooting pose which was folding the torso backward.

### Description
- Added a `hideGeneratedPlates` option to the chrome plate style (`CHROME_PLATE_STYLE_OPTIONS`) and only attach the generated chrome group when `hideGeneratedPlates` is false, preventing procedural chrome plates from being added by default (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Swapped Pool Royale human GLTF to the same animated Soldier model used by Goal Rush by changing `BILARDO_SHQIP_HUMAN_URL` to the `Soldier.glb` URL (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Extended the shared human rig in `shared/humanRigCore.js` with `AnimationMixer` setup and actions for `Idle/Walk/Run`, added `setHumanAction` and `updateGoalRushWalkAnimation` helpers, and integrated them into `driveHuman` so GLTF walk animations drive visual walking and bypass procedural IK while walking.
- Flipped the shooting bend from `shootBendDirection: -1` to `shootBendDirection: 1` so the shooter folds toward the table instead of bending backward (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Threaded `dt` and movement telemetry (`lastMoveAmountRaw`) through the pose update path so animation time-scaling stays synchronized with the perimeter-walk movement (`webapp/src/pages/Games/shared/humanRigCore.js`).

### Testing
- Ran `git diff --check` with no notable issues.
- Built the web app with `npm --prefix webapp run build`; the build completed successfully (Vite build produced final `dist` bundles with chunk warnings only). ✅
- Installed Playwright browsers (`npx playwright install chromium`) successfully but an automated headless screenshot attempt failed to launch Chromium due to a missing system library `libatk-1.0.so.0` in the container, so end-to-end visual verification via Playwright could not be completed in this environment (library missing). ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcce41d3b08329b383724d19797626)