### PR TITLE
Lift bottom Snake & Ladder player's parked tokens and weapons (portrait)

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -509,15 +509,15 @@ const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
 // Portrait phone calibration: visually move only parked items for selected
 // seats higher on the screen without changing the side players' slots.
 const TOKEN_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  // Bottom/self player: lift the reserve token away from the bottom UI/logo area.
-  TILE_SIZE * 0.42,
+  // Bottom/self player: lift the reserve token farther up from the bottom UI/logo area.
+  TILE_SIZE * 0.88,
   0,
   0,
   0
 ]);
 const WEAPON_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  // Bottom/self player: lift parked weapons to visually match the raised token.
-  TILE_SIZE * 0.84,
+  // Bottom/self player: lift parked weapons farther up to visually match the raised token.
+  TILE_SIZE * 1.28,
   0,
   TILE_SIZE * 0.46,
   0


### PR DESCRIPTION
### Motivation
- Prevent the bottom/self player's reserve token and parked weapon from appearing too low on portrait phones so they don't interfere with bottom UI and visually align better with the player.

### Description
- Increased the portrait top-screen offsets for the bottom seat by changing `TOKEN_TOP_SCREEN_SHIFT_BY_SEAT[0]` from `TILE_SIZE * 0.42` to `TILE_SIZE * 0.88` and `WEAPON_TOP_SCREEN_SHIFT_BY_SEAT[0]` from `TILE_SIZE * 0.84` to `TILE_SIZE * 1.28` in `webapp/src/components/SnakeBoard3D.jsx`.

### Testing
- Built the web app with `npm --prefix webapp run build`, installed Playwright and browser deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, launched the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1`, and captured a portrait screenshot via Playwright for `/games/snake?ai=1` (output `/tmp/snake-ladder-bottom-lift.png`); all automated steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd602bbd3083298298519d1ca0ce01)