### PR TITLE
Refine Showood pocket and rail marker visuals

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -18,7 +18,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and preserved Showood chrome plates.',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, original plastic pocket liners, and TonPlaygram diamond rail markers.',
     tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
@@ -33,8 +33,10 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
-    preserveOriginalSurfaceRoles: ['trim'],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood'],
+    preserveOriginalSurfaceRoles: ['trim', 'pocket'],
+    hideOriginalRailMarkers: true,
+    keepGeneratedRailMarkers: true,
     tintOriginalTrimGold: true,
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12045,6 +12045,11 @@ export function Table3D(
       mesh.rotation.y = rotation;
       mesh.castShadow = false;
       mesh.receiveShadow = false;
+      mesh.userData = {
+        ...(mesh.userData || {}),
+        isRailMarker: true,
+        externalTableKeepVisible: true
+      };
       mesh.renderOrder = CHROME_PLATE_RENDER_ORDER + 0.1;
       registerRailMarkerMesh(mesh);
     };
@@ -12869,6 +12874,13 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   return 'wood';
 }
 
+function isPoolRoyaleExternalRailMarkerSurface(child, material) {
+  const childName = `${child?.name || ''}`.toLowerCase();
+  const materialName = `${material?.name || ''}`.toLowerCase();
+  const label = `${childName} ${materialName}`;
+  return /diamond|sight|marker|rail[_\s-]*dot|rail[_\s-]*spot/.test(label);
+}
+
 function clonePoolRoyaleMaterialTexture(texture, { isColor = false } = {}) {
   if (!texture) return null;
   const clone = texture.clone ? texture.clone() : texture;
@@ -13074,6 +13086,9 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
       if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
+        child.visible = false;
+      }
+      if (tableModel?.hideOriginalRailMarkers && isPoolRoyaleExternalRailMarkerSurface(child, material)) {
         child.visible = false;
       }
       if (tableModel?.usePoolRoyaleFinish && finishInfo) {
@@ -14043,6 +14058,7 @@ function mountPoolRoyaleExternalTableModel({
         !visible &&
         (
           (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
+          (externalTableModelForMount?.keepGeneratedRailMarkers && object.userData?.isRailMarker) ||
           (object.userData?.isChromePlate && (chromePlateStyle.showGeneratedOnExternal || forceGeneratedChrome))
         )
       ) {


### PR DESCRIPTION
### Motivation
- Preserve the original Showood GLB pocket liner/plastic appearance behind pocket jaws and prefer TonPlaygram diamond rail markers over the Showood model's original circular markers for clearer visuals.
- Ensure generated diamond markers remain visible when mounting the external Showood table while hiding the GLB's original rail marker meshes.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to treat the Showood model as preserving original pocket surfaces and added flags `hideOriginalRailMarkers` and `keepGeneratedRailMarkers` to control marker visibility.
- Tagged generated rail marker meshes with `mesh.userData.isRailMarker = true` and `mesh.userData.externalTableKeepVisible = true` when created in `Table3D` so generated markers can be selectively retained.
- Added a helper `isPoolRoyaleExternalRailMarkerSurface` to detect original GLB rail-marker surfaces and changed `preparePoolRoyaleExternalTableMaterials` to hide those original marker meshes when `hideOriginalRailMarkers` is set.
- Modified external-table visibility logic to preserve generated rail markers when `keepGeneratedRailMarkers` is enabled while still allowing generated chrome plates/pocket visuals to be toggled appropriately.

### Testing
- Ran `npm --prefix webapp run build`, which completed successfully (Vite production build completed).
- Ran `git diff --check` with no reported issues.
- Installed Playwright browsers and OS deps via `npx playwright install chromium` and `npx playwright install-deps chromium`, which completed successfully.
- Attempted an automated Playwright screenshot of `'/games/poolroyale?tableModel=showood-seven-foot'`, but the headless screenshot timed out due to external resource loading / network certificate failures in the local dev environment, so the runtime rendering verification was inconclusive.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff57076728832993cf20fe791a7850)