### PR TITLE
Make Showood GLB the default Pool Royale table; hide lobby selector and route chrome/rail materials

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -38,8 +38,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
     preserveOriginalSurfaceRoles: ['trim'],
     tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds'],
-    blackMaterialSurfaceNames: ['sideWoodApron', 'railSight'],
+    chromeMaterialSurfaceNames: ['sideWoodApron', 'railSight'],
+    blackMaterialSurfaceNames: [],
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }
@@ -51,8 +51,9 @@ export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
 
 export function resolvePoolRoyaleTableModel(modelId) {
   const key = typeof modelId === 'string' ? modelId.trim() : '';
-  return (
-    POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
-    POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  const defaultOption =
+    POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
+      (option) => option.id === DEFAULT_POOL_ROYALE_TABLE_MODEL_ID
+    ) || POOL_ROYALE_TABLE_MODEL_OPTIONS[0];
+  return POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) || defaultOption;
 }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -33,10 +33,7 @@ import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { PoolRoyaleRules } from '../../../../src/rules/PoolRoyaleRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
-import {
-  POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
-  resolvePoolRoyaleTableModel
-} from '../../config/poolRoyaleTableModels.js';
+import { resolvePoolRoyaleTableModel } from '../../config/poolRoyaleTableModels.js';
 import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { chatBeep } from '../../assets/coreSoundData.js';
@@ -12878,12 +12875,20 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   return 'wood';
 }
 
