### PR TITLE
Pool Royale: consolidate lounge table, human rig, shadows, and physics tuning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1848,7 +1848,7 @@ const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
 const RACK_VERTICAL_SCREEN_LIFT = BALL_R * 0.86; // nudge the rack farther upward on screen so object balls sit visibly higher
-const ENABLE_BALL_FLOOR_SHADOWS = true;
+const ENABLE_BALL_FLOOR_SHADOWS = false;
 const ENABLE_CUE_CLOTH_SHADOW = true;
 const ENABLE_TABLE_FLOOR_SHADOW = false;
 const BALL_SHADOW_RADIUS_MULTIPLIER = 1;
@@ -2245,7 +2245,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 2200;
 const POCKET_VIEW_EARLY_HOLD_MS = 320;
-const SPIN_GLOBAL_SCALE = 0.9; // match Snooker Royal spin controller scaling
+const SPIN_GLOBAL_SCALE = 0.82; // trim Pool Royale spin slightly for more natural cue-ball action
 const STRAIGHT_TOPSPIN_BONUS_SCALE = 1; // keep straight top spin matched to Snooker Royal without extra follow boost
 const STRAIGHT_TOPSPIN_SIDE_THRESHOLD = 0.08; // treat this as "mostly straight" topspin
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
@@ -2273,7 +2273,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1; // keep slider strength honest by removing the extra Pool Royale boost
-const SHOT_GLOBAL_POWER_SCALE = 0.72; // soften Pool Royale shot pace so ball travel matches the displayed slider power
+const SHOT_GLOBAL_POWER_SCALE = 0.82; // add more Pool Royale shot pace while keeping slider strength controllable
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -2420,7 +2420,7 @@ const POOL_ROYALE_HUMAN_LOGIC_PROFILES = Object.freeze({
     practiceStroke: 0.035,
     cueGap: 0.012,
     strikeMs: 120,
-    walkSpeed: 4.0,
+    walkSpeed: 2.85,
     shootForwardBendScale: 0.92,
     shootUpperBodyCounterLean: 0.48
   }),
@@ -2676,6 +2676,7 @@ const POOL_ROYALE_LOUNGE_TABLE_HEIGHT = BALL_R * 20.5;
 const POOL_ROYALE_LOUNGE_CHAIR_SPAN = BALL_R * 84; // larger, taller portrait-readable chairs for each player lounge.
 const POOL_ROYALE_LOUNGE_DISTANCE = BALL_R * 82;
 const POOL_ROYALE_LOUNGE_CHAIR_OFFSET = BALL_R * 82;
+const POOL_ROYALE_SHARED_LOUNGE_CHAIR_Z = BALL_R * 26;
 // Soldier.glb already faces the billiards rig forward axis; keep the child model unflipped so
 // the visible player faces inward toward the table instead of showing their back in portrait play.
 const POOL_ROYALE_HUMAN_VISUAL_YAW_FIX = 0;
@@ -9026,7 +9027,7 @@ function Guret(parent, id, color, x, y, options = {}) {
   });
   const mesh = new THREE.Mesh(BALL_GEOMETRY, material);
   mesh.position.set(x, BALL_CENTER_Y, y);
-  mesh.castShadow = false;
+  mesh.castShadow = true;
   mesh.receiveShadow = true;
   const shadow =
     ENABLE_BALL_FLOOR_SHADOWS && BALL_SHADOW_GEOMETRY && BALL_SHADOW_MATERIAL
@@ -18142,15 +18143,16 @@ const shotPowerRef = useRef(0);
       } = rig;
 
       if (settings.keyColor && key) key.color.set(settings.keyColor);
-      if (settings.keyIntensity && key) key.intensity = settings.keyIntensity;
+      const hdriShadowLightScale = 0.32;
+      if (settings.keyIntensity && key) key.intensity = settings.keyIntensity * hdriShadowLightScale;
       if (settings.fillColor && fill) fill.color.set(settings.fillColor);
-      if (settings.fillIntensity && fill) fill.intensity = settings.fillIntensity;
+      if (settings.fillIntensity && fill) fill.intensity = settings.fillIntensity * hdriShadowLightScale;
       if (settings.washColor && wash) wash.color.set(settings.washColor);
