### PR TITLE
Add Poly Pizza asset catalog, per-weapon grip/animation profiles, and realistic token break physics

### DIFF
--- a/Assets/Art/PolyPizza/BattleRoyale/README.md
+++ b/Assets/Art/PolyPizza/BattleRoyale/README.md
@@ -1,0 +1,23 @@
+# Ludo Battle Royale Poly Pizza asset intake
+
+Use this folder for the open-source Poly Pizza GLB/GLTF/FBX files that back the Ludo Battle Royale weapons, tank pickups, bullets, and shells.
+
+## Source candidates checked on 2026-05-09
+
+- Poly Pizza advertises free, game-ready low-poly models and GLTF/FBX availability on model/search pages.
+- Tanks: `https://poly.pizza/search/tank` and the Zsky tank page `https://poly.pizza/m/7GG1xDtc8l`.
+- Bullets and shells: `https://poly.pizza/search/bullet` includes Bullet, 7.62x39mm, 9x19mm, Shotgun rounds, Missile, Bullet Cartridge, Pistol Ammo, and ammo-box candidates.
+- Weapon/hand animation sources: `https://poly.pizza/search/gun%20animation` includes Animated Pistol, Fps Rig AKM, Fps Rig, Rigged FPS Arms, Rigged Glock, and similar open-source candidates.
+
+## Import rules
+
+1. Download only models whose source page permits the target use. Prefer CC0; keep attribution for Creative Commons Attribution assets.
+2. Store raw downloads in subfolders by role: `Tanks/`, `Bullets/`, `Shells/`, `Weapons/`, and `Animations/`.
+3. Create prefabs with stable names such as `BR_Rifle_Bullet.prefab`, `BR_Shotgun_Shell.prefab`, and `BR_Tank_Zsky.prefab`.
+4. Assign each bullet/shell prefab to the matching `WeaponBallisticsProfile` so every inventory weapon has its own projectile visuals and casing ejection.
+5. Assign imported aim/fire clips to the weapon animator configured in `WeaponGripPoseProfile` so each weapon can have its own grip, aim, fire, pump, bolt, reload, or launch animation.
+6. Add every downloaded asset to the `PolyPizzaBattleRoyaleAssetCatalog` ScriptableObject and preserve creator/license/source URL before shipping.
+
+## Token break setup
+
+The realistic break system expects the target token to already be split into actual mesh fragments. Add `TokenPieceHealth`, a collider, and a Rigidbody to each real fragment. Keep the fragments parented under the token root and kinematic at rest; the final bullet detaches all actual pieces with impact-driven force instead of spawning fake made-up debris.

