### PR TITLE
Add open-world city, helicopter, graphics profiles and improved asset loading; enhance Gradle wrapper fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ cache/
 # .NET build artifacts
 **/bin/
 **/obj/
+
+# Downloaded by webapp/scripts/fetch-gradle-wrapper.mjs; keep binary out of PRs.
+webapp/android/gradle/wrapper/gradle-wrapper.jar

--- a/webapp/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/webapp/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,34 +1,16 @@
 {
   "images": [
     {
-      "filename": "app-icon-29x29@3x.png",
-      "idiom": "iphone",
-      "scale": "3x",
-      "size": "29x29"
-    },
-    {
-      "filename": "app-icon-40x40@2x.png",
+      "filename": "app-icon-20x20@2x.png",
       "idiom": "iphone",
       "scale": "2x",
-      "size": "40x40"
+      "size": "20x20"
     },
     {
       "filename": "app-icon-29x29@2x.png",
       "idiom": "iphone",
       "scale": "2x",
       "size": "29x29"
-    },
-    {
-      "filename": "app-icon-40x40@3x.png",
-      "idiom": "iphone",
-      "scale": "3x",
-      "size": "40x40"
-    },
-    {
-      "filename": "app-icon-20x20@2x.png",
-      "idiom": "iphone",
-      "scale": "2x",
-      "size": "20x20"
     },
     {
       "filename": "app-icon-20x20@3x.png",
@@ -37,22 +19,28 @@
       "size": "20x20"
     },
     {
+      "filename": "app-icon-40x40@2x.png",
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "40x40"
+    },
+    {
       "filename": "app-icon-60x60@2x.png",
       "idiom": "iphone",
       "scale": "2x",
       "size": "60x60"
     },
     {
-      "filename": "app-icon-29x29@1x.png",
-      "idiom": "ipad",
-      "scale": "1x",
-      "size": "29x29"
+      "filename": "app-icon-40x40@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "40x40"
     },
     {
-      "filename": "app-icon-20x20@2x.png",
-      "idiom": "ipad",
-      "scale": "2x",
-      "size": "20x20"
+      "filename": "app-icon-29x29@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "29x29"
     },
     {
       "filename": "app-icon-20x20@1x.png",
@@ -61,21 +49,39 @@
       "size": "20x20"
     },
     {
+      "filename": "app-icon-20x20@2x.png",
+      "idiom": "ipad",
+      "scale": "2x",
+      "size": "20x20"
+    },
+    {
+      "filename": "app-icon-60x60@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "60x60"
+    },
+    {
       "filename": "app-icon-29x29@2x.png",
       "idiom": "ipad",
       "scale": "2x",
       "size": "29x29"
     },
     {
-      "filename": "app-icon-40x40@1x.png",
+      "filename": "app-icon-29x29@1x.png",
       "idiom": "ipad",
       "scale": "1x",
-      "size": "40x40"
+      "size": "29x29"
     },
     {
       "filename": "app-icon-40x40@2x.png",
       "idiom": "ipad",
       "scale": "2x",
+      "size": "40x40"
+    },
+    {
+      "filename": "app-icon-40x40@1x.png",
+      "idiom": "ipad",
+      "scale": "1x",
       "size": "40x40"
     },
     {
@@ -85,10 +91,10 @@
       "size": "76x76"
     },
     {
-      "filename": "app-icon-60x60@3x.png",
-      "idiom": "iphone",
-      "scale": "3x",
-      "size": "60x60"
+      "filename": "app-icon-76x76@2x.png",
+      "idiom": "ipad",
+      "scale": "2x",
+      "size": "76x76"
     },
     {
       "filename": "app-icon-1024x1024@1x.png",
@@ -101,12 +107,6 @@
       "idiom": "ipad",
       "scale": "2x",
       "size": "83.5x83.5"
-    },
-    {
-      "filename": "app-icon-76x76@2x.png",
-      "idiom": "ipad",
-      "scale": "2x",
-      "size": "76x76"
     }
   ],
   "info": {

--- a/webapp/scripts/fetch-gradle-wrapper.mjs
+++ b/webapp/scripts/fetch-gradle-wrapper.mjs
@@ -1,21 +1,53 @@
+import { spawn } from 'child_process';
 import { createWriteStream } from 'fs';
-import { access, mkdir } from 'fs/promises';
+import { mkdir, readFile, rename, rm, stat } from 'fs/promises';
 import { dirname } from 'path';
 import https from 'https';
 import { fileURLToPath } from 'url';
 
-const WRAPPER_PATH = fileURLToPath(new URL('../android/gradle/wrapper/gradle-wrapper.jar', import.meta.url));
-const WRAPPER_URL = 'https://raw.githubusercontent.com/gradle/gradle/v8.2.1/gradle/wrapper/gradle-wrapper.jar';
+const WRAPPER_PATH = fileURLToPath(
+  new URL('../android/gradle/wrapper/gradle-wrapper.jar', import.meta.url)
+);
+const WRAPPER_TMP_PATH = `${WRAPPER_PATH}.tmp`;
+const WRAPPER_URL =
+  'https://raw.githubusercontent.com/gradle/gradle/v8.2.1/gradle/wrapper/gradle-wrapper.jar';
 
-async function downloadJar() {
-  await mkdir(dirname(WRAPPER_PATH), { recursive: true });
+async function hasValidWrapperJar() {
+  try {
+    const [{ size }, header] = await Promise.all([
+      stat(WRAPPER_PATH),
+      readFile(WRAPPER_PATH, { encoding: null })
+    ]);
+    return (
+      size > 0 &&
+      header[0] === 0x50 &&
+      header[1] === 0x4b &&
+      header[2] === 0x03 &&
+      header[3] === 0x04
+    );
+  } catch {
+    return false;
+  }
+}
 
+function formatError(error) {
+  if (error instanceof Error && error.message) return error.message;
+  if (error && typeof error === 'object' && 'code' in error)
+    return String(error.code);
+  return String(error);
+}
+
+async function downloadWithHttps() {
   await new Promise((resolve, reject) => {
-    const file = createWriteStream(WRAPPER_PATH);
+    const file = createWriteStream(WRAPPER_TMP_PATH);
     https
       .get(WRAPPER_URL, (response) => {
         if (response.statusCode !== 200) {
-          reject(new Error(`Unable to download Gradle wrapper (status ${response.statusCode})`));
+          reject(
+            new Error(
+              `Unable to download Gradle wrapper (status ${response.statusCode})`
+            )
+          );
           response.resume();
           return;
         }
@@ -24,25 +56,60 @@ async function downloadJar() {
         file.on('finish', () => {
           file.close(resolve);
         });
+        file.on('error', reject);
       })
-      .on('error', (error) => {
-        reject(error);
-      });
+      .on('error', reject);
+  });
+
+}
+
+async function downloadWithCurl() {
+  await new Promise((resolve, reject) => {
+    const child = spawn('curl', [
+      '--fail',
+      '--location',
+      '--silent',
+      '--show-error',
+      '--output',
+      WRAPPER_TMP_PATH,
+      WRAPPER_URL
+    ]);
+
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`curl exited with status ${code ?? 'unknown'}`));
+    });
+    child.on('error', reject);
   });
 }
 
