### PR TITLE
Tune Domino Royal camera and hand dominos

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1030,8 +1030,8 @@ const CAMERA_LATERAL_OFFSET = {
   landscape: 0 * CAMERA_LAYOUT_SCALE
 };
 const CAMERA_REAR_OFFSET = {
-  portrait: 0.42 * CAMERA_LAYOUT_SCALE,
-  landscape: 0.52 * CAMERA_LAYOUT_SCALE
+  portrait: 0.5 * CAMERA_LAYOUT_SCALE,
+  landscape: 0.58 * CAMERA_LAYOUT_SCALE
 };
 const CAMERA_HEIGHT_BOOST = {
   portrait: 2.58 * CAMERA_LAYOUT_SCALE,
@@ -6673,12 +6673,12 @@ const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.0025; // keep chain tiles touching without visible overlap
 const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
 const PLAYER_HAND_GAP_SCALE = 0.56;
-const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 2.82;
-const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 0.36;
-const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 2.42;
+const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 3.18;
+const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 0.5;
+const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 2.78;
 const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.0;
-const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 0.22;
-const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 0.38;
+const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 0.42;
+const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 0.56;
 const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.88;
 const DOMINO_DOUBLE_NEIGHBOR_EXTRA_GAP = 0;
 const DOMINO_OPENING_DOUBLE_SIDE_GAP = DOMINO_LENGTH * 0.11;
@@ -8221,6 +8221,11 @@ function normalizeDominoCharacterRoot(root) {
   if (!bounds.isEmpty()) root.position.y -= bounds.min.y;
 }
 
+const DOMINO_HELD_RACK_HAND_LIFT = 0.22 * MODEL_SCALE;
+const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.28 * MODEL_SCALE;
+const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 0.28 * MODEL_SCALE;
+const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 0.36 * MODEL_SCALE;
+
 function createHeldDominoRack(seatIndex, handTiles = []) {
   const rack = new THREE.Group();
   const visibleTiles = Array.isArray(handTiles) ? handTiles.slice(0, 5) : [];
@@ -8230,12 +8235,18 @@ function createHeldDominoRack(seatIndex, handTiles = []) {
     const mini = makeDomino(tile.a ?? 0, tile.b ?? 0, { flat: false, faceUp: true });
     const centered = index - (tiles.length - 1) / 2;
     mini.scale.setScalar(0.34);
-    mini.position.set(centered * 0.12 * MODEL_SCALE, (1.34 + Math.abs(centered) * 0.012) * MODEL_SCALE, 0.5 * MODEL_SCALE + index * 0.006);
+    mini.position.set(centered * 0.12 * MODEL_SCALE, (1.42 + Math.abs(centered) * 0.014) * MODEL_SCALE, 0.5 * MODEL_SCALE + index * 0.006);
     mini.rotation.set(THREE.MathUtils.degToRad(-74), THREE.MathUtils.degToRad(centered * -7), THREE.MathUtils.degToRad(centered * 10));
     rack.add(mini);
   });
   const isBottom = seatIndex === human;
-  rack.position.set(0, isBottom ? 1.62 * MODEL_SCALE : 2.58 * MODEL_SCALE, isBottom ? -0.2 * MODEL_SCALE : -1.66 * MODEL_SCALE);
+  const handLift = isBottom ? DOMINO_HELD_RACK_BOTTOM_HAND_LIFT : DOMINO_HELD_RACK_HAND_LIFT;
+  const outwardOffset = isBottom ? DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET : DOMINO_HELD_RACK_OUTWARD_OFFSET;
+  rack.position.set(
+    0,
+    (isBottom ? 1.62 * MODEL_SCALE : 2.58 * MODEL_SCALE) + handLift,
+    (isBottom ? -0.2 * MODEL_SCALE : -1.66 * MODEL_SCALE) - outwardOffset
+  );
   rack.rotation.set(THREE.MathUtils.degToRad(-18), 0, 0);
   rack.scale.setScalar(isBottom ? 1.28 : 1.1);
   rack.userData.signature = desiredSignature;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-08-domino-human-layout-v27';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-08-domino-human-layout-v28';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Improve portrait/mobile readability by bringing the camera slightly closer to the table. 
- Make player dominos appear more outward and higher so held tiles visually sit in characters' hands like Murlan Royale cards. 
- Ensure clients load the new layout by bumping the public script version.

### Description
- Increased seated camera rear offsets for portrait and landscape in `webapp/public/domino-royal-game.js` (`CAMERA_REAR_OFFSET`), moving the camera visually closer to the table. 
- Pushed and raised player hand domino layout parameters in `webapp/public/domino-royal-game.js` (`PLAYER_HAND_OUTWARD_OFFSET`, `PLAYER_HAND_VERTICAL_RAISE`, `HUMAN_HAND_OUTWARD_OFFSET`, `HUMAN_BOTTOM_*` adjustments) so tiles sit farther outward and higher. 
- Adjusted held domino rack placement and per-seat bottom offsets by adding constants and shifting the rack origin in `webapp/public/domino-royal-game.js` (`DOMINO_HELD_RACK_*` and `createHeldDominoRack`) to lift and outward-offset character-held dominos. 
- Bumped the public script cache version in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `'2026-05-08-domino-human-layout-v28'` so clients fetch the updated bundle.

### Testing
- Ran `git diff --check` and `node --check webapp/public/domino-royal-game.js`, both succeeded. 
- Built the webapp with `npm --prefix webapp run build` and verified a production build completed successfully. 
- Installed Playwright, required OS deps and ran a headless portrait smoke check (CDP/Playwright) that produced portrait and 3D screenshots of `/games/domino-royal` to verify camera/hand placement visually; screenshots were produced successfully after installing Playwright browsers and system deps. 
- Changes were committed: updated `webapp/public/domino-royal-game.js` and `webapp/src/pages/Games/DominoRoyalArena.jsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6c635a708329bad11aa78d5d0a98)