### PR TITLE
Refine Showood table visuals, seating and chrome/pocket mapping

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -24,8 +24,11 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.clothRepeatScale, 5.25);
     assert.deepEqual(showood.hideSurfaceRoles, []);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['trim']);
-    assert.equal(showood.tintOriginalTrimGold, true);
+    assert.equal(showood.tintOriginalTrimFromChromeOption, true);
+    assert.equal(showood.tintOriginalPocketFromLinerOption, true);
     assert.equal(showood.forceGeneratedChromePlates, false);
+    assert.deepEqual(showood.hideSurfaceNamePatterns, ['net', 'basket', 'drop', 'holder', 'bar']);
+    assert.equal(showood.hideHudPottedBalls, true);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -18,7 +18,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and preserved Showood chrome plates.',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and preserved Showood trim mapping; net baskets/holder bars stay hidden for the showroom table.',
     tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
@@ -35,9 +35,12 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
     preserveOriginalSurfaceRoles: ['trim'],
-    tintOriginalTrimGold: true,
+    tintOriginalTrimFromChromeOption: true,
+    tintOriginalPocketFromLinerOption: true,
     forceGeneratedChromePlates: false,
-    hideSurfaceRoles: []
+    hideSurfaceRoles: [],
+    hideSurfaceNamePatterns: ['net', 'basket', 'drop', 'holder', 'bar'],
+    hideHudPottedBalls: true
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2677,11 +2677,13 @@ const resolvePoolRoyaleHumanCharacter = (id) =>
   POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
 const POOL_ROYALE_HUMAN_UNIT_SCALE = BALL_R / 0.0525;
 const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.85 * POOL_ROYALE_HUMAN_UNIT_SCALE; // make the shooter larger again without returning to the oversized direct scale
-const POOL_ROYALE_LOUNGE_TABLE_RADIUS = BALL_R * 24; // match Murlan Royale's default octagon table proportions at pool-side scale.
-const POOL_ROYALE_LOUNGE_TABLE_HEIGHT = BALL_R * 16.5;
-const POOL_ROYALE_LOUNGE_CHAIR_SPAN = BALL_R * 64; // oversized portrait-readable chairs matching Murlan's default dining-chair asset.
-const POOL_ROYALE_LOUNGE_DISTANCE = BALL_R * 38;
-const POOL_ROYALE_LOUNGE_CHAIR_OFFSET = BALL_R * 54;
+const POOL_ROYALE_LOUNGE_TABLE_RADIUS = BALL_R * 30; // larger side tables so they read clearly in portrait beside the pool table.
+const POOL_ROYALE_LOUNGE_TABLE_HEIGHT = BALL_R * 20.5; // taller hospitality tables with usable chair clearance.
+const POOL_ROYALE_LOUNGE_CHAIR_SPAN = BALL_R * 78; // larger player chairs that remain visible from the mobile camera.
+const POOL_ROYALE_LOUNGE_DISTANCE = BALL_R * 54; // push the player seating farther away from the table edge.
+const POOL_ROYALE_LOUNGE_CHAIR_OFFSET = BALL_R * 72; // map each chair behind its table with enough room for the seated rig.
+const POOL_ROYALE_LOUNGE_CHAIR_SEAT_HEIGHT = BALL_R * 5.8;
+const POOL_ROYALE_LOUNGE_CHAIR_BACK_OFFSET = BALL_R * 12.5;
 // Soldier.glb already faces the billiards rig forward axis; keep the child model unflipped so
 // the visible player faces inward toward the table instead of showing their back in portrait play.
 const POOL_ROYALE_HUMAN_VISUAL_YAW_FIX = Math.PI;
