### PR TITLE
Refine Showood external table visuals and shooter pose

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -21,10 +21,14 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.equal(showood.fitScale, 1.08);
-    assert.equal(showood.clothRepeatScale, 5.25);
+    assert.equal(showood.clothRepeatScale, 8.4);
     assert.deepEqual(showood.hideSurfaceRoles, ['trim']);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
     assert.equal(showood.forceGeneratedChromePlates, true);
+    assert.equal(showood.forceGeneratedPocketHolders, true);
+    assert.equal(showood.addGeneratedLegLevelers, true);
+    assert.equal(showood.railBottomTrimScale, 0.68);
+    assert.equal(showood.baseHeightScale, 1.18);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -25,7 +25,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.08,
-    clothRepeatScale: 5.25,
+    clothRepeatScale: 8.4,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
@@ -35,6 +35,10 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
     preserveOriginalSurfaceRoles: [],
     forceGeneratedChromePlates: true,
+    forceGeneratedPocketHolders: true,
+    addGeneratedLegLevelers: true,
+    railBottomTrimScale: 0.68,
+    baseHeightScale: 1.18,
     hideSurfaceRoles: ['trim']
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12952,6 +12952,124 @@ function resolvePoolRoyaleExternalTableFitBounds(model, tableModel = null) {
   return { fullBox, footprintBox };
 }
 
