### PR TITLE
Showood: preserve pocket plastics, use diamond rail markers, and make Showood default

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -6,10 +6,10 @@ import {
 } from '../webapp/src/config/poolRoyaleTableModels.js';
 
 describe('Pool Royale table models', () => {
-  test('defaults to the native Royal Original table', () => {
-    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'royal-original');
-    assert.equal(resolvePoolRoyaleTableModel(null).id, 'royal-original');
-    assert.equal(resolvePoolRoyaleTableModel('unknown').id, 'royal-original');
+  test('defaults to the Showood table model', () => {
+    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'showood-seven-foot');
+    assert.equal(resolvePoolRoyaleTableModel(null).id, 'showood-seven-foot');
+    assert.equal(resolvePoolRoyaleTableModel('unknown').id, 'showood-seven-foot');
   });
 
   test('Showood uses original GLB surface layout with Pool Royale finish textures', () => {
@@ -23,13 +23,12 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.fitScale, 1.08);
     assert.equal(showood.clothRepeatScale, 5.25);
     assert.deepEqual(showood.hideSurfaceRoles, ['trim']);
-    assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
+    assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['pocket']);
     assert.equal(showood.forceGeneratedChromePlates, true);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',
-      'wood',
-      'pocket'
+      'wood'
     ]);
     assert.equal('playfieldVisualLift' in showood, false);
     assert.equal('fitHeightScale' in showood, false);

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -18,13 +18,13 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and preserved Showood chrome plates.',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, original pocket plastics, and Pool Royale diamond rail markers.',
     tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
-    fitScale: 1.02,
+    fitScale: 1.08,
     lowerBaseHeightScale: 1.16,
     clothRepeatScale: 5.25,
     fitStrategy: 'exact',
@@ -33,11 +33,11 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
-    preserveOriginalSurfaceRoles: ['trim'],
-    tintOriginalTrimGold: true,
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: []
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood'],
+    preserveOriginalSurfaceRoles: ['pocket'],
+    tintOriginalTrimGold: false,
+    forceGeneratedChromePlates: true,
+    hideSurfaceRoles: ['trim']
   }
 ]);
 
@@ -49,6 +49,9 @@ export function resolvePoolRoyaleTableModel(modelId) {
   const key = typeof modelId === 'string' ? modelId.trim() : '';
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
+    POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
+      (option) => option.id === DEFAULT_POOL_ROYALE_TABLE_MODEL_ID
+    ) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
   );
 }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4494,8 +4494,7 @@ const CLOTH_COLOR_OPTIONS = Object.freeze(
 
 const DEFAULT_RAIL_MARKER_SHAPE = 'diamond';
 const RAIL_MARKER_SHAPE_OPTIONS = Object.freeze([
-  { id: 'diamond', label: 'Diamonds' },
-  { id: 'circle', label: 'Circles' }
+  { id: 'diamond', label: 'Diamonds' }
 ]);
 const RAIL_MARKER_THICKNESS = TABLE.THICK * 0.06;
 
@@ -12046,6 +12045,10 @@ export function Table3D(
       mesh.castShadow = false;
       mesh.receiveShadow = false;
       mesh.renderOrder = CHROME_PLATE_RENDER_ORDER + 0.1;
+      mesh.userData = {
+        ...(mesh.userData || {}),
+        isGeneratedRailMarker: true
+      };
       registerRailMarkerMesh(mesh);
     };
     [1, 2, 3, 5, 6, 7].forEach((step) => {
@@ -14043,7 +14046,8 @@ function mountPoolRoyaleExternalTableModel({
         !visible &&
         (
           (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
-          (object.userData?.isChromePlate && (chromePlateStyle.showGeneratedOnExternal || forceGeneratedChrome))
+          (object.userData?.isChromePlate && (chromePlateStyle.showGeneratedOnExternal || forceGeneratedChrome)) ||
+          (object.userData?.isGeneratedRailMarker && forceGeneratedChrome)
         )
       ) {
         object.visible = true;


### PR DESCRIPTION
### Motivation

- Make the Showood GLB table render the original plastic pocket textures visible behind the pocket jaws instead of hiding them behind generated chrome/trim. 
- Replace circle rail markings with diamond markers for Pool Royale and keep those generated diamond markers visible when mounting the Showood external GLB. 
- Use Showood as the resolved default table model to match the new presentation and test expectations.

### Description

- Update the Showood table model configuration in `webapp/src/config/poolRoyaleTableModels.js` to preserve original pocket plastics, hide original trim, use Pool Royale diamond markers, adjust `fitScale`, and enable `forceGeneratedChromePlates` while preserving pocket surface roles (`preserveOriginalSurfaceRoles: ['pocket']`).
- Change default/fallback resolution so the Showood model becomes the resolved default (`DEFAULT_POOL_ROYALE_TABLE_MODEL_ID` points to `showood-seven-foot`) and `resolvePoolRoyaleTableModel` will prefer that default when appropriate.
- Restrict the rail marker picker in `webapp/src/pages/Games/PoolRoyale.jsx` to only provide the diamond shape by removing the circle option, and tag generated rail marker meshes with `mesh.userData.isGeneratedRailMarker = true` so they can be treated specially.
- Ensure generated diamond rail markers remain visible when external GLB visuals would otherwise hide generated visuals by updating the `setGeneratedVisualsVisible` logic in `webapp/src/pages/Games/PoolRoyale.jsx` to keep `isGeneratedRailMarker` objects visible when `forceGeneratedChromePlates` is set.
- Update `test/poolRoyaleTableModels.test.js` to reflect the new default model and the modified Showood configuration.

### Testing

- Ran unit tests with `npm test -- --runInBand test/poolRoyaleTableModels.test.js`, and the updated suite passed (2 tests, 2 passed).
- Ran `npx eslint` on the modified files; ESLint completed but reported the files were ignored by repo ignore patterns (warnings only).
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.
- Installed Playwright browsers and system deps with `npx playwright install chromium` and `npx playwright install-deps chromium` (successful downloads/install), and attempted an automated mobile screenshot of `/games/poolroyale` to visually verify markers; the headless screenshot attempt timed out during in-browser rendering in this environment so a full screenshot could not be captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff57076728832993cf20fe791a7850)