### PR TITLE
Adjust Texas Hold'em human seating

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -401,7 +401,7 @@ const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT = 0;
 const CAMERA_LANDSCAPE_MIN_LOOK_UP = THREE.MathUtils.degToRad(10);
 const CAMERA_LANDSCAPE_MAX_LOOK_DOWN = THREE.MathUtils.degToRad(34);
-const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: CARD_W * -0.12, landscape: -CARD_W * 0.78 });
+const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: CARD_W * -0.46, landscape: -CARD_W * 0.78 });
 const OVERHEAD_ZOOM_DEFAULT = 1;
 const OVERHEAD_ZOOM_MIN = 0.82;
 const OVERHEAD_ZOOM_MAX = 1.1;
@@ -657,6 +657,8 @@ const TEXAS_MURLAN_SEATED_OFFSET_Y = -0.92;
 const TEXAS_MURLAN_SEATED_OFFSET_Z = -0.24;
 const TEXAS_MURLAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.88;
 const TEXAS_MURLAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.18;
+const TEXAS_HUMAN_CHARACTER_TABLE_INWARD_OFFSET = 0.24;
+const TEXAS_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.14;
 const TEXAS_CHARACTER_CARD_HAND_LIFT = 0.36 * MODEL_SCALE;
 const texasDominoCharacterTemplateCache = new Map();
 const texasDominoCharacterTextureCache = new Map();
@@ -1458,10 +1460,12 @@ async function attachTexasDominoCharacterToSeat(seatGroup, seatIndex, renderer) 
     seatRoot.scale.setScalar(seatScale);
     const baseSeatOffsetY = (theme.normalizedSeatOffsetY ?? TEXAS_MURLAN_SEATED_OFFSET_Y) - 0.2;
     const baseSeatOffsetZ = theme.normalizedSeatOffsetZ ?? TEXAS_MURLAN_SEATED_OFFSET_Z;
+    const humanLowerOffset = isHumanSeat ? TEXAS_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET : 0;
+    const humanTableInwardOffset = isHumanSeat ? TEXAS_HUMAN_CHARACTER_TABLE_INWARD_OFFSET : 0;
     seatRoot.position.set(
       0,
-      baseSeatOffsetY - 0.22 - scaleDelta * 0.08 - TEXAS_MURLAN_CHARACTER_EXTRA_LOWER_OFFSET,
-      baseSeatOffsetZ - 0.03 - TEXAS_MURLAN_CHARACTER_EXTRA_OUTWARD_OFFSET
+      baseSeatOffsetY - 0.22 - scaleDelta * 0.08 - TEXAS_MURLAN_CHARACTER_EXTRA_LOWER_OFFSET - humanLowerOffset,
+      baseSeatOffsetZ - 0.03 - TEXAS_MURLAN_CHARACTER_EXTRA_OUTWARD_OFFSET - humanTableInwardOffset
     );
     seatRoot.add(instance);
     seatGroup.group.add(seatRoot);


### PR DESCRIPTION
### Motivation
- Make the human (player) avatar appear closer to and lower relative to the poker table on portrait/mobile so the local player feels seated at the table.
- Keep AI/opponent seat geometry and offsets unchanged while applying the visual tweak only to human seats.

### Description
- Updated portrait seating inward offset by changing `HUMAN_SEAT_INWARD_OFFSETS.portrait` from `CARD_W * -0.12` to `CARD_W * -0.46` in `webapp/src/pages/Games/TexasHoldemArena.jsx` to move the human seat closer to the table.
- Added two new human-only constants `TEXAS_HUMAN_CHARACTER_TABLE_INWARD_OFFSET` and `TEXAS_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET` to control inward (Z) and extra lower (Y) offsets for human GLTF characters.
- Applied the new human offsets when mounting the seated GLTF model inside `attachTexasDominoCharacterToSeat` so only `isHumanSeat` attachments receive the lowered and inward positioning.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite emitted chunk-size warnings but built artifacts were produced).
- Installed Playwright browsers and system deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully.
- Launched the dev site and executed a Playwright mobile screenshot script that loads `/games/texasholdem?players=6&mode=local` and captures a portrait screenshot; the script completed and produced the screenshot confirming the visual change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdf71cb808329a24acdbc23be3994)