--- a/Assets/Art/PolyPizza/BattleRoyale/poly-pizza-sources.json
+++ b/Assets/Art/PolyPizza/BattleRoyale/poly-pizza-sources.json
@@ -1,0 +1,38 @@
+{
+  "checkedAtUtc": "2026-05-09T00:00:00Z",
+  "note": "Use Poly Pizza source pages/search pages to download GLB/GLTF/FBX manually, verify the exact model license, then fill importedPrefab or AnimationClip fields in PolyPizzaBattleRoyaleAssetCatalog before shipping.",
+  "searchPages": {
+    "tanks": "https://poly.pizza/search/tank",
+    "bulletsAndShells": "https://poly.pizza/search/bullet",
+    "weaponAnimations": "https://poly.pizza/search/gun%20animation",
+    "weapons": "https://poly.pizza/search/weapon"
+  },
+  "tankCandidates": [
+    { "name": "Tank", "creator": "Zsky", "sourceUrl": "https://poly.pizza/m/7GG1xDtc8l", "license": "Creative Commons Attribution", "format": "FBX/GLTF" },
+    { "name": "Tank", "creator": "KolosStudios", "sourceUrl": "https://poly.pizza/search/tank" },
+    { "name": "Tank", "creator": "Quaternius", "sourceUrl": "https://poly.pizza/search/tank" },
+    { "name": "Tank", "creator": "Poly by Google", "sourceUrl": "https://poly.pizza/search/tank" },
+    { "name": "Tank", "creator": "Zayn", "sourceUrl": "https://poly.pizza/search/tank" },
+    { "name": "Light Tank", "creator": "Zsky", "sourceUrl": "https://poly.pizza/search/tank" },
+    { "name": "Tank", "creator": "SomeoneUnknown", "sourceUrl": "https://poly.pizza/search/tank" },
+    { "name": "Pickup Tank", "creator": "Quaternius", "sourceUrl": "https://poly.pizza/search/tank" }
+  ],
+  "projectileCandidates": [
+    { "name": "Bullet", "creator": "Poly by Google", "role": "Bullet", "weaponTypes": ["Rifle", "SMG", "Sniper"] },
+    { "name": "7.62x39mm", "creator": "J-Toastie", "role": "Bullet", "weaponTypes": ["Rifle"] },
+    { "name": "9x19mm", "creator": "J-Toastie", "role": "Bullet", "weaponTypes": ["Pistol", "SMG"] },
+    { "name": "Shotgun rounds", "creator": "Poly by Google", "role": "Shell", "weaponTypes": ["Shotgun"] },
+    { "name": "Bullet Cartridge (Glock)", "creator": "Reprdev", "role": "Shell", "weaponTypes": ["Pistol"] },
+    { "name": "Pistol Ammo", "creator": "CreativeTrio", "role": "Shell", "weaponTypes": ["Pistol"] },
+    { "name": "Missile", "creator": "Poly by Google", "role": "Missile", "weaponTypes": ["SideMissile", "StrikeJet", "AttackHelicopter"] },
+    { "name": "Ammo Grenade Launcher", "creator": "CreativeTrio", "role": "Grenade", "weaponTypes": ["GrenadeLauncher"] }
+  ],
+  "animationCandidates": [
+    { "name": "Fps Rig AKM", "creator": "J-Toastie", "weaponTypes": ["Rifle", "SMG"] },
+    { "name": "Fps Rig", "creator": "J-Toastie", "weaponTypes": ["Rifle", "Pistol", "Shotgun"] },
+    { "name": "Rigged Fps Arms", "creator": "J-Toastie", "weaponTypes": ["Rifle", "Pistol", "Shotgun", "Sniper"] },
+    { "name": "Animated Pistol", "creator": "Quaternius", "weaponTypes": ["Pistol"] },
+    { "name": "Rigged Glock", "creator": "J-Toastie", "weaponTypes": ["Pistol"] },
+    { "name": "Rigged Desert Eagle", "creator": "PuKkBuMXDD", "sourceUrl": "https://poly.pizza/m/e9k4dwOzCX", "weaponTypes": ["Pistol"] }
+  ]
+}

--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -25,6 +25,46 @@ namespace TonPlaygram.Gameplay.Weapons
         StrikeJet
     }
 
