### PR TITLE
Refine Domino Royal tile and hand placement

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6700,7 +6700,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 
 const SCALE = MODEL_SCALE * 0.92;
 const DOMINO_SHRINK_FACTOR = 1;
-const DOMINO_EXTRA_SHRINK_FACTOR = 0.62;
+const DOMINO_EXTRA_SHRINK_FACTOR = 0.54;
 const DOMINO_SIZE_BOOST = 1.86;
 const DOMINO_SCALE =
   1.5 *
@@ -6715,14 +6715,14 @@ const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.0025; // keep chain tiles touching without visible overlap
 const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
-// May 8, 2026 16:00 visual baseline: preserve the hand/domino rack positions users approved.
+// May 9, 2026 mobile portrait tuning: compact the rack and pull hands visually inward toward the tiles.
 const PLAYER_HAND_GAP_SCALE = 0.56;
-const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 8.65;
-const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 5.9;
+const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 7.4;
+const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 4.7;
 const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 3.15;
-const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 5.25;
+const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 4.15;
 const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.0;
-const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 0.85;
+const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 0.22;
 const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 3.45;
 const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.88;
 const DOMINO_DOUBLE_NEIGHBOR_EXTRA_GAP = 0;
@@ -7175,18 +7175,7 @@ const PLACE_ANIM_LIFT_END = 0.34;
 const PLACE_ANIM_CARRY_END = 0.74;
 const PLACE_ANIM_LOWER_END = 0.92;
 const PLACE_ANIM_ARC = 0.075;
-const PLACE_CONTACT_PRESS_DEPTH = 0.0048;
-const PLACE_CONTACT_PAD_CLEARANCE = DOMINO_WIDTH * 0.2;
-const PLACE_CONTACT_RELEASE_LIFT = DOMINO_WIDTH * 0.72;
-const PLACE_CONTACT_SKIN_COLORS = Object.freeze([
-  0xd9a27d,
-  0xc78f68,
-  0xe0b18d,
-  0xb87957,
-  0xd39a72,
-  0xc88b64,
-  0xe3b08b
-]);
+// Placement now uses the seated character rigs directly; no procedural contact hand overlay.
 const CPU_PLAY_DELAY = 2600;
 
 const TMP_WORLD_POS = new THREE.Vector3();
