### PR TITLE
Murlan Royale: push opponent cards outward/top and assign unique AI characters per match

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -171,6 +171,59 @@ const MURLAN_CHARACTER_CLOTH_MATERIALS = Object.freeze({
     tint: 0xc44f42
   }
 });
+
+function hashMurlanCharacterRosterSeed(input) {
+  const text = String(input ?? '');
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 4294967295;
+}
+
+function buildSeatCharacterThemeRoster(baseTheme, players = [], humanSeatIndex = 0, rosterSeed = 0) {
+  const availableThemes = MURLAN_CHARACTER_THEMES.filter((theme) =>
+    theme && (theme.url || (Array.isArray(theme.modelUrls) && theme.modelUrls.length))
+  );
+  if (!availableThemes.length) return [];
+
+  const selectedTheme = baseTheme || availableThemes[0];
+  const selectedId = selectedTheme?.id;
+  const usedThemeIds = new Set(selectedId ? [selectedId] : []);
+  const playerSignature = players
+    .map((player, index) => `${index}:${player?.name || ''}:${player?.avatar || ''}:${player?.isHuman ? 'h' : 'ai'}`)
+    .join('|');
+  const shuffledAiThemes = availableThemes
+    .filter((theme) => theme.id !== selectedId)
+    .map((theme, index) => ({
+      theme,
+      order: hashMurlanCharacterRosterSeed(`${rosterSeed}|${playerSignature}|${index}|${theme.id}`)
+    }))
+    .sort((a, b) => a.order - b.order)
+    .map((entry) => entry.theme);
+
+  let aiThemeIndex = 0;
+  return players.map((player, index) => {
+    if (player?.isHuman || index === humanSeatIndex) {
+      return selectedTheme;
+    }
+
+    let nextTheme = shuffledAiThemes[aiThemeIndex % Math.max(shuffledAiThemes.length, 1)] || selectedTheme;
+    aiThemeIndex += 1;
+    if (usedThemeIds.has(nextTheme.id)) {
+      const unusedTheme = availableThemes.find((theme) => !usedThemeIds.has(theme.id));
+      if (unusedTheme) nextTheme = unusedTheme;
+    }
+    if (nextTheme?.id) usedThemeIds.add(nextTheme.id);
+    return nextTheme;
+  });
+}
+
+function characterThemeRosterSignature(roster = []) {
+  return roster.map((theme) => theme?.id || 'none').join('|');
+}
+
 const MURLAN_CHARACTER_CLOTH_COMBOS = Object.freeze({
   royalDenim: {
     upper: { material: 'denim', tint: 0x2f5f9f, repeat: 4.2 },
@@ -2974,12 +3027,12 @@ const AI_HAND_FAN_ARC_LIFT = 0.062 * MODEL_SCALE;
 const AI_HAND_CARD_SCALE = 0.76;
 const AI_SIDE_HAND_EXTRA_INWARD_PULL = 0.01 * MODEL_SCALE;
 const AI_TOP_HAND_EXTRA_INWARD_PULL = 0.03 * MODEL_SCALE;
-const AI_SIDE_HAND_EXTRA_OUTWARD_PUSH = 1.24 * MODEL_SCALE;
-const AI_TOP_HAND_EXTRA_OUTWARD_PUSH = 1.52 * MODEL_SCALE;
+const AI_SIDE_HAND_EXTRA_OUTWARD_PUSH = 1.52 * MODEL_SCALE;
+const AI_TOP_HAND_EXTRA_OUTWARD_PUSH = 1.86 * MODEL_SCALE;
 const AI_SIDE_HAND_UP_SHIFT_Y = -0.2 * MODEL_SCALE;
 const AI_TOP_HAND_UP_SHIFT_Y = 0.02 * MODEL_SCALE;
 const AI_SIDE_HAND_LATERAL_PALM_SHIFT = 0.07 * MODEL_SCALE;
-const AI_SIDE_HAND_TOPWARD_SHIFT = 1.24 * MODEL_SCALE;
+const AI_SIDE_HAND_TOPWARD_SHIFT = 1.58 * MODEL_SCALE;
 const AI_TOP_HAND_LATERAL_PALM_SHIFT = 0;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
 const HUMAN_HAND_EXTRA_INWARD_PULL = 0.2 * MODEL_SCALE;
@@ -3363,6 +3416,7 @@ const START_CARD = { rank: '3', suit: '♠' };
 export default function MurlanRoyaleArena({ search }) {
   const mountRef = useRef(null);
   const players = useMemo(() => buildPlayers(search), [search]);
+  const characterRosterSeedRef = useRef(Math.random());
 
   const [murlanInventory, setMurlanInventory] = useState(() => getMurlanInventory(murlanAccountId()));
 
@@ -4877,7 +4931,15 @@ export default function MurlanRoyaleArena({ search }) {
         store.characterThemeId = null;
         return;
       }
+      const currentPlayers = gameStateRef.current?.players ?? players;
+      const humanSeatIndex = currentPlayers.findIndex((player) => player?.isHuman);
       const safe = characterTheme || MURLAN_CHARACTER_THEMES[0];
+      const characterRoster = buildSeatCharacterThemeRoster(
+        safe,
+        currentPlayers,
+        humanSeatIndex >= 0 ? humanSeatIndex : 0,
+        characterRosterSeedRef.current
+      );
 
       store.characterInstances?.forEach((entry) => {
         if (!entry) return;
@@ -4888,25 +4950,31 @@ export default function MurlanRoyaleArena({ search }) {
       store.characterRigs = new Map();
       store.characterActionAnimations = [];
 
-      let template;
-      try {
-        template = await loadCharacterModel(safe, store.renderer);
-      } catch (error) {
-        console.warn('Failed to load character theme', safe?.id, error);
-        return;
-      }
-
       const currentAppearance = normalizeAppearance(appearanceRef.current);
       const expectedTheme = MURLAN_CHARACTER_THEMES[currentAppearance.characters] ?? MURLAN_CHARACTER_THEMES[0];
       if (expectedTheme.id !== safe.id) return;
 
-      store.characterThemeId = safe.id;
-      const currentPlayers = gameStateRef.current?.players ?? players;
+      const uniqueThemes = [...new Map(characterRoster.map((theme) => [theme?.id, theme])).values()].filter(Boolean);
+      const templateEntries = await Promise.all(uniqueThemes.map(async (theme) => {
+        try {
+          return [theme.id, await loadCharacterModel(theme, store.renderer)];
+        } catch (error) {
+          console.warn('Failed to load character theme', theme?.id, error);
+          return [theme.id, null];
+        }
+      }));
+      const templatesById = new Map(templateEntries.filter(([, template]) => template));
+      const fallbackTemplate = templatesById.get(safe.id) || templatesById.values().next().value || null;
+      if (!fallbackTemplate) return;
+
+      store.characterThemeId = characterThemeRosterSignature(characterRoster);
       store.seatConfigs.forEach((seatConfig, seatIndex) => {
+        const seatTheme = characterRoster[seatIndex] || safe;
+        const template = templatesById.get(seatTheme.id) || fallbackTemplate;
         attachSeatedCharacter({
           template,
           seatConfig,
-          characterTheme: safe,
+          characterTheme: seatTheme,
           store,
           player: currentPlayers[seatIndex] ?? null,
           playerIndex: seatIndex,
@@ -5042,7 +5110,15 @@ export default function MurlanRoyaleArena({ search }) {
           applyChairThemeMaterials(three, stoolTheme);
         }
         if (ENABLE_3D_HUMAN_CHARACTERS && characterTheme) {
-          if (three.characterThemeId !== characterTheme.id) {
+          const currentPlayers = gameStateRef.current?.players ?? players;
+          const rosterHumanSeatIndex = currentPlayers.findIndex((player) => player?.isHuman);
+          const expectedCharacterRoster = buildSeatCharacterThemeRoster(
+            characterTheme,
+            currentPlayers,
+            rosterHumanSeatIndex >= 0 ? rosterHumanSeatIndex : 0,
+            characterRosterSeedRef.current
+          );
+          if (three.characterThemeId !== characterThemeRosterSignature(expectedCharacterRoster)) {
             void rebuildSeatCharacters(characterTheme);
           }
         } else if (three.characterInstances?.length) {
@@ -5849,16 +5925,30 @@ export default function MurlanRoyaleArena({ search }) {
       const humanSeatIndex = players.findIndex((player) => player?.isHuman);
       const humanSeatConfig = humanSeatIndex >= 0 ? seatConfigs[humanSeatIndex] : null;
 
+      let initialCharacterRoster = [];
       if (ENABLE_3D_HUMAN_CHARACTERS && characterTheme) {
         try {
-          const characterTemplate = await loadCharacterModel(characterTheme, renderer);
+          initialCharacterRoster = buildSeatCharacterThemeRoster(
+            characterTheme,
+            players,
+            humanSeatIndex >= 0 ? humanSeatIndex : 0,
+            characterRosterSeedRef.current
+          );
+          const uniqueThemes = [...new Map(initialCharacterRoster.map((theme) => [theme?.id, theme])).values()].filter(Boolean);
+          const templateEntries = await Promise.all(uniqueThemes.map(async (theme) => [
+            theme.id,
+            await loadCharacterModel(theme, renderer)
+          ]));
+          const templatesById = new Map(templateEntries);
+          const fallbackTemplate = templatesById.get(characterTheme.id) || templatesById.values().next().value || null;
           for (let i = 0; i < seatConfigs.length; i++) {
             const seatConfig = seatConfigs[i];
             const player = players[i] ?? null;
+            const seatTheme = initialCharacterRoster[i] || characterTheme;
             attachSeatedCharacter({
-              template: characterTemplate,
+              template: templatesById.get(seatTheme.id) || fallbackTemplate,
               seatConfig,
-              characterTheme,
+              characterTheme: seatTheme,
               store: threeStateRef.current,
               player,
               playerIndex: i,
@@ -5873,7 +5963,7 @@ export default function MurlanRoyaleArena({ search }) {
 
       threeStateRef.current.outfitParts = [];
       threeStateRef.current.appearance = { ...currentAppearance };
-      threeStateRef.current.characterThemeId = ENABLE_3D_HUMAN_CHARACTERS && characterTheme ? characterTheme.id : null;
+      threeStateRef.current.characterThemeId = ENABLE_3D_HUMAN_CHARACTERS && characterTheme ? characterThemeRosterSignature(initialCharacterRoster) : null;
 
       spotTarget.position.set(0, TABLE_HEIGHT + 0.2 * MODEL_SCALE, 0);
       spot.target.updateMatrixWorld();


### PR DESCRIPTION
### Motivation
- Improve card visibility and framing by moving the top/side opponents' hand cards further outward and higher on portrait screens. 
- Prevent the same human-character model from appearing on multiple seats in a single game by assigning distinct character themes to AI seats each match.

### Description
- Increased AI hand layout offsets by adjusting `AI_SIDE_HAND_EXTRA_OUTWARD_PUSH`, `AI_TOP_HAND_EXTRA_OUTWARD_PUSH`, and `AI_SIDE_HAND_TOPWARD_SHIFT` in `MurlanRoyaleArena.jsx` so opponent cards sit farther outward and the side/top players are pushed higher. 
- Added deterministic roster helpers `hashMurlanCharacterRosterSeed`, `buildSeatCharacterThemeRoster`, and `characterThemeRosterSignature` to compute a per-game roster of character themes for seats. 
- Added a `characterRosterSeedRef` and wired roster generation into initial scene setup and `rebuildSeatCharacters` to load per-seat templates and attach distinct character themes while preserving the selected human character. 
- Updated appearance/scene update logic to compare and store a roster signature (`three.characterThemeId`) so characters are rebuilt only when the roster changes and multiple templates are loaded once for unique themes.

### Testing
- Ran `npm run build` in `webapp` and the Vite production build completed successfully. 
- Ran `git diff --check` and no diff errors were reported. 
- Attempted `node --check webapp/src/pages/Games/MurlanRoyaleArena.jsx` but Node rejected direct `.jsx` ESM checking (expected for this project); this did not block the Vite build which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0149d4d84c832994e0e24065d4660c)