### PR TITLE
Add Mobile Urban FPS prototype (three.js/React) with assets, route and UI

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,6 +23,8 @@
     "@capacitor/push-notifications": "6.0.5",
     "@letele/playing-cards": "^0.1.0",
     "@github/webauthn-json": "^2.0.2",
+    "@react-three/drei": "^9.122.0",
+    "@react-three/fiber": "^8.17.10",
     "@tonconnect/sdk": "^3.4.1",
     "@tonconnect/ui-react": "^2.4.1",
     "@vitejs/plugin-react": "^4.0.0",
@@ -44,7 +46,8 @@
     "socket.io-client": "^4.8.1",
     "tailwindcss": "^3.4.1",
     "three": "^0.164.0",
-    "vite": "^4.4.9"
+    "vite": "^4.4.9",
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@capacitor/cli": "6.1.2",

--- a/webapp/public/assets/icons/mobile-urban-fps.svg
+++ b/webapp/public/assets/icons/mobile-urban-fps.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Mobile Urban FPS">
+  <defs>
+    <linearGradient id="sky" x1="0" x2="0" y1="0" y2="1"><stop stop-color="#172554"/><stop offset="1" stop-color="#020617"/></linearGradient>
+    <linearGradient id="fire" x1="0" x2="1"><stop stop-color="#fde68a"/><stop offset="1" stop-color="#ef4444"/></linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="48" fill="url(#sky)"/>
+  <path d="M33 205h190v25H33z" fill="#111827"/>
+  <path d="M43 80h43v125H43zM94 50h54v155H94zM158 92h54v113h-54z" fill="#374151"/>
+  <path d="M53 96h18v18H53zm0 35h18v18H53zm54-59h18v18h-18zm0 36h18v18h-18zm64 4h18v18h-18zm0 35h18v18h-18z" fill="#93c5fd" opacity=".65"/>
+  <path d="M62 174h80l55 25-5 15-73-15H62z" fill="#1f2937"/>
+  <path d="M126 165h79v18h-79z" fill="#020617"/>
+  <path d="M206 166l32 8-32 9z" fill="url(#fire)"/>
+  <circle cx="128" cy="119" r="34" fill="none" stroke="#f8fafc" stroke-width="7" opacity=".9"/>
+  <path d="M128 73v92M82 119h92" stroke="#f8fafc" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -72,6 +72,9 @@ import TableTennis from './pages/Games/TableTennis.tsx';
 import TennisLobby from './pages/Games/TennisLobby.jsx';
 import BowlingRealistic from './pages/Games/BowlingRealistic.tsx';
 import FreeKickArena from './pages/Games/FreeKickArena.tsx';
+const MobileUrbanFps = React.lazy(
+  () => import('./games/mobileUrbanFps/MobileUrbanFps.tsx')
+);
 import StoreThumbnailStudioPoolRoyale from './pages/Tools/StoreThumbnailStudioPoolRoyale.jsx';
 
 import Layout from './components/Layout.jsx';
