### PR TITLE
Add Poly Pizza tank assets, per-weapon visuals/animations and realistic token fracture

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -25,6 +25,85 @@ namespace TonPlaygram.Gameplay.Weapons
         StrikeJet
     }
 
+    public enum LudoAmmoVisualType
+    {
+        NineMillimeter,
+        FiveFiveSixRifle,
+        SevenSixTwoRifle,
+        ShotgunShell,
+        SniperRound,
+        GrenadeRound,
+        Rocket,
+        Missile,
+        EnergyCell
+    }
+
+    [Serializable]
+    public sealed class LudoWeaponGripPose
+    {
+        [Tooltip("Right hand offset measured back from the muzzle along the aiming direction.")]
+        public float rightHandBackFromMuzzle = 0.12f;
+
+        [Tooltip("Left support hand offset measured back from the muzzle along the aiming direction.")]
+        public float leftHandBackFromMuzzle = 0.06f;
+
+        [Tooltip("Left support hand offset to the visible left side of the weapon.")]
+        public float leftHandSideOffset = 0.06f;
+
+        [Tooltip("Raises/lowers both grip sockets in world space for chunky launchers/tanks.")]
+        public float handLift = 0f;
+
+        [Tooltip("Extra local offset applied by the human retargeter when this weapon is equipped.")]
+        public Vector3 retargetGripPositionOffset;
+
+        [Tooltip("Extra local Euler offset applied by the human retargeter when this weapon is equipped.")]
+        public Vector3 retargetGripEulerOffset;
+    }
+
+    [Serializable]
+    public sealed class LudoWeaponAnimationProfile
+    {
+        [Tooltip("Animator on the visible weapon or imported open-source weapon rig.")]
+        public Animator weaponAnimator;
+
+        [Tooltip("Trigger fired when the player equips/swaps to this weapon.")]
+        public string equipTrigger = "Equip";
+
+        [Tooltip("Trigger fired for every shot so each weapon can use its own recoil/bolt/pump animation.")]
+        public string fireTrigger = "Fire";
+
+        [Tooltip("Trigger fired once after the final round when a reload/settle animation exists.")]
+        public string reloadTrigger = "Reload";
+
+        public AnimationClip equipClip;
+        public AnimationClip fireClip;
+        public AnimationClip reloadClip;
+
+        public void PlayEquip() => PlayTrigger(equipTrigger, equipClip);
+
+        public void PlayFire() => PlayTrigger(fireTrigger, fireClip);
+
+        public void PlayReload() => PlayTrigger(reloadTrigger, reloadClip);
+
+        private void PlayTrigger(string triggerName, AnimationClip fallbackClip)
+        {
+            if (weaponAnimator == null)
+                return;
+
+            if (!string.IsNullOrWhiteSpace(triggerName))
+            {
+                weaponAnimator.ResetTrigger(triggerName);
+                weaponAnimator.SetTrigger(triggerName);
+                return;
+            }
+
+            if (fallbackClip != null)
+            {
+                weaponAnimator.Play(fallbackClip.name, 0, 0f);
+            }
+        }
+    }
+
     [Serializable]
     public sealed class WeaponBallisticsProfile
     {
@@ -42,10 +121,27 @@ namespace TonPlaygram.Gameplay.Weapons
         public float aimFov = 40f;
         public float aimTransitionSeconds = 0.08f;
         public float impactFollowSeconds = 1.15f;
+        public LudoAmmoVisualType ammoVisualType = LudoAmmoVisualType.FiveFiveSixRifle;
+        [Tooltip("Visible weapon GLB/GLTF prefab imported from the asset catalog (Poly Pizza, Gunify, etc.).")]
+        public GameObject weaponPrefab;
         public GameObject bulletPrefab;
         public GameObject shellPrefab;
+        [Tooltip("Optional separate casing prefab. Falls back to shellPrefab when empty.")]
+        public GameObject casingPrefab;
         public AudioClip shotSfx;
         public bool requiresAerialStrike;
+        public LudoWeaponGripPose gripPose = new LudoWeaponGripPose();
+        public LudoWeaponAnimationProfile animationProfile = new LudoWeaponAnimationProfile();
+        [Header("Shell ejection")]
+        public float shellMass = 0.02f;
+        public Vector2 shellEjectSpeedRange = new Vector2(1.8f, 3.1f);
+        public Vector2 shellEjectLiftRange = new Vector2(0.8f, 1.3f);
+        public float shellTumble = 13f;
+        public float shellLifetime = 5f;
+        [Header("Token fracture")]
+        public float nonFinalBreakForce = 3.5f;
+        public float finalBreakForce = 8f;
+        public float breakRadius = 2f;
     }
 
     public interface ILudoWeaponEvents
