### PR TITLE
Align Showood 7ft as default table, tint Showood trim, and enlarge lounge furniture

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -4,12 +4,25 @@ import {
   POOL_ROYALE_TABLE_MODEL_OPTIONS,
   resolvePoolRoyaleTableModel
 } from '../webapp/src/config/poolRoyaleTableModels.js';
+import { resolveTableSize } from '../webapp/src/config/poolRoyaleTables.js';
 
 describe('Pool Royale table models', () => {
   test('defaults to the Showood GLB table', () => {
     assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'showood-seven-foot');
-    assert.equal(resolvePoolRoyaleTableModel(null).id, 'royal-original');
-    assert.equal(resolvePoolRoyaleTableModel('unknown').id, 'royal-original');
+    assert.equal(resolvePoolRoyaleTableModel(null).id, 'showood-seven-foot');
+    assert.equal(resolvePoolRoyaleTableModel('unknown').id, 'showood-seven-foot');
+  });
+
+  test('Showood procedural fallback uses the 7 ft physical table size', () => {
+    const fallback = POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
+      (option) => option.id === 'royal-original'
+    );
+    const showood = resolvePoolRoyaleTableModel('showood-seven-foot');
+    const spec = resolveTableSize(showood.tableSizeId);
+
+    assert.equal(fallback.tableSizeId, '7ft');
+    assert.equal(spec.id, '7ft');
+    assert.deepEqual(spec.playfield, { widthMm: 1981.2, heightMm: 990.6 });
   });
 
   test('Showood uses original GLB surface layout with Pool Royale finish textures', () => {
@@ -20,12 +33,13 @@ describe('Pool Royale table models', () => {
     assert.ok(showood, 'Showood table model must be configured');
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
-    assert.equal(showood.fitScale, 1.02);
+    assert.equal(showood.fitScale, 1);
     assert.equal(showood.clothRepeatScale, 5.25);
     assert.deepEqual(showood.hideSurfaceRoles, []);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['trim']);
-    assert.equal(showood.tintOriginalTrimGold, true);
+    assert.equal(showood.tintOriginalTrimWithChrome, true);
     assert.equal(showood.forceGeneratedChromePlates, false);
+    assert.equal(showood.tableSizeId, '7ft');
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -7,8 +7,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'royal-original',
     label: 'Royal Original',
-    description: 'Current TonPlaygram table with existing gameplay geometry.',
-    tableSizeId: '9ft',
+    description: 'Procedural fallback table matched to the Showood 7 ft gameplay geometry.',
+    tableSizeId: '7ft',
     finishId: 'peelingPaintWeathered',
     baseId: 'classicCylinders',
     icon: '🎱',
@@ -19,7 +19,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     label: 'Showood 7 ft GLB',
     description:
       'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and preserved Showood chrome plates.',
-    tableSizeId: '9ft',
+    tableSizeId: '7ft',
     assetUrl:
       'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
@@ -37,7 +37,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
     preserveOriginalSurfaceRoles: ['trim'],
-    tintOriginalTrimGold: true,
+    tintOriginalTrimWithChrome: true,
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }
@@ -51,6 +51,7 @@ export function resolvePoolRoyaleTableModel(modelId) {
   const key = typeof modelId === 'string' ? modelId.trim() : '';
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
+    POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === DEFAULT_POOL_ROYALE_TABLE_MODEL_ID) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
   );
 }

--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -4,6 +4,24 @@ const BASE_TABLE_COMPACT_SCALE = 1.44;
 const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
+  '7ft': {
+    id: '7ft',
+    label: '7 ft (Showood)',
+    playfield: Object.freeze({ widthMm: 1981.2, heightMm: 990.6 }), // 78" × 39" Showood/WPA 7 ft playing surface
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 114.3,
+      side: 127
+    }),
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    scaleOverrides: Object.freeze({
+      scale: 1.218,
+      mobileScale: 1.342,
+      compactScale: 1.154
+    })
+  },
   '9ft': {
     id: '9ft',
     label: '9 ft (Tournament)',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2677,11 +2677,11 @@ const resolvePoolRoyaleHumanCharacter = (id) =>
   POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
 const POOL_ROYALE_HUMAN_UNIT_SCALE = BALL_R / 0.0525;
 const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.85 * POOL_ROYALE_HUMAN_UNIT_SCALE; // make the shooter larger again without returning to the oversized direct scale
-const POOL_ROYALE_LOUNGE_TABLE_RADIUS = BALL_R * 24; // match Murlan Royale's default octagon table proportions at pool-side scale.
-const POOL_ROYALE_LOUNGE_TABLE_HEIGHT = BALL_R * 16.5;
-const POOL_ROYALE_LOUNGE_CHAIR_SPAN = BALL_R * 64; // oversized portrait-readable chairs matching Murlan's default dining-chair asset.
-const POOL_ROYALE_LOUNGE_DISTANCE = BALL_R * 38;
-const POOL_ROYALE_LOUNGE_CHAIR_OFFSET = BALL_R * 54;
+const POOL_ROYALE_LOUNGE_TABLE_RADIUS = BALL_R * 28; // match Murlan Royale's default octagon table proportions at pool-side scale.
+const POOL_ROYALE_LOUNGE_TABLE_HEIGHT = BALL_R * 19.2;
+const POOL_ROYALE_LOUNGE_CHAIR_SPAN = BALL_R * 74; // oversized portrait-readable chairs matching Murlan's default dining-chair asset.
+const POOL_ROYALE_LOUNGE_DISTANCE = BALL_R * 56;
+const POOL_ROYALE_LOUNGE_CHAIR_OFFSET = BALL_R * 68;
 // Soldier.glb already faces the billiards rig forward axis; keep the child model unflipped so
 // the visible player faces inward toward the table instead of showing their back in portrait play.
 const POOL_ROYALE_HUMAN_VISUAL_YAW_FIX = Math.PI;
@@ -12860,6 +12860,9 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   // must win over material names for physics mapping and finish assignment.
   if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(childName)) return 'cushion';
   if (/pocket|liner|leather|net|basket|drop|holder/.test(childName)) return 'pocket';