@@ -168,6 +171,22 @@ export default function App() {
             />
             <Route path="/games" element={<Games />} />
             <Route path="/games/transactions" element={<GameTransactions />} />
+            <Route
+              path="/games/mobile-urban-fps"
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Urban Ops FPS…
+                    </div>
+                  }
+                >
+                  <GameLiveAvatarOverlay gameSlug="mobile-urban-fps">
+                    <MobileUrbanFps />
+                  </GameLiveAvatarOverlay>
+                </Suspense>
+              }
+            />
             <Route
               path="/games/runman"
               element={

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -12,6 +12,7 @@ const withBase = (path) => {
 
 export const gameThumbnails = {
   runman: '/assets/icons/runman.svg',
+  'mobile-urban-fps': '/assets/icons/mobile-urban-fps.svg',
   texasholdem: '/assets/icons/Texas%20holdem%20poker%20game%20logo.png',
   'domino-royal': '/assets/icons/Domino%20battle%20Royal%20logo.png',
   poolroyale: '/assets/icons/Pool%20Royal%20game%20logo.png',
@@ -37,6 +38,10 @@ const buildLobbyIconSet = (keys, icon) =>
 
 export const lobbyOptionIcons = {
   runman: buildLobbyIconSet(['mode-local', 'queue-instant'], '/assets/icons/runman.svg'),
+  'mobile-urban-fps': buildLobbyIconSet(
+    ['mode-local', 'queue-instant'],
+    '/assets/icons/mobile-urban-fps.svg'
+  ),
   texasholdem: buildLobbyIconSet(
     [
       'mode-local',

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -1,5 +1,14 @@
 const gamesCatalog = [
   {
+    name: 'Urban Ops FPS',
+    route: '/games/mobile-urban-fps',
+    slug: 'mobile-urban-fps',
+    image: '/assets/icons/mobile-urban-fps.svg',
+    description:
+      'Mobile-first portrait FPS prototype with touch aiming, rifle recoil, city cover, and enemy AI.'
+  },
+
+  {
     name: 'The Maze Battle Royal',
     route: '/games/runman',
     slug: 'runman',

--- a/webapp/src/config/onlineContract.js
+++ b/webapp/src/config/onlineContract.js
@@ -12,6 +12,10 @@ export const ONLINE_READINESS_BY_GAME = Object.freeze({
     checks: { lobby: false, runtime: true, backend: false, security: false },
     label: 'Beta'
   },
+  'mobile-urban-fps': {
+    checks: { lobby: false, runtime: true, backend: false, security: false },
+    label: 'Beta'
+  },
   poolroyale: {
     checks: { lobby: true, runtime: true, backend: true, security: true },
     label: 'Online Ready'

--- a/webapp/src/games/mobileUrbanFps/MobileUrbanFps.css
+++ b/webapp/src/games/mobileUrbanFps/MobileUrbanFps.css
@@ -1,0 +1,216 @@
+.mobile-fps-shell {
+  min-height: calc(100vh - 5.5rem);
+  margin: 0 -0.75rem;
+  display: flex;
+  justify-content: center;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(79, 70, 229, 0.28), transparent 42%),
+    #06070b;
+  color: white;
+  overscroll-behavior: none;
+  touch-action: none;
+}
+
+.mobile-fps-frame {
+  position: relative;
+  width: min(100vw, 430px);
+  height: min(calc(100vh - 5.5rem), 860px);
+  min-height: 640px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 28px;
+  background: #070a10;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.65);
+}
+
+.mobile-fps-canvas {
+  position: absolute;
+  inset: 0;
+}
+.mobile-fps-hud {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-family: Inter, system-ui, sans-serif;
+}
+.mobile-fps-topbar {
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  top: max(12px, env(safe-area-inset-top));
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+.mobile-fps-pill {
+  min-width: 96px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: rgba(5, 8, 14, 0.62);
+  backdrop-filter: blur(12px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+.mobile-fps-label {
+  display: block;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  color: rgba(255, 255, 255, 0.55);
+}
+.mobile-fps-value {
+  font-size: 16px;
+  font-weight: 800;
+}
+.mobile-fps-crosshair {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 34px;
+  height: 34px;
+  transform: translate(-50%, -50%);
+}
+.mobile-fps-crosshair::before,
+.mobile-fps-crosshair::after {
+  content: '';
+  position: absolute;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.45);
+}
+.mobile-fps-crosshair::before {
+  left: 16px;
+  top: 4px;
+  width: 2px;
+  height: 26px;
+}
+.mobile-fps-crosshair::after {
+  left: 4px;
+  top: 16px;
+  width: 26px;
+  height: 2px;
+}
+.mobile-fps-hit {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 54px;
+  height: 54px;
+  transform: translate(-50%, -50%);
+  border: 2px solid rgba(255, 74, 74, 0.9);
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 80ms ease;
+}
+.mobile-fps-hit.active {
+  opacity: 1;
+}
+.mobile-fps-joystick {
+  pointer-events: auto;
+  position: absolute;
+  left: 22px;
+  bottom: max(26px, env(safe-area-inset-bottom));
+  width: 126px;
+  height: 126px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(10px);
+}
+.mobile-fps-stick {
+  position: absolute;
+  left: 43px;
+  top: 43px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, #e8f0ff, #7787a8);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+}
+.mobile-fps-lookzone {
+  pointer-events: auto;
+  position: absolute;
+  right: 0;
+  top: 18%;
+  bottom: 0;
+  width: 58%;
+}
+.mobile-fps-button {
+  pointer-events: auto;
+  position: absolute;
+  right: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  color: white;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  touch-action: none;
+  backdrop-filter: blur(12px);
+}
+.mobile-fps-shoot {
+  bottom: max(34px, env(safe-area-inset-bottom));
+  width: 92px;
+  height: 92px;
+  background: radial-gradient(circle, #ffefe7, #ef4444 50%, #7f1d1d);
+  box-shadow: 0 12px 38px rgba(239, 68, 68, 0.45);
+}
+.mobile-fps-reload {
+  bottom: max(138px, calc(env(safe-area-inset-bottom) + 104px));
+  width: 76px;
+  height: 50px;
+  background: rgba(37, 99, 235, 0.55);
+}
+.mobile-fps-status {
+  position: absolute;
+  left: 18px;
+  right: 18px;
+  bottom: 170px;
+  text-align: center;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.72);
+  text-shadow: 0 2px 8px black;
+}
+.mobile-fps-modal {
+  pointer-events: auto;
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.58);
+  backdrop-filter: blur(8px);
+}
+.mobile-fps-card {
+  width: 100%;
+  max-width: 340px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 24px;
+  padding: 22px;
+  background: linear-gradient(
+    180deg,
+    rgba(17, 24, 39, 0.94),
+    rgba(3, 7, 18, 0.96)
+  );
+  text-align: center;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.65);
+}
+.mobile-fps-card h2 {
+  margin: 0 0 8px;
+  font-size: 24px;
+}
+.mobile-fps-card button {
+  margin-top: 14px;
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 18px;
+  background: #22c55e;
+  color: #02130a;
+  font-weight: 900;
+}
+.mobile-fps-notes {
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 8px;
+  font-size: 9px;
+  color: rgba(255, 255, 255, 0.48);
+  text-align: center;
+}

--- a/webapp/src/games/mobileUrbanFps/MobileUrbanFps.tsx
+++ b/webapp/src/games/mobileUrbanFps/MobileUrbanFps.tsx
@@ -1,0 +1,1117 @@
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { useGLTF } from '@react-three/drei';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { mobileUrbanFpsAssets, assetSourceNotes } from './assetConfig';
+import {
+  DISPLAY_ITEMS,
+  FIRST_PERSON_WEAPON,
+  FPS_HAND_DONOR,
+  TOTAL_ITEMS,
+  type DisplayEntry
+} from './assetCatalog';
+import { rifleStats, useMobileFpsStore } from './store';
+import type { EnemyRuntime } from './types';
+import {
+  ShootAction,
+  type ShootTarget,
+  stableStep
+} from './systems/ShootAction';
+import {
+  attachHandsToWeapon,
+  configureModel,
+  createProceduralMachine,
+  disposeObject,
+  loadModelByUrls,
+  normalizeObject,
+  targetDisplayLength
+} from './systems/AssetLoader';
+import './MobileUrbanFps.css';
+
+const enemySeed: Array<[number, number, number]> = [
+  [-4, 0.9, -11],
+  [3.8, 0.9, -14],
+  [-1.2, 0.9, -19],
+  [5.5, 0.9, -24],
+  [-5.5, 0.9, -27],
+  [0.6, 0.9, -33]
+];
+
+const colliders = [
+  new THREE.Box3(new THREE.Vector3(-8, -1, -36), new THREE.Vector3(8, 4, -35)),
+  new THREE.Box3(new THREE.Vector3(-8, -1, 1), new THREE.Vector3(8, 4, 2)),
+  new THREE.Box3(
+    new THREE.Vector3(-8.5, -1, -36),
+    new THREE.Vector3(-7.5, 4, 2)
+  ),
+  new THREE.Box3(new THREE.Vector3(7.5, -1, -36), new THREE.Vector3(8.5, 4, 2)),
+  new THREE.Box3(
+    new THREE.Vector3(-2.4, -1, -9),
+    new THREE.Vector3(0.4, 2, -7.8)
+  ),
+  new THREE.Box3(
+    new THREE.Vector3(2.4, -1, -17),
+    new THREE.Vector3(5.8, 2, -15.8)
+  ),
+  new THREE.Box3(
+    new THREE.Vector3(-6.4, -1, -22),
+    new THREE.Vector3(-3.6, 2, -20.6)
+  )
+];
+
+function clampPlayer(position: THREE.Vector3) {
+  position.x = THREE.MathUtils.clamp(position.x, -6.8, 6.8);
+  position.z = THREE.MathUtils.clamp(position.z, -34, -0.5);
+  const playerBox = new THREE.Box3().setFromCenterAndSize(
+    position,
+    new THREE.Vector3(0.7, 1.7, 0.7)
+  );
+  for (const box of colliders) {
+    if (playerBox.intersectsBox(box)) {
+      const left = Math.abs(playerBox.max.x - box.min.x);
+      const right = Math.abs(box.max.x - playerBox.min.x);
+      const front = Math.abs(playerBox.max.z - box.min.z);
+      const back = Math.abs(box.max.z - playerBox.min.z);
+      const min = Math.min(left, right, front, back);
+      if (min === left) position.x -= left;
+      else if (min === right) position.x += right;
+      else if (min === front) position.z -= front;
+      else position.z += back;
+    }
+  }
+}
+
+function AssetLoader() {
+  useEffect(() => {
+    useGLTF.preload(mobileUrbanFpsAssets.weapon.rifleGlb);
+    useGLTF.preload(mobileUrbanFpsAssets.hands.armsGlb);
+    useGLTF.preload(mobileUrbanFpsAssets.enemies.soldierGlb);
+    useGLTF.preload(mobileUrbanFpsAssets.city.buildingGlb);
+    useGLTF.preload(mobileUrbanFpsAssets.city.propsGlb);
+  }, []);
+  return null;
+}
+
+function PbrMaterials() {
+  const road = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: '#202025',
+        roughness: 0.84,
+        metalness: 0.02
+      }),
+    []
+  );
+  const concrete = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: '#77736b',
+        roughness: 0.92,
+        metalness: 0.01
+      }),
+    []
+  );
+  const brick = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: '#70463c',
+        roughness: 0.88,
+        metalness: 0.02
+      }),
+    []
+  );
+  const metal = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: '#4b5360',
+        roughness: 0.48,
+        metalness: 0.82
+      }),
+    []
+  );
+  const glass = useMemo(
+    () =>
+      new THREE.MeshPhysicalMaterial({
+        color: '#a5c7dc',
+        roughness: 0.16,
+        metalness: 0,
+        transmission: 0.18,
+        transparent: true,
+        opacity: 0.42
+      }),
+    []
+  );
+  return { road, concrete, brick, metal, glass };
+}
+
+function Building({
+  x,
+  z,
+  height,
+  width,
+  depth,
+  material,
+  glass
+}: {
+  x: number;
+  z: number;
+  height: number;
+  width: number;
+  depth: number;
+  material: THREE.Material;
+  glass: THREE.Material;
+}) {
+  const windows = [];
+  for (let floor = 1; floor < height; floor += 1.5) {
+    windows.push(
+      <mesh
+        key={`w-${floor}`}
+        position={[x, floor, z + depth / 2 + 0.011]}
+        material={glass}
+      >
+        <boxGeometry args={[width * 0.62, 0.58, 0.03]} />
+      </mesh>
+    );
+  }
+  return (
+    <group>
+      <mesh
+        position={[x, height / 2, z]}
+        material={material}
+        castShadow
+        receiveShadow
+      >
+        <boxGeometry args={[width, height, depth]} />
+      </mesh>
+      {windows}
+      <mesh position={[x, height + 0.05, z]} material={material} receiveShadow>
+        <boxGeometry args={[width + 0.35, 0.1, depth + 0.35]} />
+      </mesh>
+    </group>
+  );
+}
+
+function UrbanArena() {
+  const mats = PbrMaterials();
+  const lampPositions = [-4, 4];
+  const cover = [
+    [-1, 0.55, -8.6, 2.8, 1.1, 1],
+    [4.1, 0.55, -16.4, 3.4, 1.1, 1.1],
+    [-5, 0.55, -21.5, 2.8, 1.1, 1.4]
+  ];
+  return (
+    <group>
+      <fog attach="fog" args={['#111827', 18, 48]} />
+      <mesh rotation-x={-Math.PI / 2} material={mats.road} receiveShadow>
+        <planeGeometry args={[16, 40]} />
+      </mesh>
+      <mesh
+        position={[-5.2, 0.012, -17]}
+        rotation-x={-Math.PI / 2}
+        material={mats.concrete}
+        receiveShadow
+      >
+        <planeGeometry args={[4.2, 38]} />
+      </mesh>
+      <mesh
+        position={[5.2, 0.012, -17]}
+        rotation-x={-Math.PI / 2}
+        material={mats.concrete}
+        receiveShadow
+      >
+        <planeGeometry args={[4.2, 38]} />
+      </mesh>
+      {[-7.1, 7.1].map((x) =>
+        [-5, -12, -20, -29].map((z, i) => (
+          <Building
+            key={`${x}-${z}`}
+            x={x}
+            z={z}
+            width={2.2 + (i % 2)}
+            depth={2.8}
+            height={5 + i * 0.9}
+            material={i % 2 ? mats.brick : mats.concrete}
+            glass={mats.glass}
+          />
+        ))
+      )}
+      {cover.map(([x, y, z, w, h, d], i) => (
+        <mesh
+          key={i}
+          position={[x, y, z]}
+          material={i === 1 ? mats.metal : mats.concrete}
+          castShadow
+          receiveShadow
+        >
+          <boxGeometry args={[w, h, d]} />
+        </mesh>
+      ))}
+      {[-12, -18, -26].map((z) => (
+        <group key={z} position={[0, 0, z]}>
+          <mesh
+            position={[-2.8, 0.45, 0]}
+            material={mats.metal}
+            castShadow
+            receiveShadow
+          >
+            <boxGeometry args={[1, 0.9, 1.2]} />
+          </mesh>
+          <mesh
+            position={[2.2, 0.35, 0.7]}
+            material={mats.brick}
+            castShadow
+            receiveShadow
+          >
+            <boxGeometry args={[1.2, 0.7, 1.2]} />
+          </mesh>
+        </group>
+      ))}
+      {lampPositions.map((x) =>
+        [-6, -18, -30].map((z) => (
+          <group key={`${x}-${z}`} position={[x, 0, z]}>
+            <mesh position={[0, 1.8, 0]} material={mats.metal} castShadow>
+              <cylinderGeometry args={[0.045, 0.06, 3.6, 8]} />
+            </mesh>
+            <pointLight
+              position={[0, 3.4, 0]}
+              intensity={1.2}
+              distance={8}
+              color="#f4c982"
+            />
+            <mesh position={[0, 3.38, 0]} material={mats.glass}>
+              <sphereGeometry args={[0.15, 12, 8]} />
+            </mesh>
+          </group>
+        ))
+      )}
+    </group>
+  );
+}
+
+type RuntimeDisplayAsset = {
+  entry: DisplayEntry;
+  root: THREE.Object3D;
+  mixer?: THREE.AnimationMixer;
+  basePosition: THREE.Vector3;
+  baseRotation: THREE.Euler;
+  index: number;
+};
+
+function assetSlotPosition(index: number) {
+  const col = index % 3;
+  const row = Math.floor(index / 3);
+  return new THREE.Vector3(-4.8 + col * 4.8, 0.18, -6.5 - row * 3.15);
+}
+
+function AssetArmory() {
+  const groupRef = useRef<THREE.Group>(null);
+  const runtimes = useRef<RuntimeDisplayAsset[]>([]);
+  const { gl } = useThree();
+
+  useEffect(() => {
+    const mountedGroup = groupRef.current;
+    if (!mountedGroup) return undefined;
+    const liveGroup: THREE.Group = mountedGroup;
+    let disposed = false;
+    const loadedRoots: THREE.Object3D[] = [];
+
+    async function loadDonor() {
+      try {
+        const { gltf } = await loadModelByUrls(
+          'FPS donor hands',
+          FPS_HAND_DONOR.urls,
+          12000
+        );
+        if (disposed) return null;
+        configureModel(gltf.scene, gl, { mobileMaxAnisotropy: 2 });
+        return gltf.scene;
+      } catch (error) {
+        console.warn(
+          'Urban FPS donor hands unavailable; weapons still load without cloned hands.',
+          error
+        );
+        return null;
+      }
+    }
+
+    async function loadEntry(
+      entry: DisplayEntry,
+      index: number,
+      donorScene: THREE.Object3D | null
+    ) {
+      if (disposed) return;
+      const slot = new THREE.Group();
+      slot.position.copy(assetSlotPosition(index));
+      slot.rotation.y = Math.PI;
+      liveGroup.add(slot);
+      loadedRoots.push(slot);
+
+      try {
+        const { gltf } = await loadModelByUrls(entry.name, entry.urls, 14000);
+        if (disposed) return;
+        const model = gltf.scene;
+        configureModel(model, gl, { mobileMaxAnisotropy: 2 });
+        normalizeObject(model, targetDisplayLength(entry) * 0.72);
+        model.rotation.x =
+          entry.rotateX ?? (entry.kind === 'weapon' ? -0.06 : 0);
+        model.rotation.y =
+          (entry.rotateY ?? 0) + (entry.kind === 'weapon' ? Math.PI : 0);
+        attachHandsToWeapon(entry, model, donorScene, gl);
+        slot.add(model);
+        const mixer = gltf.animations.length
+          ? new THREE.AnimationMixer(model)
+          : undefined;
+        if (mixer) {
+          gltf.animations.forEach((clip) =>
+            mixer
+              .clipAction(clip)
+              .setLoop(THREE.LoopRepeat, Infinity)
+              .reset()
+              .play()
+          );
+        }
+        runtimes.current.push({
+          entry,
+          root: model,
+          mixer,
+          basePosition: model.position.clone(),
+          baseRotation: model.rotation.clone(),
+          index
+        });
+      } catch (error) {
+        console.warn(
+          'Urban FPS asset fell back to procedural stand-in:',
+          entry.name,
+          error
+        );
+        const fallback = createProceduralMachine(entry);
+        normalizeObject(fallback, targetDisplayLength(entry) * 0.72);
+        fallback.rotation.y = entry.rotateY ?? 0;
+        slot.add(fallback);
+        runtimes.current.push({
+          entry,
+          root: fallback,
+          basePosition: fallback.position.clone(),
+          baseRotation: fallback.rotation.clone(),
+          index
+        });
+      }
+    }
+
+    async function loadAll() {
+      const donorScene = await loadDonor();
+      await Promise.allSettled(
+        DISPLAY_ITEMS.map((entry, index) => loadEntry(entry, index, donorScene))
+      );
+    }
+
+    loadAll();
+
+    return () => {
+      disposed = true;
+      runtimes.current.forEach((runtime) => disposeObject(runtime.root));
+      loadedRoots.forEach((root) => liveGroup.remove(root));
+      runtimes.current = [];
+    };
+  }, [gl]);
+
+  useFrame((_, dt) => {
+    const elapsed = performance.now() / 1000;
+    runtimes.current.forEach((runtime) => {
+      runtime.mixer?.update(Math.min(dt, 0.05));
+      const offset = runtime.index * 0.61;
+      const isWeapon = runtime.entry.kind === 'weapon';
+      const isFloating =
+        runtime.entry.kind === 'aircraft' || runtime.entry.kind === 'equipment';
+      const idle = Math.sin(elapsed * 2.2 + offset) * 0.018;
+      const float =
+        Math.sin(elapsed * (1.35 + offset * 0.03)) *
+        (runtime.entry.floatAmp ?? 0.0);
+      const sway = Math.sin(elapsed * 1.25 + offset) * 0.028;
+      runtime.root.position.y = THREE.MathUtils.lerp(
+        runtime.root.position.y,
+        runtime.basePosition.y +
+          (isWeapon ? idle : 0) +
+          (isFloating ? float : 0),
+        0.16
+      );
+      runtime.root.rotation.y = THREE.MathUtils.lerp(
+        runtime.root.rotation.y,
+        runtime.baseRotation.y +
+          (isWeapon
+            ? sway
+            : isFloating
+              ? elapsed * (runtime.entry.spinSpeed ?? 0.0006)
+              : 0),
+        0.12
+      );
+      runtime.root.traverse((obj) => {
+        if (obj.name === 'procedural-propeller') obj.rotation.x = elapsed * 28;
+      });
+    });
+  });
+
+  return (
+    <group ref={groupRef}>
+      <mesh position={[0, 0.04, -19]} receiveShadow>
+        <boxGeometry args={[14.8, 0.08, 29.5]} />
+        <meshStandardMaterial
+          color="#10151f"
+          roughness={0.82}
+          metalness={0.08}
+        />
+      </mesh>
+      <mesh position={[0, 0.1, -19]} receiveShadow>
+        <boxGeometry args={[15.1, 0.1, 30.2]} />
+        <meshStandardMaterial
+          color="#252b35"
+          roughness={0.78}
+          metalness={0.16}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+function FirstPersonWeaponAsset({
+  visible,
+  onReady
+}: {
+  visible: boolean;
+  onReady: () => void;
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+  const { gl } = useThree();
+
+  useEffect(() => {
+    const mountedGroup = groupRef.current;
+    if (!mountedGroup) return undefined;
+    const liveGroup: THREE.Group = mountedGroup;
+    let disposed = false;
+    let root: THREE.Object3D | null = null;
+
+    async function loadFirstPersonRig() {
+      try {
+        const [weaponResult, donorResult] = await Promise.allSettled([
+          loadModelByUrls(
+            FIRST_PERSON_WEAPON.name,
+            FIRST_PERSON_WEAPON.urls,
+            14000
+          ),
+          loadModelByUrls('FPS donor hands', FPS_HAND_DONOR.urls, 14000)
+        ]);
+        if (disposed || weaponResult.status !== 'fulfilled') return;
+        const weapon = weaponResult.value.gltf.scene;
+        const donorScene =
+          donorResult.status === 'fulfilled'
+            ? donorResult.value.gltf.scene
+            : null;
+        configureModel(weapon, gl, {
+          frustumCulled: false,
+          mobileMaxAnisotropy: 2
+        });
+        if (donorScene)
+          configureModel(donorScene, gl, {
+            frustumCulled: false,
+            mobileMaxAnisotropy: 2
+          });
+        normalizeObject(weapon, 0.86);
+        weapon.position.set(0, 0.02, 0);
+        weapon.rotation.set(-0.04, Math.PI, 0);
+        attachHandsToWeapon(FIRST_PERSON_WEAPON, weapon, donorScene, gl);
+        root = weapon;
+        liveGroup.add(weapon);
+        onReady();
+      } catch (error) {
+        console.warn(
+          'Urban FPS first-person GLTF rig unavailable; using procedural fallback.',
+          error
+        );
+      }
+    }
+
+    loadFirstPersonRig();
+
+    return () => {
+      disposed = true;
+      if (root) {
+        liveGroup.remove(root);
+        disposeObject(root);
+      }
+    };
+  }, [gl, onReady]);
+
+  useFrame(() => {
+    if (!groupRef.current) return;
+    const recoil = useMobileFpsStore.getState().recoil;
+    groupRef.current.position.z = -0.86 + recoil * 2.4;
+    groupRef.current.position.y = -0.42 - recoil * 0.75;
+  });
+
+  return (
+    <group
+      ref={groupRef}
+      visible={visible}
+      position={[0.48, -0.42, -0.86]}
+      rotation={[0.03, -0.08, 0]}
+    />
+  );
+}
+
+function WeaponView() {
+  const [assetReady, setAssetReady] = useState(false);
+  const muzzleFlashUntil = useMobileFpsStore((state) => state.muzzleFlashUntil);
+  const now = performance.now();
+  const rifleMetal = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: '#24272d',
+        roughness: 0.38,
+        metalness: 0.92
+      }),
+    []
+  );
+  const wornWood = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: '#5c3822',
+        roughness: 0.68,
+        metalness: 0.04
+      }),
+    []
+  );
+  const leather = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: '#2b1c16',
+        roughness: 0.86,
+        metalness: 0.02
+      }),
+    []
+  );
+  return (
+    <>
+      <FirstPersonWeaponAsset
+        visible={assetReady}
+        onReady={() => setAssetReady(true)}
+      />
+      <group
+        visible={!assetReady}
+        position={[0.48, -0.42, -0.86]}
+        rotation={[0.03, -0.08, 0]}
+      >
+        <mesh material={wornWood} castShadow>
+          <boxGeometry args={[0.18, 0.16, 0.78]} />
+        </mesh>
+        <mesh position={[0, 0.08, -0.55]} material={rifleMetal} castShadow>
+          <boxGeometry args={[0.12, 0.1, 1.08]} />
+        </mesh>
+        <mesh
+          position={[0, 0.08, -1.2]}
+          rotation-x={Math.PI / 2}
+          material={rifleMetal}
+          castShadow
+        >
+          <cylinderGeometry args={[0.038, 0.048, 0.7, 16]} />
+        </mesh>
+        <mesh position={[-0.15, -0.11, -0.18]} material={leather} castShadow>
+          <boxGeometry args={[0.12, 0.24, 0.32]} />
+        </mesh>
+        {now < muzzleFlashUntil && (
+          <pointLight
+            position={[0, 0.1, -1.62]}
+            intensity={7}
+            distance={4}
+            color="#ffb15c"
+          />
+        )}
+        {now < muzzleFlashUntil && (
+          <mesh
+            position={[0, 0.1, -1.58]}
+            material={
+              new THREE.MeshBasicMaterial({
+                color: '#ffdd8a',
+                transparent: true,
+                opacity: 0.82
+              })
+            }
+          >
+            <coneGeometry args={[0.18, 0.5, 12]} />
+          </mesh>
+        )}
+      </group>
+      {now < muzzleFlashUntil && assetReady && (
+        <pointLight
+          position={[0.48, -0.32, -2.44]}
+          intensity={7}
+          distance={4}
+          color="#ffb15c"
+        />
+      )}
+    </>
+  );
+}
+
+function EnemyMesh({
+  enemy,
+  register
+}: {
+  enemy: EnemyRuntime;
+  register: (target: ShootTarget | null) => void;
+}) {
+  const ref = useRef<THREE.Group>(null);
+  const body = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: '#52605a',
+        roughness: 0.78,
+        metalness: 0.05
+      }),
+    []
+  );
+  const vest = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: '#22272c',
+        roughness: 0.62,
+        metalness: 0.18
+      }),
+    []
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+    register({
+      id: enemy.id,
+      object: ref.current,
+      applyDamage: (damage) => {
+        enemy.health = Math.max(0, enemy.health - damage);
+        enemy.hitFlash = 0.12;
+      }
+    });
+    return () => register(null);
+  }, [enemy, register]);
+
+  useFrame((_, dt) => {
+    if (!ref.current) return;
+    ref.current.position.copy(enemy.position);
+    enemy.hitFlash = Math.max(0, enemy.hitFlash - dt);
+    ref.current.visible = enemy.state !== 'dead';
+  });
+
+  return (
+    <group ref={ref}>
+      <mesh
+        position={[0, 0.05, 0]}
+        material={
+          enemy.hitFlash > 0
+            ? new THREE.MeshBasicMaterial({ color: '#ff4d4d' })
+            : vest
+        }
+        castShadow
+      >
+        <capsuleGeometry args={[0.34, 0.78, 6, 10]} />
+      </mesh>
+      <mesh position={[0, 0.78, 0]} material={body} castShadow>
+        <sphereGeometry args={[0.24, 12, 10]} />
+      </mesh>
+      <mesh position={[0, -0.43, 0.12]} material={body} castShadow>
+        <boxGeometry args={[0.55, 0.34, 0.22]} />
+      </mesh>
+    </group>
+  );
+}
+
+function TracerLine({
+  from,
+  to,
+  material
+}: {
+  from: [number, number, number];
+  to: [number, number, number];
+  material: THREE.LineBasicMaterial;
+}) {
+  const line = useMemo(() => {
+    const geometry = new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(...from),
+      new THREE.Vector3(...to)
+    ]);
+    return new THREE.Line(geometry, material);
+  }, [from, material, to]);
+  useEffect(() => () => line.geometry.dispose(), [line]);
+  return <primitive object={line} />;
+}
+
+function Effects() {
+  const tracers = useMobileFpsStore((state) => state.tracers);
+  const impacts = useMobileFpsStore((state) => state.impacts);
+  const tracerMaterial = useMemo(
+    () =>
+      new THREE.LineBasicMaterial({
+        color: '#ffe7a3',
+        transparent: true,
+        opacity: 0.9
+      }),
+    []
+  );
+  const impactMaterial = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: '#ffb86b',
+        transparent: true,
+        opacity: 0.62
+      }),
+    []
+  );
+  return (
+    <group>
+      {tracers.map((tracer) => (
+        <TracerLine
+          key={tracer.id}
+          from={tracer.from}
+          to={tracer.to}
+          material={tracerMaterial}
+        />
+      ))}
+      {impacts.map((impact) => (
+        <mesh
+          key={impact.id}
+          position={impact.position}
+          material={impactMaterial}
+        >
+          <sphereGeometry args={[0.11 + impact.life * 0.16, 8, 8]} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function CameraController({ enemies }: { enemies: EnemyRuntime[] }) {
+  const { camera } = useThree();
+  const yaw = useRef(0);
+  const pitch = useRef(0);
+  const player = useRef(new THREE.Vector3(0, 1.55, -1.2));
+  const fixedAccumulator = useRef(0);
+  const shootAction = useMemo(() => new ShootAction(), []);
+  const targets = useRef<Map<string, ShootTarget>>(new Map());
+
+  useEffect(() => {
+    camera.position.copy(player.current);
+    camera.rotation.order = 'YXZ';
+  }, [camera]);
+
+  useFrame((_, dt) => {
+    const state = useMobileFpsStore.getState();
+    state.tickFx(dt);
+    state.recoverRecoil(rifleStats.recoilRecovery * dt * 0.02);
+    if (state.phase !== 'playing') return;
+
+    const lookSensitivity = 2.45;
+    yaw.current -= state.input.lookX * lookSensitivity * dt;
+    pitch.current = THREE.MathUtils.clamp(
+      pitch.current - state.input.lookY * lookSensitivity * dt - state.recoil,
+      -1.1,
+      1.05
+    );
+    state.setInput({ lookX: 0, lookY: 0 });
+
+    fixedAccumulator.current += Math.min(dt, 0.05);
+    while (fixedAccumulator.current >= stableStep) {
+      const forward = new THREE.Vector3(
+        Math.sin(yaw.current),
+        0,
+        Math.cos(yaw.current) * -1
+      );
+      const right = new THREE.Vector3(
+        Math.cos(yaw.current),
+        0,
+        Math.sin(yaw.current)
+      );
+      const move = forward
+        .multiplyScalar(state.input.moveY)
+        .add(right.multiplyScalar(state.input.moveX));
+      if (move.lengthSq() > 1) move.normalize();
+      player.current.addScaledVector(move, 4.2 * stableStep);
+      clampPlayer(player.current);
+      updateEnemies(enemies, player.current, stableStep);
+      fixedAccumulator.current -= stableStep;
+    }
+
+    const alive = enemies.filter((enemy) => enemy.state !== 'dead').length;
+    state.setEnemiesAlive(alive);
+    camera.position.lerp(player.current, 0.72);
+    camera.rotation.set(pitch.current, yaw.current, 0);
+    shootAction.update(
+      performance.now(),
+      Array.from(targets.current.values()),
+      camera
+    );
+  });
+
+  return (
+    <>
+      {enemies.map((enemy) => (
+        <EnemyMesh
+          key={enemy.id}
+          enemy={enemy}
+          register={(target) => {
+            if (target) targets.current.set(enemy.id, target);
+            else targets.current.delete(enemy.id);
+          }}
+        />
+      ))}
+      <primitive object={camera}>
+        <WeaponView />
+      </primitive>
+    </>
+  );
+}
+
+function updateEnemies(
+  enemies: EnemyRuntime[],
+  player: THREE.Vector3,
+  dt: number
+) {
+  const store = useMobileFpsStore.getState();
+  for (const enemy of enemies) {
+    if (enemy.health <= 0) {
+      enemy.state = 'dead';
+      continue;
+    }
+    const toPlayer = player.clone().sub(enemy.position);
+    const distance = toPlayer.length();
+    if (distance < 1.45) {
+      enemy.state = 'attack';
+      enemy.attackCooldown -= dt;
+      if (enemy.attackCooldown <= 0) {
+        store.damagePlayer(8);
+        enemy.attackCooldown = 0.95;
+      }
+      continue;
+    }
+    enemy.state = distance < 11 ? 'chase' : 'patrol';
+    const target = enemy.state === 'chase' ? player : enemy.patrolTarget;
+    const desired = target.clone().sub(enemy.position);
+    desired.y = 0;
+    if (desired.length() < 0.25 && enemy.state === 'patrol') {
+      enemy.patrolTarget.set(
+        enemy.position.x + (Math.random() - 0.5) * 3,
+        enemy.position.y,
+        enemy.position.z + (Math.random() - 0.5) * 3
+      );
+    } else {
+      desired.normalize();
+      enemy.position.addScaledVector(
+        desired,
+        (enemy.state === 'chase' ? 1.45 : 0.55) * dt
+      );
+    }
+  }
+}
+
+const Scene = memo(function Scene() {
+  const enemies = useMemo<EnemyRuntime[]>(
+    () =>
+      enemySeed.map((pos, index) => ({
+        id: `enemy-${index}`,
+        position: new THREE.Vector3(...pos),
+        patrolTarget: new THREE.Vector3(
+          pos[0] + (index % 2 ? 1.8 : -1.4),
+          pos[1],
+          pos[2] - 1.2
+        ),
+        health: 100,
+        maxHealth: 100,
+        state: 'idle',
+        attackCooldown: 0.7,
+        hitFlash: 0
+      })),
+    []
+  );
+  return (
+    <>
+      <AssetLoader />
+      <ambientLight intensity={0.42} />
+      <directionalLight
+        position={[3, 8, 2]}
+        intensity={2.3}
+        castShadow
+        shadow-mapSize={[1024, 1024]}
+      />
+      <hemisphereLight args={['#9fb7ff', '#1f2937', 0.65]} />
+      <UrbanArena />
+      <AssetArmory />
+      <CameraController enemies={enemies} />
+      <Effects />
+    </>
+  );
+});
+
+function TouchHud() {
+  const health = useMobileFpsStore((state) => state.health);
+  const ammo = useMobileFpsStore((state) => state.ammo);
+  const reserveAmmo = useMobileFpsStore((state) => state.reserveAmmo);
+  const reloading = useMobileFpsStore((state) => state.reloading);
+  const enemiesAlive = useMobileFpsStore((state) => state.enemiesAlive);
+  const phase = useMobileFpsStore((state) => state.phase);
+  const hitMarkerUntil = useMobileFpsStore((state) => state.hitMarkerUntil);
+  const setInput = useMobileFpsStore((state) => state.setInput);
+  const reset = useMobileFpsStore((state) => state.reset);
+  const stick = useRef<HTMLDivElement>(null);
+  const joystickId = useRef<number | null>(null);
+  const lookId = useRef<number | null>(null);
+  const lookLast = useRef({ x: 0, y: 0 });
+
+  const resetStick = () => {
+    joystickId.current = null;
+    setInput({ moveX: 0, moveY: 0 });
+    if (stick.current) stick.current.style.transform = 'translate(0px, 0px)';
+  };
+
+  return (
+    <div className="mobile-fps-hud">
+      <div className="mobile-fps-topbar">
+        <div className="mobile-fps-pill">
+          <span className="mobile-fps-label">HEALTH</span>
+          <span className="mobile-fps-value">{health}</span>
+        </div>
+        <div className="mobile-fps-pill">
+          <span className="mobile-fps-label">AMMO</span>
+          <span className="mobile-fps-value">
+            {reloading ? 'RELOAD' : `${ammo}/${reserveAmmo}`}
+          </span>
+        </div>
+        <div className="mobile-fps-pill">
+          <span className="mobile-fps-label">TARGETS</span>
+          <span className="mobile-fps-value">{enemiesAlive}</span>
+        </div>
+      </div>
+      <div className="mobile-fps-crosshair" />
+      <div
+        className={`mobile-fps-hit ${performance.now() < hitMarkerUntil ? 'active' : ''}`}
+      />
+      <div
+        className="mobile-fps-joystick"
+        onPointerDown={(event) => {
+          joystickId.current = event.pointerId;
+          event.currentTarget.setPointerCapture(event.pointerId);
+        }}
+        onPointerMove={(event) => {
+          if (joystickId.current !== event.pointerId) return;
+          const rect = event.currentTarget.getBoundingClientRect();
+          const dx = event.clientX - (rect.left + rect.width / 2);
+          const dy = event.clientY - (rect.top + rect.height / 2);
+          const len = Math.min(48, Math.hypot(dx, dy));
+          const angle = Math.atan2(dy, dx);
+          const x = Math.cos(angle) * len;
+          const y = Math.sin(angle) * len;
+          setInput({ moveX: x / 48, moveY: -y / 48 });
+          if (stick.current)
+            stick.current.style.transform = `translate(${x}px, ${y}px)`;
+        }}
+        onPointerCancel={resetStick}
+        onPointerUp={resetStick}
+      >
+        <div ref={stick} className="mobile-fps-stick" />
+      </div>
+      <div
+        className="mobile-fps-lookzone"
+        onPointerDown={(event) => {
+          lookId.current = event.pointerId;
+          lookLast.current = { x: event.clientX, y: event.clientY };
+          event.currentTarget.setPointerCapture(event.pointerId);
+        }}
+        onPointerMove={(event) => {
+          if (lookId.current !== event.pointerId) return;
+          const dx = event.clientX - lookLast.current.x;
+          const dy = event.clientY - lookLast.current.y;
+          lookLast.current = { x: event.clientX, y: event.clientY };
+          setInput({
+            lookX: THREE.MathUtils.clamp(dx / 44, -1, 1),
+            lookY: THREE.MathUtils.clamp(dy / 44, -1, 1)
+          });
+        }}
+        onPointerUp={() => {
+          lookId.current = null;
+          setInput({ lookX: 0, lookY: 0 });
+        }}
+        onPointerCancel={() => {
+          lookId.current = null;
+          setInput({ lookX: 0, lookY: 0 });
+        }}
+      />
+      <button
+        className="mobile-fps-button mobile-fps-reload"
+        onPointerDown={() => setInput({ reloading: true })}
+      >
+        RELOAD
+      </button>
+      <button
+        className="mobile-fps-button mobile-fps-shoot"
+        onPointerDown={() => setInput({ firing: true })}
+        onPointerUp={() => setInput({ firing: false })}
+        onPointerCancel={() => setInput({ firing: false })}
+      >
+        FIRE
+      </button>
+      <div className="mobile-fps-status">
+        Left thumb moves · right drag aims · {TOTAL_ITEMS} loaded asset slots
+      </div>
+      {phase !== 'playing' && (
+        <div className="mobile-fps-modal">
+          <div className="mobile-fps-card">
+            <h2>{phase === 'won' ? 'Zone cleared' : 'You were downed'}</h2>
+            <p>
+              {phase === 'won'
+                ? 'All enemy targets neutralized.'
+                : 'Use cover, reload early, and keep distance.'}
+            </p>
+            <button
+              onClick={() => {
+                reset();
+                window.location.reload();
+              }}
+            >
+              Restart Mission
+            </button>
+          </div>
+        </div>
+      )}
+      <div className="mobile-fps-notes">
+        PBR/GLB paths are configurable; mobile build targets low draw calls,
+        simple colliders, no heavy postprocessing.
+      </div>
+    </div>
+  );
+}
+
+export default function MobileUrbanFps() {
+  useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
+  return (
+    <main
+      className="mobile-fps-shell"
+      aria-label="Mobile portrait FPS preview frame"
+    >
+      <section className="mobile-fps-frame">
+        <Canvas
+          className="mobile-fps-canvas"
+          shadows
+          dpr={[1, 1.65]}
+          gl={{ antialias: false, powerPreference: 'high-performance' }}
+          camera={{ fov: 68, near: 0.08, far: 58, position: [0, 1.55, -1.2] }}
+        >
+          <Scene />
+        </Canvas>
+        <TouchHud />
+      </section>
+      <div className="sr-only">{assetSourceNotes.join(' ')}</div>
+    </main>
+  );
+}

--- a/webapp/src/games/mobileUrbanFps/assetCatalog.ts
+++ b/webapp/src/games/mobileUrbanFps/assetCatalog.ts
@@ -1,0 +1,544 @@
+export type HandMode = 'right' | 'both';
+export type GripPreset = 'pistol' | 'rifle' | 'sniper';
+export type ItemKind = 'weapon' | 'vehicle' | 'aircraft' | 'equipment';
+
+export type DisplayEntry = {
+  id: string;
+  name: string;
+  shortName: string;
+  source: 'Quaternius' | 'Extra' | 'Vehicle' | 'Aircraft' | 'Equipment';
+  kind: ItemKind;
+  urls: string[];
+  handMode?: HandMode;
+  gripPreset?: GripPreset;
+  rotateY?: number;
+  rotateX?: number;
+  displayLength?: number;
+  floatAmp?: number;
+  spinSpeed?: number;
+  fallbackColor?: string;
+};
+
+export type HandTransform = {
+  position: [number, number, number];
+  rotation: [number, number, number];
+};
+
+export type GripProfile = {
+  right: HandTransform;
+  left?: HandTransform;
+};
+
+export const WEAPON_COUNT = 18;
+export const VEHICLE_COUNT = 2;
+export const AIRCRAFT_COUNT = 3;
+export const EQUIPMENT_COUNT = 3;
+export const TOTAL_ITEMS =
+  WEAPON_COUNT + VEHICLE_COUNT + AIRCRAFT_COUNT + EQUIPMENT_COUNT;
+
+export const FPS_SHOTGUN_DISPLAY_LENGTH = 1.18;
+export const VEHICLE_DISPLAY_LENGTH = 1.55;
+export const AIRCRAFT_DISPLAY_LENGTH = 1.7;
+export const EQUIPMENT_DISPLAY_LENGTH = 1.7;
+
+const HAND_SIZE_BY_TYPE = {
+  pistolRight: 0.052,
+  rifleRight: 0.058,
+  rifleLeft: 0.054,
+  sniperRight: 0.058,
+  sniperLeft: 0.054
+};
+
+function polyGlb(uuid: string) {
+  return `https://static.poly.pizza/${uuid}.glb`;
+}
+
+const SAMPLE =
+  'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0';
+const RAW_SAMPLE =
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0';
+const FERRARI = 'https://threejs.org/examples/models/gltf/ferrari.glb';
+const BUGGY = `${SAMPLE}/Buggy/glTF-Binary/Buggy.glb`;
+const BUGGY_RAW = `${RAW_SAMPLE}/Buggy/glTF-Binary/Buggy.glb`;
+
+const MILITARY_HOSTS = [
+  'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main',
+  'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main',
+  'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main'
+] as const;
+
+function militaryUrls(filename: string) {
+  return MILITARY_HOSTS.map((host) => `${host}/${filename}`);
+}
+
+export const KNOWN_WORKING_GLB = {
+  awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
+  awpRaw:
+    'https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb',
+  mrtk: 'https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  mrtkRaw:
+    'https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  mrtkMaster:
+    'https://cdn.jsdelivr.net/gh/Microsoft/MixedRealityToolkit@master/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  pistolHolster:
+    'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
+  pistolHolsterRaw:
+    'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
+  fps: 'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
+  fpsRaw:
+    'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf'
+};
+
+export const QUATERNIUS_WEAPONS: DisplayEntry[] = [
+  {
+    id: 'poly-shotgun-01',
+    name: 'Quaternius Shotgun',
+    shortName: 'Shotgun',
+    source: 'Quaternius',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')]
+  },
+  {
+    id: 'poly-assault-rifle-01',
+    name: 'Quaternius Assault Rifle',
+    shortName: 'Assault Rifle',
+    source: 'Quaternius',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')]
+  },
+  {
+    id: 'poly-pistol-01',
+    name: 'Quaternius Pistol',
+    shortName: 'Pistol',
+    source: 'Quaternius',
+    kind: 'weapon',
+    handMode: 'right',
+    gripPreset: 'pistol',
+    urls: [polyGlb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc')]
+  },
+  {
+    id: 'poly-revolver-01',
+    name: 'Quaternius Heavy Revolver',
+    shortName: 'Heavy Revolver',
+    source: 'Quaternius',
+    kind: 'weapon',
+    handMode: 'right',
+    gripPreset: 'pistol',
+    urls: [polyGlb('9e728565-67a3-44db-9567-982320abff09')]
+  },
+  {
+    id: 'poly-sawed-off-01',
+    name: 'Quaternius Sawed-Off Shotgun',
+    shortName: 'Sawed-Off',
+    source: 'Quaternius',
+    kind: 'weapon',
+    handMode: 'right',
+    gripPreset: 'pistol',
+    urls: [polyGlb('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e')]
+  },
+  {
+    id: 'poly-revolver-02',
+    name: 'Quaternius Revolver Silver',
+    shortName: 'Silver Revolver',
+    source: 'Quaternius',
+    kind: 'weapon',
+    handMode: 'right',
+    gripPreset: 'pistol',
+    urls: [polyGlb('7951b3b9-d3a5-4ec8-81b7-11111f1c8e88')]
+  },
+  {
+    id: 'poly-shotgun-02',
+    name: 'Quaternius Long Shotgun',
+    shortName: 'Long Shotgun',
+    source: 'Quaternius',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [polyGlb('f71d6771-f512-4374-bd23-ba00b564db68')]
+  },
+  {
+    id: 'poly-shotgun-03',
+    name: 'Quaternius Pump Shotgun',
+    shortName: 'Pump Shotgun',
+    source: 'Quaternius',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [polyGlb('08f27141-8e64-425a-9161-1bbd6956dfca')]
+  },
+  {
+    id: 'poly-smg-01',
+    name: 'Quaternius Submachine Gun',
+    shortName: 'SMG',
+    source: 'Quaternius',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [polyGlb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710')]
+  }
+];
+
+export const EXTRA_WEAPONS: DisplayEntry[] = [
+  {
+    id: 'slot-10-ak47-gltf',
+    name: 'AK47 GLTF',
+    shortName: 'AK47',
+    source: 'Extra',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
+      KNOWN_WORKING_GLB.awp,
+      KNOWN_WORKING_GLB.awpRaw
+    ]
+  },
+  {
+    id: 'slot-11-krsv-gltf',
+    name: 'KRSV GLTF',
+    shortName: 'KRSV',
+    source: 'Extra',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf',
+      KNOWN_WORKING_GLB.mrtk,
+      KNOWN_WORKING_GLB.mrtkRaw
+    ]
+  },
+  {
+    id: 'slot-12-smith-gltf',
+    name: 'Smith GLTF',
+    shortName: 'Smith',
+    source: 'Extra',
+    kind: 'weapon',
+    handMode: 'right',
+    gripPreset: 'pistol',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
+      KNOWN_WORKING_GLB.pistolHolster,
+      KNOWN_WORKING_GLB.pistolHolsterRaw
+    ]
+  },
+  {
+    id: 'slot-13-mosin-gltf',
+    name: 'Mosin GLTF',
+    shortName: 'Mosin',
+    source: 'Extra',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'sniper',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
+      KNOWN_WORKING_GLB.awp,
+      KNOWN_WORKING_GLB.awpRaw
+    ]
+  },
+  {
+    id: 'slot-14-uzi-gltf',
+    name: 'Uzi GLTF',
+    shortName: 'Uzi',
+    source: 'Extra',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf',
+      KNOWN_WORKING_GLB.mrtk,
+      KNOWN_WORKING_GLB.mrtkMaster
+    ]
+  },
+  {
+    id: 'slot-15-sigsauer-gltf',
+    name: 'SigSauer GLTF',
+    shortName: 'SigSauer',
+    source: 'Extra',
+    kind: 'weapon',
+    handMode: 'right',
+    gripPreset: 'pistol',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf',
+      KNOWN_WORKING_GLB.pistolHolster,
+      KNOWN_WORKING_GLB.pistolHolsterRaw
+    ]
+  },
+  {
+    id: 'slot-16-awp-glb',
+    name: 'AWP Sniper GLB',
+    shortName: 'AWP Sniper',
+    source: 'Extra',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'sniper',
+    urls: [KNOWN_WORKING_GLB.awp, KNOWN_WORKING_GLB.awpRaw]
+  },
+  {
+    id: 'slot-17-mrtk-gun-glb',
+    name: 'MRTK Gun GLB',
+    shortName: 'MRTK Gun',
+    source: 'Extra',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [
+      KNOWN_WORKING_GLB.mrtk,
+      KNOWN_WORKING_GLB.mrtkRaw,
+      KNOWN_WORKING_GLB.mrtkMaster
+    ]
+  },
+  {
+    id: 'slot-18-fps-gun-gltf',
+    name: 'FPS Gun GLTF',
+    shortName: 'FPS Shotgun',
+    source: 'Extra',
+    kind: 'weapon',
+    handMode: 'both',
+    gripPreset: 'rifle',
+    urls: [
+      KNOWN_WORKING_GLB.fps,
+      KNOWN_WORKING_GLB.fpsRaw,
+      KNOWN_WORKING_GLB.awp,
+      KNOWN_WORKING_GLB.awpRaw
+    ]
+  }
+];
+
+export const VEHICLES: DisplayEntry[] = [
+  {
+    id: 'vehicle-19-ferrari-sports-car',
+    name: 'Ferrari Sports Car',
+    shortName: 'Ferrari',
+    source: 'Vehicle',
+    kind: 'vehicle',
+    urls: [FERRARI],
+    rotateY: Math.PI,
+    displayLength: VEHICLE_DISPLAY_LENGTH
+  },
+  {
+    id: 'vehicle-20-go-kart-buggy',
+    name: 'Go-Kart Buggy',
+    shortName: 'Go-Kart',
+    source: 'Vehicle',
+    kind: 'vehicle',
+    urls: [BUGGY, BUGGY_RAW, FERRARI],
+    displayLength: VEHICLE_DISPLAY_LENGTH
+  }
+];
+
+export const AIRCRAFT: DisplayEntry[] = [
+  {
+    id: 'aircraft-21-military-drone',
+    name: 'Military Drone',
+    shortName: 'Drone',
+    source: 'Aircraft',
+    kind: 'aircraft',
+    urls: militaryUrls('drone.glb'),
+    rotateY: 0.45,
+    displayLength: AIRCRAFT_DISPLAY_LENGTH,
+    floatAmp: 0.06,
+    spinSpeed: 0.0015,
+    fallbackColor: '#7b8792'
+  },
+  {
+    id: 'aircraft-22-military-helicopter',
+    name: 'Military Helicopter',
+    shortName: 'Helicopter',
+    source: 'Aircraft',
+    kind: 'aircraft',
+    urls: militaryUrls('helicopter.glb'),
+    rotateY: -0.55,
+    displayLength: AIRCRAFT_DISPLAY_LENGTH * 1.12,
+    floatAmp: 0.045,
+    spinSpeed: 0.001,
+    fallbackColor: '#6f7763'
+  },
+  {
+    id: 'aircraft-23-f15-fighter-jet',
+    name: 'F-15 Fighter Jet',
+    shortName: 'F-15 Jet',
+    source: 'Aircraft',
+    kind: 'aircraft',
+    urls: militaryUrls('f15.glb'),
+    rotateY: -0.18,
+    displayLength: AIRCRAFT_DISPLAY_LENGTH * 1.14,
+    floatAmp: 0.04,
+    spinSpeed: 0.0008,
+    fallbackColor: '#9aa2aa'
+  }
+];
+
+export const EQUIPMENT: DisplayEntry[] = [
+  {
+    id: 'equipment-24-atlas-v-rocket',
+    name: 'Atlas V Rocket',
+    shortName: 'Rocket',
+    source: 'Equipment',
+    kind: 'equipment',
+    urls: militaryUrls('atlas_v.glb'),
+    rotateY: 0.15,
+    displayLength: EQUIPMENT_DISPLAY_LENGTH * 1.35,
+    floatAmp: 0.018,
+    spinSpeed: 0.00045,
+    fallbackColor: '#d9dedf'
+  },
+  {
+    id: 'equipment-25-antenna-tower',
+    name: 'Antenna Tower',
+    shortName: 'Antenna',
+    source: 'Equipment',
+    kind: 'equipment',
+    urls: militaryUrls('antenna.glb'),
+    rotateY: 0.4,
+    displayLength: EQUIPMENT_DISPLAY_LENGTH * 1.3,
+    floatAmp: 0.012,
+    spinSpeed: 0.00035,
+    fallbackColor: '#707981'
+  },
+  {
+    id: 'equipment-26-support-truck',
+    name: 'Support Truck',
+    shortName: 'Support Truck',
+    source: 'Equipment',
+    kind: 'equipment',
+    urls: militaryUrls('fire_truck.glb'),
+    rotateY: 0.55,
+    displayLength: EQUIPMENT_DISPLAY_LENGTH * 1.05,
+    floatAmp: 0.02,
+    spinSpeed: 0.0008,
+    fallbackColor: '#a92a24'
+  }
+];
+
+export const DISPLAY_ITEMS: DisplayEntry[] = [
+  ...QUATERNIUS_WEAPONS,
+  ...EXTRA_WEAPONS,
+  ...VEHICLES,
+  ...AIRCRAFT,
+  ...EQUIPMENT
+];
+
+export const FIRST_PERSON_WEAPON =
+  EXTRA_WEAPONS.find((entry) => entry.id === 'slot-10-ak47-gltf') ??
+  DISPLAY_ITEMS[0];
+export const FPS_HAND_DONOR =
+  EXTRA_WEAPONS.find((entry) => entry.id === 'slot-18-fps-gun-gltf') ??
+  DISPLAY_ITEMS[0];
+
+export const GRIP_PROFILES: Record<GripPreset, GripProfile> = {
+  pistol: {
+    right: { position: [0.055, 0.068, 0.012], rotation: [0.0, -1.2, 0.03] }
+  },
+  rifle: {
+    right: { position: [0.09, 0.078, 0.018], rotation: [0.02, -1.16, 0.04] },
+    left: { position: [-0.16, 0.074, 0.032], rotation: [0.05, -1.36, 0.09] }
+  },
+  sniper: {
+    right: { position: [0.095, 0.078, 0.018], rotation: [0.02, -1.15, 0.04] },
+    left: { position: [-0.25, 0.072, 0.036], rotation: [0.06, -1.4, 0.1] }
+  }
+};
+
+export const GRIP_OVERRIDES: Partial<Record<string, Partial<GripProfile>>> = {
+  'poly-pistol-01': {
+    right: { position: [0.05, 0.064, 0.01], rotation: [0.0, -1.22, 0.03] }
+  },
+  'poly-revolver-01': {
+    right: { position: [0.052, 0.066, 0.01], rotation: [0.02, -1.2, 0.03] }
+  },
+  'poly-revolver-02': {
+    right: { position: [0.052, 0.066, 0.01], rotation: [0.02, -1.2, 0.03] }
+  },
+  'poly-sawed-off-01': {
+    right: { position: [0.058, 0.066, 0.012], rotation: [0.02, -1.18, 0.04] }
+  },
+  'slot-14-uzi-gltf': {
+    left: { position: [-0.115, 0.072, 0.028], rotation: [0.05, -1.34, 0.08] }
+  },
+  'slot-16-awp-glb': {
+    left: { position: [-0.28, 0.07, 0.035], rotation: [0.08, -1.42, 0.1] }
+  }
+};
+
+const HAND_SIZE_OVERRIDES: Partial<
+  Record<string, Partial<Record<'right' | 'left', number>>>
+> = {
+  'poly-pistol-01': { right: 0.047 },
+  'poly-revolver-01': { right: 0.049 },
+  'poly-revolver-02': { right: 0.049 },
+  'poly-sawed-off-01': { right: 0.05 },
+  'slot-12-smith-gltf': { right: 0.049 },
+  'slot-15-sigsauer-gltf': { right: 0.049 },
+  'slot-16-awp-glb': { right: 0.055, left: 0.051 }
+};
+
+export function mergedGripProfile(entry: DisplayEntry): GripProfile | null {
+  if (entry.kind !== 'weapon' || !entry.gripPreset) return null;
+  const base = GRIP_PROFILES[entry.gripPreset];
+  const override = GRIP_OVERRIDES[entry.id] || {};
+  return {
+    right: override.right ?? base.right,
+    left: override.left ?? base.left
+  };
+}
+
+export function targetHandSize(entry: DisplayEntry, side: 'left' | 'right') {
+  const fromOverride = HAND_SIZE_OVERRIDES[entry.id]?.[side];
+  if (fromOverride) return fromOverride;
+  if (entry.gripPreset === 'pistol') return HAND_SIZE_BY_TYPE.pistolRight;
+  if (entry.gripPreset === 'sniper') {
+    return side === 'right'
+      ? HAND_SIZE_BY_TYPE.sniperRight
+      : HAND_SIZE_BY_TYPE.sniperLeft;
+  }
+  return side === 'right'
+    ? HAND_SIZE_BY_TYPE.rifleRight
+    : HAND_SIZE_BY_TYPE.rifleLeft;
+}
+
+function isModelUrl(url: string) {
+  return /\.(glb|gltf)(\?|#|$)/i.test(url);
+}
+
+export function runAssetSelfTests() {
+  if (DISPLAY_ITEMS.length !== TOTAL_ITEMS)
+    throw new Error('Urban FPS assets must have exactly 26 display items');
+  if (
+    DISPLAY_ITEMS.filter((item) => item.kind === 'weapon').length !==
+    WEAPON_COUNT
+  )
+    throw new Error('Urban FPS assets must keep exactly 18 weapons');
+  if (
+    DISPLAY_ITEMS.filter((item) => item.kind === 'vehicle').length !==
+    VEHICLE_COUNT
+  )
+    throw new Error('Urban FPS assets must keep exactly 2 vehicles');
+  if (
+    DISPLAY_ITEMS.filter((item) => item.kind === 'aircraft').length !==
+    AIRCRAFT_COUNT
+  )
+    throw new Error('Urban FPS assets must keep exactly 3 aircraft');
+  if (
+    DISPLAY_ITEMS.filter((item) => item.kind === 'equipment').length !==
+    EQUIPMENT_COUNT
+  )
+    throw new Error('Urban FPS assets must keep exactly 3 equipment items');
+  if (new Set(DISPLAY_ITEMS.map((item) => item.id)).size !== TOTAL_ITEMS)
+    throw new Error('Urban FPS asset ids must be unique');
+  if (!DISPLAY_ITEMS.every((item) => item.urls.length > 0))
+    throw new Error('Each Urban FPS asset needs at least one URL');
+  if (!DISPLAY_ITEMS.every((item) => item.urls.every(isModelUrl)))
+    throw new Error('All Urban FPS assets must be GLB/GLTF');
+}
+
+runAssetSelfTests();

--- a/webapp/src/games/mobileUrbanFps/assetConfig.ts
+++ b/webapp/src/games/mobileUrbanFps/assetConfig.ts
@@ -1,0 +1,47 @@
+export const mobileUrbanFpsAssets = {
+  weapon: {
+    rifleGlb: '/assets/games/mobile-urban-fps/weapons/aged-rifle.glb',
+    normal:
+      '/assets/games/mobile-urban-fps/weapons/worn_blued_steel_normal.webp',
+    roughness:
+      '/assets/games/mobile-urban-fps/weapons/oily_scratched_roughness.webp',
+    metallic: '/assets/games/mobile-urban-fps/weapons/rusty_metallic.webp',
+    woodAlbedo:
+      '/assets/games/mobile-urban-fps/weapons/cracked_varnished_wood.webp'
+  },
+  hands: {
+    armsGlb: '/assets/games/mobile-urban-fps/characters/tactical-arms.glb',
+    gloveNormal:
+      '/assets/games/mobile-urban-fps/characters/dirty_leather_glove_normal.webp'
+  },
+  enemies: {
+    soldierGlb: '/assets/games/mobile-urban-fps/enemies/urban-soldier-lod0.glb',
+    soldierLod1Glb:
+      '/assets/games/mobile-urban-fps/enemies/urban-soldier-lod1.glb',
+    clothNormal: '/assets/games/mobile-urban-fps/enemies/worn_cloth_normal.webp'
+  },
+  city: {
+    buildingGlb: '/assets/games/mobile-urban-fps/city/modular-building-kit.glb',
+    road: '/assets/games/mobile-urban-fps/materials/asphalt_wet_dry_1k.webp',
+    roadNormal:
+      '/assets/games/mobile-urban-fps/materials/asphalt_normal_1k.webp',
+    concrete:
+      '/assets/games/mobile-urban-fps/materials/stained_concrete_1k.webp',
+    brick: '/assets/games/mobile-urban-fps/materials/dirty_brick_1k.webp',
+    metal: '/assets/games/mobile-urban-fps/materials/edge_worn_metal_1k.webp',
+    glass:
+      '/assets/games/mobile-urban-fps/materials/dusty_reflective_glass_1k.webp',
+    propsGlb: '/assets/games/mobile-urban-fps/city/urban-cover-props.glb'
+  },
+  audio: {
+    shoot: '/assets/games/mobile-urban-fps/audio/rifle-shot.ogg',
+    reload: '/assets/games/mobile-urban-fps/audio/rifle-reload.ogg',
+    hit: '/assets/games/mobile-urban-fps/audio/hit-marker.ogg',
+    enemyAttack: '/assets/games/mobile-urban-fps/audio/enemy-attack.ogg'
+  }
+} as const;
+
+export const assetSourceNotes = [
+  'Replace placeholder paths with CC0/CC-BY GLB and PBR texture packs from Poly Haven, AmbientCG, CGBookcase, Kenney, Quaternius, Sketchfab CC, OpenGameArt, ShareTextures, or 3DTextures.',
+  'Keep mobile texture variants around 512px-1024px, prefer KTX2/Basis where supported, and ship LOD GLB variants for enemies and city modules.'
+];

--- a/webapp/src/games/mobileUrbanFps/store.ts
+++ b/webapp/src/games/mobileUrbanFps/store.ts
@@ -1,0 +1,143 @@
+import { create } from 'zustand';
+import type {
+  BulletTracer,
+  GamePhase,
+  ImpactFx,
+  TouchInputState,
+  WeaponStats
+} from './types';
+
+export const rifleStats: WeaponStats = {
+  magazineSize: 24,
+  reserveAmmo: 96,
+  fireRateMs: 145,
+  reloadMs: 1450,
+  damage: 34,
+  spread: 0.013,
+  recoilKick: 0.035,
+  recoilRecovery: 8,
+  falloffStart: 12,
+  falloffEnd: 42
+};
+
+type GameStore = {
+  phase: GamePhase;
+  health: number;
+  maxHealth: number;
+  ammo: number;
+  reserveAmmo: number;
+  reloading: boolean;
+  enemiesAlive: number;
+  hitMarkerUntil: number;
+  muzzleFlashUntil: number;
+  recoil: number;
+  input: TouchInputState;
+  tracers: BulletTracer[];
+  impacts: ImpactFx[];
+  setInput: (patch: Partial<TouchInputState>) => void;
+  damagePlayer: (amount: number) => void;
+  setEnemiesAlive: (count: number) => void;
+  spendRound: () => void;
+  finishReload: () => void;
+  beginReload: () => void;
+  addRecoil: (amount: number) => void;
+  recoverRecoil: (amount: number) => void;
+  showHitMarker: () => void;
+  showMuzzleFlash: () => void;
+  addTracer: (tracer: BulletTracer) => void;
+  addImpact: (impact: ImpactFx) => void;
+  tickFx: (dt: number) => void;
+  reset: () => void;
+};
+
+const initialInput: TouchInputState = {
+  moveX: 0,
+  moveY: 0,
+  lookX: 0,
+  lookY: 0,
+  firing: false,
+  reloading: false
+};
+
+export const useMobileFpsStore = create<GameStore>((set, get) => ({
+  phase: 'playing',
+  health: 100,
+  maxHealth: 100,
+  ammo: rifleStats.magazineSize,
+  reserveAmmo: rifleStats.reserveAmmo,
+  reloading: false,
+  enemiesAlive: 6,
+  hitMarkerUntil: 0,
+  muzzleFlashUntil: 0,
+  recoil: 0,
+  input: initialInput,
+  tracers: [],
+  impacts: [],
+  setInput: (patch) =>
+    set((state) => ({ input: { ...state.input, ...patch } })),
+  damagePlayer: (amount) =>
+    set((state) => {
+      const health = Math.max(0, state.health - amount);
+      return { health, phase: health <= 0 ? 'lost' : state.phase };
+    }),
+  setEnemiesAlive: (count) =>
+    set((state) => ({
+      enemiesAlive: count,
+      phase: count <= 0 ? 'won' : state.phase
+    })),
+  spendRound: () => set((state) => ({ ammo: Math.max(0, state.ammo - 1) })),
+  beginReload: () => {
+    const state = get();
+    if (
+      !state.reloading &&
+      state.ammo < rifleStats.magazineSize &&
+      state.reserveAmmo > 0
+    ) {
+      set({ reloading: true });
+    }
+  },
+  finishReload: () =>
+    set((state) => {
+      const needed = rifleStats.magazineSize - state.ammo;
+      const loaded = Math.min(needed, state.reserveAmmo);
+      return {
+        ammo: state.ammo + loaded,
+        reserveAmmo: state.reserveAmmo - loaded,
+        reloading: false
+      };
+    }),
+  addRecoil: (amount) =>
+    set((state) => ({ recoil: Math.min(0.18, state.recoil + amount) })),
+  recoverRecoil: (amount) =>
+    set((state) => ({ recoil: Math.max(0, state.recoil - amount) })),
+  showHitMarker: () => set({ hitMarkerUntil: performance.now() + 120 }),
+  showMuzzleFlash: () => set({ muzzleFlashUntil: performance.now() + 70 }),
+  addTracer: (tracer) =>
+    set((state) => ({ tracers: [...state.tracers.slice(-5), tracer] })),
+  addImpact: (impact) =>
+    set((state) => ({ impacts: [...state.impacts.slice(-10), impact] })),
+  tickFx: (dt) =>
+    set((state) => ({
+      tracers: state.tracers
+        .map((fx) => ({ ...fx, life: fx.life - dt }))
+        .filter((fx) => fx.life > 0),
+      impacts: state.impacts
+        .map((fx) => ({ ...fx, life: fx.life - dt }))
+        .filter((fx) => fx.life > 0)
+    })),
+  reset: () =>
+    set({
+      phase: 'playing',
+      health: 100,
+      ammo: rifleStats.magazineSize,
+      reserveAmmo: rifleStats.reserveAmmo,
+      reloading: false,
+      enemiesAlive: 6,
+      hitMarkerUntil: 0,
+      muzzleFlashUntil: 0,
+      recoil: 0,
+      input: initialInput,
+      tracers: [],
+      impacts: []
+    })
+}));

--- a/webapp/src/games/mobileUrbanFps/systems/AssetLoader.ts
+++ b/webapp/src/games/mobileUrbanFps/systems/AssetLoader.ts
@@ -1,0 +1,520 @@
+import * as THREE from 'three';
+import {
+  GLTFLoader,
+  type GLTF
+} from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { clone as cloneSkinned } from 'three/examples/jsm/utils/SkeletonUtils.js';
+import {
+  AIRCRAFT_DISPLAY_LENGTH,
+  EQUIPMENT_DISPLAY_LENGTH,
+  FPS_SHOTGUN_DISPLAY_LENGTH,
+  type DisplayEntry,
+  type HandTransform,
+  mergedGripProfile,
+  targetHandSize
+} from '../assetCatalog';
+
+function isImageUrl(url: string) {
+  return /\.(png|jpe?g|webp|bmp|gif|ktx2?|basis)(\?|#|$)/i.test(url);
+}
+
+function isAbsoluteOrDataUrl(url: string) {
+  return (
+    /^(https?:)?\/\//i.test(url) ||
+    url.startsWith('data:') ||
+    url.startsWith('blob:')
+  );
+}
+
+function parentFolder(url: string) {
+  return url.slice(0, url.lastIndexOf('/') + 1);
+}
+
+function resolveRelativeUrl(url: string, baseFolder: string) {
+  if (isAbsoluteOrDataUrl(url)) return url;
+  return new URL(url, baseFolder).toString();
+}
+
+function makeLoaderForUrl(modelUrl: string) {
+  const baseFolder = parentFolder(modelUrl);
+  const manager = new THREE.LoadingManager();
+  manager.setURLModifier((resourceUrl) => {
+    if (isAbsoluteOrDataUrl(resourceUrl)) return resourceUrl;
+    if (isImageUrl(resourceUrl))
+      return resolveRelativeUrl(resourceUrl, baseFolder);
+    return resolveRelativeUrl(resourceUrl, baseFolder);
+  });
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin('anonymous');
+  return loader;
+}
+
+export async function loadModelByUrls(
+  name: string,
+  urls: string[],
+  timeoutMs = 18000
+): Promise<{ gltf: GLTF; url: string }> {
+  let lastError: unknown = null;
+
+  for (const url of urls) {
+    try {
+      const loader = makeLoaderForUrl(url);
+      const gltf = await new Promise<GLTF>((resolve, reject) => {
+        const timer = window.setTimeout(
+          () => reject(new Error(`Timeout loading ${name}`)),
+          timeoutMs
+        );
+        loader.load(
+          url,
+          (loaded) => {
+            window.clearTimeout(timer);
+            resolve(loaded);
+          },
+          undefined,
+          (error) => {
+            window.clearTimeout(timer);
+            reject(error);
+          }
+        );
+      });
+      return { gltf, url };
+    } catch (error) {
+      lastError = error;
+      console.warn('Urban FPS asset candidate failed:', name, url, error);
+    }
+  }
+
+  throw lastError ?? new Error(`All URLs failed for ${name}`);
+}
+
+function getBounds(object: THREE.Object3D) {
+  object.updateMatrixWorld(true);
+  return new THREE.Box3().setFromObject(object);
+}
+
+export function normalizeObject(model: THREE.Object3D, targetLength: number) {
+  model.updateMatrixWorld(true);
+  const box = getBounds(model);
+  const size = box.getSize(new THREE.Vector3());
+  const maxLength = Math.max(size.x, size.y, size.z);
+  if (!Number.isFinite(maxLength) || maxLength <= 0) return;
+
+  model.scale.setScalar(targetLength / maxLength);
+  model.updateMatrixWorld(true);
+
+  const fittedBox = getBounds(model);
+  const center = fittedBox.getCenter(new THREE.Vector3());
+  model.position.x -= center.x;
+  model.position.z -= center.z;
+  model.position.y += -fittedBox.min.y + 0.05;
+  model.updateMatrixWorld(true);
+}
+
+export function configureModel(
+  model: THREE.Object3D,
+  renderer: THREE.WebGLRenderer,
+  options: { mobileMaxAnisotropy?: number; frustumCulled?: boolean } = {}
+) {
+  const maxAnisotropy = Math.min(
+    options.mobileMaxAnisotropy ?? 4,
+    renderer.capabilities.getMaxAnisotropy()
+  );
+
+  model.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh) return;
+
+    (mesh as any).castShadow = true;
+    (mesh as any).receiveShadow = true;
+    (mesh as any).frustumCulled = options.frustumCulled ?? true;
+
+    const materials = Array.isArray((mesh as any).material)
+      ? (mesh as any).material
+      : (mesh as any).material
+        ? [(mesh as any).material]
+        : [];
+
+    materials.forEach((material: any) => {
+      [
+        'map',
+        'emissiveMap',
+        'normalMap',
+        'roughnessMap',
+        'metalnessMap',
+        'aoMap',
+        'alphaMap'
+      ].forEach((key) => {
+        const texture = material[key] as THREE.Texture | null | undefined;
+        if (texture && texture.isTexture) {
+          if (key === 'map' || key === 'emissiveMap')
+            texture.colorSpace = THREE.SRGBColorSpace;
+          texture.anisotropy = maxAnisotropy;
+          texture.needsUpdate = true;
+        }
+      });
+      material.needsUpdate = true;
+    });
+  });
+}
+
+function buildObjectPath(object: THREE.Object3D) {
+  const names: string[] = [];
+  let current: THREE.Object3D | null = object;
+  while (current) {
+    names.push(current.name || current.type);
+    current = current.parent;
+  }
+  return names.reverse().join('/');
+}
+
+function centerXOfObject(object: THREE.Object3D) {
+  const box = new THREE.Box3().setFromObject(object);
+  const center = box.getCenter(new THREE.Vector3());
+  return center.x;
+}
+
+function sideScore(path: string, side: 'left' | 'right') {
+  const leftRegex = /(^|[^a-z])(left|l)([^a-z]|$)/i;
+  const rightRegex = /(^|[^a-z])(right|r)([^a-z]|$)/i;
+  if (side === 'left')
+    return leftRegex.test(path) ? 2 : rightRegex.test(path) ? -2 : 0;
+  return rightRegex.test(path) ? 2 : leftRegex.test(path) ? -2 : 0;
+}
+
+function isRenderable(obj: THREE.Object3D) {
+  return (obj as any).isMesh || (obj as any).isSkinnedMesh;
+}
+
+function visibleMeshBounds(root: THREE.Object3D) {
+  root.updateMatrixWorld(true);
+  const box = new THREE.Box3();
+  let hasMesh = false;
+
+  root.traverse((obj) => {
+    if (!isRenderable(obj) || !obj.visible) return;
+    const meshBox = new THREE.Box3().setFromObject(obj);
+    if (!Number.isFinite(meshBox.min.x) || !Number.isFinite(meshBox.max.x))
+      return;
+    box.union(meshBox);
+    hasMesh = true;
+  });
+
+  return hasMesh ? box : null;
+}
+
+function visibleMaxDimension(root: THREE.Object3D) {
+  const box = visibleMeshBounds(root);
+  if (!box) return 0;
+  const size = box.getSize(new THREE.Vector3());
+  return Math.max(size.x, size.y, size.z);
+}
+
+function centerVisibleMeshesAtLocalOrigin(root: THREE.Object3D) {
+  root.updateMatrixWorld(true);
+  const box = visibleMeshBounds(root);
+  if (!box) return;
+  const center = box.getCenter(new THREE.Vector3());
+
+  root.position.x -= center.x;
+  root.position.y -= center.y;
+  root.position.z -= center.z;
+  root.updateMatrixWorld(true);
+}
+
+export function makeHandRigFromDonor(
+  donorScene: THREE.Object3D,
+  side: 'left' | 'right'
+) {
+  const rig = cloneSkinned(donorScene);
+  rig.updateMatrixWorld(true);
+
+  const renderables: THREE.Object3D[] = [];
+  rig.traverse((obj) => {
+    if (isRenderable(obj)) renderables.push(obj);
+  });
+
+  let keptCount = 0;
+  renderables.forEach((obj) => {
+    const path = buildObjectPath(obj).toLowerCase();
+    const isHand = /(hand|finger|wrist|glove)/i.test(path);
+    const isArmOnly =
+      /(arm|sleeve|forearm|elbow|shoulder)/i.test(path) && !isHand;
+    const isWeaponPart =
+      /(gun|weapon|rifle|shotgun|barrel|mag|magazine|scope|stock|trigger)/i.test(
+        path
+      );
+    const score =
+      (isHand ? 40 : 0) +
+      sideScore(path, side) * 20 +
+      (side === 'right' ? centerXOfObject(obj) : -centerXOfObject(obj));
+    const keep = !isWeaponPart && !isArmOnly && score > 20;
+    (obj as any).visible = keep;
+    if (keep) keptCount += 1;
+  });
+
+  if (keptCount === 0) {
+    renderables.forEach((obj) => {
+      const path = buildObjectPath(obj).toLowerCase();
+      const isWeaponPart =
+        /(gun|weapon|rifle|shotgun|barrel|mag|magazine|scope|stock|trigger)/i.test(
+          path
+        );
+      const x = centerXOfObject(obj);
+      const keep = !isWeaponPart && (side === 'right' ? x >= 0 : x <= 0);
+      (obj as any).visible = keep;
+    });
+  }
+
+  return rig;
+}
+
+export function makeFittedHandGroup(
+  donorScene: THREE.Object3D,
+  entry: DisplayEntry,
+  side: 'left' | 'right',
+  transform: HandTransform,
+  renderer: THREE.WebGLRenderer
+) {
+  const group = new THREE.Group();
+  group.name = `${entry.id}-${side}-small-fps-hand`;
+  group.position.set(
+    transform.position[0],
+    transform.position[1],
+    transform.position[2]
+  );
+  group.rotation.set(
+    transform.rotation[0],
+    transform.rotation[1],
+    transform.rotation[2]
+  );
+
+  const rig = makeHandRigFromDonor(donorScene, side);
+  rig.name = `${entry.id}-${side}-human-fps-hand-rig`;
+  configureModel(rig, renderer, {
+    frustumCulled: false,
+    mobileMaxAnisotropy: 2
+  });
+
+  centerVisibleMeshesAtLocalOrigin(rig);
+  const currentMax = visibleMaxDimension(rig);
+  const desiredMax = targetHandSize(entry, side);
+
+  if (currentMax > 0) rig.scale.setScalar(desiredMax / currentMax);
+  else rig.scale.setScalar(0.018);
+
+  group.add(rig);
+  return group;
+}
+
+export function attachHandsToWeapon(
+  entry: DisplayEntry,
+  root: THREE.Object3D,
+  donorScene: THREE.Object3D | null,
+  renderer: THREE.WebGLRenderer
+) {
+  if (entry.kind !== 'weapon' || !donorScene) return;
+  if (entry.id === 'slot-18-fps-gun-gltf') return;
+
+  const profile = mergedGripProfile(entry);
+  if (!profile) return;
+
+  root.add(
+    makeFittedHandGroup(donorScene, entry, 'right', profile.right, renderer)
+  );
+  if (entry.handMode === 'both' && profile.left) {
+    root.add(
+      makeFittedHandGroup(donorScene, entry, 'left', profile.left, renderer)
+    );
+  }
+}
+
+export function targetDisplayLength(entry: DisplayEntry) {
+  if (entry.kind === 'equipment')
+    return entry.displayLength ?? EQUIPMENT_DISPLAY_LENGTH;
+  if (entry.kind === 'aircraft')
+    return entry.displayLength ?? AIRCRAFT_DISPLAY_LENGTH;
+  if (entry.kind === 'vehicle') return entry.displayLength ?? 1.55;
+  return entry.displayLength ?? FPS_SHOTGUN_DISPLAY_LENGTH;
+}
+
+export function createProceduralMachine(entry: DisplayEntry) {
+  const group = new THREE.Group();
+  const bodyColor =
+    entry.fallbackColor ?? (entry.kind === 'equipment' ? '#9ca3af' : '#7c8791');
+  const bodyMat = new THREE.MeshStandardMaterial({
+    color: bodyColor,
+    roughness: 0.65,
+    metalness: 0.2
+  });
+  const darkMat = new THREE.MeshStandardMaterial({
+    color: '#374151',
+    roughness: 0.7,
+    metalness: 0.12
+  });
+  const glassMat = new THREE.MeshStandardMaterial({
+    color: '#1e3a5f',
+    roughness: 0.22,
+    metalness: 0.22
+  });
+
+  if (entry.kind === 'weapon') {
+    const stock = new THREE.Mesh(
+      new THREE.BoxGeometry(0.34, 0.16, 0.12),
+      darkMat
+    );
+    stock.position.set(-0.36, 0.3, 0);
+    group.add(stock);
+    const receiver = new THREE.Mesh(
+      new THREE.BoxGeometry(0.48, 0.16, 0.14),
+      bodyMat
+    );
+    receiver.position.set(0.05, 0.32, 0);
+    group.add(receiver);
+    const barrel = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.035, 0.045, 0.72, 14),
+      darkMat
+    );
+    barrel.rotation.z = Math.PI / 2;
+    barrel.position.set(0.62, 0.33, 0);
+    group.add(barrel);
+    const grip = new THREE.Mesh(
+      new THREE.BoxGeometry(0.12, 0.28, 0.1),
+      darkMat
+    );
+    grip.position.set(-0.08, 0.12, 0);
+    grip.rotation.z = -0.25;
+    group.add(grip);
+  } else if (entry.id.includes('helicopter')) {
+    const body = new THREE.Mesh(
+      new THREE.CapsuleGeometry(0.24, 0.95, 8, 18),
+      bodyMat
+    );
+    body.rotation.z = Math.PI / 2;
+    body.position.y = 0.35;
+    group.add(body);
+    const tail = new THREE.Mesh(
+      new THREE.BoxGeometry(0.9, 0.08, 0.08),
+      darkMat
+    );
+    tail.position.set(-0.72, 0.36, 0);
+    group.add(tail);
+    const cockpit = new THREE.Mesh(
+      new THREE.SphereGeometry(0.18, 18, 12),
+      glassMat
+    );
+    cockpit.position.set(0.37, 0.42, 0);
+    group.add(cockpit);
+    const rotor = new THREE.Mesh(
+      new THREE.BoxGeometry(1.45, 0.025, 0.08),
+      darkMat
+    );
+    rotor.position.set(0, 0.92, 0);
+    rotor.name = 'procedural-propeller';
+    group.add(rotor);
+    const rotor2 = rotor.clone();
+    rotor2.rotation.y = Math.PI / 2;
+    rotor2.name = 'procedural-propeller';
+    group.add(rotor2);
+  } else if (entry.id.includes('f15') || entry.id.includes('drone')) {
+    const body = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.12, 0.18, 1.6, 18),
+      bodyMat
+    );
+    body.rotation.z = Math.PI / 2;
+    body.position.y = 0.32;
+    group.add(body);
+    const nose = new THREE.Mesh(
+      new THREE.ConeGeometry(0.13, 0.42, 18),
+      bodyMat
+    );
+    nose.rotation.z = -Math.PI / 2;
+    nose.position.set(1.0, 0.32, 0);
+    group.add(nose);
+    const wing = new THREE.Mesh(
+      new THREE.BoxGeometry(0.62, 0.035, 1.3),
+      bodyMat
+    );
+    wing.position.set(-0.05, 0.28, 0);
+    group.add(wing);
+  } else if (entry.id.includes('rocket')) {
+    const shaft = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.14, 0.17, 1.75, 24),
+      bodyMat
+    );
+    shaft.position.y = 0.9;
+    group.add(shaft);
+    const nose = new THREE.Mesh(
+      new THREE.ConeGeometry(0.14, 0.42, 24),
+      bodyMat
+    );
+    nose.position.y = 1.98;
+    group.add(nose);
+  } else if (entry.id.includes('antenna')) {
+    const mast = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.035, 0.045, 2.15, 12),
+      bodyMat
+    );
+    mast.position.y = 1.05;
+    group.add(mast);
+    for (let i = 0; i < 4; i += 1) {
+      const arm = new THREE.Mesh(
+        new THREE.BoxGeometry(0.95 - i * 0.13, 0.025, 0.025),
+        darkMat
+      );
+      arm.position.y = 0.65 + i * 0.38;
+      arm.rotation.y = i % 2 === 0 ? 0 : Math.PI / 2;
+      group.add(arm);
+    }
+  } else {
+    const chassis = new THREE.Mesh(
+      new THREE.BoxGeometry(1.15, 0.28, 0.45),
+      bodyMat
+    );
+    chassis.position.y = 0.35;
+    group.add(chassis);
+    const cabin = new THREE.Mesh(
+      new THREE.BoxGeometry(0.38, 0.35, 0.42),
+      bodyMat
+    );
+    cabin.position.set(0.38, 0.65, 0);
+    group.add(cabin);
+  }
+
+  group.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (mesh.isMesh) {
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+    }
+  });
+
+  return group;
+}
+
+export function disposeObject(object: THREE.Object3D) {
+  object.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh) return;
+    mesh.geometry?.dispose?.();
+    const materials = Array.isArray((mesh as any).material)
+      ? (mesh as any).material
+      : (mesh as any).material
+        ? [(mesh as any).material]
+        : [];
+    materials.forEach((material: any) => {
+      [
+        'map',
+        'emissiveMap',
+        'normalMap',
+        'roughnessMap',
+        'metalnessMap',
+        'aoMap',
+        'alphaMap'
+      ].forEach((key) => {
+        const texture = material[key] as THREE.Texture | null | undefined;
+        texture?.dispose?.();
+      });
+      material.dispose?.();
+    });
+  });
+}

