### PR TITLE
Isolate cue‑sports human player module (HumanPoolPlayer)

### DIFF
--- a/webapp/src/pages/Games/shared/HumanPoolPlayer.js
+++ b/webapp/src/pages/Games/shared/HumanPoolPlayer.js
@@ -1,0 +1,86 @@
+import {
+  createHumanRig,
+  chooseHumanEdgePosition,
+  updateHumanPose as driveStandaloneHumanPose
+} from './humanRigCore';
+
+/**
+ * Standalone reusable human-character controller for cue-sports avatars.
+ *
+ * This module intentionally does not contain billiard physics, rules, scoring,
+ * table logic, camera gameplay logic, HUD logic, shot validation, or ball state.
+ * It is a thin API boundary around the existing proven human rig/IK/pose solver
+ * so the visual behavior, quaternion math, hand placement, bridge hand, cue grip,
+ * stance, walking, and follow-through remain byte-for-byte delegated to the
+ * current implementation.
+ */
+export class HumanPoolPlayer {
+  constructor(scene, opts = {}) {
+    this.rig = createHumanRig(scene, opts);
+  }
+
+  updateHumanPose(dt, frameData) {
+    return updateHumanPose(this.rig, dt, frameData);
+  }
+
+  updateHumanMovement(dt, frameData) {
+    return updateHumanMovement(this.rig, dt, frameData);
+  }
+
+  updateCueGrip(dt, frameData) {
+    return updateCueGrip(this.rig, dt, frameData);
+  }
+
+  updateBridgeHand(dt, frameData) {
+    return updateBridgeHand(this.rig, dt, frameData);
+  }
+
+  updateShotPose(dt, frameData) {
+    return updateShotPose(this.rig, dt, frameData);
+  }
+
+  updateIdlePose(dt, frameData) {
+    return updateIdlePose(this.rig, dt, frameData);
+  }
+
+  updateWalkCycle(dt, frameData) {
+    return updateWalkCycle(this.rig, dt, frameData);
+  }
+}
+
+export function createHumanPoolPlayer(scene, opts = {}) {
+  return createHumanRig(scene, opts);
+}
+
+export function updateHumanPose(human, dt, frameData) {
+  return driveStandaloneHumanPose(human, dt, frameData);
+}
+
+// Public cue-sports human-character API. Each function deliberately delegates to
+// the same solver entrypoint; splitting the API here isolates the human system
+// without rewriting or reinterpreting the existing pose/IK math.
+export function updateHumanMovement(human, dt, frameData) {
+  return updateHumanPose(human, dt, frameData);
+}
+
+export function updateCueGrip(human, dt, frameData) {
+  return updateHumanPose(human, dt, frameData);
+}
+
+export function updateBridgeHand(human, dt, frameData) {
+  return updateHumanPose(human, dt, frameData);
+}
+
+export function updateShotPose(human, dt, frameData) {
+  return updateHumanPose(human, dt, { ...frameData, state: frameData?.state || 'striking' });
+}
+
+export function updateIdlePose(human, dt, frameData) {
+  return updateHumanPose(human, dt, { ...frameData, state: frameData?.state || 'idle' });
+}
+
+export function updateWalkCycle(human, dt, frameData) {
+  return updateHumanPose(human, dt, frameData);
+}
+
+export { chooseHumanEdgePosition };

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -1,7 +1,7 @@
-import { createHumanRig, chooseHumanEdgePosition, updateHumanPose } from './humanRigCore';
+import { createHumanPoolPlayer, chooseHumanEdgePosition, updateHumanPose } from './HumanPoolPlayer';
 
 export function createBilardoHumanRig(scene, opts = {}) {
-  return createHumanRig(scene, opts);
+  return createHumanPoolPlayer(scene, opts);
 }
 
 export { chooseHumanEdgePosition };

--- a/webapp/src/pages/Games/shared/snookerHumanRig.js
+++ b/webapp/src/pages/Games/shared/snookerHumanRig.js
@@ -1,7 +1,7 @@
-import { createHumanRig, chooseHumanEdgePosition, updateHumanPose } from './humanRigCore';
+import { createHumanPoolPlayer, chooseHumanEdgePosition, updateHumanPose } from './HumanPoolPlayer';
 
 export function createSnookerHumanRig(scene, opts = {}) {
-  return createHumanRig(scene, opts);
+  return createHumanPoolPlayer(scene, opts);
 }
 
 export { chooseHumanEdgePosition };


### PR DESCRIPTION
### Motivation
- Extract the proven human-character pose/IK/animation logic into a focused, reusable module so the human system can be consumed independently from billiard gameplay code. 
- Preserve the exact visual result: body orientation, elbow/hand placement, cue grip, bridge hand, stance, IK, quaternion math and follow-through must remain unchanged. 
- Explicitly keep gameplay systems (physics, scoring, UI, camera gameplay, table logic, shot validation, etc.) out of the human module so it can be reused safely.

### Description
- Added a standalone controller `webapp/src/pages/Games/shared/HumanPoolPlayer.js` that delegates to the existing solver in `humanRigCore` and exposes the reusable API surface: `updateHumanPose`, `updateHumanMovement`, `updateCueGrip`, `updateBridgeHand`, `updateShotPose`, `updateIdlePose`, `updateWalkCycle`, and `createHumanPoolPlayer`/`HumanPoolPlayer` class. 
- The new module intentionally delegates to the same solver entrypoint (`createHumanRig` / `updateHumanPose`) and does not alter any math, bone/twist/IK logic, quaternions, or pose blending so visual behavior is preserved exactly. 
- Rewired compatibility wrappers `webapp/src/pages/Games/shared/snookerHumanRig.js` and `webapp/src/pages/Games/shared/bilardoHumanRig.js` to instantiate the new `HumanPoolPlayer` API instead of calling `createHumanRig` directly, keeping existing callers unchanged. 
- Removed no gameplay, physics, scoring, camera, UI, or table logic — the change is purely an isolation/refactor of the human character interface.

### Testing
- Ran the production build: `cd webapp && npm run build`, which completed successfully (Vite build completed without runtime errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e93b54c08329be9513b90bf28317)