### PR TITLE
Pool Royale: shared lounge, natural HDRI shadows, human-rig & shot tuning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1848,7 +1848,7 @@ const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
 const RACK_VERTICAL_SCREEN_LIFT = BALL_R * 0.86; // nudge the rack farther upward on screen so object balls sit visibly higher
-const ENABLE_BALL_FLOOR_SHADOWS = true;
+const ENABLE_BALL_FLOOR_SHADOWS = false;
 const ENABLE_CUE_CLOTH_SHADOW = true;
 const ENABLE_TABLE_FLOOR_SHADOW = false;
 const BALL_SHADOW_RADIUS_MULTIPLIER = 1;
@@ -2245,7 +2245,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 2200;
 const POCKET_VIEW_EARLY_HOLD_MS = 320;
-const SPIN_GLOBAL_SCALE = 0.9; // match Snooker Royal spin controller scaling
+const SPIN_GLOBAL_SCALE = 0.82; // reduce Pool Royale cue spin slightly for a more natural roll
 const STRAIGHT_TOPSPIN_BONUS_SCALE = 1; // keep straight top spin matched to Snooker Royal without extra follow boost
 const STRAIGHT_TOPSPIN_SIDE_THRESHOLD = 0.08; // treat this as "mostly straight" topspin
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
@@ -2272,8 +2272,8 @@ const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
-const SHOT_POWER_BOOST = 1; // keep slider strength honest by removing the extra Pool Royale boost
-const SHOT_GLOBAL_POWER_SCALE = 0.72; // soften Pool Royale shot pace so ball travel matches the displayed slider power
+const SHOT_POWER_BOOST = 1.16; // add more cue drive while preserving slider feel
+const SHOT_GLOBAL_POWER_SCALE = 0.76; // keep Pool Royale stronger than before without over-speeding the table
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -9026,7 +9026,7 @@ function Guret(parent, id, color, x, y, options = {}) {
   });
   const mesh = new THREE.Mesh(BALL_GEOMETRY, material);
   mesh.position.set(x, BALL_CENTER_Y, y);
-  mesh.castShadow = false;
+  mesh.castShadow = true;
   mesh.receiveShadow = true;
   const shadow =
     ENABLE_BALL_FLOOR_SHADOWS && BALL_SHADOW_GEOMETRY && BALL_SHADOW_MATERIAL
@@ -18179,6 +18179,7 @@ const shotPowerRef = useRef(0);
   const envSkyboxTextureRef = useRef(null);
   const envSkyboxSettingsRef = useRef(null);
   const envSkyboxScaleRef = useRef(1);
+  const floorShadowCatcherRef = useRef(null);
   const environmentHdriRef = useRef(environmentHdriId);
   const activeEnvironmentVariantRef = useRef(activeEnvironmentHdri);
   const cameraRef = useRef(null);
@@ -20346,7 +20347,7 @@ const shotPowerRef = useRef(0);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       renderer.sortObjects = true;
-      renderer.shadowMap.enabled = false;
+      renderer.shadowMap.enabled = true;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       rendererRef.current = renderer;
       updateRendererAnisotropyCap(renderer);
@@ -20453,6 +20454,25 @@ const shotPowerRef = useRef(0);
             sceneInstance.backgroundIntensity = activeVariant.backgroundIntensity;
           }
         }
+        if (floorShadowCatcherRef.current) {
+          floorShadowCatcherRef.current.parent?.remove(floorShadowCatcherRef.current);
+          floorShadowCatcherRef.current.geometry?.dispose?.();
+          floorShadowCatcherRef.current.material?.dispose?.();
+          floorShadowCatcherRef.current = null;
+        }
+        const shadowCatcherSize = Math.max(skyboxRadius * 1.85, Math.max(roomWidth, roomDepth) * resolvedWorldScale * 1.35);
+        const shadowCatcher = new THREE.Mesh(
+          new THREE.PlaneGeometry(shadowCatcherSize, shadowCatcherSize),
+          new THREE.ShadowMaterial({ color: 0x000000, opacity: 0.28, transparent: true, depthWrite: false })
+        );
+        shadowCatcher.name = 'PoolRoyale_HdriFloorShadowCatcher';
+        shadowCatcher.rotation.x = -Math.PI / 2;
+        shadowCatcher.position.y = floorWorldY + MICRO_EPS * resolvedWorldScale;
+        shadowCatcher.receiveShadow = true;
+        shadowCatcher.castShadow = false;
+        shadowCatcher.renderOrder = -4;
+        sceneInstance.add(shadowCatcher);
+        floorShadowCatcherRef.current = shadowCatcher;
         if (
           'environmentIntensity' in sceneInstance &&
           typeof activeVariant?.environmentIntensity === 'number'
@@ -20478,6 +20498,12 @@ const shotPowerRef = useRef(0);
             }
             envSkyboxSettingsRef.current = null;
             envSkyboxScaleRef.current = 1;