--- a/webapp/src/games/mobileUrbanFps/systems/ShootAction.ts
+++ b/webapp/src/games/mobileUrbanFps/systems/ShootAction.ts
@@ -1,0 +1,115 @@
+import { Raycaster, Vector2, Vector3, type Object3D } from 'three';
+import { rifleStats, useMobileFpsStore } from '../store';
+
+export type ShootTarget = {
+  id: string;
+  object: Object3D;
+  applyDamage: (damage: number) => void;
+};
+
+export class ShootAction {
+  private raycaster = new Raycaster();
+  private lastShotAt = 0;
+  private reloadStartedAt = 0;
+  private fxId = 1;
+
+  update(now: number, targets: ShootTarget[], camera: Object3D) {
+    const store = useMobileFpsStore.getState();
+
+    if (store.reloading && now - this.reloadStartedAt >= rifleStats.reloadMs) {
+      store.finishReload();
+    }
+
+    if (store.input.reloading && !store.reloading) {
+      this.startReload(now);
+      useMobileFpsStore.getState().setInput({ reloading: false });
+    }
+
+    if (!store.input.firing || store.phase !== 'playing' || store.reloading)
+      return;
+    if (now - this.lastShotAt < rifleStats.fireRateMs) return;
+    if (store.ammo <= 0) {
+      this.startReload(now);
+      return;
+    }
+
+    this.lastShotAt = now;
+    store.spendRound();
+    store.showMuzzleFlash();
+    store.addRecoil(rifleStats.recoilKick);
+
+    const origin = new Vector3();
+    const direction = new Vector3();
+    camera.getWorldPosition(origin);
+    camera.getWorldDirection(direction);
+    direction.x += (Math.random() - 0.5) * rifleStats.spread;
+    direction.y += (Math.random() - 0.5) * rifleStats.spread;
+    direction.normalize();
+
+    this.raycaster.set(origin, direction);
+    this.raycaster.far = rifleStats.falloffEnd;
+    const intersections = this.raycaster.intersectObjects(
+      targets.map((target) => target.object),
+      true
+    );
+    const end = origin.clone().add(direction.multiplyScalar(32));
+
+    if (intersections[0]) {
+      const hit = intersections[0];
+      const rootTarget = targets.find((target) => {
+        let current: Object3D | null = hit.object;
+        while (current) {
+          if (current === target.object) return true;
+          current = current.parent;
+        }
+        return false;
+      });
+      if (rootTarget) {
+        const distance = hit.distance;
+        const falloffRange = rifleStats.falloffEnd - rifleStats.falloffStart;
+        const falloff =
+          distance <= rifleStats.falloffStart
+            ? 1
+            : Math.max(
+                0.35,
+                1 - (distance - rifleStats.falloffStart) / falloffRange
+              );
+        rootTarget.applyDamage(Math.round(rifleStats.damage * falloff));
+        store.showHitMarker();
+      }
+      end.copy(hit.point);
+      store.addImpact({
+        id: this.fxId++,
+        position: [hit.point.x, hit.point.y, hit.point.z],
+        normal: [
+          hit.face?.normal.x ?? 0,
+          hit.face?.normal.y ?? 1,
+          hit.face?.normal.z ?? 0
+        ],
+        life: 0.35
+      });
+    }
+
+    store.addTracer({
+      id: this.fxId++,
+      from: [origin.x, origin.y - 0.16, origin.z],
+      to: [end.x, end.y, end.z],
+      life: 0.08
+    });
+  }
+
+  startReload(now: number) {
+    const store = useMobileFpsStore.getState();
+    if (
+      store.reloading ||
+      store.ammo >= rifleStats.magazineSize ||
+      store.reserveAmmo <= 0
+    )
+      return;
+    this.reloadStartedAt = now;
+    store.beginReload();
+  }
+}
+
+export const stableStep = 1 / 60;
+export const centerAim = new Vector2(0, 0);

