### PR TITLE
Tune Pool Royale shot feel and Showood table proportions

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -25,11 +25,18 @@ describe('Pool Royale table models', () => {
     assert.deepEqual(showood.hideSurfaceRoles, []);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
     assert.equal(showood.tintOriginalTrimGold, false);
-    assert.equal(showood.lowerBaseHeightScale, 0.78);
+    assert.equal(showood.lowerBaseHeightScale, 0.68);
     assert.equal(showood.legLengthScale, 0.84);
-    assert.equal(showood.baseFootWidthScale, 1.42);
-    assert.deepEqual(showood.chromeMaterialSurfaceNames, ['diamonds', 'railSight', 'sideWoodApron', 'apron']);
+    assert.equal(showood.baseFootWidthScale, 1.68);
+    assert.deepEqual(showood.chromeMaterialSurfaceNames, ['diamonds', 'railSight']);
     assert.deepEqual(showood.blackMaterialSurfaceNames, []);
+    assert.deepEqual(showood.clothMaterialSurfaceNames, [
+      'pocketCutoutEdge',
+      'pocketCut',
+      'pocketMouth',
+      'pocketLip',
+      'pocketNotch'
+    ]);
     assert.equal(showood.forceGeneratedChromePlates, false);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -19,9 +19,9 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitScale: 1,
     fitFootprintScale: 1.075,
     fitHeightScale: 1,
-    lowerBaseHeightScale: 0.78,
+    lowerBaseHeightScale: 0.68,
     legLengthScale: 0.84,
-    baseFootWidthScale: 1.42,
+    baseFootWidthScale: 1.68,
     clothRepeatScale: 7.5,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
@@ -33,8 +33,9 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
     preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: false,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideWoodApron', 'apron'],
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight'],
     blackMaterialSurfaceNames: [],
+    clothMaterialSurfaceNames: ['pocketCutoutEdge', 'pocketCut', 'pocketMouth', 'pocketLip', 'pocketNotch'],
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1833,7 +1833,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.24; // add more cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.88; // give Pool Royale shots more drive without over-speeding the table
+const SHOT_GLOBAL_POWER_SCALE = 0.98; // give Pool Royale shots more drive without over-speeding the table
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -11294,7 +11294,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 1.68;
+  const brandPlateOutwardShift = endRailW * 1.92;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -12188,6 +12188,10 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   const blackSurfaceNames = Array.isArray(child?.userData?.poolRoyaleBlackSurfaceNames)
     ? child.userData.poolRoyaleBlackSurfaceNames
     : [];
+  const clothSurfaceNames = Array.isArray(child?.userData?.poolRoyaleClothSurfaceNames)
+    ? child.userData.poolRoyaleClothSurfaceNames
+    : [];
+  if (clothSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'pocketCutoutEdge';
   if (chromeSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
   if (blackSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
   if (/rail[_\s-]*sight|railsight|diamond|sight|marker|inlay/.test(childName)) return 'railSight';
@@ -12339,7 +12343,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'railSight',
+    sideWoodApron: 'baseCornerBlock',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',
@@ -12576,7 +12580,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+      const linkedPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];
@@ -12737,10 +12741,14 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const blackSurfaceNames = Array.isArray(tableModel?.blackMaterialSurfaceNames)
       ? tableModel.blackMaterialSurfaceNames
       : [];
+    const clothSurfaceNames = Array.isArray(tableModel?.clothMaterialSurfaceNames)
+      ? tableModel.clothMaterialSurfaceNames
+      : [];
     child.userData = {
       ...(child.userData || {}),
       poolRoyaleChromeSurfaceNames: chromeSurfaceNames,
-      poolRoyaleBlackSurfaceNames: blackSurfaceNames
+      poolRoyaleBlackSurfaceNames: blackSurfaceNames,
+      poolRoyaleClothSurfaceNames: clothSurfaceNames
     };
 
     const prepareMaterial = (material) => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -11,7 +11,7 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const SPIN_RESPONSE_EXPONENT = 1.32;
-export const SPIN_CENTER_TOPSPIN_BIAS = 0.1;
+export const SPIN_CENTER_TOPSPIN_BIAS = 0.075;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',


### PR DESCRIPTION
### Motivation
- Make Pool Royale shots feel punchier by increasing global shot drive and slightly reducing the default topspin bias so shooting feels more responsive. 
- Adjust the Showood external table fit and visuals so branding plates sit farther out, the lower base is shorter, feet are wider, and pocket cutouts use cloth texturing rather than appearing metallic/gold. 

### Description
- Increased `SHOT_GLOBAL_POWER_SCALE` from `0.88` to `0.98` in `PoolRoyale.jsx` and adjusted related shot constants to boost effective shot force. 
- Reduced the center topspin bias by changing `SPIN_CENTER_TOPSPIN_BIAS` from `0.1` to `0.075` in `poolRoyaleSpinUtils.js`. 
- Moved generated branding plates outward by increasing `brandPlateOutwardShift` in `PoolRoyale.jsx`. 
- Tuned the Showood table model in `webapp/src/config/poolRoyaleTableModels.js` by lowering `lowerBaseHeightScale`, increasing `baseFootWidthScale`, limiting `chromeMaterialSurfaceNames`, and adding `clothMaterialSurfaceNames` for pocket-cut surface mapping. 
- Updated external table material handling in `PoolRoyale.jsx` to: map `sideWoodApron` -> `baseCornerBlock` for Showood, propagate the new `clothMaterialSurfaceNames` into `child.userData`, and classify cloth-named surfaces as pocket cutout edges so pocket cuts pick up the cloth material. 
- Updated the Showood mapping/remap logic so side aprons are treated as base/body material (not rail chrome) and the remapping links side-apron parts to `baseCornerBlock`. 
- Adjusted unit tests in `test/poolRoyaleTableModels.test.js` to match the new Showood model values. 

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleTableModels.test.js test/poolRoyaleSpinController.test.js`, both suites passed (all tests green). 
- Verified TypeScript build with `npm run build`, which completed successfully. 
- Attempted an automated Playwright screenshot of the local Pool Royale page after installing browser dependencies; Playwright/browser installation completed but the page screenshot timed out while the route loaded external assets (screenshot step failed due to page load/resource errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029905177883299599ea19214d0aff)