### PR TITLE
Center Snake & Ladder board on portrait screens

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -274,7 +274,10 @@ const CAMERA_FOV = ARENA_CAMERA_DEFAULTS.fov;
 const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
-const CAMERA_TARGET_EXTRA = 0.12 * MODEL_SCALE;
+// Portrait framing calibration: aim the camera at the physical board surface center,
+// not above the table, so the Snake board center projects to the exact phone center.
+const BOARD_SURFACE_CENTER_LIFT = BOARD_SCALE * (((0.07 + 0.26) * RAW_BOARD_SIZE) / 10.2) - 0.01;
+const CAMERA_TARGET_EXTRA = 0;
 const CAMERA_SIDE_LOOK_EXTRA = 0.6 * MODEL_SCALE;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
 const CAMERA_BROADCAST_TARGET_BLEND = 0.5;
@@ -557,7 +560,7 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: 1.72,
   forwardOffset: 0.34,
   heightOffset: 2.46,
-  targetLift: 0.16 * MODEL_SCALE
+  targetLift: BOARD_SURFACE_CENTER_LIFT
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.9,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -346,11 +346,12 @@ function resolveAiTokenShapes(options, count) {
 }
 
 const FALLBACK_SEAT_POSITIONS = [
-  { left: '50%', top: '92%' },
-  { left: '78%', top: '54%' },
-  { left: '48%', top: '22%' },
-  { left: '22%', top: '55%' }
+  { left: '50%', top: '94%' },
+  { left: '78%', top: '58%' },
+  { left: '48%', top: '27%' },
+  { left: '22%', top: '59%' }
 ];
+const AVATAR_RING_SCREEN_DOWN_OFFSET_PERCENT = 3.8;
 const SELF_AVATAR_SCREEN_DOWN_OFFSET_PERCENT = 12.4;
 
 const clampValue = (value, min, max) => Math.max(min, Math.min(max, value));
@@ -3927,7 +3928,7 @@ export default function SnakeAndLadder() {
                   left: `${anchor.x}%`,
                   top: `${Math.min(
                     97,
-                    anchor.y + (seatIndex === 0 ? SELF_AVATAR_SCREEN_DOWN_OFFSET_PERCENT : 0)
+                    anchor.y + AVATAR_RING_SCREEN_DOWN_OFFSET_PERCENT + (seatIndex === 0 ? SELF_AVATAR_SCREEN_DOWN_OFFSET_PERCENT : 0)
                   )}%`,
                   transform: 'translate(-50%, -50%)'
                 }


### PR DESCRIPTION
### Motivation
- On portrait phones the Snake & Ladder board and avatar ring were visually too high; the camera should target the physical board surface center so the board center sits exactly at the phone center and player avatars/chairs appear lower on the screen.

### Description
- Recalibrated portrait camera framing in `webapp/src/components/SnakeBoard3D.jsx` by computing `BOARD_SURFACE_CENTER_LIFT` and setting `CAMERA_TARGET_EXTRA` to `0`, and using `BOARD_SURFACE_CENTER_LIFT` for the portrait `targetLift` so the camera aims at the board surface center instead of above the table.
- Lowered the projected avatar ring and fallback avatar positions in `webapp/src/pages/Games/SnakeAndLadder.jsx` by adjusting `FALLBACK_SEAT_POSITIONS` and adding `AVATAR_RING_SCREEN_DOWN_OFFSET_PERCENT`, then applying that offset when projecting seat anchors so chairs and avatars sit further down the phone screen.

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully.
- Attempted an automated mobile rendering check with Playwright (headless Chromium) to capture a portrait screenshot; Playwright and missing system libs were installed but the page screenshot timed out because several external 3D / network resources failed to load in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd52eb5c6c8329821db4f2d1b8948c)