@@ -117,6 +213,7 @@ namespace TonPlaygram.Gameplay.Weapons
         private Vector3 _swapIconWorldPos;
         private Quaternion _swapIconWorldRot;
         private bool _isAnimationCameraActive;
+        private GameObject _equippedWeaponInstance;
 
         private void Awake()
         {
@@ -160,6 +257,9 @@ namespace TonPlaygram.Gameplay.Weapons
             }
 
             _activeWeapon = profile;
+            EquipWeaponVisual(profile);
+            ApplyRetargetGrip(profile);
+            profile.animationProfile?.PlayEquip();
             for (int i = 0; i < _eventListeners.Length; i++)
             {
                 _eventListeners[i].OnWeaponEquipped(weaponType);
@@ -226,9 +326,15 @@ namespace TonPlaygram.Gameplay.Weapons
             Vector3 shotDirection = (directionToTarget + spreadVec).normalized;
             RefreshWeaponPose(shotDirection);
 
+            weapon.animationProfile?.PlayFire();
             SpawnProjectiles(weapon, shotDirection, isLastBullet, shotIndex, totalShots);
             SpawnShell(weapon);
             PlayShotSfx(weapon);
+
+            if (isLastBullet)
+            {
+                weapon.animationProfile?.PlayReload();
+            }
 
             for (int i = 0; i < _eventListeners.Length; i++)
             {
@@ -289,7 +395,8 @@ namespace TonPlaygram.Gameplay.Weapons
             if (weapon.shellPrefab == null || shellEject == null)
                 return;
 
-            GameObject shellObj = Instantiate(weapon.shellPrefab, shellEject.position, shellEject.rotation);
+            GameObject shellSource = weapon.casingPrefab != null ? weapon.casingPrefab : weapon.shellPrefab;
+            GameObject shellObj = Instantiate(shellSource, shellEject.position, shellEject.rotation);
             shellObj.transform.localScale *= weapon.shellScale;
 
             Rigidbody rb = shellObj.GetComponent<Rigidbody>();
@@ -298,10 +405,11 @@ namespace TonPlaygram.Gameplay.Weapons
                 rb = shellObj.AddComponent<Rigidbody>();
             }
 
-            rb.mass = 0.02f;
-            rb.velocity = (shellEject.right * UnityEngine.Random.Range(1.8f, 3.1f)) + (Vector3.up * UnityEngine.Random.Range(0.8f, 1.3f));
-            rb.angularVelocity = UnityEngine.Random.insideUnitSphere * 13f;
-            Destroy(shellObj, 5f);
+            rb.mass = Mathf.Max(0.001f, weapon.shellMass);
+            rb.velocity = (shellEject.right * UnityEngine.Random.Range(weapon.shellEjectSpeedRange.x, weapon.shellEjectSpeedRange.y))
+                + (Vector3.up * UnityEngine.Random.Range(weapon.shellEjectLiftRange.x, weapon.shellEjectLiftRange.y));
+            rb.angularVelocity = UnityEngine.Random.insideUnitSphere * weapon.shellTumble;
+            Destroy(shellObj, Mathf.Max(0.25f, weapon.shellLifetime));
         }
 
         private void PlayShotSfx(WeaponBallisticsProfile weapon)
