### PR TITLE
Tune Texas Hold'em seating and camera pitch

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -255,7 +255,7 @@ const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.91737499003112
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478 * CHAIR_SIZE_SCALE;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005 * CHAIR_SIZE_SCALE;
 const BASE_HUMAN_CHAIR_RADIUS = 5.6 * MODEL_SCALE * ARENA_GROWTH * 0.85;
-const HUMAN_CHAIR_PULLBACK = 0.08 * MODEL_SCALE;
+const HUMAN_CHAIR_PULLBACK = 0.2 * MODEL_SCALE;
 const CHAIR_RADIUS = BASE_HUMAN_CHAIR_RADIUS + HUMAN_CHAIR_PULLBACK;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
@@ -264,7 +264,7 @@ const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
-const AI_CHAIR_GAP = CARD_W * 0.85;
+const AI_CHAIR_GAP = CARD_W * 1.15;
 const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP;
 const DEFAULT_PLAYER_COUNT = 6;
 const MIN_PLAYER_COUNT = 2;
@@ -390,8 +390,8 @@ const CAMERA_SETTINGS = buildArenaCameraConfig(BOARD_SIZE);
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = -0.12 * MODEL_SCALE;
 const CAMERA_HEAD_TURN_LIMIT = THREE.MathUtils.degToRad(175);
-const CAMERA_HEAD_PITCH_UP = THREE.MathUtils.degToRad(12);
-const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(28);
+const CAMERA_HEAD_PITCH_UP = THREE.MathUtils.degToRad(18);
+const CAMERA_HEAD_PITCH_DOWN = THREE.MathUtils.degToRad(34);
 const HEAD_YAW_SENSITIVITY = 0.0042;
 const HEAD_PITCH_SENSITIVITY = 0.0032;
 const CAMERA_LATERAL_OFFSETS = Object.freeze({ portrait: -0.05, landscape: 0.6 });
@@ -400,6 +400,8 @@ const CAMERA_ELEVATION_OFFSETS = Object.freeze({ portrait: 1.55, landscape: 0.72
 const CAMERA_LANDSCAPE_LOOK_UP_LIFT = CARD_H * 0.24;
 const CAMERA_PORTRAIT_LOOK_UP_LIFT = CARD_H * 0.16;
 const CAMERA_LANDSCAPE_LOOK_RIGHT_SHIFT = 0;
+const CAMERA_PORTRAIT_MIN_LOOK_UP = THREE.MathUtils.degToRad(7);
+const CAMERA_PORTRAIT_MAX_LOOK_DOWN = THREE.MathUtils.degToRad(32);
 const CAMERA_LANDSCAPE_MIN_LOOK_UP = THREE.MathUtils.degToRad(10);
 const CAMERA_LANDSCAPE_MAX_LOOK_DOWN = THREE.MathUtils.degToRad(34);
 const HUMAN_SEAT_INWARD_OFFSETS = Object.freeze({ portrait: CARD_W * -0.24, landscape: -CARD_W * 0.55 });
@@ -657,10 +659,10 @@ const TEXAS_DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0;
 const TEXAS_MURLAN_SEATED_OFFSET_Y = -0.92;
 const TEXAS_MURLAN_SEATED_OFFSET_Z = -0.24;
 const TEXAS_MURLAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.88;
-const TEXAS_MURLAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.18;
-const TEXAS_CHARACTER_TABLE_INWARD_OFFSET = 0.38;
-const TEXAS_HUMAN_CHARACTER_TABLE_INWARD_OFFSET = 1.18;
-const TEXAS_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.14;
+const TEXAS_MURLAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.28;
+const TEXAS_CHARACTER_TABLE_INWARD_OFFSET = 0.52;
+const TEXAS_HUMAN_CHARACTER_TABLE_INWARD_OFFSET = 1.34;
+const TEXAS_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.24;
 const TEXAS_CHARACTER_CARD_HAND_LIFT = 0.36 * MODEL_SCALE;
 const texasDominoCharacterTemplateCache = new Map();
 const texasDominoCharacterTextureCache = new Map();
@@ -5239,7 +5241,10 @@ function TexasHoldemArena({ search }) {
       const targetRight = new THREE.Vector3().crossVectors(targetForward, targetUp).normalize();
       const computedPitchLimits = computeCameraPitchLimits(position, targetForward, { seatTopPoint });
       const pitchLimits = portrait
-        ? computedPitchLimits
+        ? {
+          min: Math.min(computedPitchLimits.min, -CAMERA_PORTRAIT_MIN_LOOK_UP),
+          max: Math.max(computedPitchLimits.max, CAMERA_PORTRAIT_MAX_LOOK_DOWN)
+        }
         : {
           min: Math.min(computedPitchLimits.min, -CAMERA_LANDSCAPE_MIN_LOOK_UP),
           max: Math.max(computedPitchLimits.max, CAMERA_LANDSCAPE_MAX_LOOK_DOWN)
@@ -5256,7 +5261,11 @@ function TexasHoldemArena({ search }) {
         -CAMERA_HEAD_TURN_LIMIT,
         CAMERA_HEAD_TURN_LIMIT
       );
-      headAnglesRef.current.pitch = 0;
+      headAnglesRef.current.pitch = clampValue(
+        headAnglesRef.current.pitch,
+        pitchLimits.min,
+        pitchLimits.max
+      );
       const finalize = () => {
         camera.position.copy(position);
         camera.quaternion.copy(targetQuaternion);


### PR DESCRIPTION
### Motivation
- Improve portrait framing by moving seated human characters visually closer to the table and grounding their feet, while keeping chairs slightly farther from the table for readable spacing.
- Allow players to look a bit up and down during seated view to improve camera control on mobile portrait screens.

### Description
- Increased player chair pullback and AI chair gap by updating `HUMAN_CHAIR_PULLBACK` and `AI_CHAIR_GAP` to nudge chairs slightly further from the table.
- Pulled characters inward and lowered seating by increasing `TEXAS_MURLAN_CHARACTER_EXTRA_LOWER_OFFSET`, `TEXAS_CHARACTER_TABLE_INWARD_OFFSET`, `TEXAS_HUMAN_CHARACTER_TABLE_INWARD_OFFSET`, and `TEXAS_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET` so feet align better with chair/ground.
- Expanded camera pitch ranges for portrait by raising `CAMERA_HEAD_PITCH_UP` / `CAMERA_HEAD_PITCH_DOWN` and adding portrait-specific look limits (`CAMERA_PORTRAIT_MIN_LOOK_UP` / `CAMERA_PORTRAIT_MAX_LOOK_DOWN`).
- Preserve and clamp the current head pitch when applying seated camera updates by clamping `headAnglesRef.current.pitch` to the computed `pitchLimits` so existing look position is kept within the new limits.

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.
- Ran `git diff --check` during the workflow and it produced no blocking warnings.
- Installed Playwright and platform dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium` which completed successfully.
- Performed a portrait smoke check by launching a headless Playwright session against `/games/texasholdem?players=6`, waited, and captured a screenshot (`/tmp/texas-holdem-layout.png`) which was produced; the browser logs showed external asset/network warnings (remote GLTF/HDRI/wallet fetches) but the scene fell back to procedural assets as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6d713df483299ab3abd158b24b7e)