+    public enum ProjectileVisualRole
+    {
+        Bullet,
+        Shell,
+        Rocket,
+        Missile,
+        Grenade,
+        Pellet
+    }
+
+    [Serializable]
+    public sealed class WeaponGripPoseProfile
+    {
+        [Tooltip("Visible right-hand grip socket offset for this weapon, in muzzle/local aim space.")]
+        public Vector3 rightGripBackOffset = new Vector3(0f, 0f, -0.12f);
+
+        [Tooltip("Visible left/support-hand grip socket offset for this weapon, in muzzle/local aim space.")]
+        public Vector3 leftGripBackOffset = new Vector3(-0.06f, 0f, -0.06f);
+
+        [Tooltip("Extra rotation applied to both visible grip sockets after aiming at the token.")]
+        public Vector3 gripEulerOffset;
+
+        [Tooltip("Animator that owns the imported weapon or FPS-rig animation states for this specific weapon.")]
+        public Animator animator;
+
+        [Tooltip("Optional state to play when the weapon is equipped, e.g. Rifle_Equip.")]
+        public string equipStateName;
+
+        [Tooltip("Optional trigger fired for every shot, e.g. Fire, Pump, Bolt, ReloadShell.")]
+        public string fireTriggerName = "Fire";
+
+        [Tooltip("Optional state to cross-fade while the player aims, e.g. Rifle_AimPose.")]
+        public string aimStateName;
+
+        [Tooltip("Cross-fade time for authored open-source weapon/hand animation states.")]
+        public float animationFadeSeconds = 0.04f;
+
+        public Quaternion GripRotationOffset => Quaternion.Euler(gripEulerOffset);
+    }
+
     [Serializable]
     public sealed class WeaponBallisticsProfile
     {
@@ -46,6 +86,9 @@ namespace TonPlaygram.Gameplay.Weapons
         public GameObject shellPrefab;
         public AudioClip shotSfx;
         public bool requiresAerialStrike;
+        public ProjectileVisualRole projectileRole = ProjectileVisualRole.Bullet;
+        public ProjectileVisualRole spentCasingRole = ProjectileVisualRole.Shell;
+        public WeaponGripPoseProfile gripPose = new WeaponGripPoseProfile();
     }
 
     public interface ILudoWeaponEvents
@@ -160,6 +203,7 @@ namespace TonPlaygram.Gameplay.Weapons
             }
 
             _activeWeapon = profile;
+            PlayWeaponEquipAnimation(profile);
             for (int i = 0; i < _eventListeners.Length; i++)
             {
                 _eventListeners[i].OnWeaponEquipped(weaponType);
@@ -195,6 +239,15 @@ namespace TonPlaygram.Gameplay.Weapons
             return true;
         }
 
+        private static void PlayWeaponEquipAnimation(WeaponBallisticsProfile weapon)
+        {
+            WeaponGripPoseProfile gripPose = weapon != null ? weapon.gripPose : null;
+            if (gripPose == null || gripPose.animator == null || string.IsNullOrWhiteSpace(gripPose.equipStateName))
+                return;
+
+            gripPose.animator.CrossFadeInFixedTime(gripPose.equipStateName, Mathf.Max(0f, gripPose.animationFadeSeconds));
+        }
+
         private IEnumerator FireRoutine(WeaponBallisticsProfile weapon)
         {
             int shots = weapon.fireMode == WeaponFireMode.Single ? 1 : Mathf.Max(1, weapon.magazineSize);
@@ -226,8 +279,9 @@ namespace TonPlaygram.Gameplay.Weapons
             Vector3 shotDirection = (directionToTarget + spreadVec).normalized;
             RefreshWeaponPose(shotDirection);
 
+            PlayWeaponFireAnimation(weapon);
             SpawnProjectiles(weapon, shotDirection, isLastBullet, shotIndex, totalShots);
-            SpawnShell(weapon);
+            SpawnShell(weapon, shotDirection);
             PlayShotSfx(weapon);
 
             for (int i = 0; i < _eventListeners.Length; i++)
@@ -284,7 +338,7 @@ namespace TonPlaygram.Gameplay.Weapons
             return weapon.bulletScale;
         }
 
-        private void SpawnShell(WeaponBallisticsProfile weapon)
+        private void SpawnShell(WeaponBallisticsProfile weapon, Vector3 shotDirection)
         {
             if (weapon.shellPrefab == null || shellEject == null)
                 return;
@@ -298,10 +352,47 @@ namespace TonPlaygram.Gameplay.Weapons
                 rb = shellObj.AddComponent<Rigidbody>();
             }
 
