### PR TITLE
Adjust Texas Hold'em seating camera layout

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -409,6 +409,7 @@ const OVERHEAD_PINCH_SENSITIVITY = 0.0025;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * -0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
+const PORTRAIT_CAMERA_LOOK_UP_LIFT = 0.12 * MODEL_SCALE;
 const HUMAN_CARD_INWARD_SHIFT = CARD_W * -2.66;
 const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.82;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.4;
@@ -658,6 +659,8 @@ const TEXAS_MURLAN_SEATED_OFFSET_Z = -0.24;
 const TEXAS_MURLAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.88;
 const TEXAS_MURLAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.18;
 const TEXAS_HUMAN_CHARACTER_TABLE_INWARD_OFFSET = 0.24;
+const TEXAS_CHARACTER_TABLE_INWARD_NUDGE = 0.18 * MODEL_SCALE;
+const TEXAS_CHAIR_TABLE_OUTWARD_NUDGE = 0.1 * MODEL_SCALE;
 const TEXAS_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.14;
 const TEXAS_CHARACTER_CARD_HAND_LIFT = 0.36 * MODEL_SCALE;
 const texasDominoCharacterTemplateCache = new Map();
@@ -1465,7 +1468,11 @@ async function attachTexasDominoCharacterToSeat(seatGroup, seatIndex, renderer) 
     seatRoot.position.set(
       0,
       baseSeatOffsetY - 0.22 - scaleDelta * 0.08 - TEXAS_MURLAN_CHARACTER_EXTRA_LOWER_OFFSET - humanLowerOffset,
-      baseSeatOffsetZ - 0.03 - TEXAS_MURLAN_CHARACTER_EXTRA_OUTWARD_OFFSET - humanTableInwardOffset
+      baseSeatOffsetZ -
+        0.03 -
+        TEXAS_MURLAN_CHARACTER_EXTRA_OUTWARD_OFFSET -
+        humanTableInwardOffset -
+        TEXAS_CHARACTER_TABLE_INWARD_NUDGE
     );
     seatRoot.add(instance);
     seatGroup.group.add(seatRoot);
@@ -4691,6 +4698,7 @@ function TexasHoldemArena({ search }) {
               chairMeshes.push(obj);
             }
           });
+          clone.position.z += TEXAS_CHAIR_TABLE_OUTWARD_NUDGE;
           group.add(clone);
           seat.chairMeshes = chairMeshes;
         });
@@ -5219,7 +5227,9 @@ function TexasHoldemArena({ search }) {
         railFocus.y -= HUMAN_TURN_RAIL_FOCUS_DROP;
         focus.copy(potFocus.clone().lerp(railFocus, HUMAN_TURN_RAIL_FOCUS_BLEND));
       }
-      if (!portrait) {
+      if (portrait) {
+        focus.y += PORTRAIT_CAMERA_LOOK_UP_LIFT;
+      } else {
         focus.y += CAMERA_LANDSCAPE_LOOK_UP_LIFT;
         focus.addScaledVector(humanSeat.right, CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT);
       }
@@ -5348,6 +5358,7 @@ function TexasHoldemArena({ search }) {
             chairMeshes.push(obj);
           }
         });
+        chairModel.position.z += TEXAS_CHAIR_TABLE_OUTWARD_NUDGE;
         group.add(chairModel);
         arenaGroup.add(group);
 


### PR DESCRIPTION
### Motivation
- Improve portrait seating composition for Texas Hold’em by bringing human characters visually closer to the table, nudging chairs slightly away, and raising the portrait camera look so the view reads better on phone portrait screens.

### Description
- Introduced small tuning constants: `PORTRAIT_CAMERA_LOOK_UP_LIFT`, `TEXAS_CHARACTER_TABLE_INWARD_NUDGE`, and `TEXAS_CHAIR_TABLE_OUTWARD_NUDGE` in `webapp/src/pages/Games/TexasHoldemArena.jsx` to control independent camera / character / chair offsets.
- Adjusted seated character placement so character rigs are moved slightly inward toward the table by using `TEXAS_CHARACTER_TABLE_INWARD_NUDGE` when mounting character `seatRoot` in `attachTexasDominoCharacterToSeat`.
- Applied an outward Z offset to chair models in both chair-template application and initial chair creation to keep chairs visually a bit farther from the table (`clone.position.z += TEXAS_CHAIR_TABLE_OUTWARD_NUDGE` and `chairModel.position.z += TEXAS_CHAIR_TABLE_OUTWARD_NUDGE`).
- Tweaked `applySeatedCamera` focus logic to add `PORTRAIT_CAMERA_LOOK_UP_LIFT` when in portrait mode so the camera looks a touch more upward on phones.

### Testing
- Ran `git diff --check` to validate changes (no issues found) and committed the patch.
- Built the webapp with `npm --prefix webapp run build` which completed successfully.
- Installed Playwright and browser dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium` (succeeded) and used a headless Playwright script to load the local dev site and capture a portrait screenshot, which exercised the portrait camera/seat layout changes; the run completed with some non-blocking resource/load warnings reported by the page but the automation finished.
- All automated steps above completed; no new unit tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd543b0dc88329a860eba92bed3f9f)