### PR TITLE
Add cinematic Ludo final-hit headshots

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -988,6 +988,15 @@ const FIREARM_CAMERA_FOCUS_BLEND = 0.58;
 const FIREARM_CAMERA_SIDE_PULLBACK = 0.16;
 const FIREARM_CAMERA_LIFT = 0.048;
 const FIREARM_CAMERA_TARGET_OFFSET = 0.036;
+const UNIVERSAL_FINAL_HIT_HEADSHOT_HEIGHT_RATIO = 0.84;
+const UNIVERSAL_FINAL_HIT_IMPACT_PROFILE = Object.freeze({
+  slowMotionFactor: 0.072,
+  cameraPullback: 0.046,
+  cameraSideDrift: 0.012,
+  cameraLift: 0.03,
+  impactHoldTtl: 2.1,
+  impactShake: 0.011
+});
 const FIREARM_PICKUP_PHASE_RATIO = 0.24;
 const FIREARM_SHOULDER_SETTLE_PHASE_RATIO = 0.43;
 const FIREARM_AIM_LOCK_PHASE_RATIO = 0.56;
@@ -995,7 +1004,7 @@ const FIREARM_AIM_SLERP_FAST = 0.62;
 const FIREARM_AIM_SLERP_LOCKED = 0.88;
 const FIREARM_RECOIL_ROTATION_RAD = 0.026;
 const FIREARM_RECOIL_RECOVER_MS = 94;
