### PR TITLE
Chess Battle Royal: switch default table to CoffeeTable_01, tighten 3D look, and extend parked-weapon/firearm capture behaviour

### DIFF
--- a/test/chessBattleInventoryConfig.test.js
+++ b/test/chessBattleInventoryConfig.test.js
@@ -6,11 +6,12 @@ import {
   CHESS_BATTLE_TABLE_OPTIONS,
   CHESS_TABLE_FINISH_OPTIONS
 } from '../webapp/src/config/chessBattleInventoryConfig.js';
+import { CAPTURE_ANIMATION_OPTIONS } from '../webapp/src/config/ludoBattleOptions.js';
 
 describe('chess battle inventory config', () => {
-  test('defaults to octagon table for battle royal', () => {
-    expect(CHESS_BATTLE_TABLE_OPTIONS[0]?.id).toBe('murlan-default');
-    expect(CHESS_BATTLE_ROYAL_DEFAULT_UNLOCKS.tables[0]).toBe('murlan-default');
+  test('defaults to Coffee Table 01 for battle royal', () => {
+    expect(CHESS_BATTLE_TABLE_OPTIONS[0]?.id).toBe('CoffeeTable_01');
+    expect(CHESS_BATTLE_ROYAL_DEFAULT_UNLOCKS.tables[0]).toBe('CoffeeTable_01');
   });
 
   test('store includes octagon, hexagon, and oval table shapes', () => {
@@ -28,9 +29,21 @@ describe('chess battle inventory config', () => {
       CHESS_BATTLE_ROYAL_STORE_ITEMS.filter((item) => item.type === 'tableFinish').map((item) => item.optionId)
     );
 
-    ['carbonFiberChalk', 'carbonFiberSnakeChalk', 'carbonFiberAlligatorNight'].forEach((id) => {
+    ['carbonFiberChalk', 'carbonFiberChalkDarkGreen', 'carbonFiberAlligatorNight'].forEach((id) => {
       expect(finishIds.has(id)).toBe(true);
       expect(storeFinishIds.has(id)).toBe(true);
+    });
+  });
+
+
+  test('sells every Ludo capture animation weapon for Chess Battle Royal', () => {
+    const storeCaptureIds = new Set(
+      CHESS_BATTLE_ROYAL_STORE_ITEMS.filter((item) => item.type === 'captureAnimation').map((item) => item.optionId)
+    );
+    const purchasableLudoCaptureIds = CAPTURE_ANIMATION_OPTIONS.slice(1).map((option) => option.id);
+
+    purchasableLudoCaptureIds.forEach((id) => {
+      expect(storeCaptureIds.has(id)).toBe(true);
     });
   });
 

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -311,7 +311,7 @@ export const CHESS_TABLE_OPTIONS = Object.freeze([
 ]);
 
 const CHESS_BATTLE_REMOVED_TABLE_IDS = new Set(['diamondEdge']);
-const CHESS_BATTLE_DEFAULT_TABLE_ID = 'murlan-default';
+const CHESS_BATTLE_DEFAULT_TABLE_ID = 'CoffeeTable_01';
 
 export const CHESS_BATTLE_TABLE_OPTIONS = Object.freeze(
   CHESS_TABLE_OPTIONS

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -434,9 +434,14 @@ const CAMERA_PULL_FORWARD_MIN = THREE.MathUtils.degToRad(15);
 const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(21); // raise forced 3D animation camera for a stronger portrait top-down feel.
 const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 1.18; // keep forced 3D animation wider during capture so the board stays fully readable
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 6; // keep local player's avatar lower so chair/animation view stays clear
-const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(34); // lower portrait 3D camera angle so the board feels more eye-level while preserving depth.
-const CAMERA_LOCKED_3D_LOOK_TARGET_LIFT = BOARD.tile * BOARD_SCALE * 0.9; // aim a little higher so the lower camera looks up across the arena.
-const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.96; // keep 3D camera almost at 2D distance so the whole board remains visible in portrait.
+const CAMERA_LOCKED_3D_PHI = CAMERA_PULL_FORWARD_MIN; // match the forced 3D capture-animation framing for normal 3D play.
+const CAMERA_LOCKED_3D_LOOK_TARGET_LIFT = 0; // keep 3D and capture cameras aimed at the same board target.
+const CAMERA_LOCKED_3D_RADIUS_SCALE = 1.04; // mirror the wide animation framing while keeping the camera locked in place.
+const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
+const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
+const CAMERA_LOOK_MIN_PITCH = -CAMERA_LOOK_PITCH_LIMIT;
+const CAMERA_LOOK_YAW_DRAG_FACTOR = -0.0055;
+const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
 const SAND_TIMER_RADIUS_FACTOR = 0.68;
 const SAND_TIMER_SURFACE_OFFSET = 0.2;
 const SAND_TIMER_SCALE = 0.36;
@@ -481,9 +486,13 @@ const SEATED_HUMAN_GRIP_CONTACT_BLEND = 0.98;
 const SEATED_HUMAN_CONTACT_IK_STRENGTH = 0.98;
 
 
-function resolveChairDistanceForDirection(tableInfo, ...layoutArgs) {
+const CHESS_COFFEE_TABLE_01_LAYOUT_RADIUS = TABLE_RADIUS;
+
+function resolveChairDistanceForDirection(_tableInfo, ...layoutArgs) {
   const seatDepth = Number.isFinite(layoutArgs[1]) ? layoutArgs[1] : SEAT_DEPTH;
-  const tableRadius = Number.isFinite(tableInfo?.radius) ? tableInfo.radius : TABLE_RADIUS;
+  // CoffeeTable_01 is the canonical Chess Battle Royal layout reference.
+  // All table skins use this same radius so chairs, humans, board, pieces, and side weapons stay fixed.
+  const tableRadius = CHESS_COFFEE_TABLE_01_LAYOUT_RADIUS;
   const clearance = clamp(
     CHAIR_CLEARANCE + seatDepth * 0.1 + CHAIR_HUMAN_LEG_GAP,
     CHAIR_TABLE_GAP_MIN,
@@ -2650,6 +2659,8 @@ const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -2.2; // push parked vehicles much f
 const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.26; // lift pad markers/parked units from floor to board/table level
 const SIDE_PARKED_AIR_UNITS_LANE_SPREAD = 1.92; // increase spacing between parking slots
 const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.06; // keep truck close to true-size relative to helicopter shell
+const SIDE_PARKED_SWAPPED_WEAPON_JET_SCALE =
+  CAPTURE_JET_SCALE * 1.15 * SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER * 2.8;
 
 function getTableHeightForShape(shapeId) {
   if (LOWER_PROFILE_TABLE_SHAPE_IDS.has(shapeId)) {
@@ -7667,37 +7678,6 @@ function Chess3D({
         .filter(Boolean),
     [chessInventory]
   );
-  const QUICK_SWAP_WEAPON_IDS = useMemo(
-    () =>
-      [
-        'polyShotgun01Attack',
-        'polyAssaultRifle01Attack',
-        'polyPistol01Attack',
-        'polyRevolver01Attack',
-        'polySawedOff01Attack',
-        'polyRevolver02Attack',
-        'polyShotgun02Attack',
-        'polyShotgun03Attack',
-        'polySmg01Attack',
-        'ak47VolleyAttack',
-        'krsvBurstAttack',
-        'smithSidearmAttack',
-        'mosinMarksmanAttack',
-        'uziSprayAttack',
-        'sigsauerTacticalAttack',
-        'sniperShotAttack',
-        'compactCarbineAttack',
-        'fpsGunAttack'
-      ],
-    []
-  );
-  const quickSwapWeapons = useMemo(() => {
-    const ownedIds = new Set((ownedCaptureAnimations || []).map((option) => option.id));
-    return QUICK_SWAP_WEAPON_IDS
-      .filter((id) => ownedIds.has(id))
-      .map((id) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === id))
-      .filter(Boolean);
-  }, [ownedCaptureAnimations, QUICK_SWAP_WEAPON_IDS]);
   const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
   const [weaponSwapTargetKind, setWeaponSwapTargetKind] = useState(null);
   const PIECE_GROUP_BY_PARKED_KIND = useMemo(() => ({
@@ -7742,25 +7722,18 @@ function Chess3D({
     [PIECE_GROUP_BY_PARKED_KIND, resolvedAccountId, selectedCaptureAnimationId, weaponSwapTargetKind]
   );
   const quickSwapWeaponList = useMemo(() => {
-    const pool = quickSwapWeapons.length ? quickSwapWeapons : ownedCaptureAnimations;
+    const pool = ownedCaptureAnimations;
     if (!weaponSwapTargetKind) return pool;
 
-    // Parked pads (jet / drone / helicopter / truck) can now be swapped with any owned firearm.
-    // Keep full firearm inventory visible when player taps one of those parked vehicles.
-    if (['jet', 'drone', 'helicopter', 'truck'].includes(weaponSwapTargetKind)) {
-      const firearmOnly = pool.filter((option) =>
-        FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)
-      );
-      if (firearmOnly.length) return firearmOnly;
-    }
-
+    // Show every owned Ludo firearm/heavy weapon plus the matching vehicle for the tapped pad.
+    // Different vehicle families stay on their own pads so jet/truck/helicopter/drone timing remains unchanged.
     const filtered = pool.filter((option) => {
       if (FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)) return true;
       return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[option.id] === weaponSwapTargetKind;
     });
     if (filtered.length) return filtered;
     return pool;
-  }, [ownedCaptureAnimations, quickSwapWeapons, weaponSwapTargetKind]);
+  }, [ownedCaptureAnimations, weaponSwapTargetKind]);
   useEffect(() => {
     const handler = (event) => {
       if (!event?.detail?.accountId || event.detail.accountId === resolvedAccountId) {
@@ -7828,6 +7801,8 @@ function Chess3D({
   });
   const locked3dViewRef = useRef({
     activeLook: false,
+    baseYaw: 0,
+    basePitch: -0.28,
     yaw: 0,
     pitch: -0.28,
     targetYaw: 0,
@@ -7946,6 +7921,7 @@ function Chess3D({
         players.find((p) => String(p.id) === String(accountId))?.side ||
         (meIndex === 0 ? 'white' : 'black');
       onlineRef.current.side = mySide;
+      arenaRef.current?.syncParkedWeaponSwaps?.();
       onlineRef.current.status = 'started';
       setOnlineStatus('starting');
       socket.emit('joinChessRoom', { tableId: startedId, accountId });
@@ -9815,7 +9791,7 @@ function Chess3D({
         camera.near = CAM.near;
         camera.updateProjectionMatrix();
         controls.enabled = true;
-        controls.enableRotate = true;
+        controls.enableRotate = false;
         controls.enablePan = false;
         controls.enableZoom = true;
         controls.minPolarAngle = CAMERA_PULL_FORWARD_MIN;
@@ -9848,6 +9824,8 @@ function Chess3D({
         const lookDir = lockedLookTarget.sub(targetPosition).normalize();
         const yaw = Math.atan2(lookDir.x, lookDir.z);
         const pitch = Math.asin(clamp(lookDir.y, -1, 1));
+        locked3dViewRef.current.baseYaw = yaw;
+        locked3dViewRef.current.basePitch = pitch;
         locked3dViewRef.current.yaw = yaw;
         locked3dViewRef.current.pitch = pitch;
         locked3dViewRef.current.targetYaw = yaw;
@@ -9860,11 +9838,11 @@ function Chess3D({
     };
 
     cameraViewRef.current = { setMode: setViewModeInternal };
-    // Start every match in locked 2D mode by default and preserve board state when customizations change.
+    // Start every match in locked 3D with the same framing used by capture animations.
     restoreAutoViewTo2dRef.current = false;
-    viewModeRef.current = '2d';
-    setViewMode('2d');
-    setViewModeInternal('2d');
+    viewModeRef.current = '3d';
+    setViewMode('3d');
+    setViewModeInternal('3d');
 
     const fit = () => {
       const w = host.clientWidth;
@@ -10585,6 +10563,17 @@ function Chess3D({
       drone: 'knight',
       truck: 'pawn'
     };
+    const DEFAULT_CAPTURE_ANIMATION_BY_PIECE_GROUP = Object.freeze({
+      kingQueen: 'fighterJetAttack',
+      bishopRook: 'helicopterAttack',
+      knight: 'droneAttack',
+      pawn: 'missileJavelin'
+    });
+    const isLocalParkedWeaponSide = (isWhiteSide) => {
+      const localSide = onlineRef.current.enabled ? onlineRef.current.side || normalizedInitialSide : 'white';
+      const localIsWhite = localSide !== 'black';
+      return Boolean(isWhiteSide) === localIsWhite;
+    };
     const createParkedFirearmDisplay = (captureAnimationId, parkedKind, isWhiteSide) => {
       const root = new THREE.Group();
       root.name = `parkedFirearm-${parkedKind}-${captureAnimationId}`;
@@ -10623,7 +10612,7 @@ function Chess3D({
       root.userData.muzzle = muzzle;
       root.userData.animationPhase = Math.random() * Math.PI * 2;
       root.userData.recoil = 0;
-      root.scale.setScalar(tile * (isLongGun ? 0.54 : 0.48));
+      root.scale.setScalar(SIDE_PARKED_SWAPPED_WEAPON_JET_SCALE);
       root.rotation.set(-Math.PI * 0.5, isWhiteSide ? -Math.PI * 0.5 : Math.PI * 0.5, 0);
       root.userData = {
         ...(root.userData || {}),
@@ -10638,8 +10627,17 @@ function Chess3D({
     const syncParkedWeaponSwaps = (mapping = captureAnimationByPieceGroupRef.current) => {
       parkedAirUnits.forEach((unit) => {
         if (!unit?.root) return;
+        if (!isLocalParkedWeaponSide(unit.isWhite)) {
+          if (unit.firearmRoot) {
+            unit.firearmRoot.parent?.remove?.(unit.firearmRoot);
+            disposeObject3D(unit.firearmRoot);
+            unit.firearmRoot = null;
+          }
+          unit.root.visible = !unit.busy;
+          return;
+        }
         const group = PIECE_GROUP_BY_PARKED_KIND_LOCAL[unit.kind];
-        const selectedId = mapping?.[group];
+        const selectedId = mapping?.[group] || DEFAULT_CAPTURE_ANIMATION_BY_PIECE_GROUP[group];
         const showFirearm = FIREARM_CAPTURE_ANIMATION_IDS.has(selectedId);
         if (showFirearm) {
           if (!unit.firearmRoot || unit.firearmRoot.userData?.captureAnimationId !== selectedId) {
@@ -11350,17 +11348,62 @@ function Chess3D({
       'polyShotgun01Attack',
       'polyShotgun02Attack',
       'polyShotgun03Attack',
+      'shotgunBlastAttack',
       'sniperShotAttack',
       'mosinMarksmanAttack',
-      'compactCarbineAttack'
+      'compactCarbineAttack',
+      'marksmanDmrAttack',
+      'polyBazooka01Attack',
+      'polyGrenadeLauncher01Attack',
+      'polyDynamiteBomb01Attack',
+      'polyMolotov01Attack',
+      'polyGasTank01Attack',
+      'polyHandGrenade01Attack',
+      'polyTank01Attack'
     ]);
+    const FIREARM_CAPTURE_PROFILE_BY_ID = Object.freeze({
+      fpsGunAttack: { bulletCount: 9, duration: 1.05, impactAt: 0.9 },
+      glockSidearmAttack: { bulletCount: 4, duration: 0.82, impactAt: 0.9 },
+      assaultRifleAttack: { bulletCount: 9, duration: 1.08, impactAt: 0.91 },
+      uziSprayAttack: { bulletCount: 12, duration: 1.18, impactAt: 0.9 },
+      ak47VolleyAttack: { bulletCount: 8, duration: 1.08, impactAt: 0.9 },
+      krsvBurstAttack: { bulletCount: 6, duration: 0.96, impactAt: 0.9 },
+      smithSidearmAttack: { bulletCount: 3, duration: 0.78, impactAt: 0.92 },
+      mosinMarksmanAttack: { bulletCount: 1, duration: 0.82, impactAt: 1 },
+      sigsauerTacticalAttack: { bulletCount: 5, duration: 0.92, impactAt: 0.91 },
+      grenadeBlastAttack: { bulletCount: 1, duration: 0.95, impactAt: 1 },
+      shotgunBlastAttack: { bulletCount: 1, duration: 0.68, impactAt: 1 },
+      sniperShotAttack: { bulletCount: 1, duration: 0.86, impactAt: 1 },
+      smgBurstAttack: { bulletCount: 10, duration: 1.08, impactAt: 0.9 },
+      compactCarbineAttack: { bulletCount: 1, duration: 0.76, impactAt: 1 },
+      marksmanDmrAttack: { bulletCount: 1, duration: 0.84, impactAt: 1 },
+      polyShotgun01Attack: { bulletCount: 1, duration: 0.62, impactAt: 1 },
+      polyAssaultRifle01Attack: { bulletCount: 8, duration: 1.04, impactAt: 0.9 },
+      polyPistol01Attack: { bulletCount: 3, duration: 0.74, impactAt: 0.92 },
+      polyRevolver01Attack: { bulletCount: 2, duration: 0.78, impactAt: 0.94 },
+      polySawedOff01Attack: { bulletCount: 1, duration: 0.58, impactAt: 1 },
+      polyRevolver02Attack: { bulletCount: 2, duration: 0.78, impactAt: 0.94 },
+      polyShotgun02Attack: { bulletCount: 1, duration: 0.66, impactAt: 1 },
+      polyShotgun03Attack: { bulletCount: 1, duration: 0.68, impactAt: 1 },
+      polySmg01Attack: { bulletCount: 11, duration: 1.12, impactAt: 0.9 },
+      polyRobotLargeGunAttack: { bulletCount: 10, duration: 1.22, impactAt: 0.9 },
+      polyRobotFlyingGunAttack: { bulletCount: 8, duration: 1.08, impactAt: 0.9 },
+      polyBazooka01Attack: { bulletCount: 1, duration: 1.05, impactAt: 1 },
+      polyGrenadeLauncher01Attack: { bulletCount: 1, duration: 1.0, impactAt: 1 },
+      polyDynamiteBomb01Attack: { bulletCount: 1, duration: 1.08, impactAt: 1 },
+      polyMolotov01Attack: { bulletCount: 1, duration: 0.98, impactAt: 1 },
+      polyGasTank01Attack: { bulletCount: 1, duration: 1.1, impactAt: 1 },
+      polyHandGrenade01Attack: { bulletCount: 1, duration: 0.92, impactAt: 1 },
+      polyTank01Attack: { bulletCount: 1, duration: 1.16, impactAt: 1 }
+    });
 
     const resolveFirearmCaptureProfile = (captureAnimationId = selectedCaptureAnimationId) => {
-      const singleShot = SINGLE_SHOT_FIREARM_IDS.has(captureAnimationId);
+      const configured = FIREARM_CAPTURE_PROFILE_BY_ID[captureAnimationId] || null;
+      const singleShot = configured?.bulletCount === 1 || SINGLE_SHOT_FIREARM_IDS.has(captureAnimationId);
       return {
-        bulletCount: singleShot ? 1 : 7,
-        duration: singleShot ? 0.62 : 1.15,
-        impactAt: singleShot ? 1 : 0.92,
+        bulletCount: configured?.bulletCount ?? (singleShot ? 1 : 7),
+        duration: configured?.duration ?? (singleShot ? 0.62 : 1.15),
+        impactAt: configured?.impactAt ?? (singleShot ? 1 : 0.92),
         singleShot
       };
     };
@@ -11373,10 +11416,12 @@ function Chess3D({
       return 'pawn';
     };
 
-    const resolveCaptureSelectionForPiece = (pieceType) => {
+    const resolveCaptureSelectionForPiece = (pieceType, isWhiteSide = true) => {
       const group = resolvePieceGroupFromType(pieceType);
-      const liveMapping = captureAnimationByPieceGroupRef.current || captureAnimationByPieceGroup;
-      const selectedId = liveMapping[group] || selectedCaptureAnimationId;
+      const liveMapping = isLocalParkedWeaponSide(isWhiteSide)
+        ? captureAnimationByPieceGroupRef.current || captureAnimationByPieceGroup
+        : DEFAULT_CAPTURE_ANIMATION_BY_PIECE_GROUP;
+      const selectedId = liveMapping[group] || DEFAULT_CAPTURE_ANIMATION_BY_PIECE_GROUP[group] || selectedCaptureAnimationId;
       const parkedKind = PARKED_KIND_BY_PIECE_GROUP[group] || 'truck';
       const captureKind = FIREARM_CAPTURE_ANIMATION_IDS.has(selectedId)
         ? 'firearm'
@@ -11401,7 +11446,7 @@ function Chess3D({
         }
         return timing;
       };
-      const captureSelection = resolveCaptureSelectionForPiece(movingType);
+      const captureSelection = resolveCaptureSelectionForPiece(movingType, Boolean(movingMesh?.userData?.w));
       const { captureKind, selectedId: selectedPieceCaptureAnimationId, parkedKind: selectedParkedKind } = captureSelection;
       if (captureKind === 'truck') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
@@ -12448,7 +12493,8 @@ function Chess3D({
         lastAppliedAppearance: normalizedAppearance,
         applyPieceSetAssets,
         setProceduralBoardVisible,
-        usingProceduralBoard: proceduralBoardVisible
+        usingProceduralBoard: proceduralBoardVisible,
+        syncParkedWeaponSwaps
       };
       arenaRef.current.sandTimer = sandTimer;
       arenaRef.current.palette = palette;
@@ -13208,6 +13254,7 @@ function Chess3D({
         let node = hit.object;
         while (node) {
           if (node?.userData?.type === 'parkedWeapon' && node?.userData?.parkedWeaponKind) {
+            if (!isLocalParkedWeaponSide(node.userData.parkedIsWhite)) break;
             return {
               object: node,
               point: hit.point,
@@ -13285,8 +13332,16 @@ function Chess3D({
               : 0;
           locked.lastPointerX = Number.isFinite(clientX) ? clientX : locked.lastPointerX;
           locked.lastPointerY = Number.isFinite(clientY) ? clientY : locked.lastPointerY;
-          locked.targetYaw -= movementX * 0.0024;
-          locked.targetPitch = clamp(locked.targetPitch - movementY * 0.002, -0.86, 0.2);
+          locked.targetYaw = clamp(
+            locked.targetYaw + movementX * CAMERA_LOOK_YAW_DRAG_FACTOR,
+            locked.baseYaw - CAMERA_LOOK_YAW_LIMIT,
+            locked.baseYaw + CAMERA_LOOK_YAW_LIMIT
+          );
+          locked.targetPitch = clamp(
+            locked.targetPitch + movementY * CAMERA_LOOK_PITCH_DRAG_FACTOR,
+            locked.basePitch + CAMERA_LOOK_MIN_PITCH,
+            locked.basePitch + CAMERA_LOOK_PITCH_LIMIT
+          );
         }
         return;
       }


### PR DESCRIPTION
### Motivation
- Set the canonical Battle Royal layout to the Coffee Table reference and ensure all table skins share the same layout radius for consistent chair/human/weapon placement. 
- Expose and sell Ludo capture animations in Chess Battle Royal so Ludo firearms/heavy weapons are available as purchasables. 
- Improve locked 3D camera framing and add controlled look yaw/pitch limits and drag behavior for a stable, animation-consistent experience. 
- Make parked-weapon visuals and firearm capture profiles more robust and configurable per animation id. 

### Description
- Changed the default table id from `murlan-default` to `CoffeeTable_01` and added `CHESS_COFFEE_TABLE_01_LAYOUT_RADIUS` so `resolveChairDistanceForDirection` uses a fixed layout radius. 
- Updated inventory config/test expectations and added a test to ensure every Ludo `CAPTURE_ANIMATION_OPTIONS` item is sold in `CHESS_BATTLE_ROYAL_STORE_ITEMS`. 
- Reworked camera constants and interaction: replaced `CAMERA_LOCKED_3D_PHI` with `CAMERA_PULL_FORWARD_MIN`, added `CAMERA_LOOK_*` limits and drag factors, and start matches in locked `3d` view by default. 
- Replaced the old quick-swap filtering with logic that shows all owned capture animations relevant to the tapped parked pad, removed the hardcoded `QUICK_SWAP_WEAPON_IDS`, and simplified the quick-swap pool to `ownedCaptureAnimations`. 
- Added `SIDE_PARKED_SWAPPED_WEAPON_JET_SCALE`, `DEFAULT_CAPTURE_ANIMATION_BY_PIECE_GROUP`, `FIREARM_CAPTURE_PROFILE_BY_ID`, and expanded `SINGLE_SHOT_FIREARM_IDS`; used these to control parked firearm display scaling, per-id firearm profiles, single-shot detection, and selection fallback behavior. 
- Updated parked weapon sync and pointer picking so parked firearm visuals only appear for the local side via `isLocalParkedWeaponSide`, and added `syncParkedWeaponSwaps` integration with the arena. 

### Testing
- Ran the updated unit test file `test/chessBattleInventoryConfig.test.js` with `jest` and the test suite passed. 
- Verified the modified inventory assertions (default table id, LT finishes, and capture animation store entries) via the updated Jest tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fece09627c8329873480875a9721be)