### PR TITLE
Add Poly Pizza heavy weapons (GLB) to Ludo capture/store configs

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -68,7 +68,16 @@ const PREFERRED_CAPTURE_ANIMATION_BY_FAMILY = Object.freeze({
   marksman: 'sniperShotAttack',
   shotgun: 'shotgunBlastAttack',
   revolver: 'polyRevolver02Attack',
-  explosive: 'grenadeBlastAttack'
+  explosive: 'grenadeBlastAttack',
+  bazooka: 'polyBazooka01Attack',
+  grenadeLauncher: 'polyGrenadeLauncher01Attack',
+  dynamite: 'polyDynamiteBomb01Attack',
+  gasTank: 'polyGasTank01Attack',
+  handGrenade: 'polyHandGrenade01Attack',
+  incendiary: 'polyMolotov01Attack',
+  armor: 'polyTank01Attack',
+  robotLargeGun: 'polyRobotLargeGunAttack',
+  robotFlyingGun: 'polyRobotFlyingGunAttack'
 });
 
 const CAPTURE_ANIMATION_FAMILY_BY_ID = Object.freeze({
@@ -97,7 +106,16 @@ const CAPTURE_ANIMATION_FAMILY_BY_ID = Object.freeze({
   polySawedOff01Attack: 'shotgun',
   polyRevolver01Attack: 'revolver',
   polyRevolver02Attack: 'revolver',
-  grenadeBlastAttack: 'explosive'
+  grenadeBlastAttack: 'explosive',
+  polyHandGrenade01Attack: 'handGrenade',
+  polyGrenadeLauncher01Attack: 'grenadeLauncher',
+  polyBazooka01Attack: 'bazooka',
+  polyDynamiteBomb01Attack: 'dynamite',
+  polyGasTank01Attack: 'gasTank',
+  polyMolotov01Attack: 'incendiary',
+  polyTank01Attack: 'armor',
+  polyRobotLargeGunAttack: 'robotLargeGun',
+  polyRobotFlyingGunAttack: 'robotFlyingGun'
 });
 
 const shouldShowCaptureAnimationInStore = (optionId) => {

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -313,6 +313,60 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     label: 'Quaternius Submachine Gun',
     description: 'Poly Pizza compact SMG variant with fast burst behavior.',
     thumbnail: captureWeaponGlyphThumb('▯', '#0f172a')
+  },
+  {
+    id: 'polyRobotLargeGunAttack',
+    label: 'Quaternius Robot Large Gun',
+    description: 'Animated CC0 Poly Pizza robot heavy-gun model for premium Ludo capture attacks.',
+    thumbnail: 'https://static.poly.pizza/78e23275-cb6a-4ba3-ae5e-48a9b4ee2e65.webp'
+  },
+  {
+    id: 'polyRobotFlyingGunAttack',
+    label: 'Quaternius Robot Flying Gun',
+    description: 'Animated CC0 Poly Pizza flying gun drone adapted as a compact capture weapon.',
+    thumbnail: 'https://static.poly.pizza/6d0889f1-0c3f-4f98-b011-fbcf6c79a93b.webp'
+  },
+  {
+    id: 'polyBazooka01Attack',
+    label: 'CreativeTrio Bazooka',
+    description: 'CC0 Poly Pizza bazooka/RPG launcher model added for explosive capture loadouts.',
+    thumbnail: 'https://static.poly.pizza/613e3b1b-d07c-496b-94a1-7c85b507bac4.webp'
+  },
+  {
+    id: 'polyGrenadeLauncher01Attack',
+    label: 'CreativeTrio Grenade Launcher',
+    description: 'CC0 Poly Pizza grenade launcher firearm with a heavy explosive ballistics profile.',
+    thumbnail: 'https://static.poly.pizza/503bb2c5-4a69-404b-9b82-13e85e8f8467.webp'
+  },
+  {
+    id: 'polyDynamiteBomb01Attack',
+    label: 'CreativeTrio Dynamite Bomb',
+    description: 'CC0 Poly Pizza bomb/dynamite bundle for high-impact table capture effects.',
+    thumbnail: 'https://static.poly.pizza/38e858db-325f-4dce-9680-da62c20c5c31.webp'
+  },
+  {
+    id: 'polyMolotov01Attack',
+    label: 'CreativeTrio Molotov',
+    description: 'CC0 Poly Pizza molotov bottle for incendiary capture loadouts.',
+    thumbnail: 'https://static.poly.pizza/d7bb0b50-09af-49f8-b1f9-dbdb0c707d40.webp'
+  },
+  {
+    id: 'polyGasTank01Attack',
+    label: 'Quaternius Gas Tank',
+    description: 'CC0 Poly Pizza explosive gas tank model for demolition-style captures.',
+    thumbnail: 'https://static.poly.pizza/9c4d2ac5-114b-4da2-a26a-8049e2b1ba04.webp'
+  },
+  {
+    id: 'polyHandGrenade01Attack',
+    label: 'CreativeTrio Hand Grenade',
+    description: 'CC0 Poly Pizza hand grenade model added alongside the existing grenade fallback.',
+    thumbnail: 'https://static.poly.pizza/03fa7f5b-4df5-45d6-86fb-87e8590f28d7.webp'
+  },
+  {
+    id: 'polyTank01Attack',
+    label: 'Quaternius Battle Tank',
+    description: 'CC0 Poly Pizza tank model for heavy battle-royal capture strike cosmetics.',
+    thumbnail: 'https://static.poly.pizza/58c387b2-636f-49dc-a900-13b0852717d6.webp'
   }
 
 ]);