-const FIREARM_FINAL_BULLET_SLOWMO_FACTOR = 0.105;
+const FIREARM_FINAL_BULLET_SLOWMO_FACTOR = UNIVERSAL_FINAL_HIT_IMPACT_PROFILE.slowMotionFactor;
 const FIREARM_FINAL_BULLET_SPIN_RATE = 0.118;
 const FIREARM_NON_FINAL_BULLET_CINEMATIC_FACTOR = 0.46;
 const FIREARM_BROADCAST_PROFILE = Object.freeze({
@@ -3357,6 +3366,31 @@ function createActualTokenSurfaceFragments({ scene, token, impactPoint, forward,
   return chunks;
 }
 
+
+function resolveCinematicHeadshotPoint(token, fallbackPosition, tableSurfaceY = 0) {
+  const fallback = fallbackPosition?.isVector3
+    ? fallbackPosition.clone()
+    : new THREE.Vector3(0, Math.max(tableSurfaceY + 0.04, 0.04), 0);
+  if (!token?.isObject3D) {
+    fallback.y = Math.max(fallback.y, tableSurfaceY + FIREARM_CAMERA_TARGET_OFFSET);
+    return fallback;
+  }
+  token.updateMatrixWorld?.(true);
+  const box = new THREE.Box3().setFromObject(token);
+  if (!Number.isFinite(box.min.x) || !Number.isFinite(box.max.x)) {
+    fallback.y = Math.max(fallback.y, tableSurfaceY + FIREARM_CAMERA_TARGET_OFFSET);
+    return fallback;
+  }
+  const size = box.getSize(new THREE.Vector3());
+  const center = box.getCenter(new THREE.Vector3());
+  const headY = THREE.MathUtils.lerp(box.min.y, box.max.y, UNIVERSAL_FINAL_HIT_HEADSHOT_HEIGHT_RATIO);
+  return new THREE.Vector3(
+    center.x,
+    Math.max(headY, tableSurfaceY + Math.max(FIREARM_CAMERA_TARGET_OFFSET, size.y * 0.55)),
+    center.z
+  );
+}
+
 function createTokenImpactCrackDecals({ scene, impactPoint, forward, tableSurfaceY, profileScale = 1 }) {
   if (!scene || !impactPoint?.isVector3) return [];
   const decals = [];
@@ -3482,7 +3516,8 @@ function spawnTokenBreakDebris({
     profileScale: clamp(profileScale, 0.55, 1.6)
   });
   const startMs = performance.now();
-  const dustCount = weaponId === 'missileJavelin' || weaponId === 'droneAttack' ? 18 : 12;
+  const isUniversalCinematicHit = FIREARM_CAPTURE_ANIMATION_IDS.has(weaponId) || CAPTURE_AIR_ATTACK_ID_SET.has(weaponId) || weaponId === 'missileJavelin';
+  const dustCount = weaponId === 'missileJavelin' || weaponId === 'droneAttack' ? 26 : isUniversalCinematicHit ? 20 : 12;
   const dustClouds = Array.from({ length: dustCount }, (_, idx) => {
     const dust = new THREE.Mesh(
       new THREE.SphereGeometry(0.012 + idx * 0.0016, 10, 10),
@@ -3502,24 +3537,82 @@ function spawnTokenBreakDebris({
     scene.add(dust);
     return dust;
   });
+  const sparkMaterial = new THREE.MeshBasicMaterial({
+    color: '#ffd166',
+    transparent: true,
+    opacity: 0.94,
+    depthWrite: false
+  });
+  const sparks = Array.from({ length: isUniversalCinematicHit ? 28 : 12 }, (_, idx) => {
+    const spark = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.0009, 0.0009, THREE.MathUtils.randFloat(0.018, 0.042) * profileScale, 6),
+      sparkMaterial.clone()
+    );
+    const lateral = right.clone().multiplyScalar(THREE.MathUtils.randFloatSpread(0.012));
+    spark.position.copy(impactPoint).add(lateral).addScaledVector(worldUp, THREE.MathUtils.randFloat(0.002, 0.03));
+    spark.userData.velocity = forward.clone().multiplyScalar(THREE.MathUtils.randFloat(0.018, 0.055))
+      .add(right.clone().multiplyScalar(THREE.MathUtils.randFloatSpread(0.05)))
+      .add(worldUp.clone().multiplyScalar(THREE.MathUtils.randFloat(0.012, 0.052)));
+    spark.userData.spin = THREE.MathUtils.randFloat(0.18, 0.42) * (idx % 2 === 0 ? 1 : -1);
+    spark.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), spark.userData.velocity.clone().normalize());
+    scene.add(spark);
+    return spark;
+  });
+  const armorFragments = Array.from({ length: isUniversalCinematicHit ? 10 : 4 }, (_, idx) => {
+    const shard = new THREE.Mesh(
+      new THREE.TetrahedronGeometry(THREE.MathUtils.randFloat(0.005, 0.014) * profileScale, 0),
+      new THREE.MeshStandardMaterial({
+        color: idx % 3 === 0 ? '#9ca3af' : idx % 3 === 1 ? '#64748b' : '#cbd5e1',
+        metalness: 0.78,
+        roughness: 0.2,
+        transparent: true,
+        opacity: 1
+      })
+    );
+    shard.position.copy(impactPoint).addScaledVector(right, THREE.MathUtils.randFloatSpread(0.025));
+    shard.userData.velocity = forward.clone().multiplyScalar(THREE.MathUtils.randFloat(0.015, 0.047))
+      .add(right.clone().multiplyScalar(THREE.MathUtils.randFloatSpread(0.035)))
+      .add(worldUp.clone().multiplyScalar(THREE.MathUtils.randFloat(0.015, 0.06)));
+    shard.userData.spin = new THREE.Vector3(
+      THREE.MathUtils.randFloatSpread(0.44),
+      THREE.MathUtils.randFloatSpread(0.44),
+      THREE.MathUtils.randFloatSpread(0.44)
+    );
+    scene.add(shard);
+    return shard;
+  });
   const bloodMarks =
-    FIREARM_CAPTURE_ANIMATION_IDS.has(weaponId)
-      ? Array.from({ length: 3 }, (_, idx) => {
+    isUniversalCinematicHit
+      ? Array.from({ length: 6 }, (_, idx) => {
           const mark = new THREE.Mesh(
-            new THREE.CircleGeometry(0.007 + idx * 0.003, 20),
+            new THREE.CircleGeometry((0.007 + idx * 0.0025) * profileScale, 20),
             new THREE.MeshBasicMaterial({
-              color: idx === 0 ? '#7f1d1d' : '#991b1b',
+              color: idx % 2 === 0 ? '#7f1d1d' : '#991b1b',
               transparent: true,
-              opacity: 0.34,
+              opacity: 0.38,
               depthWrite: false
             })
           );
           mark.rotation.x = -Math.PI / 2;
-          mark.position.copy(impactPoint).add(new THREE.Vector3((Math.random() - 0.5) * 0.04, 0.004, (Math.random() - 0.5) * 0.04));
+          mark.position.copy(impactPoint).add(new THREE.Vector3((Math.random() - 0.5) * 0.055, 0.004, (Math.random() - 0.5) * 0.055));
           scene.add(mark);
           return mark;
         })
       : [];
+  const redLiquidDrops = isUniversalCinematicHit
+    ? Array.from({ length: 14 }, (_, idx) => {
+        const drop = new THREE.Mesh(
+          new THREE.SphereGeometry(THREE.MathUtils.randFloat(0.0022, 0.0052) * profileScale, 8, 8),
+          new THREE.MeshBasicMaterial({ color: idx % 2 === 0 ? '#7f1d1d' : '#b91c1c', transparent: true, opacity: 0.72, depthWrite: false })
+        );
+        drop.position.copy(impactPoint).addScaledVector(worldUp, THREE.MathUtils.randFloat(0.004, 0.035));
+        drop.userData.velocity = forward.clone().multiplyScalar(THREE.MathUtils.randFloat(0.004, 0.022))
+          .add(right.clone().multiplyScalar(THREE.MathUtils.randFloatSpread(0.032)))
+          .add(worldUp.clone().multiplyScalar(THREE.MathUtils.randFloat(0.008, 0.044)));
+        scene.add(drop);
+        return drop;
+      })
+    : [];
   const fallY = tableSurfaceY + 0.004;
   const tick = () => {
     const now = performance.now();
@@ -3550,8 +3643,42 @@ function spawnTokenBreakDebris({
       dust.material.opacity = clamp((1 - fade) * (0.5 - idx * 0.012), 0, 0.5);
       dust.scale.setScalar(1 + age * 0.00018 * drift * (dust.userData.grow || 3));
     });
+    sparks.forEach((spark) => {
+      if (spark.userData.velocity?.isVector3) spark.position.add(spark.userData.velocity);
+      spark.userData.velocity?.multiplyScalar?.(0.9);
+      spark.rotation.z += spark.userData.spin || 0.2;
+      spark.material.opacity = clamp((1 - fade) * 0.94, 0, 0.94);
+    });
+    armorFragments.forEach((shard) => {
+      if (shard.userData.velocity?.isVector3) {
+        shard.position.add(shard.userData.velocity);
+        shard.userData.velocity.y -= 0.009;
+        if (shard.position.y <= fallY) {
+          shard.position.y = fallY;
+          shard.userData.velocity.multiplyScalar(0.42);
+          shard.userData.velocity.y = Math.abs(shard.userData.velocity.y) * 0.18;
+        }
+      }
+      if (shard.userData.spin?.isVector3) {
+        shard.rotation.x += shard.userData.spin.x;
+        shard.rotation.y += shard.userData.spin.y;
+        shard.rotation.z += shard.userData.spin.z;
+      }
+      shard.material.opacity = 1 - fade;
+    });
     bloodMarks.forEach((mark) => {
-      mark.material.opacity = clamp(0.34 * (1 - fade * 0.45), 0.06, 0.34);
+      mark.material.opacity = clamp(0.38 * (1 - fade * 0.45), 0.06, 0.38);
+    });
+    redLiquidDrops.forEach((drop) => {
+      if (drop.userData.velocity?.isVector3) {
+        drop.position.add(drop.userData.velocity);
+        drop.userData.velocity.y -= 0.0075;
+        if (drop.position.y <= fallY + 0.002) {
+          drop.position.y = fallY + 0.002;
+          drop.userData.velocity.multiplyScalar(0.24);
+        }
+      }
+      drop.material.opacity = clamp((1 - fade * 0.6) * 0.72, 0.05, 0.72);
     });
     if (age < life) {
       requestAnimationFrame(tick);
@@ -3567,10 +3694,25 @@ function spawnTokenBreakDebris({
       dust.geometry?.dispose?.();
       dust.material?.dispose?.();
     });
+    sparks.forEach((spark) => {
+      spark.parent?.remove?.(spark);
+      spark.geometry?.dispose?.();
+      spark.material?.dispose?.();
+    });
+    armorFragments.forEach((shard) => {
+      shard.parent?.remove?.(shard);
+      shard.geometry?.dispose?.();
+      shard.material?.dispose?.();
+    });
     bloodMarks.forEach((mark) => {
       mark.parent?.remove?.(mark);
       mark.geometry?.dispose?.();
       mark.material?.dispose?.();
+    });
+    redLiquidDrops.forEach((drop) => {
+      drop.parent?.remove?.(drop);
+      drop.geometry?.dispose?.();
+      drop.material?.dispose?.();
     });
     crackDecals.forEach((mark) => {
       mark.parent?.remove?.(mark);
@@ -10797,7 +10939,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (!isCamera2d && camera && controls && dynamicFirearmCameraRef.current && firearmCinematicCameraPoseRef.current) {
         const pose = firearmCinematicCameraPoseRef.current;
         const lerpFactor = clamp(pose.lerp ?? 0.28, 0.02, 1);
-        if (pose.position?.isVector3) camera.position.lerp(pose.position, lerpFactor);
+        if (pose.position?.isVector3) {
+          camera.position.lerp(pose.position, lerpFactor);
+          const shake = Number(pose.shake ?? 0);
+          if (shake > 0) {
+            const shakeClock = performance.now() * 0.055;
+            camera.position.x += Math.sin(shakeClock) * shake;
+            camera.position.y += Math.cos(shakeClock * 1.37) * shake * 0.55;
+            camera.position.z += Math.sin(shakeClock * 0.73) * shake * 0.72;
+          }
+        }
         if (pose.target?.isVector3) {
           controls.target.lerp(pose.target, Math.min(1, lerpFactor * 1.18));
           cameraTurnStateRef.current.currentTarget = controls.target.clone();
@@ -11189,7 +11340,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           } else {
             muzzleOrigin.copy(startPosition).add(new THREE.Vector3(0, 0.08, 0));
           }
-          muzzleTarget.copy(targetPosition).add(new THREE.Vector3(0, 0.03, 0));
+          muzzleTarget.copy(resolveCinematicHeadshotPoint(targetToken, targetPosition, tableSurfaceY));
           const shots = FIREARM_MAGAZINE_SHOTS[resolvedCaptureAnimationId] ?? 18;
           const ballisticsProfile = resolveFirearmBallisticsProfile(resolvedCaptureAnimationId);
           const bridgeBallisticsBias =
@@ -11210,7 +11361,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const cadenceMs = (FIREARM_MARKSMAN_IDS.has(resolvedCaptureAnimationId) ? 155 : FIREARM_SHOTGUN_IDS.has(resolvedCaptureAnimationId) ? 92 : 56) * FIREARM_VOLLEY_SLOW_FACTOR;
           const volleyStart = performance.now();
           const preFireLeadMs = pickupLeadMs + reloadLeadMs + aimLeadMs;
-          const durationMs = preFireLeadMs + shots * cadenceMs + 760;
+          const durationMs = preFireLeadMs + shots * cadenceMs + UNIVERSAL_FINAL_HIT_IMPACT_PROFILE.impactHoldTtl * 1000;
           seatedHumanActionRef.current = {
             ...seatedHumanActionRef.current,
             captureEndMs: volleyStart + durationMs
@@ -11258,12 +11409,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const aimTargetQuat = new THREE.Quaternion();
           const recoilEuler = new THREE.Euler(0, 0, 0, 'XYZ');
           const recoilQuat = new THREE.Quaternion();
-          const setFirearmCinematicPose = (position, target, lerp = 0.34) => {
+          const setFirearmCinematicPose = (position, target, lerp = 0.34, extras = {}) => {
             if (!position?.isVector3 || !target?.isVector3) return;
             firearmCinematicCameraPoseRef.current = {
               position: position.clone(),
               target: target.clone(),
-              lerp
+              lerp,
+              shake: extras.shake ?? 0,
+              focusDistance: extras.focusDistance ?? null
             };
           };
           const rackLocalStart = new THREE.Vector3();
@@ -11290,7 +11443,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               fallbackPosition: targetPosition
             });
             if (liveTarget?.isVector3) {
-              muzzleTarget.copy(liveTarget).add(new THREE.Vector3(0, FIREARM_CAMERA_TARGET_OFFSET, 0));
+              muzzleTarget.copy(resolveCinematicHeadshotPoint(targetToken, liveTarget, tableSurfaceY));
             }
             if (handWeaponAttachment?.weapon?.isObject3D && handWeaponAttachment.weapon.parent?.isObject3D) {
               const parent = handWeaponAttachment.weapon.parent;
@@ -11437,7 +11590,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               const shotProgress = isFinalProjectile ? easeInOutSine01(rawShotProgress) : rawShotProgress;
               const start = muzzleOrigin.clone();
               const pelletIndex = Number(bulletMesh.userData?.pelletIndex ?? 0);
-              const pelletOffset = FIREARM_SCATTER_PROJECTILE_IDS.has(resolvedCaptureAnimationId)
+              const pelletOffset = FIREARM_SCATTER_PROJECTILE_IDS.has(resolvedCaptureAnimationId) && !isFinalProjectile
                 ? new THREE.Vector3(
                   Math.cos(pelletIndex * 2.399) * mergedBallistics.tracerSpread * 0.72,
                   Math.sin(pelletIndex * 2.399) * mergedBallistics.tracerSpread * 0.36,
@@ -11495,11 +11648,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               const followingFinalBullet = leadBulletMesh && Number(leadBulletMesh.userData?.shotIndex ?? -1) >= shots - 1;
               cinematicPosition
                 .copy(leadBulletPos)
-                .addScaledVector(bulletDir, followingFinalBullet ? -0.052 : -0.15)
-                .addScaledVector(cinematicSide, followingFinalBullet ? 0.01 : singleShotFirearm ? 0.018 : 0.03);
-              cinematicPosition.addScaledVector(cameraWorldUp, followingFinalBullet ? 0.034 : singleShotFirearm ? 0.07 : 0.082);
+                .addScaledVector(bulletDir, followingFinalBullet ? -UNIVERSAL_FINAL_HIT_IMPACT_PROFILE.cameraPullback : -0.15)
+                .addScaledVector(cinematicSide, followingFinalBullet ? UNIVERSAL_FINAL_HIT_IMPACT_PROFILE.cameraSideDrift : singleShotFirearm ? 0.018 : 0.03);
+              cinematicPosition.addScaledVector(cameraWorldUp, followingFinalBullet ? UNIVERSAL_FINAL_HIT_IMPACT_PROFILE.cameraLift : singleShotFirearm ? 0.07 : 0.082);
               cinematicTarget.copy(leadBulletPos).addScaledVector(bulletDir, followingFinalBullet ? 0.13 : 0.34);
-              setFirearmCinematicPose(cinematicPosition, cinematicTarget, followingFinalBullet ? 0.9 : 0.72);
+              setFirearmCinematicPose(cinematicPosition, cinematicTarget, followingFinalBullet ? 0.94 : 0.72, {
+                focusDistance: followingFinalBullet ? leadBulletPos.distanceTo(muzzleTarget) : null
+              });
               if (leadBulletMesh && Number(leadBulletMesh.userData?.shotIndex ?? -1) >= shots - 1) {
                 aerodynamicRings.visible = true;
                 aerodynamicRings.position.copy(leadBulletPos);
@@ -11575,7 +11730,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 .addScaledVector(cinematicSide, 0.08)
                 .addScaledVector(cameraWorldUp, 0.16);
               cinematicTarget.copy(muzzleTarget).addScaledVector(cameraWorldUp, 0.018);
-              setFirearmCinematicPose(cinematicPosition, cinematicTarget, 0.62);
+              setFirearmCinematicPose(cinematicPosition, cinematicTarget, 0.72, {
+                shake: UNIVERSAL_FINAL_HIT_IMPACT_PROFILE.impactShake,
+                focusDistance: cinematicPosition.distanceTo(muzzleTarget)
+              });
             }
             if (elapsed < durationMs) {
               requestAnimationFrame(tickFirearm);
@@ -11757,13 +11915,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           tokenIndex: targetTokenIndex,
           fallbackPosition: impactPosition?.isVector3 === true ? impactPosition : targetPosition
         });
-        const safeImpactPoint =
-          resolvedImpactPoint?.isVector3 === true
-            ? resolvedImpactPoint
-            : targetPosition?.clone?.() ?? launchAnchor.clone();
-        const impactAnchor = safeImpactPoint
-          .clone()
-          .add(new THREE.Vector3(0, Math.max(0.02, 0.04 - CAPTURE_ANIMATION_HEIGHT_COMPENSATION), 0));
+        const safeImpactPoint = resolveCinematicHeadshotPoint(
+          targetToken,
+          resolvedImpactPoint?.isVector3 === true ? resolvedImpactPoint : targetPosition?.clone?.() ?? launchAnchor.clone(),
+          tableSurfaceY
+        );
         const from = launchAnchor.clone();
         const baseTravelTime =
           resolvedCaptureAnimationId === 'fighterJetAttack'
@@ -11858,9 +12014,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               fallbackPosition: safeImpactPoint
             }) ?? safeImpactPoint.clone();
           const dynamicFrom = liveFromBase.clone().add(new THREE.Vector3(0, bishopHeight * 0.5, 0));
-          const dynamicTo = liveTarget
-            .clone()
-            .add(new THREE.Vector3(0, Math.max(0.024, 0.045 - CAPTURE_ANIMATION_HEIGHT_COMPENSATION), 0));
+          const dynamicTo = resolveCinematicHeadshotPoint(targetToken, liveTarget, tableSurfaceY);
           const arenaCenter =
             boardLookTargetRef.current?.clone?.() ?? new THREE.Vector3(0, dynamicFrom.y, 0);
           arenaCenter.y = dynamicFrom.y;
@@ -12243,7 +12397,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 spawnTokenBreakDebris({
                   scene,
                   token: targetToken,
-                  impactPoint: liveTarget.clone(),
+                  impactPoint: resolveCinematicHeadshotPoint(targetToken, liveTarget, tableSurfaceY),
                   impactDirection: blastDir,
                   weaponId: resolvedCaptureAnimationId,
                   tableSurfaceY


### PR DESCRIPTION
### Motivation
- Provide a universal cinematic final-hit sequence so any equipped weapon can trigger an ultra slow‑motion, camera‑tracked headshot with dramatic impact FX. 
- Make final projectiles consistently target the token head area for pistols, rifles, shotguns, SMGs, snipers, bows, lasers and aerial/futuristic weapons. 

### Description
- Add a global tuning profile `UNIVERSAL_FINAL_HIT_IMPACT_PROFILE` and `UNIVERSAL_FINAL_HIT_HEADSHOT_HEIGHT_RATIO`, and use it to drive slow‑motion, camera pullback/lift, impact hold TTL and shake behavior. 
- Implement `resolveCinematicHeadshotPoint(token, fallback, tableSurfaceY)` to compute a head‑area impact point from token bounds and replace generic muzzle/impact targets with that point for firearm and aerial captures. 
- Extend firearm cinematic plumbing by adding `firearmCinematicCameraPoseRef` extras (`shake` and `focusDistance`) and applying camera shake during cinematic poses. 
- Enhance `spawnTokenBreakDebris` FX with extra dust, sparks, armor fragments, red liquid drops/decals and stronger cleanup logic for all cinematic hits. 
- Tune projectile logic so shotgun pellet scatter avoids moving the final cinematic projectile off the head target and use `UNIVERSAL_FINAL_HIT_IMPACT_PROFILE.impactHoldTtl` to extend the final hold window. 
- File changed: `webapp/src/pages/Games/LudoBattleRoyal.jsx` (inserts and updates described functions/constants/FX/camera handling). 

### Testing
- Ran `npm --prefix webapp run build` to produce production bundles, and the build completed successfully. 
- Ran `git diff --check` to validate no whitespace/errors, which passed with no issues. 
- Launched the dev server and captured a Playwright screenshot of the Ludo scene at `/tmp/tonplaygram-screenshots/ludo-battle-royal-final-hit.png`, which was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01784b90d88329bf772b6441229b47)