### PR TITLE
Restore Snooker cue behavior; align spin controller with Pool Royale

### DIFF
--- a/test/snookerRoyalSpinController.test.js
+++ b/test/snookerRoyalSpinController.test.js
@@ -1,0 +1,25 @@
+import { mapSpinForPhysics as mapPoolSpinForPhysics } from '../webapp/src/pages/Games/poolRoyaleSpinUtils.js';
+import { mapSpinForPhysics as mapSnookerSpinForPhysics } from '../webapp/src/pages/Games/snookerRoyalSpinUtils.js';
+
+const SPIN_SAMPLES = [
+  { x: 0, y: 0 },
+  { x: -1, y: 0 },
+  { x: 1, y: 0 },
+  { x: 0, y: 1 },
+  { x: 0, y: -1 },
+  { x: -1, y: -1 },
+  { x: 1, y: -1 },
+  { x: -1, y: 1 },
+  { x: 1, y: 1 },
+  { x: 0.35, y: 0.6 },
+  { x: -0.45, y: 0.7 },
+  { x: 0.9, y: -0.25 }
+];
+
+describe('Snooker Royal spin controller mapping', () => {
+  it('matches Pool Royale spin directions and physics response', () => {
+    for (const sample of SPIN_SAMPLES) {
+      expect(mapSnookerSpinForPhysics(sample)).toEqual(mapPoolSpinForPhysics(sample));
+    }
+  });
+});

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -24,11 +24,6 @@ import {
   TABLE_MODEL_OPENSOURCE,
   TABLE_MODEL_OPENSOURCE_GLB_URL
 } from './snookerTableModel.js';
-import {
-  createSnookerHumanRig,
-  chooseHumanEdgePosition as chooseSnookerHumanEdgePosition,
-  updateBilardoHumanPose as updateSnookerHumanPose
-} from './shared/snookerHumanRig.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -1534,7 +1529,7 @@ const POCKET_VIEW_MIN_DURATION_MS = 560;
 const POCKET_VIEW_ACTIVE_EXTENSION_MS = 300;
 const POCKET_VIEW_POST_POT_HOLD_MS = 160;
 const POCKET_VIEW_MAX_HOLD_MS = 3200;
-const SPIN_GLOBAL_SCALE = 0.9; // match Pool Royale spin controller scaling
+const SPIN_GLOBAL_SCALE = 0.72; // match Pool Royale spin controller scaling
 const CUE_LOGIC_STRIKE_TIME_MS = 120;
 const CUE_LOGIC_HOLD_TIME_MS = 50;
 const CUE_LOGIC_PULL_EASE_RANGE = 0.34;
@@ -21025,72 +21020,6 @@ const powerRef = useRef(hud.power);
       };
       const cueTipLocal = new THREE.Vector3(0, 0, -cueLen / 2);
       const cueButtLocal = new THREE.Vector3(0, 0, cueLen / 2);
