### PR TITLE
Center snake board in portrait view

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -4059,7 +4059,9 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
   const fit = () => {
     const w = host.clientWidth;
     const h = host.clientHeight;
+    const isPhonePortrait = h > w;
     renderer.setSize(w, h, false);
+    camera.clearViewOffset();
     camera.aspect = w / h || 1;
     camera.updateProjectionMatrix();
     const tableSpan = (tableInfo.radius ?? TABLE_RADIUS) * 2.6;
@@ -4070,6 +4072,23 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     const radius = clamp(Math.max(needed, currentRadius), CAM.minR, CAM.maxR);
     const dir = camera.position.clone().sub(boardLookTarget).normalize();
     camera.position.copy(boardLookTarget).addScaledVector(dir, radius);
+    camera.updateMatrixWorld(true);
+
+    // Phone portrait calibration: the board itself, not the lifted look target above it,
+    // must land exactly at the visual center of the screen. The computed view offset also
+    // brings the full table/chair/avatar composition slightly lower when it was reading high.
+    if (isPhonePortrait && w > 0 && h > 0) {
+      boardGroup.updateMatrixWorld(true);
+      const boardCenter = boardGroup.getWorldPosition(new THREE.Vector3());
+      const projectedCenter = boardCenter.clone().project(camera);
+      const centerOffsetX = (projectedCenter.x * 0.5 + 0.5) * w - w / 2;
+      const centerOffsetY = (0.5 - projectedCenter.y * 0.5) * h - h / 2;
+      if (Number.isFinite(centerOffsetX) && Number.isFinite(centerOffsetY)) {
+        camera.setViewOffset(w, h, centerOffsetX, centerOffsetY, w, h);
+        camera.updateProjectionMatrix();
+      }
+    }
+
     controls.minDistance = CAM.minR;
     controls.maxDistance = CAM.maxR;
     controls.update();


### PR DESCRIPTION
### Motivation
- Ensure the Snake & Ladder board itself is visually centered on small portrait phones so the table, tokens and seated humans read correctly on the mobile screen.
- Remove the visual offset where the camera’s lifted look-target (above the board) was visually centered instead of the actual board geometry, which made chairs/avatars appear too high.

### Description
- Detect phone portrait layout in the arena `fit()` routine and clear any existing camera view offset before recomputing the camera fit. 
- Project the `boardGroup` world center into screen space and compute pixel offsets, then call `camera.setViewOffset(...)` so the board center lands at the visual center of the phone viewport. 
- Call `camera.updateMatrixWorld(true)` and `camera.updateProjectionMatrix()` after applying offsets, and keep renderer size/controls updated so the full table/chair/avatar composition remains aligned. 
- Change applied to `webapp/src/components/SnakeBoard3D.jsx` (portrait calibration and view-offset logic). 

### Testing
- Ran the production build with `npm run build` for the webapp and the build completed successfully. 
- Launched the dev server with `npm run dev` (Vite) to exercise the change during development and the server started successfully. 
- Attempted an automated Playwright screenshot of `/games/snake` to validate the portrait render, but Chromium could not launch in this environment due to a missing system library (`libatk-1.0.so.0`), so headless screenshot capture failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd52eb5c6c8329821db4f2d1b8948c)