### PR TITLE
Push Murlan Royale player hand cards farther from table

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2833,15 +2833,28 @@ const AI_CARD_LIFT = 0.076 * MODEL_SCALE;
 const AI_CARD_PRE_LIFT = 0.058 * MODEL_SCALE;
 const AI_CARD_PRE_LIFT_PORTION = 0.32;
 const AI_CARD_OUTWARD = 0.26 * MODEL_SCALE;
+const PLAYER_HAND_TABLE_OUTWARD_PUSH = 0.34 * MODEL_SCALE;
 const PLAYER_HAND_OUTWARD_PUSH_ONE_CARD = CARD_H;
 const PLAYER_HAND_UP_LIFT_ONE_CARD = CARD_H;
 
 function resolveSeatHandRadius(tableRadius, isHumanSeat) {
   const safeTableRadius = Number.isFinite(tableRadius) ? tableRadius : TABLE_RADIUS;
   if (isHumanSeat) {
-    return safeTableRadius + HUMAN_HAND_TABLE_EDGE_MARGIN - HUMAN_HAND_CLOSER_OFFSET - HAND_CARDS_INWARD_BIAS;
+    return (
+      safeTableRadius +
+      HUMAN_HAND_TABLE_EDGE_MARGIN +
+      PLAYER_HAND_TABLE_OUTWARD_PUSH -
+      HUMAN_HAND_CLOSER_OFFSET -
+      HAND_CARDS_INWARD_BIAS
+    );
   }
-  return safeTableRadius + AI_HAND_TABLE_EDGE_MARGIN - AI_HAND_CLOSER_OFFSET - HAND_CARDS_INWARD_BIAS;
+  return (
+    safeTableRadius +
+    AI_HAND_TABLE_EDGE_MARGIN +
+    PLAYER_HAND_TABLE_OUTWARD_PUSH -
+    AI_HAND_CLOSER_OFFSET -
+    HAND_CARDS_INWARD_BIAS
+  );
 }
 
 function calcFanCardPose(cardCount, cardIdx) {


### PR DESCRIPTION
### Motivation
- Move player-held cards visually farther away from the table on portrait mobile so hands read as more separated from the table edge.

### Description
- Add a new constant `PLAYER_HAND_TABLE_OUTWARD_PUSH` to tune a shared outward offset for player hand placement.
- Apply `PLAYER_HAND_TABLE_OUTWARD_PUSH` inside `resolveSeatHandRadius` so both human and AI seat radii are increased and cards are rendered farther from the table.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production `dist` output.
- Ran `npx playwright install chromium` and `npx playwright install-deps chromium` which completed successfully to prepare browser dependencies.
- Attempted an automated portrait screenshot via Playwright (narrow viewport) against the local dev server, but `page.screenshot` timed out / failed in the headless CI-like environment due to browser/resource/loading issues; visual verification should be validated in an interactive/dev environment if needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5497d264832988a00ba4af780d4c)