+  // Showood names the metallic apron/sight meshes after their table position;
+  // keep those pieces on the trim/chrome path instead of treating them as wood.
+  if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|rail[_\s-]*sight|railsight/.test(childName)) return 'trim';
   if (/diamond|gold|metal|chrome|sight|marker|plate|trim|screw|bolt/.test(childName)) return 'trim';
   if (/slate|cloth|felt|baize|bed|playfield|playing[_\s-]*surface/.test(childName)) return 'cloth';
   if (/cloth|felt|baize|slate|bed|playfield|playing[_\s-]*surface/.test(label)) return 'cloth';
@@ -12973,13 +12976,24 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
   const shouldUsePoolRoyaleFinish = !finishRoles || finishRoles.includes(role);
   if (!shouldUsePoolRoyaleFinish || preserveRoles.includes(role)) {
     const originalMat = material.clone ? material.clone() : material;
-    if (role === 'trim' && tableModel?.tintOriginalTrimGold) {
-      if (originalMat.color) originalMat.color.set(0xd8b45a);
-      if ('metalness' in originalMat) originalMat.metalness = Math.max(0.88, originalMat.metalness ?? 0.88);
-      if ('roughness' in originalMat) originalMat.roughness = Math.min(0.24, originalMat.roughness ?? 0.18);
-      if ('envMapIntensity' in originalMat) originalMat.envMapIntensity = Math.max(1.15, originalMat.envMapIntensity ?? 1.15);
-      if ('clearcoat' in originalMat) originalMat.clearcoat = Math.max(0.55, originalMat.clearcoat ?? 0.55);
-      if ('clearcoatRoughness' in originalMat) originalMat.clearcoatRoughness = Math.min(0.18, originalMat.clearcoatRoughness ?? 0.12);
+    if (role === 'trim' && (tableModel?.tintOriginalTrimWithChrome || tableModel?.tintOriginalTrimGold)) {
+      const chromeMat = finishInfo?.materials?.trim;
+      if (originalMat.color) originalMat.color.copy(chromeMat?.color ?? new THREE.Color(0xd8b45a));
+      if ('metalness' in originalMat) {
+        originalMat.metalness = Math.max(chromeMat?.metalness ?? 0.88, originalMat.metalness ?? 0.88);
+      }
+      if ('roughness' in originalMat) {
+        originalMat.roughness = Math.min(chromeMat?.roughness ?? 0.24, originalMat.roughness ?? 0.18);
+      }
+      if ('envMapIntensity' in originalMat) {
+        originalMat.envMapIntensity = Math.max(chromeMat?.envMapIntensity ?? 1.15, originalMat.envMapIntensity ?? 1.15);
+      }
+      if ('clearcoat' in originalMat) {
+        originalMat.clearcoat = Math.max(chromeMat?.clearcoat ?? 0.55, originalMat.clearcoat ?? 0.55);
+      }
+      if ('clearcoatRoughness' in originalMat) {
+        originalMat.clearcoatRoughness = Math.min(chromeMat?.clearcoatRoughness ?? 0.18, originalMat.clearcoatRoughness ?? 0.12);
+      }
     }
     preparePoolRoyaleExternalTexture(originalMat.map, true);
     preparePoolRoyaleExternalTexture(originalMat.emissiveMap, true);
@@ -26194,14 +26208,14 @@ const shotPowerRef = useRef(0);
         const group = new THREE.Group();
         const woodMat = new THREE.MeshStandardMaterial({ color: 0x5b351f, roughness: 0.62, metalness: 0.05 });
         const seatMat = new THREE.MeshStandardMaterial({ color: seat === 'A' ? 0x0f766e : 0x7c2d12, roughness: 0.55, metalness: 0.08 });
-        const tableTop = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 18.4, BALL_R * 18.9, BALL_R * 1.45, 64), woodMat);
+        const tableTop = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 21.5, BALL_R * 22.0, BALL_R * 1.65, 64), woodMat);
         tableTop.position.set(0, tableTopY, 0);
