### PR TITLE
Isolate Snooker Royal human player controller

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -27,7 +27,7 @@ import {
 import {
   createSnookerHumanRig,
   chooseHumanEdgePosition as chooseSnookerHumanEdgePosition,
-  updateBilardoHumanPose as updateSnookerHumanPose
+  updateSnookerHumanPose
 } from './shared/snookerHumanRig.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';

--- a/webapp/src/pages/Games/shared/HumanPoolPlayer.js
+++ b/webapp/src/pages/Games/shared/HumanPoolPlayer.js
@@ -1,0 +1,65 @@
+import {
+  createHumanRig,
+  chooseHumanEdgePosition,
+  updateHumanPose as updateCoreHumanPose
+} from './humanRigCore.js';
+
+/**
+ * Standalone human character facade for cue-sport players.
+ *
+ * This module intentionally contains no billiard physics, scoring, table rules,
+ * shot validation, HUD, camera gameplay, or ball state. It preserves the existing
+ * rig/IK/pose math by delegating to the known-good humanRigCore implementation
+ * and exposes cue-sport-specific APIs for movement, cue grip, bridge hand,
+ * shot stance, idle stance, walk cycle, and full-frame pose updates.
+ */
+export function createHumanPoolPlayer(scene, opts = {}) {
+  return createHumanRig(scene, opts);
+}
+
+export { chooseHumanEdgePosition };
+
+export function updateHumanPose(human, dt, frameData) {
+  return updateCoreHumanPose(human, dt, frameData);
+}
+
+export function updateHumanMovement(human, dt, frameData) {
+  return updateHumanPose(human, dt, frameData);
+}
+
+export function updateCueGrip(human, dt, frameData) {
+  return updateHumanPose(human, dt, frameData);
+}
+
+export function updateBridgeHand(human, dt, frameData) {
+  return updateHumanPose(human, dt, frameData);
+}
+
+export function updateShotPose(human, dt, frameData) {
+  return updateHumanPose(human, dt, frameData);
+}
+
+export function updateIdlePose(human, dt, frameData) {
+  return updateHumanPose(human, dt, {
+    ...frameData,
+    state: 'idle'
+  });
+}
+
+export function updateWalkCycle(human, dt, frameData) {
+  return updateHumanPose(human, dt, frameData);
+}
+
+export const HumanCharacterController = Object.freeze({
+  create: createHumanPoolPlayer,
+  chooseHumanEdgePosition,
+  updateHumanPose,
+  updateHumanMovement,
+  updateCueGrip,
+  updateBridgeHand,
+  updateShotPose,
+  updateIdlePose,
+  updateWalkCycle
+});
+
+export const HumanPoolPlayer = HumanCharacterController;

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -1,7 +1,17 @@
-import { createHumanRig, chooseHumanEdgePosition, updateHumanPose } from './humanRigCore';
+import {
+  createHumanPoolPlayer,
+  chooseHumanEdgePosition,
+  updateHumanPose,
+  updateHumanMovement,
+  updateCueGrip,
+  updateBridgeHand,
+  updateShotPose,
+  updateIdlePose,
+  updateWalkCycle
+} from './HumanPoolPlayer.js';
 
 export function createBilardoHumanRig(scene, opts = {}) {
-  return createHumanRig(scene, opts);
+  return createHumanPoolPlayer(scene, opts);
 }
 
 export { chooseHumanEdgePosition };
@@ -9,3 +19,13 @@ export { chooseHumanEdgePosition };
 export function updateBilardoHumanPose(human, dt, frameData) {
   return updateHumanPose(human, dt, frameData);
 }
+
+export {
+  updateHumanPose,
+  updateHumanMovement,
+  updateCueGrip,
+  updateBridgeHand,
+  updateShotPose,
+  updateIdlePose,
+  updateWalkCycle
+};

--- a/webapp/src/pages/Games/shared/snookerHumanRig.js
+++ b/webapp/src/pages/Games/shared/snookerHumanRig.js
@@ -1,11 +1,34 @@
-import { createHumanRig, chooseHumanEdgePosition, updateHumanPose } from './humanRigCore';
+import {
+  createHumanPoolPlayer,
+  chooseHumanEdgePosition,
+  updateHumanPose,
+  updateHumanMovement,
+  updateCueGrip,
+  updateBridgeHand,
+  updateShotPose,
+  updateIdlePose,
+  updateWalkCycle
+} from './HumanPoolPlayer.js';
 
 export function createSnookerHumanRig(scene, opts = {}) {
-  return createHumanRig(scene, opts);
+  return createHumanPoolPlayer(scene, opts);
 }
 
 export { chooseHumanEdgePosition };
 
-export function updateBilardoHumanPose(human, dt, frameData) {
+export function updateSnookerHumanPose(human, dt, frameData) {
   return updateHumanPose(human, dt, frameData);
 }
+
+// Backward-compatible alias for existing callers while Snooker migrates names.
+export const updateBilardoHumanPose = updateSnookerHumanPose;
+
+export {
+  updateHumanPose,
+  updateHumanMovement,
+  updateCueGrip,
+  updateBridgeHand,
+  updateShotPose,
+  updateIdlePose,
+  updateWalkCycle
+};


### PR DESCRIPTION
### Motivation
- Separate and expose the existing, proven human-character logic as a standalone, reusable facade so game systems can consume the human rig without touching billiard gameplay code. 
- Preserve the exact IK/pose/animation math and visual result while removing table/ball/gameplay responsibilities from the human module.

### Description
- Added `webapp/src/pages/Games/shared/HumanPoolPlayer.js`, a minimal facade that delegates to the existing `humanRigCore` and exposes the required API surface: `create`, `chooseHumanEdgePosition`, `updateHumanPose`, `updateHumanMovement`, `updateCueGrip`, `updateBridgeHand`, `updateShotPose`, `updateIdlePose`, and `updateWalkCycle` (also exported as `HumanCharacterController` / `HumanPoolPlayer`).
- Updated `webapp/src/pages/Games/shared/snookerHumanRig.js` and `webapp/src/pages/Games/shared/bilardoHumanRig.js` to consume the new facade instead of calling `humanRigCore` directly, preserving backward-compatible exports (`updateBilardoHumanPose` alias retained for Snooker callers).
- Adjusted the Snooker call site import to use the new `updateSnookerHumanPose` export name without changing any pose math, IK, animations, or gameplay systems.
- This change does not touch billiard physics, cue/shot logic, scoring, camera gameplay, UI, or any of the preserved human behavior math and transforms.

### Testing
- Ran the webapp production build with `npm --prefix webapp run build` and the build completed successfully. 
- No automated unit tests were added or modified; the change is a refactor that delegates to existing, tested rig code and preserves current visual/pose behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e93b54c08329be9513b90bf28317)