### PR TITLE
Fix Pool Royale shooting pose and bridge-hand placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2390,7 +2390,7 @@ const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 2.34; // move the low cue camer
 const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 0.22; // preserve subtle right-eye bias without exposing too much of the avatar body
 const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
 const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
-const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.34; // set the bridge farther behind the cue ball to match real pool hand placement
+const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.18; // keep the bridge hand close behind the cue ball like the reference shooting photos
 const HUMAN_BRIDGE_HAND_SIDE = -0.008; // match Bilardo Shqip bridge hand lateral placement
 const HUMAN_BRIDGE_CUE_LIFT = 0.018; // flatten the cue closer to the cloth like the reference shooting photos
 const HUMAN_GRIP_RATIO = 0.9; // anchor right-hand grip much closer to the cue butt so the hand no longer drifts toward the tip
@@ -25805,7 +25805,10 @@ const shotPowerRef = useRef(0);
             // the shooter folding toward the table instead of bending backward away from it.
             shootBendDirection: 1,
             shootCounterLeanSide: -1,
-            shootUpperBodyCounterLean: 0.72,
+            shootUpperBodyCounterLean: 0.45,
+            shootForwardBendScale: 0.62,
+            shootVerticalBendScale: 0.72,
+            bridgeHandTablePress: 0.004 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             plantFeetDuringShot: true,
             bridgeArmStraightDown: true,
             forceTableFacingAim: true,
@@ -25828,9 +25831,9 @@ const shotPowerRef = useRef(0);
             kneeBendShot: 0.16 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             desiredShootDistance: 1.32 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             edgeMargin: 0.68 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            bridgeHandBackFromBall: 0.145 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            bridgeHandSide: -0.012 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            bridgeCueLift: 0.018 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            bridgeHandBackFromBall: HUMAN_BRIDGE_HAND_BACK_FROM_BALL,
+            bridgeHandSide: HUMAN_BRIDGE_HAND_SIDE,
+            bridgeCueLift: HUMAN_BRIDGE_CUE_LIFT,
             shootCueGripFromBack: 0.58 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightElbowShotRise: 0.18 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightElbowShotSide: -0.46 * POOL_ROYALE_HUMAN_UNIT_SCALE,
@@ -26029,13 +26032,13 @@ const shotPowerRef = useRef(0);
             }
             const bridgeTarget = cueWorld
               .clone()
-              .addScaledVector(aimForward, -0.105 * humanUnitScale)
-              .addScaledVector(side, -0.038 * humanUnitScale)
+              .addScaledVector(aimForward, -HUMAN_BRIDGE_HAND_BACK_FROM_BALL)
+              .addScaledVector(side, HUMAN_BRIDGE_HAND_SIDE)
               .setY(TABLE_Y + TABLE.THICK + 0.006 * humanUnitScale);
             const bridgeCuePoint = bridgeTarget
               .clone()
               .addScaledVector(aimForward, 0.014 * humanUnitScale)
-              .add(new THREE.Vector3(0, 0.018 * humanUnitScale, 0));
+              .add(new THREE.Vector3(0, HUMAN_BRIDGE_CUE_LIFT, 0));
             const cueTipShoot = cueWorld
               .clone()
               .addScaledVector(aimForward, -(BALL_R + cueBallGap));
@@ -26043,10 +26046,7 @@ const shotPowerRef = useRef(0);
               .clone()
               .addScaledVector(aimForward, -(cueLen - 0.28 * humanUnitScale - BALL_R - cueBallGap))
               .add(new THREE.Vector3(0, 0.024 * humanUnitScale, 0));
