### PR TITLE
Resolve domino character seat placement relative to chair orientation and bump script version

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8306,6 +8306,52 @@ function refreshAllDominoCharacterRacks() {
   });
 }
 
+const DOMINO_CHARACTER_WORLD_VECTOR = new THREE.Vector3();
+const DOMINO_CHARACTER_WORLD_ORIGIN = new THREE.Vector3();
+const DOMINO_CHARACTER_WORLD_TARGET = new THREE.Vector3();
+const DOMINO_CHARACTER_LOCAL_ORIGIN = new THREE.Vector3();
+const DOMINO_CHARACTER_LOCAL_TARGET = new THREE.Vector3();
+
+function resolveDominoCharacterOutwardLocalSign(chair) {
+  if (!chair?.isObject3D) return 1;
+  chair.updateWorldMatrix(true, false);
+  chair.getWorldPosition(DOMINO_CHARACTER_WORLD_ORIGIN);
+  DOMINO_CHARACTER_WORLD_VECTOR
+    .copy(DOMINO_CHARACTER_WORLD_ORIGIN)
+    .setY(0);
+  if (DOMINO_CHARACTER_WORLD_VECTOR.lengthSq() <= 1e-6) return 1;
+  DOMINO_CHARACTER_WORLD_VECTOR.normalize();
+  DOMINO_CHARACTER_WORLD_TARGET
+    .copy(DOMINO_CHARACTER_WORLD_ORIGIN)
+    .add(DOMINO_CHARACTER_WORLD_VECTOR);
+  DOMINO_CHARACTER_LOCAL_ORIGIN.copy(DOMINO_CHARACTER_WORLD_ORIGIN);
+  DOMINO_CHARACTER_LOCAL_TARGET.copy(DOMINO_CHARACTER_WORLD_TARGET);
+  chair.worldToLocal(DOMINO_CHARACTER_LOCAL_ORIGIN);
+  chair.worldToLocal(DOMINO_CHARACTER_LOCAL_TARGET);
+  return DOMINO_CHARACTER_LOCAL_TARGET.z >= DOMINO_CHARACTER_LOCAL_ORIGIN.z ? 1 : -1;
+}
+
+function resolveDominoCharacterSeatPosition(chair, theme, isHumanSeat, scaleDelta) {
+  const visibleSeatLift = Number.isFinite(chair?.userData?.dominoCharacterSeatLift)
+    ? chair.userData.dominoCharacterSeatLift
+    : 0;
+  const outwardDistance =
+    (theme.seatOffsetZ ?? 0.52) -
+    0.03 +
+    DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET +
+    (isHumanSeat ? DOMINO_HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET : 0);
+  return new THREE.Vector3(
+    0,
+    visibleSeatLift +
+      (theme.seatOffsetY ?? -0.4) -
+      0.22 -
+      scaleDelta * 0.08 -
+      DOMINO_CHARACTER_EXTRA_LOWER_OFFSET +
+      (isHumanSeat ? DOMINO_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET : 0),
+    outwardDistance * resolveDominoCharacterOutwardLocalSign(chair)
+  );
+}
+
 function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   const theme = getDominoCharacterThemeForSeat(seatIndex);
   const instance = cloneSkeleton(template);
@@ -8329,19 +8375,8 @@ function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   const seatScale = (theme.scale || 1) * characterScale;
   const scaleDelta = Math.max(0, characterScale - 1);
   seatRoot.scale.setScalar(seatScale);
-  const visibleSeatLift = Number.isFinite(chair?.userData?.dominoCharacterSeatLift)
-    ? chair.userData.dominoCharacterSeatLift
-    : 0;
-  seatRoot.position.set(
-    0,
-    visibleSeatLift +
-      (theme.seatOffsetY ?? -0.4) -
-      0.22 -
-      scaleDelta * 0.08 -
-      DOMINO_CHARACTER_EXTRA_LOWER_OFFSET +
-      (isHumanSeat ? DOMINO_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET : 0),
-    (theme.seatOffsetZ ?? 0.52) - 0.03 + DOMINO_CHARACTER_EXTRA_OUTWARD_OFFSET +
-      (isHumanSeat ? DOMINO_HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET : 0)
+  seatRoot.position.copy(
+    resolveDominoCharacterSeatPosition(chair, theme, isHumanSeat, scaleDelta)
   );
   seatRoot.add(instance);
   const rig = createDominoCharacterRig(instance, seatRoot, seatIndex, player);

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-08-domino-human-layout-v24';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-08-domino-human-layout-v26';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation

- Fix character placement when chairs are rotated or placed near the arena center by computing the outward direction in chair-local space instead of assuming a fixed axis. 
- Reduce per-frame allocations and centralize seat-position logic for consistent placement and easier tuning across themes.

### Description

- Added reusable `THREE.Vector3` instances for temporary world/local math to avoid allocations during placement calculations. 
- Implemented `resolveDominoCharacterOutwardLocalSign(chair)` to determine the outward sign by converting world positions into the chair's local space and comparing Z coordinates. 
- Implemented `resolveDominoCharacterSeatPosition(chair, theme, isHumanSeat, scaleDelta)` and replaced the inline `seatRoot.position.set(...)` call with `seatRoot.position.copy(...)` using the new resolver. 
- Bumped the domino script version constant from `2026-05-08-domino-human-layout-v24` to `2026-05-08-domino-human-layout-v26`.

### Testing

- Ran the project unit test suite with `npm test` and it completed successfully. 
- Ran the linter with `npm run lint` and it passed without errors. 
- Built the frontend with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5615108c8329b6af2c534bd9eaf0)