@@ -314,7 +422,7 @@ namespace TonPlaygram.Gameplay.Weapons
 
         public void OnBulletImpact(Vector3 point, bool isLastBullet)
         {
-            ApplyProgressiveDamage(isLastBullet);
+            ApplyProgressiveDamage(point, isLastBullet, _activeWeapon);
             if (isLastBullet)
             {
                 StartFinalImpactCamera(point);
@@ -349,24 +457,40 @@ namespace TonPlaygram.Gameplay.Weapons
             }
         }
 
-        private void ApplyProgressiveDamage(bool isLastBullet)
+        private void ApplyProgressiveDamage(Vector3 impactPoint, bool isLastBullet, WeaponBallisticsProfile weapon)
         {
             if (_tokenPieces.Count == 0)
                 return;
 
+            float breakForce = weapon != null ? weapon.finalBreakForce : 8f;
+            float breakRadius = weapon != null ? weapon.breakRadius : 2f;
             if (isLastBullet)
             {
                 for (int i = 0; i < _tokenPieces.Count; i++)
                 {
-                    _tokenPieces[i].BreakCompletely();
+                    _tokenPieces[i].BreakCompletely(impactPoint, breakForce, breakRadius);
                 }
                 return;
             }
 
-            int maxPieces = Mathf.Clamp(minorPiecesPerNonFinalShot, 1, _tokenPieces.Count);
-            for (int i = 0; i < maxPieces; i++)
+            _tokenPieces.Sort((a, b) =>
             {
-                _tokenPieces[i].DamageMinor();
+                float da = a == null ? float.MaxValue : (a.transform.position - impactPoint).sqrMagnitude;
+                float db = b == null ? float.MaxValue : (b.transform.position - impactPoint).sqrMagnitude;
+                return da.CompareTo(db);
+            });
+
+            int maxPieces = Mathf.Clamp(minorPiecesPerNonFinalShot, 1, _tokenPieces.Count);
+            float nonFinalForce = weapon != null ? weapon.nonFinalBreakForce : 3.5f;
+            int damaged = 0;
+            for (int i = 0; i < _tokenPieces.Count && damaged < maxPieces; i++)
+            {
+                TokenPieceHealth piece = _tokenPieces[i];
+                if (piece == null || piece.IsDetached)
+                    continue;
+
+                piece.DamageMinor(impactPoint, nonFinalForce, breakRadius);
+                damaged++;
             }
         }
 
@@ -391,16 +515,19 @@ namespace TonPlaygram.Gameplay.Weapons
                 weaponRoot.localRotation = _weaponRootLocalRot;
             }
 
+            LudoWeaponGripPose gripPose = _activeWeapon?.gripPose ?? new LudoWeaponGripPose();
+            Vector3 lift = Vector3.up * gripPose.handLift;
+
             if (rightHandGrip != null)
             {
-                rightHandGrip.position = muzzle.position - (shotDirection * 0.12f);
+                rightHandGrip.position = muzzle.position - (shotDirection * gripPose.rightHandBackFromMuzzle) + lift;
                 rightHandGrip.rotation = Quaternion.LookRotation(shotDirection, Vector3.up);
             }
 
             if (leftHandGrip != null)
             {
-                Vector3 leftOffset = Vector3.Cross(Vector3.up, shotDirection).normalized * 0.06f;
-                leftHandGrip.position = muzzle.position - (shotDirection * 0.06f) - leftOffset;
+                Vector3 side = Vector3.Cross(Vector3.up, shotDirection).normalized * gripPose.leftHandSideOffset;
+                leftHandGrip.position = muzzle.position - (shotDirection * gripPose.leftHandBackFromMuzzle) - side + lift;
                 leftHandGrip.rotation = Quaternion.LookRotation(shotDirection, Vector3.up);
             }
 
