### PR TITLE
Improve Pool Royale human orientation & positioning; add debug vectors and shot-context poses

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26613,6 +26613,9 @@ const shotPowerRef = useRef(0);
           if (rig?.heldCue?.parent) {
             rig.heldCue.parent.remove(rig.heldCue);
           }
+          if (rig?.debugVectors?.parent) {
+            rig.debugVectors.parent.remove(rig.debugVectors);
+          }
         });
         playerCharacterRigsRef.current = [];
       };
@@ -26816,6 +26819,131 @@ const shotPowerRef = useRef(0);
       };
 
       let setCueStickFromHumanCuePose = null;
+
+      const shouldShowHumanDebugVectors = () => {
+        try {
+          const params = new URLSearchParams(window.location.search || '');
+          return params.get('debugHuman') === '1' || window.localStorage?.getItem('poolRoyaleHumanDebugVectors') === '1';
+        } catch (_) {
+          return false;
+        }
+      };
+
+      const createHumanDebugVectorGroup = () => {
+        const group = new THREE.Group();
+        group.name = 'PoolRoyaleHumanDebugVectors';
+        const makeArrow = (name, color) => {
+          const arrow = new THREE.ArrowHelper(new THREE.Vector3(0, 0, -1), new THREE.Vector3(), 1, color, 0.18, 0.09);
+          arrow.name = name;
+          arrow.visible = false;
+          group.add(arrow);
+          return arrow;
+        };
+        group.userData.arrows = {
+          tableCenter: makeArrow('table-center-direction', 0xffd400),
+          shot: makeArrow('shot-direction', 0x40e0ff),
+          characterForward: makeArrow('character-forward-direction', 0x66ff66),
+          cue: makeArrow('cue-direction', 0xff66cc)
+        };
+        group.visible = false;
+        return group;
+      };
+
+      const updateHumanDebugVectors = (rig, { root, cueWorld, aimForward, cueBack, cueTip, tableCenter }) => {
+        if (!rig) return;
+        if (!rig.debugVectors) {
+          rig.debugVectors = createHumanDebugVectorGroup();
+          world.add(rig.debugVectors);
+        }
+        const visible = shouldShowHumanDebugVectors();
+        rig.debugVectors.visible = visible;
+        if (!visible || !root || !cueWorld || !aimForward || !cueBack || !cueTip) return;
+        const arrows = rig.debugVectors.userData.arrows || {};
+        const placeArrow = (arrow, origin, dir, length) => {
+          if (!arrow || !origin || !dir || dir.lengthSq() < 1e-8) return;
+          const flatDir = dir.clone();
+          flatDir.y = Math.abs(dir.y) > 0.001 ? dir.y : 0.02;
+          arrow.position.copy(origin);
+          arrow.setDirection(flatDir.normalize());
+          arrow.setLength(length, 0.18, 0.09);
+          arrow.visible = true;
+        };
+        const rootPos = root.clone().setY(TABLE_Y + TABLE.THICK + BALL_R * 2.4);
+        const tableDir = (tableCenter || new THREE.Vector3()).clone().sub(root).setY(0);
+        const characterForward = cueWorld.clone().sub(root).setY(0);
+        const cueDir = cueTip.clone().sub(cueBack);
+        placeArrow(arrows.tableCenter, rootPos, tableDir, 0.72);
+        placeArrow(arrows.shot, cueWorld.clone().setY(rootPos.y + 0.06), aimForward.clone().setY(0), 0.82);
+        placeArrow(arrows.characterForward, rootPos.clone().add(new THREE.Vector3(0, 0.08, 0)), characterForward, 0.66);
+        placeArrow(arrows.cue, cueBack.clone().setY(rootPos.y + 0.12), cueDir, 0.9);
+      };
+
+      const resolvePoolPlayerShotContext = ({ cueWorld, aimForward, root, activePower = 0, state = 'idle' }) => {
+        const railGapX = PLAY_W / 2 - Math.abs(cueWorld.x);
+        const railGapZ = PLAY_H / 2 - Math.abs(cueWorld.z);
+        const railGap = Math.min(railGapX, railGapZ);
+        const rootReach = root ? root.distanceTo(cueWorld) : 0;
+        const anglePressure = Math.abs(aimForward.x * aimForward.z);
+        const railShot = railGap < BALL_R * 5.5;
+        const longReach = rootReach > POOL_ROYALE_HUMAN_UNIT_SCALE * 1.62;
+        const closeCueBall = railGap < BALL_R * 3.2 || activePower < 0.16;
+        const powerShot = activePower > 0.72;
+        const softPrecision = activePower > 0 && activePower < 0.28 && !railShot;
+        const difficultAngle = anglePressure > 0.42;
+        let type = 'standard';
+        if (powerShot) type = 'power';
+        else if (railShot) type = 'rail';
+        else if (longReach) type = 'longReach';
+        else if (closeCueBall) type = 'closeCueBall';
+        else if (softPrecision) type = 'softPrecision';
+        else if (difficultAngle) type = 'difficultAngle';
+        return { type, railShot, longReach, closeCueBall, powerShot, softPrecision, difficultAngle, active: state !== 'idle' };
+      };
+
+      const applyPoolPlayerShotContext = (behavior, context) => {
+        const next = { ...behavior };
+        switch (context?.type) {
+          case 'rail':
+            next.bridgeBack = Math.max(0.048, (behavior.bridgeBack ?? 0.08) * 0.76);
+            next.bridgeLift = Math.max(behavior.bridgeLift ?? 0.006, 0.014);
+            next.desiredShootDistance = Math.max(1.16, (behavior.desiredShootDistance ?? 1.4) * 0.9);
+            next.strokePull = Math.min(0.38, (behavior.strokePull ?? 0.42) * 0.82);
+            next.rightElbowRise = (behavior.rightElbowRise ?? 0.22) + 0.08;
+            break;
+          case 'longReach':
+            next.bridgeBack = (behavior.bridgeBack ?? 0.08) * 1.22;
+            next.desiredShootDistance = (behavior.desiredShootDistance ?? 1.4) * 1.08;
+            next.stanceWidth = (behavior.stanceWidth ?? 0.56) * 1.1;
+            next.shootForwardBendScale = Math.min(1, (behavior.shootForwardBendScale ?? 0.7) * 1.18);
+            break;
+          case 'closeCueBall':
+            next.bridgeBack = Math.max(0.045, (behavior.bridgeBack ?? 0.08) * 0.7);
+            next.strokePull = Math.min(0.3, (behavior.strokePull ?? 0.42) * 0.68);
+            next.strokePush = Math.min(0.12, (behavior.strokePush ?? 0.16) * 0.72);
+            next.desiredShootDistance = Math.max(1.08, (behavior.desiredShootDistance ?? 1.4) * 0.84);
+            break;
+          case 'power':
+            next.strokePull = Math.max(0.56, (behavior.strokePull ?? 0.42) * 1.28);
+            next.strokePush = Math.max(0.26, (behavior.strokePush ?? 0.18) * 1.35);
+            next.stanceWidth = (behavior.stanceWidth ?? 0.56) * 1.14;
+            next.rightElbowBack = (behavior.rightElbowBack ?? -0.8) * 1.08;
+            break;
+          case 'softPrecision':
+            next.strokePull = Math.min(0.28, (behavior.strokePull ?? 0.42) * 0.58);
+            next.strokePush = Math.min(0.1, (behavior.strokePush ?? 0.16) * 0.62);
+            next.practiceStroke = Math.min(0.014, (behavior.practiceStroke ?? 0.03) * 0.55);
+            next.rightElbowRise = (behavior.rightElbowRise ?? 0.22) * 0.82;
+            break;
+          case 'difficultAngle':
+            next.bridgeSide = (behavior.bridgeSide ?? -0.024) * 1.45;
+            next.stanceWidth = (behavior.stanceWidth ?? 0.56) * 1.08;
+            next.shootUpperBodyCounterLean = Math.min(0.95, (behavior.shootUpperBodyCounterLean ?? 0.55) * 1.18);
+            break;
+          default:
+            break;
+        }
+        return next;
+      };
 
       const createHumanHeldCueMesh = () => {
         const group = new THREE.Group();
@@ -27067,9 +27195,23 @@ const shotPowerRef = useRef(0);
           if (anim) anim.mode = mode;
 
           if (human) {
-            const behavior = human.userData?.poolRoyaleLogic || activeHumanCharacterRef.current?.logic || POOL_ROYALE_HUMAN_LOGIC_PROFILES['rpm-current'];
+            const baseBehavior = human.userData?.poolRoyaleLogic || activeHumanCharacterRef.current?.logic || POOL_ROYALE_HUMAN_LOGIC_PROFILES['rpm-current'];
             const aimForward = new THREE.Vector3(normalizedAim.x, 0, normalizedAim.y).normalize();
             const side = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+            turnFlow.seatedBySeat = { ...(turnFlow.seatedBySeat || {}), [seat]: true };
+            characterTurnFlowRef.current = turnFlow;
+            const state = mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
+            const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
+            const strikingPower = Math.max(0, Math.min(1, shotPowerRef.current ?? draggingPower));
+            const activePower = state === 'dragging' ? draggingPower : strikingPower;
+            const shotContextPreview = resolvePoolPlayerShotContext({
+              cueWorld,
+              aimForward,
+              root: human.root?.position,
+              activePower,
+              state
+            });
+            const behavior = applyPoolPlayerShotContext(baseBehavior, shotContextPreview);
             const desiredRoot = chooseBilardoHumanEdgePosition(cueWorld, aimForward, {
               tableW: TABLE.W,
               tableL: TABLE.H,
@@ -27094,12 +27236,6 @@ const shotPowerRef = useRef(0);
               1
             );
             const walkRoot = perimeterTToPoint(human.walkPerimeterT);
-            turnFlow.seatedBySeat = { ...(turnFlow.seatedBySeat || {}), [seat]: true };
-            characterTurnFlowRef.current = turnFlow;
-            const state = mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
-            const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
-            const strikingPower = Math.max(0, Math.min(1, shotPowerRef.current ?? draggingPower));
-            const activePower = state === 'dragging' ? draggingPower : strikingPower;
             const humanUnitScale = POOL_ROYALE_HUMAN_UNIT_SCALE;
             const pull = (behavior.strokePull ?? 0.42) * humanUnitScale * (1 - Math.pow(1 - activePower, 3));
             const practiceStroke =
@@ -27116,8 +27252,8 @@ const shotPowerRef = useRef(0);
                 1 - Math.pow(1 - strikeNorm, 3)
               );
             }
-            const bridgeBackFromBall = human?.cfg?.bridgeHandBackFromBall ?? (behavior.bridgeBack ?? 0.072) * humanUnitScale;
-            const bridgeSideOffset = human?.cfg?.bridgeHandSide ?? (behavior.bridgeSide ?? -0.024) * humanUnitScale;
+            const bridgeBackFromBall = (behavior.bridgeBack ?? 0.072) * humanUnitScale;
+            const bridgeSideOffset = (behavior.bridgeSide ?? -0.024) * humanUnitScale;
             const bridgeTarget = cueWorld
               .clone()
               // Put the left bridge hand on the cloth right beside the cue ball, like a real pool stance.
@@ -27188,7 +27324,16 @@ const shotPowerRef = useRef(0);
               cueBack,
               cueTip,
               power: activePower,
+              shotContext: shotContextPreview,
               directRootTarget: false
+            });
+            updateHumanDebugVectors(rig, {
+              root: walkRoot,
+              cueWorld,
+              aimForward: poseForward,
+              cueBack,
+              cueTip,
+              tableCenter: new THREE.Vector3(0, TABLE_Y + TABLE.THICK, 0)
             });
             if (rig.heldCue) {
               rig.heldCue.userData?.setFromBackTip?.(cueBack, cueTip);

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -324,7 +324,9 @@ function ensureHumanFacingTable(human, frameData, cfg) {
   const visualYaw = human.yaw + (cfg.humanVisualYawFix || 0);
   const liveForward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, visualYaw).normalize();
   if (liveForward.dot(rootToTable) < -0.05) {
-    human.yaw = yawFromForward(rootToTable) - (cfg.humanVisualYawFix || 0);
+    const targetYaw = yawFromForward(rootToTable) - (cfg.humanVisualYawFix || 0);
+    const delta = THREE.MathUtils.euclideanModulo(targetYaw - human.yaw + Math.PI, Math.PI * 2) - Math.PI;
+    human.yaw += delta * 0.18;
   }
 }
 