+
+function tunePoolRoyaleExternalTableVerticalProportions(model, tableModel = null) {
+  if (!model || !tableModel) return;
+  const railScale = Number.isFinite(tableModel.railBottomTrimScale)
+    ? THREE.MathUtils.clamp(tableModel.railBottomTrimScale, 0.35, 1)
+    : 1;
+  const baseScale = Number.isFinite(tableModel.baseHeightScale)
+    ? THREE.MathUtils.clamp(tableModel.baseHeightScale, 1, 1.6)
+    : 1;
+  if (Math.abs(railScale - 1) <= MICRO_EPS && Math.abs(baseScale - 1) <= MICRO_EPS) return;
+
+  model.updateMatrixWorld(true);
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return;
+  const fullSize = fullBox.getSize(new THREE.Vector3());
+  const lowerCutoff = fullBox.min.y + fullSize.y * 0.48;
+  const upperCutoff = fullBox.min.y + fullSize.y * 0.58;
+  const tableTop = fullBox.max.y;
+  const floorY = fullBox.min.y;
+  const center = new THREE.Vector3();
+
+  model.traverse((child) => {
+    if (!child?.isMesh) return;
+    const material = Array.isArray(child.material) ? child.material[0] : child.material;
+    const role = classifyPoolRoyaleExternalTableSurface(child, material);
+    if (role !== 'wood') return;
+    const childBox = new THREE.Box3().setFromObject(child);
+    if (childBox.isEmpty()) return;
+    childBox.getCenter(center);
+    if (center.y >= upperCutoff && railScale < 1) {
+      const worldPos = child.getWorldPosition(new THREE.Vector3());
+      const targetWorldY = tableTop - (tableTop - worldPos.y) * railScale;
+      child.scale.y *= railScale;
+      if (child.parent) {
+        const localPos = child.parent.worldToLocal(worldPos.setY(targetWorldY));
+        child.position.y = localPos.y;
+      }
+      child.userData = {
+        ...(child.userData || {}),
+        poolRoyaleExternalRailBottomTrimScale: railScale
+      };
+    } else if (center.y <= lowerCutoff && baseScale > 1) {
+      const worldPos = child.getWorldPosition(new THREE.Vector3());
+      const targetWorldY = floorY + (worldPos.y - floorY) * baseScale;
+      child.scale.y *= baseScale;
+      if (child.parent) {
+        const localPos = child.parent.worldToLocal(worldPos.setY(targetWorldY));
+        child.position.y = localPos.y;
+      }
+      child.userData = {
+        ...(child.userData || {}),
+        poolRoyaleExternalBaseHeightScale: baseScale
+      };
+    }
+  });
+  model.updateMatrixWorld(true);
+}
+
+function addPoolRoyaleExternalLegLevelers(model, tableModel = null) {
+  if (!model || !tableModel?.addGeneratedLegLevelers) return;
+  model.updateMatrixWorld(true);
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return;
+  const size = fullBox.getSize(new THREE.Vector3());
+  const levelerRadius = Math.max(BALL_R * 0.52, Math.min(size.x, size.z) * 0.022);
+  const levelerHeight = Math.max(BALL_R * 0.16, levelerRadius * 0.18);
+  const stemRadius = levelerRadius * LEG_LEVELER_STEM_RADIUS_SCALE;
+  const stemHeight = Math.max(BALL_R * 0.16, levelerHeight * 1.25);
+  const rubberHeight = Math.max(BALL_R * 0.08, levelerHeight * LEG_LEVELER_RUBBER_RING_HEIGHT_SCALE);
+  const insetX = size.x * 0.23;
+  const insetZ = size.z * 0.24;
+  const y = fullBox.min.y - rubberHeight;
+  const chromeMat = new THREE.MeshStandardMaterial({
+    color: 0xdbeafe,
+    metalness: 0.94,
+    roughness: 0.2,
+    envMapIntensity: 1.3
+  });
+  const rubberMat = new THREE.MeshStandardMaterial({
+    color: 0x0f172a,
+    metalness: 0.02,
+    roughness: 0.82
+  });
+  const discGeo = new THREE.CylinderGeometry(levelerRadius * 0.84, levelerRadius, levelerHeight, 42);
+  const stemGeo = new THREE.CylinderGeometry(stemRadius, stemRadius, stemHeight, 32);
+  const rubberGeo = new THREE.CylinderGeometry(
+    levelerRadius * LEG_LEVELER_RUBBER_RING_RADIUS_SCALE,
+    levelerRadius * LEG_LEVELER_RUBBER_RING_RADIUS_SCALE,
+    rubberHeight,
+    42
+  );
+  const group = new THREE.Group();
+  group.name = 'showood-generated-chrome-leg-levelers';
+  [
+    [fullBox.min.x + insetX, fullBox.min.z + insetZ],
+    [fullBox.max.x - insetX, fullBox.min.z + insetZ],
+    [fullBox.min.x + insetX, fullBox.max.z - insetZ],
+    [fullBox.max.x - insetX, fullBox.max.z - insetZ]
+  ].forEach(([x, z]) => {
+    const foot = new THREE.Group();
+    foot.position.copy(model.worldToLocal(new THREE.Vector3(x, y, z)));
+    const rubber = new THREE.Mesh(rubberGeo, rubberMat);
+    rubber.position.y = rubberHeight * 0.5;
+    rubber.receiveShadow = true;
+    const disc = new THREE.Mesh(discGeo, chromeMat);
+    disc.position.y = rubberHeight + levelerHeight * 0.5;
+    disc.castShadow = true;
+    disc.receiveShadow = true;
+    const stem = new THREE.Mesh(stemGeo, chromeMat);
+    stem.position.y = rubberHeight + levelerHeight + stemHeight * 0.5 - MICRO_EPS;
+    stem.castShadow = true;
+    stem.receiveShadow = true;
+    foot.add(rubber, disc, stem);
+    group.add(foot);
+  });
+  model.add(group);
+}
+
 function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   if (!model || !dims) return;
   model.position.set(0, 0, 0);
@@ -13013,6 +13131,8 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   const targetTopLocal = dims.targetTopLocal ?? dims.cushionTopLocal;
   model.position.y += targetTopLocal - fullBox.max.y + (tableModel?.verticalOffset ?? 0);
   model.updateMatrixWorld(true);