-        const tablePedestal = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 2.05, BALL_R * 2.9, tableTopY, 32), woodMat);
+        const tablePedestal = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 2.35, BALL_R * 3.3, tableTopY, 32), woodMat);
         tablePedestal.position.set(0, tableTopY * 0.5, 0);
-        const chairSeat = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 19.6, BALL_R * 2.05, BALL_R * 16.8), seatMat);
-        chairSeat.position.set(0, BALL_R * 4.4, zSign * BALL_R * 37.5);
-        const chairBack = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 19.6, BALL_R * 15.8, BALL_R * 2.05), seatMat);
-        chairBack.position.set(0, BALL_R * 11.2, zSign * BALL_R * 46.0);
+        const chairSeat = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 23.5, BALL_R * 2.45, BALL_R * 20.2), seatMat);
+        chairSeat.position.set(0, BALL_R * 5.3, zSign * BALL_R * 46.0);
+        const chairBack = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 23.5, BALL_R * 18.8, BALL_R * 2.45), seatMat);
+        chairBack.position.set(0, BALL_R * 13.6, zSign * BALL_R * 56.5);
         [tableTop, tablePedestal, chairSeat, chairBack].forEach((mesh) => {
           mesh.castShadow = true;
           mesh.receiveShadow = true;
@@ -38069,7 +38083,20 @@ export default function PoolRoyale() {
   const tableSizeKey = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const requested = params.get('tableSize');
-    return resolveTableSize(requested).id;
+    if (requested) return resolveTableSize(requested).id;
+    const requestedModel = params.get('tableModel');
+    const model = requestedModel
+      ? resolvePoolRoyaleTableModel(requestedModel)
+      : (() => {
+          try {
+            return resolvePoolRoyaleTableModel(
+              window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY)
+            );
+          } catch {
+            return resolvePoolRoyaleTableModel();
+          }
+        })();
+    return resolveTableSize(model?.tableSizeId).id;
   }, [location.search]);
   const tableModelKey = useMemo(() => {
     const params = new URLSearchParams(location.search);


### PR DESCRIPTION
### Motivation
- Make the Showood GLB the resolved default visual table while keeping the native Royal Original as a procedural 7 ft fallback so the game uses the Showood layout by default but falls back to procedural geometry if the GLB fails.
- Ensure Showood metallic apron / sight pieces (sideWoodApron / railSight) follow the chrome/trim materials so chrome plate color selections (gold/silver) affect those parts.
- Use the physical dimensions of the Showood 7 ft table for playfield/pocket/cushion sizing so the procedural fallback and physics mapping match the real Showood table.
- Increase lounge furniture size/offset so chairs/tables around the table are larger, taller, and positioned further from the table to better match visual requirements.

### Description
- Added a 7 ft physical table spec to `webapp/src/config/poolRoyaleTables.js` and wired the Showood model to use `tableSizeId: '7ft'` so playfield, pocket and ball metrics match the Showood dimensions.
- Updated `webapp/src/config/poolRoyaleTableModels.js` to make `showood-seven-foot` the default model and mark the native `royal-original` as a 7 ft procedural fallback, and renamed the trim-tint flag to `tintOriginalTrimWithChrome` to tint preserved trim using the active chrome material.
- In `webapp/src/pages/Games/PoolRoyale.jsx` classified Showood apron/sight mesh names (e.g. `sideWoodApron`, `railSight`) as `trim` so they are treated as chrome/trim surfaces, and adjusted `applyPoolRoyaleFinishToExternalMaterial` to copy chrome material properties when `tintOriginalTrimWithChrome` is set.
- Enlarged and repositioned the pool-side lounge furniture and fallback chair/table geometry (constants and fallback builders) so chairs are bigger, further from the table, and taller to match the requested visual spacing.
- Changed table-size resolution logic so when `tableSize` is not explicitly provided the code derives the playfield size from the selected/default `tableModel` (localStorage or URL param) so procedural mapping uses the Showood size if the Showood model is active.
- Tests and test helper updated: `test/poolRoyaleTableModels.test.js` extended to assert the Showood defaults, the 7 ft fallback mapping, and the chrome-trim tint configuration.

### Testing
- Ran unit test `npm test -- --runInBand test/poolRoyaleTableModels.test.js` which passed (3 tests, all green).
- Built the webapp with `npm --prefix webapp run build` which completed successfully and produced the production bundle.
- Attempted an automated visual smoke screenshot via Playwright, but Chromium failed to launch in the container due to a missing system library (`libatk-1.0.so.0`), so the screenshot step could not complete (Playwright browser installation succeeded, runtime launch failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005ef8ca948329be2d66e214122137)