### PR TITLE
Bundle Showood GLB and update Pool Royale table model, materials and tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ cache/
 
 # Downloaded by webapp/scripts/fetch-gradle-wrapper.mjs; keep binary out of PRs.
 webapp/android/gradle/wrapper/gradle-wrapper.jar
+# Downloaded by webapp/scripts/fetch-pool-royale-showood-model.mjs; keep binary out of PRs.
+webapp/public/assets/models/pool-royale/showood/seven_foot_showood.glb

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "thumbs:pool-table-finishes": "node scripts/generatePoolRoyaleTableFinishThumbs.mjs",
     "help:ingest": "node --loader ts-node/esm packages/ingestion-public/src/cli.ts",
     "help:api": "node --loader ts-node/esm/transpile-only packages/api/src/server.ts",
-    "help:test": "jest test/platformHelpAgent --runInBand"
+    "help:test": "jest test/platformHelpAgent --runInBand",
+    "fetch:pool-showood": "npm --prefix webapp run fetch:pool-showood"
   },
   "engines": {
     "node": ">=18"

--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -19,17 +19,33 @@ describe('Pool Royale table models', () => {
 
     assert.ok(showood, 'Showood table model must be configured');
     assert.equal(showood.kind, 'gltf');
+    assert.equal(showood.assetUrl, '/assets/models/pool-royale/showood/seven_foot_showood.glb');
+    assert.equal(
+      showood.fallbackAssetUrl,
+      'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb'
+    );
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.equal(showood.fitScale, 1);
     assert.equal(showood.clothRepeatScale, 7.5);
     assert.deepEqual(showood.hideSurfaceRoles, []);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
     assert.equal(showood.tintOriginalTrimGold, false);
-    assert.equal(showood.lowerBaseHeightScale, 0.78);
+    assert.equal(showood.lowerBaseHeightScale, 0.68);
     assert.equal(showood.legLengthScale, 0.84);
-    assert.equal(showood.baseFootWidthScale, 1.42);
-    assert.deepEqual(showood.chromeMaterialSurfaceNames, ['diamonds', 'railSight', 'sideWoodApron', 'apron']);
+    assert.equal(showood.baseFootWidthScale, 1.68);
+    assert.deepEqual(showood.chromeMaterialSurfaceNames, [
+      'diamonds',
+      'railSight',
+      'sideWoodApron',
+      'apron'
+    ]);
     assert.deepEqual(showood.blackMaterialSurfaceNames, []);
+    assert.deepEqual(showood.clothMaterialSurfaceNames, [
+      'pocketCutoutEdge',
+      'pocketCut',
+      'pocketMouth',
+      'pocketNotch'
+    ]);
     assert.equal(showood.forceGeneratedChromePlates, false);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -9,7 +9,8 @@
     "generate:native-assets": "node scripts/generate-native-assets.mjs",
     "fetch:gradle-wrapper": "node scripts/fetch-gradle-wrapper.mjs",
     "fetch:launcher": "node scripts/fetch-launcher.mjs",
-    "postinstall": "node scripts/postinstall.mjs"
+    "postinstall": "node scripts/postinstall.mjs",
+    "fetch:pool-showood": "node scripts/fetch-pool-royale-showood-model.mjs"
   },
   "type": "module",
   "dependencies": {

--- a/webapp/scripts/fetch-pool-royale-showood-model.mjs
+++ b/webapp/scripts/fetch-pool-royale-showood-model.mjs
@@ -1,0 +1,123 @@
+import { createWriteStream } from 'fs';
+import { mkdir, readFile, rename, rm, stat } from 'fs/promises';
+import { createHash } from 'crypto';
+import { dirname } from 'path';
+import https from 'https';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const MODEL_PATH = fileURLToPath(
+  new URL('../public/assets/models/pool-royale/showood/seven_foot_showood.glb', import.meta.url)
+);
+const MODEL_TMP_PATH = `${MODEL_PATH}.tmp`;
+const MODEL_URL =
+  process.env.POOL_ROYALE_SHOWOOD_MODEL_URL ||
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb';
+const EXPECTED_SHA256 = (process.env.POOL_ROYALE_SHOWOOD_MODEL_SHA256 || '').trim().toLowerCase();
+const MIN_MODEL_BYTES = 1_000_000;
+
+function formatError(error) {
+  if (error instanceof Error && error.message) return error.message;
+  if (error && typeof error === 'object' && 'code' in error) return String(error.code);
+  return String(error);
+}
+
+async function isValidGlb(path) {
+  try {
+    const [{ size }, header] = await Promise.all([stat(path), readFile(path, { encoding: null })]);
+    return (
+      size > MIN_MODEL_BYTES &&
+      header[0] === 0x67 &&
+      header[1] === 0x6c &&
+      header[2] === 0x54 &&
+      header[3] === 0x46
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function verifyHashIfConfigured(path) {
+  if (!EXPECTED_SHA256) return;
+  const buffer = await readFile(path);
+  const actual = createHash('sha256').update(buffer).digest('hex');
+  if (actual !== EXPECTED_SHA256) {
+    throw new Error(`SHA-256 mismatch. Expected ${EXPECTED_SHA256} but got ${actual}`);
+  }
+}
+
+async function downloadWithHttps() {
+  await new Promise((resolve, reject) => {
+    const file = createWriteStream(MODEL_TMP_PATH);
+    https
+      .get(MODEL_URL, (response) => {
+        if (response.statusCode !== 200) {
+          reject(new Error(`Unable to download Showood model (status ${response.statusCode})`));
+          response.resume();
+          return;
+        }
+
+        response.pipe(file);
+        file.on('finish', () => file.close(resolve));
+        file.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+async function downloadWithCurl() {
+  await new Promise((resolve, reject) => {
+    const child = spawn('curl', [
+      '--fail',
+      '--location',
+      '--silent',
+      '--show-error',
+      '--output',
+      MODEL_TMP_PATH,
+      MODEL_URL
+    ]);
+
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`curl exited with status ${code ?? 'unknown'}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+async function downloadModel() {
+  await mkdir(dirname(MODEL_PATH), { recursive: true });
+  await rm(MODEL_TMP_PATH, { force: true });
+
+  try {
+    await downloadWithHttps();
+  } catch (error) {
+    console.warn(`Direct Showood model download failed (${formatError(error)}); retrying with curl.`);
+    await rm(MODEL_TMP_PATH, { force: true });
+    await downloadWithCurl();
+  }
+
+  if (!(await isValidGlb(MODEL_TMP_PATH))) {
+    throw new Error('Downloaded Showood model is not a valid GLB or is unexpectedly small.');
+  }
+  await verifyHashIfConfigured(MODEL_TMP_PATH);
+  await rename(MODEL_TMP_PATH, MODEL_PATH);
+}
+
+async function ensureModel() {
+  if (await isValidGlb(MODEL_PATH)) {
+    console.info(`Showood model already exists at ${MODEL_PATH}.`);
+    return;
+  }
+
+  await downloadModel();
+  const { size } = await stat(MODEL_PATH);
+  console.info(`Saved Showood model to ${MODEL_PATH} (${(size / (1024 * 1024)).toFixed(2)} MiB).`);
+}
+
+ensureModel().catch(async (error) => {
+  await rm(MODEL_TMP_PATH, { force: true });
+  console.error('Showood model could not be downloaded. Pool Royale will fall back to the remote GLB at runtime.');
+  console.error(formatError(error));
+  process.exitCode = 1;
+});

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -8,20 +8,19 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the CDN GLB cannot load, Pool Royale retries the raw Showood GLB and keeps the Showood original base selection.',
+      'Local Pooltool Showood showroom table matched to Pool Royale footprint for faster startup. If the bundled GLB cannot load, Pool Royale retries the remote Showood GLB and keeps the Showood original base selection.',
     tableSizeId: '7ft',
     baseId: 'showoodOriginal',
-    assetUrl:
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    assetUrl: '/assets/models/pool-royale/showood/seven_foot_showood.glb',
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
     fitFootprintScale: 1.075,
     fitHeightScale: 1,
-    lowerBaseHeightScale: 0.78,
+    lowerBaseHeightScale: 0.68,
     legLengthScale: 0.84,
-    baseFootWidthScale: 1.42,
+    baseFootWidthScale: 1.68,
     clothRepeatScale: 7.5,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
@@ -35,6 +34,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     tintOriginalTrimGold: false,
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideWoodApron', 'apron'],
     blackMaterialSurfaceNames: [],
+    clothMaterialSurfaceNames: ['pocketCutoutEdge', 'pocketCut', 'pocketMouth', 'pocketNotch'],
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1833,7 +1833,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.24; // add more cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.88; // give Pool Royale shots more drive without over-speeding the table
+const SHOT_GLOBAL_POWER_SCALE = 1.12; // give Pool Royale shots stronger drive without changing slider control
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -11294,7 +11294,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 1.68;
+  const brandPlateOutwardShift = endRailW * 1.92;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -12188,6 +12188,15 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   const blackSurfaceNames = Array.isArray(child?.userData?.poolRoyaleBlackSurfaceNames)
     ? child.userData.poolRoyaleBlackSurfaceNames
     : [];
+  const clothSurfaceNames = Array.isArray(child?.userData?.poolRoyaleClothSurfaceNames)
+    ? child.userData.poolRoyaleClothSurfaceNames
+    : [];
+  const matchesConfiguredClothCutout = clothSurfaceNames.some((name) => {
+    const normalized = `${name}`.trim().toLowerCase();
+    return normalized && label.includes(normalized);
+  });
+  const isPocketCupSurface = /pocket.*(cup|liner|leather|net|basket|drop|holder)|(cup|liner|leather|net|basket|drop|holder).*pocket/.test(label);
+  if (matchesConfiguredClothCutout && !isPocketCupSurface) return 'pocketCutoutEdge';
   if (chromeSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
   if (blackSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
   if (/rail[_\s-]*sight|railsight|diamond|sight|marker|inlay/.test(childName)) return 'railSight';
@@ -12737,10 +12746,14 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const blackSurfaceNames = Array.isArray(tableModel?.blackMaterialSurfaceNames)
       ? tableModel.blackMaterialSurfaceNames
       : [];
+    const clothSurfaceNames = Array.isArray(tableModel?.clothMaterialSurfaceNames)
+      ? tableModel.clothMaterialSurfaceNames
+      : [];
     child.userData = {
       ...(child.userData || {}),
       poolRoyaleChromeSurfaceNames: chromeSurfaceNames,
-      poolRoyaleBlackSurfaceNames: blackSurfaceNames
+      poolRoyaleBlackSurfaceNames: blackSurfaceNames,
+      poolRoyaleClothSurfaceNames: clothSurfaceNames
     };
 
     const prepareMaterial = (material) => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -11,7 +11,7 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const SPIN_RESPONSE_EXPONENT = 1.32;
-export const SPIN_CENTER_TOPSPIN_BIAS = 0.1;
+export const SPIN_CENTER_TOPSPIN_BIAS = 0.075;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',


### PR DESCRIPTION
### Motivation
- Improve Pool Royale startup by bundling the Showood GLB locally and keep a remote fallback when the bundled asset cannot load.
- Adjust table geometry and material mapping to better match the Pool Royale finish system and tuning changes to shot/spin behavior.

### Description
- Add a download helper `webapp/scripts/fetch-pool-royale-showood-model.mjs` that saves `seven_foot_showood.glb` into `webapp/public/assets/models/pool-royale/showood/`, with optional SHA-256 verification, GLB header/size validation, and a curl fallback.
- Update `webapp/src/config/poolRoyaleTableModels.js` to point `assetUrl` to the local bundled GLB, change copy/description, and modify tuning values (`lowerBaseHeightScale`, `baseFootWidthScale`) and add `clothMaterialSurfaceNames`.
- Update rendering/material logic in `webapp/src/pages/Games/PoolRoyale.jsx` to handle cloth surface name configuration and pocket cutout detection, adjust brand plate outward shift, and wire the new cloth surface names through `preparePoolRoyaleExternalTableMaterials` and `classifyPoolRoyaleExternalTableSurface`.
- Change shot/spin tuning values in `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/pages/Games/poolRoyaleSpinUtils.js` (`SHOT_GLOBAL_POWER_SCALE` and `SPIN_CENTER_TOPSPIN_BIAS`) to alter shot drive and spin bias.
- Add an npm script `fetch:pool-showood` in both root `package.json` and `webapp/package.json`, and add the GLB file path to `.gitignore` so the binary is excluded from commits.
- Update unit test expectations in `test/poolRoyaleTableModels.test.js` to reflect the new `assetUrl`, `fallbackAssetUrl`, material name arrays, and numeric tuning changes.

### Testing
- Ran the unit tests with `jest` (including `test/poolRoyaleTableModels.test.js`) and the updated assertions passed.
- Ran `npm test` and the test suite completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029905177883299599ea19214d0aff)