@@ -958,13 +960,11 @@ export function updateHumanPose(human, dt, frameData) {
   const facingForward = shootingPoseActive && tableForward
     ? tableForward
     : resolveTableFacingForward(frameData.aimForward, rootGoal, frameData, cfg);
-  // When the low cue camera/shot pose is active, lock yaw directly toward the
-  // cue-ball/table reference. Damped yaw could leave the upper body bending toward
-  // the previous direction for a few frames, which made the pose look backwards.
+  // Always rotate through damped interpolation.  The pose still corrects toward
+  // the cue-ball/table quickly, but never snaps or spins instantly when the aim
+  // line crosses to another rail.
   const targetRootYaw = yawFromForward(facingForward) - (cfg.humanVisualYawFix || 0);
-  human.yaw = shootingPoseActive
-    ? targetRootYaw
-    : dampScalar(human.yaw, targetRootYaw, cfg.rotLambda, dt);
+  human.yaw = dampScalar(human.yaw, targetRootYaw, shootingPoseActive ? cfg.rotLambda * 1.6 : cfg.rotLambda, dt);
   ensureHumanFacingTable(human, frameData, cfg);
 
   const t = easeInOut(human.poseT);
@@ -993,28 +993,50 @@ export function updateHumanPose(human, dt, frameData) {
   const shotCounterLeanX = (value) => value * counterLeanSide * upperBodyCounterLean;
   const rootWorld = human.root.position.clone();
   rootWorld.y = cfg.groundY;
+  const shotContext = frameData.shotContext || {};
+  const shotType = shotContext.type || 'standard';
+  const longReachPose = shotType === 'longReach' ? 1 : 0;
+  const railPose = shotType === 'rail' ? 1 : 0;
+  const compactPose = shotType === 'closeCueBall' ? 1 : 0;
+  const powerPose = shotType === 'power' ? 1 : 0;
+  const softPose = shotType === 'softPrecision' ? 1 : 0;
+  const difficultPose = shotType === 'difficultAngle' ? 1 : 0;
+  const reachLeanBoost = 1 + longReachPose * 0.16 + powerPose * 0.06 - compactPose * 0.12 - railPose * 0.08;
+  const stanceWidthBoost = 1 + powerPose * 0.16 + longReachPose * 0.1 + difficultPose * 0.08 - compactPose * 0.08;
+  const rearFootBackBoost = 1 + longReachPose * 0.22 + powerPose * 0.16 - compactPose * 0.18;
+  const frontFootForwardBoost = 1 + longReachPose * 0.14 + difficultPose * 0.08 - railPose * 0.08;
+  const bridgeHeightBoost = railPose * 0.05 * cfg.unit;
+  const gripCompactness = compactPose * 0.16 * cfg.unit + softPose * 0.08 * cfg.unit;
+  const shoulderSideAdjust = difficultPose * 0.045;
+  human.poolPlayerState = activeState === 'idle'
+    ? (moveAmountRaw > cfg.unit * 0.04 ? 'WalkToShotPosition' : 'IdleWaiting')
+    : activeState === 'dragging'
+      ? (human.settleT > 0.72 ? 'AimAdjust' : 'AlignCue')
+      : activeState === 'striking'
+        ? (human.strikeClock < cfg.strikeTime * 0.38 ? 'CuePullBack' : human.strikeClock < cfg.strikeTime ? 'CueStrike' : 'FollowThrough')
+        : 'WatchBalls';
 
   // Real pool stance: feet/hips stay grounded and carry the weight; the fold is
   // from the belly upward, lowering the head toward the cue line without pushing
   // the entire body backward or off the floor.
-  const torso = local(new THREE.Vector3(shotCounterLeanX(0.012 * t) * cfg.unit, lerp(1.3, 1.16, t) * cfg.unit + breath, shotBendZ(lerp(0.01, -0.12, t) - 0.008 * powerLean) * cfg.unit));
-  const chest = local(new THREE.Vector3(shotCounterLeanX(0.038 * t + 0.006 * powerLean) * cfg.unit, lerp(1.52, 1.25, t) * cfg.unit + breath, shotBendZ(lerp(0.015, -0.36, t) - 0.014 * powerLean) * cfg.unit));
-  const neck = local(new THREE.Vector3(shotCounterLeanX(0.055 * t + 0.008 * powerLean) * cfg.unit, lerp(1.68, 1.32, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.52, t) - 0.016 * powerLean) * cfg.unit));
-  const head = local(new THREE.Vector3(shotCounterLeanX(0.066 * t + 0.01 * powerLean) * cfg.unit, lerp(1.84, 1.39, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.42 * t, shotBendZ(lerp(0.03, -0.62, t) - 0.018 * powerLean) * cfg.unit));
-  const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.048 * t)) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.43, t) - 0.012 * human.settleT) * cfg.unit));
-  const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.034 * t)) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.36, t) - 0.012 * human.settleT) * cfg.unit));
+  const torso = local(new THREE.Vector3(shotCounterLeanX(0.012 * t) * cfg.unit, lerp(1.3, 1.16, t) * cfg.unit + breath, shotBendZ((lerp(0.01, -0.12, t) - 0.008 * powerLean) * reachLeanBoost) * cfg.unit));
+  const chest = local(new THREE.Vector3(shotCounterLeanX(0.038 * t + 0.006 * powerLean) * cfg.unit, lerp(1.52, 1.25, t) * cfg.unit + breath, shotBendZ((lerp(0.015, -0.36, t) - 0.014 * powerLean) * reachLeanBoost) * cfg.unit));
+  const neck = local(new THREE.Vector3(shotCounterLeanX(0.055 * t + 0.008 * powerLean) * cfg.unit, lerp(1.68, 1.32, t) * cfg.unit + breath, shotBendZ((lerp(0.02, -0.52, t) - 0.016 * powerLean) * reachLeanBoost) * cfg.unit));
+  const head = local(new THREE.Vector3(shotCounterLeanX(0.066 * t + 0.01 * powerLean) * cfg.unit, lerp(1.84, 1.39, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.42 * t, shotBendZ((lerp(0.03, -0.62, t) - 0.018 * powerLean) * reachLeanBoost) * cfg.unit));
+  const leftShoulder = local(new THREE.Vector3((-0.23 * stanceWidthBoost + shotCounterLeanX(0.048 * t) - shoulderSideAdjust) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.43, t) - 0.012 * human.settleT) * cfg.unit));
+  const rightShoulder = local(new THREE.Vector3((0.23 * stanceWidthBoost + shotCounterLeanX(0.034 * t) + shoulderSideAdjust) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.36, t) - 0.012 * human.settleT) * cfg.unit));
   const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const footWalkBlend = plantFeetDuringShot ? idle : 1;
   const plantedLeftFootLocal = new THREE.Vector3(
-    -cfg.stanceWidth * 0.56,
+    -cfg.stanceWidth * 0.56 * stanceWidthBoost,
     cfg.footGroundY,
-    -0.41 * cfg.unit
+    -0.41 * cfg.unit * frontFootForwardBoost
   );
   const plantedRightFootLocal = new THREE.Vector3(
-    cfg.stanceWidth * 0.58,
+    cfg.stanceWidth * 0.58 * stanceWidthBoost,
     cfg.footGroundY,
-    0.39 * cfg.unit
+    0.39 * cfg.unit * rearFootBackBoost
   );
   const leftFoot = local(new THREE.Vector3(
     -0.13 * cfg.unit,
@@ -1033,7 +1055,7 @@ export function updateHumanPose(human, dt, frameData) {
   const bridgePalmTarget = frameData.bridgeTarget.clone()
     .addScaledVector(forward, -0.006 * cfg.unit * t)
     .addScaledVector(side, bridgePalmSide * t)
-    .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
+    .setY(cfg.tableTopY + cfg.bridgePalmTableLift + bridgeHeightBoost)
     .addScaledVector(UP, -0.01 * cfg.unit * human.settleT);
   const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);
   const cueDirForHand = frameData.cueTip.clone().sub(frameData.cueBack).normalize();
@@ -1054,7 +1076,7 @@ export function updateHumanPose(human, dt, frameData) {
     .addScaledVector(side, cfg.rightForearmOutward * t)
     .addScaledVector(UP, -cfg.rightForearmDown * t)
     .addScaledVector(UP, cfg.rightHandShotLift * t)
-    .addScaledVector(forward, -cfg.rightForearmBack * t)
+    .addScaledVector(forward, (-cfg.rightForearmBack + gripCompactness) * t)
     .addScaledVector(cueDirForHand, cfg.rightForearmLength);
   const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
   if (frameData.gripTarget) liveCueGripPoint.lerp(frameData.gripTarget, 0.72 * t);
@@ -1105,17 +1127,82 @@ export function updateHumanPose(human, dt, frameData) {
   });
 }
 
+function closestPointOnWalkRectangle(point, halfX, halfZ, groundY = 0) {
+  const x = clamp(point?.x ?? 0, -halfX, halfX);
+  const z = clamp(point?.z ?? 0, -halfZ, halfZ);
+  const distLeft = Math.abs(x + halfX);
+  const distRight = Math.abs(x - halfX);
+  const distNear = Math.abs(z + halfZ);
+  const distFar = Math.abs(z - halfZ);
+  const nearest = Math.min(distLeft, distRight, distNear, distFar);
+  if (nearest === distLeft) return new THREE.Vector3(-halfX, groundY, z);
+  if (nearest === distRight) return new THREE.Vector3(halfX, groundY, z);
+  if (nearest === distNear) return new THREE.Vector3(x, groundY, -halfZ);
+  return new THREE.Vector3(x, groundY, halfZ);
+}
+
+function rayToWalkRectangle(origin, dir, halfX, halfZ, groundY = 0) {
+  const hits = [];
+  if (Math.abs(dir.x) > 1e-6) {
+    const txA = (-halfX - origin.x) / dir.x;
+    const zA = origin.z + dir.z * txA;
+    if (txA >= 0 && zA >= -halfZ && zA <= halfZ) hits.push(new THREE.Vector3(-halfX, groundY, zA));
+    const txB = (halfX - origin.x) / dir.x;
+    const zB = origin.z + dir.z * txB;
+    if (txB >= 0 && zB >= -halfZ && zB <= halfZ) hits.push(new THREE.Vector3(halfX, groundY, zB));
+  }
+  if (Math.abs(dir.z) > 1e-6) {
+    const tzA = (-halfZ - origin.z) / dir.z;
+    const xA = origin.x + dir.x * tzA;
+    if (tzA >= 0 && xA >= -halfX && xA <= halfX) hits.push(new THREE.Vector3(xA, groundY, -halfZ));
+    const tzB = (halfZ - origin.z) / dir.z;
+    const xB = origin.x + dir.x * tzB;
+    if (tzB >= 0 && xB >= -halfX && xB <= halfX) hits.push(new THREE.Vector3(xB, groundY, halfZ));
+  }
+  return hits.sort((a, b) => a.distanceToSquared(origin) - b.distanceToSquared(origin))[0] || null;
+}
+
 export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
   const cfg = scaleVectorConfig(opts);
-  const desired = cueBallWorld.clone().addScaledVector(aimForward, -cfg.desiredShootDistance);
-  const xEdge = (opts.tableW ?? 2.0) / 2 + cfg.edgeMargin;
-  const zEdge = (opts.tableL ?? 3.6) / 2 + cfg.edgeMargin;
   const groundY = cfg.groundY || 0;
+  const shotForward = aimForward?.clone?.() ?? new THREE.Vector3(0, 0, -1);
+  shotForward.y = 0;
+  if (shotForward.lengthSq() < 1e-8) shotForward.set(0, 0, -1);
+  shotForward.normalize();
+
+  const halfX = (opts.tableW ?? 2.0) / 2 + cfg.edgeMargin;
+  const halfZ = (opts.tableL ?? 3.6) / 2 + cfg.edgeMargin;
+  const behindDir = shotForward.clone().multiplyScalar(-1);
+  const desired = cueBallWorld.clone().addScaledVector(behindDir, cfg.desiredShootDistance).setY(groundY);
+
+  // Prefer the real pool-player spot: directly behind the cue ball on the opposite
+  // side of the shot line, then intersect that ray with the walkable rectangle
+  // around the rails.  The old nearest-edge choice could put the avatar on a side
+  // rail for diagonal shots, making the body and cue appear sideways to the table.
+  const linePosition = rayToWalkRectangle(cueBallWorld, behindDir, halfX, halfZ, groundY);
+  const nearestPerimeter = closestPointOnWalkRectangle(desired, halfX, halfZ, groundY);
+  const cueToCandidateForward = (candidate) => cueBallWorld.clone().sub(candidate).setY(0).normalize();
+  const clearancePenalty = (candidate) => {
+    const insideX = Math.max(0, Math.abs(candidate.x) < halfX ? halfX - Math.abs(candidate.x) : 0);
+    const insideZ = Math.max(0, Math.abs(candidate.z) < halfZ ? halfZ - Math.abs(candidate.z) : 0);
+    return Math.min(insideX, insideZ) * 1000;
+  };
   const candidates = [
-    new THREE.Vector3(-xEdge, groundY, clamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(xEdge, groundY, clamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), groundY, -zEdge),
-    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), groundY, zEdge)
-  ];
-  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+    linePosition,
+    nearestPerimeter,
+    new THREE.Vector3(-halfX, groundY, clamp(desired.z, -halfZ, halfZ)),
+    new THREE.Vector3(halfX, groundY, clamp(desired.z, -halfZ, halfZ)),
+    new THREE.Vector3(clamp(desired.x, -halfX, halfX), groundY, -halfZ),
+    new THREE.Vector3(clamp(desired.x, -halfX, halfX), groundY, halfZ)
+  ].filter(Boolean);
+
+  return candidates
+    .sort((a, b) => {
+      const aLine = Math.max(0, 1 - cueToCandidateForward(a).dot(shotForward));
+      const bLine = Math.max(0, 1 - cueToCandidateForward(b).dot(shotForward));
+      const aScore = a.distanceToSquared(desired) + aLine * 12 + clearancePenalty(a);
+      const bScore = b.distanceToSquared(desired) + bLine * 12 + clearancePenalty(b);
+      return aScore - bScore;
+    })[0]
+    .clone();
 }


