### PR TITLE
Tune Domino Royal hand placement visuals

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6701,7 +6701,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 const SCALE = MODEL_SCALE * 0.92;
 const DOMINO_SHRINK_FACTOR = 1;
 const DOMINO_EXTRA_SHRINK_FACTOR = 0.62;
-const DOMINO_SIZE_BOOST = 1.86;
+const DOMINO_SIZE_BOOST = 1.52;
 const DOMINO_SCALE =
   1.5 *
   1.26 *
@@ -7175,18 +7175,6 @@ const PLACE_ANIM_LIFT_END = 0.34;
 const PLACE_ANIM_CARRY_END = 0.74;
 const PLACE_ANIM_LOWER_END = 0.92;
 const PLACE_ANIM_ARC = 0.075;
-const PLACE_CONTACT_PRESS_DEPTH = 0.0048;
-const PLACE_CONTACT_PAD_CLEARANCE = DOMINO_WIDTH * 0.2;
-const PLACE_CONTACT_RELEASE_LIFT = DOMINO_WIDTH * 0.72;
-const PLACE_CONTACT_SKIN_COLORS = Object.freeze([
-  0xd9a27d,
-  0xc78f68,
-  0xe0b18d,
-  0xb87957,
-  0xd39a72,
-  0xc88b64,
-  0xe3b08b
-]);
 const CPU_PLAY_DELAY = 2600;
 
 const TMP_WORLD_POS = new THREE.Vector3();