--- a/webapp/src/games/mobileUrbanFps/types.ts
+++ b/webapp/src/games/mobileUrbanFps/types.ts
@@ -1,0 +1,51 @@
+import type { Vector3 } from 'three';
+
+export type GamePhase = 'playing' | 'won' | 'lost';
+export type EnemyAiState = 'idle' | 'patrol' | 'chase' | 'attack' | 'dead';
+
+export type TouchInputState = {
+  moveX: number;
+  moveY: number;
+  lookX: number;
+  lookY: number;
+  firing: boolean;
+  reloading: boolean;
+};
+
+export type WeaponStats = {
+  magazineSize: number;
+  reserveAmmo: number;
+  fireRateMs: number;
+  reloadMs: number;
+  damage: number;
+  spread: number;
+  recoilKick: number;
+  recoilRecovery: number;
+  falloffStart: number;
+  falloffEnd: number;
+};
+
+export type EnemyRuntime = {
+  id: string;
+  position: Vector3;
+  patrolTarget: Vector3;
+  health: number;
+  maxHealth: number;
+  state: EnemyAiState;
+  attackCooldown: number;
+  hitFlash: number;
+};
+
+export type ImpactFx = {
+  id: number;
+  position: [number, number, number];
+  normal: [number, number, number];
+  life: number;
+};
+
+export type BulletTracer = {
+  id: number;
+  from: [number, number, number];
+  to: [number, number, number];
+  life: number;
+};


