### PR TITLE
Fix Snooker Royal GLB cushion mapping

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   applySnookerTableModelParam,
+  resolveSnookerCushionBoundaryPolyline,
   resolveSnookerGlbFitTransform,
   resolveSnookerTableModel,
   usesProceduralSnookerTableRailDecor,
@@ -58,4 +59,62 @@ describe('snooker table model selection', () => {
       /pooltool\/models\/table\/snooker_generic\/snooker_generic\.glb$/
     );
   });
+
+  test('resolveSnookerCushionBoundaryPolyline follows angled jaw vertices instead of a flat bounding box', () => {
+    const points = [
+      { x: -4, z: 2.4 },
+      { x: -3, z: 2.2 },
+      { x: -2, z: 2 },
+      { x: 0, z: 2 },
+      { x: 2, z: 2 },
+      { x: 3, z: 2.2 },
+      { x: 4, z: 2.4 },
+      { x: -4, z: 2.9 },
+      { x: -3, z: 2.9 },
+      { x: -2, z: 2.9 },
+      { x: 0, z: 2.9 },
+      { x: 2, z: 2.9 },
+      { x: 3, z: 2.9 },
+      { x: 4, z: 2.9 }
+    ];
+
+    const polyline = resolveSnookerCushionBoundaryPolyline(points, {
+      horizontal: true,
+      side: 1,
+      binSize: 1,
+      minPoints: 4
+    });
+
+    assert.ok(polyline.length >= 7);
+    assert.deepEqual(polyline[0], { x: -4, z: 2.4 });
+    assert.deepEqual(polyline[3], { x: 0, z: 2 });
+    assert.deepEqual(polyline[polyline.length - 1], { x: 4, z: 2.4 });
+  });
+
+  test('resolveSnookerCushionBoundaryPolyline mirrors the lower cushion inward edge', () => {
+    const points = [
+      { x: -2, z: -2.8 },
+      { x: -1, z: -2 },
+      { x: 0, z: -2 },
+      { x: 1, z: -2 },
+      { x: 2, z: -2.8 },
+      { x: -2, z: -3.1 },
+      { x: -1, z: -3.1 },
+      { x: 0, z: -3.1 },
+      { x: 1, z: -3.1 },
+      { x: 2, z: -3.1 }
+    ];
+
+    const polyline = resolveSnookerCushionBoundaryPolyline(points, {
+      horizontal: true,
+      side: -1,
+      binSize: 1,
+      minPoints: 4
+    });
+
+    assert.equal(polyline[0].z, -2.8);
+    assert.equal(polyline[2].z, -2);
+    assert.equal(polyline[polyline.length - 1].z, -2.8);
+  });
+
 });

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -17,6 +17,7 @@ import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import {
+  resolveSnookerCushionBoundaryPolyline,
   resolveSnookerGlbFitTransform,
   resolveSnookerTableModel,
   usesProceduralSnookerTableRailDecor,
@@ -6170,6 +6171,40 @@ function reflectRails(ball) {
         tangent: bestImpact.tangent.clone()
       };
     }