--- a/webapp/src/config/ludoWeaponDirectorBridge.js
+++ b/webapp/src/config/ludoWeaponDirectorBridge.js
@@ -24,7 +24,16 @@ export const LUDO_WEAPON_DIRECTOR_BRIDGE = Object.freeze({
     polyShotgun02Attack: 'Shotgun',
     polyShotgun03Attack: 'Shotgun',
     polySawedOff01Attack: 'Shotgun',
-    grenadeBlastAttack: 'GrenadeLauncher'
+    grenadeBlastAttack: 'GrenadeLauncher',
+    polyHandGrenade01Attack: 'GrenadeLauncher',
+    polyDynamiteBomb01Attack: 'GrenadeLauncher',
+    polyMolotov01Attack: 'GrenadeLauncher',
+    polyGasTank01Attack: 'GrenadeLauncher',
+    polyBazooka01Attack: 'GrenadeLauncher',
+    polyGrenadeLauncher01Attack: 'GrenadeLauncher',
+    polyTank01Attack: 'GrenadeLauncher',
+    polyRobotLargeGunAttack: 'Rifle',
+    polyRobotFlyingGunAttack: 'SMG'
   }),
   firearmBroadcastProfile: Object.freeze({
     aimLift: 0.064,

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -161,7 +161,16 @@ const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'polyRevolver02Attack',
   'polyShotgun02Attack',
   'polyShotgun03Attack',
-  'polySmg01Attack'
+  'polySmg01Attack',
+  'polyRobotLargeGunAttack',
+  'polyRobotFlyingGunAttack',
+  'polyBazooka01Attack',
+  'polyGrenadeLauncher01Attack',
+  'polyDynamiteBomb01Attack',
+  'polyMolotov01Attack',
+  'polyGasTank01Attack',
+  'polyHandGrenade01Attack',
+  'polyTank01Attack'
 ]);
 const LARGE_RACK_FIREARM_IDS = new Set([
   'ak47VolleyAttack',
@@ -173,7 +182,12 @@ const LARGE_RACK_FIREARM_IDS = new Set([
   'polyShotgun01Attack',
   'polyAssaultRifle01Attack',
   'polyShotgun02Attack',
-  'polyShotgun03Attack'
+  'polyShotgun03Attack',
+  'polyRobotLargeGunAttack',
+  'polyRobotFlyingGunAttack',
+  'polyBazooka01Attack',
+  'polyGrenadeLauncher01Attack',
+  'polyTank01Attack'
 ]);
 const FIREARM_TWO_HANDED_IDS = new Set([
   'fpsGunAttack',
@@ -188,7 +202,12 @@ const FIREARM_TWO_HANDED_IDS = new Set([
   'polyAssaultRifle01Attack',
   'polyShotgun02Attack',
   'polyShotgun03Attack',
-  'polySmg01Attack'
+  'polySmg01Attack',
+  'polyRobotLargeGunAttack',
+  'polyRobotFlyingGunAttack',
+  'polyBazooka01Attack',
+  'polyGrenadeLauncher01Attack',
+  'polyTank01Attack'
 ]);
 const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
   'glockSidearmAttack',
@@ -200,7 +219,11 @@ const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
   'polyPistol01Attack',
   'polyRevolver01Attack',
   'polySawedOff01Attack',
-  'polyRevolver02Attack'
+  'polyRevolver02Attack',
+  'polyDynamiteBomb01Attack',
+  'polyMolotov01Attack',
+  'polyGasTank01Attack',
+  'polyHandGrenade01Attack'
 ]);
 const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   fpsGunAttack: 2.2,
@@ -222,7 +245,16 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   polyRevolver02Attack: 1.08,
   polyShotgun02Attack: 2.22,
   polyShotgun03Attack: 2.1,
-  polySmg01Attack: 1.68
+  polySmg01Attack: 1.68,
+  polyRobotLargeGunAttack: 1.95,
+  polyRobotFlyingGunAttack: 1.45,
+  polyBazooka01Attack: 2.6,
+  polyGrenadeLauncher01Attack: 2.35,
+  polyDynamiteBomb01Attack: 1.22,
+  polyMolotov01Attack: 0.92,
+  polyGasTank01Attack: 1.28,
+  polyHandGrenade01Attack: 0.48,
+  polyTank01Attack: 2.3
 });
 
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
@@ -487,6 +519,51 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
     label: 'Quaternius Submachine Gun',
     urls: ['https://static.poly.pizza/fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710.glb'],
     scale: 0.17
