### PR TITLE
Tune Pool Royale Showood table visuals and human shooting pose

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -21,10 +21,13 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.equal(showood.fitScale, 1.08);
-    assert.equal(showood.clothRepeatScale, 5.25);
-    assert.deepEqual(showood.hideSurfaceRoles, ['trim']);
-    assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
-    assert.equal(showood.forceGeneratedChromePlates, true);
+    assert.equal(showood.clothRepeatScale, 8.4);
+    assert.deepEqual(showood.hideSurfaceRoles, []);
+    assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['trim']);
+    assert.equal(showood.forceGeneratedChromePlates, false);
+    assert.equal(showood.showGeneratedPocketHoldersOnExternal, true);
+    assert.equal(showood.upperRailBottomTrim, 0.07);
+    assert.equal(showood.baseHeightCompensation, 0.07);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -25,7 +25,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.08,
-    clothRepeatScale: 5.25,
+    clothRepeatScale: 8.4,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
@@ -33,9 +33,12 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
-    preserveOriginalSurfaceRoles: [],
-    forceGeneratedChromePlates: true,
-    hideSurfaceRoles: ['trim']
+    preserveOriginalSurfaceRoles: ['trim'],
+    forceGeneratedChromePlates: false,
+    showGeneratedPocketHoldersOnExternal: true,
+    upperRailBottomTrim: 0.07,
+    baseHeightCompensation: 0.07,
+    hideSurfaceRoles: []
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12847,6 +12847,89 @@ function clonePoolRoyaleExternalTableTemplate(template, tableModel = null, finis
   return clone;
 }
 