-async function ensureWrapper() {
+async function downloadJar() {
+  await mkdir(dirname(WRAPPER_PATH), { recursive: true });
+  await rm(WRAPPER_TMP_PATH, { force: true });
+
   try {
-    await access(WRAPPER_PATH);
-    return;
-  } catch {
-    // continue to download
+    await downloadWithHttps();
+  } catch (error) {
+    console.warn(
+      `Direct Gradle wrapper download failed (${formatError(error)}); retrying with curl.`
+    );
+    await rm(WRAPPER_TMP_PATH, { force: true });
+    await downloadWithCurl();
   }
+
+  await rename(WRAPPER_TMP_PATH, WRAPPER_PATH);
+}
+
+async function ensureWrapper() {
+  if (await hasValidWrapperJar()) return;
 
   await downloadJar();
 }
 
-ensureWrapper().catch((error) => {
-  console.warn('Gradle wrapper jar could not be downloaded automatically. Please download it manually if you need the Android build tools.');
-  console.warn(error.message);
+ensureWrapper().catch(async (error) => {
+  await rm(WRAPPER_TMP_PATH, { force: true });
+  console.warn(
+    'Gradle wrapper jar could not be downloaded automatically. Please download it manually if you need the Android build tools.'
+  );
+  console.warn(formatError(error));
 });

--- a/webapp/src/games/mobileUrbanFps/MobileUrbanFps.css
+++ b/webapp/src/games/mobileUrbanFps/MobileUrbanFps.css
@@ -4,8 +4,12 @@
   display: flex;
   justify-content: center;
   background:
-    radial-gradient(circle at 50% 0%, rgba(79, 70, 229, 0.28), transparent 42%),
-    #06070b;
+    radial-gradient(
+      circle at 50% 0%,
+      rgba(125, 211, 252, 0.28),
+      transparent 42%
+    ),
+    linear-gradient(180deg, #233147 0%, #0b1020 100%);
   color: white;
   overscroll-behavior: none;
   touch-action: none;
@@ -19,7 +23,7 @@
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 28px;
-  background: #070a10;
+  background: #9db6d1;
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.65);
 }
 
@@ -108,19 +112,19 @@
   position: absolute;
   left: 22px;
   bottom: max(26px, env(safe-area-inset-bottom));
-  width: 126px;
-  height: 126px;
+  width: 158px;
+  height: 158px;
   border-radius: 50%;
   border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(12, 20, 32, 0.24);
   backdrop-filter: blur(10px);
 }
 .mobile-fps-stick {
   position: absolute;
-  left: 43px;
-  top: 43px;
-  width: 40px;
-  height: 40px;
+  left: 52px;
+  top: 52px;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
   background: linear-gradient(145deg, #e8f0ff, #7787a8);
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
@@ -158,11 +162,54 @@
   height: 50px;
   background: rgba(37, 99, 235, 0.55);
 }
+.mobile-fps-heli {
+  right: 112px;
+  bottom: max(138px, calc(env(safe-area-inset-bottom) + 104px));
+  width: 94px;
+  height: 50px;
+  background: rgba(14, 165, 233, 0.7);
+  box-shadow: 0 12px 34px rgba(14, 165, 233, 0.32);
+}
+.mobile-fps-weapon-switch {
+  pointer-events: auto;
+  position: absolute;
+  left: 50%;
+  bottom: 132px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(5, 8, 14, 0.58);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.32);
+}
+.mobile-fps-weapon-switch button {
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(96, 165, 250, 0.88);
+  color: white;
+  font-weight: 900;
+}
+.mobile-fps-weapon-switch span {
+  min-width: 94px;
+  max-width: 122px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 900;
+}
 .mobile-fps-status {
   position: absolute;
   left: 18px;
   right: 18px;
-  bottom: 170px;
+  bottom: 184px;
   text-align: center;
   font-size: 12px;
   color: rgba(255, 255, 255, 0.72);
@@ -213,4 +260,100 @@
   font-size: 9px;
   color: rgba(255, 255, 255, 0.48);
   text-align: center;
+}
+.mobile-fps-heli-lift {
+  pointer-events: auto;
+  position: absolute;
+  right: 18px;
+  top: 42%;
+  display: grid;
+  gap: 10px;
+}
+.mobile-fps-heli-lift button {
+  width: 74px;
+  height: 54px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 18px;
+  background: rgba(14, 165, 233, 0.72);
+  color: white;
+  font-weight: 900;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+.mobile-fps-sensitivity {
+  pointer-events: auto;
+  position: absolute;
+  left: 50%;
+  top: max(82px, calc(env(safe-area-inset-top) + 72px));
+  transform: translateX(-50%);
+  width: min(260px, calc(100% - 40px));
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(5, 8, 14, 0.52);
+  backdrop-filter: blur(12px);
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+.mobile-fps-sensitivity input {
+  width: 100%;
+  accent-color: #38bdf8;
+}
+.mobile-fps-graphics {
+  pointer-events: auto;
+  position: absolute;
+  left: 50%;
+  top: max(126px, calc(env(safe-area-inset-top) + 116px));
+  transform: translateX(-50%);
+  display: flex;
+  gap: 7px;
+  padding: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  background: rgba(5, 8, 14, 0.46);
+  backdrop-filter: blur(12px);
+}
+.mobile-fps-graphics button {
+  min-width: 42px;
+  min-height: 30px;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 10px;
+  font-weight: 900;
+}
+.mobile-fps-graphics button.active {
+  background: #34d399;
+  color: #02130a;
+  box-shadow: 0 0 16px rgba(52, 211, 153, 0.46);
+}
+.mobile-fps-fallback {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: grid;
+  place-content: center;
+  gap: 10px;
+  padding: 28px;
+  background: radial-gradient(circle at 50% 0%, #1e3a8a, #020617 62%);
+  text-align: center;
+  color: white;
+}
+.mobile-fps-fallback strong {
+  font-size: 22px;
+}
+.mobile-fps-fallback button {
+  margin: 8px auto 0;
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 18px;
+  background: #34d399;
+  color: #02130a;
+  font-weight: 900;
 }

--- a/webapp/src/games/mobileUrbanFps/MobileUrbanFps.tsx
+++ b/webapp/src/games/mobileUrbanFps/MobileUrbanFps.tsx
@@ -1,12 +1,26 @@
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { useGLTF } from '@react-three/drei';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Component,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import type { PointerEvent, ReactNode } from 'react';
 import * as THREE from 'three';
 import { mobileUrbanFpsAssets, assetSourceNotes } from './assetConfig';
+import {
+  openWorldAssetManifest,
+  openWorldMaterialSources
+} from './openWorldAssets';
 import {
   DISPLAY_ITEMS,
   FIRST_PERSON_WEAPON,
   FPS_HAND_DONOR,
+  FPS_WEAPON_OPTIONS,
   TOTAL_ITEMS,
   type DisplayEntry
 } from './assetCatalog';
@@ -26,47 +40,315 @@ import {
   normalizeObject,
   targetDisplayLength
 } from './systems/AssetLoader';
+import {
+  helicopterFlightConfig,
+  isNearPoint,
+  stepHelicopterFlight
+} from './systems/HelicopterSystem';
+import {
+  mapPortraitLookDelta,
+  normalizeJoystickInput
+} from './systems/MobileControlsSystem';
+import { applyFirstPersonRecoil } from './systems/RecoilSystem';
 import './MobileUrbanFps.css';
 
+const FPS_GRAPHICS_STORAGE_KEY = 'mobileUrbanFpsGraphics';
+const FPS_GRAPHICS_OPTIONS = [
+  {
+    id: 'fhd60',
+    label: 'Performance (60 Hz)',
+    fps: 60,
+    dpr: [1, 1.15] as [number, number],
+    shadows: false,
+    antialias: false,
+    note: 'Pool Royale style 2K/mobile battery profile.'
+  },
+  {
+    id: 'qhd90',
+    label: 'Smooth (90 Hz)',
+    fps: 90,
+    dpr: [1, 1.45] as [number, number],
+    shadows: true,
+    antialias: false,
+    note: 'Pool Royale style 4K clarity target for modern phones.'
+  },
+  {
+    id: 'uhd120',
+    label: 'Ultra (120 Hz)',
+    fps: 120,
+    dpr: [1, 1.75] as [number, number],
+    shadows: true,
+    antialias: true,
+    note: 'High refresh profile; use only on strong devices.'
+  }
+] as const;
+
+function readInitialGraphicsId() {
+  if (typeof window === 'undefined') return 'fhd60';
+  const stored = window.localStorage?.getItem(FPS_GRAPHICS_STORAGE_KEY);
+  if (FPS_GRAPHICS_OPTIONS.some((option) => option.id === stored))
+    return stored;
+  const memory = (navigator as any).deviceMemory ?? 4;
+  const cores = navigator.hardwareConcurrency ?? 4;
+  return memory >= 6 && cores >= 6 ? 'qhd90' : 'fhd60';
+}
+
+class MobileFpsErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('Mobile Urban FPS render failed', error);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="mobile-fps-fallback">
+          <strong>Graphics reset needed</strong>
+          <span>Urban Ops could not start WebGL on this device.</span>
+          <button onClick={() => window.location.reload()}>Reload game</button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const CITY_BOUNDS = {
+  minX: -24,
+  maxX: 24,
+  minZ: -162,
+  maxZ: 8
+} as const;
+
+const PLAYER_STANDING_Y = 1.55;
+const HELIPAD_POSITION = new THREE.Vector3(0, 12.45, -70);
+const ARMORY_VISIBLE_ITEM_LIMIT = 9;
+const ARMORY_REMOTE_LOAD_LIMIT = 4;
+const ARMORY_REMOTE_LOAD_DELAY_MS = 700;
+
+type PbrMaterialSet = ReturnType<typeof PbrMaterials>;
+
 const enemySeed: Array<[number, number, number]> = [
-  [-4, 0.9, -11],
-  [3.8, 0.9, -14],
-  [-1.2, 0.9, -19],
-  [5.5, 0.9, -24],
-  [-5.5, 0.9, -27],
-  [0.6, 0.9, -33]
+  [-5, 0.9, -18],
+  [6, 0.9, -31],
+  [-11, 0.9, -48],
+  [10, 0.9, -66],
+  [-6, 0.9, -91],
+  [7, 0.9, -118],
+  [-12, 0.9, -139],
+  [12, 0.9, -152]
 ];
 
-const colliders = [
-  new THREE.Box3(new THREE.Vector3(-8, -1, -36), new THREE.Vector3(8, 4, -35)),
-  new THREE.Box3(new THREE.Vector3(-8, -1, 1), new THREE.Vector3(8, 4, 2)),
-  new THREE.Box3(
-    new THREE.Vector3(-8.5, -1, -36),
-    new THREE.Vector3(-7.5, 4, 2)
-  ),
-  new THREE.Box3(new THREE.Vector3(7.5, -1, -36), new THREE.Vector3(8.5, 4, 2)),
-  new THREE.Box3(
-    new THREE.Vector3(-2.4, -1, -9),
-    new THREE.Vector3(0.4, 2, -7.8)
-  ),
-  new THREE.Box3(
-    new THREE.Vector3(2.4, -1, -17),
-    new THREE.Vector3(5.8, 2, -15.8)
-  ),
-  new THREE.Box3(
-    new THREE.Vector3(-6.4, -1, -22),
-    new THREE.Vector3(-3.6, 2, -20.6)
-  )
+type BuildingSpec = {
+  id: string;
+  x: number;
+  z: number;
+  width: number;
+  depth: number;
+  height: number;
+  material: 'concrete' | 'brick' | 'metal' | 'mall';
+  label?: string;
+  mall?: boolean;
+};
+
+type CityCollider = {
+  box: THREE.Box3;
+  roofHeight: number;
+};
+
+type StairSpec = {
+  id: string;
+  x: number;
+  z: number;
+  width: number;
+  depth: number;
+  height: number;
+  side: -1 | 1;
+};
+
+const districtBlocks = Array.from(
+  { length: 13 },
+  (_, index) => -8 - index * 12
+);
+const crossStreets = [-16, -40, -64, -88, -112, -136, -156];
+
+const TONPLAYGRAM_MALL: BuildingSpec = {
+  id: 'tonplaygram-mall',
+  x: 0,
+  z: -70,
+  width: 17,
+  depth: 22,
+  height: 10.8,
+  material: 'mall',
+  label: 'TonPlaygram Mall',
+  mall: true
+};
+
+const generatedBuildings: BuildingSpec[] = districtBlocks.flatMap((z, row) =>
+  [-1, 1].flatMap((side) => {
+    const nearMall = z < -56 && z > -84;
+    const frontX = side * (9.8 + (row % 2) * 0.8);
+    const backX = side * (18.2 + (row % 3) * 0.45);
+    const baseHeight = 8 + ((row * 1.7 + (side > 0 ? 2 : 0)) % 7);
+    return [
+      {
+        id: `tower-${side}-${row}-front`,
+        x: nearMall ? side * 19 : frontX,
+        z,
+        width: 4.8 + (row % 3) * 0.7,
+        depth: 5.6,
+        height: baseHeight,
+        material: row % 2 ? 'brick' : 'concrete'
+      },
+      {
+        id: `tower-${side}-${row}-rear`,
+        x: backX,
+        z: z - 3.2,
+        width: 4.4 + ((row + 1) % 3) * 0.65,
+        depth: 5.2,
+        height: baseHeight + 2.6,
+        material: row % 2 ? 'concrete' : 'brick'
+      }
+    ] as BuildingSpec[];
+  })
+);
+
+const cityBuildings: BuildingSpec[] = [TONPLAYGRAM_MALL, ...generatedBuildings];
+
+const roofStairs: StairSpec[] = cityBuildings.map((building) => {
+  const side = building.x >= 0 ? 1 : -1;
+  const width = building.mall ? 3.8 : 1.35;
+  const depth = building.mall ? 9.8 : 5.2;
+  return {
+    id: `${building.id}-roof-stairs`,
+    x: building.x + side * (building.width / 2 + width / 2 + 0.22),
+    z: building.z + building.depth * 0.12,
+    width,
+    depth,
+    height: building.height,
+    side
+  };
+});
+
+function makeCollider(building: BuildingSpec): CityCollider {
+  return {
+    box: new THREE.Box3(
+      new THREE.Vector3(
+        building.x - building.width / 2,
+        -1,
+        building.z - building.depth / 2
+      ),
+      new THREE.Vector3(
+        building.x + building.width / 2,
+        building.height + 1.4,
+        building.z + building.depth / 2
+      )
+    ),
+    roofHeight: building.height
+  };
+}
+
+const cityColliders: CityCollider[] = [
+  {
+    box: new THREE.Box3(
+      new THREE.Vector3(CITY_BOUNDS.minX - 3, -1, CITY_BOUNDS.minZ - 3),
+      new THREE.Vector3(CITY_BOUNDS.maxX + 3, 20, CITY_BOUNDS.minZ)
+    ),
+    roofHeight: 99
+  },
+  ...cityBuildings.map(makeCollider)
 ];
 
-function clampPlayer(position: THREE.Vector3) {
-  position.x = THREE.MathUtils.clamp(position.x, -6.8, 6.8);
-  position.z = THREE.MathUtils.clamp(position.z, -34, -0.5);
+function isInsideRect(
+  x: number,
+  z: number,
+  centerX: number,
+  centerZ: number,
+  width: number,
+  depth: number
+) {
+  return (
+    x >= centerX - width / 2 &&
+    x <= centerX + width / 2 &&
+    z >= centerZ - depth / 2 &&
+    z <= centerZ + depth / 2
+  );
+}
+
+function navigationHeight(position: THREE.Vector3) {
+  let targetY = PLAYER_STANDING_Y;
+
+  for (const stair of roofStairs) {
+    if (
+      !isInsideRect(
+        position.x,
+        position.z,
+        stair.x,
+        stair.z,
+        stair.width,
+        stair.depth
+      )
+    )
+      continue;
+    const localZ = THREE.MathUtils.clamp(
+      (position.z - (stair.z - stair.depth / 2)) / stair.depth,
+      0,
+      1
+    );
+    targetY = Math.max(targetY, PLAYER_STANDING_Y + localZ * stair.height);
+  }
+
+  for (const building of cityBuildings) {
+    const onRoof = isInsideRect(
+      position.x,
+      position.z,
+      building.x,
+      building.z,
+      building.width + 0.6,
+      building.depth + 0.6
+    );
+    if (onRoof && position.y >= building.height - 0.4) {
+      targetY = Math.max(targetY, building.height + PLAYER_STANDING_Y);
+    }
+  }
+
+  return targetY;
+}
+
+function clampPlayer(position: THREE.Vector3, vehicleMode = false) {
+  position.x = THREE.MathUtils.clamp(
+    position.x,
+    CITY_BOUNDS.minX,
+    CITY_BOUNDS.maxX
+  );
+  position.z = THREE.MathUtils.clamp(
+    position.z,
+    CITY_BOUNDS.minZ,
+    CITY_BOUNDS.maxZ
+  );
+
+  if (vehicleMode) {
+    position.y = THREE.MathUtils.clamp(position.y, 6, 42);
+    return;
+  }
+
+  position.y = navigationHeight(position);
   const playerBox = new THREE.Box3().setFromCenterAndSize(
     position,
     new THREE.Vector3(0.7, 1.7, 0.7)
   );
-  for (const box of colliders) {
+
+  for (const collider of cityColliders) {
+    if (position.y > collider.roofHeight + 0.9) continue;
+    const box = collider.box;
     if (playerBox.intersectsBox(box)) {
       const left = Math.abs(playerBox.max.x - box.min.x);
       const right = Math.abs(box.max.x - playerBox.min.x);
@@ -79,15 +361,30 @@ function clampPlayer(position: THREE.Vector3) {
       else position.z += back;
     }
   }
+
+  position.y = navigationHeight(position);
+}
+
+function isNearHelipad(position: THREE.Vector3) {
+  return isNearPoint(position, HELIPAD_POSITION, 6.8);
 }
 
 function AssetLoader() {
   useEffect(() => {
     useGLTF.preload(mobileUrbanFpsAssets.weapon.rifleGlb);
     useGLTF.preload(mobileUrbanFpsAssets.hands.armsGlb);
-    useGLTF.preload(mobileUrbanFpsAssets.enemies.soldierGlb);
-    useGLTF.preload(mobileUrbanFpsAssets.city.buildingGlb);
-    useGLTF.preload(mobileUrbanFpsAssets.city.propsGlb);
+
+    const preloadOptionalAssets = () => {
+      FPS_WEAPON_OPTIONS.slice(0, 2).forEach((entry) => {
+        useGLTF.preload(entry.urls[0]);
+      });
+    };
+
+    const idleId = window.setTimeout(
+      preloadOptionalAssets,
+      ARMORY_REMOTE_LOAD_DELAY_MS
+    );
+    return () => window.clearTimeout(idleId);
   }, []);
   return null;
 }
@@ -144,6 +441,86 @@ function PbrMaterials() {
   return { road, concrete, brick, metal, glass };
 }
 
+function createTextSpriteMaterial(
+  text: string,
+  options: {
+    width?: number;
+    height?: number;
+    bg?: string;
+    fg?: string;
+    fontSize?: number;
+  } = {}
+) {
+  const width = options.width ?? 1024;
+  const height = options.height ?? 256;
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (ctx) {
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = options.bg ?? 'rgba(3, 7, 18, 0.78)';
+    const drawRoundedRect =
+      typeof ctx.roundRect === 'function'
+        ? (mode: 'fill' | 'stroke') => {
+            ctx.beginPath();
+            ctx.roundRect(18, 18, width - 36, height - 36, 32);
+            if (mode === 'fill') ctx.fill();
+            else ctx.stroke();
+          }
+        : null;
+    if (drawRoundedRect) drawRoundedRect('fill');
+    else ctx.fillRect(18, 18, width - 36, height - 36);
+    ctx.strokeStyle = 'rgba(255,255,255,0.45)';
+    ctx.lineWidth = 8;
+    if (drawRoundedRect) drawRoundedRect('stroke');
+    ctx.fillStyle = options.fg ?? '#ffffff';
+    ctx.font = `900 ${options.fontSize ?? 78}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(text, width / 2, height / 2, width - 90);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+  const material = new THREE.SpriteMaterial({
+    map: texture,
+    transparent: true,
+    depthWrite: false
+  });
+  material.userData.disposeTexture = () => texture.dispose();
+  return material;
+}
+
+function LabelSprite({
+  text,
+  position,
+  scale = [4, 1, 1],
+  bg,
+  fg,
+  fontSize
+}: {
+  text: string;
+  position: [number, number, number];
+  scale?: [number, number, number];
+  bg?: string;
+  fg?: string;
+  fontSize?: number;
+}) {
+  const material = useMemo(
+    () => createTextSpriteMaterial(text, { bg, fg, fontSize }),
+    [bg, fg, fontSize, text]
+  );
+  useEffect(
+    () => () => {
+      material.userData.disposeTexture?.();
+      material.dispose();
+    },
+    [material]
+  );
+  return <sprite position={position} scale={scale} material={material} />;
+}
+
 function Building({
   x,
   z,
@@ -191,99 +568,643 @@ function Building({
   );
 }
 
-function UrbanArena() {
-  const mats = PbrMaterials();
-  const lampPositions = [-4, 4];
-  const cover = [
-    [-1, 0.55, -8.6, 2.8, 1.1, 1],
-    [4.1, 0.55, -16.4, 3.4, 1.1, 1.1],
-    [-5, 0.55, -21.5, 2.8, 1.1, 1.4]
-  ];
+function RoadMarkings({ material }: { material: THREE.Material }) {
   return (
     <group>
-      <fog attach="fog" args={['#111827', 18, 48]} />
-      <mesh rotation-x={-Math.PI / 2} material={mats.road} receiveShadow>
-        <planeGeometry args={[16, 40]} />
-      </mesh>
-      <mesh
-        position={[-5.2, 0.012, -17]}
-        rotation-x={-Math.PI / 2}
-        material={mats.concrete}
-        receiveShadow
-      >
-        <planeGeometry args={[4.2, 38]} />
-      </mesh>
-      <mesh
-        position={[5.2, 0.012, -17]}
-        rotation-x={-Math.PI / 2}
-        material={mats.concrete}
-        receiveShadow
-      >
-        <planeGeometry args={[4.2, 38]} />
-      </mesh>
-      {[-7.1, 7.1].map((x) =>
-        [-5, -12, -20, -29].map((z, i) => (
-          <Building
-            key={`${x}-${z}`}
-            x={x}
-            z={z}
-            width={2.2 + (i % 2)}
-            depth={2.8}
-            height={5 + i * 0.9}
-            material={i % 2 ? mats.brick : mats.concrete}
-            glass={mats.glass}
-          />
-        ))
-      )}
-      {cover.map(([x, y, z, w, h, d], i) => (
+      {Array.from({ length: 50 }, (_, i) => 4 - i * 3.3).map((z) => (
         <mesh
-          key={i}
-          position={[x, y, z]}
-          material={i === 1 ? mats.metal : mats.concrete}
-          castShadow
-          receiveShadow
+          key={`lane-${z}`}
+          position={[0, 0.026, z]}
+          rotation-x={-Math.PI / 2}
+          material={material}
         >
-          <boxGeometry args={[w, h, d]} />
+          <planeGeometry args={[0.18, 1.25]} />
         </mesh>
       ))}
-      {[-12, -18, -26].map((z) => (
-        <group key={z} position={[0, 0, z]}>
+      {crossStreets.map((z) => (
+        <group key={`crosswalk-${z}`} position={[0, 0.029, z]}>
+          {[-3.7, -2.5, -1.25, 0, 1.25, 2.5, 3.7].map((x) => (
+            <mesh
+              key={`${z}-${x}`}
+              position={[x, 0, 0]}
+              rotation-x={-Math.PI / 2}
+              material={material}
+            >
+              <planeGeometry args={[0.38, 2.35]} />
+            </mesh>
+          ))}
+        </group>
+      ))}
+    </group>
+  );
+}
+
+function StreetLight({
+  x,
+  z,
+  mats
+}: {
+  x: number;
+  z: number;
+  mats: PbrMaterialSet;
+}) {
+  return (
+    <group position={[x, 0, z]}>
+      <mesh position={[0, 1.85, 0]} material={mats.metal} castShadow>
+        <cylinderGeometry args={[0.045, 0.06, 3.7, 8]} />
+      </mesh>
+      <mesh position={[x < 0 ? 0.32 : -0.32, 3.55, 0]} material={mats.metal}>
+        <boxGeometry args={[0.62, 0.06, 0.08]} />
+      </mesh>
+      <mesh position={[x < 0 ? 0.46 : -0.46, 3.38, 0]} material={mats.glass}>
+        <sphereGeometry args={[0.14, 12, 8]} />
+      </mesh>
+    </group>
+  );
+}
+
+function TrafficSignal({
+  x,
+  z,
+  mats
+}: {
+  x: number;
+  z: number;
+  mats: PbrMaterialSet;
+}) {
+  return (
+    <group position={[x, 0, z]}>
+      <mesh position={[0, 1.6, 0]} material={mats.metal}>
+        <cylinderGeometry args={[0.035, 0.045, 3.2, 8]} />
+      </mesh>
+      <mesh position={[0, 3.05, 0]} material={mats.metal} castShadow>
+        <boxGeometry args={[0.28, 0.72, 0.18]} />
+      </mesh>
+      {[
+        ['#ff3b30', 3.24],
+        ['#ffd60a', 3.05],
+        ['#30d158', 2.86]
+      ].map(([color, y]) => (
+        <mesh key={color} position={[0, Number(y), -0.095]}>
+          <sphereGeometry args={[0.055, 10, 8]} />
+          <meshBasicMaterial color={String(color)} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function BusStop({
+  x,
+  z,
+  mats
+}: {
+  x: number;
+  z: number;
+  mats: PbrMaterialSet;
+}) {
+  return (
+    <group position={[x, 0, z]}>
+      <mesh position={[0, 1.15, 0]} material={mats.glass}>
+        <boxGeometry args={[1.25, 1.7, 0.05]} />
+      </mesh>
+      <mesh position={[0, 2.08, 0]} material={mats.metal} castShadow>
+        <boxGeometry args={[1.5, 0.12, 0.72]} />
+      </mesh>
+      <mesh position={[0, 0.42, -0.25]} material={mats.metal} castShadow>
+        <boxGeometry args={[1.08, 0.16, 0.28]} />
+      </mesh>
+      <mesh position={[0, 1.5, -0.33]} material={mats.metal}>
+        <boxGeometry args={[0.72, 0.34, 0.04]} />
+      </mesh>
+    </group>
+  );
+}
+
+const mallGameSections = [
+  'Urban Ops FPS',
+  'Pool Royale',
+  'Domino Royal',
+  'Texas Holdem',
+  'Chess Battle',
+  'Goal Rush',
+  'Air Hockey',
+  'Snake & Ladder',
+  'Murlan Royale',
+  'Snooker Royal',
+  'Tennis',
+  'Bowling'
+];
+
+function BuildingBlock({
+  building,
+  mats
+}: {
+  building: BuildingSpec;
+  mats: PbrMaterialSet;
+}) {
+  const material =
+    building.material === 'brick'
+      ? mats.brick
+      : building.material === 'metal'
+        ? mats.metal
+        : building.material === 'mall'
+          ? mats.glass
+          : mats.concrete;
+  return (
+    <group>
+      <Building
+        x={building.x}
+        z={building.z}
+        width={building.width}
+        depth={building.depth}
+        height={building.height}
+        material={material}
+        glass={mats.glass}
+      />
+      {building.mall && (
+        <>
+          <LabelSprite
+            text="TONPLAYGRAM MALL"
+            position={[
+              building.x,
+              building.height + 0.72,
+              building.z + building.depth / 2 + 0.18
+            ]}
+            scale={[8.5, 1.8, 1]}
+            bg="rgba(14, 116, 144, 0.82)"
+            fontSize={86}
+          />
           <mesh
-            position={[-2.8, 0.45, 0]}
+            position={[building.x, building.height + 0.16, building.z]}
             material={mats.metal}
-            castShadow
-            receiveShadow
           >
-            <boxGeometry args={[1, 0.9, 1.2]} />
+            <boxGeometry args={[7.2, 0.12, 7.2]} />
           </mesh>
           <mesh
-            position={[2.2, 0.35, 0.7]}
-            material={mats.brick}
+            position={[
+              HELIPAD_POSITION.x,
+              building.height + 0.24,
+              HELIPAD_POSITION.z
+            ]}
+            rotation-x={-Math.PI / 2}
+          >
+            <ringGeometry args={[1.7, 2.35, 32]} />
+            <meshBasicMaterial color="#f8fafc" transparent opacity={0.82} />
+          </mesh>
+        </>
+      )}
+    </group>
+  );
+}
+
+function RooftopStair({
+  stair,
+  mats
+}: {
+  stair: StairSpec;
+  mats: PbrMaterialSet;
+}) {
+  const stepCount = 8;
+  return (
+    <group>
+      {Array.from({ length: stepCount }, (_, i) => {
+        const t = (i + 0.5) / stepCount;
+        return (
+          <mesh
+            key={`${stair.id}-${i}`}
+            position={[
+              stair.x,
+              0.12 + t * stair.height * 0.5,
+              stair.z - stair.depth / 2 + t * stair.depth
+            ]}
+            material={mats.concrete}
             castShadow
             receiveShadow
           >
-            <boxGeometry args={[1.2, 0.7, 1.2]} />
+            <boxGeometry
+              args={[
+                stair.width,
+                0.24 + t * stair.height,
+                stair.depth / stepCount
+              ]}
+            />
+          </mesh>
+        );
+      })}
+      <mesh
+        position={[stair.x, stair.height + 0.05, stair.z + stair.depth / 2]}
+        material={mats.metal}
+        receiveShadow
+      >
+        <boxGeometry args={[stair.width * 1.15, 0.1, 1.2]} />
+      </mesh>
+    </group>
+  );
+}
+
+function TonPlaygramMallInterior({ mats }: { mats: PbrMaterialSet }) {
+  return (
+    <group position={[0, 0.06, -70]}>
+      <mesh position={[0, 0.03, 0]} rotation-x={-Math.PI / 2} receiveShadow>
+        <planeGeometry args={[13.8, 17.5]} />
+        <meshStandardMaterial
+          color="#d8c8a4"
+          roughness={0.58}
+          metalness={0.08}
+        />
+      </mesh>
+      {mallGameSections.map((name, index) => {
+        const side = index % 2 === 0 ? -1 : 1;
+        const row = Math.floor(index / 2);
+        const z = -7 + row * 2.55;
+        return (
+          <group
+            key={name}
+            position={[side * 4.7, 0, z]}
+            rotation={[0, side > 0 ? -Math.PI / 2 : Math.PI / 2, 0]}
+          >
+            <mesh position={[0, 1.55, 0]} material={mats.metal} castShadow>
+              <boxGeometry args={[2.7, 1.7, 0.16]} />
+            </mesh>
+            <mesh position={[0, 1.57, -0.09]}>
+              <planeGeometry args={[2.35, 1.26]} />
+              <meshBasicMaterial
+                color={
+                  index % 3 === 0
+                    ? '#2563eb'
+                    : index % 3 === 1
+                      ? '#7c3aed'
+                      : '#059669'
+                }
+              />
+            </mesh>
+            <LabelSprite
+              text={name}
+              position={[0, 1.58, -0.16]}
+              scale={[1.95, 0.48, 1]}
+              bg="rgba(2, 6, 23, 0.72)"
+              fontSize={70}
+            />
+            <mesh
+              position={[-0.55, 0.48, -0.42]}
+              material={mats.concrete}
+              castShadow
+            >
+              <capsuleGeometry args={[0.16, 0.55, 5, 8]} />
+            </mesh>
+            <mesh
+              position={[0.55, 0.48, -0.42]}
+              material={mats.brick}
+              castShadow
+            >
+              <capsuleGeometry args={[0.16, 0.55, 5, 8]} />
+            </mesh>
+          </group>
+        );
+      })}
+      <mesh position={[0, 0.08, 0]}>
+        <cylinderGeometry args={[1.2, 1.45, 0.16, 32]} />
+        <meshStandardMaterial
+          color="#6ee7b7"
+          roughness={0.36}
+          metalness={0.12}
+        />
+      </mesh>
+      <pointLight
+        position={[0, 4.8, 0]}
+        intensity={1.7}
+        distance={18}
+        color="#bde7ff"
+      />
+    </group>
+  );
+}
+
+function ParkAndCourts() {
+  return (
+    <group>
+      <mesh
+        position={[-14.5, 0.035, -96]}
+        rotation-x={-Math.PI / 2}
+        receiveShadow
+      >
+        <planeGeometry args={[8.2, 15]} />
+        <meshStandardMaterial color="#237a3f" roughness={0.9} />
+      </mesh>
+      <mesh
+        position={[14.5, 0.04, -96]}
+        rotation-x={-Math.PI / 2}
+        receiveShadow
+      >
+        <planeGeometry args={[8.2, 15]} />
+        <meshStandardMaterial color="#3454d1" roughness={0.76} />
+      </mesh>
+      <mesh position={[14.5, 0.052, -96]} rotation-x={-Math.PI / 2}>
+        <ringGeometry args={[3.2, 3.26, 4]} />
+        <meshBasicMaterial color="#ffffff" transparent opacity={0.8} />
+      </mesh>
+      {[-17, -14.5, -12].map((x, i) => (
+        <group key={`park-tree-${i}`} position={[x, 0, -91 - i * 3.8]}>
+          <mesh position={[0, 0.72, 0]} castShadow>
+            <cylinderGeometry args={[0.11, 0.16, 1.4, 8]} />
+            <meshStandardMaterial color="#6b3f23" roughness={0.86} />
+          </mesh>
+          <mesh position={[0, 1.66, 0]} castShadow>
+            <sphereGeometry args={[0.72, 14, 10]} />
+            <meshStandardMaterial color="#1f7a3f" roughness={0.9} />
           </mesh>
         </group>
       ))}
-      {lampPositions.map((x) =>
-        [-6, -18, -30].map((z) => (
-          <group key={`${x}-${z}`} position={[x, 0, z]}>
-            <mesh position={[0, 1.8, 0]} material={mats.metal} castShadow>
-              <cylinderGeometry args={[0.045, 0.06, 3.6, 8]} />
-            </mesh>
-            <pointLight
-              position={[0, 3.4, 0]}
-              intensity={1.2}
-              distance={8}
-              color="#f4c982"
+      <mesh position={[0, 0.08, -118]} receiveShadow>
+        <cylinderGeometry args={[2.5, 2.8, 0.16, 36]} />
+        <meshStandardMaterial
+          color="#9bd4ff"
+          roughness={0.22}
+          metalness={0.02}
+        />
+      </mesh>
+      <pointLight
+        position={[0, 2.4, -118]}
+        intensity={0.65}
+        distance={10}
+        color="#9bd4ff"
+      />
+      <mesh position={[0, 0.06, -145]} rotation-x={-Math.PI / 2} receiveShadow>
+        <planeGeometry args={[17, 10]} />
+        <meshStandardMaterial color="#1e7a42" roughness={0.84} />
+      </mesh>
+      <LabelSprite
+        text="TONPLAYGRAM STADIUM"
+        position={[0, 1.4, -145]}
+        scale={[8.8, 1.6, 1]}
+        bg="rgba(22, 101, 52, 0.78)"
+        fontSize={82}
+      />
+    </group>
+  );
+}
+
+function CityTraffic() {
+  const vehicles = useMemo(
+    () => [
+      {
+        id: 'police',
+        color: '#1d4ed8',
+        z: -18,
+        lane: -1.8,
+        speed: 7.5,
+        light: '#ef4444'
+      },
+      {
+        id: 'ambulance',
+        color: '#f8fafc',
+        z: -54,
+        lane: 1.8,
+        speed: 6.5,
+        light: '#60a5fa'
+      },
+      {
+        id: 'fire',
+        color: '#dc2626',
+        z: -94,
+        lane: -1.8,
+        speed: 5.4,
+        light: '#f97316'
+      },
+      {
+        id: 'taxi',
+        color: '#facc15',
+        z: -130,
+        lane: 1.8,
+        speed: 6.8,
+        light: '#fde68a'
+      }
+    ],
+    []
+  );
+  const refs = useRef<Array<THREE.Group | null>>([]);
+
+  useFrame((_, dt) => {
+    refs.current.forEach((ref, index) => {
+      if (!ref) return;
+      const config = vehicles[index];
+      ref.position.z -= config.speed * dt;
+      if (ref.position.z < CITY_BOUNDS.minZ + 5)
+        ref.position.z = CITY_BOUNDS.maxZ - 4;
+    });
+  });
+
+  return (
+    <group>
+      {vehicles.map((vehicle, index) => (
+        <group
+          key={vehicle.id}
+          ref={(ref) => {
+            refs.current[index] = ref;
+          }}
+          position={[vehicle.lane, 0.38, vehicle.z]}
+        >
+          <mesh castShadow receiveShadow>
+            <boxGeometry
+              args={[1.35, 0.55, vehicle.id === 'fire' ? 2.4 : 1.9]}
             />
-            <mesh position={[0, 3.38, 0]} material={mats.glass}>
-              <sphereGeometry args={[0.15, 12, 8]} />
-            </mesh>
-          </group>
+            <meshStandardMaterial
+              color={vehicle.color}
+              roughness={0.48}
+              metalness={0.18}
+            />
+          </mesh>
+          <mesh position={[0, 0.42, -0.18]}>
+            <boxGeometry args={[0.82, 0.12, 0.24]} />
+            <meshBasicMaterial color={vehicle.light} />
+          </mesh>
+          <pointLight
+            position={[0, 0.75, -0.3]}
+            intensity={0.45}
+            distance={4}
+            color={vehicle.light}
+          />
+        </group>
+      ))}
+    </group>
+  );
+}
+
+function FarCitySkyline() {
+  const skyline = useMemo(
+    () =>
+      Array.from({ length: 34 }, (_, index) => ({
+        x: -48 + index * 3,
+        h: 8 + ((index * 7) % 19),
+        z: -188 - (index % 5) * 3,
+        w: 1.6 + (index % 4) * 0.6
+      })),
+    []
+  );
+  return (
+    <group>
+      {skyline.map((tower, index) => (
+        <mesh
+          key={`skyline-${index}`}
+          position={[tower.x, tower.h / 2 - 1, tower.z]}
+        >
+          <boxGeometry args={[tower.w, tower.h, 2.2]} />
+          <meshBasicMaterial color="#172033" transparent opacity={0.56} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function ParkedHelicopter({ active }: { active: boolean }) {
+  const rotor = useRef<THREE.Mesh>(null);
+  useFrame((_, dt) => {
+    if (rotor.current) rotor.current.rotation.y += dt * (active ? 28 : 3.2);
+  });
+  return (
+    <group
+      position={[
+        HELIPAD_POSITION.x,
+        HELIPAD_POSITION.y + 0.65,
+        HELIPAD_POSITION.z
+      ]}
+      scale={2.15}
+    >
+      <mesh castShadow>
+        <capsuleGeometry args={[0.32, 1.45, 8, 16]} />
+        <meshStandardMaterial
+          color="#52616b"
+          roughness={0.58}
+          metalness={0.35}
+        />
+      </mesh>
+      <mesh position={[0, 0.13, -0.9]} castShadow>
+        <boxGeometry args={[0.14, 0.12, 1.5]} />
+        <meshStandardMaterial
+          color="#2d3742"
+          roughness={0.62}
+          metalness={0.35}
+        />
+      </mesh>
+      <mesh ref={rotor} position={[0, 0.55, 0]}>
+        <boxGeometry args={[2.5, 0.025, 0.11]} />
+        <meshStandardMaterial color="#111827" roughness={0.5} metalness={0.4} />
+      </mesh>
+      <mesh position={[0.36, 0.08, 0.34]}>
+        <sphereGeometry args={[0.22, 14, 10]} />
+        <meshStandardMaterial
+          color="#9bd4ff"
+          roughness={0.18}
+          transparent
+          opacity={0.62}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+function UrbanArena() {
+  const mats = PbrMaterials();
+  const vehicleMode = useMobileFpsStore((state) => state.vehicleMode);
+  const markings = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: '#f8fafc',
+        transparent: true,
+        opacity: 0.76
+      }),
+    []
+  );
+  return (
+    <group>
+      <color attach="background" args={['#8fc8ff']} />
+      <fog attach="fog" args={['#b7d9f4', 76, 225]} />
+      <hemisphereLight args={['#f7fbff', '#70906f', 1.9]} />
+      <directionalLight
+        position={[-20, 35, 18]}
+        intensity={3.1}
+        color="#fff1cf"
+        castShadow
+        shadow-mapSize-width={1536}
+        shadow-mapSize-height={1536}
+      />
+      <mesh position={[0, -0.08, -78]} rotation-x={-Math.PI / 2} receiveShadow>
+        <planeGeometry args={[190, 230]} />
+        <meshStandardMaterial
+          color="#1d6fa3"
+          roughness={0.32}
+          metalness={0.02}
+          transparent
+          opacity={0.88}
+        />
+      </mesh>
+      <mesh position={[0, 0, -78]} rotation-x={-Math.PI / 2} receiveShadow>
+        <planeGeometry args={[50, 176]} />
+        <meshStandardMaterial
+          color="#64735e"
+          roughness={0.88}
+          metalness={0.02}
+        />
+      </mesh>
+      <mesh
+        position={[0, 0.02, -78]}
+        rotation-x={-Math.PI / 2}
+        material={mats.road}
+        receiveShadow
+      >
+        <planeGeometry args={[8.6, 168]} />
+      </mesh>
+      <mesh
+        position={[-6.8, 0.032, -78]}
+        rotation-x={-Math.PI / 2}
+        material={mats.concrete}
+        receiveShadow
+      >
+        <planeGeometry args={[3.2, 168]} />
+      </mesh>
+      <mesh
+        position={[6.8, 0.032, -78]}
+        rotation-x={-Math.PI / 2}
+        material={mats.concrete}
+        receiveShadow
+      >
+        <planeGeometry args={[3.2, 168]} />
+      </mesh>
+      <RoadMarkings material={markings} />
+      {crossStreets.map((z) => (
+        <mesh
+          key={`avenue-${z}`}
+          position={[0, 0.038, z]}
+          rotation-x={-Math.PI / 2}
+          material={mats.road}
+          receiveShadow
+        >
+          <planeGeometry args={[47, 4.2]} />
+        </mesh>
+      ))}
+      {cityBuildings.map((building) => (
+        <BuildingBlock key={building.id} building={building} mats={mats} />
+      ))}
+      {roofStairs.map((stair) => (
+        <RooftopStair key={stair.id} stair={stair} mats={mats} />
+      ))}
+      <TonPlaygramMallInterior mats={mats} />
+      <ParkAndCourts />
+      <CityTraffic />
+      <ParkedHelicopter active={vehicleMode === 'helicopter'} />
+      {[-5.2, 5.2, -20, 20].map((x) =>
+        Array.from({ length: 18 }, (_, i) => -4 - i * 9).map((z) => (
+          <StreetLight key={`${x}-${z}`} x={x} z={z} mats={mats} />
         ))
       )}
+      {crossStreets.flatMap((z) => [
+        <TrafficSignal key={`tl-${z}-l`} x={-4.9} z={z + 1.9} mats={mats} />,
+        <TrafficSignal key={`tl-${z}-r`} x={4.9} z={z - 1.9} mats={mats} />
+      ])}
+      <BusStop x={-7.9} z={-30} mats={mats} />
+      <BusStop x={7.9} z={-104} mats={mats} />
+      <FarCitySkyline />
     </group>
   );
 }
@@ -337,17 +1258,14 @@ function AssetArmory() {
     async function loadEntry(
       entry: DisplayEntry,
       index: number,
-      donorScene: THREE.Object3D | null
+      donorScene: THREE.Object3D | null,
+      slot: THREE.Group,
+      fallbackRoot?: THREE.Object3D
     ) {
       if (disposed) return;
-      const slot = new THREE.Group();
-      slot.position.copy(assetSlotPosition(index));
-      slot.rotation.y = Math.PI;
-      liveGroup.add(slot);
-      loadedRoots.push(slot);
 
       try {
-        const { gltf } = await loadModelByUrls(entry.name, entry.urls, 14000);
+        const { gltf } = await loadModelByUrls(entry.name, entry.urls, 7000);
         if (disposed) return;
         const model = gltf.scene;
         configureModel(model, gl, { mobileMaxAnisotropy: 2 });
@@ -357,6 +1275,13 @@ function AssetArmory() {
         model.rotation.y =
           (entry.rotateY ?? 0) + (entry.kind === 'weapon' ? Math.PI : 0);
         attachHandsToWeapon(entry, model, donorScene, gl);
+        if (fallbackRoot) {
+          slot.remove(fallbackRoot);
+          disposeObject(fallbackRoot);
+          runtimes.current = runtimes.current.filter(
+            (runtime) => runtime.root !== fallbackRoot
+          );
+        }
         slot.add(model);
         const mixer = gltf.animations.length
           ? new THREE.AnimationMixer(model)
@@ -380,14 +1305,24 @@ function AssetArmory() {
         });
       } catch (error) {
         console.warn(
-          'Urban FPS asset fell back to procedural stand-in:',
+          'Urban FPS asset kept procedural stand-in after remote load failed:',
           entry.name,
           error
         );
+      }
+    }
+
+    async function loadAll() {
+      const visibleItems = DISPLAY_ITEMS.slice(0, ARMORY_VISIBLE_ITEM_LIMIT);
+      visibleItems.forEach((entry, index) => {
+        const fallbackSlot = new THREE.Group();
+        fallbackSlot.position.copy(assetSlotPosition(index));
+        fallbackSlot.rotation.y = Math.PI;
         const fallback = createProceduralMachine(entry);
         normalizeObject(fallback, targetDisplayLength(entry) * 0.72);
-        fallback.rotation.y = entry.rotateY ?? 0;
-        slot.add(fallback);
+        fallbackSlot.add(fallback);
+        liveGroup.add(fallbackSlot);
+        loadedRoots.push(fallbackSlot);
         runtimes.current.push({
           entry,
           root: fallback,
@@ -395,14 +1330,22 @@ function AssetArmory() {
           baseRotation: fallback.rotation.clone(),
           index
         });
-      }
-    }
+      });
 
-    async function loadAll() {
-      const donorScene = await loadDonor();
-      await Promise.allSettled(
-        DISPLAY_ITEMS.map((entry, index) => loadEntry(entry, index, donorScene))
+      await new Promise((resolve) =>
+        window.setTimeout(resolve, ARMORY_REMOTE_LOAD_DELAY_MS)
       );
+      const donorScene = await loadDonor();
+      for (const [index, entry] of visibleItems
+        .slice(0, ARMORY_REMOTE_LOAD_LIMIT)
+        .entries()) {
+        if (disposed) return;
+        const slot = loadedRoots[index] as THREE.Group | undefined;
+        const fallbackRoot = runtimes.current.find(
+          (runtime) => runtime.index === index
+        )?.root;
+        if (slot) await loadEntry(entry, index, donorScene, slot, fallbackRoot);
+      }
     }
 
     loadAll();
@@ -475,9 +1418,11 @@ function AssetArmory() {
 
 function FirstPersonWeaponAsset({
   visible,
+  selectedWeapon,
   onReady
 }: {
   visible: boolean;
+  selectedWeapon: DisplayEntry;
   onReady: () => void;
 }) {
   const groupRef = useRef<THREE.Group>(null);
@@ -493,11 +1438,7 @@ function FirstPersonWeaponAsset({
     async function loadFirstPersonRig() {
       try {
         const [weaponResult, donorResult] = await Promise.allSettled([
-          loadModelByUrls(
-            FIRST_PERSON_WEAPON.name,
-            FIRST_PERSON_WEAPON.urls,
-            14000
-          ),
+          loadModelByUrls(selectedWeapon.name, selectedWeapon.urls, 14000),
           loadModelByUrls('FPS donor hands', FPS_HAND_DONOR.urls, 14000)
         ]);
         if (disposed || weaponResult.status !== 'fulfilled') return;
@@ -518,7 +1459,7 @@ function FirstPersonWeaponAsset({
         normalizeObject(weapon, 0.86);
         weapon.position.set(0, 0.02, 0);
         weapon.rotation.set(-0.04, Math.PI, 0);
-        attachHandsToWeapon(FIRST_PERSON_WEAPON, weapon, donorScene, gl);
+        attachHandsToWeapon(selectedWeapon, weapon, donorScene, gl);
         root = weapon;
         liveGroup.add(weapon);
         onReady();
@@ -539,13 +1480,12 @@ function FirstPersonWeaponAsset({
         disposeObject(root);
       }
     };
-  }, [gl, onReady]);
+  }, [gl, onReady, selectedWeapon]);
 
   useFrame(() => {
     if (!groupRef.current) return;
     const recoil = useMobileFpsStore.getState().recoil;
-    groupRef.current.position.z = -0.86 + recoil * 2.4;
-    groupRef.current.position.y = -0.42 - recoil * 0.75;
+    applyFirstPersonRecoil(groupRef.current, recoil);
   });
 
   return (
@@ -559,7 +1499,17 @@ function FirstPersonWeaponAsset({
 }
 
 function WeaponView() {
+  const vehicleMode = useMobileFpsStore((state) => state.vehicleMode);
+  const selectedWeaponId = useMobileFpsStore((state) => state.selectedWeaponId);
+  const selectedWeapon =
+    FPS_WEAPON_OPTIONS.find((entry) => entry.id === selectedWeaponId) ??
+    FIRST_PERSON_WEAPON;
   const [assetReady, setAssetReady] = useState(false);
+  const handleWeaponReady = useCallback(() => setAssetReady(true), []);
+
+  useEffect(() => {
+    setAssetReady(false);
+  }, [selectedWeapon.id]);
   const muzzleFlashUntil = useMobileFpsStore((state) => state.muzzleFlashUntil);
   const now = performance.now();
   const rifleMetal = useMemo(
@@ -589,11 +1539,14 @@ function WeaponView() {
       }),
     []
   );
+  if (vehicleMode === 'helicopter') return null;
   return (
     <>
       <FirstPersonWeaponAsset
+        key={selectedWeapon.id}
         visible={assetReady}
-        onReady={() => setAssetReady(true)}
+        selectedWeapon={selectedWeapon}
+        onReady={handleWeaponReady}
       />
       <group
         visible={!assetReady}
@@ -649,6 +1602,46 @@ function WeaponView() {
         />
       )}
     </>
+  );
+}
+
+function HelicopterCockpit() {
+  const vehicleMode = useMobileFpsStore((state) => state.vehicleMode);
+  const rotor = useRef<THREE.Mesh>(null);
+  useFrame((_, dt) => {
+    if (rotor.current) rotor.current.rotation.y += dt * 34;
+  });
+  if (vehicleMode !== 'helicopter') return null;
+  return (
+    <group position={[0, -0.52, -1.35]} rotation={[0.02, 0, 0]}>
+      <mesh position={[0, 0.08, -0.18]}>
+        <boxGeometry args={[1.35, 0.42, 0.68]} />
+        <meshStandardMaterial
+          color="#1f2937"
+          roughness={0.52}
+          metalness={0.35}
+        />
+      </mesh>
+      <mesh position={[0, 0.44, -0.58]}>
+        <boxGeometry args={[1.55, 0.42, 0.05]} />
+        <meshPhysicalMaterial
+          color="#8bd3ff"
+          transparent
+          opacity={0.28}
+          roughness={0.06}
+        />
+      </mesh>
+      <mesh ref={rotor} position={[0, 1.18, -0.42]}>
+        <boxGeometry args={[3.2, 0.025, 0.1]} />
+        <meshBasicMaterial color="#0f172a" transparent opacity={0.6} />
+      </mesh>
+      <pointLight
+        position={[0, 0.4, -0.9]}
+        intensity={0.75}
+        distance={3.5}
+        color="#8bd3ff"
+      />
+    </group>
   );
 }
 
@@ -803,43 +1796,63 @@ function CameraController({ enemies }: { enemies: EnemyRuntime[] }) {
   useFrame((_, dt) => {
     const state = useMobileFpsStore.getState();
     state.tickFx(dt);
-    state.recoverRecoil(rifleStats.recoilRecovery * dt * 0.02);
+    state.recoverRecoil(rifleStats.recoilRecovery * dt);
     if (state.phase !== 'playing') return;
 
-    const lookSensitivity = 2.45;
+    const lookSensitivity = state.vehicleMode === 'helicopter' ? 3.2 : 4.35;
     yaw.current -= state.input.lookX * lookSensitivity * dt;
     pitch.current = THREE.MathUtils.clamp(
-      pitch.current - state.input.lookY * lookSensitivity * dt - state.recoil,
-      -1.1,
-      1.05
+      pitch.current - state.input.lookY * lookSensitivity * dt,
+      -1.28,
+      1.18
     );
     state.setInput({ lookX: 0, lookY: 0 });
 
     fixedAccumulator.current += Math.min(dt, 0.05);
     while (fixedAccumulator.current >= stableStep) {
-      const forward = new THREE.Vector3(
-        Math.sin(yaw.current),
-        0,
-        Math.cos(yaw.current) * -1
-      );
-      const right = new THREE.Vector3(
-        Math.cos(yaw.current),
-        0,
-        Math.sin(yaw.current)
-      );
-      const move = forward
-        .multiplyScalar(state.input.moveY)
-        .add(right.multiplyScalar(state.input.moveX));
-      if (move.lengthSq() > 1) move.normalize();
-      player.current.addScaledVector(move, 4.2 * stableStep);
-      clampPlayer(player.current);
+      const flying = state.vehicleMode === 'helicopter';
+      if (flying) {
+        stepHelicopterFlight({
+          position: player.current,
+          yaw: yaw.current,
+          pitch: pitch.current,
+          moveX: state.input.moveX,
+          moveY: state.input.moveY,
+          lift: state.input.lift,
+          dt: stableStep,
+          bounds: CITY_BOUNDS
+        });
+      } else {
+        const forward = new THREE.Vector3(
+          Math.sin(yaw.current),
+          0,
+          Math.cos(yaw.current) * -1
+        );
+        const right = new THREE.Vector3(
+          Math.cos(yaw.current),
+          0,
+          Math.sin(yaw.current)
+        );
+        const move = forward
+          .multiplyScalar(state.input.moveY)
+          .add(right.multiplyScalar(state.input.moveX));
+        if (move.lengthSq() > 1) move.normalize();
+        player.current.addScaledVector(move, 9.4 * stableStep);
+        clampPlayer(player.current, false);
+      }
+      state.setCanBoardHelicopter(!flying && isNearHelipad(player.current));
       updateEnemies(enemies, player.current, stableStep);
       fixedAccumulator.current -= stableStep;
     }
 
     const alive = enemies.filter((enemy) => enemy.state !== 'dead').length;
     state.setEnemiesAlive(alive);
-    camera.position.lerp(player.current, 0.72);
+    camera.position.lerp(
+      player.current,
+      state.vehicleMode === 'helicopter'
+        ? helicopterFlightConfig.cameraLerp
+        : 0.8
+    );
     camera.rotation.set(pitch.current, yaw.current, 0);
     shootAction.update(
       performance.now(),
@@ -862,6 +1875,7 @@ function CameraController({ enemies }: { enemies: EnemyRuntime[] }) {
       ))}
       <primitive object={camera}>
         <WeaponView />
+        <HelicopterCockpit />
       </primitive>
     </>
   );
@@ -947,7 +1961,13 @@ const Scene = memo(function Scene() {
   );
 });
 
-function TouchHud() {
+function TouchHud({
+  graphicsId,
+  onGraphicsChange
+}: {
+  graphicsId: string;
+  onGraphicsChange: (id: string) => void;
+}) {
   const health = useMobileFpsStore((state) => state.health);
   const ammo = useMobileFpsStore((state) => state.ammo);
   const reserveAmmo = useMobileFpsStore((state) => state.reserveAmmo);
@@ -955,8 +1975,22 @@ function TouchHud() {
   const enemiesAlive = useMobileFpsStore((state) => state.enemiesAlive);
   const phase = useMobileFpsStore((state) => state.phase);
   const hitMarkerUntil = useMobileFpsStore((state) => state.hitMarkerUntil);
+  const selectedWeaponId = useMobileFpsStore((state) => state.selectedWeaponId);
+  const aimSensitivity = useMobileFpsStore((state) => state.aimSensitivity);
+  const setAimSensitivity = useMobileFpsStore(
+    (state) => state.setAimSensitivity
+  );
+  const vehicleMode = useMobileFpsStore((state) => state.vehicleMode);
+  const canBoardHelicopter = useMobileFpsStore(
+    (state) => state.canBoardHelicopter
+  );
+  const setVehicleMode = useMobileFpsStore((state) => state.setVehicleMode);
+  const cycleWeapon = useMobileFpsStore((state) => state.cycleWeapon);
   const setInput = useMobileFpsStore((state) => state.setInput);
   const reset = useMobileFpsStore((state) => state.reset);
+  const selectedWeapon =
+    FPS_WEAPON_OPTIONS.find((entry) => entry.id === selectedWeaponId) ??
+    FIRST_PERSON_WEAPON;
   const stick = useRef<HTMLDivElement>(null);
   const joystickId = useRef<number | null>(null);
   const lookId = useRef<number | null>(null);
@@ -966,6 +2000,18 @@ function TouchHud() {
     joystickId.current = null;
     setInput({ moveX: 0, moveY: 0 });
     if (stick.current) stick.current.style.transform = 'translate(0px, 0px)';
+  };
+
+  const updateJoystick = (event: PointerEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const dx = event.clientX - (rect.left + rect.width / 2);
+    const dy = event.clientY - (rect.top + rect.height / 2);
+    const maxRadius = rect.width * 0.42;
+    const rawLength = Math.hypot(dx, dy);
+    const normalized = normalizeJoystickInput(dx, dy, maxRadius);
+    setInput({ moveX: normalized.moveX, moveY: normalized.moveY });
+    if (stick.current)
+      stick.current.style.transform = `translate(${normalized.knobX}px, ${normalized.knobY}px)`;
   };
 
   return (
@@ -995,19 +2041,11 @@ function TouchHud() {
         onPointerDown={(event) => {
           joystickId.current = event.pointerId;
           event.currentTarget.setPointerCapture(event.pointerId);
+          updateJoystick(event);
         }}
         onPointerMove={(event) => {
           if (joystickId.current !== event.pointerId) return;
-          const rect = event.currentTarget.getBoundingClientRect();
-          const dx = event.clientX - (rect.left + rect.width / 2);
-          const dy = event.clientY - (rect.top + rect.height / 2);
-          const len = Math.min(48, Math.hypot(dx, dy));
-          const angle = Math.atan2(dy, dx);
-          const x = Math.cos(angle) * len;
-          const y = Math.sin(angle) * len;
-          setInput({ moveX: x / 48, moveY: -y / 48 });
-          if (stick.current)
-            stick.current.style.transform = `translate(${x}px, ${y}px)`;
+          updateJoystick(event);
         }}
         onPointerCancel={resetStick}
         onPointerUp={resetStick}
@@ -1026,10 +2064,7 @@ function TouchHud() {
           const dx = event.clientX - lookLast.current.x;
           const dy = event.clientY - lookLast.current.y;
           lookLast.current = { x: event.clientX, y: event.clientY };
-          setInput({
-            lookX: THREE.MathUtils.clamp(dx / 44, -1, 1),
-            lookY: THREE.MathUtils.clamp(dy / 44, -1, 1)
-          });
+          setInput(mapPortraitLookDelta(dx, dy, aimSensitivity));
         }}
         onPointerUp={() => {
           lookId.current = null;
@@ -1046,6 +2081,61 @@ function TouchHud() {
       >
         RELOAD
       </button>
+      {(canBoardHelicopter || vehicleMode === 'helicopter') && (
+        <button
+          className="mobile-fps-button mobile-fps-heli"
+          onPointerDown={() =>
+            setVehicleMode(
+              vehicleMode === 'helicopter' ? 'onFoot' : 'helicopter'
+            )
+          }
+        >
+          {vehicleMode === 'helicopter' ? 'EXIT HELI' : 'FLY HELI'}
+        </button>
+      )}
+      {vehicleMode === 'helicopter' && (
+        <div className="mobile-fps-heli-lift">
+          <button
+            type="button"
+            onPointerDown={() => setInput({ lift: 1 })}
+            onPointerUp={() => setInput({ lift: 0 })}
+            onPointerCancel={() => setInput({ lift: 0 })}
+          >
+            UP
+          </button>
+          <button
+            type="button"
+            onPointerDown={() => setInput({ lift: -1 })}
+            onPointerUp={() => setInput({ lift: 0 })}
+            onPointerCancel={() => setInput({ lift: 0 })}
+          >
+            DOWN
+          </button>
+        </div>
+      )}
+      <label className="mobile-fps-sensitivity">
+        <span>AIM {Math.round(aimSensitivity * 100)}%</span>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={aimSensitivity}
+          onChange={(event) => setAimSensitivity(Number(event.target.value))}
+        />
+      </label>
+      <div className="mobile-fps-graphics" aria-label="Graphics quality">
+        {FPS_GRAPHICS_OPTIONS.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            className={option.id === graphicsId ? 'active' : ''}
+            onPointerDown={() => onGraphicsChange(option.id)}
+          >
+            {option.fps}
+          </button>
+        ))}
+      </div>
       <button
         className="mobile-fps-button mobile-fps-shoot"
         onPointerDown={() => setInput({ firing: true })}
@@ -1054,8 +2144,27 @@ function TouchHud() {
       >
         FIRE
       </button>
+      <div className="mobile-fps-weapon-switch">
+        <button
+          type="button"
+          onPointerDown={() => cycleWeapon(-1)}
+          aria-label="Previous weapon"
+        >
+          ◀
+        </button>
+        <span>{selectedWeapon.shortName}</span>
+        <button
+          type="button"
+          onPointerDown={() => cycleWeapon(1)}
+          aria-label="Next weapon"
+        >
+          ▶
+        </button>
+      </div>
       <div className="mobile-fps-status">
-        Left thumb moves · right drag aims · {TOTAL_ITEMS} loaded asset slots
+        {vehicleMode === 'helicopter'
+          ? 'Helicopter mode · joystick flies · right drag turns fast'
+          : `Fast joystick · responsive aim · ${TOTAL_ITEMS} open-source GLB/GLTF slots`}
       </div>
       {phase !== 'playing' && (
         <div className="mobile-fps-modal">
@@ -1078,14 +2187,19 @@ function TouchHud() {
         </div>
       )}
       <div className="mobile-fps-notes">
-        PBR/GLB paths are configurable; mobile build targets low draw calls,
-        simple colliders, no heavy postprocessing.
+        Open-world GLB manifest: {openWorldAssetManifest.length} asset groups ·{' '}
+        {openWorldMaterialSources.length} PBR material sources.
       </div>
     </div>
   );
 }
 
 export default function MobileUrbanFps() {
+  const [graphicsId, setGraphicsId] = useState(readInitialGraphicsId);
+  const graphicsProfile =
+    FPS_GRAPHICS_OPTIONS.find((option) => option.id === graphicsId) ??
+    FPS_GRAPHICS_OPTIONS[0];
+
   useEffect(() => {
     const previous = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -1094,24 +2208,50 @@ export default function MobileUrbanFps() {
     };
   }, []);
 
+  useEffect(() => {
+    window.localStorage?.setItem(FPS_GRAPHICS_STORAGE_KEY, graphicsProfile.id);
+  }, [graphicsProfile.id]);
+
   return (
     <main
       className="mobile-fps-shell"
       aria-label="Mobile portrait FPS preview frame"
+      data-graphics={graphicsProfile.id}
     >
       <section className="mobile-fps-frame">
-        <Canvas
-          className="mobile-fps-canvas"
-          shadows
-          dpr={[1, 1.65]}
-          gl={{ antialias: false, powerPreference: 'high-performance' }}
-          camera={{ fov: 68, near: 0.08, far: 58, position: [0, 1.55, -1.2] }}
-        >
-          <Scene />
-        </Canvas>
-        <TouchHud />
+        <MobileFpsErrorBoundary key={graphicsProfile.id}>
+          <Canvas
+            className="mobile-fps-canvas"
+            shadows={graphicsProfile.shadows}
+            dpr={graphicsProfile.dpr}
+            gl={{
+              antialias: graphicsProfile.antialias,
+              powerPreference: 'high-performance',
+              alpha: false,
+              depth: true,
+              stencil: false
+            }}
+            camera={{
+              fov: 70,
+              near: 0.08,
+              far: 260,
+              position: [0, 1.55, -1.2]
+            }}
+            onCreated={({ gl }) => {
+              gl.setClearColor('#8fc8ff', 1);
+            }}
+          >
+            <Scene />
+          </Canvas>
+        </MobileFpsErrorBoundary>
+        <TouchHud
+          graphicsId={graphicsProfile.id}
+          onGraphicsChange={setGraphicsId}
+        />
       </section>
-      <div className="sr-only">{assetSourceNotes.join(' ')}</div>
+      <div className="sr-only">
+        {assetSourceNotes.join(' ')} {graphicsProfile.note}
+      </div>
     </main>
   );
 }

--- a/webapp/src/games/mobileUrbanFps/assetCatalog.ts
+++ b/webapp/src/games/mobileUrbanFps/assetCatalog.ts
@@ -428,12 +428,13 @@ export const DISPLAY_ITEMS: DisplayEntry[] = [
   ...EQUIPMENT
 ];
 
-export const FIRST_PERSON_WEAPON =
-  EXTRA_WEAPONS.find((entry) => entry.id === 'slot-10-ak47-gltf') ??
-  DISPLAY_ITEMS[0];
 export const FPS_HAND_DONOR =
   EXTRA_WEAPONS.find((entry) => entry.id === 'slot-18-fps-gun-gltf') ??
   DISPLAY_ITEMS[0];
+export const FIRST_PERSON_WEAPON = FPS_HAND_DONOR;
+export const FPS_WEAPON_OPTIONS = DISPLAY_ITEMS.filter(
+  (entry) => entry.kind === 'weapon'
+);
 
 export const GRIP_PROFILES: Record<GripPreset, GripProfile> = {
   pistol: {

--- a/webapp/src/games/mobileUrbanFps/openWorldAssets.ts
+++ b/webapp/src/games/mobileUrbanFps/openWorldAssets.ts
@@ -1,0 +1,94 @@
+export type OpenWorldAssetRole =
+  | 'building'
+  | 'vehicle'
+  | 'helicopter'
+  | 'npc'
+  | 'tree'
+  | 'prop'
+  | 'weaponStore';
+
+export type OpenWorldAssetDefinition = {
+  id: string;
+  role: OpenWorldAssetRole;
+  label: string;
+  urls: string[];
+  source: string;
+  licenseNote: string;
+  targetUse: string;
+};
+
+const kenney = 'https://kenney.nl/assets';
+
+export const openWorldAssetManifest: OpenWorldAssetDefinition[] = [
+  {
+    id: 'quaternius-city-building-pack',
+    role: 'building',
+    label: 'Quaternius modular city buildings',
+    urls: [
+      '/assets/games/mobile-urban-fps/city/buildings/quaternius-city-kit.glb'
+    ],
+    source: 'Quaternius / local optimized GLB slot',
+    licenseNote: 'Replace with bundled CC0/royalty-free Quaternius GLB export.',
+    targetUse:
+      'Primary city towers, shops, police station, hospital, fire station.'
+  },
+  {
+    id: 'kenney-city-kit-roads-props',
+    role: 'prop',
+    label: 'Kenney city kit roads and props',
+    urls: ['/assets/games/mobile-urban-fps/city/props/kenney-city-kit.glb'],
+    source: kenney,
+    licenseNote:
+      'Kenney assets are generally CC0; bundle optimized GLB before production.',
+    targetUse: 'Road signs, barriers, fences, benches, lamps, traffic props.'
+  },
+  {
+    id: 'quaternius-vehicles',
+    role: 'vehicle',
+    label: 'Traffic vehicle set',
+    urls: ['/assets/games/mobile-urban-fps/vehicles/traffic-pack.glb'],
+    source: 'Quaternius / Kenney vehicle kits',
+    licenseNote: 'Use locally bundled open-source GLB variants for mobile.',
+    targetUse:
+      'Civilian cars, police, ambulance, fire truck, buses, delivery vans.'
+  },
+  {
+    id: 'city-helicopter-glb',
+    role: 'helicopter',
+    label: 'Large rooftop helicopter',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/helicopter.glb'
+    ],
+    source: 'Open-source GLB reference asset',
+    licenseNote:
+      'Verify upstream license before shipping; keep local optimized copy.',
+    targetUse: 'Mall rooftop flyable helicopter and cockpit reference.'
+  },
+  {
+    id: 'domino-royal-humans',
+    role: 'npc',
+    label: 'Domino Royal human character set',
+    urls: ['/assets/games/mobile-urban-fps/characters/domino-royal-humans.glb'],
+    source: 'Existing Domino Royal character pipeline',
+    licenseNote: 'Bundle the existing in-game human GLBs here for shared use.',
+    targetUse:
+      'City pedestrians, store NPC, mall game players, playable character skins.'
+  },
+  {
+    id: 'weapon-store-racks',
+    role: 'weaponStore',
+    label: 'Weapon store racks and display cases',
+    urls: ['/assets/games/mobile-urban-fps/stores/weapon-shop.glb'],
+    source: 'Poly Pizza / Quaternius / local optimized GLB slot',
+    licenseNote:
+      'Use only downloadable CC/open assets and keep attribution metadata.',
+    targetUse:
+      'Weapon racks, glass cases, ammo boxes, shop lights, store counter.'
+  }
+];
+
+export const openWorldMaterialSources = [
+  'Poly Haven PBR HDRI/materials for sky, concrete, asphalt, and metal.',
+  'AmbientCG / CGBookcase / 3DTextures PBR sets for roads, wall tiles, mall floors, grass, wood, glass, and worn weapon materials.',
+  'ShareTextures and OpenGameArt only where licenses allow commercial redistribution.'
+];

--- a/webapp/src/games/mobileUrbanFps/store.ts
+++ b/webapp/src/games/mobileUrbanFps/store.ts
@@ -1,9 +1,12 @@
 import { create } from 'zustand';
+import { FIRST_PERSON_WEAPON, FPS_WEAPON_OPTIONS } from './assetCatalog';
+import { recoverWeaponRecoil, recoilConfig } from './systems/RecoilSystem';
 import type {
   BulletTracer,
   GamePhase,
   ImpactFx,
   TouchInputState,
+  VehicleMode,
   WeaponStats
 } from './types';
 
@@ -14,8 +17,8 @@ export const rifleStats: WeaponStats = {
   reloadMs: 1450,
   damage: 34,
   spread: 0.013,
-  recoilKick: 0.035,
-  recoilRecovery: 8,
+  recoilKick: 0.026,
+  recoilRecovery: 12,
   falloffStart: 12,
   falloffEnd: 42
 };
@@ -31,9 +34,18 @@ type GameStore = {
   hitMarkerUntil: number;
   muzzleFlashUntil: number;
   recoil: number;
+  aimSensitivity: number;
   input: TouchInputState;
   tracers: BulletTracer[];
   impacts: ImpactFx[];
+  selectedWeaponId: string;
+  vehicleMode: VehicleMode;
+  canBoardHelicopter: boolean;
+  setVehicleMode: (mode: VehicleMode) => void;
+  setCanBoardHelicopter: (canBoard: boolean) => void;
+  setAimSensitivity: (value: number) => void;
+  selectWeapon: (id: string) => void;
+  cycleWeapon: (direction: 1 | -1) => void;
   setInput: (patch: Partial<TouchInputState>) => void;
   damagePlayer: (amount: number) => void;
   setEnemiesAlive: (count: number) => void;
@@ -56,7 +68,8 @@ const initialInput: TouchInputState = {
   lookX: 0,
   lookY: 0,
   firing: false,
-  reloading: false
+  reloading: false,
+  lift: 0
 };
 
 export const useMobileFpsStore = create<GameStore>((set, get) => ({
@@ -70,9 +83,37 @@ export const useMobileFpsStore = create<GameStore>((set, get) => ({
   hitMarkerUntil: 0,
   muzzleFlashUntil: 0,
   recoil: 0,
+  aimSensitivity: 0.72,
   input: initialInput,
   tracers: [],
   impacts: [],
+  selectedWeaponId: FIRST_PERSON_WEAPON.id,
+  vehicleMode: 'onFoot',
+  canBoardHelicopter: false,
+  setVehicleMode: (mode) => set({ vehicleMode: mode }),
+  setCanBoardHelicopter: (canBoard) =>
+    set((state) =>
+      state.canBoardHelicopter === canBoard
+        ? state
+        : { canBoardHelicopter: canBoard }
+    ),
+  setAimSensitivity: (value) =>
+    set({ aimSensitivity: Math.min(1, Math.max(0, value)) }),
+  selectWeapon: (id) => {
+    if (FPS_WEAPON_OPTIONS.some((entry) => entry.id === id))
+      set({ selectedWeaponId: id });
+  },
+  cycleWeapon: (direction) =>
+    set((state) => {
+      const currentIndex = FPS_WEAPON_OPTIONS.findIndex(
+        (entry) => entry.id === state.selectedWeaponId
+      );
+      const safeIndex = currentIndex >= 0 ? currentIndex : 0;
+      const nextIndex =
+        (safeIndex + direction + FPS_WEAPON_OPTIONS.length) %
+        FPS_WEAPON_OPTIONS.length;
+      return { selectedWeaponId: FPS_WEAPON_OPTIONS[nextIndex].id };
+    }),
   setInput: (patch) =>
     set((state) => ({ input: { ...state.input, ...patch } })),
   damagePlayer: (amount) =>
@@ -81,10 +122,11 @@ export const useMobileFpsStore = create<GameStore>((set, get) => ({
       return { health, phase: health <= 0 ? 'lost' : state.phase };
     }),
   setEnemiesAlive: (count) =>
-    set((state) => ({
-      enemiesAlive: count,
-      phase: count <= 0 ? 'won' : state.phase
-    })),
+    set((state) => {
+      const phase = count <= 0 ? 'won' : state.phase;
+      if (state.enemiesAlive === count && state.phase === phase) return state;
+      return { enemiesAlive: count, phase };
+    }),
   spendRound: () => set((state) => ({ ammo: Math.max(0, state.ammo - 1) })),
   beginReload: () => {
     const state = get();
@@ -107,9 +149,14 @@ export const useMobileFpsStore = create<GameStore>((set, get) => ({
       };
     }),
   addRecoil: (amount) =>
-    set((state) => ({ recoil: Math.min(0.18, state.recoil + amount) })),
+    set((state) => ({
+      recoil: Math.min(recoilConfig.maxWeaponRecoil, state.recoil + amount)
+    })),
   recoverRecoil: (amount) =>
-    set((state) => ({ recoil: Math.max(0, state.recoil - amount) })),
+    set((state) => {
+      if (state.recoil <= 0) return state;
+      return { recoil: recoverWeaponRecoil(state.recoil, amount, 1) };
+    }),
   showHitMarker: () => set({ hitMarkerUntil: performance.now() + 120 }),
   showMuzzleFlash: () => set({ muzzleFlashUntil: performance.now() + 70 }),
   addTracer: (tracer) =>
@@ -117,14 +164,18 @@ export const useMobileFpsStore = create<GameStore>((set, get) => ({
   addImpact: (impact) =>
     set((state) => ({ impacts: [...state.impacts.slice(-10), impact] })),
   tickFx: (dt) =>
-    set((state) => ({
-      tracers: state.tracers
-        .map((fx) => ({ ...fx, life: fx.life - dt }))
-        .filter((fx) => fx.life > 0),
-      impacts: state.impacts
-        .map((fx) => ({ ...fx, life: fx.life - dt }))
-        .filter((fx) => fx.life > 0)
-    })),
+    set((state) => {
+      if (state.tracers.length === 0 && state.impacts.length === 0)
+        return state;
+      return {
+        tracers: state.tracers
+          .map((fx) => ({ ...fx, life: fx.life - dt }))
+          .filter((fx) => fx.life > 0),
+        impacts: state.impacts
+          .map((fx) => ({ ...fx, life: fx.life - dt }))
+          .filter((fx) => fx.life > 0)
+      };
+    }),
   reset: () =>
     set({
       phase: 'playing',
@@ -136,6 +187,10 @@ export const useMobileFpsStore = create<GameStore>((set, get) => ({
       hitMarkerUntil: 0,
       muzzleFlashUntil: 0,
       recoil: 0,
+      aimSensitivity: 0.72,
+      selectedWeaponId: FIRST_PERSON_WEAPON.id,
+      vehicleMode: 'onFoot',
+      canBoardHelicopter: false,
       input: initialInput,
       tracers: [],
       impacts: []

--- a/webapp/src/games/mobileUrbanFps/systems/HelicopterSystem.ts
+++ b/webapp/src/games/mobileUrbanFps/systems/HelicopterSystem.ts
@@ -1,0 +1,67 @@
+import * as THREE from 'three';
+
+export type FlightBounds = {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+};
+
+export const helicopterFlightConfig = {
+  forwardSpeed: 25,
+  strafeSpeed: 15,
+  liftSpeed: 15,
+  minAltitude: 4.5,
+  maxAltitude: 75,
+  cameraLerp: 0.28
+} as const;
+
+export function isNearPoint(
+  position: THREE.Vector3,
+  point: THREE.Vector3,
+  radius: number
+) {
+  return position.distanceTo(point) <= radius;
+}
+
+export function stepHelicopterFlight({
+  position,
+  yaw,
+  pitch,
+  moveX,
+  moveY,
+  lift,
+  dt,
+  bounds
+}: {
+  position: THREE.Vector3;
+  yaw: number;
+  pitch: number;
+  moveX: number;
+  moveY: number;
+  lift: number;
+  dt: number;
+  bounds: FlightBounds;
+}) {
+  const forward = new THREE.Vector3(
+    Math.sin(yaw),
+    Math.sin(-pitch) * 0.4,
+    Math.cos(yaw) * -1
+  );
+  const right = new THREE.Vector3(Math.cos(yaw), 0, Math.sin(yaw));
+  const forwardMove = forward.multiplyScalar(
+    moveY * helicopterFlightConfig.forwardSpeed
+  );
+  const sideMove = right.multiplyScalar(
+    moveX * helicopterFlightConfig.strafeSpeed
+  );
+  position.addScaledVector(forwardMove.add(sideMove), dt);
+  position.y += lift * helicopterFlightConfig.liftSpeed * dt;
+  position.x = THREE.MathUtils.clamp(position.x, bounds.minX, bounds.maxX);
+  position.z = THREE.MathUtils.clamp(position.z, bounds.minZ, bounds.maxZ);
+  position.y = THREE.MathUtils.clamp(
+    position.y,
+    helicopterFlightConfig.minAltitude,
+    helicopterFlightConfig.maxAltitude
+  );
+}

--- a/webapp/src/games/mobileUrbanFps/systems/MobileControlsSystem.ts
+++ b/webapp/src/games/mobileUrbanFps/systems/MobileControlsSystem.ts
@@ -1,0 +1,44 @@
+import * as THREE from 'three';
+
+export type NormalizedJoystick = {
+  moveX: number;
+  moveY: number;
+  knobX: number;
+  knobY: number;
+};
+
+export function normalizeJoystickInput(
+  dx: number,
+  dy: number,
+  radius: number,
+  deadZone = 0.055
+): NormalizedJoystick {
+  const rawLength = Math.hypot(dx, dy);
+  const angle = Math.atan2(dy, dx);
+  const clampedLength = Math.min(radius, rawLength);
+  const normalizedLength = clampedLength / radius;
+  const playableLength =
+    normalizedLength <= deadZone
+      ? 0
+      : (normalizedLength - deadZone) / (1 - deadZone);
+
+  return {
+    moveX: Math.cos(angle) * playableLength,
+    moveY: -Math.sin(angle) * playableLength,
+    knobX: Math.cos(angle) * clampedLength,
+    knobY: Math.sin(angle) * clampedLength
+  };
+}
+
+export function mapPortraitLookDelta(
+  dx: number,
+  dy: number,
+  aimSensitivity: number
+) {
+  const divisor = THREE.MathUtils.lerp(62, 24, aimSensitivity);
+  const maxDelta = THREE.MathUtils.lerp(0.75, 1.55, aimSensitivity);
+  return {
+    lookX: THREE.MathUtils.clamp(dx / divisor, -maxDelta, maxDelta),
+    lookY: THREE.MathUtils.clamp(dy / divisor, -maxDelta, maxDelta)
+  };
+}

--- a/webapp/src/games/mobileUrbanFps/systems/RecoilSystem.ts
+++ b/webapp/src/games/mobileUrbanFps/systems/RecoilSystem.ts
@@ -1,0 +1,26 @@
+import * as THREE from 'three';
+
+export const recoilConfig = {
+  maxWeaponRecoil: 0.11,
+  recoveryScale: 0.035,
+  kickUpScale: 0.34,
+  kickBackScale: 1.35
+} as const;
+
+export function recoverWeaponRecoil(
+  recoil: number,
+  recovery: number,
+  dt: number
+) {
+  return Math.max(0, recoil - recovery * dt * recoilConfig.recoveryScale);
+}
+
+export function applyFirstPersonRecoil(
+  group: THREE.Group,
+  recoil: number,
+  base = { x: 0.48, y: -0.42, z: -0.86 }
+) {
+  group.position.x = base.x;
+  group.position.z = base.z + recoil * recoilConfig.kickBackScale;
+  group.position.y = base.y + recoil * recoilConfig.kickUpScale;
+}

--- a/webapp/src/games/mobileUrbanFps/types.ts
+++ b/webapp/src/games/mobileUrbanFps/types.ts
@@ -1,6 +1,7 @@
 import type { Vector3 } from 'three';
 
 export type GamePhase = 'playing' | 'won' | 'lost';
+export type VehicleMode = 'onFoot' | 'helicopter';
 export type EnemyAiState = 'idle' | 'patrol' | 'chase' | 'attack' | 'dead';
 
 export type TouchInputState = {
@@ -10,6 +11,7 @@ export type TouchInputState = {
   lookY: number;
   firing: boolean;
   reloading: boolean;
+  lift: number;
 };
 
 export type WeaponStats = {


### PR DESCRIPTION
### Motivation
- Expand the MobileUrbanFps demo into a simple open-world city with rooftop interaction and a flyable helicopter to showcase larger-scene asset composition and vehicle controls.
- Improve mobile input, aim tuning, recoil behavior and weapon selection to make the portrait FPS experience more playable and adjustable on varied devices.
- Make asset loading and the Gradle wrapper fetch more robust for CI/dev by adding retries, validation and a fallback download method.

### Description
- Large refactor of `webapp/src/games/mobileUrbanFps/*` adding open-world support: new `openWorldAssets.ts`, `systems/HelicopterSystem.ts`, `systems/MobileControlsSystem.ts`, and `systems/RecoilSystem.ts`, plus substantial updates to `MobileUrbanFps.tsx`, `store.ts`, `assetCatalog.ts` and new UI/scene pieces (city buildings, streets, traffic, mall, rooftop helicopter, cockpit, weapon switching, graphics profiles, error boundary, joystick/aim mapping and more). 
- Asset loading improvements: deferred/placeholder procedural armory, remote GLB lazy-load with fallbacks, better handling of donor hands and slot replacement, and new `openWorldAssetManifest` with material sources notes. 
- Controls and gameplay changes: normalized joystick input, portrait look mapping, aim sensitivity slider, vehicle mode switching (`helicopter`), helicopter flight stepper and camera behavior, refined recoil config and first-person recoil application, and weapon cycling/selecting stored in the `zustand` store. 
- Visual and CSS updates: redesigned HUD/controls styles, added graphics quality buttons, new fallback UI for WebGL errors, and reorganized iOS app icon `Contents.json` entries. 
- Tooling and infra tweaks: `webapp/scripts/fetch-gradle-wrapper.mjs` now validates existing `gradle-wrapper.jar`, downloads to a `.tmp` path, retries with `curl` on https failures, reports clearer error messages and cleans up partial downloads, and `.gitignore` excludes the downloaded `gradle-wrapper.jar` binary.

### Testing
- No automated test suite was added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff598b42c0832991f406f06592bbd7)