-            const cueShootDir = cueTipShoot.clone().sub(cueBackShoot).normalize();
-            const shootGripTarget = cueBackShoot
-              .clone()
-              .addScaledVector(cueShootDir, 0.58 * humanUnitScale);
+            const shootGripTarget = cueTipShoot.clone().lerp(cueBackShoot, HUMAN_GRIP_RATIO);
             if (isHumanShooter && state === 'dragging') {
               activeHumanCueViewRef.current = {
                 cueBack: cueBackShoot.clone(),

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -244,6 +244,9 @@ const BASE_CFG = {
   shootBendDirection: -1,
   shootCounterLeanSide: -1,
   shootUpperBodyCounterLean: 1,
+  shootForwardBendScale: 1,
+  shootVerticalBendScale: 1,
+  bridgeHandTablePress: 0.006,
   plantFeetDuringShot: true,
   bridgeArmStraightDown: false,
   forceTableFacingAim: true
@@ -761,7 +764,7 @@ function driveHuman(human, frame) {
   const leftHand = frame.leftHandWorld.clone()
     .addScaledVector(frame.forward, 0.032 * cfg.unit * ik)
     .addScaledVector(frame.side, bridgeIkHandSide * ik)
-    .addScaledVector(UP, -0.018 * cfg.unit * ik);
+    .addScaledVector(UP, -0.006 * cfg.unit * ik);
   const leftElbow = frame.leftElbow.clone()
     .addScaledVector(frame.forward, 0.045 * cfg.unit * ik)
     .addScaledVector(frame.side, bridgeIkElbowSide * ik)
@@ -828,18 +831,25 @@ export function updateHumanPose(human, dt, frameData) {
   const upperBodyCounterLean = Number.isFinite(cfg.shootUpperBodyCounterLean)
     ? Math.max(0, cfg.shootUpperBodyCounterLean)
     : 1;
+  const forwardBendScale = Number.isFinite(cfg.shootForwardBendScale)
+    ? THREE.MathUtils.clamp(cfg.shootForwardBendScale, 0.25, 1.15)
+    : 1;
+  const verticalBendScale = Number.isFinite(cfg.shootVerticalBendScale)
+    ? THREE.MathUtils.clamp(cfg.shootVerticalBendScale, 0.35, 1.15)
+    : 1;
   const plantFeetDuringShot = cfg.plantFeetDuringShot !== false;
-  const shotBendZ = (value) => value * bendDirection;
+  const shotBendZ = (value) => value * bendDirection * forwardBendScale;
   const shotCounterLeanX = (value) => value * counterLeanSide * upperBodyCounterLean;
+  const shotY = (standing, shooting) => lerp(standing, lerp(standing, shooting, verticalBendScale), t);
   const rootWorld = human.root.position.clone();
   rootWorld.y = cfg.groundY;
 
-  const torso = local(new THREE.Vector3(shotCounterLeanX(0.025 * t) * cfg.unit, lerp(1.3, 1.14, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.16, t) - 0.014 * powerLean) * cfg.unit));
-  const chest = local(new THREE.Vector3(shotCounterLeanX(0.07 * t + 0.012 * powerLean) * cfg.unit, lerp(1.52, 1.24, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.42, t) - 0.024 * powerLean) * cfg.unit));
-  const neck = local(new THREE.Vector3(shotCounterLeanX(0.105 * t + 0.016 * powerLean) * cfg.unit, lerp(1.68, 1.28, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.61, t) - 0.028 * powerLean) * cfg.unit));
-  const head = local(new THREE.Vector3(shotCounterLeanX(0.12 * t + 0.018 * powerLean) * cfg.unit, lerp(1.84, 1.37, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.16 * t, shotBendZ(lerp(0.04, -0.72, t) - 0.028 * powerLean) * cfg.unit));
-  const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.075 * t)) * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.46, t) - 0.018 * human.settleT) * cfg.unit));
-  const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.058 * t)) * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.unit));
+  const torso = local(new THREE.Vector3(shotCounterLeanX(0.025 * t) * cfg.unit, shotY(1.3, 1.14) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.16, t) - 0.014 * powerLean) * cfg.unit));
+  const chest = local(new THREE.Vector3(shotCounterLeanX(0.07 * t + 0.012 * powerLean) * cfg.unit, shotY(1.52, 1.24) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.42, t) - 0.024 * powerLean) * cfg.unit));
+  const neck = local(new THREE.Vector3(shotCounterLeanX(0.105 * t + 0.016 * powerLean) * cfg.unit, shotY(1.68, 1.28) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.61, t) - 0.028 * powerLean) * cfg.unit));
+  const head = local(new THREE.Vector3(shotCounterLeanX(0.12 * t + 0.018 * powerLean) * cfg.unit, shotY(1.84, 1.37) * cfg.unit + breath - cfg.chinToCueHeight * 0.16 * t, shotBendZ(lerp(0.04, -0.72, t) - 0.028 * powerLean) * cfg.unit));
+  const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.075 * t)) * cfg.unit, shotY(1.58, 1.36) * cfg.unit + breath, shotBendZ(lerp(0, -0.46, t) - 0.018 * human.settleT) * cfg.unit));
+  const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.058 * t)) * cfg.unit, shotY(1.58, 1.36) * cfg.unit + breath, shotBendZ(lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.unit));
   const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const footWalkBlend = plantFeetDuringShot ? idle : 1;
@@ -871,7 +881,7 @@ export function updateHumanPose(human, dt, frameData) {
     .addScaledVector(forward, -0.006 * cfg.unit * t)
     .addScaledVector(side, bridgePalmSide * t)
     .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
-    .addScaledVector(UP, -0.01 * cfg.unit * human.settleT);
+    .addScaledVector(UP, -cfg.bridgeHandTablePress * human.settleT);
   const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);
   const cueDirForHand = frameData.cueTip.clone().sub(frameData.cueBack).normalize();
   const handIk = easeInOut(clamp01(t));


### PR DESCRIPTION
### Motivation
- Players reported the avatar bending backward during shots and the left (bridge) hand not sitting next to the cue ball; the goal is to make the avatar lean toward the shot and keep the left hand planted next to the cue ball like the reference photos. 

### Description
- Added configurable pose controls to the shared human rig: `shootForwardBendScale`, `shootVerticalBendScale`, and `bridgeHandTablePress` and applied them in `updateHumanPose` to reduce the forward/backward fold and tune vertical drop. 
- Reduced the bridge-hand IK upward offset so the left hand stays at table height and closer to the cloth (`leftHand` UP offset changed from `-0.018 * cfg.unit * ik` to `-0.006 * cfg.unit * ik`) in `shared/humanRigCore.js`. 
- Exposed and tuned Pool Royale-specific rig parameters when creating the shooter rig (reduced `shootUpperBodyCounterLean`, added forward/vertical bend scales and small `bridgeHandTablePress`) and reused the shared `HUMAN_BRIDGE_*` constants so bridge/cue math stays aligned in `PoolRoyale.jsx`. 
- Moved Pool Royale bridge target math to use the shared constants (`HUMAN_BRIDGE_HAND_BACK_FROM_BALL`, `HUMAN_BRIDGE_HAND_SIDE`, `HUMAN_BRIDGE_CUE_LIFT`) and changed grip calculation to lerp using `HUMAN_GRIP_RATIO` to keep the right hand near the cue butt. 

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully. 
- Installed Playwright browsers with `npx playwright install chromium` and dependencies with `npx playwright install-deps chromium` successfully. 
- Launched the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1` and performed an automated smoke check of the Pool Royale lobby using Playwright that produced `/tmp/tonplaygram-screens/pool-royale-lobby-smoke.png` successfully. 
- Attempted a Practice-mode Playwright screenshot of the in-game canvas to verify the shooting pose; the heavy WebGL canvas timed out in one capture attempt (Playwright timeout) while the lobby smoke check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce09126948329897e47ed891efda1)