@@ -9277,6 +9279,8 @@ export function Table3D(
     CHROME_PLATE_STYLE_BY_ID[resolvedTableOptions?.chromePlateStyle?.id] ??
     CHROME_PLATE_STYLE_BY_ID[DEFAULT_CHROME_PLATE_STYLE_ID] ??
     CHROME_PLATE_STYLE_OPTIONS[0];
+  const selectedChromeOption = resolvedTableOptions?.chromeOption || CHROME_COLOR_OPTIONS[0];
+  const selectedPocketLinerOption = resolvedTableOptions?.pocketLinerOption || POCKET_LINER_OPTIONS[0];
   const usesExternalTableModel = resolvedTableOptions?.tableModel?.kind === 'gltf';
   const externalTableUsesOriginalLayout =
     usesExternalTableModel && resolvedTableOptions?.tableModel?.useOriginalLayoutSurfaces === true;
@@ -12852,10 +12856,29 @@ export function Table3D(
 const poolRoyaleExternalTableTemplates = new Map();
 const poolRoyaleExternalTablePromises = new Map();
 
-function classifyPoolRoyaleExternalTableSurface(child, material) {
+function getPoolRoyaleExternalSurfaceLabel(child, material) {
   const childName = `${child?.name || ''}`.toLowerCase();
   const materialName = `${material?.name || ''}`.toLowerCase();
-  const label = `${childName} ${materialName}`;
+  return `${childName} ${materialName}`;
+}
+
+function matchesPoolRoyaleExternalSurfaceName(child, material, patterns = []) {
+  if (!Array.isArray(patterns) || patterns.length === 0) return false;
+  const label = getPoolRoyaleExternalSurfaceLabel(child, material);
+  return patterns.some((pattern) => {
+    const source = typeof pattern === 'string' ? pattern.trim() : '';
+    if (!source) return false;
+    try {
+      return new RegExp(source, 'i').test(label);
+    } catch {
+      return label.includes(source.toLowerCase());
+    }
+  });
+}
+
+function classifyPoolRoyaleExternalTableSurface(child, material) {
+  const childName = `${child?.name || ''}`.toLowerCase();
+  const label = getPoolRoyaleExternalSurfaceLabel(child, material);
   // Showood uses a shared "cloth" material on the cushion meshes, so mesh names
   // must win over material names for physics mapping and finish assignment.
   if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(childName)) return 'cushion';
@@ -12973,13 +12996,22 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
   const shouldUsePoolRoyaleFinish = !finishRoles || finishRoles.includes(role);
   if (!shouldUsePoolRoyaleFinish || preserveRoles.includes(role)) {
     const originalMat = material.clone ? material.clone() : material;
-    if (role === 'trim' && tableModel?.tintOriginalTrimGold) {
-      if (originalMat.color) originalMat.color.set(0xd8b45a);
-      if ('metalness' in originalMat) originalMat.metalness = Math.max(0.88, originalMat.metalness ?? 0.88);
-      if ('roughness' in originalMat) originalMat.roughness = Math.min(0.24, originalMat.roughness ?? 0.18);
-      if ('envMapIntensity' in originalMat) originalMat.envMapIntensity = Math.max(1.15, originalMat.envMapIntensity ?? 1.15);
-      if ('clearcoat' in originalMat) originalMat.clearcoat = Math.max(0.55, originalMat.clearcoat ?? 0.55);
-      if ('clearcoatRoughness' in originalMat) originalMat.clearcoatRoughness = Math.min(0.18, originalMat.clearcoatRoughness ?? 0.12);
+    if (role === 'trim' && tableModel?.tintOriginalTrimFromChromeOption) {
+      const chrome = tableModel.selectedChromeOption || CHROME_COLOR_OPTIONS[0];
+      if (originalMat.color) originalMat.color.set(chrome.color ?? 0xd8b45a);
+      if ('metalness' in originalMat) originalMat.metalness = Math.max(chrome.metalness ?? 0.88, originalMat.metalness ?? 0.88);
+      if ('roughness' in originalMat) originalMat.roughness = Math.min(chrome.roughness ?? 0.24, originalMat.roughness ?? 0.18);
+      if ('envMapIntensity' in originalMat) originalMat.envMapIntensity = Math.max(chrome.envMapIntensity ?? 1.15, originalMat.envMapIntensity ?? 1.15);
+      if ('clearcoat' in originalMat) originalMat.clearcoat = Math.max(chrome.clearcoat ?? 0.55, originalMat.clearcoat ?? 0.55);
+      if ('clearcoatRoughness' in originalMat) originalMat.clearcoatRoughness = Math.min(chrome.clearcoatRoughness ?? 0.18, originalMat.clearcoatRoughness ?? 0.12);
+    } else if (role === 'pocket' && tableModel?.tintOriginalPocketFromLinerOption) {
+      const liner = tableModel.selectedPocketLinerOption || POCKET_LINER_OPTIONS[0];
+      if (originalMat.color) originalMat.color.set(liner?.baseColor ?? liner?.jawColor ?? '#151515');
+      if ('metalness' in originalMat) originalMat.metalness = liner?.metalness ?? 0.06;
+      if ('roughness' in originalMat) originalMat.roughness = liner?.roughness ?? 0.28;
+      if ('envMapIntensity' in originalMat) originalMat.envMapIntensity = liner?.envMapIntensity ?? 0.35;
+      if ('clearcoat' in originalMat) originalMat.clearcoat = liner?.clearcoat ?? 0.62;
+      if ('clearcoatRoughness' in originalMat) originalMat.clearcoatRoughness = liner?.clearcoatRoughness ?? 0.22;
     }
     preparePoolRoyaleExternalTexture(originalMat.map, true);
     preparePoolRoyaleExternalTexture(originalMat.emissiveMap, true);
@@ -13073,7 +13105,10 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const prepareMaterial = (material) => {
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
-      if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
+      if (
+        (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) ||
+        matchesPoolRoyaleExternalSurfaceName(child, material, tableModel?.hideSurfaceNamePatterns)
+      ) {
         child.visible = false;
       }
       if (tableModel?.usePoolRoyaleFinish && finishInfo) {
@@ -14038,7 +14073,9 @@ function mountPoolRoyaleExternalTableModel({
     : generatedUpperComponentBounds.getSize(new THREE.Vector3());
   const setGeneratedVisualsVisible = (visible) => {
     generatedVisualObjects.forEach((object) => {
-      const forceGeneratedChrome = Boolean(externalTableModelForMount?.forceGeneratedChromePlates);
+      const forceGeneratedChrome = Boolean(
+        externalTableModelForMount?.forceGeneratedChromePlates || chromePlateStyle.showGeneratedOnExternal
+      );
       if (
         !visible &&
         (
@@ -14056,6 +14093,8 @@ function mountPoolRoyaleExternalTableModel({
     resolvedTableOptions?.tableModel?.kind === 'gltf'
       ? {
           ...resolvedTableOptions.tableModel,
+          selectedChromeOption,
+          selectedPocketLinerOption,
           preserveOriginalSurfaceRoles: resolvedTableOptions.tableModel.useOriginalLayoutSurfaces
             ? Array.from(new Set([
                 ...(resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles || []),
@@ -25438,7 +25477,12 @@ const shotPowerRef = useRef(0);
         railMarkerStyleRef.current,
         activeTableBase,
         rendererRef.current,
-        { tableModel: activeTableModel, chromePlateStyle: activeChromePlateStyle }
+        {
+          tableModel: activeTableModel,
+          chromePlateStyle: activeChromePlateStyle,
+          chromeOption: activeChromeOption,
+          pocketLinerOption: activePocketLinerOption
+        }
       );
       const SPOTS = spotPositions(baulkZ);
 
@@ -25493,7 +25537,12 @@ const shotPowerRef = useRef(0);
         railMarkerStyleRef.current,
         activeTableBase,
         rendererRef.current,
-        { tableModel: activeTableModel, chromePlateStyle: activeChromePlateStyle }
+        {
+          tableModel: activeTableModel,
+          chromePlateStyle: activeChromePlateStyle,
+          chromeOption: activeChromeOption,
+          pocketLinerOption: activePocketLinerOption
+        }
       );
       secondaryTableRef.current = secondaryTableEntry?.group ?? null;
       secondaryBaseSetterRef.current = secondaryTableEntry?.setBaseVariant ?? null;
@@ -26180,18 +26229,22 @@ const shotPowerRef = useRef(0);
         return asset;
       };
 
-      const createFallbackPoolSideFurniture = (seat, zSign, tableTopY) => {
+      const createFallbackPoolSideFurniture = (seat, zSign, tableTopY, chairLocalZ) => {
         const group = new THREE.Group();
         const woodMat = new THREE.MeshStandardMaterial({ color: 0x5b351f, roughness: 0.62, metalness: 0.05 });
         const seatMat = new THREE.MeshStandardMaterial({ color: seat === 'A' ? 0x0f766e : 0x7c2d12, roughness: 0.55, metalness: 0.08 });
-        const tableTop = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 18.4, BALL_R * 18.9, BALL_R * 1.45, 64), woodMat);
+        const tableTop = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 23.5, BALL_R * 24.1, BALL_R * 1.8, 64), woodMat);
         tableTop.position.set(0, tableTopY, 0);
-        const tablePedestal = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 2.05, BALL_R * 2.9, tableTopY, 32), woodMat);
+        const tablePedestal = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 2.7, BALL_R * 3.5, tableTopY, 32), woodMat);
         tablePedestal.position.set(0, tableTopY * 0.5, 0);
-        const chairSeat = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 19.6, BALL_R * 2.05, BALL_R * 16.8), seatMat);
-        chairSeat.position.set(0, BALL_R * 4.4, zSign * BALL_R * 37.5);
-        const chairBack = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 19.6, BALL_R * 15.8, BALL_R * 2.05), seatMat);
-        chairBack.position.set(0, BALL_R * 11.2, zSign * BALL_R * 46.0);
+        const chairSeat = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 25.5, BALL_R * 2.65, BALL_R * 21.5), seatMat);
+        chairSeat.position.set(0, POOL_ROYALE_LOUNGE_CHAIR_SEAT_HEIGHT, chairLocalZ);
+        const chairBack = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 25.5, BALL_R * 20.5, BALL_R * 2.65), seatMat);
+        chairBack.position.set(
+          0,
+          POOL_ROYALE_LOUNGE_CHAIR_SEAT_HEIGHT + BALL_R * 8.8,
+          chairLocalZ + zSign * POOL_ROYALE_LOUNGE_CHAIR_BACK_OFFSET
+        );
         [tableTop, tablePedestal, chairSeat, chairBack].forEach((mesh) => {
           mesh.castShadow = true;
           mesh.receiveShadow = true;
@@ -26212,7 +26265,7 @@ const shotPowerRef = useRef(0);
 
         const tableTopY = POOL_ROYALE_LOUNGE_TABLE_HEIGHT;
         const chairLocalZ = zSign * POOL_ROYALE_LOUNGE_CHAIR_OFFSET;
-        const fallbackFurniture = createFallbackPoolSideFurniture(seat, zSign, tableTopY);
+        const fallbackFurniture = createFallbackPoolSideFurniture(seat, zSign, tableTopY, chairLocalZ);
         fallbackFurniture.name = `PoolRoyale_${seat}_VisibleLoungeFallback`;
         group.add(fallbackFurniture);
 
@@ -26252,9 +26305,16 @@ const shotPowerRef = useRef(0);
 
         const serviceProps = createWaterServiceProps(tableTopY);
         group.add(serviceProps);
-        group.userData.chairRoot = new THREE.Vector3(x, floorY, z + chairLocalZ);
+        const chairSeatCenter = new THREE.Vector3(x, floorY + POOL_ROYALE_LOUNGE_CHAIR_SEAT_HEIGHT, z + chairLocalZ);
+        const chairFootRoot = new THREE.Vector3(x, floorY, z + chairLocalZ);
+        group.userData.chairRoot = chairFootRoot;
         group.userData.chairFacing = new THREE.Vector3(0, 0, -zSign).normalize();
-        group.userData.chairSeatWorld = new THREE.Vector3(x, floorY, z + chairLocalZ);
+        group.userData.chairSeatWorld = chairSeatCenter;
+        group.userData.chairBackWorld = new THREE.Vector3(
+          x,
+          floorY + POOL_ROYALE_LOUNGE_CHAIR_SEAT_HEIGHT + BALL_R * 8.8,
+          z + chairLocalZ + zSign * POOL_ROYALE_LOUNGE_CHAIR_BACK_OFFSET
+        );
         group.userData.glass = serviceProps.userData.glass;
         group.userData.glassBase = serviceProps.userData.glassBase.clone();
         return group;
@@ -35942,6 +36002,7 @@ const shotPowerRef = useRef(0);
       pottedTokenSize
     ]
   );
+  const hideHudPottedBalls = activeTableModel?.hideHudPottedBalls === true;
   const playerSeatId = localSeat === 'A' ? 'A' : 'B';
   const opponentSeatId = playerSeatId === 'A' ? 'B' : 'A';
   const playerPotted = pottedBySeat[playerSeatId] || [];
@@ -37595,9 +37656,11 @@ const shotPowerRef = useRef(0);
                     </span>
                   )}
                 </div>
-                <div className="mt-1">
-                  {renderPottedRow(playerPotted, lastPlayerPotId, lastPotGlow)}
-                </div>
+                {!hideHudPottedBalls && (
+                  <div className="mt-1">
+                    {renderPottedRow(playerPotted, lastPlayerPotId, lastPotGlow)}
+                  </div>
+                )}
               </div>
             </div>
             {!isFreePractice && (
@@ -37630,9 +37693,11 @@ const shotPowerRef = useRef(0);
                           {opponentDisplayName}
                         </span>
                       </div>
-                      <div className="mt-1">
-                        {renderPottedRow(opponentPotted, lastOpponentPotId, lastPotGlow)}
-                      </div>
+                      {!hideHudPottedBalls && (
+                        <div className="mt-1">
+                          {renderPottedRow(opponentPotted, lastOpponentPotId, lastPotGlow)}
+                        </div>
+                      )}
                     </div>
                   ) : (
                     <div className="flex min-w-0 flex-col">
@@ -37650,9 +37715,11 @@ const shotPowerRef = useRef(0);
                           {aiFlagLabel}
                         </span>
                       </div>
-                      <div className="mt-1">
-                        {renderPottedRow(opponentPotted, lastOpponentPotId, lastPotGlow)}
-                      </div>
+                      {!hideHudPottedBalls && (
+                        <div className="mt-1">
+                          {renderPottedRow(opponentPotted, lastOpponentPotId, lastPotGlow)}
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
### Motivation
- Make the Showood GLB behave as a showroom table by hiding net/basket/holder/bar parts and remove the potted-ball HUD row which was visually under the table.
- Allow preserved Showood trim and pocket materials to reflect the user-selected chrome color and pocket-liner so finishes (gold/chrome/plastic-black) update mapped GLB parts.
- Improve side lounge furniture so player chairs and tables read correctly on mobile portrait and provide precise chair seat/back/root points for seated human rigs.

### Description
- Add new Showood table model options in `webapp/src/config/poolRoyaleTableModels.js` including `hideSurfaceNamePatterns` and `hideHudPottedBalls` and rename tint flags to `tintOriginalTrimFromChromeOption` and `tintOriginalPocketFromLinerOption`.
- Pass selected chrome and pocket-liner options into the external-mount pipeline and use them when tinting preserved `trim` and `pocket` materials in `Table3D` (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Add surface-name pattern matching (`matchesPoolRoyaleExternalSurfaceName`) and hide matching meshes during `preparePoolRoyaleExternalTableMaterials` so nets/baskets/holders are hidden for the Showood model.
- Change chrome generation logic to respect both `forceGeneratedChromePlates` and the chrome plate style's `showGeneratedOnExternal`, and conditionally hide potted-ball HUD rows when `hideHudPottedBalls` is set.
- Enlarge and reposition side-lounge furniture by increasing table/chair constants and update fallback lounge creation to expose `chairRoot`, `chairSeatWorld`, and `chairBackWorld` for precise seated placement, and scale/fit GLTF chair assets.
- Update test expectations in `test/poolRoyaleTableModels.test.js` to reflect the new option keys and added Showood flags.

### Testing
- Ran unit tests with `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and the suite passed.
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully.
- Ran `npx eslint` on changed files and observed that ESLint ran but reported the files were ignored by repo ignore rules (warning only).
- Attempted a Playwright mobile screenshot to verify visual changes, but Chromium could not launch in this container due to a missing system library (`libatk-1.0.so.0`), so automated screenshot verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff7255aba08329adf7b5ee8abaa890)