### PR TITLE
Adjust Snooker GLB fitting and add reference-pose human rig

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10915,10 +10915,12 @@ function Table3D(
           { x: sourceFitSize.x, y: sourceFitSize.y, z: sourceFitSize.z },
           { x: targetSize.x, y: targetSize.y, z: targetSize.z }
         );
-        const upperTableScale = Math.min(fit.scale.x, fit.scale.z);
-        if (Number.isFinite(upperTableScale) && upperTableScale > MICRO_EPS) {
-          fit.scale.y = upperTableScale;
-          fit.preservesOriginalUpperTableProportions = true;
+        const originalSizeScale = fit.scale.y;
+        if (Number.isFinite(originalSizeScale) && originalSizeScale > MICRO_EPS) {
+          fit.scale.x = originalSizeScale;
+          fit.scale.z = originalSizeScale;
+          fit.preservesOriginalGlbFootprint = true;
+          fit.usesProceduralHeightOnly = true;
         }
         model.scale.set(fit.scale.x, fit.scale.y, fit.scale.z);
 
@@ -10946,7 +10948,10 @@ function Table3D(
           ...(model.userData || {}),
           isOpenSourceVisual: true,
           sourceUrl: TABLE_MODEL_OPENSOURCE_GLB_URL,
-          fitToProceduralMapping: true,
+          fitToProceduralMapping: false,
+          keepsOriginalGlbFootprint: true,
+          keepsProceduralHeightForCameraView: true,
+          mappingSource: 'glb-cushion-bounds',
           keepsDefaultPocketDropHardware: true,
           preservesProceduralChromeHoldersLeatherStrapsAndNets: true,
           removesProceduralFrameRailsChromePlatesAndJaws: !keepProceduralRailDecor,
@@ -21071,7 +21076,8 @@ const powerRef = useRef(hud.power);
         idleRightHandX: 0.31 * humanUnitScale,
         idleRightHandZ: -0.015 * humanUnitScale,
         idleCueGripFromBack: 0.24 * humanUnitScale,
-        rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(humanUnitScale)
+        rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(humanUnitScale),
+        referencePoseOnly: true
       });
       let lastHumanPoseTime = performance.now();
 

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -250,7 +250,12 @@ const BASE_CFG = {
   plantFeetDuringShot: true,
   bridgeArmStraightDown: false,
   forceTableFacingAim: true,
-  addFaceDetails: true
+  addFaceDetails: true,
+  // Compatibility mode for games that need the exact ReadyPlayer reference
+  // pose/orientation behaviour: keep the avatar in its normalized rest pose,
+  // drive only the root yaw, and pin the head to the same world basis as the
+  // HumanOnlyExport snippet.
+  referencePoseOnly: false
 };
 
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
@@ -733,6 +738,26 @@ function updateGoalRushWalkAnimation(human, dt, frame) {
   return walkWeight > 0.05 && frame.t < 0.025;
 }
 
+
+function driveReferenceHumanPose(human, rootWorld) {
+  if (!human.activeGlb || !human.model) return;
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(rootWorld);
+  human.modelRoot.rotation.y = human.yaw;
+  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
+  human.modelRoot.updateMatrixWorld(true);
+
+  const forward = new THREE.Vector3(0, 0, -1);
+  const side = new THREE.Vector3(1, 0, 0);
+  const shotQ = makeBasisQuaternion(side, UP, forward);
+
+  if (human.bones.head) {
+    setBoneWorldQuaternion(human.bones.head, shotQ);
+  }
+
+  human.modelRoot.updateMatrixWorld(true);
+}
+
 function driveHuman(human, frame) {
   if (!human.activeGlb || !human.model) return;
   const cfg = human.cfg;
@@ -900,6 +925,15 @@ export function updateHumanPose(human, dt, frameData) {
     ? targetRootYaw
     : dampScalar(human.yaw, targetRootYaw, cfg.rotLambda, dt);
   ensureHumanFacingTable(human, frameData, cfg);
+
+  if (cfg.referencePoseOnly) {
+    human.poseT = dampScalar(human.poseT, 0, cfg.poseLambda, dt);
+    human.root.visible = true;
+    const rootWorld = human.root.position.clone();
+    rootWorld.y = cfg.groundY;
+    driveReferenceHumanPose(human, rootWorld);
+    return;
+  }
 
   const t = easeInOut(human.poseT);
   const idle = 1 - t;


### PR DESCRIPTION
### Motivation
- Preserve the original footprint and visual proportions of the open-source Snooker GLB while keeping the same camera/table height and mapping behavior. 
- Reproduce the ReadyPlayer-style human pose behaviour for the Snooker player by driving only the root yaw/position and pinning the head to a fixed world basis when required. 

### Description
- Change GLB fit logic in `webapp/src/pages/Games/SnookerRoyal.jsx` to scale the GLB X/Z from the GLB height scale only (preserve GLB footprint) and set flags `fitToProceduralMapping: false`, `mappingSource: 'glb-cushion-bounds'`, and related metadata to indicate mapping comes from GLB cushions instead of procedural fitting. 
- Add a `referencePoseOnly` config flag to the human rig base config in `webapp/src/pages/Games/shared/humanRigCore.js` to enable ReadyPlayer-style behavior. 
- Implement `driveReferenceHumanPose(human, rootWorld)` in `humanRigCore.js` which restores rest quaternions, positions the model root (yaw/position), and pins the head basis to the reference basis. 
- Wire `referencePoseOnly: true` into the Snooker Royal human instantiation so the Snooker player uses the reference-pose mode in the scene. 

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully and produced updated `dist` assets. 
- Ran repository checks (`git diff --check`) with no reported issues. 
- Attempted an automated visual smoke check using Playwright to capture a screenshot, but Chromium could not launch in the container due to a missing native library (`libatk-1.0.so.0`), so the visual confirmation step failed; the code changes were exercised by the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0082f3fd7483298911b409b70b593e)