### PR DESCRIPTION
### Motivation
- The human avatar sometimes stood on the wrong side of the table or rotated sideways/backwards for a shot, making the pose look disconnected from the table.  
- Orientation and base position must be correct and smooth before changing advanced animation/IK so the player visually lines up with the cue and shot line.

### Description
- Replace nearest-edge placement with a ray-to-rectangle + scoring approach that prefers a spot directly behind the cue ball along the shot line and falls back to walk-perimeter points; implemented in `chooseHumanEdgePosition` (shared/humanRigCore.js).  
- Smooth table-facing corrections and yaw interpolation to avoid instant snapping and backwards poses by damping yaw and adding a small angular lerp when correcting toward table reference (shared/humanRigCore.js).  
- Add shot-context detection and behaviour overrides (rail, long-reach, close-cue-ball, power, soft-precision, difficult-angle) and apply those adjustments to bridge/back, stance width, stroke pull/push, etc., before computing pose (PoolRoyale.jsx).  
- Add optional visual debug arrows (table-center direction, shot direction, character forward, cue direction), toggled with `?debugHuman=1` or `localStorage.poolRoyaleHumanDebugVectors = '1'`, and integrate creation/cleanup and per-frame updates (PoolRoyale.jsx + small hooks into rig cleanup).

### Testing
- Built the webapp production bundle with `npm --prefix webapp run build` which completed successfully.  
- Ran static/consistency checks (`git diff --check`) and addressed no-check issues.  
- Executed a node/three sanity check for `chooseHumanEdgePosition` (script-based) which validated that the chosen edge positions place the avatar behind the cue ball for representative directions.  
- Attempted automated visual verification using Playwright to capture the in-game canvas (`/games/poolroyale?mode=practice&debugHuman=1`); the app loaded but headless WebGL screenshot capture in this CI environment was unreliable due to remote asset fetch failures and platform limitations, so visual validation should be done in a local/dev environment or QA stage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d5ab62f88329a4e42a4c478adc68)