### PR TITLE
Adjust Murlan Royale opponent card placement and scale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2974,13 +2974,15 @@ const AI_HAND_FAN_ARC_LIFT = 0.062 * MODEL_SCALE;
 const AI_HAND_CARD_SCALE = 0.82;
 const AI_SIDE_HAND_EXTRA_INWARD_PULL = 0.01 * MODEL_SCALE;
 const AI_TOP_HAND_EXTRA_INWARD_PULL = 0.03 * MODEL_SCALE;
-const AI_SIDE_HAND_EXTRA_OUTWARD_PUSH = 1.08 * MODEL_SCALE;
+const AI_SIDE_HAND_EXTRA_OUTWARD_PUSH = 1.22 * MODEL_SCALE;
 const AI_TOP_HAND_EXTRA_OUTWARD_PUSH = 1.42 * MODEL_SCALE;
-const AI_SIDE_HAND_UP_SHIFT_Y = -0.16 * MODEL_SCALE;
+const AI_SIDE_HAND_UP_SHIFT_Y = -0.19 * MODEL_SCALE;
 const AI_TOP_HAND_UP_SHIFT_Y = 0.06 * MODEL_SCALE;
 const AI_SIDE_HAND_LATERAL_PALM_SHIFT = 0.07 * MODEL_SCALE;
-const AI_SIDE_HAND_TOPWARD_SHIFT = 1.1 * MODEL_SCALE;
+const AI_SIDE_HAND_TOPWARD_SHIFT = 1.22 * MODEL_SCALE;
 const AI_TOP_HAND_LATERAL_PALM_SHIFT = 0;
+const AI_SIDE_HAND_CARD_SCALE = 0.78;
+const AI_TOP_HAND_CARD_SCALE = 0.8;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
 const HUMAN_HAND_EXTRA_INWARD_PULL = 0.2 * MODEL_SCALE;
 const AI_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.2;
@@ -4559,7 +4561,12 @@ export default function MurlanRoyaleArena({ search }) {
           leftWeight * HUMAN_HAND_DIRECTIONAL_LIFT +
           PLAYER_HAND_UP_LIFT_ONE_CARD;
         if (isHumanCard && selectionSet.has(card.id)) target.y += HUMAN_SELECTION_OFFSET;
-        mesh.scale.setScalar(isHumanCard ? HUMAN_HAND_CARD_SCALE : AI_HAND_CARD_SCALE);
+        const aiCardScale = aiHandVariant === 'side'
+          ? AI_SIDE_HAND_CARD_SCALE
+          : aiHandVariant === 'top'
+            ? AI_TOP_HAND_CARD_SCALE
+            : AI_HAND_CARD_SCALE;
+        mesh.scale.setScalar(isHumanCard ? HUMAN_HAND_CARD_SCALE : aiCardScale);
         const handLookTarget = target.clone().addScaledVector(forward, 2.4 * MODEL_SCALE);
         setCommunityCardLegibility(mesh, false);
         const previousPlayer = previous?.players?.[idx];


### PR DESCRIPTION
### Motivation
- Improve the visual layout of opponent (left/right/top) hands so their cards sit slightly farther outward, a bit lower, and visually closer to the top of the viewport for better framing. 
- Make non-human hands a touch smaller so they don't compete with the human player's hand while keeping the human card size unchanged.

### Description
- Updated layout/positioning constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`, including `AI_SIDE_HAND_EXTRA_OUTWARD_PUSH`, `AI_SIDE_HAND_UP_SHIFT_Y`, and `AI_SIDE_HAND_TOPWARD_SHIFT` to nudge opponent hands outward and lower. 
- Added per-position AI scale constants `AI_SIDE_HAND_CARD_SCALE` and `AI_TOP_HAND_CARD_SCALE` to render side/top opponent cards smaller than the human hand. 
- Apply the new per-seat scale in the hand rendering logic inside `applyStateToScene` so non-human hands use the appropriate `aiCardScale` while the human hand keeps `HUMAN_HAND_CARD_SCALE`.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npx playwright install chromium` and `npx playwright install-deps chromium` successfully to prepare headless browser tooling. 
- Attempted an automated Playwright screenshot of the local dev page at `http://127.0.0.1:5173/games/murlanroyale?opponents=3&points=30&type=classic` to verify layout, but the screenshot capture timed out due to headless WebGL/resource loading issues in the CI environment. 
- No unit tests were added or changed for this layout tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d6e694bc83298a0cb51abd1a8b0e)