### PR TITLE
Improve Ludo bottom-seat camera focus

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3957,8 +3957,8 @@ const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.072 * MODEL_SCALE;
 // The bottom-seat gameplay camera is intentionally raised and pushed farther toward the table so
 // portrait players see over the local avatar and closer into the Ludo board/action area.
 const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.31 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.42 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.255 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.58 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.38 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 9;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.34;
 const SEATED_CONTACT_DICE_Y_OFFSET = 0.005;
@@ -4022,6 +4022,10 @@ const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
 const LUDO_CAMERA_BROADCAST_LOCKED_POSITION = true;
 const LUDO_CAMERA_SEAT_LOCK_ENABLED = true;
 const LUDO_CAMERA_ANIMATION_BOTTOM_TURN_VIEW = false;
+const BOTTOM_SEAT_GAMEPLAY_FOCUS_BLEND = 0.74;
+const BOTTOM_SEAT_DICE_FOCUS_TTL_MS = 1900;
+const BOTTOM_SEAT_TOKEN_FOCUS_TTL_MS = 2800;
+const BOTTOM_SEAT_RESULT_FOCUS_TTL_MS = 1600;
 const CAPTURE_ATTACK_CAMERA_FRAME = Object.freeze({
   fighterJetAttack: { focusWeight: 0.52, targetLift: 0.014, followPullback: 0.082, followLift: 0.022 },
   helicopterAttack: { focusWeight: 0.56, targetLift: 0.02, followPullback: 0.068, followLift: 0.026 },
@@ -7727,6 +7731,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const cameraFocusFrameRef = useRef(0);
   const cameraViewFrameRef = useRef(0);
   const cameraSeatLockPositionRef = useRef(null);
+  const bottomSeatGameplayFocusRef = useRef(null);
   const dynamicFirearmCameraRef = useRef(false);
   const firearmCinematicCameraPoseRef = useRef(null);
   const lockUserTurnSeatViewRef = useRef(false);
@@ -10774,9 +10779,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
       if (!isCamera2d && camera && LUDO_CAMERA_SEAT_LOCK_ENABLED && !dynamicFirearmCameraRef.current) {
         const bottomActorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === 0);
-        const gameplayTarget = boardLookTargetRef.current?.isVector3
-          ? boardLookTargetRef.current.clone()
-          : null;
+        const gameplayTarget = resolveBottomPlayerGameplayTarget();
         const liveFacePose = resolveSeatedFaceCameraPose(bottomActorEntry, gameplayTarget);
         const hardLockedPosition = liveFacePose?.position?.isVector3
           ? liveFacePose.position
@@ -12538,8 +12541,49 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   );
 
 
+  const setBottomSeatGameplayFocus = useCallback((focus = {}) => {
+    const {
+      object = null,
+      target = null,
+      ttlMs = BOTTOM_SEAT_RESULT_FOCUS_TTL_MS,
+      blend = BOTTOM_SEAT_GAMEPLAY_FOCUS_BLEND,
+      offset = CAMERA_TARGET_LIFT + 0.026
+    } = focus;
+    if (!object?.isObject3D && !target?.isVector3) {
+      bottomSeatGameplayFocusRef.current = null;
+      return;
+    }
+    bottomSeatGameplayFocusRef.current = {
+      object: object?.isObject3D ? object : null,
+      target: target?.isVector3 ? target.clone() : null,
+      expiresAt: ttlMs > 0 ? performance.now() + ttlMs : Infinity,
+      blend: clamp(blend, 0, 1),
+      offset
+    };
+  }, []);
+
   const resolveBottomPlayerGameplayTarget = useCallback(() => {
-    return boardLookTargetRef.current?.isVector3 ? boardLookTargetRef.current.clone() : null;
+    const boardTarget = boardLookTargetRef.current?.isVector3 ? boardLookTargetRef.current.clone() : null;
+    const focus = bottomSeatGameplayFocusRef.current;
+    if (!focus) return boardTarget;
+    if (Number.isFinite(focus.expiresAt) && performance.now() > focus.expiresAt) {
+      bottomSeatGameplayFocusRef.current = null;
+      return boardTarget;
+    }
+
+    let focusTarget = null;
+    if (focus.object?.isObject3D) {
+      focusTarget = focus.object.getWorldPosition(new THREE.Vector3());
+    } else if (focus.target?.isVector3) {
+      focusTarget = focus.target.clone();
+    }
+    if (!focusTarget?.isVector3) return boardTarget;
+
+    const surfaceY = arenaRef.current?.tableInfo?.surfaceY ?? boardTarget?.y ?? focusTarget.y;
+    focusTarget.y = surfaceY + (focus.offset ?? CAMERA_TARGET_LIFT + 0.026);
+    if (!boardTarget) return focusTarget;
+    boardTarget.y = surfaceY + CAMERA_TARGET_LIFT;
+    return boardTarget.lerp(focusTarget, focus.blend ?? BOTTOM_SEAT_GAMEPLAY_FOCUS_BLEND);
   }, []);
 
   const setCameraViewForTurn = useCallback((player, duration = CAMERA_TURN_VIEW_DURATION_MS, { force = false } = {}) => {
@@ -12793,6 +12837,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     if (!segments.length) {
       if (token && shouldFollowCamera) {
+        setBottomSeatGameplayFocus({
+          object: token,
+          ttlMs: BOTTOM_SEAT_TOKEN_FOCUS_TTL_MS,
+          offset: CAMERA_TARGET_LIFT + 0.038
+        });
         setCameraFocus({
           target: token.position.clone(),
           follow: false,
@@ -12807,6 +12856,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       return;
     }
       if (token && shouldFollowCamera) {
+        setBottomSeatGameplayFocus({
+          object: token,
+          ttlMs: BOTTOM_SEAT_TOKEN_FOCUS_TTL_MS,
+          offset: CAMERA_TARGET_LIFT + 0.038
+        });
         setCameraFocus({
           object: token,
           follow: true,
@@ -13314,6 +13368,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     baseTarget.y = baseHeight;
     stopDiceTransition();
     dice.userData.isRolling = true;
+    setBottomSeatGameplayFocus({
+      object: dice,
+      ttlMs: BOTTOM_SEAT_DICE_FOCUS_TTL_MS,
+      offset: CAMERA_TARGET_LIFT + 0.04
+    });
     if (!isHumanTurn) {
       setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
       setCameraFocus({
@@ -13359,6 +13418,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       dice: value,
       status: player === 0 ? `You rolled ${value}` : `${COLOR_NAMES[player]} rolled ${value}`
     }));
+    setBottomSeatGameplayFocus({
+      target: landingFocus,
+      ttlMs: BOTTOM_SEAT_RESULT_FOCUS_TTL_MS,
+      offset: CAMERA_TARGET_LIFT + 0.05
+    });
     if (value === 6) {
       playSixRollSound();
     }


### PR DESCRIPTION
### Motivation
- Make the bottom-seat (local human) camera sit higher and look more downward so portrait players see more of the Ludo board and gameplay.
- Ensure the camera follows important gameplay events (dice throw, dice result, token movement) so the bottom-seat view focuses on action automatically.

### Description
- Raised the bottom-seat face camera pose by increasing `SEATED_FACE_CAMERA_GAMEPLAY_UP` and `SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN` to position the camera higher and look more down in `LudoBattleRoyal.jsx`.
- Added temporary bottom-seat gameplay focus constants (`BOTTOM_SEAT_GAMEPLAY_FOCUS_BLEND`, `BOTTOM_SEAT_DICE_FOCUS_TTL_MS`, `BOTTOM_SEAT_TOKEN_FOCUS_TTL_MS`, `BOTTOM_SEAT_RESULT_FOCUS_TTL_MS`) to control blend/TTL behavior for transient focus targets.
- Introduced `bottomSeatGameplayFocusRef` and `setBottomSeatGameplayFocus` to track short-lived focus targets and updated `resolveBottomPlayerGameplayTarget` to lerp the locked face-camera target toward active gameplay objects when present.
- Wired the new focus API into dice and token flows so dice rolling, dice result hold, and token movement set temporary focus targets (and token movement sets token focus) to make the locked bottom-seat camera look toward the active action.

### Testing
- Ran `git diff --check` to validate diffs and formatting with no blocking issues detected (success).
- Built the web app with `npm --prefix webapp run build` and verified a successful production build (Vite build completed without fatal errors, generated `dist/` assets).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c7f15c8883299c50e90f6fdec673)