@@ -569,6 +696,43 @@ namespace TonPlaygram.Gameplay.Weapons
             return targetTokenRoot != null ? targetTokenRoot.position : muzzle.position + muzzle.forward;
         }
 
+
+        private void EquipWeaponVisual(WeaponBallisticsProfile profile)
+        {
+            if (weaponRoot == null)
+                return;
+
+            if (_equippedWeaponInstance != null)
+            {
+                Destroy(_equippedWeaponInstance);
+                _equippedWeaponInstance = null;
+            }
+
+            if (profile == null || profile.weaponPrefab == null)
+                return;
+
+            _equippedWeaponInstance = Instantiate(profile.weaponPrefab, weaponRoot);
+            _equippedWeaponInstance.transform.localPosition = Vector3.zero;
+            _equippedWeaponInstance.transform.localRotation = Quaternion.identity;
+            _equippedWeaponInstance.transform.localScale = Vector3.one;
+
+            Animator importedAnimator = _equippedWeaponInstance.GetComponentInChildren<Animator>(true);
+            if (profile.animationProfile != null && profile.animationProfile.weaponAnimator == null)
+            {
+                profile.animationProfile.weaponAnimator = importedAnimator;
+            }
+        }
+
+        private void ApplyRetargetGrip(WeaponBallisticsProfile profile)
+        {
+            if (humanHandRetargeter == null || profile?.gripPose == null)
+                return;
+
+            humanHandRetargeter.SetWeaponGripOffsets(
+                profile.gripPose.retargetGripPositionOffset,
+                profile.gripPose.retargetGripEulerOffset);
+        }
+
         private void BuildProfileMap()
         {
             _profiles.Clear();
@@ -709,23 +873,28 @@ namespace TonPlaygram.Gameplay.Weapons
             }
         }
 
-        public void DamageMinor()
+        public bool IsDetached { get; private set; }
+
+        public void DamageMinor(Vector3 impactPoint, float force, float radius)
         {
             _minorHits++;
             if (_minorHits >= minorHitsToDetach)
             {
-                BreakCompletely();
+                BreakCompletely(impactPoint, force, radius);
             }
         }
 
-        public void BreakCompletely()
+        public void BreakCompletely(Vector3 impactPoint, float force, float radius)
         {
-            if (rb == null)
+            if (rb == null || IsDetached)
                 return;
 
+            IsDetached = true;
+            transform.SetParent(null, true);
             rb.isKinematic = false;
-            rb.AddExplosionForce(8f, transform.position + Vector3.back, 2f, 0.3f, ForceMode.Impulse);
-            rb.AddTorque(UnityEngine.Random.insideUnitSphere * 5.5f, ForceMode.Impulse);
+            rb.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+            rb.AddExplosionForce(force, impactPoint, Mathf.Max(0.05f, radius), 0.3f, ForceMode.Impulse);
+            rb.AddTorque(UnityEngine.Random.insideUnitSphere * force * 0.7f, ForceMode.Impulse);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
+++ b/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
@@ -128,6 +128,14 @@ namespace TonPlaygram.Gameplay.Weapons
             SnapWeaponToHumanGrip();
         }
 
