### PR TITLE
Bundle local Showood GLB, refine table model surfaces, and tweak shot/spin tuning

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -19,17 +19,30 @@ describe('Pool Royale table models', () => {
 
     assert.ok(showood, 'Showood table model must be configured');
     assert.equal(showood.kind, 'gltf');
+    assert.equal(showood.assetUrl, '/assets/models/pool-royale/showood/seven_foot_showood.glb');
+    assert.match(showood.fallbackAssetUrl, /seven_foot_showood\/seven_foot_showood\.glb$/);
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.equal(showood.fitScale, 1);
     assert.equal(showood.clothRepeatScale, 7.5);
     assert.deepEqual(showood.hideSurfaceRoles, []);
     assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
     assert.equal(showood.tintOriginalTrimGold, false);
-    assert.equal(showood.lowerBaseHeightScale, 0.78);
+    assert.equal(showood.lowerBaseHeightScale, 0.68);
     assert.equal(showood.legLengthScale, 0.84);
-    assert.equal(showood.baseFootWidthScale, 1.42);
-    assert.deepEqual(showood.chromeMaterialSurfaceNames, ['diamonds', 'railSight', 'sideWoodApron', 'apron']);
+    assert.equal(showood.baseFootWidthScale, 1.68);
+    assert.deepEqual(showood.chromeMaterialSurfaceNames, [
+      'diamonds',
+      'railSight',
+      'sideWoodApron',
+      'apron'
+    ]);
     assert.deepEqual(showood.blackMaterialSurfaceNames, []);
+    assert.deepEqual(showood.clothMaterialSurfaceNames, [
+      'pocketCutoutEdge',
+      'pocketCut',
+      'pocketMouth',
+      'pocketNotch'
+    ]);
     assert.equal(showood.forceGeneratedChromePlates, false);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',

--- a/webapp/public/assets/models/pool-royale/showood/.gitignore
+++ b/webapp/public/assets/models/pool-royale/showood/.gitignore
@@ -1,0 +1,3 @@
+# Keep the large Showood GLB out of git/PRs.
+# The deploy pipeline should place this file here out-of-band.
+/seven_foot_showood.glb

--- a/webapp/public/assets/models/pool-royale/showood/README.md
+++ b/webapp/public/assets/models/pool-royale/showood/README.md
@@ -1,0 +1,5 @@
+# Showood Pool Royale table asset
+
+The Pool Royale Showood table is configured to load `seven_foot_showood.glb` from this directory first for faster in-app loading.
+
+Do **not** commit the GLB binary to git. Place/sync the file here out-of-band during deployment or local setup. If the local file is missing at runtime, Pool Royale falls back to the remote Pooltool raw GLB URL configured in `webapp/src/config/poolRoyaleTableModels.js`.

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -8,20 +8,19 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the CDN GLB cannot load, Pool Royale retries the raw Showood GLB and keeps the Showood original base selection.',
+      'Local Pooltool Showood showroom table matched to Pool Royale footprint for faster startup. If the bundled GLB cannot load, Pool Royale retries the remote Showood GLB and keeps the Showood original base selection.',
     tableSizeId: '7ft',
     baseId: 'showoodOriginal',
-    assetUrl:
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    assetUrl: '/assets/models/pool-royale/showood/seven_foot_showood.glb',
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
     fitFootprintScale: 1.075,
     fitHeightScale: 1,
-    lowerBaseHeightScale: 0.78,
+    lowerBaseHeightScale: 0.68,
     legLengthScale: 0.84,
-    baseFootWidthScale: 1.42,
+    baseFootWidthScale: 1.68,
     clothRepeatScale: 7.5,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
@@ -35,6 +34,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     tintOriginalTrimGold: false,
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideWoodApron', 'apron'],
     blackMaterialSurfaceNames: [],
+    clothMaterialSurfaceNames: ['pocketCutoutEdge', 'pocketCut', 'pocketMouth', 'pocketNotch'],
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1833,7 +1833,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.24; // add more cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.88; // give Pool Royale shots more drive without over-speeding the table
+const SHOT_GLOBAL_POWER_SCALE = 1.12; // give Pool Royale shots stronger drive without changing slider control
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -11294,7 +11294,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 1.68;
+  const brandPlateOutwardShift = endRailW * 1.92;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -12188,6 +12188,15 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   const blackSurfaceNames = Array.isArray(child?.userData?.poolRoyaleBlackSurfaceNames)
     ? child.userData.poolRoyaleBlackSurfaceNames
     : [];
+  const clothSurfaceNames = Array.isArray(child?.userData?.poolRoyaleClothSurfaceNames)
+    ? child.userData.poolRoyaleClothSurfaceNames
+    : [];
+  const matchesConfiguredClothCutout = clothSurfaceNames.some((name) => {
+    const normalized = `${name}`.trim().toLowerCase();
+    return normalized && label.includes(normalized);
+  });
+  const isPocketCupSurface = /pocket.*(cup|liner|leather|net|basket|drop|holder)|(cup|liner|leather|net|basket|drop|holder).*pocket/.test(label);
+  if (matchesConfiguredClothCutout && !isPocketCupSurface) return 'pocketCutoutEdge';
   if (chromeSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
   if (blackSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
   if (/rail[_\s-]*sight|railsight|diamond|sight|marker|inlay/.test(childName)) return 'railSight';
@@ -12737,10 +12746,14 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const blackSurfaceNames = Array.isArray(tableModel?.blackMaterialSurfaceNames)
       ? tableModel.blackMaterialSurfaceNames
       : [];
+    const clothSurfaceNames = Array.isArray(tableModel?.clothMaterialSurfaceNames)
+      ? tableModel.clothMaterialSurfaceNames
+      : [];
     child.userData = {
       ...(child.userData || {}),
       poolRoyaleChromeSurfaceNames: chromeSurfaceNames,
-      poolRoyaleBlackSurfaceNames: blackSurfaceNames
+      poolRoyaleBlackSurfaceNames: blackSurfaceNames,
+      poolRoyaleClothSurfaceNames: clothSurfaceNames
     };
 
     const prepareMaterial = (material) => {

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -11,7 +11,7 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const SPIN_RESPONSE_EXPONENT = 1.32;
-export const SPIN_CENTER_TOPSPIN_BIAS = 0.1;
+export const SPIN_CENTER_TOPSPIN_BIAS = 0.075;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',


### PR DESCRIPTION
### Motivation

- Reduce startup time by preferring a local Showood GLB and make Pool Royale mapping/finish assignment more accurate for the Showood model.
- Tune visual and physics parameters so Pool Royale shots, brand plates, and cloth handling better match intended feel and visuals.

### Description

- Change `showood-seven-foot` table option to prefer a local asset at `/assets/models/pool-royale/showood/seven_foot_showood.glb` and leave a fallback to the remote Pooltool raw GLB, update descriptive text in `webapp/src/config/poolRoyaleTableModels.js`.
- Adjust Showood model parameters: `lowerBaseHeightScale` from `0.78` to `0.68`, `baseFootWidthScale` from `1.42` to `1.68`, add `clothMaterialSurfaceNames`, and reformat `chromeMaterialSurfaceNames` array.
- Add an assets directory helper: `webapp/public/assets/models/pool-royale/showood/.gitignore` to exclude the large GLB and `README.md` explaining out-of-band deployment of the GLB.
- Improve external table material classification and preparation in `webapp/src/pages/Games/PoolRoyale.jsx` by honoring `clothMaterialSurfaceNames`, adding pocket-cup detection to avoid misclassifying pocket cups as cloth cutouts, and storing `poolRoyaleClothSurfaceNames` on mesh `userData` for use at runtime.
- Modify table geometry/visual placement by increasing `brandPlateOutwardShift` multiplier from `1.68` to `1.92`.
- Tweak shot and spin tuning values: change `SHOT_GLOBAL_POWER_SCALE` from `0.88` to `1.12` and adjust `SPIN_CENTER_TOPSPIN_BIAS` from `0.1` to `0.075` in `poolRoyaleSpinUtils.js` and `PoolRoyale.jsx`.
- Update unit test expectations in `test/poolRoyaleTableModels.test.js` to match the new Showood configuration and added fields.

### Testing

- Ran the unit test `test/poolRoyaleTableModels.test.js` and it passed after updating assertions to match the new configuration.
- Ran the project test suite with `npm test` and the automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029905177883299599ea19214d0aff)