-      const humanLoader = new GLTFLoader();
-      const humanUnitScale = SCALE;
-      const humanTableTopY = BALL_CENTER_Y - BALL_R;
-      const humanGroundY = FLOOR_Y - TABLE_Y;
-      const humanBridgeBackFromBall = 0.18 * humanUnitScale;
-      const humanBridgeSideOffset = 0.045 * humanUnitScale;
-      const human = createSnookerHumanRig(table, {
-        loader: humanLoader,
-        modelUrl: 'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
-        unit: humanUnitScale,
-        humanScale: 1.82 * humanUnitScale,
-        // Snooker Royal uses the opposite shooting-side bend so the avatar drops
-        // into position on the visually correct side of the cue in portrait view.
-        shootBendDirection: -1,
-        tableTopY: humanTableTopY,
-        groundY: humanGroundY,
-        tableW: PLAY_W,
-        tableL: PLAY_H,
-        perimeterWalk: true,
-        perimeterWalkSpeed: 4.0 * humanUnitScale,
-        edgeMargin: 0.68 * humanUnitScale,
-        desiredShootDistance: 1.25 * humanUnitScale,
-        stanceWidth: 0.52 * humanUnitScale,
-        bridgePalmTableLift: 0.004 * humanUnitScale,
-        bridgeCueLift: 0.014 * humanUnitScale,
-        bridgeHandBackFromBall: humanBridgeBackFromBall,
-        bridgeHandSide: humanBridgeSideOffset,
-        bridgePoseUsesConfiguredSide: true,
-        chinToCueHeight: 0.11 * humanUnitScale,
-        footGroundY: 0.035 * humanUnitScale,
-        kneeBendShot: 0.16 * humanUnitScale,
-        rightElbowShotRise: 0.18 * humanUnitScale,
-        rightElbowShotSide: -0.46 * humanUnitScale,
-        rightElbowShotBack: -0.78 * humanUnitScale,
-        rightForearmOutward: 0.36 * humanUnitScale,
-        rightForearmBack: 0.44 * humanUnitScale,
-        rightForearmDown: 0.48 * humanUnitScale,
-        rightForearmLength: 0.34 * humanUnitScale,
-        rightStrokePull: 0.30 * humanUnitScale,
-        rightStrokePush: 0.08 * humanUnitScale,
-        rightHandShotLift: -0.30 * humanUnitScale,
-        shootCueGripFromBack: 0.58 * humanUnitScale,
-        idleRightHandY: 0.8 * humanUnitScale,
-        idleRightHandX: 0.31 * humanUnitScale,
-        idleRightHandZ: -0.015 * humanUnitScale,
-        idleCueGripFromBack: 0.24 * humanUnitScale,
-        rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(humanUnitScale)
-      });
-      let lastHumanPoseTime = performance.now();
-
-      const setCueStickFromHumanCuePose = (back, tip) => {
-        if (!cueStick || !back || !tip) return;
-        const dir = tip.clone().sub(back);
-        if (dir.lengthSq() < 1e-8) return;
-        const n = dir.normalize();
-        cueStick.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, -1), n);
-        cueStick.position.copy(back).add(tip).multiplyScalar(0.5);
-        cueStick.visible = true;
-        const info = cueStick.userData?.buttTilt;
-        if (info) {
-          info.current = cueStick.rotation.x;
-          info.extra = cueStick.rotation.x - (info.angle ?? 0);
-          info.buttHeightOffset = Math.max(0, back.y - tip.y);
-        }
-      };
-
       const resolveCueButtTiltSign = (group, tilt) => {
         if (!group || !Number.isFinite(tilt) || tilt === 0) return 1;
         const rotY = group.rotation.y;
@@ -26615,93 +26544,6 @@ const powerRef = useRef(hud.power);
             fit(1 + edge * 0.08);
           }
           const frameCamera = updateCamera();
