### PR TITLE
Cinematic firearm camera, slower bullets, and AK‑47 rear-stock removal in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -787,7 +787,7 @@ const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
 });
 // Keep FPS gun and Shotgun Blast visually matched in hand.
 const SHOTGUN_HAND_SCALE = FIREARM_ATTACH_SCALE_MULTIPLIER.shotgunBlastAttack;
-const FIREARM_VOLLEY_SLOW_FACTOR = 1.72;
+const FIREARM_VOLLEY_SLOW_FACTOR = 2.08;
 const FIREARM_CAMERA_FOCUS_BLEND = 0.58;
 const FIREARM_CAMERA_SIDE_PULLBACK = 0.16;
 const FIREARM_CAMERA_LIFT = 0.048;
@@ -905,6 +905,44 @@ function playCaptureWeaponSourceSound(captureAnimationId, { volume = 1, muted = 
   audio.currentTime = 0;
   audio.play().catch(() => {});
   return true;
+}
+
+function removeAk47RearWoodStock(root) {
+  if (!root?.isObject3D) return;
+  root.updateMatrixWorld?.(true);
+  const rootBox = new THREE.Box3().setFromObject(root);
+  const rootCenter = rootBox.getCenter(new THREE.Vector3());
+  const rootSize = rootBox.getSize(new THREE.Vector3());
+  const rootCenterLocal = root.worldToLocal(rootCenter.clone());
+  const meshBox = new THREE.Box3();
+  const meshCenter = new THREE.Vector3();
+  const meshSize = new THREE.Vector3();
+  const brownish = (material) => {
+    const color = material?.color;
+    if (!color?.isColor) return false;
+    const hsl = { h: 0, s: 0, l: 0 };
+    color.getHSL(hsl);
+    return hsl.h >= 0.035 && hsl.h <= 0.16 && hsl.s > 0.18 && hsl.l < 0.58;
+  };
+  root.traverse((node) => {
+    if (!node?.isMesh) return;
+    const name = `${node.name || ''}`.toLowerCase();
+    if (/grip|handle|trigger|mag|magazine|handguard|fore/.test(name)) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    const hasWoodMaterial = materials.some(brownish);
+    meshBox.setFromObject(node);
+    meshBox.getCenter(meshCenter);
+    meshBox.getSize(meshSize);
+    const localCenter = root.worldToLocal(meshCenter.clone());
+    const rearByZ = localCenter.z < rootCenterLocal.z - rootSize.z * 0.22;
+    const rearByX = localCenter.x < rootCenterLocal.x - rootSize.x * 0.28;
+    const stockName = /stock|butt/.test(name);
+    const isSmallGrip = meshSize.y > rootSize.y * 0.35 && meshSize.z < rootSize.z * 0.22;
+    if ((stockName || hasWoodMaterial) && (rearByZ || rearByX) && !isSmallGrip) {
+      node.visible = false;
+      node.userData.removedAk47RearStock = true;
+    }
+  });
 }
 
 async function loadCaptureWeaponModel(captureAnimationId) {
@@ -1032,6 +1070,9 @@ async function loadCaptureWeaponModel(captureAnimationId) {
       });
       applyModelQualityToObject(root);
       fitObjectToTargetSize(root, config.scale ?? 0.12);
+      if (normalizedCaptureAnimationId === 'ak47VolleyAttack') {
+        removeAk47RearWoodStock(root);
+      }
       return root;
     } catch (error) {
       console.warn('Capture weapon model setup failed', captureAnimationId, error);
@@ -3266,8 +3307,8 @@ const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.072 * MODEL_SCALE;
 // The bottom-seat gameplay camera is intentionally raised and pushed farther toward the table so
 // portrait players see over the local avatar and closer into the Ludo board/action area.
 const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.31 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.32 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.178 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.42 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.255 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 9;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.34;
 const SEATED_CONTACT_DICE_Y_OFFSET = 0.005;
@@ -6995,6 +7036,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const cameraFocusFrameRef = useRef(0);
   const cameraViewFrameRef = useRef(0);
   const cameraSeatLockPositionRef = useRef(null);
+  const dynamicFirearmCameraRef = useRef(false);
   const lockUserTurnSeatViewRef = useRef(false);
   const preserveUserTurnCameraRef = useRef(false);
   const cameraTurnStateRef = useRef({
@@ -9997,8 +10039,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         !isCamera2d &&
         cameraTurnStateRef.current.followObject?.isObject3D &&
         controls &&
-        !LUDO_CAMERA_SEAT_LOCK_ENABLED &&
-        !cameraLookStateRef.current.active
+        (!LUDO_CAMERA_SEAT_LOCK_ENABLED || dynamicFirearmCameraRef.current) &&
+        (!cameraLookStateRef.current.active || dynamicFirearmCameraRef.current)
       ) {
         const followedTarget = cameraTurnStateRef.current.followObject.getWorldPosition(new THREE.Vector3());
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
@@ -10012,7 +10054,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
       }
 
-      if (!isCamera2d && camera && LUDO_CAMERA_SEAT_LOCK_ENABLED) {
+      if (!isCamera2d && camera && LUDO_CAMERA_SEAT_LOCK_ENABLED && !dynamicFirearmCameraRef.current) {
         const bottomActorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === 0);
         const gameplayTarget = boardLookTargetRef.current?.isVector3
           ? boardLookTargetRef.current.clone()
@@ -10366,6 +10408,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const isFighterJetAttack = resolvedCaptureAnimationId === 'fighterJetAttack';
         const isFirearmAttack = FIREARM_CAPTURE_ANIMATION_IDS.has(resolvedCaptureAnimationId);
         if (isFirearmAttack) {
+          dynamicFirearmCameraRef.current = true;
           const directorWeaponType =
             LUDO_WEAPON_DIRECTOR_BRIDGE.weaponTypeByCaptureAnimationId[resolvedCaptureAnimationId] ?? 'Rifle';
           const attackerEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === attackerPlayer);
@@ -10519,9 +10562,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               aimDir.lengthSq() > 1e-7
                 ? aimDir
                     .normalize()
-                    .multiplyScalar(singleShotFirearm ? FIREARM_BROADCAST_PROFILE.aimRearPullback * 0.62 : FIREARM_BROADCAST_PROFILE.aimRearPullback)
-                    .setY(singleShotFirearm ? FIREARM_BROADCAST_PROFILE.aimLift * 1.28 : FIREARM_BROADCAST_PROFILE.aimLift)
-                : new THREE.Vector3(0, FIREARM_BROADCAST_PROFILE.aimLift, FIREARM_BROADCAST_PROFILE.aimRearPullback);
+                    .multiplyScalar(singleShotFirearm ? -FIREARM_BROADCAST_PROFILE.aimRearPullback * 0.82 : -FIREARM_BROADCAST_PROFILE.aimRearPullback * 1.12)
+                    .add(new THREE.Vector3(0, singleShotFirearm ? FIREARM_BROADCAST_PROFILE.aimLift * 1.42 : FIREARM_BROADCAST_PROFILE.aimLift * 1.18, 0))
+                : new THREE.Vector3(0, FIREARM_BROADCAST_PROFILE.aimLift, -FIREARM_BROADCAST_PROFILE.aimRearPullback);
             setCameraFocus({
               target: cameraMid,
               object: handWeaponAttachment?.weapon,
@@ -10588,7 +10631,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 bulletMesh.visible = false;
                 return;
               }
-              const shotProgress = clamp((life * mergedBallistics.bulletSpeed) / Math.max(24, cadenceMs * 0.72), 0, 1);
+              const cinematicBulletSpeed = mergedBallistics.bulletSpeed * 0.62;
+              const shotProgress = clamp((life * cinematicBulletSpeed) / Math.max(24, cadenceMs * 0.82), 0, 1);
               const start = muzzleOrigin.clone();
               const end = muzzleTarget.clone();
               const bulletPos = start.lerp(end, shotProgress);
@@ -10718,6 +10762,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             bulletGeometry.dispose();
             bulletMaterial.dispose();
             handWeaponAttachment?.release?.();
+            dynamicFirearmCameraRef.current = false;
             if (parkedEntry?.weaponHolder) parkedEntry.weaponHolder.visible = true;
             playCapture();
             seatedHumanActionRef.current = {
@@ -11436,6 +11481,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         };
           requestAnimationFrame(tick);
         } catch (error) {
+          dynamicFirearmCameraRef.current = false;
           stopCaptureVehicleSounds();
           if (parkedVehicleToRestore?.isObject3D) parkedVehicleToRestore.visible = true;
           if (isDroneAttack && parkedDronePayload?.isObject3D) {
@@ -11532,7 +11578,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       ? cameraSeatLockPositionRef.current
       : null;
     const destinationPosition =
-      LUDO_CAMERA_SEAT_LOCK_ENABLED && lockedSeatPosition
+      LUDO_CAMERA_SEAT_LOCK_ENABLED && lockedSeatPosition && !dynamicFirearmCameraRef.current
         ? lockedSeatPosition.clone()
         : toPosition?.isVector3
           ? toPosition.clone()
@@ -11642,11 +11688,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       1,
       Math.abs(focusTarget.x - boardLookTarget.x) / Math.max(BOARD_CLOTH_HALF * 0.75, 0.01)
     );
-    const dynamicBlend = THREE.MathUtils.lerp(
-      CAMERA_BROADCAST_TARGET_BLEND,
-      CAMERA_BROADCAST_SIDE_BLEND,
-      sideDistance
-    );
+    const dynamicBlend = dynamicFirearmCameraRef.current
+      ? 1
+      : THREE.MathUtils.lerp(
+        CAMERA_BROADCAST_TARGET_BLEND,
+        CAMERA_BROADCAST_SIDE_BLEND,
+        sideDistance
+      );
     const target = boardLookTarget.clone().lerp(focusTarget, dynamicBlend);
     target.y = (arena.tableInfo?.surfaceY ?? target.y) + offset;
 
@@ -11795,8 +11843,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const state = stateRef.current;
       const controls = controlsRef.current;
       if (!state || !controls || isCamera2d || !LUDO_CAMERA_AUTO_LOOK_ENABLED) return;
-      if (state.turn === 0 && lockUserTurnSeatViewRef.current) return;
-      if (!focus.force && shouldRespectUserCamera(state.turn)) return;
+      if (state.turn === 0 && lockUserTurnSeatViewRef.current && !focus.force && !dynamicFirearmCameraRef.current) return;
+      if (!focus.force && !dynamicFirearmCameraRef.current && shouldRespectUserCamera(state.turn)) return;
       const {
         object,
         target,


### PR DESCRIPTION
### Motivation
- Improve the bottom-seat (portrait) camera framing so the local human avatar does not block the table action and the view looks slightly more downward. 
- Provide a cinematic, dynamic camera mode for firearm capture animations that follows the attacker, weapon muzzle and bullets for clearer, more cinematic attack visuals. 
- Hide the wooden rear stock on the AK‑47 capture model so the visible weapon does not overlap the handler's hand while preserving grip/trigger meshes. 

### Description
- Raised portrait face/gameplay camera offsets by increasing `SEATED_FACE_CAMERA_GAMEPLAY_UP` and `SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN` in `webapp/src/pages/Games/LudoBattleRoyal.jsx`. 
- Added a runtime flag `dynamicFirearmCameraRef` and wired it into camera-selection and focus logic so firearm sequences temporarily override seat-locked camera behavior and restore it on finish or error. 
- Tuned firearm broadcast behavior: increased `FIREARM_VOLLEY_SLOW_FACTOR`, reduced cinematic bullet speed for on-screen bullet follow, and adjusted camera follow offsets so the camera pulls back/lifts into a cinematic viewpoint while following the muzzle/lead bullet. Changes are implemented in `playCaptureMissileSequence` and related camera helpers (`setCameraFocus`, `resolveFocusCameraState`, `animateCameraPose`). 
- Implemented `removeAk47RearWoodStock(root)` that heuristically hides rear/stock meshes (based on mesh naming and brownish material detection) and invoke it after loading the AK‑47 capture model in `loadCaptureWeaponModel`, so the AK‑47's wooden rear does not intersect the hand. 
- Minor safety: ensure `dynamicFirearmCameraRef` is reset on normal completion and on error paths. 
- Changes are contained in `webapp/src/pages/Games/LudoBattleRoyal.jsx` (camera, firearm flow, ballistics, and AK‑47 cleaning) and a small helper function added adjacent to weapon loading logic. 

### Testing
- Built the web client to verify the changes compile: ran `npm --prefix webapp run build` and the Vite build completed successfully (production build artifacts emitted). (Succeeded) 
- Attempted a headless visual smoke test with Playwright to capture an in-app screenshot of the Ludo scene and verify camera framing, but Chromium failed to launch in the container due to missing system library `libatk-1.0.so.0` (Playwright browser dependency). (Failed — environment dependency) 
- Committed the change under the message `Improve Ludo firearm camera direction` and verified no lint or diff-check errors during commit. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbd50a36c832982f7db4bf7352f6e)