### PR TITLE
Preserve GLB table footprint and add exact-original human pose mode for Snooker Royal

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10895,7 +10895,6 @@ function Table3D(
 
   const applyOpenSourceTableVisualOverride = () => {
     const targetBounds = resolveOpenSourceTargetBounds();
-    const clothUvBounds = resolveOpenSourceClothUvBounds();
     const targetSize = targetBounds.getSize(new THREE.Vector3());
     const targetCenter = targetBounds.getCenter(new THREE.Vector3());
     const targetTopY = targetBounds.max.y;
@@ -10909,16 +10908,17 @@ function Table3D(
         model.updateMatrixWorld(true);
         const fullSourceBounds = new THREE.Box3().setFromObject(model);
         const sourceFitBounds = resolveOpenSourceUpperBounds(model, fullSourceBounds);
-        const fullSourceSize = fullSourceBounds.getSize(new THREE.Vector3());
         const sourceFitSize = sourceFitBounds.getSize(new THREE.Vector3());
         const fit = resolveSnookerGlbFitTransform(
           { x: sourceFitSize.x, y: sourceFitSize.y, z: sourceFitSize.z },
           { x: targetSize.x, y: targetSize.y, z: targetSize.z }
         );
-        const upperTableScale = Math.min(fit.scale.x, fit.scale.z);
-        if (Number.isFinite(upperTableScale) && upperTableScale > MICRO_EPS) {
-          fit.scale.y = upperTableScale;
-          fit.preservesOriginalUpperTableProportions = true;
+        const originalSizeHeightScale = fit.scale.y;
+        if (Number.isFinite(originalSizeHeightScale) && originalSizeHeightScale > MICRO_EPS) {
+          fit.scale.x = originalSizeHeightScale;
+          fit.scale.z = originalSizeHeightScale;
+          fit.usesOriginalGlbFootprint = true;
+          fit.keepsProceduralHeight = true;
         }
         model.scale.set(fit.scale.x, fit.scale.y, fit.scale.z);
 
@@ -10936,31 +10936,34 @@ function Table3D(
         model.updateMatrixWorld(true);
 
         applyDefaultTableFinishToOpenSourceModel(model);
-        const removedOriginalBaseMeshCount = removeOpenSourceOriginalTableBase(model, scaledFitBounds);
-        remapOpenSourceClothTextureCoordinates(model, clothUvBounds);
+        const glbMappingBounds = scaledFitBounds.clone();
+        remapOpenSourceClothTextureCoordinates(model, glbMappingBounds);
         applyOpenSourceCushionPhysicsFromModel(model);
         removeOpenSourceProceduralRailDecor();
-        setProceduralTableMeshesVisible(false, { keepProceduralBase: true });
+        setProceduralTableMeshesVisible(false, { keepProceduralBase: false });
         model.name = 'pooltool-snooker-generic-table';
         model.userData = {
           ...(model.userData || {}),
           isOpenSourceVisual: true,
           sourceUrl: TABLE_MODEL_OPENSOURCE_GLB_URL,
-          fitToProceduralMapping: true,
+          fitToProceduralMapping: false,
+          fitToOriginalGlbHeight: true,
           keepsDefaultPocketDropHardware: true,
           preservesProceduralChromeHoldersLeatherStrapsAndNets: true,
           removesProceduralFrameRailsChromePlatesAndJaws: !keepProceduralRailDecor,
-          preservesOriginalTableBase: false,
-          removedOriginalBaseMeshCount,
-          usesProceduralTableBase: true,
+          preservesOriginalTableBase: true,
+          removedOriginalBaseMeshCount: 0,
+          usesProceduralTableBase: false,
           usesGlbCushionShapes: true,
-          clothUvMappedToDefaultPlayfield: true,
-          clothUvUsesProceduralWorldScale: true
+          clothUvMappedToGlbPlayfield: true,
+          clothUvUsesProceduralWorldScale: false,
+          keepsProceduralHeightWithOriginalGlbFootprint: true
         };
         table.userData.openSourceVisual = model;
         table.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;
         table.userData.openSourceVisualFit = fit;
         table.userData.openSourceVisualTargetBounds = targetBounds;
+        table.userData.openSourceGlbMappingBounds = glbMappingBounds;
       })
       .catch((error) => {
         setProceduralTableMeshesVisible(true);

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -250,7 +250,8 @@ const BASE_CFG = {
   plantFeetDuringShot: true,
   bridgeArmStraightDown: false,
   forceTableFacingAim: true,
-  addFaceDetails: true
+  addFaceDetails: true,
+  exactOriginalPoseLogic: false
 };
 
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
@@ -859,6 +860,45 @@ function driveHuman(human, frame) {
   setHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, cfg.footLockStrength * ik);
 }
 
+
+function updateOriginalExportHumanPose(human, dt, frameData, activeState) {
+  const cfg = human.cfg;
+  const rootGoal = activeState === 'striking' ? human.strikeRoot : frameData.rootTarget;
+  const directRootTarget = frameData.directRootTarget || activeState === 'seated';
+  if (activeState === 'striking' || directRootTarget) {
+    dampVector(human.root.position, rootGoal, directRootTarget ? cfg.moveLambda : 12, dt);
+    human.root.position.y = cfg.groundY;
+  } else {
+    moveRootAroundPerimeter(human, rootGoal, cfg, dt);
+  }
+
+  const forward = new THREE.Vector3(0, 0, -1);
+  const side = new THREE.Vector3(1, 0, 0);
+  const shotQ = makeBasisQuaternion(side, UP, forward);
+
+  human.poseT = dampScalar(human.poseT, 0, cfg.poseLambda, dt);
+  const aimForward = frameData.aimForward?.clone?.() || forward.clone();
+  aimForward.y = 0;
+  if (aimForward.lengthSq() > 1e-8) {
+    human.yaw = dampScalar(
+      human.yaw,
+      yawFromForward(aimForward.normalize()) - (cfg.humanVisualYawFix || 0),
+      cfg.rotLambda,
+      dt
+    );
+  }
+
+  human.root.visible = true;
+  if (!human.activeGlb || !human.model) return;
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(human.root.position);
+  human.modelRoot.rotation.y = human.yaw;
+  human.modelRoot.updateMatrixWorld(true);
+  if (human.bones.head) {
+    setBoneWorldQuaternion(human.bones.head, shotQ);
+  }
+}
+
 export function updateHumanPose(human, dt, frameData) {
   if (!human || !frameData || !Number.isFinite(dt) || dt < 0 || !frameData.rootTarget || !frameData.aimForward) return;
   const cfg = human.cfg;
@@ -875,6 +915,11 @@ export function updateHumanPose(human, dt, frameData) {
     human.strikeClock += dt;
   } else {
     human.strikeClock = 0;
+  }
+
+  if (cfg.exactOriginalPoseLogic) {
+    updateOriginalExportHumanPose(human, dt, frameData, activeState);
+    return;
   }
 
   const rootGoal = activeState === 'striking' ? human.strikeRoot : frameData.rootTarget;

--- a/webapp/src/pages/Games/shared/snookerHumanRig.js
+++ b/webapp/src/pages/Games/shared/snookerHumanRig.js
@@ -1,7 +1,11 @@
 import { createHumanRig, chooseHumanEdgePosition, updateHumanPose } from './humanRigCore';
 
 export function createSnookerHumanRig(scene, opts = {}) {
-  return createHumanRig(scene, opts);
+  return createHumanRig(scene, {
+    exactOriginalPoseLogic: true,
+    addFaceDetails: false,
+    ...opts
+  });
 }
 
 export { chooseHumanEdgePosition };


### PR DESCRIPTION
### Motivation
- Preserve the original GLB snooker table footprint and mapping while keeping the same visual table height and view; the procedural table should no longer force-fit the GLB footprint.
- Make the human avatar behave like the pasted human-only export: simple damp-to-idle pose, fixed head/world-orientation logic and yaw application instead of the full IK/shot rig for Snooker Royal.

### Description
- Adjusted the open-source GLB table override in `Table3D` (`webapp/src/pages/Games/SnookerRoyal.jsx`) to compute the fit from the GLB upper bounds and apply the GLB height scale uniformly to X/Z so the GLB keeps its original footprint while still aligning the table top to the procedural height.
- Remapped cloth UVs to the GLB playfield bounds and switched table metadata flags to mark that the GLB is used for visual/mapping (kept the GLB base visible and hid the procedural base), and stored `openSourceGlbMappingBounds` for mapping.
- Added an `exactOriginalPoseLogic` option to the human rig core (`webapp/src/pages/Games/shared/humanRigCore.js`) and implemented `updateOriginalExportHumanPose` which replicates the simplified behavior from the provided export (damped `poseT` toward 0, fixed head quaternion built from `(side, up, forward)`, and `modelRoot.rotation.y = human.yaw`).
- Enabled the new exact-original mode for Snooker Royal by default in the Snooker wrapper (`webapp/src/pages/Games/shared/snookerHumanRig.js`) and disabled face-detail injection for that wrapper.

### Testing
- Built the web app with `cd webapp && npm run build` and the production build completed successfully (Vite build output produced).
- Ran a repository static check with `git diff --check` on the modified files and no whitespace errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0082f3fd7483298911b409b70b593e)