-          if (human && cue?.active) {
-            const nowHumanPose = performance.now();
-            const humanDt = Math.min(0.033, Math.max(0, (nowHumanPose - lastHumanPoseTime) / 1000));
-            lastHumanPoseTime = nowHumanPose;
-            const humanState = sliderInstanceRef.current?.dragging
-              ? 'dragging'
-              : shooting
-                ? 'striking'
-                : 'idle';
-            const activePower = THREE.MathUtils.clamp(powerRef.current ?? 0, 0, 1);
-            const strokeAnchor = cueStickAnchorRef.current;
-            const cueBallWorld = humanState === 'striking' && strokeAnchor
-              ? new THREE.Vector3(strokeAnchor.x, BALL_CENTER_Y, strokeAnchor.z)
-              : new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
-            const aimForward = new THREE.Vector3(aimDir.x, 0, aimDir.y);
-            if (aimForward.lengthSq() < 1e-8) aimForward.set(0, 0, 1);
-            else aimForward.normalize();
-            const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
-            const rootTarget = chooseSnookerHumanEdgePosition(cueBallWorld, aimForward, {
-              groundY: humanGroundY,
-              tableW: PLAY_W,
-              tableL: PLAY_H,
-              edgeMargin: 0.68 * humanUnitScale,
-              desiredShootDistance: 1.25 * humanUnitScale
-            });
-            const pull = 0.42 * humanUnitScale * (1 - Math.pow(1 - activePower, 3));
-            const practiceStroke = humanState === 'dragging'
-              ? Math.sin(nowHumanPose * 0.012) * 0.035 * humanUnitScale * (0.25 + activePower * 0.75)
-              : 0;
-            const strikeNorm = THREE.MathUtils.clamp((nowHumanPose - shotStartedAt) / 120, 0, 1);
-            let gap = 0.012 * humanUnitScale;
-            if (humanState === 'dragging') gap += pull + practiceStroke;
-            if (humanState === 'striking') {
-              gap = THREE.MathUtils.lerp(
-                0.012 * humanUnitScale + pull,
-                0.0012 * humanUnitScale,
-                1 - Math.pow(1 - strikeNorm, 3)
-              );
-            }
-            const bridgeTarget = cueBallWorld
-              .clone()
-              .addScaledVector(aimForward, -humanBridgeBackFromBall)
-              .addScaledVector(aimSide, humanBridgeSideOffset)
-              .setY(humanTableTopY + 0.004 * humanUnitScale);
-            const bridgeCuePoint = bridgeTarget
-              .clone()
-              .addScaledVector(aimForward, 0.018 * humanUnitScale)
-              .add(new THREE.Vector3(0, 0.014 * humanUnitScale, 0));
-            const cueTipShoot = cueBallWorld
-              .clone()
-              .addScaledVector(aimForward, -(BALL_R + gap));
-            const cueBackShoot = bridgeCuePoint
-              .clone()
-              .addScaledVector(aimForward, -(cueLen - 0.28 * humanUnitScale - BALL_R - gap))
-              .add(new THREE.Vector3(0, 0.024 * humanUnitScale, 0));
-            const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
-            const idleRight = rootTarget
-              .clone()
-              .add(new THREE.Vector3(0.31, 0.8, -0.015).multiplyScalar(humanUnitScale).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
-            const idleLeft = rootTarget
-              .clone()
-              .add(new THREE.Vector3(-0.18, 1.08, 0.03).multiplyScalar(humanUnitScale).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
-            const idleCueDir = new THREE.Vector3(0.055, 0.965, -0.13)
-              .applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw)
-              .normalize();
-            const idleCueBack = idleRight.clone().addScaledVector(idleCueDir, -0.24 * humanUnitScale);
-            const idleCueTip = idleRight.clone().addScaledVector(idleCueDir, cueLen - 0.24 * humanUnitScale);
-            const activeCueBack = humanState === 'idle' ? idleCueBack : cueBackShoot;
-            const activeCueTip = humanState === 'idle' ? idleCueTip : cueTipShoot;
-            const cueDirForGrip = activeCueTip.clone().sub(activeCueBack).normalize();
-            const gripTarget = humanState === 'idle'
-              ? idleRight
-              : activeCueBack.clone().addScaledVector(cueDirForGrip, 0.58 * humanUnitScale);
-            updateSnookerHumanPose(human, humanDt, {
-              state: humanState,
-              rootTarget,
-              aimForward,
-              bridgeTarget,
-              gripTarget,
-              idleRight,
-              idleLeft,
-              cueBack: activeCueBack,
-              cueTip: activeCueTip,
-              power: activePower
-            });
-            setCueStickFromHumanCuePose(activeCueBack, activeCueTip);
-          }
           renderer.render(scene, frameCamera ?? camera);
           const shouldStreamAim =
             isOnlineMatch &&

--- a/webapp/src/pages/Games/snookerRoyalSpinUtils.js
+++ b/webapp/src/pages/Games/snookerRoyalSpinUtils.js
@@ -10,7 +10,8 @@ export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
 export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const SPIN_RESPONSE_EXPONENT = 1.45;
+export const SPIN_RESPONSE_EXPONENT = 1.32;
+export const SPIN_CENTER_TOPSPIN_BIAS = 0.075;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',
@@ -200,9 +201,12 @@ export const mapSpinForPhysics = (spin, options = {}) => {
     y: clamp(spin?.y ?? 0, -1, 1)
   };
   const quantized = normalizeSpinInput(adjusted);
+  if (Math.hypot(quantized.x, quantized.y) <= 1e-6) {
+    return { x: 0, y: SPIN_CENTER_TOPSPIN_BIAS };
+  }
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
-    -quantized.x,
+    quantized.x,
     quantized.y,
     cameraRight,
     cameraUp,


### PR DESCRIPTION
### Motivation
- Remove the Snooker-specific human character rig and per-frame human pose updates so the cue stick is driven by the standalone cue transform again rather than the human rig. 
- Make the Snooker spin controller and mapping identical to Pool Royale so spin directions and physics response behave the same across both games. 

### Description
- Removed human rig usage and per-frame pose overrides from `webapp/src/pages/Games/SnookerRoyal.jsx` so the cue stick uses the existing cue transform and animation code (human import and runtime pose code deleted). 
- Replaced/updated `webapp/src/pages/Games/snookerRoyalSpinUtils.js` to match the `poolRoyaleSpinUtils.js` mapping and parameters (`SPIN_RESPONSE_EXPONENT`, `SPIN_CENTER_TOPSPIN_BIAS`, quantization/normalize behavior and mapping direction). 
- Adjusted Snooker global spin scale from `0.9` to `0.72` (`SPIN_GLOBAL_SCALE`) to match Pool Royale defaults used by physics. 
- Added a regression test `test/snookerRoyalSpinController.test.js` that compares `mapSpinForPhysics` outputs between Snooker and Pool for representative samples. 

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleSpinController.test.js test/snookerRoyalSpinController.test.js`, and both test suites passed. 
- Built the project: `npm run build`, and the TypeScript build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b0a2e0f8832993674f832d2836b7)