### PR TITLE
Lift bottom Snake player parked token and weapon

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -510,14 +510,14 @@ const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
 // seats higher on the screen without changing the side players' slots.
 const TOKEN_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom/self player: lift the reserve token farther up from the bottom UI/logo area.
-  TILE_SIZE * 0.88,
+  TILE_SIZE * 1.42,
   0,
   0,
   0
 ]);
 const WEAPON_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom/self player: lift parked weapons farther up to visually match the raised token.
-  TILE_SIZE * 1.28,
+  TILE_SIZE * 1.86,
   0,
   TILE_SIZE * 0.46,
   0


### PR DESCRIPTION
### Motivation
- On portrait phones the bottom (self) player's reserve token and parked weapon were visually too low and could be obscured by the UI, so raise them to better align with the seat and match the lifted token placement.

### Description
- Increased the bottom-seat offsets in `webapp/src/components/SnakeBoard3D.jsx` by updating `TOKEN_TOP_SCREEN_SHIFT_BY_SEAT[0]` from `TILE_SIZE * 0.88` to `TILE_SIZE * 1.42` and `WEAPON_TOP_SCREEN_SHIFT_BY_SEAT[0]` from `TILE_SIZE * 1.28` to `TILE_SIZE * 1.86` so the reserve token and parked weapon sit higher on portrait screens.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully; installed Playwright (`npx playwright install chromium` and `npx playwright install-deps chromium`) and used a Playwright script to open `/games/snake` in a 390x844 mobile viewport and capture a screenshot, which completed and produced `/tmp/snake-board-bottom-items.png`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd67fbfdb483298a964c57bda5d3bb)