### PR DESCRIPTION
### Motivation

- Introduce a mobile-first portrait FPS prototype to the games catalog for in-app preview and experimentation.
- Provide a self-contained three.js/React runtime with hand/weapon display, simple AI, input HUD and touch controls for mobile testing. 
- Wire the new game into app navigation, thumbnails and online readiness metadata so it appears alongside other games.

### Description

- Added new dependencies for React + three integration and state management by adding `@react-three/fiber`, `@react-three/drei`, and `zustand` to `package.json`.
- Registered a new lazy route and component import at `/games/mobile-urban-fps` in `src/App.jsx` and added the game entry to `src/config/gamesCatalog.js`, `src/config/gameAssets.js`, and `src/config/onlineContract.js`.
- Added a new SVG thumbnail `public/assets/icons/mobile-urban-fps.svg` and a full UI + canvas frame stylesheet `src/games/mobileUrbanFps/MobileUrbanFps.css`.
- Implemented the prototype under `src/games/mobileUrbanFps/` including the main `MobileUrbanFps.tsx` scene, `assetCatalog.ts`, `assetConfig.ts`, `store.ts` (Zustand), `types.ts`, `systems/AssetLoader.ts`, and `systems/ShootAction.ts`, plus asset loading, procedural fallbacks, simple enemy AI, touch HUD and input handling.

### Testing

- Executed the in-module asset integrity self-check `runAssetSelfTests()` from `assetCatalog.ts`, which validates counts/URLs/uniqueness of display assets, and it passed without errors.
- No other automated test suites were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff20e0d9d083299282bb8de6ff54ae)