### PR TITLE
Refine Showood GLB table visuals and shooting pose

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -21,10 +21,16 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.equal(showood.fitScale, 1.08);
-    assert.equal(showood.clothRepeatScale, 5.25);
-    assert.deepEqual(showood.hideSurfaceRoles, ['trim']);
-    assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
-    assert.equal(showood.forceGeneratedChromePlates, true);
+    assert.equal(showood.clothRepeatScale, 8.5);
+    assert.deepEqual(showood.hideSurfaceRoles, []);
+    assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['trim']);
+    assert.equal(showood.forceGeneratedChromePlates, false);
+    assert.equal(showood.keepGeneratedPocketHolders, true);
+    assert.deepEqual(showood.verticalProfile, {
+      upperRailBottomTrimRatio: 0.18,
+      baseHeightBoostRatio: 0.16,
+      baseSplitRatio: 0.42
+    });
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -25,7 +25,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.08,
-    clothRepeatScale: 5.25,
+    clothRepeatScale: 8.5,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
@@ -33,9 +33,15 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
-    preserveOriginalSurfaceRoles: [],
-    forceGeneratedChromePlates: true,
-    hideSurfaceRoles: ['trim']
+    preserveOriginalSurfaceRoles: ['trim'],
+    forceGeneratedChromePlates: false,
+    keepGeneratedPocketHolders: true,
+    verticalProfile: {
+      upperRailBottomTrimRatio: 0.18,
+      baseHeightBoostRatio: 0.16,
+      baseSplitRatio: 0.42
+    },
+    hideSurfaceRoles: []
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12608,12 +12608,12 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   // Showood uses a shared "cloth" material on the cushion meshes, so mesh names
   // must win over material names for physics mapping and finish assignment.
   if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(childName)) return 'cushion';
+  if (/diamond|gold|metal|chrome|sight|marker|plate|rim|trim|screw|bolt/.test(childName)) return 'trim';
   if (/pocket|liner|leather|net|basket|drop|holder/.test(childName)) return 'pocket';
-  if (/diamond|gold|metal|chrome|sight|marker|plate|trim|screw|bolt/.test(childName)) return 'trim';
   if (/slate|cloth|felt|baize|bed|playfield|playing[_\s-]*surface/.test(childName)) return 'cloth';
   if (/cloth|felt|baize|slate|bed|playfield|playing[_\s-]*surface/.test(label)) return 'cloth';
+  if (/metal|chrome|gold|diamond|sight|marker|plate|rim|trim|screw|bolt/.test(label)) return 'trim';
   if (/pocket|liner|leather|net|basket|drop/.test(label)) return 'pocket';
-  if (/metal|chrome|gold|diamond|sight|marker|plate|trim|screw|bolt/.test(label)) return 'trim';
   if (/leg|foot|base|support|frame|wood|rail|apron|cabinet|showood|bevel/.test(label)) return 'wood';
   return 'wood';
 }
@@ -12952,6 +12952,67 @@ function resolvePoolRoyaleExternalTableFitBounds(model, tableModel = null) {
   return { fullBox, footprintBox };
 }
 
+
+function applyPoolRoyaleExternalVerticalProfile(model, tableModel = null) {
+  const profile = tableModel?.verticalProfile;
+  if (!model || !profile) return false;
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return false;
+  const fullHeight = Math.max(MICRO_EPS, fullBox.max.y - fullBox.min.y);
+  const splitY = fullBox.min.y + fullHeight * THREE.MathUtils.clamp(profile.baseSplitRatio ?? 0.42, 0.18, 0.72);
+  const upperTrim = fullHeight * Math.max(0, profile.upperRailBottomTrimRatio ?? 0);
+  const baseBoost = Math.max(0, profile.baseHeightBoostRatio ?? 0);
+  let changed = false;
+
+  model.traverse((child) => {
+    if (!child?.isMesh || !child.geometry?.attributes?.position) return;
+    const childName = `${child.name || ''}`.toLowerCase();
+    const material = Array.isArray(child.material) ? child.material[0] : child.material;
+    const role = classifyPoolRoyaleExternalTableSurface(child, material);
+    const isBase = /leg|foot|base|pedestal|support/.test(childName);
+    const isUpperWood = role === 'wood' && /rail|frame|apron|cabinet|wood|showood|bevel/.test(childName) && !isBase;
+    if (!isBase && !isUpperWood) return;
+
+    child.updateMatrixWorld?.(true);
+    const position = child.geometry.attributes.position;
+    const localToModel = child.matrixWorld.clone();
+    const modelToLocal = child.matrixWorld.clone().invert();
+    const vertex = new THREE.Vector3();
+
+    for (let i = 0; i < position.count; i += 1) {
+      vertex.fromBufferAttribute(position, i).applyMatrix4(localToModel);
+      const originalY = vertex.y;
+      if (isBase && vertex.y <= splitY) {
+        vertex.y = splitY - (splitY - vertex.y) * (1 + baseBoost);
+      } else if (isUpperWood && vertex.y > splitY) {
+        const upperBandHeight = Math.max(MICRO_EPS, fullBox.max.y - splitY);
+        const bottomWeight = THREE.MathUtils.clamp((fullBox.max.y - vertex.y) / upperBandHeight, 0, 1);
+        vertex.y += upperTrim * bottomWeight;
+      }
+      if (Math.abs(vertex.y - originalY) > MICRO_EPS) {
+        vertex.applyMatrix4(modelToLocal);
+        position.setXYZ(i, vertex.x, vertex.y, vertex.z);
+        changed = true;
+      }
+    }
+    if (changed) {
+      position.needsUpdate = true;
+      child.geometry.computeBoundingBox?.();
+      child.geometry.computeBoundingSphere?.();
+    }
+  });
+
+  if (changed) {
+    model.updateMatrixWorld(true);
+    model.userData = {
+      ...(model.userData || {}),
+      poolRoyaleVerticalProfileApplied: true,
+      poolRoyaleVerticalProfile: { ...profile }
+    };
+  }
+  return changed;
+}
+
 function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   if (!model || !dims) return;
   model.position.set(0, 0, 0);
