### PR TITLE
Pool Royale: tighter cloth patterns, live Showood material refresh, single human and focused table customizer

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -21,7 +21,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitHeightScale: 1,
     lowerBaseHeightScale: 0.78,
     legLengthScale: 1.18,
-    clothRepeatScale: 5.25,
+    clothRepeatScale: 8.75,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2395,15 +2395,7 @@ const POOL_ROYALE_PRIMARY_HUMAN_FALLBACKS_BY_ID = Object.freeze({
 });
 const POOL_ROYALE_HUMAN_CHARACTER_STORAGE_KEY = 'poolRoyaleHumanCharacter';
 const POOL_ROYALE_HUMAN_CHARACTER_IDS = Object.freeze([
-  'rpm-current',
-  'rpm-67d411',
-  'rpm-67f433',
-  'rpm-67e1b5',
-  'webgl-vietnam-human',
-  'webgl-ai-teacher',
-  'webgl-ai-teacher-1',
-  'webgl-thanh-human',
-  'threejs-xbot-human'
+  'rpm-current'
 ]);
 const POOL_ROYALE_HUMAN_LOGIC_PROFILES = Object.freeze({
   'rpm-current': Object.freeze({
@@ -4984,10 +4976,10 @@ const ORIGINAL_OUTER_HALF_H =
 const CLOTH_TEXTURE_SIZE = CLOTH_QUALITY.textureSize;
 const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sharper weave
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
-const CLOTH_PATTERN_SCALE = 0.76; // match Snooker Royal's single tighter cloth weave so Pool Royal no longer shows mixed pattern sizes
-const CLOTH_TEXTURE_REPEAT_HINT = 1.52;
-const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
-const EXTERNAL_TABLE_CLOTH_REPEAT_SCALE = 2.35; // base normalization for external GLB cloth UV spans
+const CLOTH_PATTERN_SCALE = 1.15; // tighter, smaller cloth weave so Pool Royal no longer shows oversized felt patterns
+const CLOTH_TEXTURE_REPEAT_HINT = 2.15;
+const POLYHAVEN_PATTERN_REPEAT_SCALE = 1.35;
+const EXTERNAL_TABLE_CLOTH_REPEAT_SCALE = 3.4; // tighter normalization for external GLB cloth UV spans
 const POLYHAVEN_ANISOTROPY_BOOST = 9;
 const POLYHAVEN_TEXTURE_RESOLUTION =
   CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k';
@@ -13362,13 +13354,17 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
 
     const prepareMaterial = (material) => {
       if (!material) return material;
+      const sourceMaterial = material.clone ? material.clone() : material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
       if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
         child.visible = false;
       }
       if (tableModel?.usePoolRoyaleFinish && finishInfo) {
-        const nextMaterial = applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tableModel, child);
+        const nextMaterial = applyPoolRoyaleFinishToExternalMaterial(sourceMaterial, role, finishInfo, tableModel, child);
         normalizePoolRoyaleExternalClothTextureScale(child, nextMaterial, role);
+        if (nextMaterial?.userData) {
+          nextMaterial.userData.poolRoyaleSourceMaterial = sourceMaterial;
+        }
         return nextMaterial;
       }
       const mat = material.clone ? material.clone() : material;
@@ -13386,6 +13382,33 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
       child.material = child.material.map(prepareMaterial);
     } else if (child.material) {
       child.material = prepareMaterial(child.material);
+    }
+  });
+}
+
+function refreshPoolRoyaleExternalTableMaterials(table, tableModel = null, finishInfo = null) {
+  const externalRoot = table?.userData?.externalTable?.group;
+  if (!externalRoot?.traverse || !tableModel?.usePoolRoyaleFinish || !finishInfo) return;
+  externalRoot.traverse((child) => {
+    if (!child?.isMesh) return;
+    const refreshMaterial = (material) => {
+      if (!material) return material;
+      const source = material.userData?.poolRoyaleSourceMaterial || material;
+      const role = classifyPoolRoyaleExternalTableSurface(child, source);
+      const nextMaterial = applyPoolRoyaleFinishToExternalMaterial(source, role, finishInfo, tableModel, child);
+      normalizePoolRoyaleExternalClothTextureScale(child, nextMaterial, role);
+      if (nextMaterial?.userData) {
+        nextMaterial.userData.poolRoyaleSourceMaterial = source;
+      }
+      if (nextMaterial !== material) {
+        material.dispose?.();
+      }
+      return nextMaterial;
+    };
+    if (Array.isArray(child.material)) {
+      child.material = child.material.map(refreshMaterial);
+    } else {
+      child.material = refreshMaterial(child.material);
     }
   });
 }
