### PR TITLE
Improve Pool Royale shooter stance and bridge-hand placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25806,6 +25806,7 @@ const shotPowerRef = useRef(0);
             shootBendDirection: 1,
             shootCounterLeanSide: -1,
             shootUpperBodyCounterLean: 0.72,
+            shootForwardBendScale: 0.62,
             plantFeetDuringShot: true,
             bridgeArmStraightDown: true,
             forceTableFacingAim: true,
@@ -25828,8 +25829,8 @@ const shotPowerRef = useRef(0);
             kneeBendShot: 0.16 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             desiredShootDistance: 1.32 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             edgeMargin: 0.68 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            bridgeHandBackFromBall: 0.145 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            bridgeHandSide: -0.012 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            bridgeHandBackFromBall: 0.072 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            bridgeHandSide: -0.024 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             bridgeCueLift: 0.018 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             shootCueGripFromBack: 0.58 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightElbowShotRise: 0.18 * POOL_ROYALE_HUMAN_UNIT_SCALE,
@@ -26027,10 +26028,13 @@ const shotPowerRef = useRef(0);
                 1 - Math.pow(1 - strikeNorm, 3)
               );
             }
+            const bridgeBackFromBall = human?.cfg?.bridgeHandBackFromBall ?? 0.072 * humanUnitScale;
+            const bridgeSideOffset = human?.cfg?.bridgeHandSide ?? -0.024 * humanUnitScale;
             const bridgeTarget = cueWorld
               .clone()
-              .addScaledVector(aimForward, -0.105 * humanUnitScale)
-              .addScaledVector(side, -0.038 * humanUnitScale)
+              // Put the left bridge hand on the cloth right beside the cue ball, like a real pool stance.
+              .addScaledVector(aimForward, -bridgeBackFromBall)
+              .addScaledVector(side, bridgeSideOffset)
               .setY(TABLE_Y + TABLE.THICK + 0.006 * humanUnitScale);
             const bridgeCuePoint = bridgeTarget
               .clone()

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -244,6 +244,7 @@ const BASE_CFG = {
   shootBendDirection: -1,
   shootCounterLeanSide: -1,
   shootUpperBodyCounterLean: 1,
+  shootForwardBendScale: 1,
   plantFeetDuringShot: true,
   bridgeArmStraightDown: false,
   forceTableFacingAim: true
@@ -828,8 +829,11 @@ export function updateHumanPose(human, dt, frameData) {
   const upperBodyCounterLean = Number.isFinite(cfg.shootUpperBodyCounterLean)
     ? Math.max(0, cfg.shootUpperBodyCounterLean)
     : 1;
+  const forwardBendScale = Number.isFinite(cfg.shootForwardBendScale)
+    ? Math.max(0, cfg.shootForwardBendScale)
+    : 1;
   const plantFeetDuringShot = cfg.plantFeetDuringShot !== false;
-  const shotBendZ = (value) => value * bendDirection;
+  const shotBendZ = (value) => value * bendDirection * forwardBendScale;
   const shotCounterLeanX = (value) => value * counterLeanSide * upperBodyCounterLean;
   const rootWorld = human.root.position.clone();
   rootWorld.y = cfg.groundY;


### PR DESCRIPTION
### Motivation
- Shooter avatar was bending unnaturally backward during aiming/shot; stance should fold toward the table and place the left/bridge hand on the cloth beside the cue ball as in the reference photos.

### Description
- Add a new shared rig option `shootForwardBendScale` to scale forward/away bend intensity independently of bend direction in `shared/humanRigCore.js`. 
- Reduce Pool Royale forward-bend intensity by setting `shootForwardBendScale: 0.62` for the local rig and apply it in the shared pose math so the upper body no longer over-folds. 
- Move the bridge/left-hand target closer to the cue ball by lowering `bridgeHandBackFromBall` and adjusting `bridgeHandSide`, and replace the hardcoded bridge offsets with values read from the rig config so the palm sits on the cloth next to the cue ball (changes in `PoolRoyale.jsx`).

### Testing
- Ran the webapp production build with `npm --prefix webapp run build` and the build completed successfully. 
- Ran static checks (`diff --check`) with no reported issues. 
- Started the dev server and attempted automated visual verification with Playwright, but headless screenshot capture timed out in this environment (Playwright browser setup and dependency installation were exercised).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce09126948329897e47ed891efda1)