@@ -7245,7 +7234,6 @@ function clearExistingDominoMeshes() {
   });
   drawAnimations.length = 0;
   placementAnimations.forEach((anim) => {
-    disposeDominoContactHandRig(anim?.contactRig);
     if (anim?.mesh) {
       disposeDominoMesh(anim.mesh);
     }
@@ -8339,12 +8327,12 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-53), THREE.MathUtils.degToRad(-6), THREE.MathUtils.degToRad(-2));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(40), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(11), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-2));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-57), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(44), THREE.MathUtils.degToRad(3), THREE.MathUtils.degToRad(2));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(13), THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(2));
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-61), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(34), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(9), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-68), THREE.MathUtils.degToRad(9), THREE.MathUtils.degToRad(4));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(36), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));
@@ -8556,23 +8544,23 @@ function runDominoCharacterAction(seatIndex, type = 'PLAY') {
   const fingerCurl = isPass ? 0 : THREE.MathUtils.degToRad(28);
   const fingerPinch = isPass ? 0 : THREE.MathUtils.degToRad(-13);
   const approach = makeDominoPose(base, {
-    spine: { x: THREE.MathUtils.degToRad(isPass ? -8 : -15) },
-    rightUpperArm: { x: THREE.MathUtils.degToRad(isPass ? -26 : -76), y: THREE.MathUtils.degToRad(-18), z: THREE.MathUtils.degToRad(-20) },
-    rightForeArm: { x: THREE.MathUtils.degToRad(isPass ? 34 : -28), y: THREE.MathUtils.degToRad(isPass ? 0 : 5) },
-    rightHand: { x: THREE.MathUtils.degToRad(isPass ? 12 : -10), y: THREE.MathUtils.degToRad(isPass ? -6 : -21), z: THREE.MathUtils.degToRad(isPass ? 0 : -14) },
+    spine: { x: THREE.MathUtils.degToRad(isPass ? -8 : -20) },
+    rightUpperArm: { x: THREE.MathUtils.degToRad(isPass ? -26 : -92), y: THREE.MathUtils.degToRad(-14), z: THREE.MathUtils.degToRad(-16) },
+    rightForeArm: { x: THREE.MathUtils.degToRad(isPass ? 34 : -42), y: THREE.MathUtils.degToRad(isPass ? 0 : 8) },
+    rightHand: { x: THREE.MathUtils.degToRad(isPass ? 12 : -16), y: THREE.MathUtils.degToRad(isPass ? -6 : -16), z: THREE.MathUtils.degToRad(isPass ? 0 : -10) },
     head: { x: THREE.MathUtils.degToRad(isPass ? -3 : -9) }
   });
   const pinch = makeDominoPose(approach, {
-    rightHand: { x: THREE.MathUtils.degToRad(-5), y: THREE.MathUtils.degToRad(4) },
+    rightHand: { x: THREE.MathUtils.degToRad(-9), y: THREE.MathUtils.degToRad(7), z: THREE.MathUtils.degToRad(-4) },
     rightThumb: { x: fingerPinch, y: THREE.MathUtils.degToRad(9), z: THREE.MathUtils.degToRad(7) },
     rightIndex: { x: fingerCurl, y: THREE.MathUtils.degToRad(-8), z: THREE.MathUtils.degToRad(-4) },
     rightMiddle: { x: fingerCurl * 0.68, y: THREE.MathUtils.degToRad(-4), z: THREE.MathUtils.degToRad(-2) }
   });
   const carry = makeDominoPose(pinch, {
     spine: { x: THREE.MathUtils.degToRad(8) },
-    rightUpperArm: { x: THREE.MathUtils.degToRad(74), y: THREE.MathUtils.degToRad(-2), z: THREE.MathUtils.degToRad(2) },
-    rightForeArm: { x: THREE.MathUtils.degToRad(70), y: THREE.MathUtils.degToRad(-8) },
-    rightHand: { x: THREE.MathUtils.degToRad(20), y: THREE.MathUtils.degToRad(6), z: THREE.MathUtils.degToRad(6) },
+    rightUpperArm: { x: THREE.MathUtils.degToRad(88), y: THREE.MathUtils.degToRad(1), z: THREE.MathUtils.degToRad(4) },
+    rightForeArm: { x: THREE.MathUtils.degToRad(82), y: THREE.MathUtils.degToRad(-6) },
+    rightHand: { x: THREE.MathUtils.degToRad(16), y: THREE.MathUtils.degToRad(9), z: THREE.MathUtils.degToRad(4) },
     head: { x: THREE.MathUtils.degToRad(5) }
   });
   const release = makeDominoPose(carry, {
@@ -9576,176 +9564,6 @@ function takeTileMeshForAnimation(tile) {
   return mesh;
 }
 
-function createDominoContactHandRig(sourceSeat = human) {
-  const skinColor =
-    PLACE_CONTACT_SKIN_COLORS[sourceSeat % PLACE_CONTACT_SKIN_COLORS.length] ??
-    0xd9a27d;
-  const skin = new THREE.MeshStandardMaterial({
-    color: skinColor,
-    roughness: 0.68,
-    metalness: 0.015
-  });
-  const nail = new THREE.MeshStandardMaterial({
-    color: 0xf7d7c4,
-    roughness: 0.55,
-    metalness: 0.01
-  });
-  const shadow = new THREE.MeshBasicMaterial({
-    color: 0x1f2937,
-    transparent: true,
-    opacity: 0.16,
-    depthWrite: false
-  });
-  const group = new THREE.Group();
-  group.userData.dispose = () => {
-    [skin, nail, shadow].forEach((mat) => {
-      try {
-        mat.dispose?.();
-      } catch {}
-    });
-  };
-
-  const palm = new THREE.Mesh(
-    new RoundedBoxGeometry(
-      DOMINO_LENGTH * 0.64,
-      DOMINO_WIDTH * 0.26,
-      DOMINO_WIDTH * 0.34,
-      5,
-      DOMINO_WIDTH * 0.11
-    ),
-    skin
-  );
-  palm.position.set(
-    -DOMINO_LENGTH * 0.04,
-    PLACE_CONTACT_PAD_CLEARANCE + DOMINO_WIDTH * 0.16,
-    -DOMINO_WIDTH * 0.12
-  );
-  palm.rotation.x = THREE.MathUtils.degToRad(-7);
-  palm.castShadow = true;
-  group.add(palm);
-
-  const thumb = new THREE.Mesh(
-    new RoundedBoxGeometry(
-      DOMINO_LENGTH * 0.3,
-      DOMINO_WIDTH * 0.18,
-      DOMINO_WIDTH * 0.22,
-      5,
-      DOMINO_WIDTH * 0.08
-    ),
-    skin
-  );
-  thumb.position.set(
-    -DOMINO_LENGTH * 0.19,
-    PLACE_CONTACT_PAD_CLEARANCE + DOMINO_WIDTH * 0.055,
-    DOMINO_WIDTH * 0.58
-  );
-  thumb.rotation.set(THREE.MathUtils.degToRad(-8), 0, THREE.MathUtils.degToRad(-22));
-  thumb.castShadow = true;
-  group.add(thumb);
-
-  [-0.24, 0.02, 0.28].forEach((x, index) => {
-    const finger = new THREE.Mesh(
-      new RoundedBoxGeometry(
-        DOMINO_LENGTH * 0.24,
-        DOMINO_WIDTH * 0.15,
-        DOMINO_WIDTH * 0.2,
-        5,
-        DOMINO_WIDTH * 0.065
-      ),
-      skin
-    );
-    finger.position.set(
-      DOMINO_LENGTH * x,
-      PLACE_CONTACT_PAD_CLEARANCE + DOMINO_WIDTH * (0.048 + index * 0.004),
-      -DOMINO_WIDTH * 0.61
-    );
-    finger.rotation.set(
-      THREE.MathUtils.degToRad(-11 - index * 2),
-      0,
-      THREE.MathUtils.degToRad(8 - index * 5)
-    );
-    finger.castShadow = true;
-    group.add(finger);
-
-    const fingertip = new THREE.Mesh(
-      new THREE.SphereGeometry(DOMINO_WIDTH * 0.09, 14, 10),
-      nail
-    );
-    fingertip.scale.z = 0.54;
-    fingertip.position.set(
-      DOMINO_LENGTH * (x + 0.085),
-      PLACE_CONTACT_PAD_CLEARANCE + DOMINO_WIDTH * 0.032,
-      -DOMINO_WIDTH * 0.73
-    );
-    fingertip.castShadow = true;
-    group.add(fingertip);
-  });
-
-  const contactShadow = new THREE.Mesh(
-    new THREE.CircleGeometry(DOMINO_LENGTH * 0.42, 36),
-    shadow
-  );
-  contactShadow.rotation.x = -Math.PI / 2;
-  contactShadow.position.set(0, -PLACE_CONTACT_PAD_CLEARANCE * 0.8, 0);
-  contactShadow.scale.z = 0.34;
-  contactShadow.renderOrder = 12;
-  group.add(contactShadow);
-  group.visible = false;
-  piecesG.add(group);
-  return group;
-}
-
-function disposeDominoContactHandRig(rig) {
-  if (!rig) return;
-  rig.parent?.remove?.(rig);
-  rig.userData?.dispose?.();
-  rig.traverse?.((child) => {
-    try {
-      child.geometry?.dispose?.();
-    } catch {}
-  });
-}
-
-function updateDominoContactHandRig(anim, t) {
-  const rig = anim?.contactRig;
-  if (!rig || !anim?.mesh) return;
-  const showT = smoothPlacementStep(0.03, PLACE_ANIM_PICK_HOLD * 0.82, t);
-  const releaseT = smoothPlacementStep(PLACE_ANIM_LOWER_END, 1, t);
-  rig.visible = t < 0.985 && showT > 0.015;
-  if (!rig.visible) return;
-
-  const pressT = t < PLACE_ANIM_PICK_HOLD
-    ? Math.sin(smoothPlacementStep(0, PLACE_ANIM_PICK_HOLD, t) * Math.PI)
-    : 0;
-  const lowerT = t >= PLACE_ANIM_CARRY_END
-    ? smoothPlacementStep(PLACE_ANIM_CARRY_END, PLACE_ANIM_LOWER_END, t)
-    : 0;
-  const hoverLift = THREE.MathUtils.lerp(PLACE_CONTACT_RELEASE_LIFT, 0, lowerT);
-  const releaseLift = PLACE_CONTACT_RELEASE_LIFT * releaseT;
-
-  rig.position.copy(anim.mesh.position);
-  rig.position.y +=
-    PLACE_CONTACT_PAD_CLEARANCE +
-    hoverLift +
-    releaseLift -
-    pressT * PLACE_CONTACT_PRESS_DEPTH;
-  rig.quaternion.copy(anim.mesh.quaternion);
-  rig.rotateX(THREE.MathUtils.degToRad(-8 + releaseT * 17));
-  rig.rotateZ(
-    THREE.MathUtils.degToRad((anim.sourceSeat === human ? -2 : 2) + releaseT * 8)
-  );
-
-  const squeeze =
-    1 - Math.sin(Math.PI * Math.min(1, t / PLACE_ANIM_LIFT_END)) * 0.035;
-  rig.scale.set(1.02 - releaseT * 0.06, squeeze, 1.02 + releaseT * 0.08);
-  rig.traverse((child) => {
-    if (child?.material?.opacity != null && child.material.transparent) {
-      child.material.opacity = THREE.MathUtils.lerp(0.16, 0.02, releaseT);
-      child.material.needsUpdate = true;
-    }
-  });
-}
-
 function spawnPlacementAnimation(
   tile,
   segment,
@@ -9825,11 +9643,7 @@ function spawnPlacementAnimation(
     duration: duration || PLACE_ANIM_DURATION,
     arc: PLACE_ANIM_ARC,
     segment,
-    sourceSeat,
-    contactRig:
-      cameraViewMode === VIEW_MODES.twoD
-        ? null
-        : createDominoContactHandRig(sourceSeat)
+    sourceSeat
   });
 }
 
@@ -11828,8 +11642,6 @@ function updatePlacementAnimations(now) {
     const rotateT = smoothPlacementStep(PLACE_ANIM_LIFT_END, PLACE_ANIM_LOWER_END, t);
 
     anim.mesh.position.copy(resolvePrecisionPlacementPosition(anim, t));
-    updateDominoContactHandRig(anim, t);
-
     if (anim.endQuat && anim.startQuat) {
       const quat = anim.startQuat.clone().slerp(anim.endQuat, rotateT);
       anim.mesh.quaternion.copy(quat);
@@ -11844,7 +11656,6 @@ function updatePlacementAnimations(now) {
       if (anim.segment) {
         anim.segment.animating = false;
       }
-      disposeDominoContactHandRig(anim.contactRig);
       disposeDominoMesh(anim.mesh);
       placementAnimations.splice(i, 1);
       renderChain();


### PR DESCRIPTION
### Motivation
- Improve Domino Royal mobile portrait UX by making dominoes visually smaller and pulling human hands/racks closer to tiles so the seated character hand appears to pick/place the real domino instead of showing a separate procedural hand overlay.

### Description
- Reduced domino world scale by changing `DOMINO_EXTRA_SHRINK_FACTOR` and tightened hand/rack layout by lowering `PLAYER_HAND_OUTWARD_OFFSET`, `HUMAN_PLAYER_HAND_OUTWARD_OFFSET`, `HUMAN_HAND_OUTWARD_OFFSET`, and `HUMAN_BOTTOM_EXTRA_OUTWARD` in `webapp/public/domino-royal-game.js`.
- Reposed seated character rigs by modifying `addDominoBoneOffset(...)` parameters and updated the `runDominoCharacterAction` pose keyframes so the real character rig reaches, pinches, carries and releases tiles (no synthetic hand required).
- Removed the procedural placement hand overlay by deleting the `createDominoContactHandRig` / `disposeDominoContactHandRig` / `updateDominoContactHandRig` implementations and by stopping creation/use of `contactRig` in placement animation objects so placement relies on the seated character animation plus the domino animation state.
- Minor comment and cleanup adjustments to reflect the mobile portrait tuning; all edits are confined to `webapp/public/domino-royal-game.js`.

### Testing
- `node --check webapp/public/domino-royal-game.js` succeeded with no syntax errors.
- `npm --prefix webapp run build` completed successfully (Vite build finished; bundle warnings about large chunks only).
- `npx jest test/dominoRoyalHdriCatalog.test.js --runInBand` passed (1 test).
- Headless browser screenshot attempt via Playwright failed to run because the test environment lacked the native dependency `libatk-1.0.so.0`, so automated visual verification was not completed (Playwright launch error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb09c45048329bfcf99420d328bea)