### PR TITLE
Raise bottom player's tokens and parked weapons on Snake board (portrait)

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -509,15 +509,15 @@ const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
 // Portrait phone calibration: visually move only parked items for selected
 // seats higher on the screen without changing the side players' slots.
 const TOKEN_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  // Bottom/self player: lift the reserve token away from the bottom UI/logo area.
-  TILE_SIZE * 0.42,
+  // Bottom/self player: lift the reserve token higher away from the bottom UI/logo area.
+  TILE_SIZE * 0.92,
   0,
   0,
   0
 ]);
 const WEAPON_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  // Bottom/self player: lift parked weapons to visually match the raised token.
-  TILE_SIZE * 0.84,
+  // Bottom/self player: lift parked weapons higher to visually match the raised token.
+  TILE_SIZE * 1.34,
   0,
   TILE_SIZE * 0.46,
   0


### PR DESCRIPTION
### Motivation
- Visually lift the bottom/self player's reserve token and its parked weapons on portrait/mobile so they sit higher on the screen and avoid overlapping the bottom UI/logo area.

### Description
- Increase portrait offsets in `webapp/src/components/SnakeBoard3D.jsx` by updating `TOKEN_TOP_SCREEN_SHIFT_BY_SEAT[0]` from `TILE_SIZE * 0.42` to `TILE_SIZE * 0.92` and `WEAPON_TOP_SCREEN_SHIFT_BY_SEAT[0]` from `TILE_SIZE * 0.84` to `TILE_SIZE * 1.34` so tokens and parked weapons for the bottom seat are rendered higher.

### Testing
- Ran a production build with `npm run build`, which completed successfully and produced the `dist/` output.
- Installed Playwright and system deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) and attempted an automated visual check via Playwright against the local dev server, but the screenshot attempt timed out and multiple external GLTF/asset fetches failed (network/asset issues), so end-to-end visual verification could not be completed in CI; the changes are contained to the two offset constants and are safe to review in-browser during manual QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd602bbd3083298298519d1ca0ce01)