### PR TITLE
Tuck Domino Royal character hands inward

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8275,9 +8275,11 @@ function normalizeDominoCharacterRoot(root) {
 }
 
 const DOMINO_HELD_RACK_HAND_LIFT = 0.72 * MODEL_SCALE;
-const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.86 * MODEL_SCALE;
+// Keep the character-held domino fan slightly tucked in toward the tabletop
+// so seated hands read closer to their dominoes instead of floating outward.
+const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.68 * MODEL_SCALE;
 const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 1.04 * MODEL_SCALE;
-const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 1.28 * MODEL_SCALE;
+const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 1.04 * MODEL_SCALE;
 
 function createHeldDominoRack(seatIndex, handTiles = []) {
   const rack = new THREE.Group();
@@ -8330,12 +8332,12 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-61), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(34), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(9), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-68), THREE.MathUtils.degToRad(9), THREE.MathUtils.degToRad(4));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(36), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-65), THREE.MathUtils.degToRad(-5), THREE.MathUtils.degToRad(-2));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(39), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(11), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-72), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(41), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(12), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-10-domino-player-hand-outward-v34';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-10-domino-human-hand-inward-v35';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Improve visual clarity of Domino Battle Royale seating by moving human character hands slightly inward toward their dominoes so held tiles read as touching the hands rather than floating outward.

### Description
- Reduced the outward offsets for character-held domino racks by modifying `DOMINO_HELD_RACK_OUTWARD_OFFSET` and `DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET` in `webapp/public/domino-royal-game.js` and added a clarifying comment.  
- Nudged the seated character arm/hand pose by updating several `addDominoBoneOffset(...)` calls (left/right upper arm, forearm, and hand) in `webapp/public/domino-royal-game.js` so both hands sit more inward.  
- Bumped the Domino Royal script cache/version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` so clients pick up the updated public game script (`DOMINO_ROYAL_SCRIPT_VERSION`).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed without syntax errors.  
- Built the webapp with `cd webapp && npm run build`; Vite completed the production build (noting existing large-chunk warnings) and the output assets were generated.  
- Attempted an automated Playwright screenshot run to visually verify the change; Playwright browser download/install was performed, but Chromium could not launch in this container due to a missing system library (`libatk-1.0.so.0`), so headless screenshot capture could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00cc1bfaa483299f1bd87b84c5735b)