@@ -14406,7 +14429,8 @@ function mountPoolRoyaleExternalTableModel({
   table.userData.cushionLipClearance = clothPlaneWorld;
   table.userData.clothPlaneLocal = clothPlaneLocal;
   table.userData.finish = finishInfo;
-  table.userData.tableModelId = resolvedTableOptions?.tableModel?.id || 'royal-original';
+  table.userData.tableModelId = resolvedTableOptions?.tableModel?.id || 'showood-seven-foot';
+  table.userData.tableModel = resolvedTableOptions?.tableModel || null;
 
   const generatedVisualObjects = [];
   const generatedStructuralObjects = [];
@@ -17079,6 +17103,14 @@ function PoolRoyaleGame({
   useEffect(() => {
     tableFinishRef.current = tableFinish;
   }, [tableFinish]);
+  const activeTableModelRef = useRef(activeTableModel);
+  useEffect(() => {
+    activeTableModelRef.current = activeTableModel;
+  }, [activeTableModel]);
+  const showoodTableStyleRef = useRef(showoodTableStyle);
+  useEffect(() => {
+    showoodTableStyleRef.current = showoodTableStyle;
+  }, [showoodTableStyle]);
   const activeVariantRef = useRef(activeVariant);
   useEffect(() => {
     activeVariantRef.current = activeVariant;
@@ -17950,12 +17982,8 @@ const shotPowerRef = useRef(0);
   useEffect(() => {
     if (!showoodTableVisualResetReadyRef.current) {
       showoodTableVisualResetReadyRef.current = true;
-      return;
     }
-    if (activeTableModel?.kind === 'gltf') {
-      setRenderResetKey((value) => value + 1);
-    }
-  }, [activeTableModel?.id, chromeColorId, chromePlateStyleId, clothColorId, pocketLinerId, showoodTableStyle, tableFinishId]);
+  }, [activeTableModel?.id]);
   const sceneRef = useRef(null);
   const updateEnvironmentRef = useRef(() => {});
   const disposeEnvironmentRef = useRef(null);
@@ -26796,15 +26824,8 @@ const shotPowerRef = useRef(0);
           return { seat, human, heldCue };
         };
         const playerA = activeHumanCharacterRef.current || POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
-        const playerB = POOL_ROYALE_HUMAN_CHARACTER_OPTIONS.find((option) => option.id !== playerA.id) || POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[1] || playerA;
-        const loungeA = createPoolSideLounge('A', -1);
-        const loungeB = createPoolSideLounge('B', 1);
-        world.add(loungeA, loungeB);
         playerCharacterRigsRef.current = [
-          makeRig('A', -sideOffset, -zOffset, 0, playerA),
-          makeRig('B', sideOffset, zOffset, Math.PI, playerB),
-          { group: loungeA, lounge: true, seat: 'A' },
-          { group: loungeB, lounge: true, seat: 'B' }
+          makeRig('A', -sideOffset, -zOffset, 0, playerA)
         ];
       };
       spawnPlayerCharactersRef.current = spawnPlayerCharacters;
@@ -26945,7 +26966,7 @@ const shotPowerRef = useRef(0);
           const human = rig?.human;
           const seat = anim?.seat ?? rig?.seat;
           if (!anim && !human) return;
-          const singleHumanMode = rigs.length === 1;
+          const singleHumanMode = rigs.filter((entry) => entry?.human || entry?.anim).length === 1;
           const isShooter = singleHumanMode ? true : anim?.seat === activeSeat;
           const isHumanShooter = singleHumanMode ? true : seat === activeSeat;
           const cameraBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
@@ -27300,13 +27321,28 @@ const shotPowerRef = useRef(0);
       applyFinishRef.current = (nextFinish) => {
         if (table && nextFinish) {
           applyTableFinishToTable(table, nextFinish);
+          refreshPoolRoyaleExternalTableMaterials(
+            table,
+            { ...activeTableModelRef.current, showoodStyle: normalizeShowoodTableStyle(showoodTableStyleRef.current) },
+            table.userData?.finish
+          );
         }
         if (secondaryTableRef.current && nextFinish) {
           applyTableFinishToTable(secondaryTableRef.current, nextFinish);
+          refreshPoolRoyaleExternalTableMaterials(
+            secondaryTableRef.current,
+            { ...activeTableModelRef.current, showoodStyle: normalizeShowoodTableStyle(showoodTableStyleRef.current) },
+            secondaryTableRef.current.userData?.finish
+          );
         }
         decorativeTablesRef.current.forEach((entry) => {
           if (entry?.group && nextFinish) {
             applyTableFinishToTable(entry.group, nextFinish);
+            refreshPoolRoyaleExternalTableMaterials(
+              entry.group,
+              { ...activeTableModelRef.current, showoodStyle: normalizeShowoodTableStyle(showoodTableStyleRef.current) },
+              entry.group.userData?.finish
+            );
           }
         });
       };
@@ -35661,7 +35697,7 @@ const shotPowerRef = useRef(0);
   useEffect(() => {
     applyFinishRef.current?.(tableFinish);
     applyRailMarkerStyleRef.current?.(railMarkerStyleRef.current);
-  }, [tableFinish]);
+  }, [tableFinish, showoodTableStyle]);
   useEffect(() => {
     applyBaseRef.current?.(activeTableBase);
   }, [activeTableBase]);