-            rb.mass = 0.02f;
-            rb.velocity = (shellEject.right * UnityEngine.Random.Range(1.8f, 3.1f)) + (Vector3.up * UnityEngine.Random.Range(0.8f, 1.3f));
+            Vector3 side = shellEject.right.sqrMagnitude > 0.0001f ? shellEject.right : Vector3.Cross(Vector3.up, shotDirection).normalized;
+            rb.mass = ResolveShellMass(weapon.spentCasingRole);
+            rb.velocity = (side * UnityEngine.Random.Range(1.8f, 3.1f)) + (Vector3.up * UnityEngine.Random.Range(0.8f, 1.3f)) - (shotDirection * 0.25f);
             rb.angularVelocity = UnityEngine.Random.insideUnitSphere * 13f;
             Destroy(shellObj, 5f);
+        }
+
+        private static float ResolveShellMass(ProjectileVisualRole spentCasingRole)
+        {
+            switch (spentCasingRole)
+            {
+                case ProjectileVisualRole.Rocket:
+                case ProjectileVisualRole.Missile:
+                case ProjectileVisualRole.Grenade:
+                    return 0.12f;
+                case ProjectileVisualRole.Pellet:
+                    return 0.008f;
+                default:
+                    return 0.02f;
+            }
+        }
+
+        private static void PlayWeaponAimPose(WeaponBallisticsProfile weapon)
+        {
+            WeaponGripPoseProfile gripPose = weapon != null ? weapon.gripPose : null;
+            if (gripPose == null || gripPose.animator == null || string.IsNullOrWhiteSpace(gripPose.aimStateName))
+                return;
+
+            gripPose.animator.CrossFadeInFixedTime(gripPose.aimStateName, Mathf.Max(0f, gripPose.animationFadeSeconds));
+        }
+
+        private static void PlayWeaponFireAnimation(WeaponBallisticsProfile weapon)
+        {
+            WeaponGripPoseProfile gripPose = weapon != null ? weapon.gripPose : null;
+            if (gripPose == null || gripPose.animator == null)
+                return;
+
+            if (!string.IsNullOrWhiteSpace(gripPose.fireTriggerName))
+            {
+                gripPose.animator.SetTrigger(gripPose.fireTriggerName);
+            }
         }
 
         private void PlayShotSfx(WeaponBallisticsProfile weapon)
@@ -314,7 +405,12 @@ namespace TonPlaygram.Gameplay.Weapons
 
         public void OnBulletImpact(Vector3 point, bool isLastBullet)
         {
-            ApplyProgressiveDamage(isLastBullet);
+            OnBulletImpact(point, Vector3.zero, isLastBullet);
+        }
+
+        public void OnBulletImpact(Vector3 point, Vector3 incomingVelocity, bool isLastBullet)
+        {
+            ApplyProgressiveDamage(point, incomingVelocity, isLastBullet);
             if (isLastBullet)
             {
                 StartFinalImpactCamera(point);
@@ -349,25 +445,68 @@ namespace TonPlaygram.Gameplay.Weapons
             }
         }
 