-      if (settings.washIntensity && wash) wash.intensity = settings.washIntensity;
+      if (settings.washIntensity && wash) wash.intensity = settings.washIntensity * hdriShadowLightScale;
       if (settings.rimColor && rim) rim.color.set(settings.rimColor);
-      if (settings.rimIntensity && rim) rim.intensity = settings.rimIntensity;
+      if (settings.rimIntensity && rim) rim.intensity = settings.rimIntensity * hdriShadowLightScale;
       if (settings.ambientIntensity && ambient)
-        ambient.intensity = settings.ambientIntensity;
+        ambient.intensity = settings.ambientIntensity * hdriShadowLightScale;
     },
     [lightingId]
   );
@@ -20346,7 +20348,7 @@ const shotPowerRef = useRef(0);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       renderer.sortObjects = true;
-      renderer.shadowMap.enabled = false;
+      renderer.shadowMap.enabled = true;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       rendererRef.current = renderer;
       updateRendererAnisotropyCap(renderer);
@@ -25991,7 +25993,7 @@ const shotPowerRef = useRef(0);
 
       // Lights
       const addMobileLighting = () => {
-        const useHdriOnly = true;
+        const useHdriOnly = false;
         if (useHdriOnly) {
           lightingRigRef.current = null;
           return;
@@ -26018,12 +26020,12 @@ const shotPowerRef = useRef(0);
         const shadowDepth =
           lightRigHeight + Math.abs(targetY - floorY) + TABLE.THICK * 12;
 
-        const ambient = new THREE.AmbientLight(0xffffff, 0.3 * lightBrightnessTrim);
+        const ambient = new THREE.AmbientLight(0xffffff, 0.06 * lightBrightnessTrim);
         lightingRig.add(ambient);
 
         const key = new THREE.DirectionalLight(
           0xffffff,
-          1.68 * brightnessCompensation * lightBrightnessTrim
+          0.42 * brightnessCompensation * lightBrightnessTrim
         );
         key.position.set(lightLineX, lightRigHeight, lightPositionsZ[0]);
         key.target.position.set(0, targetY, 0);
@@ -26043,7 +26045,7 @@ const shotPowerRef = useRef(0);
 
         const fill = new THREE.DirectionalLight(
           0xffffff,
-          0.84 * brightnessCompensation * lightBrightnessTrim
+          0.08 * brightnessCompensation * lightBrightnessTrim
         );
         fill.position.set(-lightLineX, lightRigHeight * 1.01, lightPositionsZ[1]);
         fill.target.position.set(0, targetY, 0);
@@ -26052,7 +26054,7 @@ const shotPowerRef = useRef(0);
 
         const wash = new THREE.DirectionalLight(
           0xffffff,
-          0.76 * brightnessCompensation * lightBrightnessTrim
+          0.06 * brightnessCompensation * lightBrightnessTrim
         );
         wash.position.set(lightLineX, lightRigHeight * 1.02, lightPositionsZ[2]);
         wash.target.position.set(0, targetY, 0);
@@ -26061,12 +26063,24 @@ const shotPowerRef = useRef(0);
 
         const rim = new THREE.DirectionalLight(
           0xffffff,
-          0.68 * brightnessCompensation * lightBrightnessTrim
+          0.05 * brightnessCompensation * lightBrightnessTrim
         );
         rim.position.set(-lightLineX, lightRigHeight * 1.03, lightPositionsZ[3]);
         rim.target.position.set(0, targetY, 0);
         lightingRig.add(rim);
         lightingRig.add(rim.target);
+
+        const hdriFloorShadow = new THREE.Mesh(
+          new THREE.PlaneGeometry(shadowHalfSpan * 2.4, shadowHalfSpan * 2.4),
+          new THREE.ShadowMaterial({ color: 0x000000, opacity: 0.28, transparent: true })
+        );
+        hdriFloorShadow.name = 'PoolRoyale_HdriFloorShadowReceiver';
+        hdriFloorShadow.rotation.x = -Math.PI / 2;
+        hdriFloorShadow.position.y = floorY + MICRO_EPS;
+        hdriFloorShadow.receiveShadow = true;
+        hdriFloorShadow.castShadow = false;
+        hdriFloorShadow.renderOrder = -6;
+        lightingRig.add(hdriFloorShadow);
 
         lightingRigRef.current = {
           group: lightingRig,
@@ -26074,7 +26088,8 @@ const shotPowerRef = useRef(0);
           fill,
           wash,
           rim,
-          ambient
+          ambient,
+          hdriFloorShadow
         };
         applyLightingPreset();
       };
@@ -26843,7 +26858,7 @@ const shotPowerRef = useRef(0);
         return asset;
       };
 