+  },
+  polyRobotLargeGunAttack: {
+    label: 'Quaternius Robot Large Gun',
+    urls: ['https://static.poly.pizza/78e23275-cb6a-4ba3-ae5e-48a9b4ee2e65.glb'],
+    scale: 0.17
+  },
+  polyRobotFlyingGunAttack: {
+    label: 'Quaternius Robot Flying Gun',
+    urls: ['https://static.poly.pizza/6d0889f1-0c3f-4f98-b011-fbcf6c79a93b.glb'],
+    scale: 0.16
+  },
+  polyBazooka01Attack: {
+    label: 'CreativeTrio Bazooka',
+    urls: ['https://static.poly.pizza/613e3b1b-d07c-496b-94a1-7c85b507bac4.glb'],
+    scale: 0.22
+  },
+  polyGrenadeLauncher01Attack: {
+    label: 'CreativeTrio Grenade Launcher',
+    urls: ['https://static.poly.pizza/503bb2c5-4a69-404b-9b82-13e85e8f8467.glb'],
+    scale: 0.2
+  },
+  polyDynamiteBomb01Attack: {
+    label: 'CreativeTrio Dynamite Bomb',
+    urls: ['https://static.poly.pizza/38e858db-325f-4dce-9680-da62c20c5c31.glb'],
+    scale: 0.12
+  },
+  polyMolotov01Attack: {
+    label: 'CreativeTrio Molotov',
+    urls: ['https://static.poly.pizza/d7bb0b50-09af-49f8-b1f9-dbdb0c707d40.glb'],
+    scale: 0.095
+  },
+  polyGasTank01Attack: {
+    label: 'Quaternius Gas Tank',
+    urls: ['https://static.poly.pizza/9c4d2ac5-114b-4da2-a26a-8049e2b1ba04.glb'],
+    scale: 0.12
+  },
+  polyHandGrenade01Attack: {
+    label: 'CreativeTrio Hand Grenade',
+    urls: ['https://static.poly.pizza/03fa7f5b-4df5-45d6-86fb-87e8590f28d7.glb'],
+    scale: 0.075
+  },
+  polyTank01Attack: {
+    label: 'Quaternius Battle Tank',
+    urls: ['https://static.poly.pizza/58c387b2-636f-49dc-a900-13b0852717d6.glb'],
+    scale: 0.125
   }
 });
 const CAPTURE_WEAPON_MODEL_CACHE = new Map();
