### PR TITLE
Raise bottom Snake player token and weapons

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -506,10 +506,18 @@ const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
-// Portrait phone calibration: visually move only the bottom/top players' parked
-// weapons higher on the screen without changing the side players' slots.
+// Portrait phone calibration: visually move only parked items for selected
+// seats higher on the screen without changing the side players' slots.
+const TOKEN_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
+  // Bottom/self player: lift the reserve token away from the bottom UI/logo area.
+  TILE_SIZE * 0.42,
+  0,
+  0,
+  0
+]);
 const WEAPON_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.46,
+  // Bottom/self player: lift parked weapons to visually match the raised token.
+  TILE_SIZE * 0.84,
   0,
   TILE_SIZE * 0.46,
   0
@@ -4966,7 +4974,10 @@ function updateTokens(
               .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
               .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
           }
-          worldPos.addScaledVector(BOARD_FRONT_VECTOR, -PARKING_TOP_SCREEN_WORLD_SHIFT);
+          worldPos.addScaledVector(
+            BOARD_FRONT_VECTOR,
+            -(PARKING_TOP_SCREEN_WORLD_SHIFT + (TOKEN_TOP_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? 0))
+          );
           worldPos.y = railLayout.railHeightY + (portraitShift?.y ?? 0) + PARKING_VERTICAL_LIFT;
         }
       }


### PR DESCRIPTION
### Motivation
- On portrait phones the bottom player's reserve token and parked weapons sat too low and conflicted with UI/logo; the intent is to lift those visuals upward for clearer visibility and consistent framing.

### Description
- Added a new `TOKEN_TOP_SCREEN_SHIFT_BY_SEAT` constant and set a positive offset for the bottom/self seat to raise the reserve token in portrait view in `webapp/src/components/SnakeBoard3D.jsx`.
- Increased the bottom-seat value in `WEAPON_TOP_SCREEN_SHIFT_BY_SEAT` so parked weapons move upward to visually match the raised token while leaving side seats unchanged.
- Applied the token shift when computing reserve token world positions by including `(TOKEN_TOP_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? 0)` into the existing `BOARD_FRONT_VECTOR` offset in `updateTokens`.
- Single-file change: `webapp/src/components/SnakeBoard3D.jsx`.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully with no build-time errors.
- Launched the dev server (`npm --prefix webapp run dev`) and captured a portrait screenshot using Playwright after installing browsers and OS deps (`npx playwright install`, `npx playwright install-deps chromium`, `npx playwright screenshot`), and the screenshot was created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5bbc60048329a1832cc770a842d7)