### PR TITLE
Adjust Murlan side player card spacing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2839,11 +2839,13 @@ const SIDE_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 0.88;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = 0.062 * MODEL_SCALE;
 const AI_HAND_CARD_SCALE = 0.96;
-const AI_SIDE_HAND_EXTRA_INWARD_PULL = 0.16 * MODEL_SCALE;
+const AI_SIDE_HAND_EXTRA_INWARD_PULL = 0.02 * MODEL_SCALE;
 const AI_TOP_HAND_EXTRA_INWARD_PULL = 0.1 * MODEL_SCALE;
+const AI_SIDE_HAND_EXTRA_OUTWARD_PUSH = 0.18 * MODEL_SCALE;
 const AI_SIDE_HAND_UP_SHIFT_Y = 0.11 * MODEL_SCALE;
 const AI_TOP_HAND_UP_SHIFT_Y = 0.07 * MODEL_SCALE;
 const AI_SIDE_HAND_LATERAL_PALM_SHIFT = 0.05 * MODEL_SCALE;
+const AI_SIDE_HAND_TOPWARD_SHIFT = 0.18 * MODEL_SCALE;
 const AI_TOP_HAND_LATERAL_PALM_SHIFT = 0;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
 const HUMAN_HAND_EXTRA_INWARD_PULL = 0.2 * MODEL_SCALE;
@@ -4364,14 +4366,20 @@ export default function MurlanRoyaleArena({ search }) {
             : 0;
         const aiPalmLateralShift = aiHandVariant === 'side'
           ? (forward?.x ?? 0) < 0
-            ? -AI_SIDE_HAND_LATERAL_PALM_SHIFT
-            : AI_SIDE_HAND_LATERAL_PALM_SHIFT
+            ? AI_SIDE_HAND_LATERAL_PALM_SHIFT
+            : -AI_SIDE_HAND_LATERAL_PALM_SHIFT
           : aiHandVariant === 'top'
             ? AI_TOP_HAND_LATERAL_PALM_SHIFT
             : 0;
+        const aiSideTopwardShift = aiHandVariant === 'side'
+          ? (forward?.x ?? 0) < 0
+            ? AI_SIDE_HAND_TOPWARD_SHIFT
+            : -AI_SIDE_HAND_TOPWARD_SHIFT
+          : 0;
+        const aiSideOutwardPush = aiHandVariant === 'side' ? AI_SIDE_HAND_EXTRA_OUTWARD_PUSH : 0;
         target.addScaledVector(forward, isHumanCard ? HUMAN_HAND_CLOSER_OFFSET : AI_HAND_CLOSER_OFFSET);
-        target.addScaledVector(forward, -(HUMAN_HAND_EXTRA_INWARD_PULL + aiExtraInwardPull));
-        target.addScaledVector(layoutAxis, (isHumanCard ? HUMAN_HAND_LEFT_SHIFT : AI_HAND_LEFT_SHIFT) + aiPalmLateralShift);
+        target.addScaledVector(forward, aiSideOutwardPush - (HUMAN_HAND_EXTRA_INWARD_PULL + aiExtraInwardPull));
+        target.addScaledVector(layoutAxis, (isHumanCard ? HUMAN_HAND_LEFT_SHIFT : AI_HAND_LEFT_SHIFT) + aiPalmLateralShift + aiSideTopwardShift);
         target.y =
           baseHeight +
           centerWeight * fanArcLift +


### PR DESCRIPTION
### Motivation
- Move left/right opponent card stacks visually farther outward from the table and bias them toward the top opponent side on portrait mobile, while preserving the bottom human player card layout.
- Implement the change in the 3D card placement math so side-player cards read as more separated from the table edge on small (portrait) screens.

### Description
- Updated constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to reduce side inward pull (`AI_SIDE_HAND_EXTRA_INWARD_PULL`) and add explicit side outward push (`AI_SIDE_HAND_EXTRA_OUTWARD_PUSH`) and topward shift (`AI_SIDE_HAND_TOPWARD_SHIFT`).
- Flipped the sign logic for `aiPalmLateralShift` for side seats and added `aiSideTopwardShift` and `aiSideOutwardPush` to placement math so side-player cards move outward along the seat forward direction and slightly toward the top-opponent side.
- Changes only apply to AI seats with `handVariant === 'side'`, leaving the human (bottom) hand layout unchanged.

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully.
- Attempted an automated Playwright mobile portrait screenshot to visually verify layout, but the headless Chromium process could not launch in the container due to a missing system library (`libatk-1.0.so.0`), so screenshot validation did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdea4034a88329a5bfc5235b93509b)