### PR TITLE
Fix Snake & Ladder dice sync and bottom weapon alignment

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -520,8 +520,8 @@ const TOKEN_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_TOP_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  // Bottom/self player: lift parked weapons farther toward the top of the portrait screen.
-  TILE_SIZE * 3.12,
+  // Bottom/self player: keep the weapon visually level with the bottom reserve token row.
+  TILE_SIZE * 2.08,
   0,
   // Top player: keep the weapon cluster visually higher on the portrait screen too.
   TILE_SIZE * 1.18,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1449,6 +1449,7 @@ export default function SnakeAndLadder() {
   const [showWatchWelcome, setShowWatchWelcome] = useState(false);
 
   const diceRollerDivRef = useRef(null);
+  const activeDiceBoardRollRef = useRef(null);
   const slideStateRef = useRef(null);
   const slideIdRef = useRef(0);
   const [slideAnimation, setSlideAnimation] = useState(null);
@@ -1512,6 +1513,20 @@ export default function SnakeAndLadder() {
 
   const startDiceBoardAnimation = useCallback((phase) => {
     setDiceBoardEvent(phase);
+  }, []);
+
+  const normalizeAuthoritativeDiceValues = useCallback((value, fallbackCount = 1) => {
+    if (Array.isArray(value)) {
+      return value
+        .map((candidate) => Number(candidate))
+        .filter((candidate) => Number.isFinite(candidate))
+        .map((candidate) => Math.max(1, Math.min(6, Math.floor(candidate))));
+    }
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      return [Math.max(1, Math.min(6, Math.floor(numeric)))];
+    }
+    return Array(Math.max(1, fallbackCount || 1)).fill(1);
   }, []);
 
   const startCaptureAnimation = useCallback(
@@ -2309,12 +2324,45 @@ export default function SnakeAndLadder() {
         unseatTable(myAccountId, tableId).catch(() => {});
       }
     };
-    const onRolled = ({ value, playerId }) => {
-      setRollResult(value);
+    const onRolled = ({ value, dice, playerId, accountId }) => {
+      const authoritativeValue = dice ?? value;
+      const serverValues = normalizeAuthoritativeDiceValues(authoritativeValue, diceCount);
+      const resultTotal = serverValues.reduce((sum, face) => sum + face, 0);
+      const rollerId = playerId ?? accountId ?? playersRef.current[currentTurn]?.id;
+      const rollerIndex = resolveTurnIndex({ playerId: rollerId, currentTurn });
+      const seatIndex = rollerIndex >= 0 ? rollerIndex : currentTurn ?? 0;
+      const activeRoll = activeDiceBoardRollRef.current;
+      const canReuseActiveRoll =
+        activeRoll &&
+        activeRoll.seatIndex === seatIndex &&
+        activeRoll.phase === 'start';
+      const rollId = canReuseActiveRoll ? activeRoll.id : diceRollIdRef.current + 1;
+
+      if (!canReuseActiveRoll) {
+        diceRollIdRef.current = rollId;
+        activeDiceBoardRollRef.current = { id: rollId, seatIndex, phase: 'start' };
+        startDiceBoardAnimation({
+          id: rollId,
+          phase: 'start',
+          count: serverValues.length || 1,
+          seatIndex
+        });
+      }
+
+      window.setTimeout(() => {
+        startDiceBoardAnimation({
+          id: rollId,
+          phase: 'end',
+          values: serverValues,
+          seatIndex
+        });
+        activeDiceBoardRollRef.current = { id: rollId, seatIndex, phase: 'end' };
+      }, canReuseActiveRoll ? 0 : 80);
+
+      setRollResult(resultTotal);
       setTimeout(() => setRollResult(null), DICE_RESULT_HOLD_MS);
-      const rollerId = playerId ?? playersRef.current[currentTurn]?.id;
-      playDiceRollSound(`${rollerId ?? 'turn'}:${value}`);
-      if (rollerId === myAccountId && Number(value) === 6) {
+      playDiceRollSound(`${rollerId ?? 'turn'}:${resultTotal}`);
+      if (rollerId === myAccountId && serverValues.some((face) => Number(face) === 6)) {
         setPendingExtraRoll(true);
         setRollCooldown(0);
       }
@@ -4161,6 +4209,11 @@ export default function SnakeAndLadder() {
                 values: vals,
                 seatIndex: aiRollingIndex ?? 0
               });
+              activeDiceBoardRollRef.current = {
+                id: diceRollIdRef.current,
+                seatIndex: aiRollingIndex ?? 0,
+                phase: 'end'
+              };
               if (aiRollingIndex) {
                 handleAIRoll(aiRollingIndex, vals);
                 setAiRollingIndex(null);
@@ -4173,6 +4226,11 @@ export default function SnakeAndLadder() {
             }}
             onRollStart={() => {
               diceRollIdRef.current += 1;
+              activeDiceBoardRollRef.current = {
+                id: diceRollIdRef.current,
+                seatIndex: aiRollingIndex ?? 0,
+                phase: 'start'
+              };
               startDiceBoardAnimation({
                 id: diceRollIdRef.current,
                 phase: 'start',
@@ -4214,6 +4272,11 @@ export default function SnakeAndLadder() {
               divRef={diceRollerDivRef}
               onRollStart={() => {
                 diceRollIdRef.current += 1;
+                activeDiceBoardRollRef.current = {
+                  id: diceRollIdRef.current,
+                  seatIndex: currentTurn,
+                  phase: 'start'
+                };
                 startDiceBoardAnimation({
                   id: diceRollIdRef.current,
                   phase: 'start',
@@ -4222,17 +4285,11 @@ export default function SnakeAndLadder() {
                 });
                 setPendingExtraRoll(false);
               }}
-              onRollEnd={(vals) => {
-                startDiceBoardAnimation({
-                  id: diceRollIdRef.current,
-                  phase: 'end',
-                  values: vals,
-                  seatIndex: currentTurn
-                });
-                const rolledSix = Array.isArray(vals)
-                  ? vals.some((v) => Number(v) === 6)
-                  : Number(vals) === 6;
-                setPendingExtraRoll(rolledSix);
+              onRollEnd={() => {
+                // Multiplayer rolls are server-authoritative. The dice face and
+                // token movement are completed from the diceRolled socket event
+                // so the board never displays a local random value that differs
+                // from the value used to move the token.
               }}
             />
           ) : null}


### PR DESCRIPTION
### Motivation
- Align the bottom player's parked weapon visually with the bottom reserve-token row on portrait phones so weapons and tokens appear level and keep the weapon flat and pointed consistently. 
- Make the dice visuals authoritative with the server in multiplayer so the displayed dice faces always match the values used to move tokens. 

### Description
- Lowered the bottom weapon portrait offset by updating `WEAPON_TOP_SCREEN_SHIFT_BY_SEAT` in `webapp/src/components/SnakeBoard3D.jsx` so the bottom player's parked weapon sits level with the bottom reserve token row. 
- Added an `activeDiceBoardRollRef` and `normalizeAuthoritativeDiceValues` helper in `webapp/src/pages/Games/SnakeAndLadder.jsx` to track active board roll phases and to normalize server-provided dice data (supporting both single numbers and arrays of faces). 
- Reworked the `diceRolled` socket handling (`onRolled`) to prefer server-authoritative `dice` payloads, compute per-face values, reuse a prior local "start" animation when possible, and then send the authoritative `end` phase into the 3D board so settle animations and token movement use the same faces. 
- Adjusted local `DiceRoller` start/end usage so local (single-player) rolls still animate start/end, while multiplayer roll end is driven by the server `diceRolled` event (preventing local random faces from differing from server movement). 

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully. 
- Ran a local production build with `cd webapp && npx vite build` which completed successfully. 
- Attempted an automated portrait screenshot with Playwright after installing browser dependencies; browser artifacts and fonts caused the screenshot capture to time out in this environment (Playwright and system deps were installed but the capture timed out), so visual verification was performed by running the dev server and exercising the flows where possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdddf1c0288329b4bb67f890ed7b21)