### PR TITLE
Raise Domino Royal player hands

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6715,18 +6715,18 @@ const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.0025; // keep chain tiles touching without visible overlap
 const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
-// May 9, 2026 mobile portrait tuning: compact the rack and pull hands visually inward toward the tiles.
-// May 10, 2026: shrink only player-hand dominoes and tighten their rack spacing.
+// May 10, 2026: keep player-hand dominoes compact while placing them farther
+// beyond the rail and higher above the tabletop for clearer Battle Royal seating.
 const PLAYER_HAND_TILE_SCALE = 0.9;
 const PLAYER_HAND_GAP_SCALE = 0.5;
 const PLAYER_HAND_MIN_GAP_SCALE = 0.76;
-const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 7.4;
-const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 4.7;
-const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 3.15;
-const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 4.15;
+const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 9.2;
+const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 6.4;
+const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 4.4;
+const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 5.3;
 const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.0;
-const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 0.22;
-const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 3.45;
+const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 1.05;
+const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 4.7;
 const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.88;
 const DOMINO_DOUBLE_NEIGHBOR_EXTRA_GAP = 0;
 const DOMINO_OPENING_DOUBLE_SIDE_GAP = DOMINO_LENGTH * 0.11;
@@ -8274,10 +8274,10 @@ function normalizeDominoCharacterRoot(root) {
   if (!bounds.isEmpty()) root.position.y -= bounds.min.y;
 }
 
-const DOMINO_HELD_RACK_HAND_LIFT = 0.5 * MODEL_SCALE;
-const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.62 * MODEL_SCALE;
-const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 0.78 * MODEL_SCALE;
-const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 0.98 * MODEL_SCALE;
+const DOMINO_HELD_RACK_HAND_LIFT = 0.72 * MODEL_SCALE;
+const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.86 * MODEL_SCALE;
+const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 1.04 * MODEL_SCALE;
+const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 1.28 * MODEL_SCALE;
 
 function createHeldDominoRack(seatIndex, handTiles = []) {
   const rack = new THREE.Group();


### PR DESCRIPTION
### Motivation
- Improve Domino Battle Royal readability by moving players' dominoes outward and raising them higher above the table so hands and held racks are clearer in the 3D scene.
- Make the character-held domino racks sit further out and higher to match the new hand placement and Battle Royal seating composition.

### Description
- Update `webapp/public/domino-royal-game.js` to increase hand placement offsets and vertical lift by changing `PLAYER_HAND_OUTWARD_OFFSET`, `HUMAN_PLAYER_HAND_OUTWARD_OFFSET`, `PLAYER_HAND_VERTICAL_RAISE`, `HUMAN_HAND_OUTWARD_OFFSET`, `HUMAN_BOTTOM_EXTRA_OUTWARD`, and `HUMAN_BOTTOM_EXTRA_RAISE` so player hands are placed farther beyond the rail and higher above the tabletop.
- Raise and push outward the held-rack attachment by increasing `DOMINO_HELD_RACK_HAND_LIFT`, `DOMINO_HELD_RACK_OUTWARD_OFFSET`, `DOMINO_HELD_RACK_BOTTOM_HAND_LIFT`, and `DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET` to keep held racks aligned with the new hand positions.
- Update the local comment describing the hand tuning to reflect the new placement intention.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it succeeded.
- Ran `node --test test/dominoRoyalHdriCatalog.test.js` and the test passed.
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Attempted an automated Playwright screenshot to validate visual results but Chromium could not launch in this environment due to a missing system library (`libatk-1.0.so.0`), so the visual smoke test could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b5525b2083298caa16f02967f7ea)