### PR TITLE
Adjust Chess Battle Royal portrait camera and controls

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -434,8 +434,8 @@ const CAMERA_PULL_FORWARD_MIN = THREE.MathUtils.degToRad(15);
 const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(21); // raise forced 3D animation camera for a stronger portrait top-down feel.
 const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 1.18; // keep forced 3D animation wider during capture so the board stays fully readable
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 6; // keep local player's avatar lower so chair/animation view stays clear
-const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(20); // high diagonal angle close to 2D while still showing depth toward the opponent.
-const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.96; // keep 3D camera almost at 2D distance so the whole board remains visible in portrait.
+const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(58); // lower seated 3D angle that looks upward across the table.
+const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.9; // keep the table readable while the lower 3D camera sits closer to the player.
 const SAND_TIMER_RADIUS_FACTOR = 0.68;
 const SAND_TIMER_SURFACE_OFFSET = 0.2;
 const SAND_TIMER_SCALE = 0.36;
@@ -453,10 +453,11 @@ const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.58;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.44;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.08;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.68;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.96;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.92;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.28; // Lower the 3D player camera for a seated portrait view.
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.78;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 0.42;
-const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 2.08; // Push board/chairs/avatars further downward on portrait screens to match the reference framing.
+const PLAYER_VIEW_LOOK_TARGET_UP_BIAS = 0.22; // Aim slightly upward from the lower camera toward the pieces/opponent.
+const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 2.75; // Push board/chairs/avatars further downward on portrait screens to match the reference framing.
 const FPV_FACE_FORWARD_OFFSET = 0.006; // keep the camera almost exactly at the eyes for a true first-person perspective.
 const FPV_FACE_UP_OFFSET = 0.002; // slight lift so the board edge does not clip while still feeling eye-level.
 const FPV_LOOK_AHEAD_DISTANCE = BOARD.tile * BOARD_SCALE * 5.8; // prioritize looking down the board journey toward the opponent side.
@@ -9648,7 +9649,7 @@ function Chess3D({
     boardGroup.add(boardVisualGroup);
     const boardLookTarget = new THREE.Vector3(
       tablePlacementOffset.x,
-      boardGroup.position.y + (BOARD.baseH + 0.045) * BOARD_SCALE,
+      boardGroup.position.y + (BOARD.baseH + 0.045) * BOARD_SCALE + PLAYER_VIEW_LOOK_TARGET_UP_BIAS,
       tablePlacementOffset.z + PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS
     );
     studioCamA.lookAt(boardLookTarget);
@@ -9841,7 +9842,9 @@ function Chess3D({
         locked3dViewRef.current.pitch = pitch;
         locked3dViewRef.current.targetYaw = yaw;
         locked3dViewRef.current.targetPitch = pitch;
-        locked3dViewRef.current.activeLook = !isForcedCapture3dView;
+        // Let OrbitControls drive the normal 3D camera again so players can
+        // move forward/back with pinch or wheel and look left/right by dragging.
+        locked3dViewRef.current.activeLook = false;
         animateCameraTo(target, 420);
       }
     };


### PR DESCRIPTION
### Motivation

- Improve portrait framing by moving the table/board/chairs/avatars visually lower on the screen so they sit nearer the bottom on mobile portrait. 
- Lower the player camera and bias the look target upward so the camera feels lower and looks up toward the opponent/pieces. 
- Restore the expected 3D camera interaction so players can move forward/back and look left/right as before.

### Description

- Tweaked camera and layout constants in `webapp/src/pages/Games/ChessBattleRoyal.jsx` including `CAMERA_LOCKED_3D_PHI`, `CAMERA_LOCKED_3D_RADIUS_SCALE`, `PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT`, `PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE`, and increased the bottom placement bias `TABLE_BOTTOM_PLAYER_BIAS_Z` to push the composition downward. 
- Added `PLAYER_VIEW_LOOK_TARGET_UP_BIAS` and applied it to the scene `boardLookTarget` so the lowered camera aims slightly upward toward the pieces/opponent. 
- Restored natural OrbitControls-driven 3D interaction by disabling the automatic `locked3dViewRef.current.activeLook` during the 3D restore path so players can pinch/wheel to move forward/back and drag to look left/right. 
- Single-file change: `webapp/src/pages/Games/ChessBattleRoyal.jsx` (small constant updates and a few lines in camera setup/restore logic).

### Testing

- Ran `npm install --prefix webapp` which completed and installed missing packages used by the webapp. (succeeded)
- Built the production webapp with `npm --prefix webapp run build` which completed successfully and produced the `dist` output. (succeeded)
- Installed Playwright and platform dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium` to run a headless screenshot test. (succeeded)
- Launched the local dev server and attempted a portrait Playwright screenshot flow, but the scene did not finish loading because remote game assets failed to fetch (network / certificate errors), so the automated screenshot check could not verify the final rendered scene; the camera/control changes themselves were applied and the build verified. (partial — environment prevented full end-to-end visual verification)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff47b619dc8329828a9f792654901d)