### PR TITLE
Adjust Snake & Ladder seating calibration and portrait camera framing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -55,9 +55,9 @@ const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
 const AI_CHAIR_GAP = CARD_W * 0.74;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
-// Portrait calibration: push the chair ring slightly outward and seat humans closer to the chair backs.
-const CHAIR_GLOBAL_PUSHBACK = 0.64 * MODEL_SCALE;
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.66 * MODEL_SCALE;
+// Portrait calibration: keep the chair ring closer to the table while humans sit back toward the chair backs.
+const CHAIR_GLOBAL_PUSHBACK = 0.52 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.54 * MODEL_SCALE;
 const TABLE_HEIGHT_LIFT = -0.045 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
@@ -174,9 +174,9 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.82;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
 const SEATED_HUMAN_SEAT_Y_OFFSET = -5.6 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.38;
-// Portrait calibration: nudge the bottom/self human outward too so bodies sit closer to chairs than the table.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = SEAT_DEPTH * 0.06;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.28;
+// Portrait calibration: nudge the bottom/self human farther outward too so bodies sit closer to chairs than the table.
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = SEAT_DEPTH * 0.12;
 const SEATED_HUMAN_WEAPON_RIGHT_HAND_X = SEAT_WIDTH * 0.47;
 const SEATED_HUMAN_WEAPON_SIDE_Z = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
@@ -549,7 +549,7 @@ const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
 const CAMERA_EXTRA_LIFT = -0.1;
-const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.62;
+const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.58;
 const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.65;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;


### PR DESCRIPTION
### Motivation
- Improve visual composition on portrait phones by moving seated humans slightly away from the table toward their chairs and adjusting the chair ring and camera so characters read correctly in the portrait frame.

### Description
- Reduced `CHAIR_GLOBAL_PUSHBACK` and `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` to pull the chair ring a bit closer to the table (file: `webapp/src/components/SnakeBoard3D.jsx`).
- Moved seated human anchors by changing `SEATED_HUMAN_SEAT_Z_OFFSET` and increasing `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` so avatars sit more outward toward chair backs, with an extra offset for the bottom/self player.
- Lowered `PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR` to bring the initial portrait camera closer and keep the adjusted chairs and humans in a better frame.

### Testing
- Built the web app with `cd webapp && npx vite build` which completed successfully and produced the `dist` output.
- Installed Playwright browsers and dependencies with `npm exec -- playwright install chromium` and `npm exec -- playwright install-deps chromium` (resolved initial launch errors by installing deps), both succeeded.
- Launched the dev server with `cd webapp && npm exec -- vite -- --host 127.0.0.1` and captured a portrait smoke screenshot using a Playwright script (`node - <<'NODE' ... playwright screenshot ... NODE`), which saved `/tmp/snake-ladder-seating.png`.
- Visual/manual smoke check: verified the seating/avatars and camera framing in the generated portrait screenshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd61b44a483299563fa60fd19db10)