@@ -7245,7 +7233,6 @@ function clearExistingDominoMeshes() {
   });
   drawAnimations.length = 0;
   placementAnimations.forEach((anim) => {
-    disposeDominoContactHandRig(anim?.contactRig);
     if (anim?.mesh) {
       disposeDominoMesh(anim.mesh);
     }
@@ -8283,10 +8270,10 @@ function normalizeDominoCharacterRoot(root) {
   if (!bounds.isEmpty()) root.position.y -= bounds.min.y;
 }
 
-const DOMINO_HELD_RACK_HAND_LIFT = 0.5 * MODEL_SCALE;
-const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.62 * MODEL_SCALE;
-const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 0.78 * MODEL_SCALE;
-const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 0.98 * MODEL_SCALE;
+const DOMINO_HELD_RACK_HAND_LIFT = 0.42 * MODEL_SCALE;
+const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.42 * MODEL_SCALE;
+const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 0.62 * MODEL_SCALE;
+const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 0.62 * MODEL_SCALE;
 
 function createHeldDominoRack(seatIndex, handTiles = []) {
   const rack = new THREE.Group();
@@ -8557,9 +8544,9 @@ function runDominoCharacterAction(seatIndex, type = 'PLAY') {
   const fingerPinch = isPass ? 0 : THREE.MathUtils.degToRad(-13);
   const approach = makeDominoPose(base, {
     spine: { x: THREE.MathUtils.degToRad(isPass ? -8 : -15) },
-    rightUpperArm: { x: THREE.MathUtils.degToRad(isPass ? -26 : -76), y: THREE.MathUtils.degToRad(-18), z: THREE.MathUtils.degToRad(-20) },
-    rightForeArm: { x: THREE.MathUtils.degToRad(isPass ? 34 : -28), y: THREE.MathUtils.degToRad(isPass ? 0 : 5) },
-    rightHand: { x: THREE.MathUtils.degToRad(isPass ? 12 : -10), y: THREE.MathUtils.degToRad(isPass ? -6 : -21), z: THREE.MathUtils.degToRad(isPass ? 0 : -14) },
+    rightUpperArm: { x: THREE.MathUtils.degToRad(isPass ? -26 : -84), y: THREE.MathUtils.degToRad(-22), z: THREE.MathUtils.degToRad(-24) },
+    rightForeArm: { x: THREE.MathUtils.degToRad(isPass ? 34 : -36), y: THREE.MathUtils.degToRad(isPass ? 0 : 9) },
+    rightHand: { x: THREE.MathUtils.degToRad(isPass ? 12 : -16), y: THREE.MathUtils.degToRad(isPass ? -6 : -27), z: THREE.MathUtils.degToRad(isPass ? 0 : -18) },
     head: { x: THREE.MathUtils.degToRad(isPass ? -3 : -9) }
   });
   const pinch = makeDominoPose(approach, {
@@ -8570,9 +8557,9 @@ function runDominoCharacterAction(seatIndex, type = 'PLAY') {
   });
   const carry = makeDominoPose(pinch, {
     spine: { x: THREE.MathUtils.degToRad(8) },
-    rightUpperArm: { x: THREE.MathUtils.degToRad(74), y: THREE.MathUtils.degToRad(-2), z: THREE.MathUtils.degToRad(2) },
-    rightForeArm: { x: THREE.MathUtils.degToRad(70), y: THREE.MathUtils.degToRad(-8) },
-    rightHand: { x: THREE.MathUtils.degToRad(20), y: THREE.MathUtils.degToRad(6), z: THREE.MathUtils.degToRad(6) },
+    rightUpperArm: { x: THREE.MathUtils.degToRad(86), y: THREE.MathUtils.degToRad(-7), z: THREE.MathUtils.degToRad(4) },
+    rightForeArm: { x: THREE.MathUtils.degToRad(82), y: THREE.MathUtils.degToRad(-12) },
+    rightHand: { x: THREE.MathUtils.degToRad(16), y: THREE.MathUtils.degToRad(2), z: THREE.MathUtils.degToRad(2) },
     head: { x: THREE.MathUtils.degToRad(5) }
   });
   const release = makeDominoPose(carry, {
@@ -9576,174 +9563,35 @@ function takeTileMeshForAnimation(tile) {
   return mesh;
 }
 
-function createDominoContactHandRig(sourceSeat = human) {
-  const skinColor =
-    PLACE_CONTACT_SKIN_COLORS[sourceSeat % PLACE_CONTACT_SKIN_COLORS.length] ??
-    0xd9a27d;
-  const skin = new THREE.MeshStandardMaterial({
-    color: skinColor,
-    roughness: 0.68,
-    metalness: 0.015
-  });
-  const nail = new THREE.MeshStandardMaterial({
-    color: 0xf7d7c4,
-    roughness: 0.55,
-    metalness: 0.01
-  });
-  const shadow = new THREE.MeshBasicMaterial({
-    color: 0x1f2937,
-    transparent: true,
-    opacity: 0.16,
-    depthWrite: false
-  });
-  const group = new THREE.Group();
-  group.userData.dispose = () => {
-    [skin, nail, shadow].forEach((mat) => {
-      try {
-        mat.dispose?.();
-      } catch {}
-    });
-  };
-
-  const palm = new THREE.Mesh(
-    new RoundedBoxGeometry(
-      DOMINO_LENGTH * 0.64,
-      DOMINO_WIDTH * 0.26,
-      DOMINO_WIDTH * 0.34,
-      5,
-      DOMINO_WIDTH * 0.11
-    ),
-    skin
-  );
-  palm.position.set(
-    -DOMINO_LENGTH * 0.04,
-    PLACE_CONTACT_PAD_CLEARANCE + DOMINO_WIDTH * 0.16,
-    -DOMINO_WIDTH * 0.12
-  );
-  palm.rotation.x = THREE.MathUtils.degToRad(-7);
-  palm.castShadow = true;
-  group.add(palm);
-
-  const thumb = new THREE.Mesh(
-    new RoundedBoxGeometry(
-      DOMINO_LENGTH * 0.3,
-      DOMINO_WIDTH * 0.18,
-      DOMINO_WIDTH * 0.22,
-      5,
-      DOMINO_WIDTH * 0.08
-    ),
-    skin
-  );
-  thumb.position.set(
-    -DOMINO_LENGTH * 0.19,
-    PLACE_CONTACT_PAD_CLEARANCE + DOMINO_WIDTH * 0.055,
-    DOMINO_WIDTH * 0.58
-  );
-  thumb.rotation.set(THREE.MathUtils.degToRad(-8), 0, THREE.MathUtils.degToRad(-22));
-  thumb.castShadow = true;
-  group.add(thumb);
-
-  [-0.24, 0.02, 0.28].forEach((x, index) => {
-    const finger = new THREE.Mesh(
-      new RoundedBoxGeometry(
-        DOMINO_LENGTH * 0.24,
-        DOMINO_WIDTH * 0.15,
-        DOMINO_WIDTH * 0.2,
-        5,
-        DOMINO_WIDTH * 0.065
-      ),
-      skin
-    );
-    finger.position.set(
-      DOMINO_LENGTH * x,
-      PLACE_CONTACT_PAD_CLEARANCE + DOMINO_WIDTH * (0.048 + index * 0.004),
-      -DOMINO_WIDTH * 0.61
-    );
-    finger.rotation.set(
-      THREE.MathUtils.degToRad(-11 - index * 2),
-      0,
-      THREE.MathUtils.degToRad(8 - index * 5)
-    );
-    finger.castShadow = true;
-    group.add(finger);
-
-    const fingertip = new THREE.Mesh(
-      new THREE.SphereGeometry(DOMINO_WIDTH * 0.09, 14, 10),
-      nail
-    );
-    fingertip.scale.z = 0.54;
-    fingertip.position.set(
-      DOMINO_LENGTH * (x + 0.085),
-      PLACE_CONTACT_PAD_CLEARANCE + DOMINO_WIDTH * 0.032,
-      -DOMINO_WIDTH * 0.73
-    );
-    fingertip.castShadow = true;
-    group.add(fingertip);
-  });
-
-  const contactShadow = new THREE.Mesh(
-    new THREE.CircleGeometry(DOMINO_LENGTH * 0.42, 36),
-    shadow
-  );
-  contactShadow.rotation.x = -Math.PI / 2;
-  contactShadow.position.set(0, -PLACE_CONTACT_PAD_CLEARANCE * 0.8, 0);
-  contactShadow.scale.z = 0.34;
-  contactShadow.renderOrder = 12;
-  group.add(contactShadow);
-  group.visible = false;
-  piecesG.add(group);
-  return group;
+function getDominoCharacterHandPlacementPoint(seatIndex) {
+  const rig = dominoCharacterRigs.get(seatIndex);
+  const hand = rig?.bones?.rightHand || rig?.bones?.leftHand;
+  if (!hand || !piecesG?.worldToLocal) {
+    return null;
+  }
+  rig.seatRoot?.updateMatrixWorld?.(true);
+  hand.updateMatrixWorld?.(true);
+  const point = hand.getWorldPosition(new THREE.Vector3());
+  piecesG.worldToLocal(point);
+  point.y += DOMINO_WIDTH * 0.34;
+  return point;
 }
 
-function disposeDominoContactHandRig(rig) {
-  if (!rig) return;
-  rig.parent?.remove?.(rig);
-  rig.userData?.dispose?.();
-  rig.traverse?.((child) => {
-    try {
-      child.geometry?.dispose?.();
-    } catch {}
-  });
-}
-
-function updateDominoContactHandRig(anim, t) {
-  const rig = anim?.contactRig;
-  if (!rig || !anim?.mesh) return;
-  const showT = smoothPlacementStep(0.03, PLACE_ANIM_PICK_HOLD * 0.82, t);
-  const releaseT = smoothPlacementStep(PLACE_ANIM_LOWER_END, 1, t);
-  rig.visible = t < 0.985 && showT > 0.015;
-  if (!rig.visible) return;
-
-  const pressT = t < PLACE_ANIM_PICK_HOLD
-    ? Math.sin(smoothPlacementStep(0, PLACE_ANIM_PICK_HOLD, t) * Math.PI)
-    : 0;
-  const lowerT = t >= PLACE_ANIM_CARRY_END
-    ? smoothPlacementStep(PLACE_ANIM_CARRY_END, PLACE_ANIM_LOWER_END, t)
-    : 0;
-  const hoverLift = THREE.MathUtils.lerp(PLACE_CONTACT_RELEASE_LIFT, 0, lowerT);
-  const releaseLift = PLACE_CONTACT_RELEASE_LIFT * releaseT;
-
-  rig.position.copy(anim.mesh.position);
-  rig.position.y +=
-    PLACE_CONTACT_PAD_CLEARANCE +
-    hoverLift +
-    releaseLift -
-    pressT * PLACE_CONTACT_PRESS_DEPTH;
-  rig.quaternion.copy(anim.mesh.quaternion);
-  rig.rotateX(THREE.MathUtils.degToRad(-8 + releaseT * 17));
-  rig.rotateZ(
-    THREE.MathUtils.degToRad((anim.sourceSeat === human ? -2 : 2) + releaseT * 8)
-  );
-
-  const squeeze =
-    1 - Math.sin(Math.PI * Math.min(1, t / PLACE_ANIM_LIFT_END)) * 0.035;
-  rig.scale.set(1.02 - releaseT * 0.06, squeeze, 1.02 + releaseT * 0.08);
-  rig.traverse((child) => {
-    if (child?.material?.opacity != null && child.material.transparent) {
-      child.material.opacity = THREE.MathUtils.lerp(0.16, 0.02, releaseT);
-      child.material.needsUpdate = true;
-    }
-  });
+function guidePlacementThroughCharacterHand(anim, t, basePosition) {
+  if (!anim?.useCharacterHand || cameraViewMode === VIEW_MODES.twoD) {
+    return basePosition;
+  }
+  const handPoint = getDominoCharacterHandPlacementPoint(anim.sourceSeat);
+  if (!handPoint) {
+    return basePosition;
+  }
+  const pickupInfluence = smoothPlacementStep(PLACE_ANIM_PICK_HOLD, PLACE_ANIM_LIFT_END, t);
+  const releaseInfluence = 1 - smoothPlacementStep(PLACE_ANIM_CARRY_END, PLACE_ANIM_LOWER_END, t);
+  const handInfluence = Math.min(0.58, pickupInfluence * releaseInfluence * 0.58);
+  if (handInfluence <= 0) {
+    return basePosition;
+  }
+  return basePosition.clone().lerp(handPoint, handInfluence);
 }
 
 function spawnPlacementAnimation(
@@ -9826,10 +9674,7 @@ function spawnPlacementAnimation(
     arc: PLACE_ANIM_ARC,
     segment,
     sourceSeat,
-    contactRig:
-      cameraViewMode === VIEW_MODES.twoD
-        ? null
-        : createDominoContactHandRig(sourceSeat)
+    useCharacterHand: sourceSeat != null
   });
 }
 
@@ -11787,30 +11632,33 @@ function resolvePrecisionPlacementPosition(anim, t) {
   carryEnd.y += carryLift;
   const lowerReady = anim.end.clone();
   lowerReady.y += 0.012;
+  let pos;
 
   if (t < PLACE_ANIM_PICK_HOLD) {
     const press = smoothPlacementStep(0, PLACE_ANIM_PICK_HOLD, t);
-    const pos = anim.start.clone();
+    pos = anim.start.clone();
     pos.y -= Math.sin(press * Math.PI) * 0.004;
     return pos;
   }
   if (t < PLACE_ANIM_LIFT_END) {
-    return anim.start.clone().lerp(
+    pos = anim.start.clone().lerp(
       pickup,
       smoothPlacementStep(PLACE_ANIM_PICK_HOLD, PLACE_ANIM_LIFT_END, t)
     );
+    return guidePlacementThroughCharacterHand(anim, t, pos);
   }
   if (t < PLACE_ANIM_CARRY_END) {
     const carryT = smoothPlacementStep(PLACE_ANIM_LIFT_END, PLACE_ANIM_CARRY_END, t);
-    const pos = carryStart.lerp(carryEnd, carryT);
+    pos = carryStart.lerp(carryEnd, carryT);
     pos.y += Math.sin(Math.PI * carryT) * carryLift * 0.28;
-    return pos;
+    return guidePlacementThroughCharacterHand(anim, t, pos);
   }
   if (t < PLACE_ANIM_LOWER_END) {
-    return carryEnd.lerp(
+    pos = carryEnd.lerp(
       lowerReady,
       smoothPlacementStep(PLACE_ANIM_CARRY_END, PLACE_ANIM_LOWER_END, t)
     );
+    return guidePlacementThroughCharacterHand(anim, t, pos);
   }
   return lowerReady.lerp(
     anim.end,
@@ -11828,8 +11676,6 @@ function updatePlacementAnimations(now) {
     const rotateT = smoothPlacementStep(PLACE_ANIM_LIFT_END, PLACE_ANIM_LOWER_END, t);
 
     anim.mesh.position.copy(resolvePrecisionPlacementPosition(anim, t));
-    updateDominoContactHandRig(anim, t);
-
     if (anim.endQuat && anim.startQuat) {
       const quat = anim.startQuat.clone().slerp(anim.endQuat, rotateT);
       anim.mesh.quaternion.copy(quat);
@@ -11844,7 +11690,6 @@ function updatePlacementAnimations(now) {
       if (anim.segment) {
         anim.segment.animating = false;
       }
-      disposeDominoContactHandRig(anim.contactRig);
       disposeDominoMesh(anim.mesh);
       placementAnimations.splice(i, 1);
       renderChain();


### PR DESCRIPTION
### Motivation
- Improve player perception and fidelity by making dominoes smaller and aligning placement animations to the real character hand instead of a separate procedural hand rig.
- Bring the visible held-rack closer to seated human hands so onboarding and selection feel more precise on portrait mobile screens.

### Description
- Reduced global domino scale by lowering `DOMINO_SIZE_BOOST` to make table, rack and played tiles visually smaller (`webapp/public/domino-royal-game.js`).
- Moved held domino racks closer to characters by reducing `DOMINO_HELD_RACK_*_HAND_LIFT` and `*_OUTWARD_OFFSET` constants for normal and human-bottom seats.
- Replaced the procedural contact hand rig flow with character-driven guidance: removed creation / update / disposal of the procedural contact rig and instead added `getDominoCharacterHandPlacementPoint` and `guidePlacementThroughCharacterHand` to nudge placement paths through the real character rig hand during pickup/carry/lower.
- Tweaked the play animation pose angles for the right upper arm, forearm and hand so the character hand reaches more inward during approach/carry/release.
- Updated placement animation setup to pass `useCharacterHand` and wired `resolvePrecisionPlacementPosition` to call the guide function so on-screen domino motion visibly passes through the character hand; also removed related contact rig resource disposal calls.

### Testing
- Ran JavaScript syntax check with `node --check webapp/public/domino-royal-game.js` and it succeeded.
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully.
- Performed a portrait mobile smoke check using Playwright to load `/games/domino-royal` and capture a screenshot, which produced a screenshot artifact (Playwright run completed after installing browser deps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb09c45048329bfcf99420d328bea)