-      const createFallbackPoolSideFurniture = (seat, sideSign, tableTopY) => {
+      const createFallbackPoolSideFurniture = (seat, sideSign, tableTopY, { includeTable = true, chairLocalZ = 0 } = {}) => {
         const group = new THREE.Group();
         const woodMat = new THREE.MeshStandardMaterial({ color: 0x5b351f, roughness: 0.62, metalness: 0.05 });
         const seatMat = new THREE.MeshStandardMaterial({ color: seat === 'A' ? 0x0f766e : 0x7c2d12, roughness: 0.55, metalness: 0.08 });
@@ -26852,15 +26867,16 @@ const shotPowerRef = useRef(0);
         const tablePedestal = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 2.45, BALL_R * 3.5, tableTopY, 32), woodMat);
         tablePedestal.position.set(0, tableTopY * 0.5, 0);
         const chairSeat = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 18.6, BALL_R * 2.05, BALL_R * 20.8), seatMat);
-        chairSeat.position.set(sideSign * BALL_R * 47.5, BALL_R * 4.4, 0);
+        chairSeat.position.set(sideSign * BALL_R * 47.5, BALL_R * 4.4, chairLocalZ);
         const chairBack = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 2.05, BALL_R * 15.8, BALL_R * 20.8), seatMat);
-        chairBack.position.set(sideSign * BALL_R * 57.0, BALL_R * 11.2, 0);
+        chairBack.position.set(sideSign * BALL_R * 57.0, BALL_R * 11.2, chairLocalZ);
         [tableTop, tablePedestal, chairSeat, chairBack].forEach((mesh) => {
           mesh.castShadow = true;
           mesh.receiveShadow = true;
-          group.add(mesh);
         });
-        group.userData.tableMeshes = [tableTop, tablePedestal];
+        if (includeTable) group.add(tableTop, tablePedestal);
+        group.add(chairSeat, chairBack);
+        group.userData.tableMeshes = includeTable ? [tableTop, tablePedestal] : [];
         group.userData.chairMeshes = [chairSeat, chairBack];
         return group;
       };
