### PR TITLE
Tune Showood external table visuals, pocket holders & human shooting pose

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -21,10 +21,14 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.equal(showood.fitScale, 1.08);
-    assert.equal(showood.clothRepeatScale, 5.25);
+    assert.equal(showood.clothRepeatScale, 8.5);
     assert.deepEqual(showood.hideSurfaceRoles, ['trim']);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
     assert.equal(showood.forceGeneratedChromePlates, true);
+    assert.equal(showood.forceGeneratedPocketHolders, true);
+    assert.equal(showood.forceGeneratedLegLevelers, true);
+    assert.equal(showood.frameRailHeightScale, 0.76);
+    assert.equal(showood.tableBaseHeightScale, 1.22);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -25,7 +25,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.08,
-    clothRepeatScale: 5.25,
+    clothRepeatScale: 8.5,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
@@ -35,6 +35,10 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
     preserveOriginalSurfaceRoles: [],
     forceGeneratedChromePlates: true,
+    forceGeneratedPocketHolders: true,
+    forceGeneratedLegLevelers: true,
+    frameRailHeightScale: 0.76,
+    tableBaseHeightScale: 1.22,
     hideSurfaceRoles: ['trim']
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9902,6 +9902,7 @@ export function Table3D(
     net.receiveShadow = true;
     net.renderOrder = pocket.renderOrder - 0.25;
     net.userData.externalTableKeepVisible = true;
+    net.userData.isPocketHolder = true;
     table.add(net);
     finishParts.pocketNetMeshes.push(net);
 
@@ -9918,6 +9919,7 @@ export function Table3D(
     ring.castShadow = true;
     ring.receiveShadow = true;
     ring.userData.externalTableKeepVisible = true;
+    ring.userData.isPocketHolder = true;
     table.add(ring);
     finishParts.pocketBaseMeshes.push(ring);
     table.userData.pocketHolderAnchors[index] = {
@@ -9952,6 +9954,7 @@ export function Table3D(
       guide.castShadow = true;
       guide.receiveShadow = true;
       guide.userData.externalTableKeepVisible = true;
+      guide.userData.isPocketHolder = true;
       table.add(guide);
       finishParts.pocketBaseMeshes.push(guide);
       return guide;
@@ -10016,6 +10019,7 @@ export function Table3D(
       strap.castShadow = true;
       strap.receiveShadow = true;
       strap.userData.externalTableKeepVisible = true;
+      strap.userData.isPocketHolder = true;
       table.add(strap);
       finishParts.pocketJawMeshes.push(strap);
     }
@@ -12814,6 +12818,7 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const prepareMaterial = (material) => {
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
+      child.userData = { ...(child.userData || {}), poolRoyaleExternalSurfaceRole: role };
       if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
         child.visible = false;
       }
@@ -12841,9 +12846,65 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
   });
 }
 
+
+function scalePoolRoyaleExternalMeshGeometryY(mesh, originY, scale) {
+  const geometry = mesh?.geometry;
+  const position = geometry?.attributes?.position;
+  if (!geometry || !position || !Number.isFinite(originY) || !Number.isFinite(scale) || scale <= 0) {
+    return false;
+  }
+  if (Math.abs(scale - 1) <= MICRO_EPS) return false;
+  mesh.geometry = geometry.clone();
+  const nextPosition = mesh.geometry.attributes.position;
+  for (let i = 0; i < nextPosition.count; i += 1) {
+    const y = nextPosition.getY(i);
+    nextPosition.setY(i, originY + (y - originY) * scale);
+  }
+  nextPosition.needsUpdate = true;
+  mesh.geometry.computeBoundingBox?.();
+  mesh.geometry.computeBoundingSphere?.();
+  mesh.userData = {
+    ...(mesh.userData || {}),
+    poolRoyaleExternalHeightTuned: scale
+  };
+  return true;
+}
+
+function applyPoolRoyaleExternalTableShapeTuning(root, tableModel = null) {
+  const frameRailHeightScale = Number.isFinite(tableModel?.frameRailHeightScale)
+    ? tableModel.frameRailHeightScale
+    : 1;
+  const tableBaseHeightScale = Number.isFinite(tableModel?.tableBaseHeightScale)
+    ? tableModel.tableBaseHeightScale
+    : 1;
+  const shouldTuneFrame = frameRailHeightScale > MICRO_EPS && Math.abs(frameRailHeightScale - 1) > MICRO_EPS;
+  const shouldTuneBase = tableBaseHeightScale > MICRO_EPS && Math.abs(tableBaseHeightScale - 1) > MICRO_EPS;
+  if (!root || (!shouldTuneFrame && !shouldTuneBase)) return 0;
+
+  let tunedCount = 0;
+  root.traverse?.((child) => {
+    if (!child?.isMesh || !child.geometry) return;
+    const material = Array.isArray(child.material) ? child.material[0] : child.material;
+    const role = child.userData?.poolRoyaleExternalSurfaceRole || classifyPoolRoyaleExternalTableSurface(child, material);
+    const label = `${child.name || ''} ${material?.name || ''}`.toLowerCase();
+    const isBaseSupport = /leg|foot|feet|base|support|pedestal|stand|trestle/.test(label);
+    const isUpperWoodRail = role === 'wood' && !isBaseSupport && /rail|frame|apron|cabinet|wood|showood|bevel|body/.test(label);
+    child.geometry.computeBoundingBox?.();
+    const bbox = child.geometry.boundingBox;
+    if (!bbox || !Number.isFinite(bbox.min.y) || !Number.isFinite(bbox.max.y)) return;
+    if (shouldTuneBase && isBaseSupport) {
+      tunedCount += scalePoolRoyaleExternalMeshGeometryY(child, bbox.max.y, tableBaseHeightScale) ? 1 : 0;
+    } else if (shouldTuneFrame && isUpperWoodRail) {
+      tunedCount += scalePoolRoyaleExternalMeshGeometryY(child, bbox.max.y, frameRailHeightScale) ? 1 : 0;
+    }
+  });
+  return tunedCount;
+}
+
 function clonePoolRoyaleExternalTableTemplate(template, tableModel = null, finishInfo = null) {
   const clone = template.clone(true);
   preparePoolRoyaleExternalTableMaterials(clone, tableModel, finishInfo);
+  applyPoolRoyaleExternalTableShapeTuning(clone, tableModel);
   return clone;
 }
 
@@ -13234,18 +13295,22 @@ function mountPoolRoyaleExternalTableModel({
     );
     return centers.map((center) => {
       const group = new THREE.Group();
+      group.userData = { ...(group.userData || {}), isLegLeveler: true };
       const disc = tagBasePart(new THREE.Mesh(levelerGeom, chromeMat), 'trim');
       disc.position.set(0, levelerHeight * 0.5 + rubberHeight, 0);
       disc.castShadow = true;
       disc.receiveShadow = true;
+      disc.userData = { ...(disc.userData || {}), isLegLeveler: true };
       const stem = tagBasePart(new THREE.Mesh(stemGeom, chromeMat), 'trim');
       stem.position.set(0, levelerHeight + stemHeight * 0.5 + rubberHeight - MICRO_EPS, 0);
       stem.castShadow = true;
       stem.receiveShadow = true;
+      stem.userData = { ...(stem.userData || {}), isLegLeveler: true };
       const rubberRing = tagBasePart(new THREE.Mesh(rubberGeom, rubberMat), 'trim');
       rubberRing.position.set(0, rubberHeight * 0.5, 0);
       rubberRing.castShadow = false;
       rubberRing.receiveShadow = true;
+      rubberRing.userData = { ...(rubberRing.userData || {}), isLegLeveler: true };
       group.add(rubberRing, disc, stem);
       const legBottomY = Number.isFinite(center?.legBottomY)
         ? center.legBottomY
@@ -13745,11 +13810,15 @@ function mountPoolRoyaleExternalTableModel({
   const setGeneratedVisualsVisible = (visible) => {
     generatedVisualObjects.forEach((object) => {
       const forceGeneratedChrome = Boolean(externalTableModelForMount?.forceGeneratedChromePlates);
+      const forceGeneratedPocketHolders = Boolean(externalTableModelForMount?.forceGeneratedPocketHolders);
+      const forceGeneratedLegLevelers = Boolean(externalTableModelForMount?.forceGeneratedLegLevelers);
       if (
         !visible &&
         (
           (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
-          (object.userData?.isChromePlate && (chromePlateStyle.showGeneratedOnExternal || forceGeneratedChrome))
+          (object.userData?.isChromePlate && (chromePlateStyle.showGeneratedOnExternal || forceGeneratedChrome)) ||
+          (object.userData?.isPocketHolder && forceGeneratedPocketHolders) ||
+          (object.userData?.isLegLeveler && forceGeneratedLegLevelers)
         )
       ) {
         object.visible = true;
@@ -25804,10 +25873,10 @@ const shotPowerRef = useRef(0);
             // as the portrait camera lowers into the ready-to-shoot view. Positive bend keeps
             // the shooter folding toward the table instead of bending backward away from it.
             shootBendDirection: 1,
-            shootBendTowardCueStick: true,
+            shootBendTowardCueStick: false,
             shootCounterLeanSide: -1,
             shootUpperBodyCounterLean: 0.72,
-            shootForwardBendScale: 0.62,
+            shootForwardBendScale: 0.54,
             plantFeetDuringShot: true,
             bridgeArmStraightDown: true,
             forceTableFacingAim: true,
@@ -25836,9 +25905,9 @@ const shotPowerRef = useRef(0);
             shootCueGripFromBack: 0.58 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightElbowShotRise: 0.18 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightElbowShotSide: -0.46 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            rightElbowShotBack: -0.78 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            rightElbowShotBack: -0.62 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightForearmOutward: 0.36 * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            rightForearmBack: 0.44 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            rightForearmBack: 0.34 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightForearmDown: 0.48 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightForearmLength: 0.34 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightStrokePull: 0.30 * POOL_ROYALE_HUMAN_UNIT_SCALE,


### PR DESCRIPTION
### Motivation
- Make the Showood GLB feel visually consistent with the procedural Pool Royale table by tightening cloth pattern scale and keeping key generated hardware (pocket holders, leg levelers) visible when the external model is used.
- Preserve overall playfield height while shortening visible wooden rail/frame skirts and lengthening the table base so the table keeps the same top elevation.
- Fix the shooter pose so the avatar folds forward toward the cue (not backward) when taking shots.

### Description
- Increased Showood cloth texture tiling by changing `clothRepeatScale` from `5.25` to `8.5` in `webapp/src/config/poolRoyaleTableModels.js` so cloth pattern tiles appear smaller.
- Exposed new Showood table model flags: `forceGeneratedPocketHolders`, `forceGeneratedLegLevelers`, `frameRailHeightScale`, and `tableBaseHeightScale` to control generated visuals and per-model geometry tuning in `poolRoyaleTableModels.js`.
- Marked pocket net / ring / guide / strap meshes with `userData.isPocketHolder` and leg leveler group/children with `userData.isLegLeveler` so generated visibility rules can selectively keep those parts visible on external tables in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Added geometry tuning helpers `scalePoolRoyaleExternalMeshGeometryY` and `applyPoolRoyaleExternalTableShapeTuning` and call them from `clonePoolRoyaleExternalTableTemplate` so external GLB geometry can be scaled vertically (shorten rails, lengthen base supports) while preserving playfield top position in `PoolRoyale.jsx`.
- Updated generated-visual visibility logic (`setGeneratedVisualsVisible`) to honor the new model flags so chrome plates, pocket holders, and leg levelers remain visible when requested in `PoolRoyale.jsx`.
- Tagged leveler geometry instances when created so they can be toggled independently (rounded chrome levelers matching procedural table) in `PoolRoyale.jsx`.
- Adjusted human shooting configuration used by the avatar rig when spawning players: `shootBendTowardCueStick` disabled, `shootForwardBendScale` lowered, and right-arm/back offsets reduced (`rightElbowShotBack`, `rightForearmBack`) to make the shooter fold forward toward the cue and reduce backward torso bend in `PoolRoyale.jsx`.
- Updated unit test expectations in `test/poolRoyaleTableModels.test.js` to assert the new cloth repeat and model flags.

### Testing
- Ran the table-model unit test with `npm test -- --runTestsByPath test/poolRoyaleTableModels.test.js` and it passed (2 tests, 2 passed).
- Built the webapp with `npm --prefix webapp run build` and the Vite build completed successfully (warnings only about chunk sizes / dynamic imports).
- Attempted an automated visual smoke capture with Playwright after installing browser dependencies; Playwright/browser setup completed but an in-environment screenshot of the WebGL scene timed out (environment rendering / timeout issues), so no stable screenshot was produced in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7d45e768832981ba3808512979ac)