+    if (!inCaptureZone) {
+      let guardNormal = null;
+      if (ball.pos.x < -railLimitX && ball.vel.x < 0) {
+        const overshoot = -railLimitX - ball.pos.x;
+        ball.pos.x = -railLimitX + overshoot;
+        ball.vel.x = Math.abs(ball.vel.x) * CUSHION_RESTITUTION;
+        guardNormal = new THREE.Vector2(1, 0);
+      } else if (ball.pos.x > railLimitX && ball.vel.x > 0) {
+        const overshoot = ball.pos.x - railLimitX;
+        ball.pos.x = railLimitX - overshoot;
+        ball.vel.x = -Math.abs(ball.vel.x) * CUSHION_RESTITUTION;
+        guardNormal = new THREE.Vector2(-1, 0);
+      } else if (ball.pos.y < -railLimitY && ball.vel.y < 0) {
+        const overshoot = -railLimitY - ball.pos.y;
+        ball.pos.y = -railLimitY + overshoot;
+        ball.vel.y = Math.abs(ball.vel.y) * CUSHION_RESTITUTION;
+        guardNormal = new THREE.Vector2(0, 1);
+      } else if (ball.pos.y > railLimitY && ball.vel.y > 0) {
+        const overshoot = ball.pos.y - railLimitY;
+        ball.pos.y = railLimitY - overshoot;
+        ball.vel.y = -Math.abs(ball.vel.y) * CUSHION_RESTITUTION;
+        guardNormal = new THREE.Vector2(0, -1);
+      }
+      if (guardNormal) {
+        const tangent = new THREE.Vector2(-guardNormal.y, guardNormal.x);
+        const stamp =
+          typeof performance !== 'undefined' && performance.now
+            ? performance.now()
+            : Date.now();
+        ball.lastRailHitAt = stamp;
+        ball.lastRailHitType = 'glb-rail-guard';
+        return { type: 'rail', normal: guardNormal, tangent };
+      }
+    }
   }
   if (!hasCushionSegments) {
     for (const { sx, sy } of CORNER_SIGNS) {
@@ -10839,9 +10874,30 @@ function Table3D(
       if (normal.dot(midpoint.clone().multiplyScalar(-1)) < 0) normal.multiplyScalar(-1);
       segments.push({ start, end, type, normal });
     };
+    const addPolyline = (polyline) => {
+      for (let i = 1; i < polyline.length; i += 1) {
+        addSegment(
+          new THREE.Vector2(polyline[i - 1].x, polyline[i - 1].z),
+          new THREE.Vector2(polyline[i].x, polyline[i].z)
+        );
+      }
+    };
+    const addBoxFallbackSegment = (localBox) => {
+      const size = localBox.getSize(new THREE.Vector3());
+      const center = localBox.getCenter(new THREE.Vector3());
+      if (size.x >= size.z) {
+        const innerZ = center.z >= 0 ? localBox.min.z : localBox.max.z;
+        addSegment(new THREE.Vector2(localBox.min.x, innerZ), new THREE.Vector2(localBox.max.x, innerZ));
+      } else {
+        const innerX = center.x >= 0 ? localBox.min.x : localBox.max.x;
+        addSegment(new THREE.Vector2(innerX, localBox.min.z), new THREE.Vector2(innerX, localBox.max.z));
+      }
+    };
 
     model.updateMatrixWorld(true);
     table.updateMatrixWorld(true);
+    const vertex = new THREE.Vector3();
+    const worldVertex = new THREE.Vector3();
     model.traverse((node) => {
       if (!node?.isMesh || node.userData?.openSourceMaterialRole !== 'cushion') return;
       const worldBox = new THREE.Box3().setFromObject(node);
@@ -10860,12 +10916,28 @@ function Table3D(
       corners.forEach((corner) => localBox.expandByPoint(table.worldToLocal(corner.clone())));
       const size = localBox.getSize(new THREE.Vector3());
       const center = localBox.getCenter(new THREE.Vector3());
-      if (size.x >= size.z) {
-        const innerZ = center.z >= 0 ? localBox.min.z : localBox.max.z;
-        addSegment(new THREE.Vector2(localBox.min.x, innerZ), new THREE.Vector2(localBox.max.x, innerZ));
+      const horizontal = size.x >= size.z;
+      const side = horizontal ? (center.z >= 0 ? 1 : -1) : center.x >= 0 ? 1 : -1;
+      const position = node.geometry?.attributes?.position;
+      const localPoints = [];
+      if (position) {
+        for (let i = 0; i < position.count; i += 1) {
+          vertex.fromBufferAttribute(position, i);
+          node.localToWorld(worldVertex.copy(vertex));
+          table.worldToLocal(worldVertex);
+          localPoints.push({ x: worldVertex.x, z: worldVertex.z });
+        }
+      }
+      const polyline = resolveSnookerCushionBoundaryPolyline(localPoints, {
+        horizontal,
+        side,
+        binSize: BALL_R * 0.22,
+        minPoints: 5
+      });
+      if (polyline.length >= 5) {
+        addPolyline(polyline);
       } else {
-        const innerX = center.x >= 0 ? localBox.min.x : localBox.max.x;
-        addSegment(new THREE.Vector2(innerX, localBox.min.z), new THREE.Vector2(innerX, localBox.max.z));
+        addBoxFallbackSegment(localBox);
       }
     });
 
@@ -10877,10 +10949,28 @@ function Table3D(
       const nextSegments = [...segments, ...jaws];
       table.userData.cushionSegments = nextSegments;
       CUSHION_SEGMENTS = nextSegments;
+      let minAbsX = Infinity;
+      let minAbsZ = Infinity;
+      segments.forEach((segment) => {
+        const midpoint = segment.start.clone().add(segment.end).multiplyScalar(0.5);
+        if (Math.abs(segment.normal.x) >= Math.abs(segment.normal.y)) {
+          minAbsX = Math.min(minAbsX, Math.abs(midpoint.x));
+        } else {
+          minAbsZ = Math.min(minAbsZ, Math.abs(midpoint.y));
+        }
+      });
+      if (minAbsX !== Infinity) {
+        RAIL_LIMIT_X = Math.max(0, minAbsX - BALL_R - RAIL_LIMIT_PADDING);
+      }
+      if (minAbsZ !== Infinity) {
+        RAIL_LIMIT_Y = Math.max(0, minAbsZ - BALL_R - RAIL_LIMIT_PADDING);
+      }
       table.userData.openSourcePhysics = {
-        source: 'glb-cushion-bounds',
+        source: 'glb-cushion-vertex-boundary',
         segmentCount: segments.length,
-        proceduralJawSegmentCount: jaws.length
+        proceduralJawSegmentCount: jaws.length,
+        railLimitX: RAIL_LIMIT_X,
+        railLimitY: RAIL_LIMIT_Y
       };
       return true;
     }

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -38,3 +38,59 @@ export function applySnookerTableModelParam(params, tableModel) {
 export function usesProceduralSnookerTableRailDecor(tableModel) {
   return resolveSnookerTableModel(tableModel) === TABLE_MODEL_CLASSIC;
 }
+
+export function resolveSnookerCushionBoundaryPolyline(
+  points = [],
+  { horizontal = true, side = 1, binSize = 0.02, minPoints = 4 } = {}
+) {
+  const longKey = horizontal ? 'x' : 'z';
+  const crossKey = horizontal ? 'z' : 'x';
+  const normalizedSide = side >= 0 ? 1 : -1;
+  const valid = points
+    .map((point) => ({
+      x: Number(point?.x),
+      z: Number(point?.z)
+    }))
+    .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.z));
+
+  if (valid.length < minPoints) return [];
+
+  const minLong = Math.min(...valid.map((point) => point[longKey]));
+  const maxLong = Math.max(...valid.map((point) => point[longKey]));
+  const span = maxLong - minLong;
+  if (!Number.isFinite(span) || span <= 0) return [];
+
+  const resolvedBinSize =
+    Number.isFinite(binSize) && binSize > 0
+      ? Math.max(binSize, span / 240)
+      : span / 160;
+  const bins = new Map();
+
+  valid.forEach((point) => {
+    const bin = Math.round((point[longKey] - minLong) / resolvedBinSize);
+    const current = bins.get(bin);
+    const isBetter =
+      !current ||
+      (normalizedSide > 0
+        ? point[crossKey] < current[crossKey]
+        : point[crossKey] > current[crossKey]);
+    if (isBetter) {
+      bins.set(bin, point);
+    }
+  });
+
+  const ordered = [...bins.values()].sort((a, b) => a[longKey] - b[longKey]);
+  const deduped = [];
+  ordered.forEach((point) => {
+    const previous = deduped[deduped.length - 1];
+    if (
+      previous &&
+      Math.hypot(previous.x - point.x, previous.z - point.z) < resolvedBinSize * 0.35
+    ) {
+      return;
+    }
+    deduped.push(point);
+  });
+
+  return deduped.length >= minPoints ? deduped : [];
+}


### PR DESCRIPTION
### Motivation

- The open-source GLB table visual used for Snooker Royal contains precise cushion and jaw geometry that was being simplified to bounding boxes for physics, causing the cue ball to escape the play area; mapping must follow the actual GLB cushion vertices so collisions match the physical model. 
- Add a safety guard so balls that reach rail limits outside pocket capture zones are reflected back instead of slipping through mapping gaps.

### Description

- Add `resolveSnookerCushionBoundaryPolyline` to `webapp/src/pages/Games/snookerTableModel.js` to derive an inward cushion boundary polyline from GLB vertex positions with configurable binning and deduplication. 
- Update `applyOpenSourceCushionPhysicsFromModel` in `webapp/src/pages/Games/SnookerRoyal.jsx` to sample cushion mesh vertices, convert them to local playfield space, build jaw/polyline-derived cushion segments (with a box fallback), and populate `CUSHION_SEGMENTS` from the GLB boundary. 
- Recalculate `RAIL_LIMIT_X`/`RAIL_LIMIT_Y` from the GLB-derived cushion segments and surface a new `openSourcePhysics` source of `glb-cushion-vertex-boundary` including the computed rail limits. 
- Add a rail-guard reflection in `reflectRails` so balls that reach rail limits outside capture zones are clamped/reflected (`glb-rail-guard`) to prevent escaping through mapping gaps. 
- Add unit tests for the new polyline resolver in `test/snookerTableModel.test.js` and wire the new function into the module exports/imports. 

### Testing

- Ran unit tests with `npm test -- snookerTableModel.test.js --runInBand` and all tests passed (`9 passed`).
- Built the TypeScript backend with `npm run build` which completed successfully. 
- Built the webapp with `npm --prefix webapp run build` which completed successfully and produced the production bundles. 
- Ran targeted lint on the changed Snooker file with `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx --quiet` (no failures for the targeted file); attempting repo-wide linting exposed unrelated pre-existing/generated lint errors outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b7a91a60832998443ac23f0976e7)