@@ -559,7 +636,16 @@ const FIREARM_MAGAZINE_SHOTS = Object.freeze({
   polyRevolver02Attack: 8,
   polyShotgun02Attack: 1,
   polyShotgun03Attack: 1,
-  polySmg01Attack: 28
+  polySmg01Attack: 28,
+  polyRobotLargeGunAttack: 18,
+  polyRobotFlyingGunAttack: 16,
+  polyBazooka01Attack: 1,
+  polyGrenadeLauncher01Attack: 1,
+  polyDynamiteBomb01Attack: 1,
+  polyMolotov01Attack: 1,
+  polyGasTank01Attack: 1,
+  polyHandGrenade01Attack: 1,
+  polyTank01Attack: 1
 });
 const FIREARM_BALLISTICS_PROFILE = Object.freeze({
   default: Object.freeze({ tracerSpread: 0.018, shellDriftX: 0.00026, shellDriftZ: -0.00021, shellArc: 0.052, bulletRadius: 0.0036, bulletSpeed: 0.2, shellRadius: 0.0028 }),
@@ -596,7 +682,16 @@ const FIREARM_BALLISTICS_PROFILE_BY_ID = Object.freeze({
   polyShotgun02Attack: 'shotgun',
   polyShotgun03Attack: 'shotgun',
   polySawedOff01Attack: 'shotgun',
-  grenadeBlastAttack: 'explosive'
+  grenadeBlastAttack: 'explosive',
+  polyHandGrenade01Attack: 'explosive',
+  polyDynamiteBomb01Attack: 'explosive',
+  polyMolotov01Attack: 'explosive',
+  polyGasTank01Attack: 'explosive',
+  polyBazooka01Attack: 'explosive',
+  polyGrenadeLauncher01Attack: 'explosive',
+  polyTank01Attack: 'explosive',
+  polyRobotLargeGunAttack: 'rifle',
+  polyRobotFlyingGunAttack: 'smg'
 });
 const FIREARM_CALIBER_BY_ID = Object.freeze({
   glockSidearmAttack: { bulletRadius: 0.0032, shellRadius: 0.0024, bulletSpeed: 0.22 },
@@ -612,7 +707,10 @@ const FIREARM_CALIBER_BY_ID = Object.freeze({
   mosinMarksmanAttack: { bulletRadius: 0.0044, shellRadius: 0.0033, bulletSpeed: 0.3 },
   shotgunBlastAttack: { bulletRadius: 0.0052, shellRadius: 0.0042, bulletSpeed: 0.18 },
   polyShotgun01Attack: { bulletRadius: 0.005, shellRadius: 0.0041, bulletSpeed: 0.18 },
-  grenadeBlastAttack: { bulletRadius: 0.0062, shellRadius: 0.0047, bulletSpeed: 0.14 }
+  grenadeBlastAttack: { bulletRadius: 0.0062, shellRadius: 0.0047, bulletSpeed: 0.14 },
+  polyBazooka01Attack: { bulletRadius: 0.0072, shellRadius: 0.0052, bulletSpeed: 0.13 },
+  polyGrenadeLauncher01Attack: { bulletRadius: 0.0068, shellRadius: 0.005, bulletSpeed: 0.135 },
+  polyTank01Attack: { bulletRadius: 0.0075, shellRadius: 0.0054, bulletSpeed: 0.12 }
 });
 const FIREARM_CAPTURE_SHOT_SOUND_URL_BY_ID = Object.freeze({
   glockSidearmAttack: 'https://cdn.freesound.org/previews/414/414888_5121236-lq.mp3',
@@ -624,7 +722,14 @@ const FIREARM_CAPTURE_SHOT_SOUND_URL_BY_ID = Object.freeze({
   ak47VolleyAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
   sniperShotAttack: 'https://cdn.freesound.org/previews/533/533981_11861866-lq.mp3',
   shotgunBlastAttack: 'https://cdn.freesound.org/previews/456/456035_5121236-lq.mp3',
-  grenadeBlastAttack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3'
+  grenadeBlastAttack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyBazooka01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyGrenadeLauncher01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyDynamiteBomb01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyMolotov01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyGasTank01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyHandGrenade01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyTank01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3'
 });
 const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
   default: {


### PR DESCRIPTION
### Motivation
- Expand the Ludo Battle Royal store with high-quality Poly Pizza weapon models we didn't have and classify them to avoid inventory conflicts. 
- Make those weapons available as capture animations and wire their model URLs and runtime tuning so in-game racks, hand-attachment, and ballistics behave correctly.

### Description
- Added new capture animation options and thumbnails for Poly Pizza assets (robot large/flying guns, bazooka, grenade launcher, dynamite, molotov, gas tank, hand grenade, tank) in `webapp/src/config/ludoBattleOptions.js` with referenced `static.poly.pizza` GLB/thumbnail URLs. 
- Registered the new IDs and families in `webapp/src/config/ludoBattleInventoryConfig.js` (family mapping, preferred-per-family) so each appears in the Ludo store without colliding with existing items. 
- Wired model/scale entries into `CAPTURE_WEAPON_MODEL_CONFIG` inside `webapp/src/pages/Games/LudoBattleRoyal.jsx` pointing to the GLB URLs and added rack/display/size tuning, two-handed/single-hand sets, and large-rack membership. 
- Added ammo/magazine counts, ballistics/caliber tuning, and shot sound mappings for the new weapons in `LudoBattleRoyal.jsx`, and extended the web/Unity bridge in `webapp/src/config/ludoWeaponDirectorBridge.js` to map the new capture IDs to weapon types.

### Testing
- Ran `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` and the test suite passed. 
- Verified presence of the new capture IDs in options and store with a small Node check script, which succeeded. 
- Built the web client with `npm --prefix webapp run build` and the build completed successfully. 
- Ran ESLint: with project defaults the webapp files are ignored (warning shown), and forcing `npx eslint --no-ignore ...` surfaced many existing style issues (44 errors) unrelated to functional logic; these are lint-style problems and not regressions introduced by the asset wiring.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb63fb30483299db21650e0f87a5b)