### PR TITLE
Add selectable Pool Royal human character aiming profiles and rig/menu integration

### DIFF
--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -30,6 +30,10 @@ namespace Aiming
     public class AdaptiveAimingEngine : MonoBehaviour
     {
         public AimingConfig config;
+        [Header("Pool Royal human character")]
+        [Tooltip("Top-menu selectable human. Each preset uses a different pro-player aiming method.")]
+        public PoolHumanCharacterId selectedHumanCharacter = PoolHumanCharacterId.MurlanRoyalPro;
+        [SerializeField] private PoolHumanCharacterProfile activeHumanProfile;
         public bool showDebug = true;
 
         LineRenderer lr;
@@ -40,6 +44,7 @@ namespace Aiming
         void Awake()
         {
             if (config == null) config = Resources.Load<AimingConfig>("AimingConfig");
+            SetHumanCharacter(selectedHumanCharacter);
             ghost = new Strategies.GhostBallStrategy();
             contact = new Strategies.ContactPointStrategy();
             fractional = new Strategies.FractionalStrategy();
@@ -72,6 +77,14 @@ namespace Aiming
             lr.enabled = true;
         }
 
+        public PoolHumanCharacterProfile ActiveHumanProfile => activeHumanProfile;
+
+        public void SetHumanCharacter(PoolHumanCharacterId characterId)
+        {
+            selectedHumanCharacter = characterId;
+            activeHumanProfile = PoolHumanCharacterProfile.GetPreset(characterId);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AimSolution GetAimSolution(in ShotContext ctx)
         {
@@ -101,6 +114,7 @@ namespace Aiming
             {
                 sol = BuildDefaultSolution(evalCtx, info);
             }
+            sol = ApplyHumanProfileToSolution(evalCtx, info, sol);
             sol.recommendedPower01 = RecommendPower(info.distBucket, ctx.requiresPower);
             if (ctx.highSpin)
             {
@@ -332,7 +346,7 @@ namespace Aiming
 
         AimSolution SelectBestSolution(in ShotContext ctx, in ShotInfo info)
         {
-            IAimingStrategy[] candidates = { ghost, contact, fractional, cte };
+            IAimingStrategy[] candidates = GetHumanStrategyOrder();
             const int maxCandidates = 4;
             AimSolution[] validSolutions = new AimSolution[maxCandidates];
             float[] deterministicScores = new float[maxCandidates];
@@ -350,7 +364,7 @@ namespace Aiming
                 if (!IsCuePathClear(ctx.cueBallPos, attempt.aimEnd, ctx))
                     continue;
 
-                float score = ScoreAttempt(ctx, info, attempt);
+                float score = ScoreAttempt(ctx, info, attempt) + HumanStylePenalty(candidate.Name, info);
                 if (validCount < maxCandidates)
                 {
                     attempt.strategyUsed = candidate.Name;
@@ -372,7 +386,7 @@ namespace Aiming
             if (!hasBest)
                 return default;
 
-            if (config != null && config.enableMonteCarlo && validCount > 1 && config.monteCarloRollouts > 0)
+            if (ShouldUseMonteCarloProfile() && validCount > 1 && config != null && config.enableMonteCarlo && config.monteCarloRollouts > 0)
             {
                 best = SelectWithMonteCarlo(ctx, info, validSolutions, deterministicScores, validCount);
             }
@@ -381,11 +395,108 @@ namespace Aiming
             return best;
         }
 
+
+        AimSolution ApplyHumanProfileToSolution(in ShotContext ctx, in ShotInfo info, AimSolution sol)
+        {
+            if (!sol.isValid || activeHumanProfile.displayName == null)
+                return sol;
+
+            Vector3 cueToAim = sol.aimEnd - ctx.cueBallPos;
+            if (cueToAim.sqrMagnitude > 1e-8f)
+            {
+                Vector3 lateral = MathUtil.OrthoAround(info.vOP, Vector3.up);
+                float side = Mathf.Sign(Vector3.Dot(lateral, ctx.cueBallPos - ctx.objectBallPos));
+                if (!Mathf.Approximately(side, 0f))
+                {
+                    float cutT = Mathf.Clamp01(info.angleDeg / 70f);
+                    float compensation = activeHumanProfile.cutCompensation * activeHumanProfile.skill01 * cutT * ctx.ballRadius;
+                    float pocketCheat = activeHumanProfile.pocketCheat01 * 0.18f * cutT * ctx.ballRadius;
+                    sol.aimEnd += lateral * side * (compensation + pocketCheat);
+                }
+            }
+
+            float spin = Mathf.Min(config ? config.tipOffsetMax : 0.85f, activeHumanProfile.spinComfort01 * 0.42f);
+            if (activeHumanProfile.positionPlay01 > 0.5f)
+            {
+                float outside = Mathf.Sign(Vector3.Cross(info.vOC, info.vOP).y);
+                if (!Mathf.Approximately(outside, 0f))
+                {
+                    float follow = Mathf.Lerp(0.06f, 0.28f, activeHumanProfile.positionPlay01);
+                    sol.tipOffset = new Vector2(outside * spin, follow);
+                }
+            }
+
+            sol.debugNote = $"{sol.debugNote} · {activeHumanProfile.displayName}";
+            return sol;
+        }
+
+        IAimingStrategy[] GetHumanStrategyOrder()
+        {
+            switch (activeHumanProfile.aimStyle)
+            {
+                case PoolHumanAimStyle.GhostBall:
+                    return new[] { ghost, fractional, contact, cte };
+                case PoolHumanAimStyle.Fractional:
+                    return new[] { fractional, ghost, cte, contact };
+                case PoolHumanAimStyle.ContactPoint:
+                    return new[] { contact, ghost, fractional, cte };
+                case PoolHumanAimStyle.CtePivot:
+                    return new[] { cte, ghost, fractional, contact };
+                default:
+                    return new[] { ghost, contact, fractional, cte };
+            }
+        }
+
+        IAimingStrategy GetPrimaryHumanStrategy(in ShotInfo info)
+        {
+            switch (activeHumanProfile.aimStyle)
+            {
+                case PoolHumanAimStyle.Fractional:
+                    return fractional;
+                case PoolHumanAimStyle.ContactPoint:
+                    return contact;
+                case PoolHumanAimStyle.CtePivot:
+                    return cte;
+                case PoolHumanAimStyle.MonteCarloPattern:
+                    if (info.isStraight || info.angleDeg <= 28f) return ghost;
+                    if (info.angleDeg <= 52f) return fractional;
+                    return contact;
+                default:
+                    return ghost;
+            }
+        }
+
+        bool ShouldUseMonteCarloProfile()
+        {
+            return activeHumanProfile.displayName == null ||
+                activeHumanProfile.aimStyle == PoolHumanAimStyle.MonteCarloPattern ||
+                activeHumanProfile.skill01 >= 0.92f;
+        }
+
+        float HumanStylePenalty(string strategyName, in ShotInfo info)
+        {
+            if (activeHumanProfile.displayName == null)
+                return 0f;
+
+            float offStylePenalty = Mathf.Lerp(0.34f, 0.04f, activeHumanProfile.skill01);
+            switch (activeHumanProfile.aimStyle)
+            {
+                case PoolHumanAimStyle.GhostBall:
+                    return strategyName == ghost.Name ? 0f : offStylePenalty;
+                case PoolHumanAimStyle.Fractional:
+                    return strategyName == fractional.Name ? 0f : offStylePenalty * (info.angleDeg > 24f ? 0.7f : 1.2f);
+                case PoolHumanAimStyle.ContactPoint:
+                    return strategyName == contact.Name ? 0f : offStylePenalty;
+                case PoolHumanAimStyle.CtePivot:
+                    return strategyName == cte.Name ? 0f : offStylePenalty;
+                default:
+                    return strategyName == contact.Name && info.angleDeg > 58f ? 0.02f : 0f;
+            }
+        }
+
         AimSolution BuildDefaultSolution(in ShotContext ctx, in ShotInfo info)
         {
-            IAimingStrategy fallback = info.isStraight ? ghost :
-                (info.isRailShot || info.angleDeg < 30f) ? contact :
-                (info.angleDeg <= 45f) ? ghost : fractional;
+            IAimingStrategy fallback = GetPrimaryHumanStrategy(info);
             var sol = fallback.Solve(ctx, info, config);
             sol.strategyUsed = fallback.Name;
             return sol;
@@ -412,7 +523,8 @@ namespace Aiming
         {
             float blend = Mathf.Clamp01(config.monteCarloBlend);
             int rollouts = Mathf.Max(1, config.monteCarloRollouts);
-            float jitterDeg = Mathf.Max(0f, config.monteCarloAimJitterDeg);
+            float profileJitter = activeHumanProfile.displayName == null ? config.monteCarloAimJitterDeg : activeHumanProfile.aimJitterDeg;
+            float jitterDeg = Mathf.Max(0f, Mathf.Min(config.monteCarloAimJitterDeg, profileJitter));
             float powerJitter = Mathf.Max(0f, config.monteCarloPowerJitter);
 
             float bestCost = float.MaxValue;

--- a/Assets/Scripts/Gameplay/PoolRoyale/PoolHumanCharacterProfile.cs
+++ b/Assets/Scripts/Gameplay/PoolRoyale/PoolHumanCharacterProfile.cs
@@ -1,0 +1,142 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    public enum PoolHumanCharacterId
+    {
+        MurlanRoyalPro = 0,
+        ArtaGhostBall = 1,
+        DardanFractional = 2,
+        LiraContactPoint = 3,
+        BesnikCtePivot = 4
+    }
+
+    public enum PoolHumanAimStyle
+    {
+        GhostBall,
+        Fractional,
+        ContactPoint,
+        CtePivot,
+        MonteCarloPattern
+    }
+
+    [System.Serializable]
+    public struct PoolHumanCharacterProfile
+    {
+        public PoolHumanCharacterId id;
+        public string displayName;
+        public PoolHumanAimStyle aimStyle;
+        [Range(0f, 1f)] public float skill01;
+        [Range(0f, 1f)] public float aggressiveness01;
+        [Range(0f, 1f)] public float positionPlay01;
+        [Range(0f, 1f)] public float spinComfort01;
+        [Range(0f, 1f)] public float safetyBias01;
+        [Tooltip("Small realistic aim variation in degrees. Lower values behave like professional players.")]
+        public float aimJitterDeg;
+        [Tooltip("Negative values favor slight over-cutting on hard cut shots; positive values favor fuller hits.")]
+        public float cutCompensation;
+        [Tooltip("Pocket target lateral adjustment multiplier. Used to cheat the pocket like real players.")]
+        public float pocketCheat01;
+        [Tooltip("How long this character visually settles into stance before striking.")]
+        public float preShotSettleSeconds;
+
+        public static PoolHumanCharacterProfile GetPreset(PoolHumanCharacterId id)
+        {
+            switch (id)
+            {
+                case PoolHumanCharacterId.ArtaGhostBall:
+                    return new PoolHumanCharacterProfile
+                    {
+                        id = id,
+                        displayName = "Arta · Ghost Ball Pro",
+                        aimStyle = PoolHumanAimStyle.GhostBall,
+                        skill01 = 0.94f,
+                        aggressiveness01 = 0.74f,
+                        positionPlay01 = 0.82f,
+                        spinComfort01 = 0.78f,
+                        safetyBias01 = 0.24f,
+                        aimJitterDeg = 0.38f,
+                        cutCompensation = -0.16f,
+                        pocketCheat01 = 0.84f,
+                        preShotSettleSeconds = 0.56f
+                    };
+                case PoolHumanCharacterId.DardanFractional:
+                    return new PoolHumanCharacterProfile
+                    {
+                        id = id,
+                        displayName = "Dardan · Fractional Feel",
+                        aimStyle = PoolHumanAimStyle.Fractional,
+                        skill01 = 0.89f,
+                        aggressiveness01 = 0.66f,
+                        positionPlay01 = 0.76f,
+                        spinComfort01 = 0.62f,
+                        safetyBias01 = 0.34f,
+                        aimJitterDeg = 0.55f,
+                        cutCompensation = -0.08f,
+                        pocketCheat01 = 0.66f,
+                        preShotSettleSeconds = 0.64f
+                    };
+                case PoolHumanCharacterId.LiraContactPoint:
+                    return new PoolHumanCharacterProfile
+                    {
+                        id = id,
+                        displayName = "Lira · Contact Point",
+                        aimStyle = PoolHumanAimStyle.ContactPoint,
+                        skill01 = 0.86f,
+                        aggressiveness01 = 0.48f,
+                        positionPlay01 = 0.88f,
+                        spinComfort01 = 0.56f,
+                        safetyBias01 = 0.56f,
+                        aimJitterDeg = 0.68f,
+                        cutCompensation = 0.06f,
+                        pocketCheat01 = 0.54f,
+                        preShotSettleSeconds = 0.72f
+                    };
+                case PoolHumanCharacterId.BesnikCtePivot:
+                    return new PoolHumanCharacterProfile
+                    {
+                        id = id,
+                        displayName = "Besnik · CTE Pivot",
+                        aimStyle = PoolHumanAimStyle.CtePivot,
+                        skill01 = 0.9f,
+                        aggressiveness01 = 0.7f,
+                        positionPlay01 = 0.7f,
+                        spinComfort01 = 0.68f,
+                        safetyBias01 = 0.28f,
+                        aimJitterDeg = 0.5f,
+                        cutCompensation = -0.12f,
+                        pocketCheat01 = 0.72f,
+                        preShotSettleSeconds = 0.48f
+                    };
+                default:
+                    return new PoolHumanCharacterProfile
+                    {
+                        id = PoolHumanCharacterId.MurlanRoyalPro,
+                        displayName = "Murlan · Royal Pattern Pro",
+                        aimStyle = PoolHumanAimStyle.MonteCarloPattern,
+                        skill01 = 0.97f,
+                        aggressiveness01 = 0.82f,
+                        positionPlay01 = 0.94f,
+                        spinComfort01 = 0.9f,
+                        safetyBias01 = 0.18f,
+                        aimJitterDeg = 0.25f,
+                        cutCompensation = -0.2f,
+                        pocketCheat01 = 0.95f,
+                        preShotSettleSeconds = 0.52f
+                    };
+            }
+        }
+
+        public static PoolHumanCharacterProfile[] GetAllPresets()
+        {
+            return new[]
+            {
+                GetPreset(PoolHumanCharacterId.MurlanRoyalPro),
+                GetPreset(PoolHumanCharacterId.ArtaGhostBall),
+                GetPreset(PoolHumanCharacterId.DardanFractional),
+                GetPreset(PoolHumanCharacterId.LiraContactPoint),
+                GetPreset(PoolHumanCharacterId.BesnikCtePivot)
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/PoolRoyale/PoolHumanCharacterRigAligner.cs
+++ b/Assets/Scripts/Gameplay/PoolRoyale/PoolHumanCharacterRigAligner.cs
@@ -1,0 +1,124 @@
+using Aiming;
+using UnityEngine;
+
+namespace Gameplay.PoolRoyale
+{
+    [DisallowMultipleComponent]
+    public class PoolHumanCharacterRigAligner : MonoBehaviour
+    {
+        [System.Serializable]
+        public struct CharacterSlot
+        {
+            public PoolHumanCharacterId id;
+            public GameObject characterRoot;
+            public Transform rightGrip;
+            public Transform chest;
+            public Transform head;
+        }
+
+        [Header("Murlan Royal character slots")]
+        [Tooltip("Assign the five human character prefabs/instances copied from Murlan Royal here.")]
+        [SerializeField] private CharacterSlot[] characters = new CharacterSlot[5];
+        [SerializeField] private PoolHumanCharacterId activeCharacter = PoolHumanCharacterId.MurlanRoyalPro;
+
+        [Header("Pool-player stance")]
+        [SerializeField] private Transform cueRoot;
+        [SerializeField] private Transform cueBall;
+        [SerializeField] private float stanceBackDistance = 0.62f;
+        [SerializeField] private float stanceSideOffset = 0.08f;
+        [SerializeField] private float stanceLerp = 16f;
+        [SerializeField] private float cueHeightAboveBall = 0.035f;
+        [SerializeField] private float upperBodyLeanDeg = 9f;
+        [SerializeField] private float headDownDeg = 7f;
+
+        CharacterSlot _activeSlot;
+        Vector3 _lastAimDirection = Vector3.forward;
+
+        public PoolHumanCharacterId ActiveCharacter => activeCharacter;
+
+        void Awake()
+        {
+            SelectCharacter(activeCharacter);
+        }
+
+        public void SelectCharacter(PoolHumanCharacterId id)
+        {
+            activeCharacter = id;
+            _activeSlot = default;
+
+            for (int i = 0; i < characters.Length; i++)
+            {
+                bool isActive = characters[i].id == id;
+                if (characters[i].characterRoot != null)
+                {
+                    characters[i].characterRoot.SetActive(isActive);
+                }
+
+                if (isActive)
+                {
+                    _activeSlot = characters[i];
+                }
+            }
+        }
+
+        public void AlignToShot(Vector3 cueBallPosition, Vector3 aimPoint, PoolHumanCharacterProfile profile)
+        {
+            Vector3 aim = aimPoint - cueBallPosition;
+            aim.y = 0f;
+            if (aim.sqrMagnitude <= 1e-8f)
+            {
+                aim = _lastAimDirection;
+            }
+
+            aim.Normalize();
+            _lastAimDirection = aim;
+
+            Transform root = _activeSlot.characterRoot != null ? _activeSlot.characterRoot.transform : transform;
+            Vector3 side = Vector3.Cross(Vector3.up, aim).normalized;
+            Vector3 targetPosition = cueBallPosition - aim * stanceBackDistance + side * stanceSideOffset;
+            Quaternion targetRotation = Quaternion.LookRotation(aim, Vector3.up);
+            float lerp = Application.isPlaying ? 1f - Mathf.Exp(-stanceLerp * Time.deltaTime) : 1f;
+
+            root.position = Vector3.Lerp(root.position, targetPosition, lerp);
+            root.rotation = Quaternion.Slerp(root.rotation, targetRotation, lerp);
+
+            ApplyUpperBodyPose(targetRotation, profile);
+            AlignCue(cueBallPosition, aim, targetRotation);
+        }
+
+        public void AlignToCurrentCue(AimSolution solution)
+        {
+            Vector3 sourceCueBall = cueBall != null ? cueBall.position : solution.aimStart;
+            AlignToShot(sourceCueBall, solution.aimEnd, PoolHumanCharacterProfile.GetPreset(activeCharacter));
+        }
+
+        void ApplyUpperBodyPose(Quaternion baseRotation, PoolHumanCharacterProfile profile)
+        {
+            float settleLean = Mathf.Lerp(0.75f, 1.18f, profile.skill01);
+            if (_activeSlot.chest != null)
+            {
+                _activeSlot.chest.rotation = baseRotation * Quaternion.Euler(upperBodyLeanDeg * settleLean, 0f, 0f);
+            }
+
+            if (_activeSlot.head != null)
+            {
+                _activeSlot.head.rotation = baseRotation * Quaternion.Euler(headDownDeg * settleLean, 0f, 0f);
+            }
+        }
+
+        void AlignCue(Vector3 cueBallPosition, Vector3 aim, Quaternion targetRotation)
+        {
+            if (cueRoot == null)
+                return;
+
+            Vector3 cuePosition = cueBallPosition - aim * 0.28f + Vector3.up * cueHeightAboveBall;
+            cueRoot.position = cuePosition;
+            cueRoot.rotation = targetRotation;
+
+            if (_activeSlot.rightGrip != null)
+            {
+                cueRoot.position += _activeSlot.rightGrip.position - cueRoot.position;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/PoolRoyale/PoolHumanCharacterTopMenu.cs
+++ b/Assets/Scripts/Gameplay/PoolRoyale/PoolHumanCharacterTopMenu.cs
@@ -1,0 +1,88 @@
+using Aiming;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Gameplay.PoolRoyale
+{
+    [DisallowMultipleComponent]
+    public class PoolHumanCharacterTopMenu : MonoBehaviour
+    {
+        [Header("Top menu wiring")]
+        [SerializeField] private Dropdown characterDropdown;
+        [SerializeField] private Text selectedCharacterLabel;
+        [SerializeField] private AdaptiveAimingEngine aimingEngine;
+        [SerializeField] private PoolHumanCharacterRigAligner rigAligner;
+
+        PoolHumanCharacterProfile[] _profiles;
+
+        void Awake()
+        {
+            _profiles = PoolHumanCharacterProfile.GetAllPresets();
+            if (aimingEngine == null) aimingEngine = FindObjectOfType<AdaptiveAimingEngine>();
+            if (rigAligner == null) rigAligner = FindObjectOfType<PoolHumanCharacterRigAligner>();
+            PopulateDropdown();
+        }
+
+        void OnEnable()
+        {
+            if (characterDropdown != null)
+            {
+                characterDropdown.onValueChanged.AddListener(SelectByIndex);
+            }
+        }
+
+        void OnDisable()
+        {
+            if (characterDropdown != null)
+            {
+                characterDropdown.onValueChanged.RemoveListener(SelectByIndex);
+            }
+        }
+
+        public void SelectByIndex(int index)
+        {
+            if (_profiles == null || _profiles.Length == 0)
+                _profiles = PoolHumanCharacterProfile.GetAllPresets();
+
+            index = Mathf.Clamp(index, 0, _profiles.Length - 1);
+            PoolHumanCharacterProfile profile = _profiles[index];
+
+            if (aimingEngine != null)
+            {
+                aimingEngine.SetHumanCharacter(profile.id);
+            }
+
+            if (rigAligner != null)
+            {
+                rigAligner.SelectCharacter(profile.id);
+            }
+
+            if (selectedCharacterLabel != null)
+            {
+                selectedCharacterLabel.text = profile.displayName;
+            }
+        }
+
+        void PopulateDropdown()
+        {
+            if (characterDropdown == null)
+                return;
+
+            characterDropdown.ClearOptions();
+            var options = new System.Collections.Generic.List<string>(_profiles.Length);
+            int selectedIndex = 0;
+            for (int i = 0; i < _profiles.Length; i++)
+            {
+                options.Add(_profiles[i].displayName);
+                if (aimingEngine != null && _profiles[i].id == aimingEngine.selectedHumanCharacter)
+                {
+                    selectedIndex = i;
+                }
+            }
+
+            characterDropdown.AddOptions(options);
+            characterDropdown.SetValueWithoutNotify(selectedIndex);
+            SelectByIndex(selectedIndex);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/PoolHumanCharacterProfileTests.cs
+++ b/Assets/Tests/PlayMode/PoolHumanCharacterProfileTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Aiming.Tests
+{
+    public class PoolHumanCharacterProfileTests
+    {
+        [Test]
+        public void AllFivePoolRoyalHumansAreSelectable()
+        {
+            var profiles = PoolHumanCharacterProfile.GetAllPresets();
+            Assert.AreEqual(5, profiles.Length);
+
+            for (int i = 0; i < profiles.Length; i++)
+            {
+                Assert.IsFalse(string.IsNullOrEmpty(profiles[i].displayName));
+                Assert.Greater(profiles[i].skill01, 0f);
+            }
+        }
+
+        [Test]
+        public void CharacterSelectionChangesAimingPersonality()
+        {
+            var go = new GameObject("engine");
+            var eng = go.AddComponent<AdaptiveAimingEngine>();
+            eng.config = ScriptableObject.CreateInstance<AimingConfig>();
+            eng.config.collisionMask = 0;
+            eng.showDebug = false;
+
+            var ctx = new ShotContext
+            {
+                cueBallPos = new Vector3(-0.35f, 0f, -0.45f),
+                objectBallPos = new Vector3(0f, 0f, 0f),
+                pocketPos = new Vector3(0.72f, 0f, 1.08f),
+                ballRadius = 0.028f,
+                tableBounds = new Bounds(Vector3.zero, new Vector3(1.44f, 0.4f, 2.16f)),
+                collisionMask = 0
+            };
+
+            eng.SetHumanCharacter(PoolHumanCharacterId.ArtaGhostBall);
+            AimSolution ghostProfile = eng.GetAimSolution(ctx);
+
+            eng.SetHumanCharacter(PoolHumanCharacterId.BesnikCtePivot);
+            AimSolution cteProfile = eng.GetAimSolution(ctx);
+
+            Assert.IsTrue(ghostProfile.isValid);
+            Assert.IsTrue(cteProfile.isValid);
+            Assert.AreNotEqual(ghostProfile.debugNote, cteProfile.debugNote);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Make the in-scene human character behave like real pool players by adding several pro-style aiming personalities and wiring selection from the top menu. 
- Provide multiple different aiming approaches (ghost-ball, fractional, contact-point, CTE pivot, Monte Carlo pattern) so designers can try different heuristics to improve realism and tune behavior per-character. 

### Description
- Added `PoolHumanCharacterProfile` (presets for 5 characters: `MurlanRoyalPro`, `ArtaGhostBall`, `DardanFractional`, `LiraContactPoint`, `BesnikCtePivot`) and `GetAllPresets()` to expose display names and tuning parameters (skill, aggressiveness, position-play, spin comfort, jitter, cut compensation, pocket-cheat, etc.).
- Extended `AdaptiveAimingEngine` to support a selected human profile via `SetHumanCharacter`, `ActiveHumanProfile`, and `ApplyHumanProfileToSolution`, and changed candidate ordering and scoring to use `GetHumanStrategyOrder`, `HumanStylePenalty`, `GetPrimaryHumanStrategy`, and `ShouldUseMonteCarloProfile` so profile influences strategy ordering, fallback, Monte Carlo use, jitter and tip/spin choices.
- Added `PoolHumanCharacterRigAligner` to align/pose the chosen Murlan Royal human character to the shot (stance position, upper-body lean, head pose, cue alignment) and `PoolHumanCharacterTopMenu` to populate a top-menu `Dropdown` and apply selection to both aiming engine and rig.
- Added PlayMode tests `PoolHumanCharacterProfileTests` to validate the five presets and to assert that switching characters changes aiming output debug notes.

### Testing
- Ran code checks and diffs: `git diff --check` on modified files (no failures reported). (succeeded)
- Performed a brace-balance check with `python3` over changed C# files to validate basic syntax balance. (succeeded)
- Attempted to run the .NET unit test runner: `dotnet test billiards.Tests/Billiards.Tests.csproj` could not run in this environment because `dotnet` is not installed, so PlayMode/Unit tests were not executed here. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feac7436308329a08dd05285b5adc6)