### PR TITLE
Improve Ludo camera action tracking and human view

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3957,8 +3957,8 @@ const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.072 * MODEL_SCALE;
 // The bottom-seat gameplay camera is intentionally raised and pushed farther toward the table so
 // portrait players see over the local avatar and closer into the Ludo board/action area.
 const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.31 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.42 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.255 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.54 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.36 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 9;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.34;
 const SEATED_CONTACT_DICE_Y_OFFSET = 0.005;
@@ -10344,7 +10344,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (!option) return false;
       clearHumanSelection();
       moveToken(0, option.token, selection.roll, {
-        skipCameraFollow: selection.skipCameraFollow || option.entering
+        skipCameraFollow: false
       });
       return true;
     };
@@ -10746,14 +10746,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         !isCamera2d &&
         cameraTurnStateRef.current.followObject?.isObject3D &&
         controls &&
-        (!LUDO_CAMERA_SEAT_LOCK_ENABLED || dynamicFirearmCameraRef.current) &&
         (!cameraLookStateRef.current.active || dynamicFirearmCameraRef.current)
       ) {
         const followedTarget = cameraTurnStateRef.current.followObject.getWorldPosition(new THREE.Vector3());
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
         if (liftedTarget) {
           controls.target.lerp(liftedTarget.target, 0.18);
-          if (cameraTurnStateRef.current.followOffset?.isVector3) {
+          if (
+            cameraTurnStateRef.current.followOffset?.isVector3 &&
+            (!LUDO_CAMERA_BROADCAST_LOCKED_POSITION || dynamicFirearmCameraRef.current) &&
+            (!LUDO_CAMERA_SEAT_LOCK_ENABLED || dynamicFirearmCameraRef.current)
+          ) {
             const followCameraTarget = liftedTarget.target.clone().add(cameraTurnStateRef.current.followOffset);
             camera.position.lerp(followCameraTarget, 0.12);
           }
@@ -10787,8 +10790,18 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               : null;
         if (hardLockedPosition) {
           camera.position.copy(hardLockedPosition);
-          if (liveFacePose?.target?.isVector3 && controls) {
-            controls.target.copy(liveFacePose.target);
+          if (controls) {
+            const hasActionLook =
+              cameraTurnStateRef.current.activePriority > -Infinity ||
+              cameraTurnStateRef.current.followObject?.isObject3D;
+            const actionTarget = cameraTurnStateRef.current.currentTarget?.isVector3
+              ? cameraTurnStateRef.current.currentTarget
+              : null;
+            if (hasActionLook && actionTarget) {
+              controls.target.copy(actionTarget);
+            } else if (liveFacePose?.target?.isVector3) {
+              controls.target.copy(liveFacePose.target);
+            }
           }
         }
       }
@@ -12652,7 +12665,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
       cameraTurnStateRef.current.activePriority = priority;
       cameraTurnStateRef.current.followObject =
-        !LUDO_CAMERA_BROADCAST_LOCKED_POSITION && follow && object?.isObject3D ? object : null;
+        follow && object?.isObject3D ? object : null;
 
       const nextFocusState = resolveFocusCameraState(nextTarget, offset);
       if (nextFocusState) {
@@ -12811,7 +12824,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           object: token,
           follow: true,
           priority: 6,
-          offset: CAMERA_TARGET_LIFT + 0.02
+          offset: CAMERA_TARGET_LIFT + 0.02,
+          force: true
         });
       }
     state.animation = {
@@ -13316,16 +13330,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     dice.userData.isRolling = true;
     if (!isHumanTurn) {
       setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
-      setCameraFocus({
-        object: dice,
-        follow: false,
-        priority: 5,
-        force: true,
-        offset: CAMERA_TARGET_LIFT + 0.025
-      });
     } else {
       preserveUserTurnCameraRef.current = true;
     }
+    setCameraFocus({
+      object: dice,
+      follow: true,
+      priority: 5,
+      force: true,
+      offset: CAMERA_TARGET_LIFT + 0.025
+    });
     playDiceSound();
     const diceToTarget = baseTarget.clone().sub(dice.position);
     let throwLateral = 0;
@@ -13365,15 +13379,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const hasBoardTokenBeforeRoll = hasAnyTokenOnBoard(player);
     const options = getMovableTokens(player, value);
     scheduleDiceClear();
-    if (!isHumanTurn || !lockUserTurnSeatViewRef.current) {
-      setCameraFocus({
-        target: landingFocus,
-        follow: false,
-        priority: 7,
-        offset: CAMERA_TARGET_LIFT + 0.03,
-        force: true
-      });
-    }
+    setCameraFocus({
+      target: landingFocus,
+      follow: false,
+      priority: 7,
+      offset: CAMERA_TARGET_LIFT + 0.03,
+      force: true
+    });
     if (!options.length) {
       clearTurnAdvanceTimeout();
       turnAdvanceTimeoutRef.current = window.setTimeout(() => {
@@ -13385,7 +13397,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (player === 0) {
       preserveUserTurnCameraRef.current = true;
       lockUserTurnSeatViewRef.current = true;
-      beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
+      beginHumanSelection(value, options, { skipCameraFollow: false });
       return;
     }
     const choice = chooseMoveOption(state, player, value, options);


### PR DESCRIPTION
### Motivation
- Make the bottom-seat (human) camera sit higher and look more downward so the local player sees more of the board in portrait/gameplay framing.
- Ensure the camera reliably follows and prioritizes visible game action (dice throws and token movements) so users don't miss important events.
- Keep the seat-locked camera position while allowing the view to look at active action targets instead of always snapping back to the avatar face.

### Description
- Raised the bottom-seat face camera offsets by increasing `SEATED_FACE_CAMERA_GAMEPLAY_UP` and `SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN` to bring the camera higher and angle it more downward (changes in `LudoBattleRoyal.jsx`).
- Altered focus/follow logic so `cameraTurnStateRef.current.followObject` is set when any focus `object` is provided and follow behavior is respected during broadcast/seat locking; improved conditions for applying `followOffset` when seat-locked and when cinematic/dynamic camera modes are active (changes in `LudoBattleRoyal.jsx`).
- When a seat-locked view is active, the controls target will prefer an active action target (camera action look) over the avatar face target so the camera keeps its fixed position but looks at dice/tokens when appropriate (changes in `LudoBattleRoyal.jsx`).
- Force camera follow/focus for dice and token flows: always set a focus on the dice during a roll and hold focus on the dice landing point; ensure human token selection and token move sequences do not suppress camera following (`skipCameraFollow` forced to `false` for human interactions and `setCameraFocus` calls made `force: true`) (changes in `LudoBattleRoyal.jsx`).

### Testing
- Built the web app with `npm run build` from the `webapp/` directory and the build completed successfully.
- No other automated UI tests were available in the environment for visual verification of camera behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c7f15c8883299c50e90f6fdec673)