+  tunePoolRoyaleExternalTableVerticalProportions(model, tableModel);
+  addPoolRoyaleExternalLegLevelers(model, tableModel);
   model.userData = {
     ...(model.userData || {}),
     poolRoyaleExternalTable: true,
@@ -13748,7 +13868,10 @@ function mountPoolRoyaleExternalTableModel({
       if (
         !visible &&
         (
-          (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
+          (
+            object.userData?.externalTableKeepVisible &&
+            (!externalTableModelForMount?.useOriginalLayoutSurfaces || externalTableModelForMount?.forceGeneratedPocketHolders)
+          ) ||
           (object.userData?.isChromePlate && (chromePlateStyle.showGeneratedOnExternal || forceGeneratedChrome))
         )
       ) {

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -241,11 +241,11 @@ const BASE_CFG = {
   // The shooting pose can lock the upper-body fold to the live cue/bridge target
   // so the avatar leans toward the cue stick instead of relying on a fixed local
   // Z sign that may read as backwards after table/camera orientation changes.
-  shootBendDirection: -1,
-  shootBendTowardCueStick: false,
+  shootBendDirection: 1,
+  shootBendTowardCueStick: true,
   shootCounterLeanSide: -1,
   shootUpperBodyCounterLean: 1,
-  shootForwardBendScale: 1,
+  shootForwardBendScale: 0.86,
   plantFeetDuringShot: true,
   bridgeArmStraightDown: false,
   forceTableFacingAim: true


### PR DESCRIPTION
### Motivation
- Make the Showood GLB table visually match Pool Royale styling: finer cloth grain, shorter visible wooden frame rails (from the bottom) and taller base while preserving the original pocket layout and chrome trim.
- Add the same rounded chrome leg levelers and ensure the procedural chrome pocket holders and leather straps remain visible and aligned under pockets for the Showood model.
- Correct the player shooting stance so the avatar leans forward toward the cue and table instead of bending backwards.

### Description
- Updated external table model config in `webapp/src/config/poolRoyaleTableModels.js` to increase `clothRepeatScale` and add Showood-specific flags: `forceGeneratedPocketHolders`, `addGeneratedLegLevelers`, `railBottomTrimScale`, and `baseHeightScale`.
- Added post-fit tuning helpers in `webapp/src/pages/Games/PoolRoyale.jsx`: `tunePoolRoyaleExternalTableVerticalProportions` to trim/scale upper rail and lower base geometry, and `addPoolRoyaleExternalLegLevelers` to create rounded chrome levelers and attach them relative to the fitted GLB; these are invoked after the external GLB is fitted (`fitPoolRoyaleExternalTableModel`).
- Adjusted visibility logic so procedural pocket holder/net/strap assemblies remain visible for external Showood models when requested so chrome bars and leather straps sit precisely under pockets.
- Ensured leveler placement uses `model.worldToLocal(...)` so feet are positioned correctly in the external model’s local space.
- Tweaked shooting defaults in `webapp/src/pages/Games/shared/humanRigCore.js` to lean the upper body forward toward the cue (`shootBendDirection`, `shootBendTowardCueStick`, `shootForwardBendScale`) to correct the backward-bend pose.
- Updated unit test expectations in `test/poolRoyaleTableModels.test.js` to reflect the new cloth repeat and the new Showood flags.

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleTableModels.test.js test/poolRoyaleShotState.test.js` and both test suites passed.
- Ran the webapp build: `npm --prefix webapp run build` which completed successfully (Vite build warning about large chunks but build succeeded).
- Ran ESLint on the changed files; linter completed but repository ignore patterns caused those files to be reported as ignored (warnings only).
- Installed Playwright browsers and deps: `npx playwright install chromium` and `npx playwright install-deps chromium` completed; attempting an automated Playwright screenshot of the running dev site was attempted but could not complete reliably in this environment (browser dependency steps were required and later the page screenshot attempt timed out/hung under headless WebGL conditions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7d45e768832981ba3808512979ac)