### PR TITLE
Default Showood table model, Showood material handling, and chrome tweaks

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -8,8 +8,8 @@ import {
 describe('Pool Royale table models', () => {
   test('defaults to the Showood GLB table', () => {
     assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'showood-seven-foot');
-    assert.equal(resolvePoolRoyaleTableModel(null).id, 'royal-original');
-    assert.equal(resolvePoolRoyaleTableModel('unknown').id, 'royal-original');
+    assert.equal(resolvePoolRoyaleTableModel(null).id, 'showood-seven-foot');
+    assert.equal(resolvePoolRoyaleTableModel('unknown').id, 'showood-seven-foot');
   });
 
   test('Showood uses original GLB surface layout with Pool Royale finish textures', () => {
@@ -25,8 +25,8 @@ describe('Pool Royale table models', () => {
     assert.deepEqual(showood.hideSurfaceRoles, []);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['trim']);
     assert.equal(showood.tintOriginalTrimGold, true);
-    assert.deepEqual(showood.chromeMaterialSurfaceNames, ['diamonds']);
-    assert.deepEqual(showood.blackMaterialSurfaceNames, ['sideWoodApron', 'railSight']);
+    assert.deepEqual(showood.chromeMaterialSurfaceNames, ['diamonds', 'railSight', 'sideWoodApron']);
+    assert.deepEqual(showood.blackMaterialSurfaceNames, []);
     assert.equal(showood.forceGeneratedChromePlates, false);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -8,7 +8,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the GLB cannot load, Pool Royale keeps the native procedural table as a gameplay-safe fallback.',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the GLB cannot load, Pool Royale uses the same procedural cloth/fallback materials without spawning extra decorative tables.',
     tableSizeId: '7ft',
     baseId: 'showoodOriginal',
     assetUrl:
@@ -16,9 +16,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
-    fitScale: 1,
+    fitScale: 1.02,
     fitFootprintScale: 1.075,
-    fitHeightScale: 1,
     lowerBaseHeightScale: 0.78,
     legLengthScale: 1.18,
     clothRepeatScale: 5.25,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1707,7 +1707,7 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
 const SHOWOOD_ORIGINAL_TABLE_BASE_ID = 'showoodOriginal';
 const DEFAULT_PROCEDURAL_TABLE_BASE_ID = 'classicCylinders';
-const DEFAULT_TABLE_BASE_ID = POOL_ROYALE_BASE_VARIANTS[0]?.id || SHOWOOD_ORIGINAL_TABLE_BASE_ID;
+const DEFAULT_TABLE_BASE_ID = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
 const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
 const ENABLE_CUE_STROKE_ANIMATION = true;
@@ -4360,34 +4360,28 @@ const POOL_ROYALE_MURLAN_CHAIR_URLS = Object.freeze([
   'https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/dining_chair_02/dining_chair_02_2k.gltf',
   'https://dl.polyhaven.org/file/ph-assets/Models/gltf/4k/dining_chair_02/dining_chair_02_4k.gltf'
 ]);
-const POOL_ROYALE_REFEREE_HUMAN_URLS = Object.freeze([
-  'https://threejs.org/examples/models/gltf/Xbot.glb',
-  'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
-  BILARDO_SHQIP_HUMAN_URL
-]);
-
 const DEFAULT_CHROME_COLOR_ID =
   POOL_ROYALE_DEFAULT_UNLOCKS.chromeColor?.[0] ?? 'gold';
 const CHROME_COLOR_OPTIONS = Object.freeze([
   {
     id: 'chrome',
     label: 'Chrome',
-    color: 0xd6d8dc,
-    metalness: 0.95,
-    roughness: 0.12,
-    clearcoat: 0.5,
-    clearcoatRoughness: 0.06,
-    envMapIntensity: 0.72
+    color: 0xd7dde7,
+    metalness: 1,
+    roughness: 0.055,
+    clearcoat: 1,
+    clearcoatRoughness: 0.025,
+    envMapIntensity: 7.2
   },
   {
     id: 'gold',
     label: 'Gold',
-    color: 0xd4af37,
-    metalness: 0.92,
-    roughness: 0.16,
-    clearcoat: 0.5,
-    clearcoatRoughness: 0.06,
-    envMapIntensity: 0.72
+    color: 0xf5d978,
+    metalness: 1,
+    roughness: 0.065,
+    clearcoat: 1,
+    clearcoatRoughness: 0.035,
+    envMapIntensity: 6.7
   }
 ]);
 
@@ -6175,8 +6169,11 @@ function projectRailUVs(geometry, bounds) {
   return target;
 }
 
-function enhanceChromeMaterial(material) {
+function enhanceChromeMaterial(material, options = {}) {
   if (!material) return;
+  const maxEnvMapIntensity = Number.isFinite(options.maxEnvMapIntensity)
+    ? options.maxEnvMapIntensity
+    : 1.02;
   const ensure = (key, value, transform) => {
     if (typeof material[key] === 'number') {
       material[key] = transform(material[key], value);
@@ -6188,7 +6185,7 @@ function enhanceChromeMaterial(material) {
   ensure('roughness', 0.1, (current, target) => Math.min(current, target));
   ensure('clearcoat', 0.72, (current, target) => Math.max(current, target));
   ensure('clearcoatRoughness', 0.16, (current, target) => Math.max(current, target));
-  ensure('envMapIntensity', 1.02, (current, target) =>
+  ensure('envMapIntensity', maxEnvMapIntensity, (current, target) =>
     THREE.MathUtils.clamp(current, 0.92, target)
   );
   if (material.side !== THREE.DoubleSide) {
@@ -11995,7 +11992,9 @@ export function Table3D(
       });
   const createBrandSideMaterial = () => {
     const mat = trimMat.clone();
-    enhanceChromeMaterial(mat);
+    enhanceChromeMaterial(mat, {
+      maxEnvMapIntensity: Math.max(chromeOption?.envMapIntensity ?? 1.02, materialProps.envMapIntensity ?? 1.02)
+    });
     mat.metalness = Math.min(1, (mat.metalness ?? 0) + 0.1);
     mat.roughness = Math.max(0.06, (mat.roughness ?? 0.4) * 0.78);
     mat.clearcoat = Math.max(mat.clearcoat ?? 0.28, 0.42);
@@ -12969,10 +12968,11 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   const blackSurfaceNames = Array.isArray(child?.userData?.poolRoyaleBlackSurfaceNames)
     ? child.userData.poolRoyaleBlackSurfaceNames
     : [];
-  if (chromeSurfaceNames.some((name) => childName.includes(`${name}`.toLowerCase()))) return 'railSight';
-  if (blackSurfaceNames.some((name) => childName.includes(`${name}`.toLowerCase()))) return 'railSight';
+  if (chromeSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
+  if (blackSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
   if (/rail[_\s-]*sight|railsight|diamond|sight|marker|inlay/.test(childName)) return 'railSight';
   if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|apron/.test(childName)) return 'sideWoodApron';
+  if (/bevel[_\s.-]*1/.test(childName) && /material/.test(materialName)) return 'sideWoodApron';
   if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(childName)) return 'cushion';
   if (/pocket|liner|leather|net|basket|drop|holder|cup/.test(childName)) return 'pocketCup';
   if (/corner.*(rim|plate|cap)|rim|foot|feet|base[_\s-]*foot/.test(childName)) return 'verticalCornerRim';
@@ -13015,6 +13015,102 @@ function applyPoolRoyaleBlackExternalSurfaceMaterial(material) {
     ...(material.userData || {}),
     poolRoyaleForcedBlackSurface: true
   };
+}
+
+
+function materialIndexForGeometryOffset(geometry, offset) {
+  if (!geometry?.groups?.length) return 0;
+  const group = geometry.groups.find((item) => offset >= item.start && offset < item.start + item.count);
+  return group?.materialIndex ?? 0;
+}
+
+function isShowoodFrameSplitCandidate(child, material, role, tableModel) {
+  if (tableModel?.id !== 'showood-seven-foot' || !child?.isMesh || !child?.geometry) return false;
+  return (role === 'topWoodRail' || role === 'wood') && /frame/.test(`${child.name || ''}`.toLowerCase());
+}
+
+function splitShowoodFrameMaterialZones(child, tableModel = null, finishInfo = null) {
+  if (!child?.isMesh || !child.geometry || !finishInfo) return false;
+  const sourceMaterials = Array.isArray(child.material) ? child.material : [child.material];
+  const sourceMaterial = sourceMaterials[0];
+  const sourceRole = classifyPoolRoyaleExternalTableSurface(child, sourceMaterial);
+  if (!isShowoodFrameSplitCandidate(child, sourceMaterial, sourceRole, tableModel)) return false;
+
+  const geometry = child.geometry.clone();
+  const position = geometry.attributes.position;
+  if (!position) return false;
+  const index = geometry.index;
+  const total = index ? index.count : position.count;
+  if (total < 3) return false;
+
+  geometry.computeBoundingBox();
+  const box = geometry.boundingBox;
+  const size = box.getSize(new THREE.Vector3());
+  const topThreshold = box.max.y - Math.max(size.y * 0.18, 0.012);
+  const tableCenter = box.getCenter(new THREE.Vector3());
+  const halfX = Math.max(size.x * 0.5, MICRO_EPS);
+  const halfZ = Math.max(size.z * 0.5, MICRO_EPS);
+
+  const finalMaterials = [];
+  const materialLookup = new Map();
+  const getFinalMaterialIndex = (sourceIndex, role) => {
+    const key = `${sourceIndex}:${role}`;
+    if (materialLookup.has(key)) return materialLookup.get(key);
+    const source = sourceMaterials[Math.max(0, Math.min(sourceIndex, sourceMaterials.length - 1))] ?? sourceMaterial;
+    const material = applyShowoodStyleToExternalMaterial(source, role, tableModel, finishInfo);
+    material.userData = {
+      ...(material.userData || {}),
+      poolRoyaleShowoodSplitFrameRole: role
+    };
+    const finalIndex = finalMaterials.length;
+    finalMaterials.push(material);
+    materialLookup.set(key, finalIndex);
+    return finalIndex;
+  };
+
+  const a = new THREE.Vector3();
+  const b = new THREE.Vector3();
+  const c = new THREE.Vector3();
+  const center = new THREE.Vector3();
+  const normal = new THREE.Vector3();
+  const ab = new THREE.Vector3();
+  const ac = new THREE.Vector3();
+  const finalIndex = [];
+  geometry.clearGroups();
+
+  for (let offset = 0; offset + 2 < total; offset += 3) {
+    const ia = index ? index.getX(offset) : offset;
+    const ib = index ? index.getX(offset + 1) : offset + 1;
+    const ic = index ? index.getX(offset + 2) : offset + 2;
+    a.fromBufferAttribute(position, ia);
+    b.fromBufferAttribute(position, ib);
+    c.fromBufferAttribute(position, ic);
+    center.copy(a).add(b).add(c).multiplyScalar(1 / 3);
+    ab.subVectors(b, a);
+    ac.subVectors(c, a);
+    normal.crossVectors(ab, ac).normalize();
+    const relX = Math.abs(center.x - tableCenter.x) / halfX;
+    const relZ = Math.abs(center.z - tableCenter.z) / halfZ;
+    const nearOutside = relX > 0.72 || relZ > 0.72;
+    const isTopRail = normal.y > 0.34 && center.y >= topThreshold;
+    const role = isTopRail || !nearOutside ? 'topWoodRail' : 'sideWoodApron';
+    const materialIndex = getFinalMaterialIndex(materialIndexForGeometryOffset(geometry, offset), role);
+    const start = finalIndex.length;
+    finalIndex.push(ia, ib, ic);
+    geometry.addGroup(start, 3, materialIndex);
+  }
+
+  geometry.setIndex(finalIndex);
+  geometry.computeBoundingBox();
+  geometry.computeBoundingSphere();
+  child.geometry?.dispose?.();
+  child.geometry = geometry;
+  child.material = finalMaterials.length > 1 ? finalMaterials : finalMaterials[0];
+  child.userData = {
+    ...(child.userData || {}),
+    poolRoyaleShowoodFrameSplit: true
+  };
+  return true;
 }
 
 function clonePoolRoyaleMaterialTexture(texture, { isColor = false } = {}) {
@@ -13123,8 +13219,8 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     trim: 'railSight',
     pocket: 'pocketCup',
     pocketCup: 'pocketCup',
-    verticalCornerRim: 'railSight',
-    baseFoot: 'railSight',
+    verticalCornerRim: 'verticalCornerRim',
+    baseFoot: 'verticalCornerRim',
     baseCornerBlock: 'baseCornerBlock',
     leg: 'leg'
   };
@@ -13177,7 +13273,12 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
       const value = chromeOption?.[key] ?? materialProps[key];
       if (typeof value === 'number' && key in mat) mat[key] = value;
     });
-    enhanceChromeMaterial(mat);
+    enhanceChromeMaterial(mat, {
+      maxEnvMapIntensity: Math.max(
+        chromeOption?.envMapIntensity ?? 1.02,
+        materialProps.envMapIntensity ?? 1.02
+      )
+    });
   } else if (part === 'cloth' || part === 'cushion') {
     copyMaterialLook(part === 'cushion' ? finishInfo?.cushionMat : finishInfo?.clothMat);
     if (part === 'cushion') {
@@ -13363,6 +13464,9 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const prepareMaterial = (material) => {
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
+      if (splitShowoodFrameMaterialZones(child, tableModel, finishInfo)) {
+        return child.material;
+      }
       if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
         child.visible = false;
       }
@@ -15300,14 +15404,7 @@ function PoolRoyaleGame({
       DEFAULT_TABLE_FINISH_ID
     );
   });
-  const [tableBaseId, setTableBaseId] = useState(() => {
-    return resolveStoredSelection(
-      'tableBase',
-      TABLE_BASE_STORAGE_KEY,
-      (id) => POOL_ROYALE_BASE_VARIANTS.some((variant) => variant.id === id),
-      DEFAULT_TABLE_BASE_ID
-    );
-  });
+  const [tableBaseId, setTableBaseId] = useState(DEFAULT_TABLE_BASE_ID);
   const [humanCharacterId, setHumanCharacterId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(POOL_ROYALE_HUMAN_CHARACTER_STORAGE_KEY);
@@ -15521,11 +15618,8 @@ function PoolRoyaleGame({
     [poolInventory]
   );
   const availableTableBases = useMemo(
-    () =>
-      POOL_ROYALE_BASE_VARIANTS.filter((variant) =>
-        isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
-      ),
-    [poolInventory]
+    () => POOL_ROYALE_BASE_VARIANTS.filter((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID),
+    []
   );
   const availableChromeOptions = useMemo(
     () =>
@@ -15660,7 +15754,7 @@ function PoolRoyaleGame({
     if (!isPoolOptionUnlocked('tableFinish', tableFinishId, poolInventory)) {
       setTableFinishId(DEFAULT_TABLE_FINISH_ID);
     }
-    if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
+    if (tableBaseId !== DEFAULT_TABLE_BASE_ID) {
       setTableBaseId(DEFAULT_TABLE_BASE_ID);
     }
     if (!isPoolOptionUnlocked('clothColor', clothColorId, poolInventory)) {
@@ -25930,17 +26024,11 @@ const shotPowerRef = useRef(0);
         }
         return secondarySpacingBase;
       };
-      const secondaryTableEntry = Table3D(
-        world,
-        finishForScene,
-        tableSizeMeta,
-        railMarkerStyleRef.current,
-        activeTableBase,
-        rendererRef.current,
-        { tableModel: activeTableModel, chromePlateStyle: activeChromePlateStyle, showoodStyle: showoodTableStyle }
-      );
-      secondaryTableRef.current = secondaryTableEntry?.group ?? null;
-      secondaryBaseSetterRef.current = secondaryTableEntry?.setBaseVariant ?? null;
+      // The second full table was hidden by default but still built all procedural geometry
+      // and kicked off another Showood GLB clone. Keep the slot API inert so environments
+      // can opt out without paying that startup cost.
+      secondaryTableRef.current = null;
+      secondaryBaseSetterRef.current = null;
       const resolveSnookerScale = () => {
         const poolWidth = tableSizeMeta?.playfield?.widthMm ?? 2540;
         const snookerWidth = resolveSnookerTableSize()?.playfield?.widthMm ?? 3556;
@@ -26704,68 +26792,6 @@ const shotPowerRef = useRef(0);
         return group;
       };
 
-      const createFallbackRefereeOfficial = () => {
-        const group = new THREE.Group();
-        const black = new THREE.MeshStandardMaterial({ color: 0x050505, roughness: 0.5, metalness: 0.04 });
-        const white = new THREE.MeshStandardMaterial({ color: 0xf8fafc, roughness: 0.46, metalness: 0.02 });
-        const skin = new THREE.MeshStandardMaterial({ color: 0xc9906e, roughness: 0.6, metalness: 0.01 });
-        const torso = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 1.0, BALL_R * 1.15, BALL_R * 4.4, 16), white);
-        torso.position.y = BALL_R * 6.1;
-        const vest = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 1.9, BALL_R * 3.4, BALL_R * 0.28), black);
-        vest.position.set(0, BALL_R * 6.25, -BALL_R * 0.72);
-        const head = new THREE.Mesh(new THREE.SphereGeometry(BALL_R * 0.92, 18, 12), skin);
-        head.position.y = BALL_R * 8.9;
-        const leftLeg = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 0.34, BALL_R * 0.38, BALL_R * 3.8, 12), black);
-        leftLeg.position.set(-BALL_R * 0.55, BALL_R * 2.8, 0);
-        const rightLeg = leftLeg.clone();
-        rightLeg.position.x = BALL_R * 0.55;
-        const rightArm = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 0.22, BALL_R * 0.28, BALL_R * 3.2, 10), white);
-        rightArm.position.set(BALL_R * 1.35, BALL_R * 6.0, 0);
-        rightArm.rotation.z = THREE.MathUtils.degToRad(-10);
-        [torso, vest, head, leftLeg, rightLeg, rightArm].forEach((mesh) => {
-          mesh.castShadow = true;
-          mesh.receiveShadow = true;
-          group.add(mesh);
-        });
-        return group;
-      };
-
-      const createRefereeOfficial = async () => {
-        const group = new THREE.Group();
-        const gltf = await loadFirstAvailableGltf(POOL_ROYALE_REFEREE_HUMAN_URLS).catch(() => null);
-        const model = gltf?.scene?.clone?.(true) ?? gltf?.scene ?? null;
-        if (model) {
-          model.traverse((child) => {
-            if (!child?.isMesh) return;
-            child.castShadow = true;
-            child.receiveShadow = true;
-            const materials = Array.isArray(child.material) ? child.material : [child.material];
-            const key = `${child.name || ''} ${materials.map((mat) => mat?.name || '').join(' ')}`.toLowerCase();
-            const cloned = materials.map((mat) => {
-              const next = mat?.clone?.() ?? new THREE.MeshStandardMaterial();
-              if (key.includes('shirt') || key.includes('top') || key.includes('torso') || key.includes('body')) {
-                next.color?.setHex?.(0xf8fafc);
-              }
-              if (key.includes('pant') || key.includes('leg') || key.includes('shoe') || key.includes('boot')) {
-                next.color?.setHex?.(0x050505);
-              }
-              next.roughness = Math.max(next.roughness ?? 0.5, 0.46);
-              next.needsUpdate = true;
-              return next;
-            });
-            child.material = Array.isArray(child.material) ? cloned : cloned[0];
-          });
-          fitAssetToSpan(model, BALL_R * 18.5);
-          group.add(model);
-        } else {
-          group.add(createFallbackRefereeOfficial());
-        }
-        group.position.set(TABLE.W / 2 + BALL_R * 16, floorY, 0);
-        group.userData.referee = true;
-        group.userData.walkT = 0;
-        group.userData.gltfReferee = Boolean(model);
-        return group;
-      };
 
       const spawnPlayerCharacters = async () => {
         disposePlayerCharacters();
@@ -26851,15 +26877,11 @@ const shotPowerRef = useRef(0);
         const playerA = activeHumanCharacterRef.current || POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
         const playerB = POOL_ROYALE_HUMAN_CHARACTER_OPTIONS.find((option) => option.id !== playerA.id) || POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[1] || playerA;
         const loungeA = createPoolSideLounge('A', -1);
-        const loungeB = createPoolSideLounge('B', 1);
-        const referee = await createRefereeOfficial();
-        world.add(loungeA, loungeB, referee);
+        world.add(loungeA);
         playerCharacterRigsRef.current = [
           makeRig('A', -sideOffset, -zOffset, 0, playerA),
           makeRig('B', sideOffset, zOffset, Math.PI, playerB),
-          { group: loungeA, lounge: true, seat: 'A' },
-          { group: loungeB, lounge: true, seat: 'B' },
-          { group: referee, referee: true }
+          { group: loungeA, lounge: true, seat: 'A' }
         ];
       };
       spawnPlayerCharactersRef.current = spawnPlayerCharacters;
@@ -37010,50 +37032,6 @@ const shotPowerRef = useRef(0);
                             loading="lazy"
                           />
                         ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Base
-                </h3>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {availableTableBases.map((option) => {
-                    const active = option.id === tableBaseId;
-                    const swatchA = option.swatches?.[0] ?? '#0f172a';
-                    const swatchB = option.swatches?.[1] ?? '#1f2937';
-                    const thumb = option.thumbnail;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setTableBaseId(option.id)}
-                        aria-pressed={active}
-                        className={`flex min-w-[9rem] flex-1 items-center justify-between gap-3 rounded-full px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
-                            : 'bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="truncate">{option.name}</span>
-                        {thumb ? (
-                          <img
-                            src={thumb}
-                            alt={option.name}
-                            className="h-6 w-10 rounded-lg border border-white/25 object-cover"
-                            loading="lazy"
-                          />
-                        ) : (
-                          <span
-                            className="h-5 w-8 rounded-lg border border-white/25"
-                            aria-hidden="true"
-                            style={{
-                              background: `linear-gradient(135deg, ${swatchA}, ${swatchB})`
-                            }}
-                          />
-                        )}
                       </button>
                     );
                   })}


### PR DESCRIPTION
### Motivation
- Make the Showood GLB the canonical default table model and avoid spawning extra decorative procedural tables as a fallback. 
- Improve chrome/gold appearance and env map handling for external GLB assets to match Showood showroom styling. 
- Correct and enhance mapping of GLB surface names to Pool Royale roles and split Showood frame geometry into rail vs apron material zones for better trim/rail visuals. 
- Reduce runtime cost and complexity by simplifying table base selection and disabling the secondary full table/referee extras.

### Description
- Updated `POOL_ROYALE_TABLE_MODEL_OPTIONS` to clarify fallback behavior, set `fitScale` for `showood-seven-foot`, and move `railSight`/`sideWoodApron` names into `chromeMaterialSurfaceNames` while clearing `blackMaterialSurfaceNames`.
- Made `SHOWOOD_ORIGINAL_TABLE_BASE_ID` the fixed `DEFAULT_TABLE_BASE_ID` and constrained available base variants to the Showood base; removed stored selection logic for table base and the table-base UI selector.
- Tuned `CHROME_COLOR_OPTIONS` numeric properties (`color`, `metalness`, `roughness`, `clearcoat`, `clearcoatRoughness`, `envMapIntensity`) to stronger showroom values.
- Refactored `enhanceChromeMaterial` to accept an `options` param with `maxEnvMapIntensity` and used that value when clamping `envMapIntensity`.
- Threaded `maxEnvMapIntensity` through brand/trim material creation and Showood finish application using computed chrome option and material props.
- Improved surface classification by matching against a combined label of mesh and material names and added an explicit rule to treat certain bevel/material combos as `sideWoodApron`.
- Implemented `splitShowoodFrameMaterialZones` (with helper `materialIndexForGeometryOffset`) to split frame meshes into multiple material zones based on triangle centroids and normals so rails and aprons can receive distinct materials; integrated this into `preparePoolRoyaleExternalTableMaterials` to run before material application.
- Adjusted `applyShowoodStyleToExternalMaterial` mappings for corner/frame roles and applied `enhanceChromeMaterial` with the new `maxEnvMapIntensity` path.
- Disabled creation of the second full procedural table and referee GLTFs at startup to avoid unnecessary geometry/asset work, and removed the table base selector UI block.
- Updated unit test expectations in `test/poolRoyaleTableModels.test.js` to reflect the new default and Showood material name arrays.

### Testing
- Ran the unit test file `test/poolRoyaleTableModels.test.js` after updates and the test passed.
- Ran the project test suite via `npm test` and the automated tests passed (including the updated table model assertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00bad51f148329aebf5df387f24b4a)