### PR TITLE
Improve Snake & Ladder weapon placement and movement animation

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -520,10 +520,11 @@ const TOKEN_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  // Bottom/self player: lift parked weapons farther up to visually match the raised token.
-  TILE_SIZE * 2.56,
+  // Bottom/self player: lift parked weapons farther toward the top of the portrait screen.
+  TILE_SIZE * 3.12,
   0,
-  TILE_SIZE * 0.46,
+  // Top player: keep the weapon cluster visually higher on the portrait screen too.
+  TILE_SIZE * 1.18,
   0
 ]);
 const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.38;
@@ -5465,6 +5466,43 @@ function createCaptureVehicleFallbackMesh(kind = 'fighter') {
   return root;
 }
 
+function stripAk47RearWoodStock(model) {
+  if (!model?.isObject3D) return model;
+  model.updateMatrixWorld(true);
+  const rootBox = new THREE.Box3().setFromObject(model);
+  const rootSize = rootBox.getSize(new THREE.Vector3());
+  const rearCutoffX = rootBox.min.x + rootSize.x * 0.34;
+  const minWoodScore = 0.08;
+  const meshesToHide = [];
+
+  model.traverse((obj) => {
+    if (!obj.isMesh) return;
+    const meshName = `${obj.name || ''} ${obj.parent?.name || ''}`.toLowerCase();
+    const meshBox = new THREE.Box3().setFromObject(obj);
+    if (!Number.isFinite(meshBox.min.x) || !Number.isFinite(meshBox.max.x)) return;
+    const meshCenter = meshBox.getCenter(new THREE.Vector3());
+    const meshSize = meshBox.getSize(new THREE.Vector3());
+    const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+    const hasWoodName = /stock|butt|rear|wood|wooden/.test(meshName) && !/grip|handle|hand/.test(meshName);
+    const hasWoodColor = mats.some((mat) => {
+      if (!mat?.color) return false;
+      const { r, g, b } = mat.color;
+      return r > g + minWoodScore && g > b + minWoodScore && r > 0.22 && g > 0.1;
+    });
+    const isRearOnly = meshCenter.x < rearCutoffX && meshSize.x < rootSize.x * 0.58;
+    const isGripOrHandle = /grip|handle|trigger|magazine|mag/.test(meshName) || meshCenter.y < rootBox.min.y + rootSize.y * 0.38;
+    if (isRearOnly && !isGripOrHandle && (hasWoodName || hasWoodColor)) {
+      meshesToHide.push(obj);
+    }
+  });
+
+  meshesToHide.forEach((mesh) => {
+    mesh.visible = false;
+    mesh.userData.snakeAk47RearWoodStockHidden = true;
+  });
+  return model;
+}
+
 function normalizeCaptureVehicleModel(model) {
   if (!model) return model;
   const box = new THREE.Box3().setFromObject(model);
@@ -5945,7 +5983,9 @@ async function loadCaptureWeaponCatalogModel(weaponId) {
             const root = gltf?.scene || gltf?.scenes?.[0] || null;
             if (!root) continue;
             prepareLoadedModel(root);
-            return normalizeCaptureVehicleModel(root);
+            const normalized = normalizeCaptureVehicleModel(root);
+            if (weaponId === 'slot-10-ak47-gltf') stripAk47RearWoodStock(normalized);
+            return normalized;
           } catch (error) {
             console.warn(`Capture weapon model load failed`, weaponId, url, error);
           }
@@ -7142,7 +7182,7 @@ export default function SnakeBoard3D({
     }
     const curve = pathInfo.curve;
     token.userData.isSliding = true;
-    const duration = 1100;
+    const duration = Number.isFinite(slide.duration) ? slide.duration : 1100;
     const startTime = performance.now();
     const lift = TOKEN_HEIGHT * 0.6;
     const camera = cameraRef.current;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1481,7 +1481,7 @@ export default function SnakeAndLadder() {
 
 
   const requestSlideAnimation = useCallback(
-    ({ playerIndex, from, to, type, onComplete }) => {
+    ({ playerIndex, from, to, type, duration, onComplete }) => {
       if (slideStateRef.current) return false;
       slideIdRef.current += 1;
       const payload = {
@@ -1490,6 +1490,7 @@ export default function SnakeAndLadder() {
         from,
         to,
         type,
+        duration,
         onComplete
       };
       slideStateRef.current = payload;
@@ -2784,6 +2785,17 @@ export default function SnakeAndLadder() {
           }),
         FINAL_TILE,
         playerIndex: 0,
+        currentPosition: current,
+        stepDurationMs: 430,
+        startStepAnimation: ({ from, to, type, duration, onComplete }) =>
+          requestSlideAnimation({
+            playerIndex: 0,
+            from,
+            to,
+            type,
+            duration,
+            onComplete
+          }),
         startSlide: ({ from, to, type, onComplete }) =>
           requestSlideAnimation({
             playerIndex: 0,
@@ -3007,6 +3019,17 @@ export default function SnakeAndLadder() {
       muted,
       FINAL_TILE,
       playerIndex: index,
+      currentPosition: current,
+      stepDurationMs: 430,
+      startStepAnimation: ({ from, to, type, duration, onComplete }) =>
+        requestSlideAnimation({
+          playerIndex: index,
+          from,
+          to,
+          type,
+          duration,
+          onComplete
+        }),
       startSlide: ({ from, to, type, onComplete }) =>
         requestSlideAnimation({
           playerIndex: index,

--- a/webapp/src/utils/moveHelpers.js
+++ b/webapp/src/utils/moveHelpers.js
@@ -8,22 +8,41 @@ export function flashHighlight(cell, type, ctx, times = 1, done = () => {}) {
 }
 
 export function moveSeq(seq, type, ctx, done = () => {}, dir = 'forward') {
-  const stepMove = (idx) => {
+  const stepMove = (idx, fromCell = ctx.currentPosition ?? 0) => {
     if (idx >= seq.length) return done();
     const next = seq[idx];
-    ctx.updatePosition(next);
-    if (ctx.moveSoundRef?.current) {
-      ctx.moveSoundRef.current.currentTime = 0;
-      if (!ctx.muted) ctx.moveSoundRef.current.play().catch(() => {});
-    }
-    if (typeof ctx.onStepSfx === 'function') {
-      ctx.onStepSfx();
-    }
     const hType = idx === seq.length - 1 ? type : dir === 'back' ? 'back' : 'forward';
-    ctx.setHighlight({ cell: next, type: hType });
-    ctx.setTrail((t) => [...t, { cell: next, type: hType }]);
-    if (idx === seq.length - 2 && ctx.hahaSoundRef?.current) ctx.hahaSoundRef.current.pause();
-    setTimeout(() => stepMove(idx + 1), 700);
+
+    const finishStep = () => {
+      ctx.updatePosition(next);
+      if (ctx.moveSoundRef?.current) {
+        ctx.moveSoundRef.current.currentTime = 0;
+        if (!ctx.muted) ctx.moveSoundRef.current.play().catch(() => {});
+      }
+      if (typeof ctx.onStepSfx === 'function') {
+        ctx.onStepSfx();
+      }
+      ctx.setHighlight({ cell: next, type: hType });
+      ctx.setTrail((t) => [...t, { cell: next, type: hType }]);
+      if (idx === seq.length - 2 && ctx.hahaSoundRef?.current) ctx.hahaSoundRef.current.pause();
+      setTimeout(() => stepMove(idx + 1, next), 80);
+    };
+
+    if (
+      typeof ctx.startStepAnimation === 'function' &&
+      ctx.startStepAnimation({
+        playerIndex: ctx.playerIndex ?? 0,
+        from: fromCell,
+        to: next,
+        type: hType,
+        duration: Number.isFinite(ctx.stepDurationMs) ? ctx.stepDurationMs : 430,
+        onComplete: finishStep
+      })
+    ) {
+      return;
+    }
+
+    finishStep();
   };
   stepMove(0);
 }


### PR DESCRIPTION
### Motivation
- Improve portrait framing by moving parked weapons for bottom/top players visually higher on the screen.
- Remove the unwanted wooden rear stock on the AK47 GLTF while preserving grip/handle geometry so the weapon looks correct in-hand.
- Make token movement and dice handoff match dice results and feel smoother by reusing the existing 3D slide/jump animation per dice step and by allowing per-step durations.

### Description
- Adjusted portrait calibration offsets by increasing `WEAPON_TOP_SCREEN_SHIFT_BY_SEAT` so bottom and top player parked weapons sit higher on the phone screen. (file: `webapp/src/components/SnakeBoard3D.jsx`)
- Added `stripAk47RearWoodStock(model)` which heuristically hides rear/wood-stock meshes (by name/colour/position) and invoke it after normalizing the loaded AK47 model so only the wooden butt is removed while grips/triggers remain. (file: `webapp/src/components/SnakeBoard3D.jsx`)
- When loading catalog models, run the AK47 cleanup for `slot-10-ak47-gltf` before returning the normalized model. (file: `webapp/src/components/SnakeBoard3D.jsx`)
- Reworked `moveSeq` to support an optional `startStepAnimation` hook plus `currentPosition` and `stepDurationMs` in the movement context so each dice step can either run the existing per-step 3D slide animation or fall back to an immediate update; per-step completion now advances precisely one tile and triggers SFX consistently. (file: `webapp/src/utils/moveHelpers.js`)
- Added `duration` to the slide request API and threaded `duration` through `requestSlideAnimation`/`startStepAnimation` so callers can request faster per-step jumps while preserving longer snake/ladder slide timings. (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`)
- Use `slide.duration` as the animation duration in the slide playback so slides can accept custom timing when started. (file: `webapp/src/components/SnakeBoard3D.jsx`)
- Minor glue: pass `currentPosition`, `stepDurationMs`, and `startStepAnimation` into the human and AI movement contexts so token moves use the new per-step animation path. (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`)

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build output reported modules transformed and assets emitted). 
- Ran a repository hygiene check (`git diff --check`) and addressed/verified changes before committing. 
- Attempted an automated Playwright screenshot to validate portrait framing, but Chromium could not launch in this container due to a missing system library (`libatk-1.0.so.0`), so the screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd23ac4848329846f887e5c089c0d)