### PR TITLE
Preserve GLB table proportions and restore ReadyPlayer head pose for Snooker Royal

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -17,7 +17,6 @@ import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import {
-  resolveSnookerGlbFitTransform,
   resolveSnookerTableModel,
   usesProceduralSnookerTableRailDecor,
   TABLE_MODEL_CLASSIC,
@@ -10806,7 +10805,21 @@ function Table3D(
     return removedMeshes.length;
   };
 
-  const remapOpenSourceClothTextureCoordinates = (root, targetBounds = resolveOpenSourceClothUvBounds()) => {
+  const resolveOpenSourceModelClothUvBounds = (root) => {
+    const bounds = new THREE.Box3();
+    root?.updateMatrixWorld?.(true);
+    table.updateMatrixWorld(true);
+    root?.traverse?.((node) => {
+      if (!node?.isMesh || node.userData?.openSourceMaterialRole !== 'cloth') return;
+      expandBoxByObjectLocalBounds(bounds, node);
+    });
+    if (bounds.isEmpty() && root) {
+      expandBoxByObjectLocalBounds(bounds, root);
+    }
+    return bounds.isEmpty() ? resolveOpenSourceClothUvBounds() : bounds;
+  };
+
+  const remapOpenSourceClothTextureCoordinates = (root, targetBounds = resolveOpenSourceModelClothUvBounds(root)) => {
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     if (targetSize.x <= MICRO_EPS || targetSize.z <= MICRO_EPS) return;
     const localPoint = new THREE.Vector3();
@@ -10827,7 +10840,11 @@ function Table3D(
         localPoint.fromBufferAttribute(position, i);
         node.localToWorld(worldPoint.copy(localPoint));
         table.worldToLocal(worldPoint);
-        uv.setXY(i, worldPoint.x, worldPoint.z);
+        uv.setXY(
+          i,
+          (worldPoint.x - targetBounds.min.x) / targetSize.x,
+          (worldPoint.z - targetBounds.min.z) / targetSize.z
+        );
       }
       uv.needsUpdate = true;
       geometry.computeBoundingBox();
@@ -10895,7 +10912,6 @@ function Table3D(
 
   const applyOpenSourceTableVisualOverride = () => {
     const targetBounds = resolveOpenSourceTargetBounds();
-    const clothUvBounds = resolveOpenSourceClothUvBounds();
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     const targetCenter = targetBounds.getCenter(new THREE.Vector3());
     const targetTopY = targetBounds.max.y;
@@ -10909,18 +10925,21 @@ function Table3D(
         model.updateMatrixWorld(true);
         const fullSourceBounds = new THREE.Box3().setFromObject(model);
         const sourceFitBounds = resolveOpenSourceUpperBounds(model, fullSourceBounds);
-        const fullSourceSize = fullSourceBounds.getSize(new THREE.Vector3());
         const sourceFitSize = sourceFitBounds.getSize(new THREE.Vector3());
-        const fit = resolveSnookerGlbFitTransform(
-          { x: sourceFitSize.x, y: sourceFitSize.y, z: sourceFitSize.z },
-          { x: targetSize.x, y: targetSize.y, z: targetSize.z }
-        );
-        const upperTableScale = Math.min(fit.scale.x, fit.scale.z);
-        if (Number.isFinite(upperTableScale) && upperTableScale > MICRO_EPS) {
-          fit.scale.y = upperTableScale;
-          fit.preservesOriginalUpperTableProportions = true;
-        }
-        model.scale.set(fit.scale.x, fit.scale.y, fit.scale.z);
+        const heightScale = sourceFitSize.y > MICRO_EPS ? targetSize.y / sourceFitSize.y : 1;
+        const originalProportionScale =
+          Number.isFinite(heightScale) && heightScale > MICRO_EPS ? heightScale : 1;
+        const fit = {
+          scale: {
+            x: originalProportionScale,
+            y: originalProportionScale,
+            z: originalProportionScale
+          },
+          source: 'original-glb-height',
+          preservesOriginalGlbProportions: true,
+          usesProceduralHeightOnly: true
+        };
+        model.scale.setScalar(originalProportionScale);
 
         model.updateMatrixWorld(true);
         const scaledFullBounds = new THREE.Box3().setFromObject(model);
@@ -10937,7 +10956,8 @@ function Table3D(
 
         applyDefaultTableFinishToOpenSourceModel(model);
         const removedOriginalBaseMeshCount = removeOpenSourceOriginalTableBase(model, scaledFitBounds);
-        remapOpenSourceClothTextureCoordinates(model, clothUvBounds);
+        const glbClothUvBounds = resolveOpenSourceModelClothUvBounds(model);
+        remapOpenSourceClothTextureCoordinates(model, glbClothUvBounds);
         applyOpenSourceCushionPhysicsFromModel(model);
         removeOpenSourceProceduralRailDecor();
         setProceduralTableMeshesVisible(false, { keepProceduralBase: true });
@@ -10946,7 +10966,7 @@ function Table3D(
           ...(model.userData || {}),
           isOpenSourceVisual: true,
           sourceUrl: TABLE_MODEL_OPENSOURCE_GLB_URL,
-          fitToProceduralMapping: true,
+          fitToProceduralMapping: false,
           keepsDefaultPocketDropHardware: true,
           preservesProceduralChromeHoldersLeatherStrapsAndNets: true,
           removesProceduralFrameRailsChromePlatesAndJaws: !keepProceduralRailDecor,
@@ -10954,13 +10974,15 @@ function Table3D(
           removedOriginalBaseMeshCount,
           usesProceduralTableBase: true,
           usesGlbCushionShapes: true,
-          clothUvMappedToDefaultPlayfield: true,
-          clothUvUsesProceduralWorldScale: true
+          clothUvMappedToDefaultPlayfield: false,
+          clothUvUsesProceduralWorldScale: false,
+          clothUvMappedFromGlbBounds: true
         };
         table.userData.openSourceVisual = model;
         table.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;
         table.userData.openSourceVisualFit = fit;
         table.userData.openSourceVisualTargetBounds = targetBounds;
+        table.userData.openSourceVisualClothUvBounds = glbClothUvBounds;
       })
       .catch((error) => {
         setProceduralTableMeshesVisible(true);
@@ -21053,6 +21075,7 @@ const powerRef = useRef(hud.power);
         bridgeHandBackFromBall: humanBridgeBackFromBall,
         bridgeHandSide: humanBridgeSideOffset,
         bridgePoseUsesConfiguredSide: true,
+        exactReadyPlayerHeadOnly: true,
         chinToCueHeight: 0.11 * humanUnitScale,
         footGroundY: 0.035 * humanUnitScale,
         kneeBendShot: 0.16 * humanUnitScale,

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -250,7 +250,8 @@ const BASE_CFG = {
   plantFeetDuringShot: true,
   bridgeArmStraightDown: false,
   forceTableFacingAim: true,
-  addFaceDetails: true
+  addFaceDetails: true,
+  exactReadyPlayerHeadOnly: false
 };
 
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
@@ -859,9 +860,41 @@ function driveHuman(human, frame) {
   setHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, cfg.footLockStrength * ik);
 }
 
+
+function updateExactReadyPlayerHeadOnlyPose(human, dt, frameData) {
+  const cfg = human.cfg;
+  human.poseT = dampScalar(human.poseT, 0, cfg.poseLambda, dt);
+  human.breathT += dt;
+  dampVector(human.root.position, frameData.rootTarget, cfg.moveLambda, dt);
+  human.root.position.y = cfg.groundY;
+  human.root.visible = true;
+
+  if (!human.activeGlb || !human.model) return;
+
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(human.root.position);
+  human.modelRoot.rotation.y = human.yaw;
+  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
+  human.modelRoot.updateMatrixWorld(true);
+
+  const forward = new THREE.Vector3(0, 0, -1);
+  const side = new THREE.Vector3(1, 0, 0);
+  const shotQ = makeBasisQuaternion(side, UP, forward);
+
+  if (human.bones.head) {
+    setBoneWorldQuaternion(human.bones.head, shotQ);
+  }
+
+  human.modelRoot.updateMatrixWorld(true);
+}
+
 export function updateHumanPose(human, dt, frameData) {
   if (!human || !frameData || !Number.isFinite(dt) || dt < 0 || !frameData.rootTarget || !frameData.aimForward) return;
   const cfg = human.cfg;
+  if (cfg.exactReadyPlayerHeadOnly) {
+    updateExactReadyPlayerHeadOnlyPose(human, dt, frameData);
+    return;
+  }
   const state = frameData.state || 'idle';
   const activeState = state === 'rolling' || state === 'turnEnd' || state === 'gameOver' ? 'idle' : state;
   human.poseT = dampScalar(human.poseT, activeState === 'idle' || activeState === 'seated' ? 0 : 1, cfg.poseLambda, dt);


### PR DESCRIPTION
### Motivation

- Keep the Pooltool/GLB snooker table visuals using the GLB's original proportions and mapping rather than stretching or reprojecting them to the procedural footprint so the table appears at its author-intended scale and UV layout. 
- Make the seated human behave exactly like the supplied ReadyPlayer.me snippet when required (head orientation fixed to the cue basis) so visual framing and pose match the reference behavior.

### Description

- Change GLB fitting to preserve the original GLB proportions by deriving a single uniform scale from the GLB height instead of independently fitting X/Z to the procedural table footprint, and apply that uniform scale to the imported model (`webapp/src/pages/Games/SnookerRoyal.jsx`).
- Remap cloth UVs from coordinates derived from the loaded GLB model bounds (compute GLB cloth bounds and normalize UVs against those bounds) so the GLB cloth texture mapping follows the GLB geometry rather than the procedural playfield (`webapp/src/pages/Games/SnookerRoyal.jsx`).
- Adjust open-source visual metadata flags to indicate the GLB is no longer fit to procedural mapping and store the GLB cloth-UV bounds for later use (`webapp/src/pages/Games/SnookerRoyal.jsx`).
- Add an `exactReadyPlayerHeadOnly` mode and helper `updateExactReadyPlayerHeadOnlyPose` that implements the simplified ReadyPlayer-like head pose: damp pose, keep model-root yaw, reset rest quaternions, and set the head basis quaternion to the fixed shot basis; expose the `exactReadyPlayerHeadOnly` config option on the human rig (`webapp/src/pages/Games/shared/humanRigCore.js`).
- Enable the `exactReadyPlayerHeadOnly` mode for Snooker Royal human rigs so the game uses the exact head-only behavior by default for this mode (`webapp/src/pages/Games/SnookerRoyal.jsx`).

### Testing

- Built the webapp with `npm run build` and the production build completed successfully (Vite build finished, artifacts produced). ✅
- Ran `git diff --check` (whitespace/merge checks) and there were no reported issues. ✅
- Launched the dev server (`npm run dev`) and reached the Snooker Royal page locally during verification; attempted an automated visual smoke screenshot with Playwright but Chromium could not launch in this environment due to a missing native dependency (`libatk-1.0.so.0`), so the screenshot step failed (environment limitation). ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0082f3fd7483298911b409b70b593e)