@@ -13005,6 +13066,7 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
     model.scale.multiplyScalar(baseFitScale * fitScaleMultiplier);
   }
   model.updateMatrixWorld(true);
+  applyPoolRoyaleExternalVerticalProfile(model, tableModel);
 
   ({ fullBox, footprintBox } = resolvePoolRoyaleExternalTableFitBounds(model, tableModel));
   const footprintCenter = footprintBox.getCenter(new THREE.Vector3());
@@ -13748,7 +13810,8 @@ function mountPoolRoyaleExternalTableModel({
       if (
         !visible &&
         (
-          (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
+          ((!externalTableModelForMount?.useOriginalLayoutSurfaces || externalTableModelForMount?.keepGeneratedPocketHolders) &&
+            object.userData?.externalTableKeepVisible) ||
           (object.userData?.isChromePlate && (chromePlateStyle.showGeneratedOnExternal || forceGeneratedChrome))
         )
       ) {
@@ -25801,10 +25864,10 @@ const shotPowerRef = useRef(0);
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: POOL_ROYALE_HUMAN_VISUAL_YAW_FIX,
             // Drop the bridge hand to the cloth while keeping the cue aligned with the aim line
-            // as the portrait camera lowers into the ready-to-shoot view. Positive bend keeps
-            // the shooter folding toward the table instead of bending backward away from it.
+            // as the portrait camera lowers into the ready-to-shoot view. Keep the upper-body
+            // fold on the avatar's table-facing forward side so it cannot bend away from the shot.
             shootBendDirection: 1,
-            shootBendTowardCueStick: true,
+            shootBendTowardCueStick: false,
             shootCounterLeanSide: -1,
             shootUpperBodyCounterLean: 0.72,
             shootForwardBendScale: 0.62,


### PR DESCRIPTION
### Motivation
- Make the Showood GLB table read correctly in Pool Royale by tightening the cloth pattern, exposing the original metal rims behind pockets, and keeping the overall table height while shortening the visible wooden rail and lengthening the base.
- Preserve the Showood chrome/trims instead of overwriting them with generated chrome plates and keep pocket holder rails/straps visible.
- Fix the player shooting pose so the avatar folds toward the table-facing shot side (avoids an opposite lean).

### Description
- Adjusted Showood table model configuration in `webapp/src/config/poolRoyaleTableModels.js` by increasing `clothRepeatScale` to `8.5`, preserving `trim` in `preserveOriginalSurfaceRoles`, disabling `forceGeneratedChromePlates`, adding `keepGeneratedPocketHolders`, and adding a `verticalProfile` block to drive vertical mesh adjustments.
- Changed external GLTF surface classification in `webapp/src/pages/Games/PoolRoyale.jsx` so metal/chrome/rim-like meshes are classified as `trim` before pocket classification to avoid cover-up of original metal rims.
- Implemented `applyPoolRoyaleExternalVerticalProfile` in `PoolRoyale.jsx` and call it during external model fitting (`fitPoolRoyaleExternalTableModel`) to trim upper wood rail geometry from the bottom and boost/extend the base so the playfield/top height is preserved.
- Updated `setGeneratedVisualsVisible` logic to respect `keepGeneratedPocketHolders` so pocket holder rails and leather straps remain visible on external Showood tables.
- Changed the Pool Royale human rig spawn/pose defaults so `shootBendTowardCueStick` is `false` (keeps upper-body fold locked to the table-facing side) to fix the incorrect upper-body bend.
- Updated `test/poolRoyaleTableModels.test.js` to assert the new Showood config values and vertical profile presence.

### Testing
- Ran unit tests with `npx jest test/poolRoyaleTableModels.test.js --runInBand`; the suite passed.
- Built the webapp with `npm --prefix webapp run build`; the production build completed (warnings about chunk sizes were reported) and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5f32241c8329a808eaf1eb7924ad)