### PR TITLE
Rebuild Real Bowling: seating, HDRI background, camera & turn-flow

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -7,8 +7,9 @@ import { RGBELoader } from "three/examples/jsm/loaders/RGBELoader.js";
 import { BOWLING_HDRI_VARIANTS, BOWLING_HUMAN_CHARACTER_OPTIONS } from "../../config/bowlingInventoryConfig.js";
 import { POOL_ROYALE_DEFAULT_UNLOCKS, POOL_ROYALE_OPTION_LABELS, POOL_ROYALE_STORE_ITEMS } from "../../config/poolRoyaleInventoryConfig.js";
 import { getCachedPoolRoyalInventory } from "../../utils/poolRoyalInventory.js";
+import { createMurlanStyleTable } from "../../utils/murlanTable.js";
 
-type PlayerAction = "idle" | "approach" | "throw" | "recover" | "toRack" | "pickBall" | "toApproach" | "replay";
+type PlayerAction = "idle" | "seated" | "standingUp" | "approach" | "throw" | "recover" | "toSeat" | "toRack" | "pickBall" | "toApproach" | "replay";
 type BallReturnState = "idle" | "toPit" | "hidden" | "returning";
 
 type HudState = {
@@ -62,6 +63,10 @@ type HumanRig = {
   walkCycle: number;
   approachFrom: THREE.Vector3;
   approachTo: THREE.Vector3;
+  seatPos: THREE.Vector3;
+  seatYaw: number;
+  standPos: THREE.Vector3;
+  seatT: number;
 };
 
 type BallVariant = { label: string; radius: number; massFactor: number; colors: [string,string,string] };
@@ -95,7 +100,7 @@ type PinState = {
 const HUMAN_URL = "https://threejs.org/examples/models/gltf/readyplayer.me.glb";
 const DEFAULT_HUMAN_CHARACTER_ID = BOWLING_HUMAN_CHARACTER_OPTIONS[0]?.id || "rpm-current-domino";
 const HUMAN_CHARACTER_OPTIONS = BOWLING_HUMAN_CHARACTER_OPTIONS as HumanCharacterOption[];
-const HUMAN_INITIAL_SCALE = 1.46;
+const HUMAN_INITIAL_SCALE = 1.0;
 const HDRI_OPTIONS = BOWLING_HDRI_VARIANTS.map((h) => ({
   id: h.id,
   name: h.name,
@@ -134,10 +139,10 @@ const CFG = {
   laneY: 0,
   laneHalfW: 1.56,
   gutterHalfW: 2.08,
-  playerStartZ: 7.15,
+  playerStartZ: 6.9,
   rackEdgeX: 1.42,
   rackStopZ: 6.34,
-  approachStopZ: 4.95,
+  approachStopZ: 4.82,
   foulZ: 4.55,
   arrowsZ: 0.95,
   pinDeckZ: -10.75,
@@ -149,6 +154,8 @@ const CFG = {
   throwDuration: 0.9,
   replayDuration: 3.2,
   recoverDuration: 0.28,
+  seatWalkDuration: 0.95,
+  standDuration: 0.42,
   returnWalkDuration: 1.08,
   pickDuration: 0.52,
   releaseT: 0.56,
@@ -160,6 +167,15 @@ const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
 const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
 const easeInOut = (t: number) => t * t * (3 - 2 * t);
 const HDRI_RES_LADDER = ["8k", "4k", "2k", "1k"] as const;
+const BOWLING_MURLAN_CHAIR_URLS = [
+  "https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/dining_chair_02/dining_chair_02_1k.gltf",
+  "https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/dining_chair_02/dining_chair_02_2k.gltf",
+  "https://dl.polyhaven.org/file/ph-assets/Models/gltf/4k/dining_chair_02/dining_chair_02_4k.gltf",
+];
+const PLAYER_SEATS = [
+  { pos: new THREE.Vector3(-2.72, CFG.laneY, 6.7), yaw: Math.PI / 2, stand: new THREE.Vector3(-0.42, CFG.laneY, CFG.playerStartZ) },
+  { pos: new THREE.Vector3(2.72, CFG.laneY, 6.7), yaw: -Math.PI / 2, stand: new THREE.Vector3(0.42, CFG.laneY, CFG.playerStartZ) },
+];
 
 function makeEmptyPlayers(): ScorePlayer[] {
   const makeFrames = () => Array.from({ length: 10 }, () => ({ rolls: [] as number[], cumulative: null }));
@@ -382,7 +398,7 @@ function pickRandomAiCharacter(playerCharacterId: string) {
   return pool[Math.floor(Math.random() * pool.length)] || HUMAN_CHARACTER_OPTIONS[0];
 }
 
-function addHuman(scene: THREE.Scene, start: THREE.Vector3, character: HumanCharacterOption): HumanRig {
+function addHuman(scene: THREE.Scene, start: THREE.Vector3, character: HumanCharacterOption, seatPos = start.clone(), seatYaw = 0): HumanRig {
   const root = new THREE.Group();
   const modelRoot = new THREE.Group();
   const fallback = makeFallbackHuman(parseHexColor(character?.accent, 0xff7a2f));
@@ -415,6 +431,10 @@ function addHuman(scene: THREE.Scene, start: THREE.Vector3, character: HumanChar
     walkCycle: 0,
     approachFrom: start.clone(),
     approachTo: start.clone(),
+    seatPos: seatPos.clone(),
+    seatYaw,
+    standPos: start.clone(),
+    seatT: 0,
   };
 
   loadHumanCharacter(rig, character);
@@ -443,7 +463,7 @@ function loadHumanCharacter(rig: HumanRig, character: HumanCharacterOption | und
       (gltf) => {
         if (cancelled) return;
         const model = gltf.scene;
-        normalizeHuman(model, 1.82);
+        normalizeHuman(model, 1.78);
         model.scale.multiplyScalar(HUMAN_INITIAL_SCALE);
         lockHumanToLaneGround(model);
         enableShadow(model);
@@ -495,8 +515,67 @@ function findRightHand(modelRoot: THREE.Object3D | null) {
   return hand;
 }
 
+
+function applyStandingPose(rig: HumanRig) {
+  rig.modelRoot.visible = true;
+  rig.shadow.visible = true;
+  if (rig.model) {
+    rig.model.position.x *= 0.3;
+    rig.model.position.z *= 0.3;
+    rig.model.rotation.x *= 0.65;
+    rig.model.rotation.z *= 0.65;
+  }
+}
+
+function applySeatedPose(rig: HumanRig) {
+  rig.modelRoot.visible = true;
+  rig.shadow.visible = true;
+  rig.pos.copy(rig.seatPos);
+  rig.yaw = rig.seatYaw;
+  rig.targetYaw = rig.seatYaw;
+  rig.action = "seated";
+  if (rig.model) {
+    rig.model.position.set(0, -0.42, -0.08);
+    rig.model.rotation.set(-0.18, 0, 0.02);
+  }
+  syncHuman(rig);
+  rig.shadow.scale.set(0.92, 0.72, 1);
+}
+
+function standRigForTurn(rig: HumanRig) {
+  rig.action = "standingUp";
+  rig.seatT = 0.001;
+  rig.approachT = 0;
+  rig.throwT = 0;
+  rig.recoverT = 0;
+  rig.returnWalkT = 0;
+  rig.walkCycle = 0;
+  rig.approachFrom.copy(rig.seatPos);
+  rig.approachTo.copy(rig.standPos);
+}
+
+function seatRigAfterTurn(rig: HumanRig) {
+  rig.action = "toSeat";
+  rig.seatT = 0.001;
+  rig.returnWalkT = 0;
+  rig.approachFrom.copy(rig.pos);
+  rig.approachTo.copy(rig.seatPos);
+}
+
+function loadFirstAvailableGltf(urls: string[], onLoad: (gltf: any) => void, onError?: () => void) {
+  const loader = new GLTFLoader().setCrossOrigin("anonymous");
+  const tryLoad = (index: number) => {
+    if (index >= urls.length) {
+      onError?.();
+      return;
+    }
+    loader.load(urls[index], onLoad, undefined, () => tryLoad(index + 1));
+  };
+  tryLoad(0);
+}
+
 function getHeldBallWorldPosition(rig: HumanRig) {
-  const handNode = findRightHand(rig.model);
+  const handNode = findRightHand(rig.model) as THREE.Object3D | null;
   const handAnchor = handNode ? handNode.getWorldPosition(new THREE.Vector3()) : null;
   let local = new THREE.Vector3(0.31, 0.92, 0.08);
   if (rig.action === "approach") {
@@ -671,14 +750,7 @@ function createEnvironment(scene: THREE.Scene, loader: THREE.TextureLoader, tabl
   if (tableFinishId.includes('dark') || tableFinishId.includes('carbon')) (woodMat as THREE.MeshStandardMaterial).color.set('#3a2b23');
   if (tableFinishId.includes('rosewood')) (woodMat as THREE.MeshStandardMaterial).color.set('#6f3a2f');
 
-  const groundingFloor = new THREE.Mesh(
-    new THREE.CircleGeometry(18, 96),
-    new THREE.MeshStandardMaterial({ color: 0x111827, roughness: 0.72, metalness: 0.02, envMapIntensity: 0.35 })
-  );
-  groundingFloor.rotation.x = -Math.PI / 2;
-  groundingFloor.position.set(0, CFG.laneY - 0.028, -2.4);
-  groundingFloor.receiveShadow = true;
-  group.add(groundingFloor);
+  // Intentionally no dark grounding floor: the lane sits directly on the HDRI ground plane so the environment remains visible.
 
   const approach = new THREE.Mesh(new THREE.PlaneGeometry(4.9, 4.25, 20, 20), woodMat);
   approach.rotation.x = -Math.PI / 2;
@@ -730,17 +802,64 @@ function createEnvironment(scene: THREE.Scene, loader: THREE.TextureLoader, tabl
   pinsetter.position.set(0, 0.32, CFG.backStopZ + 0.18);
   group.add(pinsetter);
 
-  const tableTop = new THREE.Mesh(new THREE.BoxGeometry(1.64, 0.08, 1.72), woodMat);
-  tableTop.position.set(2.02, 0.76, 6.35);
-  group.add(tableTop);
-  const legGeom = new THREE.BoxGeometry(0.1, 0.7, 0.1);
-  for (const sx of [-0.68, 0.68]) {
-    for (const sz of [-0.7, 0.7]) {
-      const leg = new THREE.Mesh(legGeom, blackMat);
-      leg.position.set(2.02 + sx, 0.37, 6.35 + sz);
-      group.add(leg);
+  const lounge = new THREE.Group();
+  lounge.position.set(0, CFG.laneY, 6.7);
+  try {
+    createMurlanStyleTable({
+      THREE,
+      arena: lounge,
+      tableRadius: 0.82,
+      tableHeight: 0.74,
+      pedestalHeightScale: 0.86,
+      includeBase: true,
+    });
+  } catch {
+    const tableTop = new THREE.Mesh(new THREE.BoxGeometry(1.64, 0.08, 1.72), woodMat);
+    tableTop.position.set(0, 0.76, 0);
+    lounge.add(tableTop);
+    const legGeom = new THREE.BoxGeometry(0.1, 0.7, 0.1);
+    for (const sx of [-0.68, 0.68]) {
+      for (const sz of [-0.7, 0.7]) {
+        const leg = new THREE.Mesh(legGeom, blackMat);
+        leg.position.set(sx, 0.37, sz);
+        lounge.add(leg);
+      }
     }
   }
+  const chairFallbackMat = new THREE.MeshPhysicalMaterial({ color: 0x5f3d26, roughness: 0.42, metalness: 0.05, clearcoat: 0.35 });
+  for (const seat of PLAYER_SEATS) {
+    const chair = new THREE.Group();
+    chair.position.copy(seat.pos);
+    chair.rotation.y = seat.yaw + Math.PI;
+    const pad = new THREE.Mesh(new THREE.BoxGeometry(0.72, 0.12, 0.72), chairFallbackMat);
+    pad.position.y = 0.43;
+    chair.add(pad);
+    const back = new THREE.Mesh(new THREE.BoxGeometry(0.78, 0.86, 0.12), chairFallbackMat);
+    back.position.set(0, 0.88, 0.33);
+    chair.add(back);
+    for (const sx of [-0.27, 0.27]) for (const sz of [-0.24, 0.24]) {
+      const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.035, 0.045, 0.44, 12), chairFallbackMat);
+      leg.position.set(sx, 0.21, sz);
+      chair.add(leg);
+    }
+    group.add(chair);
+    loadFirstAvailableGltf(BOWLING_MURLAN_CHAIR_URLS, (gltf) => {
+      if (!group.parent) return;
+      const model = gltf.scene.clone(true);
+      enableShadow(model);
+      model.updateMatrixWorld(true);
+      const box = new THREE.Box3().setFromObject(model);
+      const span = Math.max(box.max.x - box.min.x, box.max.y - box.min.y, box.max.z - box.min.z) || 1;
+      model.scale.setScalar(1.05 / span);
+      model.updateMatrixWorld(true);
+      const box2 = new THREE.Box3().setFromObject(model);
+      model.position.set(seat.pos.x - (box2.min.x + box2.max.x) / 2, CFG.laneY - box2.min.y, seat.pos.z - (box2.min.z + box2.max.z) / 2);
+      model.rotation.y = seat.yaw + Math.PI;
+      group.add(model);
+      chair.visible = false;
+    });
+  }
+  group.add(lounge);
   const returnBase = new THREE.Mesh(new THREE.BoxGeometry(0.86, 0.4, 1.55), woodMat);
   returnBase.position.set(1.67, 0.2, 5.92);
   group.add(returnBase);
@@ -808,7 +927,44 @@ function startApproach(rig: HumanRig, intent: ThrowIntent) {
 }
 
 function updateHuman(rig: HumanRig, ball: BallState, dt: number, canStartReturnCycle: boolean) {
-  if (rig.action === "approach") {
+  if (rig.action === "seated") {
+    const breath = Math.sin(performance.now() * 0.002) * 0.008;
+    rig.pos.copy(rig.seatPos);
+    rig.yaw = rig.seatYaw;
+    rig.targetYaw = rig.seatYaw;
+    if (rig.model) {
+      rig.model.position.set(0, -0.42 + breath, -0.08);
+      rig.model.rotation.set(-0.18, 0, 0.02);
+    }
+  } else if (rig.action === "standingUp") {
+    rig.seatT = clamp01(rig.seatT + dt / CFG.standDuration);
+    const k = easeInOut(rig.seatT);
+    rig.pos.lerpVectors(rig.seatPos, rig.standPos, k);
+    rig.yaw = lerp(rig.seatYaw, Math.PI, k);
+    rig.targetYaw = rig.yaw;
+    if (rig.model) {
+      rig.model.position.set(0, lerp(-0.42, 0, k), lerp(-0.08, 0, k));
+      rig.model.rotation.x = lerp(-0.18, 0, k);
+      rig.model.rotation.z = lerp(0.02, 0, k);
+    }
+    if (rig.seatT >= 1) {
+      rig.action = "idle";
+      rig.pos.copy(rig.standPos);
+      rig.yaw = Math.PI;
+      rig.targetYaw = Math.PI;
+    }
+  } else if (rig.action === "toSeat") {
+    rig.seatT = clamp01(rig.seatT + dt / CFG.seatWalkDuration);
+    rig.walkCycle += dt * 8.8;
+    const nextPos = new THREE.Vector3().lerpVectors(rig.approachFrom, rig.seatPos, easeInOut(rig.seatT));
+    smoothFacing(rig, nextPos, dt);
+    rig.pos.copy(nextPos);
+    if (rig.model) {
+      rig.model.position.y = Math.abs(Math.sin(rig.walkCycle)) * 0.035;
+      rig.model.rotation.z = Math.sin(rig.walkCycle) * 0.035;
+    }
+    if (rig.seatT >= 1) applySeatedPose(rig);
+  } else if (rig.action === "approach") {
     rig.approachT = clamp01(rig.approachT + dt / CFG.approachDuration);
     rig.walkCycle += dt * 16.8;
     const nextPos = new THREE.Vector3().lerpVectors(rig.approachFrom, rig.approachTo, easeInOut(rig.approachT));
@@ -837,7 +993,7 @@ function updateHuman(rig: HumanRig, ball: BallState, dt: number, canStartReturnC
       // left slide foot forward, right trail leg back (visual posture only).
       rig.model.position.x = t < CFG.releaseT ? lerp(0, -0.08, t / CFG.releaseT) : lerp(-0.08, -0.02, (t - CFG.releaseT) / (1 - CFG.releaseT));
       rig.model.position.z = t < CFG.releaseT ? lerp(0, -0.11, t / CFG.releaseT) : lerp(-0.11, -0.03, (t - CFG.releaseT) / (1 - CFG.releaseT));
-      const rightHand = findRightHand(rig.model);
+      const rightHand = findRightHand(rig.model) as THREE.Object3D | null;
       if (rightHand) {
         if (t < CFG.releaseT) {
           const k = easeInOut(t / CFG.releaseT);
@@ -912,12 +1068,12 @@ function updateHuman(rig: HumanRig, ball: BallState, dt: number, canStartReturnC
     rig.yawVelocity = 0;
   }
   if (rig.action === "idle") {
-    rig.targetYaw = 0;
-    rig.yaw = lerp(rig.yaw, 0, 1 - Math.pow(0.0008, dt));
+    rig.targetYaw = Math.PI;
+    rig.yaw = lerp(rig.yaw, Math.PI, 1 - Math.pow(0.0008, dt));
     rig.yawVelocity = 0;
   }
   syncHuman(rig);
-  if (ball.held) {
+  if (ball.held && canStartReturnCycle) {
     ball.pos.copy(getHeldBallWorldPosition(rig));
     ball.mesh.position.copy(ball.pos);
   }
@@ -1126,9 +1282,13 @@ function updateCamera(camera: THREE.PerspectiveCamera, ball: BallState, player: 
   } else if (player.action === "pickBall") {
     desired = player.pos.clone().add(new THREE.Vector3(0, 2.7, 5.6));
     look = player.pos.clone().add(new THREE.Vector3(0, 0.96, -0.8));
-  } else if (player.action === "approach" || player.action === "throw" || player.action === "recover" || player.action === "toRack" || player.action === "toApproach") {
-    desired = player.pos.clone().add(new THREE.Vector3(0, 2.55, 3.72));
-    look = player.pos.clone().add(new THREE.Vector3(0, 0.85, -1.7));
+  } else if (player.action === "approach" || player.action === "throw" || player.action === "recover") {
+    const shoulderSide = player.pos.x <= 0 ? -0.34 : 0.34;
+    desired = player.pos.clone().add(new THREE.Vector3(shoulderSide, 1.62, 1.18));
+    look = new THREE.Vector3(clamp(player.pos.x * 0.28, -0.42, 0.42), CFG.laneY + 0.52, CFG.pinDeckZ - 0.42);
+  } else if (player.action === "toRack" || player.action === "toApproach" || player.action === "standingUp") {
+    desired = player.pos.clone().add(new THREE.Vector3(0, 2.2, 3.2));
+    look = player.pos.clone().add(new THREE.Vector3(0, 0.78, -1.6));
   } else {
     desired = new THREE.Vector3(0, 2.9, 10.8);
     look = new THREE.Vector3(0, CFG.laneY + 0.74, -2.6);
@@ -1205,9 +1365,11 @@ export default function MobileBowlingRealistic() {
     const pmrem = new THREE.PMREMGenerator(renderer);
     pmrem.compileEquirectangularShader();
     let envTex: THREE.Texture | null = null;
+    let bgTex: THREE.Texture | null = null;
     const applyHdri = (id: string) => {
       const selected = HDRI_OPTIONS.find((h) => h.id === id) || HDRI_OPTIONS[0];
-      const preferred = Array.isArray(selected?.preferredResolutions) ? selected.preferredResolutions : ["4k", "2k"];
+      const menuPreferred = graphicsQuality === "performance" ? ["2k", "1k"] : graphicsQuality === "ultra" ? ["8k", "4k", "2k"] : ["4k", "2k"];
+      const preferred = Array.isArray(selected?.preferredResolutions) ? [...menuPreferred, ...selected.preferredResolutions] : menuPreferred;
       const candidates = [
         ...(Object.values(selected?.assetUrls || {}) as string[]),
         selected?.hdriUrl,
@@ -1223,17 +1385,19 @@ export default function MobileBowlingRealistic() {
         new RGBELoader().setCrossOrigin("anonymous").load(
           ordered[idx],
           (hdr) => {
+            envTex?.dispose();
+            bgTex?.dispose();
+            hdr.mapping = THREE.EquirectangularReflectionMapping;
+            bgTex = hdr;
             envTex = pmrem.fromEquirectangular(hdr).texture;
             scene.environment = envTex;
-            scene.background = envTex;
+            scene.background = bgTex;
             const selectedRotation = Number.isFinite(selected?.rotationY) ? selected.rotationY : 0;
             if ("backgroundRotation" in scene) scene.backgroundRotation.set(0, selectedRotation, 0);
             if ("environmentRotation" in scene) scene.environmentRotation.set(0, selectedRotation, 0);
-            if ("backgroundBlurriness" in scene) scene.backgroundBlurriness = 0.02;
-            if ("backgroundIntensity" in scene) scene.backgroundIntensity = graphicsQuality === "ultra" ? 1.08 : 1;
-            if ("environmentIntensity" in scene) scene.environmentIntensity = graphicsQuality === "performance" ? 0.88 : graphicsQuality === "ultra" ? 1.18 : 1;
-            envTex.mapping = THREE.EquirectangularReflectionMapping;
-            hdr.dispose();
+            if ("backgroundBlurriness" in scene) scene.backgroundBlurriness = 0;
+            if ("backgroundIntensity" in scene) scene.backgroundIntensity = graphicsQuality === "ultra" ? 1.12 : graphicsQuality === "performance" ? 0.92 : 1;
+            if ("environmentIntensity" in scene) scene.environmentIntensity = graphicsQuality === "performance" ? 0.86 : graphicsQuality === "ultra" ? 1.2 : 1;
           },
           undefined,
           () => tryLoad(idx + 1)
@@ -1270,7 +1434,15 @@ export default function MobileBowlingRealistic() {
     const texLoader = new THREE.TextureLoader();
     createEnvironment(scene, texLoader, selectedTableFinish, selectedChromeColor);
     const pins = createPins(scene);
-    const player = addHuman(scene, new THREE.Vector3(0, CFG.laneY, CFG.playerStartZ), playerCharacter);
+    const playerRigs = [
+      addHuman(scene, PLAYER_SEATS[0].stand.clone(), playerCharacter, PLAYER_SEATS[0].pos, PLAYER_SEATS[0].yaw),
+      addHuman(scene, PLAYER_SEATS[1].pos.clone(), aiCharacter, PLAYER_SEATS[1].pos, PLAYER_SEATS[1].yaw),
+    ];
+    playerRigs[0].standPos.copy(PLAYER_SEATS[0].stand);
+    playerRigs[1].standPos.copy(PLAYER_SEATS[1].stand);
+    applyStandingPose(playerRigs[0]);
+    applySeatedPose(playerRigs[1]);
+    let player = playerRigs[0];
     const ballVariant = BALL_VARIANTS.find((v) => v.label === selectedBallWeight) || BALL_VARIANTS[1];
     const ball = createActiveBall(ballVariant);
     scene.add(ball.mesh);
@@ -1321,9 +1493,12 @@ export default function MobileBowlingRealistic() {
       player.throwT = 0;
       player.recoverT = 0;
       player.walkCycle = 0;
-      player.pos.set(0, CFG.laneY, CFG.playerStartZ);
+      player.pos.copy(player.standPos);
+      player.yaw = Math.PI;
+      player.targetYaw = Math.PI;
       player.approachFrom.copy(player.pos);
       player.approachTo.copy(player.pos);
+      applyStandingPose(player);
       syncHuman(player);
       ball.held = true;
       ball.rolling = false;
@@ -1338,11 +1513,14 @@ export default function MobileBowlingRealistic() {
       pinsWereMoving = false;
       settleTimer = 0;
       pendingIntent = null;
-      resetPlayerPoseForNextBall();
       if (nextAction === "nextPlayer") resetPins(pins);
+      const previousPlayer = player;
+      player = playerRigs[activePlayer];
+      if (previousPlayer !== player) seatRigAfterTurn(previousPlayer);
+      resetPlayerPoseForNextBall();
+      if (previousPlayer !== player) standRigForTurn(player);
       syncReactScores();
       aiTurnDelay = activePlayer === 1 ? 0.85 + Math.random() * 0.5 : 0.85;
-      loadHumanCharacter(player, activePlayer === 0 ? playerCharacter : aiCharacter);
       const playerName = localScores[activePlayer].name;
       setHud((prev) => ({ ...prev, status: nextAction === "gameOver" ? "Game over" : activePlayer === 1 ? `${playerName} is choosing a line…` : `${playerName} swipe up to bowl` }));
     };
@@ -1354,7 +1532,7 @@ export default function MobileBowlingRealistic() {
       const playerBefore = localScores[activePlayer];
       const result = addRollToPlayer(playerBefore, knocked);
       let status = `${playerBefore.name} knocked ${knocked} pin${knocked === 1 ? "" : "s"}`;
-      let compliment = RESULT_COMPLIMENTS.open[Math.floor(Math.random()*RESULT_COMPLIMENTS.open.length)];
+      let compliment: string = RESULT_COMPLIMENTS.open[Math.floor(Math.random()*RESULT_COMPLIMENTS.open.length)];
       const strike = result.frameIndex < 9 && playerBefore.frames[result.frameIndex].rolls[0] === 10;
       const spare = result.frameIndex < 9 && playerBefore.frames[result.frameIndex].rolls.length === 2 && playerBefore.frames[result.frameIndex].rolls[0] + playerBefore.frames[result.frameIndex].rolls[1] === 10 && playerBefore.frames[result.frameIndex].rolls[0] !== 10;
       if (strike) { status = `${playerBefore.name} STRIKE!`; compliment = RESULT_COMPLIMENTS.strike[Math.floor(Math.random()*RESULT_COMPLIMENTS.strike.length)] + " " + STRIKE_DANCE_LINES[Math.floor(Math.random()*STRIKE_DANCE_LINES.length)]; }
@@ -1405,7 +1583,8 @@ export default function MobileBowlingRealistic() {
     const onPointerDown = (e: PointerEvent) => {
       if (nextAction === "gameOver") return;
       if (control.active || ball.rolling || waitingForBallReturn || replayActive) return;
-      if (player.action === "approach" || player.action === "throw" || player.action === "recover") return;
+      if (activePlayer !== 0 || player !== playerRigs[0]) return;
+      if (player.action !== "idle") return;
       canvas.setPointerCapture(e.pointerId);
       control.active = true;
       control.pointerId = e.pointerId;
@@ -1472,7 +1651,7 @@ export default function MobileBowlingRealistic() {
           setHud((prev) => ({ ...prev, status: "PLAYER 2 AI is bowling" }));
         }
       }
-      updateHuman(player, ball, dt, true);
+      for (const rig of playerRigs) updateHuman(rig, ball, dt, rig === player);
       if (player.action === "throw" && pendingIntent && player.throwT >= CFG.releaseT && ball.held) {
         lastShotStandingBefore = standingPinsCount(pins);
         releaseBall(ball, pendingIntent);


### PR DESCRIPTION
### Motivation
- Make the bowling arena read directly from HDRI background (remove dark grounding floor) and honor HDRI selection/intensity from the graphics menu. 
- Replace the single standing-only human flow with realistic seated/standing interactions so only the active player stands to bowl while the other is seated with a chair/table set matching Murlan assets. 
- Improve shot visibility by using a lower over‑the‑shoulder camera during shooting and ensure AI/human characters are distinct per match.

### Description
- Reworked `webapp/src/pages/Games/BowlingRealistic.tsx` to remove the dark grounding floor and add a Murlan-style lounge and per-player chairs with GLTF upgrade and procedural fallback geometry. 
- Introduced `PLAYER_SEATS`, `BOWLING_MURLAN_CHAIR_URLS` and a GLTF loader helper `loadFirstAvailableGltf` to attempt upgraded chair assets and fall back to procedural chairs. 
- Extended `HumanRig` with seat-related fields (`seatPos`, `seatYaw`, `standPos`, `seatT`) and added new actions (`seated`, `standingUp`, `toSeat`) plus helpers `applySeatedPose`, `applyStandingPose`, `standRigForTurn`, `seatRigAfterTurn`. 
- Split player handling into `playerRigs` (human + AI), updated `addHuman` signature to accept seat parameters, and changed turn logic so only the active player stands and the previous player walks/returns to seat. 
- Updated `updateHuman` and turn flow to orchestrate standing, approach, throw, return-to-seat sequences and to gate pointer input to the active (human) player. 
- Modified `updateCamera` to use a lower over-the-shoulder framing when the shooter is approaching/throwing and tweaked camera look targets for better pin visibility. 
- HDRI loading revised to keep the original equirectangular texture as the scene background while using PMREM for environment lighting/reflections, and to prefer HDRI resolutions according to the `graphicsQuality` menu. 
- Small gameplay/visual tuning: adjusted `CFG` values (player start Z, approach stop Z, durations) and normalized human scale for improved proportions.

### Testing
- Ran a TypeScript check against the modified file with `npx tsc --noEmit --jsx react-jsx --module esnext --target es2018 --moduleResolution bundler --allowJs false --strict false --skipLibCheck true webapp/src/pages/Games/BowlingRealistic.tsx`, which completed successfully. 
- Built the webapp with `npm --prefix webapp run build`, which completed and produced the production bundles (vite build succeeded). 
- Launched a dev server and performed a headless Playwright run to open `/games/bowling` and capture a screenshot; the screenshot run required installing Playwright browsers and additional system libraries and produced a page capture while logging multiple resource/HDRI fetch warnings (screenshot was generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a015bb2ca2c8329bf1025a36de2a1b6)