### PR TITLE
Fix Snooker Royal table collision mapping

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -6170,6 +6170,57 @@ function reflectRails(ball) {
         tangent: bestImpact.tangent.clone()
       };
     }
+
+    // Final containment guard for the GLB-derived rail map.  The exact hull
+    // segments above own normal cushion/jaw contacts, while this only catches
+    // rare high-speed tunnelling or microscopic seams so the cue ball cannot
+    // leave the physical table outline.
+    if (!inCaptureZone) {
+      let collided = null;
+      let collisionNormal = null;
+      if (ball.pos.x < -railLimitX && ball.vel.x < 0) {
+        const overshoot = -railLimitX - ball.pos.x;
+        ball.pos.x = -railLimitX + overshoot;
+        ball.vel.x = Math.abs(ball.vel.x) * CUSHION_RESTITUTION;
+        collided = nearPocket ? 'glb-seam' : 'rail';
+        collisionNormal = new THREE.Vector2(1, 0);
+      }
+      if (ball.pos.x > railLimitX && ball.vel.x > 0) {
+        const overshoot = ball.pos.x - railLimitX;
+        ball.pos.x = railLimitX - overshoot;
+        ball.vel.x = -Math.abs(ball.vel.x) * CUSHION_RESTITUTION;
+        collided = nearPocket ? 'glb-seam' : 'rail';
+        collisionNormal = new THREE.Vector2(-1, 0);
+      }
+      if (ball.pos.y < -railLimitY && ball.vel.y < 0) {
+        const overshoot = -railLimitY - ball.pos.y;
+        ball.pos.y = -railLimitY + overshoot;
+        ball.vel.y = Math.abs(ball.vel.y) * CUSHION_RESTITUTION;
+        collided = nearPocket ? 'glb-seam' : 'rail';
+        collisionNormal = new THREE.Vector2(0, 1);
+      }
+      if (ball.pos.y > railLimitY && ball.vel.y > 0) {
+        const overshoot = ball.pos.y - railLimitY;
+        ball.pos.y = railLimitY - overshoot;
+        ball.vel.y = -Math.abs(ball.vel.y) * CUSHION_RESTITUTION;
+        collided = nearPocket ? 'glb-seam' : 'rail';
+        collisionNormal = new THREE.Vector2(0, -1);
+      }
+      if (collided) {
+        const stamp =
+          typeof performance !== 'undefined' && performance.now
+            ? performance.now()
+            : Date.now();
+        ball.lastRailHitAt = stamp;
+        ball.lastRailHitType = collided;
+        const normal = collisionNormal ?? new THREE.Vector2(0, 1);
+        return {
+          type: collided,
+          normal,
+          tangent: new THREE.Vector2(-normal.y, normal.x)
+        };
+      }
+    }
   }
   if (!hasCushionSegments) {
     for (const { sx, sy } of CORNER_SIGNS) {
@@ -10831,19 +10882,111 @@ function Table3D(
 
   const applyOpenSourceCushionPhysicsFromModel = (model) => {
     const segments = [];
-    const addSegment = (start, end, type = 'glb-cushion') => {
-      if (!start || !end || start.distanceToSquared(end) < 1e-6) return;
+    const quantize = (value) =>
+      Math.round(value / Math.max(MICRO_EPS, BALL_R * 0.001));
+    const addSegment = (start, end, type = 'rail') => {
+      if (
+        !start ||
+        !end ||
+        start.distanceToSquared(end) < Math.max(1e-6, BALL_R * BALL_R * 0.0004)
+      ) {
+        return;
+      }
       const dir = end.clone().sub(start);
       const normal = new THREE.Vector2(-dir.y, dir.x).normalize();
       const midpoint = start.clone().add(end).multiplyScalar(0.5);
       if (normal.dot(midpoint.clone().multiplyScalar(-1)) < 0) normal.multiplyScalar(-1);
-      segments.push({ start, end, type, normal });
+      segments.push({ start: start.clone(), end: end.clone(), type, normal });
+    };
+    const cross = (origin, a, b) =>
+      (a.x - origin.x) * (b.y - origin.y) - (a.y - origin.y) * (b.x - origin.x);
+    const convexHull = (points) => {
+      if (points.length <= 2) return points.slice();
+      const sorted = points
+        .slice()
+        .sort((a, b) => a.x - b.x || a.y - b.y);
+      const lower = [];
+      sorted.forEach((point) => {
+        while (
+          lower.length >= 2 &&
+          cross(lower[lower.length - 2], lower[lower.length - 1], point) <= 0
+        ) {
+          lower.pop();
+        }
+        lower.push(point);
+      });
+      const upper = [];
+      for (let i = sorted.length - 1; i >= 0; i -= 1) {
+        const point = sorted[i];
+        while (
+          upper.length >= 2 &&
+          cross(upper[upper.length - 2], upper[upper.length - 1], point) <= 0
+        ) {
+          upper.pop();
+        }
+        upper.push(point);
+      }
+      lower.pop();
+      upper.pop();
+      return lower.concat(upper);
+    };
+    const collectTopDownPoints = (node) => {
+      const geometry = node.geometry;
+      const position = geometry?.attributes?.position;
+      if (!position) return [];
+      const points = [];
+      const seen = new Set();
+      const localPoint = new THREE.Vector3();
+      const worldPoint = new THREE.Vector3();
+      const tablePoint = new THREE.Vector3();
+      for (let i = 0; i < position.count; i += 1) {
+        localPoint.fromBufferAttribute(position, i);
+        node.localToWorld(worldPoint.copy(localPoint));
+        table.worldToLocal(tablePoint.copy(worldPoint));
+        const key = `${quantize(tablePoint.x)}:${quantize(tablePoint.z)}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        points.push(new THREE.Vector2(tablePoint.x, tablePoint.z));
+      }
+      return points;
+    };
+    const addFieldFacingHullSegments = (node) => {
+      const points = collectTopDownPoints(node);
+      if (points.length < 3) return false;
+      const hull = convexHull(points);
+      if (hull.length < 2) return false;
+      const localBox = new THREE.Box3();
+      points.forEach((point) =>
+        localBox.expandByPoint(new THREE.Vector3(point.x, 0, point.y))
+      );
+      const size = localBox.getSize(new THREE.Vector3());
+      const center = localBox.getCenter(new THREE.Vector3());
+      const horizontal = size.x >= size.z;
+      const side = horizontal ? Math.sign(center.z) || 1 : Math.sign(center.x) || 1;
+      const tolerance = Math.max(BALL_R * 0.08, MICRO_EPS * 8);
+      let added = 0;
+      for (let i = 0; i < hull.length; i += 1) {
+        const start = hull[i];
+        const end = hull[(i + 1) % hull.length];
+        const midpoint = start.clone().add(end).multiplyScalar(0.5);
+        const frontDistance = horizontal
+          ? (midpoint.y - center.z) * side
+          : (midpoint.x - center.x) * side;
+        if (frontDistance > tolerance) continue;
+        const dx = Math.abs(end.x - start.x);
+        const dz = Math.abs(end.y - start.y);
+        const axisAligned = dx <= tolerance || dz <= tolerance;
+        addSegment(start, end, axisAligned ? 'rail' : 'cut');
+        added += 1;
+      }
+      return added > 0;
     };
 
     model.updateMatrixWorld(true);
     table.updateMatrixWorld(true);
     model.traverse((node) => {
       if (!node?.isMesh || node.userData?.openSourceMaterialRole !== 'cushion') return;
+      if (addFieldFacingHullSegments(node)) return;
       const worldBox = new THREE.Box3().setFromObject(node);
       if (worldBox.isEmpty()) return;
       const corners = [
@@ -10878,7 +11021,7 @@ function Table3D(
       table.userData.cushionSegments = nextSegments;
       CUSHION_SEGMENTS = nextSegments;
       table.userData.openSourcePhysics = {
-        source: 'glb-cushion-bounds',
+        source: 'glb-cushion-hulls',
         segmentCount: segments.length,
         proceduralJawSegmentCount: jaws.length
       };


### PR DESCRIPTION
### Motivation
- Improve physical mapping of the Snooker Royal playfield so cushion/pocket jaw geometry in the GLB table matches the procedural physics exactly and prevent the cue ball from leaving the table due to mismapped cushions or tiny GLB seams.

### Description
- Replace coarse bounding-box cushion extraction with a field-facing top-down hull approach that samples GLB cushion mesh vertices, computes a convex hull, and emits axis-aligned/hull segments for precise cushion/rail geometry (implemented in `webapp/src/pages/Games/SnookerRoyal.jsx`).
- Add quantization and deduping of sampled top-down points and a hull-to-segments builder (`collectTopDownPoints`, `convexHull`, `addFieldFacingHullSegments`) so diagonal pocket cuts and jaw arcs are preserved for physics.
- Add a final GLB rail containment guard that reflects high-speed/tunnelling cue balls back inside the procedural rail limits when not already in a pocket capture zone, avoiding rare escapes through tiny seams.
- Mark GLB-derived physics origin as `glb-cushion-hulls` in `table.userData.openSourcePhysics` when hull segments are used, and keep the procedural fallback when hull extraction fails.

### Testing
- Ran unit tests: `npm test -- --runInBand test/snookerTableModel.test.js`, and the suite passed (`7 passed`).
- Built the webapp: `npm --prefix webapp run build`, and the production build completed successfully (Vite build finished, assets emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02b7a91a60832998443ac23f0976e7)