@@ -26868,18 +26884,23 @@ const shotPowerRef = useRef(0);
       const createPoolSideLounge = (seat, sideSign) => {
         const group = new THREE.Group();
         group.userData.seat = seat;
-        const x = sideSign * (TABLE.W / 2 + POOL_ROYALE_LOUNGE_DISTANCE);
-        const z = seat === 'A' ? -TABLE.H * 0.16 : TABLE.H * 0.16;
+        const sharedSideSign = 1;
+        const x = sharedSideSign * (TABLE.W / 2 + POOL_ROYALE_LOUNGE_DISTANCE);
+        const z = 0;
         group.position.set(x, floorY, z);
         group.rotation.y = 0;
 
         const tableTopY = POOL_ROYALE_LOUNGE_TABLE_HEIGHT;
-        const chairLocalX = sideSign * POOL_ROYALE_LOUNGE_CHAIR_OFFSET;
-        const fallbackFurniture = createFallbackPoolSideFurniture(seat, sideSign, tableTopY);
+        const chairLocalX = sharedSideSign * POOL_ROYALE_LOUNGE_CHAIR_OFFSET;
+        const chairLocalZ = seat === 'A' ? -POOL_ROYALE_SHARED_LOUNGE_CHAIR_Z : POOL_ROYALE_SHARED_LOUNGE_CHAIR_Z;
+        const showLoungeTable = seat === 'A';
+        const fallbackFurniture = createFallbackPoolSideFurniture(seat, sharedSideSign, tableTopY, {
+          includeTable: showLoungeTable,
+          chairLocalZ
+        });
         fallbackFurniture.name = `PoolRoyale_${seat}_VisibleLoungeFallback`;
         group.add(fallbackFurniture);
 
-        const showLoungeTable = true;
         fallbackFurniture.userData?.tableMeshes?.forEach((mesh) => {
           mesh.visible = showLoungeTable;
         });
@@ -26910,7 +26931,7 @@ const shotPowerRef = useRef(0);
           if (!chairModel) return;
           markHospitalityMaterials(chairModel);
           fitAssetToSpan(chairModel, POOL_ROYALE_LOUNGE_CHAIR_SPAN);
-          chairModel.position.set(chairLocalX, chairModel.position.y, 0);
+          chairModel.position.set(chairLocalX, chairModel.position.y, chairLocalZ);
           const toTable = new THREE.Vector2(-chairModel.position.x, -chairModel.position.z);
           chairModel.rotation.y = Math.atan2(toTable.x, toTable.y);
           group.add(chairModel);
@@ -26921,9 +26942,9 @@ const shotPowerRef = useRef(0);
 
         const serviceProps = showLoungeTable ? createWaterServiceProps(tableTopY) : null;
         if (serviceProps) group.add(serviceProps);
-        group.userData.chairRoot = new THREE.Vector3(x + chairLocalX, floorY, z);
-        group.userData.chairFacing = new THREE.Vector3(-sideSign, 0, 0).normalize();
-        group.userData.chairSeatWorld = new THREE.Vector3(x + chairLocalX, floorY, z);
+        group.userData.chairRoot = new THREE.Vector3(x + chairLocalX, floorY, z + chairLocalZ);
+        group.userData.chairFacing = new THREE.Vector3(-sharedSideSign, 0, 0).normalize();
+        group.userData.chairSeatWorld = new THREE.Vector3(x + chairLocalX, floorY, z + chairLocalZ);
         group.userData.glass = serviceProps?.userData?.glass || null;
         group.userData.glassBase = serviceProps?.userData?.glassBase?.clone?.() || new THREE.Vector3();
         return group;
@@ -27317,11 +27338,8 @@ const shotPowerRef = useRef(0);
               directRootTarget: walkingToChair
             });
             if (rig.heldCue) {
-              if (isHumanShooter) {
-                rig.heldCue.visible = false;
-              } else {
-                rig.heldCue.userData?.setFromBackTip?.(cueBack, cueTip);
-              }
+              rig.heldCue.visible = true;
+              rig.heldCue.userData?.setFromBackTip?.(cueBack, cueTip);
             }
             if (!isReplay && isHumanShooter && typeof setCueStickFromHumanCuePose === 'function') {
               setCueStickFromHumanCuePose(cueBack, cueTip);

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -727,7 +727,7 @@ function updateGoalRushWalkAnimation(human, dt, frame) {
   if (walk) {
     const ref = human.cfg?.perimeterWalkSpeed || human.cfg?.unit || 1;
     const normalizedSpeed = Math.max(0, Math.min(2, (human.lastMoveAmountRaw || 0) * 60 / Math.max(0.001, ref)));
-    walk.timeScale = THREE.MathUtils.clamp(normalizedSpeed || walkWeight, 0.7, 1.35);
+    walk.timeScale = THREE.MathUtils.clamp((normalizedSpeed || walkWeight) * 0.72, 0.48, 0.92);
   }
   human.mixer.update(dt);
   return walkWeight > 0.05 && frame.t < 0.025;
@@ -752,38 +752,83 @@ function driveHuman(human, frame) {
   const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
 
   if (frame.seated) {
-    // Murlan Royale seated baseline: hips fold down into the cushion, legs stay
-    // grounded in front of the chair and only light upper-body breathing remains.
+    // Match Murlan Royale seated framing: the body is lower in the cushion,
+    // arms rest naturally, and both legs fold down in front of the chair.
+    human.model.position.y = -0.09 * cfg.unit;
     if (b.hips) b.hips.rotation.x += THREE.MathUtils.degToRad(-9);
     if (b.spine) b.spine.rotation.x += THREE.MathUtils.degToRad(-3);
     if (b.chest) b.chest.rotation.x += THREE.MathUtils.degToRad(-2);
-    if (b.head) b.head.rotation.x += THREE.MathUtils.degToRad(3);
-    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += THREE.MathUtils.degToRad(-64);
-    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x += THREE.MathUtils.degToRad(-64);
-    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += THREE.MathUtils.degToRad(72);
-    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += THREE.MathUtils.degToRad(72);
-    if (b.leftUpperArm) b.leftUpperArm.rotation.x += THREE.MathUtils.degToRad(-42);
-    if (b.rightUpperArm) b.rightUpperArm.rotation.x += THREE.MathUtils.degToRad(-38);
-    if (b.leftLowerArm) b.leftLowerArm.rotation.x += THREE.MathUtils.degToRad(38);
-    if (b.rightLowerArm) b.rightLowerArm.rotation.x += THREE.MathUtils.degToRad(34);
+    if (b.head) b.head.rotation.x += THREE.MathUtils.degToRad(2);
+    if (b.leftUpperLeg) {
+      b.leftUpperLeg.rotation.x += THREE.MathUtils.degToRad(-90.5);
+      b.leftUpperLeg.rotation.y += THREE.MathUtils.degToRad(9.2);
+      b.leftUpperLeg.rotation.z += THREE.MathUtils.degToRad(2.9);
+    }
+    if (b.rightUpperLeg) {
+      b.rightUpperLeg.rotation.x += THREE.MathUtils.degToRad(-90.5);
+      b.rightUpperLeg.rotation.y += THREE.MathUtils.degToRad(1.7);
+      b.rightUpperLeg.rotation.z += THREE.MathUtils.degToRad(-1.1);
+    }
+    if (b.leftLowerLeg) {
+      b.leftLowerLeg.rotation.x += THREE.MathUtils.degToRad(-95.1);
+      b.leftLowerLeg.rotation.y += THREE.MathUtils.degToRad(1.1);
+      b.leftLowerLeg.rotation.z += THREE.MathUtils.degToRad(0.6);
+    }
+    if (b.rightLowerLeg) {
+      b.rightLowerLeg.rotation.x += THREE.MathUtils.degToRad(-95.1);
+      b.rightLowerLeg.rotation.y += THREE.MathUtils.degToRad(-1.1);
+      b.rightLowerLeg.rotation.z += THREE.MathUtils.degToRad(-0.6);
+    }
+    if (b.leftUpperArm) {
+      b.leftUpperArm.rotation.x += THREE.MathUtils.degToRad(-49);
+      b.leftUpperArm.rotation.y += THREE.MathUtils.degToRad(-7);
+      b.leftUpperArm.rotation.z += THREE.MathUtils.degToRad(-3);
+    }
+    if (b.rightUpperArm) {
+      b.rightUpperArm.rotation.x += THREE.MathUtils.degToRad(-53);
+      b.rightUpperArm.rotation.y += THREE.MathUtils.degToRad(7);
+      b.rightUpperArm.rotation.z += THREE.MathUtils.degToRad(3);
+    }
+    if (b.leftLowerArm) {
+      b.leftLowerArm.rotation.x += THREE.MathUtils.degToRad(49);
+      b.leftLowerArm.rotation.y += THREE.MathUtils.degToRad(-4);
+      b.leftLowerArm.rotation.z += THREE.MathUtils.degToRad(-3);
+    }
+    if (b.rightLowerArm) {
+      b.rightLowerArm.rotation.x += THREE.MathUtils.degToRad(53);
+      b.rightLowerArm.rotation.y += THREE.MathUtils.degToRad(4);
+      b.rightLowerArm.rotation.z += THREE.MathUtils.degToRad(3);
+    }
+    if (b.leftHand) {
+      b.leftHand.rotation.x += THREE.MathUtils.degToRad(16);
+      b.leftHand.rotation.y += THREE.MathUtils.degToRad(-5);
+      b.leftHand.rotation.z += THREE.MathUtils.degToRad(-3);
+    }
+    if (b.rightHand) {
+      b.rightHand.rotation.x += THREE.MathUtils.degToRad(18);
+      b.rightHand.rotation.y += THREE.MathUtils.degToRad(5);
+      b.rightHand.rotation.z += THREE.MathUtils.degToRad(3);
+    }
     human.modelRoot.updateMatrixWorld(true);
     poseFingers(human.leftFingers, 'idle', 1);
-    poseFingers(human.rightFingers, 'grip', 0.7);
+    poseFingers(human.rightFingers, 'grip', 0.9);
     return;
   }
+
+  human.model.position.y = 0;
 
   if (frame.walkAmount * idle > 0.001) {
     const s = Math.sin(human.walkT * 6.2);
     const c = Math.cos(human.walkT * 6.2);
     const w = frame.walkAmount * idle;
-    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
-    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
-    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
-    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
-    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
-    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
-    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
-    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.28 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.28 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.24 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.24 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.25 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.25 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.028 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.02 * w;
   }
 
   if (ik >= 0.025) {
@@ -886,7 +931,7 @@ export function updateHumanPose(human, dt, frameData) {
         return human.root.position.distanceTo(rootGoal);
       })()
     : moveRootAroundPerimeter(human, rootGoal, cfg, dt);
-  human.walkT += dt * (2 + Math.min(7, (moveAmountRaw * 10) / cfg.unit));
+  human.walkT += dt * (1.45 + Math.min(4.8, (moveAmountRaw * 7.2) / cfg.unit));
   const shootingPoseActive = activeState === 'dragging' || activeState === 'striking';
   const tableForward = resolveRootToTableForward(human.root.position, frameData);
   const facingForward = shootingPoseActive && tableForward


### PR DESCRIPTION
### Motivation
- Unify the Pool Royale lounge to a single Murlan-style table with two chairs so both human players visually share the same table and sit on their own chairs. 
- Match human seating/pose and motion to the Murlan Royale reference and make Soldier fallback rigs read and walk more naturally and slightly slower. 
- Replace the placeholder ball floor blobs with HDRI-driven lighting and real shadowing so balls, players and table receive natural shadows from the environment. 
- Slightly reduce spin scaling and increase shot power to produce stronger but more controlled cue-ball behavior.

### Description
- Consolidated lounge furniture and seating: created a shared lounge table and adjusted chair placement/roots so both players use the same table; added `POOL_ROYALE_SHARED_LOUNGE_CHAIR_Z` and related layout changes in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Human rig / seated pose and walk tuning: updated seated pose to match Murlan reference, adjusted bone rotations for legs/arms, increased right-finger grip weight for held-cue, and slowed/weighted walk animation timing and `Walk` timescale scaling in `webapp/src/pages/Games/shared/humanRigCore.js`. 
- Held-cue behavior: made each human rig keep its own visible held cue and continuously align it from back→tip (`setFromBackTip`) so players always display their cue stick (`PoolRoyale.jsx`). 
- Shadows / lighting: removed the fake ball floor shadow discs, enabled `renderer.shadowMap.enabled`, made balls cast shadows (`mesh.castShadow = true`), added an HDRI floor shadow receiver mesh and tuned lighting preset intensity scaling so HDRI remains dominant (`PoolRoyale.jsx`). 
- Physics/tuning: reduced global spin scale (`SPIN_GLOBAL_SCALE`), increased `SHOT_GLOBAL_POWER_SCALE` (so strikes feel slightly stronger), and reduced some walk profile speeds (human logic profile `rpm-current.walkSpeed`) in `PoolRoyale.jsx` and supporting constants. 
- Misc: adjusted mobile lighting rig intensities and exposed the HDri floor shadow receiver and lighting preset multiplier used when applying lighting settings (`PoolRoyale.jsx`). 

### Testing
- Ran `npm run build` (Vite production build) which completed successfully and produced `dist/` assets. 
- Ran `git diff --check` (no whitespace/merge errors) and committed the changes. 
- Attempted an automated UI render capture with Playwright after installing browser dependencies (`npx playwright install` / `npx playwright install-deps chromium`), but the headless Chromium screenshot of the full Pool Royale WebGL scene timed out in this environment despite installing deps (succeeded in installing browsers/deps but screenshot capture failed due to headless rendering/timeout issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019470aba483298f5b56d34b8283fb)