+function retunePoolRoyaleExternalTableVerticalBalance(model, tableModel = null) {
+  if (!model) return;
+  const railTrimAmount = Number(tableModel?.upperRailBottomTrim) || 0;
+  const baseRaiseAmount = Number(tableModel?.baseHeightCompensation) || 0;
+  if (railTrimAmount <= MICRO_EPS && baseRaiseAmount <= MICRO_EPS) return;
+
+  model.updateMatrixWorld(true);
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return;
+  const fullHeight = Math.max(MICRO_EPS, fullBox.max.y - fullBox.min.y);
+  const upperCutoff = fullBox.min.y + fullHeight * 0.54;
+  const baseCutoff = fullBox.min.y + fullHeight * 0.52;
+  const worldBox = new THREE.Box3();
+  const localVertex = new THREE.Vector3();
+  const worldVertex = new THREE.Vector3();
+
+  model.traverse((child) => {
+    if (!child?.isMesh || !child.geometry?.attributes?.position) return;
+    const material = Array.isArray(child.material) ? child.material[0] : child.material;
+    const role = classifyPoolRoyaleExternalTableSurface(child, material);
+    if (role !== 'wood') return;
+
+    worldBox.setFromObject(child);
+    if (worldBox.isEmpty()) return;
+    const position = child.geometry.attributes.position;
+    const childWorldInverse = new THREE.Matrix4().copy(child.matrixWorld).invert();
+    let changed = false;
+
+    if (railTrimAmount > MICRO_EPS && worldBox.max.y >= upperCutoff) {
+      const meshHeight = Math.max(MICRO_EPS, worldBox.max.y - worldBox.min.y);
+      const lowerBandTop = worldBox.min.y + meshHeight * 0.46;
+      const trimTop = Math.min(worldBox.max.y - MICRO_EPS, lowerBandTop + railTrimAmount);
+      for (let i = 0; i < position.count; i += 1) {
+        localVertex.fromBufferAttribute(position, i);
+        worldVertex.copy(localVertex).applyMatrix4(child.matrixWorld);
+        if (worldVertex.y <= lowerBandTop + MICRO_EPS) {
+          worldVertex.y = Math.min(trimTop, worldVertex.y + railTrimAmount);
+          localVertex.copy(worldVertex).applyMatrix4(childWorldInverse);
+          position.setXYZ(i, localVertex.x, localVertex.y, localVertex.z);
+          changed = true;
+        }
+      }
+    } else if (baseRaiseAmount > MICRO_EPS && worldBox.max.y <= baseCutoff) {
+      const meshHeight = Math.max(MICRO_EPS, worldBox.max.y - worldBox.min.y);
+      for (let i = 0; i < position.count; i += 1) {
+        localVertex.fromBufferAttribute(position, i);
+        worldVertex.copy(localVertex).applyMatrix4(child.matrixWorld);
+        const verticalT = THREE.MathUtils.clamp((worldVertex.y - worldBox.min.y) / meshHeight, 0, 1);
+        worldVertex.y += baseRaiseAmount * verticalT;
+        localVertex.copy(worldVertex).applyMatrix4(childWorldInverse);
+        position.setXYZ(i, localVertex.x, localVertex.y, localVertex.z);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      position.needsUpdate = true;
+      child.geometry.computeBoundingBox?.();
+      child.geometry.computeBoundingSphere?.();
+      child.userData = {
+        ...(child.userData || {}),
+        poolRoyaleShowoodVerticalBalance: {
+          railTrimAmount,
+          baseRaiseAmount,
+          preservesFittedTableTopHeight: true
+        }
+      };
+    }
+  });
+
+  model.updateMatrixWorld(true);
+  const retunedBox = new THREE.Box3().setFromObject(model);
+  const floorDelta = retunedBox.isEmpty() ? 0 : fullBox.min.y - retunedBox.min.y;
+  if (Math.abs(floorDelta) > MICRO_EPS) {
+    model.position.y += floorDelta;
+    model.updateMatrixWorld(true);
+  }
+  model.userData = {
+    ...(model.userData || {}),
+    poolRoyaleVerticalBalanceRetuned: true
+  };
+}
+
 async function loadPoolRoyaleExternalTableTemplate(tableModel, renderer = null) {
   if (!tableModel?.assetUrl) return null;
   if (poolRoyaleExternalTableTemplates.has(tableModel.id)) {
@@ -13050,6 +13133,7 @@ function mountPoolRoyaleExternalTableModel({
       if (disposed || !template) return;
       const model = clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo);
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
+      retunePoolRoyaleExternalTableVerticalBalance(model, tableModel);
       externalRoot.clear();
       externalRoot.add(model);
       setGeneratedVisualsVisible?.(false);
@@ -13745,9 +13829,14 @@ function mountPoolRoyaleExternalTableModel({
   const setGeneratedVisualsVisible = (visible) => {
     generatedVisualObjects.forEach((object) => {
       const forceGeneratedChrome = Boolean(externalTableModelForMount?.forceGeneratedChromePlates);
+      const showExternalPocketHolders = Boolean(
+        externalTableModelForMount?.showGeneratedPocketHoldersOnExternal &&
+          object.userData?.externalTableKeepVisible
+      );
       if (
         !visible &&
         (
+          showExternalPocketHolders ||
           (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
           (object.userData?.isChromePlate && (chromePlateStyle.showGeneratedOnExternal || forceGeneratedChrome))
         )
@@ -25801,13 +25890,14 @@ const shotPowerRef = useRef(0);
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: POOL_ROYALE_HUMAN_VISUAL_YAW_FIX,
             // Drop the bridge hand to the cloth while keeping the cue aligned with the aim line
-            // as the portrait camera lowers into the ready-to-shoot view. Positive bend keeps
-            // the shooter folding toward the table instead of bending backward away from it.
+            // as the portrait camera lowers into the ready-to-shoot view. The torso now bends
+            // from the table-facing yaw instead of the cue reference sign so the upper body no
+            // longer folds to the opposite side on portrait/mobile camera angles.
             shootBendDirection: 1,
-            shootBendTowardCueStick: true,
-            shootCounterLeanSide: -1,
-            shootUpperBodyCounterLean: 0.72,
-            shootForwardBendScale: 0.62,
+            shootBendTowardCueStick: false,
+            shootCounterLeanSide: 1,
+            shootUpperBodyCounterLean: 0.58,
+            shootForwardBendScale: 0.76,
             plantFeetDuringShot: true,
             bridgeArmStraightDown: true,
             forceTableFacingAim: true,


### PR DESCRIPTION
### Motivation
- Improve Showood table appearance so the cloth pattern reads smaller on-screen and the showroom chrome/trim from the original GLB is visible rather than being masked by generated finish textures. 
- Adjust external-table mounting so the wood rail geometry can be shortened and the base raised while keeping the fitted tabletop height unchanged.
- Fix the human shooting pose so the upper body no longer folds to the opposite side on portrait/mobile camera angles.

### Description
- Updated the Showood table model configuration in `webapp/src/config/poolRoyaleTableModels.js` to change `clothRepeatScale` from `5.25` to `8.4`, preserve original `trim` roles, disable forced generated chrome plates, and add new model options: `showGeneratedPocketHoldersOnExternal`, `upperRailBottomTrim`, and `baseHeightCompensation`.
- Added `retunePoolRoyaleExternalTableVerticalBalance` in `webapp/src/pages/Games/PoolRoyale.jsx` to retune mounted GLTF geometry at load time by trimming upper rail bottom vertices and raising base vertices according to the new model fields, then re-align the model so the tabletop height stays fitted.
- Called the new retuning step after `fitPoolRoyaleExternalTableModel(...)` and updated the external visuals visibility logic to keep generated pocket-holder bars/straps visible when `showGeneratedPocketHoldersOnExternal` is enabled.
- Adjusted the local human rig spawn options in `webapp/src/pages/Games/PoolRoyale.jsx` to change shooting pose parameters (`shootBendTowardCueStick: false`, `shootCounterLeanSide: 1`, `shootUpperBodyCounterLean: 0.58`, `shootForwardBendScale: 0.76`) to correct the torso fold direction on portrait/mobile.
- Updated unit test expectations in `test/poolRoyaleTableModels.test.js` to reflect the new Showood configuration values.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and the tests passed (2/2).
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully (Vite build finished).
- Attempted an automated headless screenshot run with Playwright to visually verify the mounted Showood table, but Chromium failed to launch in the container due to a missing system library (`libatk-1.0.so.0`), so no screenshot was produced (Playwright install/download succeeded, but runtime failed to launch the headless binary).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5f32241c8329a808eaf1eb7924ad)