-        private void ApplyProgressiveDamage(bool isLastBullet)
+        private void ApplyProgressiveDamage(Vector3 impactPoint, Vector3 incomingVelocity, bool isLastBullet)
         {
             if (_tokenPieces.Count == 0)
                 return;
+
+            SortTokenPiecesByImpact(impactPoint);
+            Vector3 impactDirection = incomingVelocity.sqrMagnitude > 0.0001f ? incomingVelocity.normalized : ResolveFallbackImpactDirection();
 
             if (isLastBullet)
             {
                 for (int i = 0; i < _tokenPieces.Count; i++)
                 {
-                    _tokenPieces[i].BreakCompletely();
+                    if (_tokenPieces[i] != null)
+                    {
+                        _tokenPieces[i].BreakCompletely(impactPoint, impactDirection, true);
+                    }
                 }
                 return;
             }
 
+            int detached = 0;
             int maxPieces = Mathf.Clamp(minorPiecesPerNonFinalShot, 1, _tokenPieces.Count);
-            for (int i = 0; i < maxPieces; i++)
+            for (int i = 0; i < _tokenPieces.Count && detached < maxPieces; i++)
             {
-                _tokenPieces[i].DamageMinor();
+                TokenPieceHealth piece = _tokenPieces[i];
+                if (piece == null || piece.IsDetached)
+                    continue;
+
+                piece.DamageMinor(impactPoint, impactDirection);
+                detached++;
             }
+        }
+
+        private Vector3 ResolveFallbackImpactDirection()
+        {
+            if (targetTokenRoot != null && muzzle != null)
+            {
+                Vector3 fromMuzzle = targetTokenRoot.position - muzzle.position;
+                if (fromMuzzle.sqrMagnitude > 0.0001f)
+                {
+                    return fromMuzzle.normalized;
+                }
+            }
+
+            return Vector3.forward;
+        }
+
+        private void SortTokenPiecesByImpact(Vector3 impactPoint)
+        {
+            _tokenPieces.Sort((a, b) =>
+            {
+                if (a == null && b == null)
+                    return 0;
+                if (a == null)
+                    return 1;
+                if (b == null)
+                    return -1;
+
+                float aDistance = (a.transform.position - impactPoint).sqrMagnitude;
+                float bDistance = (b.transform.position - impactPoint).sqrMagnitude;
+                return aDistance.CompareTo(bDistance);
+            });
         }
 
         private void BeginAimCamera(WeaponBallisticsProfile weapon)
@@ -380,6 +519,7 @@ namespace TonPlaygram.Gameplay.Weapons
                 StopCoroutine(_cameraRoutine);
             }
 
+            PlayWeaponAimPose(weapon);
             _cameraRoutine = StartCoroutine(AimViewRoutine(weapon));
         }
 
@@ -391,17 +531,22 @@ namespace TonPlaygram.Gameplay.Weapons
                 weaponRoot.localRotation = _weaponRootLocalRot;
             }
 
+            WeaponGripPoseProfile gripPose = _activeWeapon != null ? _activeWeapon.gripPose : null;
+            Quaternion aimRotation = Quaternion.LookRotation(shotDirection, Vector3.up);
+            Quaternion gripRotation = aimRotation * (gripPose != null ? gripPose.GripRotationOffset : Quaternion.identity);
+
             if (rightHandGrip != null)
             {
-                rightHandGrip.position = muzzle.position - (shotDirection * 0.12f);
-                rightHandGrip.rotation = Quaternion.LookRotation(shotDirection, Vector3.up);
+                Vector3 rightOffset = gripPose != null ? gripPose.rightGripBackOffset : new Vector3(0f, 0f, -0.12f);
+                rightHandGrip.position = muzzle.position + aimRotation * rightOffset;
+                rightHandGrip.rotation = gripRotation;
             }
 
             if (leftHandGrip != null)
             {
-                Vector3 leftOffset = Vector3.Cross(Vector3.up, shotDirection).normalized * 0.06f;
-                leftHandGrip.position = muzzle.position - (shotDirection * 0.06f) - leftOffset;
-                leftHandGrip.rotation = Quaternion.LookRotation(shotDirection, Vector3.up);
+                Vector3 leftOffset = gripPose != null ? gripPose.leftGripBackOffset : new Vector3(-0.06f, 0f, -0.06f);
+                leftHandGrip.position = muzzle.position + aimRotation * leftOffset;
+                leftHandGrip.rotation = gripRotation;
             }
 
             if (humanHandRetargeter != null)
@@ -689,7 +834,7 @@ namespace TonPlaygram.Gameplay.Weapons
 
             _impactSent = true;
             _director?.BroadcastProjectileImpact(_weaponType, _shotIndex, _pelletIndex, transform.position);
-            _director?.OnBulletImpact(transform.position, _isLastBullet);
+            _director?.OnBulletImpact(transform.position, _velocity, _isLastBullet);
             Destroy(gameObject);
         }
     }
