### PR TITLE
Fix Domino Royal bottom hand placement

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6714,12 +6714,10 @@ const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
 const PLAYER_HAND_GAP_SCALE = 0.56;
 const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 3.65;
 const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 0.46;
-const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 5.25;
-const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.0;
-const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 1.5;
-const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 2.86;
-const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.88;
+const HUMAN_BOTTOM_HAND_GAP_SCALE = 1.1;
 const HUMAN_BOTTOM_HAND_TILE_SCALE = 0.82;
+const HUMAN_BOTTOM_RAIL_OUTWARD = DOMINO_WIDTH * 0.34;
+const HUMAN_BOTTOM_RAIL_VERTICAL_RAISE = DOMINO_WIDTH * 0.08;
 const DOMINO_DOUBLE_NEIGHBOR_EXTRA_GAP = 0;
 const DOMINO_OPENING_DOUBLE_SIDE_GAP = DOMINO_LENGTH * 0.11;
 const TILE_UP_H = 0.2 * DOMINO_WORLD_SCALE * DOMINO_HEIGHT_ADJUST;
@@ -9199,13 +9197,13 @@ function computeHandSlotPosition(
     isHuman && !openFlat ? baseOffset * HUMAN_BOTTOM_HAND_GAP_SCALE : baseOffset;
 
   if (isHuman && !openFlat) {
-    const handAnchorZ = z0 + HUMAN_HAND_OUTWARD_OFFSET;
-    const humanExtraOutwardX = (x0 / seatLength) * HUMAN_BOTTOM_EXTRA_OUTWARD;
-    const humanExtraOutwardZ = (z0 / seatLength) * HUMAN_BOTTOM_EXTRA_OUTWARD;
+    // Keep the local player's rack on the front table apron/rail area marked in portrait view.
+    // This branch is deliberately isolated from the AI/remote player seats above.
+    const frontRailZ = TABLE_OUTER_RADIUS + HUMAN_BOTTOM_RAIL_OUTWARD;
     return new THREE.Vector3(
-      x0 + outwardX + humanExtraOutwardX + offset,
-      handY - HUMAN_HAND_VERTICAL_OFFSET + HUMAN_BOTTOM_EXTRA_RAISE,
-      handAnchorZ + outwardZ + humanExtraOutwardZ
+      offset,
+      HAND_Y + HUMAN_BOTTOM_RAIL_VERTICAL_RAISE,
+      frontRailZ
     );
   }
   if (isSide) {

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-08-domino-camera-hand-scale-v32';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-08-domino-bottom-rail-rack-v33';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Ensure the local (bottom) player's domino rack sits precisely on the front table rail/apron in portrait view while leaving AI/remote player hands unchanged.

### Description
- Reworked the bottom-player placement logic in `webapp/public/domino-royal-game.js` to isolate the human non-top-down branch and place the rack on the table front rail.
- Introduced `HUMAN_BOTTOM_RAIL_OUTWARD` and `HUMAN_BOTTOM_RAIL_VERTICAL_RAISE` and increased `HUMAN_BOTTOM_HAND_GAP_SCALE` to widen the local rack spacing without affecting other players.
- Removed the previous local-outward/raise calculations for the bottom branch and returned a fixed `THREE.Vector3` keyed to `TABLE_OUTER_RADIUS` so the local rack aligns with the apron.
- Bumped the Domino Royal script version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` for cache busting so clients load the updated placement code.

### Testing
- Ran `npm run build` in `webapp` and the build completed successfully (with existing Vite chunk-size warnings). 
- Ran `node --check webapp/public/domino-royal-game.js` which passed without syntax errors. 
- Ran `git diff --check` to validate whitespace/patch issues which reported no problems. 
- Attempted a Playwright screenshot to visually verify the change, but headless/container WebGL initialization proved unreliable so a full 3D render verification could not be captured in CI (attempts logged and timeouts observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd91529e508329b6b1b083da587722)