-function isPoolRoyaleExternalBlackSurface(child) {
+function isPoolRoyaleExternalNamedSurface(child, userDataKey) {
   const childName = `${child?.name || ''}`.toLowerCase();
-  const blackSurfaceNames = Array.isArray(child?.userData?.poolRoyaleBlackSurfaceNames)
-    ? child.userData.poolRoyaleBlackSurfaceNames
+  const surfaceNames = Array.isArray(child?.userData?.[userDataKey])
+    ? child.userData[userDataKey]
     : [];
-  return blackSurfaceNames.some((name) => childName.includes(`${name}`.toLowerCase()));
+  return surfaceNames.some((name) => childName.includes(`${name}`.toLowerCase()));
+}
+
+function isPoolRoyaleExternalBlackSurface(child) {
+  return isPoolRoyaleExternalNamedSurface(child, 'poolRoyaleBlackSurfaceNames');
+}
+
+function isPoolRoyaleExternalChromeControlledSurface(child) {
+  return isPoolRoyaleExternalNamedSurface(child, 'poolRoyaleChromeSurfaceNames');
 }
 
 function applyPoolRoyaleBlackExternalSurfaceMaterial(material) {
@@ -13005,7 +13010,8 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
     ? tableModel.preserveOriginalSurfaceRoles
     : [];
   const shouldUsePoolRoyaleFinish = !finishRoles || finishRoles.includes(role);
-  if (!shouldUsePoolRoyaleFinish || preserveRoles.includes(role)) {
+  const chromeControlledSurface = role === 'trim' && isPoolRoyaleExternalChromeControlledSurface(child);
+  if (!chromeControlledSurface && (!shouldUsePoolRoyaleFinish || preserveRoles.includes(role))) {
     const originalMat = material.clone ? material.clone() : material;
     if (isPoolRoyaleExternalBlackSurface(child)) {
       applyPoolRoyaleBlackExternalSurfaceMaterial(originalMat);
@@ -13068,6 +13074,10 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
   } else if (role === 'trim') {
     copyMaterialLook(materials.trim);
     enhanceChromeMaterial(mat);
+    mat.userData = {
+      ...(mat.userData || {}),
+      poolRoyaleChromeControlledSurface: chromeControlledSurface
+    };
   } else if (role === 'pocket') {
     copyMaterialLook(materials.pocketJaw ?? materials.pocketRim);
   } else {
@@ -13123,6 +13133,10 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const prepareMaterial = (material) => {
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
+      child.userData = {
+        ...(child.userData || {}),
+        poolRoyaleExternalSurfaceRole: role
+      };
       if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
         child.visible = false;
       }
@@ -13154,6 +13168,41 @@ function clonePoolRoyaleExternalTableTemplate(template, tableModel = null, finis
   const clone = template.clone(true);
   preparePoolRoyaleExternalTableMaterials(clone, tableModel, finishInfo);
   return clone;
+}
+
+function refreshPoolRoyaleExternalTableMaterials(table, finishInfo = null) {
+  const externalRoot = table?.userData?.externalTable?.group;
+  const tableModel = table?.userData?.externalTableModelForMount;
+  if (!externalRoot || !tableModel || !finishInfo) return;
+  externalRoot.traverse((child) => {
+    if (!child?.isMesh) return;
+    const previousMaterial = child.material;
+    const previousMaterials = Array.isArray(previousMaterial) ? previousMaterial : [previousMaterial];
+    child.userData = {
+      ...(child.userData || {}),
+      poolRoyaleChromeSurfaceNames: Array.isArray(tableModel.chromeMaterialSurfaceNames)
+        ? tableModel.chromeMaterialSurfaceNames
+        : [],
+      poolRoyaleBlackSurfaceNames: Array.isArray(tableModel.blackMaterialSurfaceNames)
+        ? tableModel.blackMaterialSurfaceNames
+        : []
+    };
+    const prepareMaterial = (material) => {
+      if (!material) return material;
+      const role = child.userData?.poolRoyaleExternalSurfaceRole ||
+        classifyPoolRoyaleExternalTableSurface(child, material);
+      child.userData.poolRoyaleExternalSurfaceRole = role;
+      return applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tableModel, child);
+    };
+    child.material = Array.isArray(previousMaterial)
+      ? previousMaterial.map(prepareMaterial)
+      : prepareMaterial(previousMaterial);
+    previousMaterials.forEach((material) => {
+      if (!material) return;
+      const nextMaterials = Array.isArray(child.material) ? child.material : [child.material];
+      if (!nextMaterials.includes(material)) material.dispose?.();
+    });
+  });
 }
 
 async function loadPoolRoyaleExternalTableTemplate(tableModel, renderer = null) {
@@ -14151,6 +14200,7 @@ function mountPoolRoyaleExternalTableModel({
         })
       : null;
   table.userData.externalTable = externalTable;
+  table.userData.externalTableModelForMount = externalTableModelForMount;
   parent.add(table);
 
   const baulkZ = baulkLineZ;
@@ -15026,7 +15076,7 @@ function PoolRoyaleGame({
     }
     return DEFAULT_POCKET_LINER_OPTION_ID;
   });
-  const [railMarkerShapeId, setRailMarkerShapeId] = useState(() => {
+  const [railMarkerShapeId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('poolRailMarkerShape');
       if (stored && RAIL_MARKER_SHAPE_OPTIONS.some((opt) => opt.id === stored)) {
@@ -15183,13 +15233,6 @@ function PoolRoyaleGame({
     () =>
       CHROME_PLATE_STYLE_OPTIONS.filter((option) =>
         isPoolOptionUnlocked('chromePlateStyle', option.id, poolInventory)
-      ),
-    [poolInventory]
-  );
-  const availableRailMarkerColors = useMemo(
-    () =>
-      RAIL_MARKER_COLOR_OPTIONS.filter((option) =>
-        isPoolOptionUnlocked('railMarkerColor', option.id, poolInventory)
       ),
     [poolInventory]
   );
@@ -26989,13 +27032,16 @@ const shotPowerRef = useRef(0);
       applyFinishRef.current = (nextFinish) => {
         if (table && nextFinish) {
           applyTableFinishToTable(table, nextFinish);
+          refreshPoolRoyaleExternalTableMaterials(table, nextFinish);
         }
         if (secondaryTableRef.current && nextFinish) {
           applyTableFinishToTable(secondaryTableRef.current, nextFinish);
+          refreshPoolRoyaleExternalTableMaterials(secondaryTableRef.current, nextFinish);
         }
         decorativeTablesRef.current.forEach((entry) => {
           if (entry?.group && nextFinish) {
             applyTableFinishToTable(entry.group, nextFinish);
+            refreshPoolRoyaleExternalTableMaterials(entry.group, nextFinish);
           }
         });
       };
@@ -36914,58 +36960,6 @@ const shotPowerRef = useRef(0);
               ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Rail Markers
-                </h3>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {RAIL_MARKER_SHAPE_OPTIONS.map((option) => {
-                    const active = option.id === railMarkerShapeId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setRailMarkerShapeId(option.id)}
-                        aria-pressed={active}
-                        className={`flex-1 min-w-[7rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        {option.label}
-                      </button>
-                    );
-                  })}
-                </div>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {availableRailMarkerColors.map((option) => {
-                    const active = option.id === railMarkerColorId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setRailMarkerColorId(option.id)}
-                        aria-pressed={active}
-                        className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="flex items-center justify-center gap-2">
-                          <span
-                            className="h-3.5 w-3.5 rounded-full border border-white/40"
-                            style={{ backgroundColor: toHexColor(option.color) }}
-                            aria-hidden="true"
-                          />
-                          {option.label}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Graphics
                 </h3>
                 <p className="mt-1 text-[0.7rem] text-white/70">
@@ -38125,11 +38119,6 @@ export default function PoolRoyale() {
     const params = new URLSearchParams(location.search);
     const requested = params.get('tableModel');
     if (requested) return resolvePoolRoyaleTableModel(requested).id;
-    try {
-      return resolvePoolRoyaleTableModel(
-        window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY)
-      ).id;
-    } catch {}
     return resolvePoolRoyaleTableModel().id;
   }, [location.search]);
   const mode = useMemo(() => {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,7 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
@@ -77,17 +76,8 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const [tableModelId, setTableModelId] = useState(() => {
-    try {
-      const stored = window.localStorage?.getItem(
-        POOL_ROYALE_TABLE_MODEL_STORAGE_KEY
-      );
-      return resolvePoolRoyaleTableModel(stored).id;
-    } catch {}
-    return resolvePoolRoyaleTableModel().id;
-  });
   const [players, setPlayers] = useState(8);
-  const selectedTableModel = resolvePoolRoyaleTableModel(tableModelId);
+  const selectedTableModel = resolvePoolRoyaleTableModel();
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -624,49 +614,6 @@ export default function PoolRoyaleLobby() {
           </div>
           <p className="mt-3 text-xs text-white/60">
             Your lobby choices persist into the match intro.
-          </p>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Pool Table</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-              GLB Arena
-            </span>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
-              const active = tableModelId === option.id;
-              return (
-                <button
-                  key={option.id}
-                  type="button"
-                  onClick={() => setTableModelId(option.id)}
-                  className={`lobby-option-card ${
-                    active
-                      ? 'lobby-option-card-active'
-                      : 'lobby-option-card-inactive'
-                  }`}
-                >
-                  <div className="lobby-option-thumb bg-gradient-to-br from-fuchsia-400/20 via-amber-500/10 to-transparent">
-                    <div className="lobby-option-thumb-inner text-2xl">
-                      {option.icon || '🎱'}
-                    </div>
-                  </div>
-                  <div className="text-center">
-                    <p className="lobby-option-label">{option.label}</p>
-                    <p className="lobby-option-subtitle">
-                      {option.kind === 'gltf'
-                        ? `${option.tableSizeId} · original textures`
-                        : 'Current table'}
-                    </p>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-          <p className="text-xs text-white/60">
-            New GLB tables replace the in-game table visually while Pool Royale keeps the matched playfield, pockets, cushions, and ball physics.
           </p>
         </div>
 


### PR DESCRIPTION
### Motivation
- Prefer the Showood GLB showroom table as the default visual for Pool Royale while keeping the procedural/native table as a fallback if external GLB fails. 
- Remove the procedural/table-model chooser from the lobby so players enter matches with the showroom table by default. 
- Ensure side apron + rail sight surfaces on the Showood GLB use the chrome/trim finish pipeline (so they share chrome plate options and textures) and keep original table markings instead of generated diamonds. 

### Description
- Update table model defaults and surface name mapping in `webapp/src/config/poolRoyaleTableModels.js` by making `showood-seven-foot` the default, moving `sideWoodApron`/`railSight` into `chromeMaterialSurfaceNames`, and clearing `blackMaterialSurfaceNames`. 
- Remove the lobby table-picker UI and selection state from `webapp/src/pages/Games/PoolRoyaleLobby.jsx` so the lobby no longer exposes procedural vs GLB table choices. 
- In `webapp/src/pages/Games/PoolRoyale.jsx` add helpers (`isPoolRoyaleExternalNamedSurface`, `isPoolRoyaleExternalChromeControlledSurface`), treat chrome-controlled trim surfaces specially in `applyPoolRoyaleFinishToExternalMaterial`, and mark chrome-controlled surfaces via material/userData. 
- Add `refreshPoolRoyaleExternalTableMaterials` and wire it into the finish-apply flow so external GLB materials are re-prepared when the chosen `tableFinish` or chrome options change. 
- Remove the in-game Rail Markers customization controls and stop reading the old `tableModel` localStorage value when resolving the runtime `tableModelKey`, ensuring the Showood table is used unless explicitly requested by query param. 
- Minor import/cleanup adjustments to ensure buildability and proper disposal of replaced external-material textures. 

### Testing
- Ran `git diff --check` to verify there are no whitespace/merge errors and it passed. 
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully. 
- Installed Playwright browsers and deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) and exercised a headless rendering step that produced a screenshot artifact successfully. 
- Captured a Playwright screenshot saved at `artifacts/pool-royale-lobby-showood-default.png` to verify lobby rendering with Showood defaults.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00803c0f98832993ed422643cb2298)