+          }
+          if (floorShadowCatcherRef.current) {
+            floorShadowCatcherRef.current.parent?.remove(floorShadowCatcherRef.current);
+            floorShadowCatcherRef.current.geometry?.dispose?.();
+            floorShadowCatcherRef.current.material?.dispose?.();
+            floorShadowCatcherRef.current = null;
           }
           if (skyboxMap) {
             skyboxMap.dispose?.();
@@ -25993,7 +26019,25 @@ const shotPowerRef = useRef(0);
       const addMobileLighting = () => {
         const useHdriOnly = true;
         if (useHdriOnly) {
-          lightingRigRef.current = null;
+          const shadowRig = new THREE.Group();
+          world.add(shadowRig);
+          const hdriShadowKey = new THREE.DirectionalLight(0xffffff, 0.22);
+          hdriShadowKey.position.set(-roomWidth * 0.22, tableSurfaceY + TABLE.THICK * 9, roomDepth * 0.18);
+          hdriShadowKey.target.position.set(0, floorY, 0);
+          hdriShadowKey.castShadow = true;
+          const shadowSpan = Math.max(roomWidth, roomDepth) * 0.72 + TABLE.THICK * 4;
+          hdriShadowKey.shadow.mapSize.set(2048, 2048);
+          hdriShadowKey.shadow.camera.near = 0.1;
+          hdriShadowKey.shadow.camera.far = TABLE.THICK * 42;
+          hdriShadowKey.shadow.camera.left = -shadowSpan;
+          hdriShadowKey.shadow.camera.right = shadowSpan;
+          hdriShadowKey.shadow.camera.top = shadowSpan;
+          hdriShadowKey.shadow.camera.bottom = -shadowSpan;
+          hdriShadowKey.shadow.bias = -0.00005;
+          hdriShadowKey.shadow.normalBias = 0.0008;
+          hdriShadowKey.shadow.camera.updateProjectionMatrix();
+          shadowRig.add(hdriShadowKey, hdriShadowKey.target);
+          lightingRigRef.current = { group: shadowRig, key: hdriShadowKey };
           return;
         }
         const lightingRig = new THREE.Group();
@@ -26865,18 +26909,32 @@ const shotPowerRef = useRef(0);
         return group;
       };
 
-      const createPoolSideLounge = (seat, sideSign) => {
+      const createPoolSideLounge = (seat, sideSign, options = {}) => {
         const group = new THREE.Group();
-        group.userData.seat = seat;
+        const sharedSeatOffsets = options.sharedSeatOffsets || { [seat]: 0 };
+        const primarySeat = options.primarySeat || seat;
+        group.userData.seat = primarySeat;
         const x = sideSign * (TABLE.W / 2 + POOL_ROYALE_LOUNGE_DISTANCE);
-        const z = seat === 'A' ? -TABLE.H * 0.16 : TABLE.H * 0.16;
+        const z = options.z ?? 0;
         group.position.set(x, floorY, z);
         group.rotation.y = 0;
 
         const tableTopY = POOL_ROYALE_LOUNGE_TABLE_HEIGHT;
         const chairLocalX = sideSign * POOL_ROYALE_LOUNGE_CHAIR_OFFSET;
-        const fallbackFurniture = createFallbackPoolSideFurniture(seat, sideSign, tableTopY);
-        fallbackFurniture.name = `PoolRoyale_${seat}_VisibleLoungeFallback`;
+        const fallbackFurniture = createFallbackPoolSideFurniture(primarySeat, sideSign, tableTopY);
+        fallbackFurniture.name = `PoolRoyale_${primarySeat}_VisibleSharedLoungeFallback`;
+        const fallbackChairMeshes = fallbackFurniture.userData?.chairMeshes || [];
+        const fallbackSeatEntries = Object.entries(sharedSeatOffsets);
+        fallbackSeatEntries.forEach(([seatKey, localZ], index) => {
+          const meshes = index === 0
+            ? fallbackChairMeshes
+            : fallbackChairMeshes.map((mesh) => mesh.clone());
+          meshes.forEach((mesh) => {
+            mesh.name = `PoolRoyale_${seatKey}_SharedFallbackChair`;
+            mesh.position.z = localZ;
+            if (index > 0) fallbackFurniture.add(mesh);
+          });
+        });
         group.add(fallbackFurniture);
 
         const showLoungeTable = true;
@@ -26885,7 +26943,7 @@ const shotPowerRef = useRef(0);
         });
         if (showLoungeTable) {
           const murlanDefaultTable = new THREE.Group();
-          murlanDefaultTable.name = `PoolRoyale_${seat}_MurlanDefaultOctagonTable`;
+          murlanDefaultTable.name = `PoolRoyale_${primarySeat}_MurlanDefaultOctagonTable`;
           try {
             createMurlanStyleTable({
               THREE,
@@ -26910,10 +26968,14 @@ const shotPowerRef = useRef(0);
           if (!chairModel) return;
           markHospitalityMaterials(chairModel);
           fitAssetToSpan(chairModel, POOL_ROYALE_LOUNGE_CHAIR_SPAN);
-          chairModel.position.set(chairLocalX, chairModel.position.y, 0);
-          const toTable = new THREE.Vector2(-chairModel.position.x, -chairModel.position.z);
-          chairModel.rotation.y = Math.atan2(toTable.x, toTable.y);
-          group.add(chairModel);
+          Object.entries(sharedSeatOffsets).forEach(([seatKey, localZ], index) => {
+            const seatChair = index === 0 ? chairModel : chairModel.clone(true);
+            seatChair.name = `PoolRoyale_${seatKey}_SharedLoungeChair`;
+            seatChair.position.set(chairLocalX, chairModel.position.y, localZ);
+            const toTable = new THREE.Vector2(-seatChair.position.x, -seatChair.position.z);
+            seatChair.rotation.y = Math.atan2(toTable.x, toTable.y);
+            group.add(seatChair);
+          });
           fallbackFurniture.visible = false;
         }).catch((error) => {
           console.warn('Failed to upgrade Pool Royale lounge chair GLTF asset', error);
@@ -26921,9 +26983,19 @@ const shotPowerRef = useRef(0);
 
         const serviceProps = showLoungeTable ? createWaterServiceProps(tableTopY) : null;
         if (serviceProps) group.add(serviceProps);
-        group.userData.chairRoot = new THREE.Vector3(x + chairLocalX, floorY, z);
-        group.userData.chairFacing = new THREE.Vector3(-sideSign, 0, 0).normalize();
-        group.userData.chairSeatWorld = new THREE.Vector3(x + chairLocalX, floorY, z);
+        group.userData.sharedSeatChairs = Object.fromEntries(
+          Object.entries(sharedSeatOffsets).map(([seatKey, localZ]) => [
+            seatKey,
+            {
+              chairRoot: new THREE.Vector3(x + chairLocalX, floorY, z + localZ),
+              chairFacing: new THREE.Vector3(-sideSign, 0, 0).normalize(),
+              chairSeatWorld: new THREE.Vector3(x + chairLocalX, floorY, z + localZ)
+            }
+          ])
+        );
+        group.userData.chairRoot = group.userData.sharedSeatChairs[primarySeat]?.chairRoot?.clone?.() || new THREE.Vector3(x + chairLocalX, floorY, z);
+        group.userData.chairFacing = group.userData.sharedSeatChairs[primarySeat]?.chairFacing?.clone?.() || new THREE.Vector3(-sideSign, 0, 0).normalize();
+        group.userData.chairSeatWorld = group.userData.sharedSeatChairs[primarySeat]?.chairSeatWorld?.clone?.() || new THREE.Vector3(x + chairLocalX, floorY, z);
         group.userData.glass = serviceProps?.userData?.glass || null;
         group.userData.glassBase = serviceProps?.userData?.glassBase?.clone?.() || new THREE.Vector3();
         return group;
@@ -27012,15 +27084,20 @@ const shotPowerRef = useRef(0);
         };
         const playerA = activeHumanCharacterRef.current || POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
         const playerB = POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
-        const loungeA = createPoolSideLounge('A', -1);
-        const loungeB = createPoolSideLounge('B', 1);
-        world.add(loungeA);
-        world.add(loungeB);
+        const sharedLounge = createPoolSideLounge('A', -1, {
+          primarySeat: 'A',
+          z: 0,
+          sharedSeatOffsets: {
+            A: -TABLE.H * 0.18,
+            B: TABLE.H * 0.18
+          }
+        });
+        world.add(sharedLounge);
         playerCharacterRigsRef.current = [
           makeRig('A', -sideOffset, -zOffset, 0, playerA),
           makeRig('B', sideOffset, zOffset, Math.PI, playerB),
-          { group: loungeA, lounge: true, seat: 'A' },
-          { group: loungeB, lounge: true, seat: 'B' }
+          { group: sharedLounge, lounge: true, seat: 'A' },
+          { group: sharedLounge, lounge: true, seat: 'B' }
         ];
       };
       spawnPlayerCharactersRef.current = spawnPlayerCharacters;
@@ -27210,10 +27287,11 @@ const shotPowerRef = useRef(0);
             let chairFacing = null;
             if (shouldRestAtChair) {
               const lounge = loungeBySeat.get(seat);
-              const chairRoot = lounge?.userData?.chairRoot;
+              const seatChair = lounge?.userData?.sharedSeatChairs?.[seat] || lounge?.userData || null;
+              const chairRoot = seatChair?.chairRoot;
               if (chairRoot) {
                 walkRoot.copy(chairRoot);
-                chairFacing = lounge?.userData?.chairFacing?.clone?.() ?? new THREE.Vector3(-chairRoot.x, 0, -chairRoot.z).normalize();
+                chairFacing = seatChair?.chairFacing?.clone?.() ?? new THREE.Vector3(-chairRoot.x, 0, -chairRoot.z).normalize();
                 walkingToChair = true;
                 seatedAtChair = (human.root?.position?.distanceTo?.(chairRoot) ?? Infinity) <= BALL_R * 5.5;
               }
@@ -27317,11 +27395,7 @@ const shotPowerRef = useRef(0);
               directRootTarget: walkingToChair
             });
             if (rig.heldCue) {
-              if (isHumanShooter) {
-                rig.heldCue.visible = false;
-              } else {
-                rig.heldCue.userData?.setFromBackTip?.(cueBack, cueTip);
-              }
+              rig.heldCue.userData?.setFromBackTip?.(cueBack, cueTip);
             }
             if (!isReplay && isHumanShooter && typeof setCueStickFromHumanCuePose === 'function') {
               setCueStickFromHumanCuePose(cueBack, cueTip);
@@ -35858,6 +35932,12 @@ const shotPowerRef = useRef(0);
         disposeEnvironmentRef.current = null;
         envTextureRef.current = null;
         envSkyboxRef.current = null;
+        if (floorShadowCatcherRef.current) {
+          floorShadowCatcherRef.current.parent?.remove(floorShadowCatcherRef.current);
+          floorShadowCatcherRef.current.geometry?.dispose?.();
+          floorShadowCatcherRef.current.material?.dispose?.();
+          floorShadowCatcherRef.current = null;
+        }
         envSkyboxTextureRef.current = null;
         cueGalleryStateRef.current.active = false;
         cueGalleryStateRef.current.rackId = null;

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -727,7 +727,8 @@ function updateGoalRushWalkAnimation(human, dt, frame) {
   if (walk) {
     const ref = human.cfg?.perimeterWalkSpeed || human.cfg?.unit || 1;
     const normalizedSpeed = Math.max(0, Math.min(2, (human.lastMoveAmountRaw || 0) * 60 / Math.max(0.001, ref)));
-    walk.timeScale = THREE.MathUtils.clamp(normalizedSpeed || walkWeight, 0.7, 1.35);
+    // Match the slower Soldier-style cadence: less skating, fuller leg/body motion.
+    walk.timeScale = THREE.MathUtils.clamp((normalizedSpeed || walkWeight) * 0.72, 0.48, 0.95);
   }
   human.mixer.update(dt);
   return walkWeight > 0.05 && frame.t < 0.025;
@@ -758,10 +759,10 @@ function driveHuman(human, frame) {
     if (b.spine) b.spine.rotation.x += THREE.MathUtils.degToRad(-3);
     if (b.chest) b.chest.rotation.x += THREE.MathUtils.degToRad(-2);
     if (b.head) b.head.rotation.x += THREE.MathUtils.degToRad(3);
-    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += THREE.MathUtils.degToRad(-64);
-    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x += THREE.MathUtils.degToRad(-64);
-    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += THREE.MathUtils.degToRad(72);
-    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += THREE.MathUtils.degToRad(72);
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += THREE.MathUtils.degToRad(-90.5);
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x += THREE.MathUtils.degToRad(-90.5);
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += THREE.MathUtils.degToRad(-95.1);
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += THREE.MathUtils.degToRad(-95.1);
     if (b.leftUpperArm) b.leftUpperArm.rotation.x += THREE.MathUtils.degToRad(-42);
     if (b.rightUpperArm) b.rightUpperArm.rotation.x += THREE.MathUtils.degToRad(-38);
     if (b.leftLowerArm) b.leftLowerArm.rotation.x += THREE.MathUtils.degToRad(38);
@@ -773,17 +774,24 @@ function driveHuman(human, frame) {
   }
 
   if (frame.walkAmount * idle > 0.001) {
-    const s = Math.sin(human.walkT * 6.2);
-    const c = Math.cos(human.walkT * 6.2);
+    const s = Math.sin(human.walkT * 5.15);
+    const c = Math.cos(human.walkT * 5.15);
     const w = frame.walkAmount * idle;
-    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
-    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
-    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
-    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
-    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
-    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
-    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
-    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+    const liftL = Math.max(0, s);
+    const liftR = Math.max(0, -s);
+    // Soldier-matching walk cycle: opposite legs/arms, visible knee flex, and a
+    // small hip/chest counter-sway so the body no longer slides stiffly.
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.34 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.34 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += liftR * 0.34 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += liftL * 0.34 * w;
+    if (b.leftFoot) b.leftFoot.rotation.x += liftR * 0.16 * w;
+    if (b.rightFoot) b.rightFoot.rotation.x += liftL * 0.16 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.3 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.3 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.035 * w;
+    if (b.chest) b.chest.rotation.z -= c * 0.022 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.03 * w;
   }
 
   if (ik >= 0.025) {
@@ -886,7 +894,7 @@ export function updateHumanPose(human, dt, frameData) {
         return human.root.position.distanceTo(rootGoal);
       })()
     : moveRootAroundPerimeter(human, rootGoal, cfg, dt);
-  human.walkT += dt * (2 + Math.min(7, (moveAmountRaw * 10) / cfg.unit));
+  human.walkT += dt * (1.45 + Math.min(5.2, (moveAmountRaw * 8.2) / cfg.unit));
   const shootingPoseActive = activeState === 'dragging' || activeState === 'striking';
   const tableForward = resolveRootToTableForward(human.root.position, frameData);
   const facingForward = shootingPoseActive && tableForward


### PR DESCRIPTION
### Motivation
- Consolidate duplicate side lounge furniture so both players share one Murlan-style table with two chairs while keeping the Showood gameplay table intact. 
- Replace the artificial ball blob shadows with ground/HDRI-driven shadows and a shadow catcher so balls, table and characters receive natural lighting from the loaded HDRI. 
- Align human seating, facing and walk/strike animation to the Murlan/Soldier references and soften shot spin while slightly increasing perceived cue power for a more natural gameplay feel.

### Description
- Reworked the lounge builders: `createPoolSideLounge` now accepts `sharedSeatOffsets` and builds a single shared Murlan-style side table with per-seat chairs and per-seat `chairRoot`/`chairFacing` data so each human walks to and sits at their own chair while sharing one table. (changes in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Restored renderer shadow support and removed the artificial ball floor blob in favor of real scene shadows by enabling `renderer.shadowMap`, adding a HDRI-aligned directional shadow key for HDRI-only lighting, and creating a floor shadow catcher mesh named `PoolRoyale_HdriFloorShadowCatcher`; ball meshes now `castShadow = true` and the previous ball shadow blob path was removed. (changes in `PoolRoyale.jsx`.)
- Shot tuning: reduced global spin mapping via `SPIN_GLOBAL_SCALE` and adjusted the shot power scaling to increase felt drive while keeping slider balance by tweaking `SHOT_POWER_BOOST` and `SHOT_GLOBAL_POWER_SCALE`. (constants in `PoolRoyale.jsx`.)
- Human rig changes: updated seated leg rotations to Murlan-style and modified walk timing, amplitude and `Walk` animation time-scale to match the Soldier cadence (slower, fuller leg/knee motion); also simplified held-cue handling so each human rig’s `heldCue` is positioned from the computed back/tip pose (no hiding active shooter cue). (changes in `webapp/src/pages/Games/shared/humanRigCore.js` and usage in `PoolRoyale.jsx`).

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully. 
- Ran quick repository checks (`git diff --check`) and inspected the modified files for syntax issues; checks passed. 
- Launched the dev server (`npm --prefix webapp run dev`) and attempted a Playwright screenshot after installing browser dependencies, but the headless capture did not complete because external model/HDRI network requests and some environment-specific resource loads failed in the headless environment (no usable screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ae4a44148329ad796fc41a81c3c3)