### PR TITLE
Tune bottom-player domino placement and scale (Domino Royal)

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6714,10 +6714,12 @@ const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
 const PLAYER_HAND_GAP_SCALE = 0.56;
 const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 3.65;
 const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 0.46;
-const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 5.25;
+const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 0.45;
 const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.0;
-const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 1.5;
-const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 2.86;
+// Bottom-seat hand placement is tuned for the portrait camera: keep the user's
+// dominoes on the front rail/fascia area instead of pushing them into the hands.
+const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 0.32;
+const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 0.34;
 const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.88;
 const HUMAN_BOTTOM_HAND_TILE_SCALE = 0.82;
 const DOMINO_DOUBLE_NEIGHBOR_EXTRA_GAP = 0;
@@ -9247,7 +9249,7 @@ function renderHands() {
       });
       m.position.copy(slotPosition);
       if (isHuman && !openFlat) {
-        m.scale.setScalar(HUMAN_BOTTOM_HAND_TILE_SCALE);
+        m.scale.multiplyScalar(HUMAN_BOTTOM_HAND_TILE_SCALE);
       }
       const yawTowardCenter = Math.atan2(-x0, -z0);
       if (openFlat) {

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-08-domino-camera-hand-scale-v32';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-08-domino-bottom-hand-rail-v33';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- User bottom-hand dominoes were visually pushed too far into the player hands on portrait screens and must sit exactly on the front rail/fascia area (marked in yellow) while leaving other players' domino placement unchanged.
- Preserve existing non-uniform domino proportions when applying the human-hand scale so the tiles don't distort.
- Ensure clients pick up the change by invalidating the cached public game script.

### Description
- Adjusted bottom-player placement constants in `webapp/public/domino-royal-game.js` by changing `HUMAN_HAND_OUTWARD_OFFSET`, `HUMAN_BOTTOM_EXTRA_OUTWARD`, and `HUMAN_BOTTOM_EXTRA_RAISE` to position the human tiles on the front rail.
- Applied the bottom-hand scale multiplicatively using `m.scale.multiplyScalar(HUMAN_BOTTOM_HAND_TILE_SCALE)` instead of `m.scale.setScalar(...)` so existing per-axis scale is preserved.
- Bumped the public script version in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-05-08-domino-bottom-hand-rail-v33` to invalidate caches and force clients to load the updated `domino-royal-game.js`.
- Files changed: `webapp/public/domino-royal-game.js`, `webapp/src/pages/Games/DominoRoyalArena.jsx`.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and the syntax check passed.
- Ran `npm run build` and the Vite build completed successfully (the build emitted existing chunk/dynamic-import size warnings but finished).
- Attempted an automated Playwright mobile screenshot to visually confirm placement, but the headless Chromium screenshot timed out / failed in this environment after browser dependency setup, so visual confirmation could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd91529e508329b6b1b083da587722)