+        public void SetWeaponGripOffsets(Vector3 positionOffset, Vector3 eulerOffset)
+        {
+            weaponGripPositionOffset = positionOffset;
+            weaponGripEulerOffset = eulerOffset;
+            _weaponGripRotationOffset = Quaternion.Euler(weaponGripEulerOffset);
+            SnapToMappedPose();
+        }
+
         [ContextMenu("Hide Original FPS Hands")]
         public void HideOriginalFpsHands()
         {

--- a/webapp/src/config/ludoBattleAssetCatalog.js
+++ b/webapp/src/config/ludoBattleAssetCatalog.js
@@ -1,0 +1,140 @@
+// Open-source asset manifest for Ludo Battle Royal weapon pickups/projectiles.
+// Poly Pizza search pages can be Cloudflare protected in automation, so keep the
+// canonical model pages and static preview ids here for manual Unity imports.
+const polyModel = (id) => `https://poly.pizza/m/${id}`;
+const polyBundle = (id) => `https://poly.pizza/bundle/${id}`;
+const polyPreview = (uuid) => `https://static.poly.pizza/${uuid}.webp`;
+const polyGlb = (uuid) => `https://static.poly.pizza/${uuid}.glb`;
+
+export const LUDO_POLY_PIZZA_TANK_ASSETS = Object.freeze([
+  {
+    id: 'poly-tank-animated-01',
+    attackId: 'polyTank01Attack',
+    label: 'Quaternius Animated Tank Mk I',
+    author: 'Quaternius',
+    license: 'CC0-1.0',
+    sourcePage: polyBundle('Animated-Tank-Pack-0tfvbeAJkU'),
+    modelPage: polyModel('Dc4k4CooN3'),
+    preview: polyPreview('52977e64-f4b3-4845-9d44-fe50ec8154e3'),
+    candidateUrls: [polyGlb('52977e64-f4b3-4845-9d44-fe50ec8154e3')],
+    weaponType: 'GrenadeLauncher',
+    ammoVisualType: 'Rocket',
+    grip: { rightHandBackFromMuzzle: 0.2, leftHandBackFromMuzzle: 0.34, leftHandSideOffset: 0.1, handLift: 0.04 },
+    animationHints: ['turret recoil', 'track idle', 'barrel settle']
+  },
+  {
+    id: 'poly-tank-animated-02',
+    attackId: 'polyTank02Attack',
+    label: 'Quaternius Animated Tank Mk II',
+    author: 'Quaternius',
+    license: 'CC0-1.0',
+    sourcePage: polyBundle('Animated-Tank-Pack-0tfvbeAJkU'),
+    preview: polyPreview('58c387b2-636f-49dc-a900-13b0852717d6'),
+    candidateUrls: [polyGlb('58c387b2-636f-49dc-a900-13b0852717d6')],
+    weaponType: 'GrenadeLauncher',
+    ammoVisualType: 'Rocket',
+    grip: { rightHandBackFromMuzzle: 0.22, leftHandBackFromMuzzle: 0.36, leftHandSideOffset: 0.11, handLift: 0.05 },
+    animationHints: ['heavy cannon recoil', 'turret traverse']
+  },
+  {
+    id: 'poly-tank-animated-03',
+    attackId: 'polyTank03Attack',
+    label: 'Quaternius Animated Tank Desert',
+    author: 'Quaternius',
+    license: 'CC0-1.0',
+    sourcePage: polyBundle('Animated-Tank-Pack-0tfvbeAJkU'),
+    preview: polyPreview('4a40c214-87f9-4cdb-bc72-003c96f49f76'),
+    candidateUrls: [polyGlb('4a40c214-87f9-4cdb-bc72-003c96f49f76')],
+    weaponType: 'GrenadeLauncher',
+    ammoVisualType: 'Rocket',
+    grip: { rightHandBackFromMuzzle: 0.2, leftHandBackFromMuzzle: 0.32, leftHandSideOffset: 0.1, handLift: 0.04 },
+    animationHints: ['desert cannon recoil', 'track idle']
+  },
+  {
+    id: 'poly-tank-animated-04',
+    attackId: 'polyTank04Attack',
+    label: 'Quaternius Animated Rocket Tank',
+    author: 'Quaternius',
+    license: 'CC0-1.0',
+    sourcePage: polyBundle('Animated-Tank-Pack-0tfvbeAJkU'),
+    preview: polyPreview('c0135fb4-3307-4c0f-a439-86ceafedc4c7'),
+    candidateUrls: [polyGlb('c0135fb4-3307-4c0f-a439-86ceafedc4c7')],
+    weaponType: 'GrenadeLauncher',
+    ammoVisualType: 'Missile',
+    grip: { rightHandBackFromMuzzle: 0.25, leftHandBackFromMuzzle: 0.4, leftHandSideOffset: 0.12, handLift: 0.06 },
+    animationHints: ['launcher tube recoil', 'rocket exhaust']
+  }
+]);
+
+export const LUDO_POLY_PIZZA_AMMO_ASSETS = Object.freeze([
+  {
+    id: 'ammo-9mm-pistol-creative-trio',
+    label: 'Pistol Ammo',
+    author: 'CreativeTrio',
+    license: 'CC0-1.0',
+    sourcePage: polyModel('Kh2hNjWMXA'),
+    ammoVisualType: 'NineMillimeter',
+    usedBy: ['Pistol', 'SMG'],
+    shellEject: { mass: 0.012, speed: [1.7, 2.8], lift: [0.65, 1.1], tumble: 16 }
+  },
+  {
+    id: 'ammo-762-j-toastie',
+    label: '7.62x39mm Round',
+    author: 'J-Toastie',
+    license: 'CC-BY-3.0',
+    sourcePage: polyModel('olPaiJI58u'),
+    ammoVisualType: 'SevenSixTwoRifle',
+    usedBy: ['Rifle', 'Sniper'],
+    shellEject: { mass: 0.018, speed: [2.1, 3.3], lift: [0.85, 1.35], tumble: 18 }
+  },
+  {
+    id: 'ammo-bullet-poly-google',
+    label: 'Bullet Projectile',
+    author: 'Poly by Google',
+    license: 'CC-BY-3.0',
+    sourcePage: polyModel('2_eJPKc_a_D'),
+    ammoVisualType: 'FiveFiveSixRifle',
+    usedBy: ['Rifle', 'SMG', 'Sniper'],
+    shellEject: { mass: 0.016, speed: [2.0, 3.2], lift: [0.75, 1.25], tumble: 15 }
+  },
+  {
+    id: 'ammo-shotgun-creative-trio',
+    label: 'Shotgun Ammo',
+    author: 'CreativeTrio',
+    license: 'CC0-1.0',
+    sourcePage: 'https://poly.pizza/search/Ammo%20Shotgun',
+    ammoVisualType: 'ShotgunShell',
+    usedBy: ['Shotgun'],
+    pelletsPerShot: 8,
+    shellEject: { mass: 0.025, speed: [1.5, 2.4], lift: [0.8, 1.4], tumble: 12 }
+  },
+  {
+    id: 'ammo-grenade-launcher-creative-trio',
+    label: 'Grenade Launcher Ammo',
+    author: 'CreativeTrio',
+    license: 'CC0-1.0',
+    sourcePage: polyModel('BPdc4pA3tv'),
+    ammoVisualType: 'GrenadeRound',
+    usedBy: ['GrenadeLauncher'],
+    shellEject: { mass: 0.08, speed: [0.9, 1.8], lift: [0.45, 0.9], tumble: 9 }
+  },
+  {
+    id: 'ammo-bullets-pickup-quaternius',
+    label: 'Bullets Pickup',
+    author: 'Quaternius',
+    license: 'CC0-1.0',
+    sourcePage: polyModel('bTEYFxKHF9'),
+    ammoVisualType: 'FiveFiveSixRifle',
+    usedBy: ['InventoryPickup']
+  }
+]);
+
+export const LUDO_WEAPON_ASSET_IMPORT_NOTES = Object.freeze({
+  preferredFormat: 'GLB/GLTF',
+  unityImportPath: 'Assets/Art/LudoBattleRoyal/Weapons',
+  tokenFracturePath: 'Assets/Art/LudoBattleRoyal/Tokens/Fractured',
+  tokenFractureRule:
+    'Split the real token mesh into named child pieces and add TokenPieceHealth + Rigidbody to every piece; never use random placeholder shards.',
+  gripRule:
+    'For every imported weapon prefab, author muzzle, shell eject, right-hand grip, and left-hand grip sockets, then tune WeaponBallisticsProfile.gripPose.'
+});

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -1,4 +1,5 @@
 import { TOKEN_TYPE_SEQUENCE } from '../utils/ludoTokenConstants.js';
+import { LUDO_POLY_PIZZA_TANK_ASSETS } from './ludoBattleAssetCatalog.js';
 
 export const HEAD_PRESET_OPTIONS = Object.freeze([
   {
@@ -362,12 +363,14 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     description: 'CC0 Poly Pizza hand grenade model added alongside the existing grenade fallback.',
     thumbnail: 'https://static.poly.pizza/03fa7f5b-4df5-45d6-86fb-87e8590f28d7.webp'
   },
-  {
-    id: 'polyTank01Attack',
-    label: 'Quaternius Battle Tank',
-    description: 'CC0 Poly Pizza tank model for heavy battle-royal capture strike cosmetics.',
-    thumbnail: 'https://static.poly.pizza/58c387b2-636f-49dc-a900-13b0852717d6.webp'
-  }
+  ...LUDO_POLY_PIZZA_TANK_ASSETS.map((tank) => ({
+    id: tank.attackId,
+    label: tank.label,
+    description: `${tank.license} Poly Pizza tank with dedicated ${tank.ammoVisualType.toLowerCase()} projectile visuals and grip offsets.`,
+    thumbnail: tank.preview,
+    assetId: tank.id,
+    sourcePage: tank.sourcePage
+  }))
 
 ]);
 

--- a/webapp/src/config/ludoWeaponDirectorBridge.js
+++ b/webapp/src/config/ludoWeaponDirectorBridge.js
@@ -32,8 +32,23 @@ export const LUDO_WEAPON_DIRECTOR_BRIDGE = Object.freeze({
     polyBazooka01Attack: 'GrenadeLauncher',
     polyGrenadeLauncher01Attack: 'GrenadeLauncher',
     polyTank01Attack: 'GrenadeLauncher',
+    polyTank02Attack: 'GrenadeLauncher',
+    polyTank03Attack: 'GrenadeLauncher',
+    polyTank04Attack: 'GrenadeLauncher',
     polyRobotLargeGunAttack: 'Rifle',
     polyRobotFlyingGunAttack: 'SMG'
+  }),
+  ammoVisualTypeByWeaponType: Object.freeze({
+    Pistol: 'NineMillimeter',
+    SMG: 'NineMillimeter',
+    Rifle: 'FiveFiveSixRifle',
+    Shotgun: 'ShotgunShell',
+    Sniper: 'SevenSixTwoRifle',
+    GrenadeLauncher: 'GrenadeRound',
+    SideMissile: 'Missile',
+    StrikeDrone: 'Missile',
+    AttackHelicopter: 'Missile',
+    StrikeJet: 'Missile'
   }),
   firearmBroadcastProfile: Object.freeze({
     aimLift: 0.064,

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -54,6 +54,7 @@ import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../../config/murlanThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from '../../config/poolRoyaleInventoryConfig.js';
 import { LUDO_WEAPON_DIRECTOR_BRIDGE } from '../../config/ludoWeaponDirectorBridge.js';
+import { LUDO_POLY_PIZZA_TANK_ASSETS } from '../../config/ludoBattleAssetCatalog.js';
 import { TOKEN_TYPE_SEQUENCE } from '../../utils/ludoTokenConstants.js';
 import {
   getLudoBattleInventory,
@@ -137,6 +138,7 @@ const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
   drone: 1.2
 });
 const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
+const POLY_PIZZA_TANK_ATTACK_IDS = LUDO_POLY_PIZZA_TANK_ASSETS.map((tank) => tank.attackId);
 const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'assaultRifleAttack',
   'fpsGunAttack',
@@ -170,7 +172,7 @@ const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'polyMolotov01Attack',
   'polyGasTank01Attack',
   'polyHandGrenade01Attack',
-  'polyTank01Attack'
+  ...POLY_PIZZA_TANK_ATTACK_IDS
 ]);
 const LARGE_RACK_FIREARM_IDS = new Set([
   'ak47VolleyAttack',
@@ -187,7 +189,7 @@ const LARGE_RACK_FIREARM_IDS = new Set([
   'polyRobotFlyingGunAttack',
   'polyBazooka01Attack',
   'polyGrenadeLauncher01Attack',
-  'polyTank01Attack'
+  ...POLY_PIZZA_TANK_ATTACK_IDS
 ]);
 const FIREARM_TWO_HANDED_IDS = new Set([
   'fpsGunAttack',
@@ -207,7 +209,7 @@ const FIREARM_TWO_HANDED_IDS = new Set([
   'polyRobotFlyingGunAttack',
   'polyBazooka01Attack',
   'polyGrenadeLauncher01Attack',
-  'polyTank01Attack'
+  ...POLY_PIZZA_TANK_ATTACK_IDS
 ]);
 const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
   'glockSidearmAttack',
@@ -254,7 +256,10 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   polyMolotov01Attack: 0.92,
   polyGasTank01Attack: 1.28,
   polyHandGrenade01Attack: 0.48,
-  polyTank01Attack: 2.3
+  polyTank01Attack: 2.3,
+  polyTank02Attack: 2.45,
+  polyTank03Attack: 2.35,
+  polyTank04Attack: 2.55
 });
 
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({


### PR DESCRIPTION
### Motivation
- Provide a canonical, open-source asset manifest and workflow so Poly Pizza tank models and matching ammo visuals can be used as Ludo capture weapons. 
- Make each weapon carry its own visible prefab, ammo/casing visuals and animation hooks so human grips, recoil and shell ejection look and behave realistically. 
- Replace placeholder/random token shards with damage applied to real pre-authored token pieces so breaking looks physically plausible. 

### Description
- Added a new asset manifest `webapp/src/config/ludoBattleAssetCatalog.js` listing four Poly Pizza tank variants plus ammo/bullet/shell source metadata and import notes for Unity. 
- Wired the tanks into game config and store flows by extending `webapp/src/config/ludoBattleOptions.js`, `webapp/src/config/ludoWeaponDirectorBridge.js` and `webapp/src/pages/Games/LudoBattleRoyal.jsx` so tanks appear as capture options and resolve to a grenade-launcher weapon type and ammo visual mapping. 
- Extended Unity weapon system (`Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs`) with: ammo visual enum, per-weapon `weaponPrefab`, `casingPrefab`, `LudoWeaponGripPose`, `LudoWeaponAnimationProfile`, shell-ejection tuning, token-fracture tuning, equip-time weapon visual instancing, play/equip/fire/reload hooks, and improved projectile/shell handling. 
- Improved token break logic and piece health (`TokenPieceHealth`) so non-final hits damage nearest pre-authored pieces and final impacts apply explosion force from the real impact point; pieces now detach and use realistic physics forces. 
- Added a small API to the retargeter (`FpsGunHumanHandRetargeter.SetWeaponGripOffsets`) so an equipped weapon can push per-weapon grip offsets into visible human hands. 

### Testing
- Ran an asset-catalog integrity check script that verifies the new tank IDs exist in `CAPTURE_ANIMATION_OPTIONS` and bridge mappings; the check completed successfully (`ludo weapon asset catalog ok`). 
- Built the web client with `npm --prefix webapp run build` and the Vite build completed successfully (production bundle created). 
- Code-level sanity checks executed: `git diff --cached --check` and local node script assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0b1aa51c8329a825295156c7c3d0)