### PR TITLE
Add Free Kick Arena (Three.js) game and make it the app entry

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import ChessBattleRoyaleStore from './ChessBattleRoyaleStore';
+import FreeKickArenaGame from './FreeKickArenaGame';
 
 export function App() {
-  return <ChessBattleRoyaleStore />;
+  return <FreeKickArenaGame />;
 }

--- a/frontend/src/FreeKickArenaGame.tsx
+++ b/frontend/src/FreeKickArenaGame.tsx
@@ -1,0 +1,590 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+
+type ShotPhase = 'aiming' | 'charging' | 'flying' | 'goal' | 'saved' | 'missed';
+type UpgradeKey = 'curve' | 'power' | 'focus';
+
+type BallRuntime = {
+  mesh: THREE.Mesh;
+  velocity: THREE.Vector3;
+  spin: THREE.Vector3;
+  active: boolean;
+};
+
+type KeeperRuntime = {
+  group: THREE.Group;
+  diveVelocity: number;
+  targetX: number;
+};
+
+type SceneRuntime = {
+  renderer: THREE.WebGLRenderer;
+  camera: THREE.PerspectiveCamera;
+  scene: THREE.Scene;
+  ball: BallRuntime;
+  keeper: KeeperRuntime;
+  aimLine: THREE.Line;
+  ghostLine: THREE.Line;
+  goalFlash: THREE.PointLight;
+};
+
+const GAME_WIDTH = 12;
+const GOAL_Z = -27.6;
+const BALL_START = new THREE.Vector3(0, 0.32, 10.5);
+const GOAL_WIDTH = 7.6;
+const GOAL_HEIGHT = 3.05;
+const WALL_Z = -8.6;
+const WALL_WIDTH = 5.7;
+const GRAVITY = -10.6;
+const DRAG = 0.988;
+
+const upgradeCopy: Record<UpgradeKey, { label: string; description: string }> = {
+  curve: { label: 'Curve Boots', description: 'More bend around the wall.' },
+  power: { label: 'Power Laces', description: 'Harder strikes and longer range.' },
+  focus: { label: 'Focus Vision', description: 'More precise targeting guide.' },
+};
+
+const clamp = THREE.MathUtils.clamp;
+
+const makeMaterial = (color: string, roughness = 0.72, metalness = 0.05) =>
+  new THREE.MeshStandardMaterial({ color, roughness, metalness });
+
+function createPlayer(color: string, shorts: string) {
+  const group = new THREE.Group();
+  const skin = makeMaterial('#f2b389', 0.65);
+  const kit = makeMaterial(color, 0.68);
+  const shortMat = makeMaterial(shorts, 0.7);
+  const boot = makeMaterial('#121826', 0.55);
+
+  const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.34, 0.86, 8, 16), kit);
+  body.position.y = 1.45;
+  group.add(body);
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.23, 18, 18), skin);
+  head.position.y = 2.22;
+  group.add(head);
+
+  const shortsMesh = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.32, 0.38), shortMat);
+  shortsMesh.position.y = 0.92;
+  group.add(shortsMesh);
+
+  [-0.2, 0.2].forEach((x) => {
+    const leg = new THREE.Mesh(new THREE.CapsuleGeometry(0.08, 0.68, 6, 10), skin);
+    leg.position.set(x, 0.48, 0);
+    group.add(leg);
+    const foot = new THREE.Mesh(new THREE.BoxGeometry(0.18, 0.12, 0.36), boot);
+    foot.position.set(x, 0.11, -0.08);
+    group.add(foot);
+  });
+
+  return group;
+}
+
+function createStadium(scene: THREE.Scene) {
+  scene.background = new THREE.Color('#08111f');
+  scene.fog = new THREE.Fog('#08111f', 24, 70);
+
+  const hemi = new THREE.HemisphereLight('#c7e8ff', '#183015', 1.25);
+  scene.add(hemi);
+
+  const sun = new THREE.DirectionalLight('#ffffff', 2.7);
+  sun.position.set(-8, 18, 12);
+  sun.castShadow = true;
+  sun.shadow.mapSize.set(2048, 2048);
+  sun.shadow.camera.near = 1;
+  sun.shadow.camera.far = 55;
+  sun.shadow.camera.left = -18;
+  sun.shadow.camera.right = 18;
+  sun.shadow.camera.top = 18;
+  sun.shadow.camera.bottom = -20;
+  scene.add(sun);
+
+  const pitch = new THREE.Mesh(
+    new THREE.PlaneGeometry(22, 48, 1, 1),
+    new THREE.MeshStandardMaterial({ color: '#17733b', roughness: 0.9 }),
+  );
+  pitch.rotation.x = -Math.PI / 2;
+  pitch.receiveShadow = true;
+  scene.add(pitch);
+
+  for (let i = 0; i < 9; i += 1) {
+    const stripe = new THREE.Mesh(
+      new THREE.PlaneGeometry(22, 48 / 9),
+      new THREE.MeshStandardMaterial({ color: i % 2 ? '#1f8b49' : '#166d37', roughness: 0.92 }),
+    );
+    stripe.rotation.x = -Math.PI / 2;
+    stripe.position.z = -24 + (i + 0.5) * (48 / 9);
+    stripe.position.y = 0.003;
+    stripe.receiveShadow = true;
+    scene.add(stripe);
+  }
+
+  const lineMat = new THREE.LineBasicMaterial({ color: '#dff7ff', transparent: true, opacity: 0.72 });
+  const addLine = (points: THREE.Vector3[]) => scene.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(points), lineMat));
+  addLine([new THREE.Vector3(-GAME_WIDTH / 2, 0.03, GOAL_Z + 0.5), new THREE.Vector3(GAME_WIDTH / 2, 0.03, GOAL_Z + 0.5)]);
+  addLine([new THREE.Vector3(-4.8, 0.03, -16), new THREE.Vector3(4.8, 0.03, -16)]);
+  addLine([new THREE.Vector3(-4.8, 0.03, -16), new THREE.Vector3(-4.8, 0.03, GOAL_Z + 0.5)]);
+  addLine([new THREE.Vector3(4.8, 0.03, -16), new THREE.Vector3(4.8, 0.03, GOAL_Z + 0.5)]);
+
+  const arc = new THREE.Line(
+    new THREE.BufferGeometry().setFromPoints(Array.from({ length: 38 }, (_, i) => {
+      const a = Math.PI * (i / 37);
+      return new THREE.Vector3(Math.cos(a) * 3.1, 0.035, -16 + Math.sin(a) * 3.1);
+    })),
+    lineMat,
+  );
+  scene.add(arc);
+
+  const goalMat = makeMaterial('#f8fafc', 0.35, 0.05);
+  const postGeo = new THREE.CylinderGeometry(0.06, 0.06, GOAL_HEIGHT, 16);
+  const leftPost = new THREE.Mesh(postGeo, goalMat);
+  leftPost.position.set(-GOAL_WIDTH / 2, GOAL_HEIGHT / 2, GOAL_Z);
+  const rightPost = leftPost.clone();
+  rightPost.position.x = GOAL_WIDTH / 2;
+  const bar = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.06, GOAL_WIDTH, 16), goalMat);
+  bar.rotation.z = Math.PI / 2;
+  bar.position.set(0, GOAL_HEIGHT, GOAL_Z);
+  scene.add(leftPost, rightPost, bar);
+
+  const net = new THREE.GridHelper(GOAL_WIDTH, 12, '#dbeafe', '#7dd3fc');
+  net.rotation.x = Math.PI / 2;
+  net.position.set(0, GOAL_HEIGHT / 2, GOAL_Z - 0.48);
+  net.scale.y = GOAL_HEIGHT / GOAL_WIDTH;
+  scene.add(net);
+
+  const crowdMatA = makeMaterial('#233352', 0.8);
+  const crowdMatB = makeMaterial('#6d1d3b', 0.8);
+  for (let row = 0; row < 5; row += 1) {
+    const stand = new THREE.Mesh(new THREE.BoxGeometry(24, 0.45, 1.2), row % 2 ? crowdMatA : crowdMatB);
+    stand.position.set(0, 1.2 + row * 0.48, GOAL_Z - 4 - row * 0.7);
+    scene.add(stand);
+  }
+
+  [-8.5, 8.5].forEach((x) => {
+    const tower = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.12, 6, 10), makeMaterial('#334155', 0.5, 0.25));
+    tower.position.set(x, 3, -18);
+    const lamp = new THREE.PointLight('#dbeafe', 4.8, 34);
+    lamp.position.set(x, 6.1, -18);
+    scene.add(tower, lamp);
+  });
+}
+
+function createWall(scene: THREE.Scene) {
+  for (let i = 0; i < 5; i += 1) {
+    const defender = createPlayer('#eab308', '#172554');
+    defender.position.set(-WALL_WIDTH / 2 + i * (WALL_WIDTH / 4), 0, WALL_Z + Math.sin(i) * 0.15);
+    defender.rotation.y = Math.PI;
+    defender.scale.setScalar(0.92);
+    scene.add(defender);
+  }
+}
+
+function createRuntime(mount: HTMLDivElement): SceneRuntime {
+  const scene = new THREE.Scene();
+  createStadium(scene);
+  createWall(scene);
+
+  const camera = new THREE.PerspectiveCamera(46, mount.clientWidth / mount.clientHeight, 0.1, 120);
+  camera.position.set(0, 7.5, 18);
+  camera.lookAt(0, 1.2, -10);
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setSize(mount.clientWidth, mount.clientHeight);
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.1;
+  mount.appendChild(renderer.domElement);
+
+  const player = createPlayer('#2563eb', '#0f172a');
+  player.position.set(-1.35, 0, 9.8);
+  player.rotation.y = -0.32;
+  scene.add(player);
+
+  const ballMesh = new THREE.Mesh(
+    new THREE.SphereGeometry(0.28, 32, 32),
+    new THREE.MeshStandardMaterial({ color: '#f8fafc', roughness: 0.48, metalness: 0.02 }),
+  );
+  ballMesh.position.copy(BALL_START);
+  ballMesh.castShadow = true;
+  scene.add(ballMesh);
+
+  const seamMat = new THREE.LineBasicMaterial({ color: '#0f172a', transparent: true, opacity: 0.72 });
+  for (let i = 0; i < 3; i += 1) {
+    const seam = new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints(Array.from({ length: 48 }, (_, p) => {
+        const a = (Math.PI * 2 * p) / 47;
+        return new THREE.Vector3(Math.cos(a) * 0.285, Math.sin(a) * 0.285, 0);
+      })),
+      seamMat,
+    );
+    seam.rotation.set(i === 0 ? Math.PI / 2 : 0, i === 1 ? Math.PI / 2 : 0, i === 2 ? Math.PI / 2 : 0);
+    ballMesh.add(seam);
+  }
+
+  const keeperGroup = createPlayer('#22c55e', '#052e16');
+  keeperGroup.position.set(0, 0, GOAL_Z + 0.55);
+  keeperGroup.scale.setScalar(1.08);
+  keeperGroup.rotation.y = 0;
+  scene.add(keeperGroup);
+
+  const aimLine = new THREE.Line(
+    new THREE.BufferGeometry().setFromPoints([BALL_START, new THREE.Vector3(0, 1.8, -14)]),
+    new THREE.LineBasicMaterial({ color: '#facc15', transparent: true, opacity: 0.95 }),
+  );
+  scene.add(aimLine);
+
+  const ghostLine = new THREE.Line(
+    new THREE.BufferGeometry().setFromPoints([BALL_START, BALL_START.clone()]),
+    new THREE.LineBasicMaterial({ color: '#38bdf8', transparent: true, opacity: 0.55 }),
+  );
+  scene.add(ghostLine);
+
+  const goalFlash = new THREE.PointLight('#facc15', 0, 18);
+  goalFlash.position.set(0, 2, GOAL_Z + 1);
+  scene.add(goalFlash);
+
+  return {
+    renderer,
+    camera,
+    scene,
+    ball: { mesh: ballMesh, velocity: new THREE.Vector3(), spin: new THREE.Vector3(), active: false },
+    keeper: { group: keeperGroup, diveVelocity: 0, targetX: 0 },
+    aimLine,
+    ghostLine,
+    goalFlash,
+  };
+}
+
+function predictTrajectory(targetX: number, targetY: number, charge: number, curve: number, power: number) {
+  const start = BALL_START.clone();
+  const goalPoint = new THREE.Vector3(targetX, targetY, GOAL_Z);
+  const direction = goalPoint.sub(start).normalize();
+  const shotPower = 20 + charge * 9.5 + power * 1.55;
+  const velocity = new THREE.Vector3(direction.x * shotPower, 5.8 + targetY * 1.15 + charge * 2.25, direction.z * shotPower);
+  const spin = new THREE.Vector3(curve * 1.15, 0, 0);
+  const points: THREE.Vector3[] = [];
+  const pos = start.clone();
+  for (let i = 0; i < 42; i += 1) {
+    const dt = 0.045;
+    velocity.x += spin.x * dt * (1.5 + i * 0.012);
+    velocity.y += GRAVITY * dt;
+    velocity.multiplyScalar(0.996);
+    pos.addScaledVector(velocity, dt);
+    if (pos.y < 0.28) pos.y = 0.28;
+    points.push(pos.clone());
+    if (pos.z < GOAL_Z - 0.5) break;
+  }
+  return points;
+}
+
+export default function FreeKickArenaGame() {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const runtimeRef = useRef<SceneRuntime | null>(null);
+  const targetRef = useRef({ x: 0.8, y: 2.05 });
+  const chargeRef = useRef(0.62);
+  const phaseRef = useRef<ShotPhase>('aiming');
+  const upgradesRef = useRef<Record<UpgradeKey, number>>({ curve: 1, power: 1, focus: 1 });
+  const streakRef = useRef(0);
+  const pointerActiveRef = useRef(false);
+  const settledAtRef = useRef(0);
+
+  const [phase, setPhase] = useState<ShotPhase>('aiming');
+  const [score, setScore] = useState(0);
+  const [coins, setCoins] = useState(120);
+  const [streak, setStreak] = useState(0);
+  const [charge, setCharge] = useState(0.62);
+  const [target, setTarget] = useState(targetRef.current);
+  const windRef = useRef(THREE.MathUtils.randFloat(-0.75, 0.75));
+  const [wind, setWindState] = useState(windRef.current);
+  const [message, setMessage] = useState('Drag to place the shot, hold SHOOT for power, release to bend it past the wall.');
+  const [upgrades, setUpgrades] = useState<Record<UpgradeKey, number>>(upgradesRef.current);
+
+  const upgradeEntries = useMemo(() => Object.entries(upgradeCopy) as Array<[UpgradeKey, { label: string; description: string }]>, []);
+
+  const setPhaseState = (next: ShotPhase) => {
+    phaseRef.current = next;
+    setPhase(next);
+  };
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return undefined;
+
+    const runtime = createRuntime(mount);
+    runtimeRef.current = runtime;
+    let raf = 0;
+    let last = performance.now();
+    let chargeDirection = 1;
+
+    const resize = () => {
+      runtime.camera.aspect = mount.clientWidth / mount.clientHeight;
+      runtime.camera.updateProjectionMatrix();
+      runtime.renderer.setSize(mount.clientWidth, mount.clientHeight);
+    };
+    window.addEventListener('resize', resize);
+
+    const resetBall = () => {
+      runtime.ball.active = false;
+      runtime.ball.velocity.set(0, 0, 0);
+      runtime.ball.spin.set(0, 0, 0);
+      runtime.ball.mesh.position.copy(BALL_START);
+      runtime.keeper.group.position.x = 0;
+      runtime.keeper.targetX = 0;
+      runtime.keeper.diveVelocity = 0;
+      runtime.goalFlash.intensity = 0;
+      setPhaseState('aiming');
+    };
+
+    const shoot = () => {
+      if (phaseRef.current !== 'charging' && phaseRef.current !== 'aiming') return;
+      const { x, y } = targetRef.current;
+      const levels = upgradesRef.current;
+      const imperfect = (1.2 - levels.focus * 0.16) * (1 - chargeRef.current) * THREE.MathUtils.randFloatSpread(0.7);
+      const currentWind = windRef.current;
+      const aimedX = x + imperfect + currentWind * 0.42;
+      const aimedY = y + THREE.MathUtils.randFloatSpread(0.18 / levels.focus);
+      const points = predictTrajectory(aimedX, aimedY, chargeRef.current, x * levels.curve * 0.42 + currentWind * 0.22, levels.power);
+      const first = points[1] ?? new THREE.Vector3(aimedX, aimedY, GOAL_Z);
+      runtime.ball.velocity.copy(first.clone().sub(BALL_START).multiplyScalar(1 / 0.045));
+      runtime.ball.spin.set(x * levels.curve * 1.9 + currentWind * 0.65, 0, -x * 4.2);
+      runtime.ball.active = true;
+      runtime.keeper.targetX = clamp(aimedX + THREE.MathUtils.randFloatSpread(1.15 - levels.focus * 0.12), -3.05, 3.05);
+      setPhaseState('flying');
+      setMessage('Shot away — watch the keeper read the curve and react.');
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (!pointerActiveRef.current || phaseRef.current === 'flying') return;
+      const rect = runtime.renderer.domElement.getBoundingClientRect();
+      const nx = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+      const ny = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+      const next = { x: (nx - 0.5) * GOAL_WIDTH * 0.88, y: 0.85 + (1 - ny) * 2.35 };
+      targetRef.current = next;
+      setTarget(next);
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      pointerActiveRef.current = true;
+      onPointerMove(event);
+    };
+    const onPointerUp = () => {
+      pointerActiveRef.current = false;
+    };
+
+    runtime.renderer.domElement.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+
+    (window as any).freeKickShoot = shoot;
+    (window as any).freeKickReset = resetBall;
+
+    const animate = (now: number) => {
+      raf = requestAnimationFrame(animate);
+      const dt = Math.min((now - last) / 1000, 0.033);
+      last = now;
+
+      if (phaseRef.current === 'charging') {
+        const nextCharge = clamp(chargeRef.current + chargeDirection * dt * 0.72, 0.18, 1);
+        chargeRef.current = nextCharge;
+        setCharge(nextCharge);
+        if (nextCharge >= 0.995 || nextCharge <= 0.185) chargeDirection *= -1;
+      }
+
+      const levels = upgradesRef.current;
+      const predicted = predictTrajectory(targetRef.current.x, targetRef.current.y, chargeRef.current, targetRef.current.x * levels.curve * 0.42 + windRef.current * 0.22, levels.power);
+      runtime.ghostLine.geometry.dispose();
+      runtime.ghostLine.geometry = new THREE.BufferGeometry().setFromPoints(predicted.filter((_, i) => i % 3 === 0));
+      const aimEnd = new THREE.Vector3(targetRef.current.x, targetRef.current.y, GOAL_Z);
+      runtime.aimLine.geometry.dispose();
+      runtime.aimLine.geometry = new THREE.BufferGeometry().setFromPoints([BALL_START, aimEnd]);
+
+      runtime.keeper.group.position.x = THREE.MathUtils.damp(runtime.keeper.group.position.x, runtime.keeper.targetX, 4.5, dt);
+      runtime.keeper.group.rotation.z = THREE.MathUtils.damp(runtime.keeper.group.rotation.z, -runtime.keeper.group.position.x * 0.12, 5, dt);
+
+      if (runtime.ball.active) {
+        runtime.ball.velocity.x += (runtime.ball.spin.x + windRef.current * 0.92) * dt;
+        runtime.ball.velocity.y += GRAVITY * dt;
+        runtime.ball.velocity.multiplyScalar(DRAG);
+        runtime.ball.mesh.position.addScaledVector(runtime.ball.velocity, dt);
+        runtime.ball.mesh.rotation.x += runtime.ball.velocity.z * dt * 1.4;
+        runtime.ball.mesh.rotation.z += runtime.ball.velocity.x * dt * 1.6;
+
+        if (runtime.ball.mesh.position.z < WALL_Z + 0.45 && runtime.ball.mesh.position.z > WALL_Z - 0.45 && Math.abs(runtime.ball.mesh.position.x) < WALL_WIDTH / 2 && runtime.ball.mesh.position.y < 2.25) {
+          runtime.ball.active = false;
+          settledAtRef.current = now + 1050;
+          setPhaseState('saved');
+          streakRef.current = 0;
+          setStreak(0);
+          setMessage('Blocked by the wall. Aim higher or add more curve.');
+        }
+
+        const keeperDistance = runtime.ball.mesh.position.distanceTo(new THREE.Vector3(runtime.keeper.group.position.x, 1.35, GOAL_Z + 0.35));
+        if (keeperDistance < 1.08 && runtime.ball.mesh.position.y < 2.65) {
+          runtime.ball.active = false;
+          settledAtRef.current = now + 1150;
+          setPhaseState('saved');
+          streakRef.current = 0;
+          setStreak(0);
+          setMessage('Keeper save! Upgrade Focus Vision to reduce readable shots.');
+        }
+
+        if (runtime.ball.mesh.position.z <= GOAL_Z) {
+          const inside = Math.abs(runtime.ball.mesh.position.x) < GOAL_WIDTH / 2 - 0.24 && runtime.ball.mesh.position.y > 0.35 && runtime.ball.mesh.position.y < GOAL_HEIGHT;
+          runtime.ball.active = false;
+          settledAtRef.current = now + 1300;
+          if (inside) {
+            const placementBonus = Math.round((Math.abs(runtime.ball.mesh.position.x) + runtime.ball.mesh.position.y) * 14);
+            const earned = 35 + placementBonus + streakRef.current * 10;
+            streakRef.current += 1;
+            setStreak(streakRef.current);
+            setScore((value) => value + 100 + placementBonus);
+            setCoins((value) => value + earned);
+            setPhaseState('goal');
+            runtime.goalFlash.intensity = 7;
+            setMessage(`GOAL! +${earned} coins for placement, curve and streak pressure.`);
+          } else {
+            streakRef.current = 0;
+            setStreak(0);
+            setPhaseState('missed');
+            setMessage('Missed the frame. Pull the target back inside the posts.');
+          }
+        }
+
+        if (runtime.ball.mesh.position.y < 0.18 || runtime.ball.mesh.position.z < GOAL_Z - 4 || Math.abs(runtime.ball.mesh.position.x) > 8) {
+          runtime.ball.active = false;
+          settledAtRef.current = now + 950;
+          setPhaseState('missed');
+          streakRef.current = 0;
+          setStreak(0);
+          setMessage('The shot lost shape. Balance charge, wind and bend.');
+        }
+      }
+
+      if (!runtime.ball.active && phaseRef.current !== 'aiming' && settledAtRef.current > 0 && now > settledAtRef.current) {
+        windRef.current = THREE.MathUtils.randFloat(-0.9, 0.9);
+        setWindState(windRef.current);
+        resetBall();
+      }
+
+      runtime.goalFlash.intensity = THREE.MathUtils.damp(runtime.goalFlash.intensity, 0, 3.5, dt);
+      const cinematicZ = phaseRef.current === 'flying' ? 16.2 : 18;
+      const cinematicY = phaseRef.current === 'flying' ? 6.3 : 7.5;
+      runtime.camera.position.lerp(new THREE.Vector3(runtime.ball.mesh.position.x * 0.18, cinematicY, cinematicZ), 0.045);
+      runtime.camera.lookAt(runtime.ball.mesh.position.x * 0.25, 1.35, -11.5);
+      runtime.renderer.render(runtime.scene, runtime.camera);
+    };
+    raf = requestAnimationFrame(animate);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+      runtime.renderer.domElement.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+      runtime.renderer.dispose();
+      mount.innerHTML = '';
+      delete (window as any).freeKickShoot;
+      delete (window as any).freeKickReset;
+    };
+  }, []);
+
+  const beginCharge = () => {
+    if (phaseRef.current !== 'aiming') return;
+    setPhaseState('charging');
+    setMessage('Release at the sweet spot for power. Wind changes every shot.');
+  };
+
+  const releaseShot = () => {
+    (window as any).freeKickShoot?.();
+  };
+
+  const buyUpgrade = (key: UpgradeKey) => {
+    const current = upgradesRef.current[key];
+    const cost = 90 + current * 70;
+    if (coins < cost || current >= 5) return;
+    const next = { ...upgradesRef.current, [key]: current + 1 };
+    upgradesRef.current = next;
+    setUpgrades(next);
+    setCoins((value) => value - cost);
+    setMessage(`${upgradeCopy[key].label} upgraded to level ${current + 1}.`);
+  };
+
+  const phaseLabel = phase === 'goal' ? 'GOAL' : phase === 'saved' ? 'SAVED' : phase === 'missed' ? 'MISS' : phase === 'charging' ? 'CHARGE' : phase === 'flying' ? 'FLIGHT' : 'AIM';
+
+  return (
+    <div style={{ position: 'relative', height: '100vh', width: '100%', overflow: 'hidden', background: '#020617', color: '#fff', fontFamily: 'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif', touchAction: 'none' }}>
+      <div ref={mountRef} style={{ position: 'absolute', inset: 0 }} />
+
+      <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', background: 'linear-gradient(180deg, rgba(2,6,23,.22), rgba(2,6,23,0) 38%, rgba(2,6,23,.78))' }} />
+
+      <section style={{ position: 'absolute', top: 12, left: 12, right: 12, display: 'grid', gap: 10, pointerEvents: 'none' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'center' }}>
+          <div style={{ padding: '10px 12px', borderRadius: 18, background: 'rgba(15,23,42,.74)', border: '1px solid rgba(255,255,255,.12)', backdropFilter: 'blur(14px)' }}>
+            <div style={{ fontSize: 11, letterSpacing: 1.5, color: '#7dd3fc', fontWeight: 900 }}>FREE KICK ARENA</div>
+            <div style={{ fontSize: 20, fontWeight: 1000, lineHeight: 1.05 }}>Pro Curve Duel</div>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 6, minWidth: 172 }}>
+            {[['Score', score], ['Coins', coins], ['Streak', `${streak}x`]].map(([label, value]) => (
+              <div key={label} style={{ textAlign: 'center', padding: '8px 7px', borderRadius: 14, background: 'rgba(15,23,42,.74)', border: '1px solid rgba(255,255,255,.11)' }}>
+                <div style={{ fontSize: 9, color: '#cbd5e1', fontWeight: 800 }}>{label}</div>
+                <div style={{ fontSize: 15, color: label === 'Coins' ? '#facc15' : '#fff', fontWeight: 1000 }}>{value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+          <div style={{ padding: '8px 10px', borderRadius: 999, background: 'rgba(14,165,233,.18)', border: '1px solid rgba(125,211,252,.32)', fontWeight: 900, fontSize: 12 }}>Wind {wind >= 0 ? '→' : '←'} {Math.abs(wind).toFixed(1)}</div>
+          <div style={{ padding: '8px 12px', borderRadius: 999, background: phase === 'goal' ? 'rgba(34,197,94,.86)' : phase === 'saved' || phase === 'missed' ? 'rgba(239,68,68,.78)' : 'rgba(250,204,21,.92)', color: phase === 'aiming' || phase === 'charging' ? '#172033' : '#fff', fontWeight: 1000, fontSize: 12, letterSpacing: 1 }}>{phaseLabel}</div>
+        </div>
+      </section>
+
+      <div style={{ position: 'absolute', left: `calc(50% + ${(target.x / (GOAL_WIDTH / 2)) * 39}vw)`, top: `${31 - ((target.y - 0.85) / 2.35) * 13}vh`, width: 34, height: 34, marginLeft: -17, marginTop: -17, borderRadius: 999, border: '2px solid #facc15', boxShadow: '0 0 24px rgba(250,204,21,.88), inset 0 0 14px rgba(250,204,21,.45)', pointerEvents: 'none' }}>
+        <div style={{ position: 'absolute', left: 15, top: -8, width: 2, height: 48, background: 'rgba(250,204,21,.68)' }} />
+        <div style={{ position: 'absolute', top: 15, left: -8, height: 2, width: 48, background: 'rgba(250,204,21,.68)' }} />
+      </div>
+
+      <section style={{ position: 'absolute', left: 12, right: 12, bottom: 12, display: 'grid', gap: 10 }}>
+        <div style={{ padding: 12, borderRadius: 20, background: 'rgba(15,23,42,.78)', border: '1px solid rgba(255,255,255,.12)', backdropFilter: 'blur(14px)', boxShadow: '0 18px 54px rgba(0,0,0,.35)' }}>
+          <div style={{ fontSize: 12, color: '#cbd5e1', lineHeight: 1.35, minHeight: 34 }}>{message}</div>
+          <div style={{ marginTop: 10, height: 12, borderRadius: 999, background: 'rgba(148,163,184,.2)', overflow: 'hidden', border: '1px solid rgba(255,255,255,.1)' }}>
+            <div style={{ width: `${charge * 100}%`, height: '100%', borderRadius: 999, background: charge > 0.82 ? 'linear-gradient(90deg,#f97316,#ef4444)' : 'linear-gradient(90deg,#22c55e,#facc15)', boxShadow: '0 0 18px rgba(250,204,21,.6)' }} />
+          </div>
+          <button
+            type="button"
+            onPointerDown={beginCharge}
+            onPointerUp={releaseShot}
+            onPointerCancel={releaseShot}
+            disabled={phase === 'flying'}
+            style={{ marginTop: 10, width: '100%', border: 0, borderRadius: 18, padding: '16px 18px', color: '#07111f', background: phase === 'flying' ? '#64748b' : 'linear-gradient(135deg,#fef08a,#facc15 45%,#fb923c)', fontSize: 17, fontWeight: 1000, letterSpacing: 1.2, boxShadow: '0 12px 30px rgba(250,204,21,.28)' }}
+          >
+            HOLD & RELEASE TO SHOOT
+          </button>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 8 }}>
+          {upgradeEntries.map(([key, item]) => {
+            const level = upgrades[key];
+            const cost = 90 + level * 70;
+            const capped = level >= 5;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => buyUpgrade(key)}
+                disabled={capped || coins < cost}
+                style={{ border: '1px solid rgba(255,255,255,.12)', borderRadius: 16, padding: '9px 7px', textAlign: 'left', background: capped ? 'rgba(34,197,94,.26)' : coins >= cost ? 'rgba(30,41,59,.86)' : 'rgba(15,23,42,.58)', color: '#fff' }}
+              >
+                <div style={{ fontSize: 10, color: '#7dd3fc', fontWeight: 1000 }}>LV {level}/5</div>
+                <div style={{ fontSize: 11, fontWeight: 1000, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{item.label}</div>
+                <div style={{ fontSize: 9, color: '#cbd5e1', minHeight: 22 }}>{item.description}</div>
+                <div style={{ marginTop: 4, fontSize: 10, color: capped ? '#86efac' : '#facc15', fontWeight: 900 }}>{capped ? 'MAXED' : `${cost} coins`}</div>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Replace the very basic demo/store view with a focused, mobile-first free-kick arena experience that is more visually rich, realistic and gameplay-driven.
- Provide an extensible single-player gameplay loop (aim → charge → shoot → reward) with upgradeable systems so the scene can be iterated and balanced easily.
- Use a modular, engine-like approach (rendering/physics/input/UI separated in a single React/Three.js module) to keep the code maintainable and performant.

### Description
- Add `frontend/src/FreeKickArenaGame.tsx` which implements a Three.js stadium, pitch, goal and crowd, player & keeper models, ball with seams, cinematic camera, lighting and fog for a stylized realistic look.
- Implement gameplay systems in the same file: drag-to-aim targeting, hold-to-charge shooting, wind and spin-influenced curved trajectory prediction, gravity/drag physics, wall/keeper/goal detection, scoring, streaks, coin rewards and three upgrade paths (`curve`, `power`, `focus`).
- Wire the new game into the app by changing `frontend/src/App.tsx` to return `FreeKickArenaGame` instead of the previous component so the web app launches the free-kick game by default.
- Expose simple debug hooks on `window` (`freeKickShoot`, `freeKickReset`) and include a mobile-oriented HUD (score, coins, streak, wind, phase badge, target reticle, charge meter and upgrade buttons) for fast onboarding.

### Testing
- `npm run build` — completed successfully (Vite produced dependency/chunk-size warnings but the build finished).
- Started a local dev server with Vite (`npm run dev`) and verified it served at `http://127.0.0.1:5173/`.
- Installed Playwright browsers and system deps using `npx playwright install chromium` and `npx playwright install-deps chromium`, both of which completed successfully in the container.
- Ran an automated Playwright script against the running dev server to open a 390×844 mobile viewport and capture a screenshot, which produced `free-kick-arena-screenshot.png` confirming the app renders in a mobile portrait viewport.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd89510edc8329ba7d36ea31188ea3)