@@ -698,8 +843,16 @@ namespace TonPlaygram.Gameplay.Weapons
     {
         [SerializeField] private int minorHitsToDetach = 2;
         [SerializeField] private Rigidbody rb;
+        [SerializeField] private Collider pieceCollider;
+        [SerializeField] private float nonFinalImpulse = 3.2f;
+        [SerializeField] private float finalImpulse = 9.5f;
+        [SerializeField] private float upwardImpulse = 0.35f;
+        [SerializeField] private float torqueImpulse = 5.5f;
 
         private int _minorHits;
+        private bool _detached;
+
+        public bool IsDetached => _detached;
 
         private void Awake()
         {
@@ -707,25 +860,60 @@ namespace TonPlaygram.Gameplay.Weapons
             {
                 rb = GetComponent<Rigidbody>();
             }
+
+            if (pieceCollider == null)
+            {
+                pieceCollider = GetComponent<Collider>();
+            }
         }
 
         public void DamageMinor()
         {
+            DamageMinor(transform.position, Vector3.forward);
+        }
+
+        public void DamageMinor(Vector3 impactPoint, Vector3 impactDirection)
+        {
+            if (_detached)
+                return;
+
             _minorHits++;
             if (_minorHits >= minorHitsToDetach)
             {
-                BreakCompletely();
+                BreakCompletely(impactPoint, impactDirection, false);
             }
         }
 
         public void BreakCompletely()
         {
+            BreakCompletely(transform.position, Vector3.forward, true);
+        }
+
+        public void BreakCompletely(Vector3 impactPoint, Vector3 impactDirection, bool isFinalBreak)
+        {
+            if (_detached && !isFinalBreak)
+                return;
+
+            _detached = true;
+            transform.SetParent(null, true);
+
             if (rb == null)
                 return;
 
             rb.isKinematic = false;
-            rb.AddExplosionForce(8f, transform.position + Vector3.back, 2f, 0.3f, ForceMode.Impulse);
-            rb.AddTorque(UnityEngine.Random.insideUnitSphere * 5.5f, ForceMode.Impulse);
+            rb.detectCollisions = true;
+            if (pieceCollider != null)
+            {
+                pieceCollider.enabled = true;
+            }
+
+            Vector3 awayFromImpact = (transform.position - impactPoint).sqrMagnitude > 0.0001f
+                ? (transform.position - impactPoint).normalized
+                : impactDirection.normalized;
+            Vector3 forceDirection = (awayFromImpact + impactDirection.normalized + (Vector3.up * upwardImpulse)).normalized;
+            float impulse = isFinalBreak ? finalImpulse : nonFinalImpulse;
+            rb.AddForceAtPosition(forceDirection * impulse, impactPoint, ForceMode.Impulse);
+            rb.AddTorque(UnityEngine.Random.insideUnitSphere * torqueImpulse, ForceMode.Impulse);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/Weapons/PolyPizzaBattleRoyaleAssetCatalog.cs
+++ b/Assets/Scripts/Gameplay/Weapons/PolyPizzaBattleRoyaleAssetCatalog.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Weapons
+{
+    public enum PolyPizzaBattleRoyaleAssetKind
+    {
+        Tank,
+        Bullet,
+        Shell,
+        Weapon,
+        WeaponAnimation,
+        VehicleStrike
+    }
+
+    [Serializable]
+    public sealed class PolyPizzaBattleRoyaleAssetEntry
+    {
+        public string displayName;
+        public PolyPizzaBattleRoyaleAssetKind kind;
+        public LudoWeaponType weaponType;
+        public ProjectileVisualRole projectileRole;
+        public string creator;
+        public string license = "Creative Commons Attribution or CC0 as listed on the source page";
+        public string sourceUrl;
+        public string expectedImportFolder = "Assets/Art/PolyPizza/BattleRoyale";
+        public GameObject importedPrefab;
+        public AnimationClip aimAnimation;
+        public AnimationClip fireAnimation;
+    }
+
+    [CreateAssetMenu(menuName = "TonPlaygram/Ludo Battle Royale/Poly Pizza Asset Catalog", fileName = "PolyPizzaBattleRoyaleAssetCatalog")]
+    public sealed class PolyPizzaBattleRoyaleAssetCatalog : ScriptableObject
+    {
+        [SerializeField] private List<PolyPizzaBattleRoyaleAssetEntry> assets = new List<PolyPizzaBattleRoyaleAssetEntry>();
+
+        public IReadOnlyList<PolyPizzaBattleRoyaleAssetEntry> Assets => assets;
+
+        public bool TryFindImportedPrefab(LudoWeaponType weaponType, PolyPizzaBattleRoyaleAssetKind kind, out GameObject prefab)
+        {
+            for (int i = 0; i < assets.Count; i++)
+            {
+                PolyPizzaBattleRoyaleAssetEntry entry = assets[i];
+                if (entry == null || entry.weaponType != weaponType || entry.kind != kind || entry.importedPrefab == null)
+                    continue;
+
+                prefab = entry.importedPrefab;
+                return true;
+            }
+
+            prefab = null;
+            return false;
+        }
+
+        public IEnumerable<PolyPizzaBattleRoyaleAssetEntry> GetOpenSourceCandidates(LudoWeaponType weaponType)
+        {
+            for (int i = 0; i < assets.Count; i++)
+            {
+                PolyPizzaBattleRoyaleAssetEntry entry = assets[i];
+                if (entry != null && entry.weaponType == weaponType)
+                {
+                    yield return entry;
+                }
+            }
+        }
+
+        [ContextMenu("Seed Recommended Poly Pizza Battle Royale Entries")]
+        public void SeedRecommendedEntries()
+        {
+            assets.Clear();
+            assets.Add(new PolyPizzaBattleRoyaleAssetEntry
+            {
+                displayName = "Tank",
+                kind = PolyPizzaBattleRoyaleAssetKind.Tank,
+                weaponType = LudoWeaponType.SideMissile,
+                projectileRole = ProjectileVisualRole.Missile,
+                creator = "Zsky",
+                sourceUrl = "https://poly.pizza/m/7GG1xDtc8l",
+                license = "Creative Commons Attribution"
+            });
+            assets.Add(new PolyPizzaBattleRoyaleAssetEntry
+            {
+                displayName = "Bullet",
+                kind = PolyPizzaBattleRoyaleAssetKind.Bullet,
+                weaponType = LudoWeaponType.Rifle,
+                projectileRole = ProjectileVisualRole.Bullet,
+                creator = "Poly by Google",
+                sourceUrl = "https://poly.pizza/search/bullet"
+            });
+            assets.Add(new PolyPizzaBattleRoyaleAssetEntry
+            {
+                displayName = "9x19mm",
+                kind = PolyPizzaBattleRoyaleAssetKind.Bullet,
+                weaponType = LudoWeaponType.Pistol,
+                projectileRole = ProjectileVisualRole.Bullet,
+                creator = "J-Toastie",
+                sourceUrl = "https://poly.pizza/search/bullet"
+            });
+            assets.Add(new PolyPizzaBattleRoyaleAssetEntry
+            {
+                displayName = "Shotgun rounds",
+                kind = PolyPizzaBattleRoyaleAssetKind.Shell,
+                weaponType = LudoWeaponType.Shotgun,
+                projectileRole = ProjectileVisualRole.Shell,
+                creator = "Poly by Google",
+                sourceUrl = "https://poly.pizza/search/bullet"
+            });
+            assets.Add(new PolyPizzaBattleRoyaleAssetEntry
+            {
+                displayName = "Missile",
+                kind = PolyPizzaBattleRoyaleAssetKind.Bullet,
+                weaponType = LudoWeaponType.SideMissile,
+                projectileRole = ProjectileVisualRole.Missile,
+                creator = "Poly by Google",
+                sourceUrl = "https://poly.pizza/search/bullet"
+            });
+            assets.Add(new PolyPizzaBattleRoyaleAssetEntry
+            {
+                displayName = "Fps Rig AKM",
+                kind = PolyPizzaBattleRoyaleAssetKind.WeaponAnimation,
+                weaponType = LudoWeaponType.Rifle,
+                projectileRole = ProjectileVisualRole.Bullet,
+                creator = "J-Toastie",
+                sourceUrl = "https://poly.pizza/search/gun%20animation"
+            });
+            assets.Add(new PolyPizzaBattleRoyaleAssetEntry
+            {
+                displayName = "Animated Pistol",
+                kind = PolyPizzaBattleRoyaleAssetKind.WeaponAnimation,
+                weaponType = LudoWeaponType.Pistol,
+                projectileRole = ProjectileVisualRole.Bullet,
+                creator = "Quaternius",
+                sourceUrl = "https://poly.pizza/search/gun%20animation"
+            });
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a pipeline and metadata for ingesting open-source Poly Pizza GLB/GLTF/FBX assets (tanks, projectile visuals, shells, weapon animations) so each inventory weapon can use dedicated visuals and clips. 
- Improve visual fidelity of weapon handling by applying per-weapon grip offsets and authored aim/fire animations then retargeting those poses to visible human characters. 
- Replace fictitious token-break effects with impact-driven breaking of real token fragments so progressive damage matches physical fragment layout and impact direction/velocity. 

### Description
- Extended `WeaponBallisticsProfile` to include `projectileRole`, `spentCasingRole` and a new `WeaponGripPoseProfile` that holds per-weapon grip offsets, animator, equip/aim/fire state names and fade timing. 
- Play per-weapon equip/aim/fire animation hooks (`PlayWeaponEquipAnimation`, `PlayWeaponAimPose`, `PlayWeaponFireAnimation`) and use grip offsets in `RefreshWeaponPose` before calling the existing `FpsGunHumanHandRetargeter`. 
- Spawn projectiles with weapon-specific prefab/scale and change shell ejection to `SpawnShell(weapon, shotDirection)` with role-based mass/velocity via `ResolveShellMass`. 
- Propagate projectile incoming velocity into impacts by changing `OnBulletImpact` signature and have `BattleRoyaleBullet` send its `_velocity` when colliding. 
- Replace simple/random token damage with `ApplyProgressiveDamage(impactPoint, incomingVelocity, isLastBullet)` that sorts token fragments by proximity to the impact, damages nearest fragments first, and detaches all real pieces on final impact using `TokenPieceHealth.BreakCompletely(impactPoint, impactDirection, isFinalBreak)`. 
- Enhance `TokenPieceHealth` to track detached state, accept impact-driven `DamageMinor`/`BreakCompletely` parameters, enable colliders, and apply directional impulse/torque tuned for non-final vs final breaks. 
- Add `PolyPizzaBattleRoyaleAssetCatalog` ScriptableObject to track candidate open-source assets with creator/license/source metadata and prefab/clip slots, plus `Assets/Art/PolyPizza/BattleRoyale/README.md` and `poly-pizza-sources.json` documenting intake rules and recommended candidates. 

### Testing
- Ran `python3 -m json.tool Assets/Art/PolyPizza/BattleRoyale/poly-pizza-sources.json` to validate the JSON manifest, which succeeded. 
- Ran a quick repository checks (`diff --check`) and basic file validation on the modified files, which produced no formatting errors for the added catalog/readme/JSON. 
- Executed the full JS test suite with `npm test -- --runInBand`; the run completed but many pre-existing, unrelated tests failed (summary: `18` test suites failed including platform help ingestion/frontmatter and exports, pool AI determinism, matchmaking metadata, snake game behaviors, wallet/route timeouts, voice playback fallback, chess inventory config, and multiple API/integration platform-help suites), indicating those failures are unrelated to the changes in the Unity weapon director and asset catalog.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0b1aa51c8329a825295156c7c3d0)