@@ -36807,14 +36843,19 @@ const shotPowerRef = useRef(0);
           <div
             id="snooker-config-panel"
             ref={configPanelRef}
-            className={`pointer-events-auto w-72 max-w-[80vw] rounded-2xl border border-emerald-400/40 bg-black/85 p-4 text-xs text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur ${
+            className={`pointer-events-auto w-[22rem] max-w-[88vw] rounded-3xl border border-emerald-400/40 bg-black/88 p-4 text-xs text-white shadow-[0_24px_48px_rgba(0,0,0,0.6)] backdrop-blur ${
               isPortrait ? 'mt-2 max-h-[56vh] overflow-y-auto' : 'mt-2'
             }`}
           >
             <div className="flex items-center justify-between gap-4">
-              <span className="text-[10px] uppercase tracking-[0.45em] text-emerald-200/70">
-                Table Setup
-              </span>
+              <div>
+                <span className="text-[10px] uppercase tracking-[0.45em] text-emerald-200/70">
+                  Table Customizer
+                </span>
+                <p className="mt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-white/55">
+                  Change only the selected part — the loaded Showood table stays live.
+                </p>
+              </div>
               <button
                 type="button"
                 onClick={() => setConfigOpen(false)}
@@ -36833,38 +36874,7 @@ const shotPowerRef = useRef(0);
                 </svg>
               </button>
             </div>
-            <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Human Pool Player
-                </h3>
-                <div className="mt-2 grid grid-cols-2 gap-1.5">
-                  {POOL_ROYALE_HUMAN_CHARACTER_OPTIONS.map((option, index) => {
-                    const active = option.id === humanCharacterId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setHumanCharacterId(option.id)}
-                        aria-pressed={active}
-                        title={`${option.label} • ${option.summary}`}
-                        className={`min-h-[3.25rem] rounded-xl border px-2.5 py-1.5 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="block truncate text-[10px] font-black uppercase tracking-[0.18em]">
-                          {index + 1}. {option.logicLabel}
-                        </span>
-                        <span className={`mt-0.5 block text-[8px] font-bold uppercase tracking-[0.12em] ${active ? 'text-black/65' : 'text-white/58'}`}>
-                          feet planted • table-facing
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
+            <div className="mt-4 max-h-[24rem] space-y-4 overflow-y-auto pr-1">
               {ENABLE_SHOT_REPLAY ? (
                 <div>
                   <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">


### PR DESCRIPTION
### Motivation
- Make the cloth weave appear much finer (smaller visible pattern) across procedural and external (Showood) table cloths so felt reads correctly at gameplay scale. 
- Apply user customization changes (table finish, cloth, chrome, pocket liners, etc.) without tearing down or fully reloading the scene, so the table stays loaded and only the changed parts update. 
- Simplify the in-game customization UI so the menu is focused on table customizations, and reduce visual clutter by keeping only one human player model. 

### Description
- Tightened cloth pattern and repeat scaling by updating cloth tiling constants and PolyHaven/external repeat normalization (`CLOTH_PATTERN_SCALE`, `CLOTH_TEXTURE_REPEAT_HINT`, `POLYHAVEN_PATTERN_REPEAT_SCALE`, `EXTERNAL_TABLE_CLOTH_REPEAT_SCALE`) and bumped the Showood model `clothRepeatScale` in `webapp/src/config/poolRoyaleTableModels.js`. 
- Added `refreshPoolRoyaleExternalTableMaterials` and per-material source tracking so external GLB (Showood) materials can be re-created/updated in-place and normalized for cloth UV spans instead of remounting the table group, and wired this refresh into the existing `applyFinishRef.current` update path. 
- Prevented unnecessary full visual reset by removing the render-reset increment on every customization change and narrowing the reset effect to only the `activeTableModel?.id`, and added refs (`activeTableModelRef`, `showoodTableStyleRef`) to ensure refresh uses current options. 
- Simplified menu and UX: replaced the broader settings header with a focused “Table Customizer” panel, widened the panel and increased content scroll area, and removed the human-character selector block so the menu concentrates on table parts. 
- Reduced the human character roster to a single option and spawn path so only one human rig is created (no second human/lounge), and adjusted single-human detection logic accordingly. 
- Store the external table model metadata on the table (`table.userData.tableModel`) and default external table fallback id to the Showood option so Showood-specific handling runs by default. 

### Testing
- Ran `npm run build` for the webapp and the production build completed successfully (Vite build reported output bundles and finished without error). 
- Ran a static check (`diff --check` equivalent) and fixed whitespace/JS issues so no build-time diagnostics remained. 
- Manual smoke: applied table finish/cloth changes in the UI flow and verified the Showood external materials are updated in-place (no full scene reload) and cloth tiling visibly reads finer after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0148aa658883299ca625e08d1bbd54)