### PR TITLE
Fix Pool Royale character facing direction

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25796,7 +25796,9 @@ const shotPowerRef = useRef(0);
             modelUrl: BILARDO_SHQIP_HUMAN_URL,
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
-            humanVisualYawFix: Math.PI,
+            // ReadyPlayer avatars face down their local -Z axis after normalization; keep
+            // that visual forward aligned with the rig yaw so the shooter faces the table.
+            humanVisualYawFix: 0,
             // Drop the bridge hand to the cloth while keeping the cue aligned with the aim line
             // as the portrait camera lowers into the ready-to-shoot view. Positive bend keeps
             // the shooter folding toward the table instead of bending backward away from it.


### PR DESCRIPTION
### Motivation
- Players' avatars were visually facing away from the table because the ReadyPlayer GLTFs are normalized to look down their local -Z axis; align the visual forward with the rig yaw so the shooter faces the table.

### Description
- Set `humanVisualYawFix` to `0` (was `Math.PI`) in the Pool Royale `createBilardoHumanRig` call inside `webapp/src/pages/Games/PoolRoyale.jsx` and added an inline comment explaining the override.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite emitted existing chunk/import warnings but the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd4d934b483299dbe27d1ebb77c83)