### PR TITLE
Tune Pool Royale Showood table fit and make shooter bend toward cue-stick

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -20,7 +20,7 @@ describe('Pool Royale table models', () => {
     assert.ok(showood, 'Showood table model must be configured');
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
-    assert.equal(showood.fitScale, 1.055);
+    assert.equal(showood.fitScale, 1.08);
     assert.equal(showood.clothRepeatScale, 5.25);
     assert.deepEqual(showood.hideSurfaceRoles, ['trim']);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -24,7 +24,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
-    fitScale: 1.055,
+    fitScale: 1.08,
     clothRepeatScale: 5.25,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25804,6 +25804,7 @@ const shotPowerRef = useRef(0);
             // as the portrait camera lowers into the ready-to-shoot view. Positive bend keeps
             // the shooter folding toward the table instead of bending backward away from it.
             shootBendDirection: 1,
+            shootBendTowardCueStick: true,
             shootCounterLeanSide: -1,
             shootUpperBodyCounterLean: 0.72,
             shootForwardBendScale: 0.62,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -238,10 +238,11 @@ const BASE_CFG = {
   groundY: 0,
   perimeterWalk: false,
   perimeterWalkSpeed: 4.0,
-  // The shooting pose bends the upper body away from the cue-side fold while the
-  // IK feet stay planted on the floor. Pool Royale can override the strength,
-  // but the default keeps spine/chest/head targets on the opposite side.
+  // The shooting pose can lock the upper-body fold to the live cue/bridge target
+  // so the avatar leans toward the cue stick instead of relying on a fixed local
+  // Z sign that may read as backwards after table/camera orientation changes.
   shootBendDirection: -1,
+  shootBendTowardCueStick: false,
   shootCounterLeanSide: -1,
   shootUpperBodyCounterLean: 1,
   shootForwardBendScale: 1,
@@ -833,7 +834,19 @@ export function updateHumanPose(human, dt, frameData) {
     ? Math.max(0, cfg.shootForwardBendScale)
     : 1;
   const plantFeetDuringShot = cfg.plantFeetDuringShot !== false;
-  const shotBendZ = (value) => value * bendDirection * forwardBendScale;
+  const cueBendReference = cfg.shootBendTowardCueStick
+    ? frameData.bridgeTarget || frameData.cueTip || frameData.gripTarget || null
+    : null;
+  const cueBendLocalZ = cueBendReference
+    ? cueBendReference.clone().sub(human.root.position).applyAxisAngle(Y_AXIS, -human.yaw).z
+    : 0;
+  const cueBendSign = Math.abs(cueBendLocalZ) > 1e-5 ? Math.sign(cueBendLocalZ) : 0;
+  const shotBendZ = (value) => {
+    if (cfg.shootBendTowardCueStick && cueBendSign !== 0) {
+      return Math.abs(value) * cueBendSign * forwardBendScale;
+    }
+    return value * bendDirection * forwardBendScale;
+  };
   const shotCounterLeanX = (value) => value * counterLeanSide * upperBodyCounterLean;
   const rootWorld = human.root.position.clone();
   rootWorld.y = cfg.groundY;


### PR DESCRIPTION
### Motivation
- Make the Showood 7 ft GLB table read slightly larger in the Pool Royale portrait framing so visuals better match design intent. 
- Improve the player shooting pose so the human avatar folds toward the live cue/bridge target (visually forward toward the cue stick) instead of sometimes bending backward due to a fixed sign rule. 

### Description
- Increased the `fitScale` for the `showood-seven-foot` table in `webapp/src/config/poolRoyaleTableModels.js` from `1.055` to `1.08` so the external GLB fits a bit larger. 
- Added a new config flag `shootBendTowardCueStick` to the shared human rig (`webapp/src/pages/Games/shared/humanRigCore.js`) and implemented runtime logic that, when enabled, computes the cue-target sign and bends the torso/chest/head toward the cue/bridge target instead of using a fixed local sign. 
- Enabled `shootBendTowardCueStick: true` for Pool Royale when creating the bilardo human rig in `webapp/src/pages/Games/PoolRoyale.jsx` so Pool Royale shooters lean toward the cue. 
- Updated the table-model unit test `test/poolRoyaleTableModels.test.js` to expect the new `fitScale` value. 

### Testing
- Ran `npm test -- poolRoyaleTableModels.test.js --runInBand` and the updated test suite passed. 
- Built the webapp with `npm --prefix webapp run build` and the Vite production build completed successfully. 
- Executed Playwright setup commands `npx playwright install chromium` and `npx playwright install-deps chromium` which completed (browsers and dependencies downloaded). 
- Launched a Playwright script against the local dev server to capture a screenshot of the Pool Royale lobby which produced `artifacts/pool-royale-lobby.png` (scripting completed without failing the automated run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd52590aa4832984e3f73235105ff6)