### PR TITLE
Restore Pool Royale game code to May 11 11:00 state

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -123,6 +123,7 @@ import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
+import { createMurlanStyleTable } from '../../utils/murlanTable.js';
 import {
   createBilardoHumanRig as sharedCreateBilardoHumanRig,
   chooseHumanEdgePosition as sharedChooseBilardoHumanEdgePosition,
@@ -2670,9 +2671,14 @@ const resolvePoolRoyaleHumanCharacter = (id) =>
   POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
 const POOL_ROYALE_HUMAN_UNIT_SCALE = BALL_R / 0.0525;
 const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.85 * POOL_ROYALE_HUMAN_UNIT_SCALE; // make the shooter larger again without returning to the oversized direct scale
-// ReadyPlayer/Soldier avatars face away from the billiards rig forward axis by default; flip the
-// child model so the visible player faces inward toward the table instead of showing their back.
-const POOL_ROYALE_HUMAN_VISUAL_YAW_FIX = Math.PI;
+const POOL_ROYALE_LOUNGE_TABLE_RADIUS = BALL_R * 38; // larger pool-side player table matching the Showood table's bigger stage presence.
+const POOL_ROYALE_LOUNGE_TABLE_HEIGHT = BALL_R * 20.5;
+const POOL_ROYALE_LOUNGE_CHAIR_SPAN = BALL_R * 84; // larger, taller portrait-readable chairs for each player lounge.
+const POOL_ROYALE_LOUNGE_DISTANCE = BALL_R * 82;
+const POOL_ROYALE_LOUNGE_CHAIR_OFFSET = BALL_R * 82;
+// Soldier.glb already faces the billiards rig forward axis; keep the child model unflipped so
+// the visible player faces inward toward the table instead of showing their back in portrait play.
+const POOL_ROYALE_HUMAN_VISUAL_YAW_FIX = 0;
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
 const HUMAN_PLAYER_AIM_LEAN = 0.2;
@@ -2687,8 +2693,8 @@ const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 4.55; // widen the perimeter walk ri
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
 const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.032; // lower the low cue camera close to cloth height for portrait aiming
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
-const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 3.85; // move the low cue camera closer toward the bridge hand/cue ball while staying behind the shot line
-const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 1.05; // offset beside the cue line so the active player never hides the cue ball or shot line
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 3.15; // move the low cue camera closer toward the bridge hand/cue ball while staying behind the shot line
+const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 0.22; // preserve subtle right-eye bias without exposing too much of the avatar body
 const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
 const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
 const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.34; // set the bridge farther behind the cue ball to match real pool hand placement
@@ -4341,6 +4347,11 @@ const CHESS_BATTLE_DEFAULT_SET_URLS = Object.freeze([
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf'
 ]);
+const POOL_ROYALE_MURLAN_CHAIR_URLS = Object.freeze([
+  'https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/dining_chair_02/dining_chair_02_1k.gltf',
+  'https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/dining_chair_02/dining_chair_02_2k.gltf',
+  'https://dl.polyhaven.org/file/ph-assets/Models/gltf/4k/dining_chair_02/dining_chair_02_4k.gltf'
+]);
 const DEFAULT_CHROME_COLOR_ID =
   POOL_ROYALE_DEFAULT_UNLOCKS.chromeColor?.[0] ?? 'gold';
 const CHROME_COLOR_OPTIONS = Object.freeze([
@@ -4517,7 +4528,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'railSight' : part;
+  const optionPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -10915,92 +10926,6 @@ export function Table3D(
 
   const carbonFiberPatternCanvas = getCarbonFiberPatternCanvas();
 
-  const createMurlanBrandPlateTexture = () => {
-    if (typeof document === 'undefined') return null;
-    const canvas = document.createElement('canvas');
-    canvas.width = 1024;
-    canvas.height = 256;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return null;
-
-    const pattern = document.createElement('canvas');
-    pattern.width = 64;
-    pattern.height = 64;
-    const pctx = pattern.getContext('2d');
-    if (pctx) {
-      pctx.fillStyle = '#0d1117';
-      pctx.fillRect(0, 0, 64, 64);
-      pctx.fillStyle = '#141a22';
-      pctx.fillRect(0, 0, 32, 32);
-      pctx.fillRect(32, 32, 32, 32);
-      pctx.strokeStyle = 'rgba(255,255,255,0.06)';
-      pctx.lineWidth = 2;
-      pctx.beginPath();
-      pctx.moveTo(0, 32);
-      pctx.lineTo(32, 0);
-      pctx.lineTo(64, 32);
-      pctx.lineTo(32, 64);
-      pctx.closePath();
-      pctx.stroke();
-    }
-
-    const bgPattern = ctx.createPattern(pattern, 'repeat');
-    ctx.fillStyle = bgPattern || '#111827';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    const goldFill = '#e6c56a';
-    const goldStroke = '#f2d783';
-    const frameX = 12;
-    const frameY = 12;
-    const frameW = canvas.width - 24;
-    const frameH = canvas.height - 24;
-    const radius = 24;
-    ctx.strokeStyle = goldStroke;
-    ctx.lineWidth = 7;
-    ctx.beginPath();
-    ctx.moveTo(frameX + radius, frameY);
-    ctx.lineTo(frameX + frameW - radius, frameY);
-    ctx.quadraticCurveTo(frameX + frameW, frameY, frameX + frameW, frameY + radius);
-    ctx.lineTo(frameX + frameW, frameY + frameH - radius);
-    ctx.quadraticCurveTo(frameX + frameW, frameY + frameH, frameX + frameW - radius, frameY + frameH);
-    ctx.lineTo(frameX + radius, frameY + frameH);
-    ctx.quadraticCurveTo(frameX, frameY + frameH, frameX, frameY + frameH - radius);
-    ctx.lineTo(frameX, frameY + radius);
-    ctx.quadraticCurveTo(frameX, frameY, frameX + radius, frameY);
-    ctx.closePath();
-    ctx.stroke();
-
-    const dotRadius = 8;
-    const dotOffset = 34;
-    [
-      [frameX + dotOffset, frameY + dotOffset],
-      [frameX + frameW - dotOffset, frameY + dotOffset],
-      [frameX + dotOffset, frameY + frameH - dotOffset],
-      [frameX + frameW - dotOffset, frameY + frameH - dotOffset]
-    ].forEach(([x, y]) => {
-      ctx.fillStyle = goldFill;
-      ctx.beginPath();
-      ctx.arc(x, y, dotRadius, 0, Math.PI * 2);
-      ctx.fill();
-    });
-
-    ctx.fillStyle = goldFill;
-    ctx.font = '700 96px "Inter", "Segoe UI", sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('TonPlaygram', canvas.width / 2, canvas.height / 2);
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
-    texture.minFilter = THREE.LinearMipmapLinearFilter;
-    texture.magFilter = THREE.LinearFilter;
-    texture.generateMipmaps = true;
-    texture.anisotropy = resolveTextureAnisotropy(texture.anisotropy ?? 1);
-    applySRGBColorSpace(texture);
-    texture.needsUpdate = true;
-    return texture;
-  };
-
   const createCarbonLabelTexture = ({
     width = 2048,
     height = 512,
@@ -12040,7 +11965,15 @@ export function Table3D(
   railsGroup.add(railsMesh);
   finishParts.railMeshes.push(railsMesh);
 
-  const brandPlateTexture = createMurlanBrandPlateTexture();
+  const brandPlateTexture =
+    createCarbonLabelTexture({
+      width: 2048,
+      height: 512,
+      lines: [{ text: 'TonPlaygram', size: 0.34, weight: '800' }],
+      borderWidth: Math.max(TABLE.THICK * 5.5, 20),
+      padding: 140,
+      studScale: 0.28
+    }) || null;
   const brandPlateTopMaterial = brandPlateTexture
     ? new THREE.MeshPhysicalMaterial({
         color: 0xffffff,
@@ -12097,8 +12030,6 @@ export function Table3D(
     plate.castShadow = true;
     plate.receiveShadow = true;
     plate.renderOrder = CHROME_PLATE_RENDER_ORDER + 0.2;
-    plate.userData.externalTableKeepVisible = true;
-    plate.userData.poolRoyaleKeepBrandPlateWithExternalOriginal = true;
     railsGroup.add(plate);
     const sideMaterials = Array.isArray(plate.material)
       ? plate.material.filter((_, index) => index !== 2)
@@ -13193,7 +13124,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'railSight',
+    sideWoodApron: 'baseCornerBlock',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',
@@ -13369,10 +13300,9 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
     (s.downFace && s.relY > 0.46 && s.relY < 0.84 && ((s.longN > 0.62 && s.longN < 0.94) || (s.shortN > 0.44 && s.shortN < 0.86)))
   );
   const topRailBand = high && (s.longN > 0.58 || s.shortN > 0.535);
-  const outsideBaseCornerRimZone = s.sideFace && s.relY > 0.06 && s.relY < 0.86 && s.longN > 0.66 && s.shortN > 0.44;
-  const outerMostVerticalCorner = s.sideFace && s.relY > 0.08 && s.relY < 0.88 && s.longN > 0.74 && s.shortN > 0.58;
-  const goldCornerDropZone = s.sideFace && s.relY > 0.12 && s.relY < 0.78 && s.longN > 0.58 && s.shortN > 0.58;
-  const sideLowerTrimZone = s.sideFace && s.relY > 0.16 && s.relY < 0.48 && (s.longN > 0.50 || s.shortN > 0.50) && !outsideBaseCornerRimZone;
+  const outsideBaseCornerRimZone = s.sideFace && s.relY > 0.08 && s.relY < 0.82 && s.longN > 0.70 && s.shortN > 0.50;
+  const outerMostVerticalCorner = s.sideFace && s.relY > 0.10 && s.relY < 0.84 && s.longN > 0.78 && s.shortN > 0.64;
+  const sideLowerTrimZone = s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54) && !outsideBaseCornerRimZone;
   const baseCornerZone = s.sideFace && midBody && (
     (s.longN > 0.08 && s.longN < 0.58 && s.shortN < 0.42) ||
     (s.longN > 0.50 && s.shortN > 0.48) ||
@@ -13384,9 +13314,9 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   if (namedSight && high) return 'railSight';
   if ((namedCloth || green) && centralCloth) return 'cloth';
   if ((namedCushion || green) && cushionBand) return 'cushion';
-  if ((outsideBaseCornerRimZone || outerMostVerticalCorner || (hardwareCandidate && goldCornerDropZone)) && !green && !s.upFace) return 'railSight';
+  if ((outsideBaseCornerRimZone || outerMostVerticalCorner) && !green && !s.upFace) return 'verticalCornerRim';
   if (hardwareCandidate && topRailBand && s.upFace && !brown && !green) return 'railSight';
-  if ((hardwareCandidate || goldCornerDropZone) && sideLowerTrimZone && !green) return 'railSight';
+  if (hardwareCandidate && sideLowerTrimZone && !green) return 'railSight';
   if (low) return 'baseFoot';
   if ((brown || namedWood || black) && baseCornerZone) return 'baseCornerBlock';
   if (midBody && s.sideFace && !(s.longN > 0.64 && s.shortN > 0.64)) return 'leg';
@@ -13417,7 +13347,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'railSight' : part;
+      const linkedPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];
@@ -14688,7 +14618,6 @@ function mountPoolRoyaleExternalTableModel({
       if (
         !visible &&
         (
-          object.userData?.poolRoyaleKeepBrandPlateWithExternalOriginal ||
           (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
           (externalTableModelForMount?.id === 'showood-seven-foot' && !table.userData.showoodUsesOriginalBase && object.userData?.showoodGeneratedPocketSupport) ||
           (externalTableModelForMount?.id === 'showood-seven-foot' && !table.userData.showoodUsesOriginalBase && object.userData?.__basePart) ||
@@ -26922,6 +26851,156 @@ const shotPowerRef = useRef(0);
         return group;
       };
 
+      const createWaterServiceProps = (tableTopY = BALL_R * 6.2) => {
+        const group = new THREE.Group();
+        const waterMat = new THREE.MeshPhysicalMaterial({ color: 0xbdeaff, transparent: true, opacity: 0.62, roughness: 0.08, metalness: 0, transmission: 0.35 });
+        const glassMat = new THREE.MeshPhysicalMaterial({ color: 0xffffff, transparent: true, opacity: 0.34, roughness: 0.04, metalness: 0, transmission: 0.55 });
+        const bottle = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 0.62, BALL_R * 0.74, BALL_R * 3.9, 20), waterMat);
+        bottle.position.set(-BALL_R * 2.15, tableTopY + BALL_R * 2.0, -BALL_R * 0.45);
+        const glass = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 0.82, BALL_R * 0.68, BALL_R * 1.85, 20), glassMat);
+        glass.position.set(BALL_R * 2.0, tableTopY + BALL_R * 0.9, BALL_R * 0.55);
+        const water = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 0.66, BALL_R * 0.56, BALL_R * 0.88, 20), waterMat);
+        water.position.set(0, -BALL_R * 0.18, 0);
+        glass.add(water);
+        [bottle, glass].forEach((mesh) => {
+          mesh.castShadow = true;
+          mesh.receiveShadow = true;
+          group.add(mesh);
+        });
+        group.userData.glass = glass;
+        group.userData.glassBase = glass.position.clone();
+        return group;
+      };
+
+      const fitAssetToSpan = (asset, targetSpan, { ground = true } = {}) => {
+        if (!asset) return asset;
+        const box = new THREE.Box3().setFromObject(asset);
+        const size = box.getSize(new THREE.Vector3());
+        const span = Math.max(size.x || 0, size.z || 0, size.y || 0);
+        if (span > 1e-6 && Number.isFinite(targetSpan)) {
+          asset.scale.multiplyScalar(targetSpan / span);
+        }
+        if (ground) {
+          const groundedBox = new THREE.Box3().setFromObject(asset);
+          asset.position.y += -groundedBox.min.y;
+        }
+        return asset;
+      };
+
+      const createFallbackPoolSideFurniture = (seat, sideSign, tableTopY) => {
+        const group = new THREE.Group();
+        const woodMat = new THREE.MeshStandardMaterial({ color: 0x5b351f, roughness: 0.62, metalness: 0.05 });
+        const seatMat = new THREE.MeshStandardMaterial({ color: seat === 'A' ? 0x0f766e : 0x7c2d12, roughness: 0.55, metalness: 0.08 });
+        const tableTop = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 25.2, BALL_R * 25.8, BALL_R * 1.65, 64), woodMat);
+        tableTop.position.set(0, tableTopY, 0);
+        const tablePedestal = new THREE.Mesh(new THREE.CylinderGeometry(BALL_R * 2.45, BALL_R * 3.5, tableTopY, 32), woodMat);
+        tablePedestal.position.set(0, tableTopY * 0.5, 0);
+        const chairSeat = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 18.6, BALL_R * 2.05, BALL_R * 20.8), seatMat);
+        chairSeat.position.set(sideSign * BALL_R * 47.5, BALL_R * 4.4, 0);
+        const chairBack = new THREE.Mesh(new THREE.BoxGeometry(BALL_R * 2.05, BALL_R * 15.8, BALL_R * 20.8), seatMat);
+        chairBack.position.set(sideSign * BALL_R * 57.0, BALL_R * 11.2, 0);
+        [tableTop, tablePedestal, chairSeat, chairBack].forEach((mesh) => {
+          mesh.castShadow = true;
+          mesh.receiveShadow = true;
+          group.add(mesh);
+        });
+        group.userData.tableMeshes = [tableTop, tablePedestal];
+        group.userData.chairMeshes = [chairSeat, chairBack];
+        return group;
+      };
+
+      const createPoolSideLounge = (seat, sideSign, options = {}) => {
+        const group = new THREE.Group();
+        const sharedSeatOffsets = options.sharedSeatOffsets || { [seat]: 0 };
+        const primarySeat = options.primarySeat || seat;
+        group.userData.seat = primarySeat;
+        const x = sideSign * (TABLE.W / 2 + POOL_ROYALE_LOUNGE_DISTANCE);
+        const z = options.z ?? 0;
+        group.position.set(x, floorY, z);
+        group.rotation.y = 0;
+
+        const tableTopY = POOL_ROYALE_LOUNGE_TABLE_HEIGHT;
+        const chairLocalX = sideSign * POOL_ROYALE_LOUNGE_CHAIR_OFFSET;
+        const fallbackFurniture = createFallbackPoolSideFurniture(primarySeat, sideSign, tableTopY);
+        fallbackFurniture.name = `PoolRoyale_${primarySeat}_VisibleSharedLoungeFallback`;
+        const fallbackChairMeshes = fallbackFurniture.userData?.chairMeshes || [];
+        const fallbackSeatEntries = Object.entries(sharedSeatOffsets);
+        fallbackSeatEntries.forEach(([seatKey, localZ], index) => {
+          const meshes = index === 0
+            ? fallbackChairMeshes
+            : fallbackChairMeshes.map((mesh) => mesh.clone());
+          meshes.forEach((mesh) => {
+            mesh.name = `PoolRoyale_${seatKey}_SharedFallbackChair`;
+            mesh.position.z = localZ;
+            if (index > 0) fallbackFurniture.add(mesh);
+          });
+        });
+        group.add(fallbackFurniture);
+
+        const showLoungeTable = true;
+        fallbackFurniture.userData?.tableMeshes?.forEach((mesh) => {
+          mesh.visible = showLoungeTable;
+        });
+        if (showLoungeTable) {
+          const murlanDefaultTable = new THREE.Group();
+          murlanDefaultTable.name = `PoolRoyale_${primarySeat}_MurlanDefaultOctagonTable`;
+          try {
+            createMurlanStyleTable({
+              THREE,
+              arena: murlanDefaultTable,
+              renderer,
+              tableRadius: POOL_ROYALE_LOUNGE_TABLE_RADIUS,
+              tableHeight: tableTopY,
+              includeBase: true
+            });
+            group.add(murlanDefaultTable);
+            fallbackFurniture.userData?.tableMeshes?.forEach((mesh) => {
+              mesh.visible = false;
+            });
+          } catch (error) {
+            console.warn('Failed to create Pool Royale Murlan default lounge table', error);
+          }
+        }
+
+        loadFirstAvailableGltf(POOL_ROYALE_MURLAN_CHAIR_URLS).then((chairGltf) => {
+          if (!group.parent) return;
+          const chairModel = chairGltf?.scene?.clone?.(true) ?? chairGltf?.scene ?? null;
+          if (!chairModel) return;
+          markHospitalityMaterials(chairModel);
+          fitAssetToSpan(chairModel, POOL_ROYALE_LOUNGE_CHAIR_SPAN);
+          Object.entries(sharedSeatOffsets).forEach(([seatKey, localZ], index) => {
+            const seatChair = index === 0 ? chairModel : chairModel.clone(true);
+            seatChair.name = `PoolRoyale_${seatKey}_SharedLoungeChair`;
+            seatChair.position.set(chairLocalX, chairModel.position.y, localZ);
+            const toTable = new THREE.Vector2(-seatChair.position.x, -seatChair.position.z);
+            seatChair.rotation.y = Math.atan2(toTable.x, toTable.y);
+            group.add(seatChair);
+          });
+          fallbackFurniture.visible = false;
+        }).catch((error) => {
+          console.warn('Failed to upgrade Pool Royale lounge chair GLTF asset', error);
+        });
+
+        const serviceProps = showLoungeTable ? createWaterServiceProps(tableTopY) : null;
+        if (serviceProps) group.add(serviceProps);
+        group.userData.sharedSeatChairs = Object.fromEntries(
+          Object.entries(sharedSeatOffsets).map(([seatKey, localZ]) => [
+            seatKey,
+            {
+              chairRoot: new THREE.Vector3(x + chairLocalX, floorY, z + localZ),
+              chairFacing: new THREE.Vector3(-sideSign, 0, 0).normalize(),
+              chairSeatWorld: new THREE.Vector3(x + chairLocalX, floorY, z + localZ)
+            }
+          ])
+        );
+        group.userData.chairRoot = group.userData.sharedSeatChairs[primarySeat]?.chairRoot?.clone?.() || new THREE.Vector3(x + chairLocalX, floorY, z);
+        group.userData.chairFacing = group.userData.sharedSeatChairs[primarySeat]?.chairFacing?.clone?.() || new THREE.Vector3(-sideSign, 0, 0).normalize();
+        group.userData.chairSeatWorld = group.userData.sharedSeatChairs[primarySeat]?.chairSeatWorld?.clone?.() || new THREE.Vector3(x + chairLocalX, floorY, z);
+        group.userData.glass = serviceProps?.userData?.glass || null;
+        group.userData.glassBase = serviceProps?.userData?.glassBase?.clone?.() || new THREE.Vector3();
+        return group;
+      };
+
       const spawnPlayerCharacters = async () => {
         disposePlayerCharacters();
         const zOffset = TABLE.H * 0.72;
@@ -26963,10 +27042,10 @@ const shotPowerRef = useRef(0);
             perimeterWalkSpeed: behavior.walkSpeed * POOL_ROYALE_HUMAN_UNIT_SCALE,
             stanceWidth: behavior.stanceWidth * POOL_ROYALE_HUMAN_UNIT_SCALE,
             bridgePalmTableLift: behavior.bridgeLift * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            chinToCueHeight: 0.14 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            chinToCueHeight: 0.11 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             footGroundY: 0.02 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             footLockStrength: 1.25,
-            kneeBendShot: 0.21 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            kneeBendShot: 0.16 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             desiredShootDistance: behavior.desiredShootDistance * POOL_ROYALE_HUMAN_UNIT_SCALE,
             edgeMargin: behavior.edgeMargin * POOL_ROYALE_HUMAN_UNIT_SCALE,
             bridgeHandBackFromBall: behavior.bridgeBack * POOL_ROYALE_HUMAN_UNIT_SCALE,
@@ -26982,7 +27061,7 @@ const shotPowerRef = useRef(0);
             rightForearmLength: 0.34 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightStrokePull: behavior.strokePull * POOL_ROYALE_HUMAN_UNIT_SCALE,
             rightStrokePush: behavior.strokePush * POOL_ROYALE_HUMAN_UNIT_SCALE,
-            rightHandShotLift: -0.34 * POOL_ROYALE_HUMAN_UNIT_SCALE,
+            rightHandShotLift: -0.30 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             idleRightHandX: 0.31 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             idleRightHandY: 0.8 * POOL_ROYALE_HUMAN_UNIT_SCALE,
             idleRightHandZ: -0.015 * POOL_ROYALE_HUMAN_UNIT_SCALE,
@@ -27004,8 +27083,21 @@ const shotPowerRef = useRef(0);
           return { seat, human, heldCue };
         };
         const playerA = activeHumanCharacterRef.current || POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
+        const playerB = POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
+        const sharedLounge = createPoolSideLounge('A', -1, {
+          primarySeat: 'A',
+          z: 0,
+          sharedSeatOffsets: {
+            A: -TABLE.H * 0.18,
+            B: TABLE.H * 0.18
+          }
+        });
+        world.add(sharedLounge);
         playerCharacterRigsRef.current = [
-          makeRig('A', -sideOffset, -zOffset, 0, playerA)
+          makeRig('A', -sideOffset, -zOffset, 0, playerA),
+          makeRig('B', sideOffset, zOffset, Math.PI, playerB),
+          { group: sharedLounge, lounge: true, seat: 'A' },
+          { group: sharedLounge, lounge: true, seat: 'B' }
         ];
       };
       spawnPlayerCharactersRef.current = spawnPlayerCharacters;
@@ -27126,6 +27218,20 @@ const shotPowerRef = useRef(0);
           Math.abs(point?.x ?? 0) < blockerHalfX && Math.abs(point?.z ?? 0) < blockerHalfZ;
 
         const desiredRoot = chooseEdgeTarget(normalizedAim);
+        const loungeBySeat = new Map();
+        rigs.forEach((entry) => {
+          if (!entry?.lounge || !entry.group) return;
+          loungeBySeat.set(entry.seat, entry.group);
+          const glass = entry.group.userData?.glass;
+          const base = entry.group.userData?.glassBase;
+          if (glass && base) {
+            const sip = (Math.sin(nowMs * 0.00075 + (entry.seat === 'A' ? 0 : Math.PI)) + 1) * 0.5;
+            const lift = sip > 0.86 ? (sip - 0.86) / 0.14 : 0;
+            glass.position.copy(base);
+            glass.position.y += lift * BALL_R * 2.0;
+            glass.position.z += (entry.seat === 'A' ? -1 : 1) * lift * BALL_R * 1.6;
+          }
+        });
 
         rigs.forEach((rig) => {
           const anim = rig?.anim;
@@ -27175,9 +27281,38 @@ const shotPowerRef = useRef(0);
               1
             );
             const walkRoot = perimeterTToPoint(human.walkPerimeterT);
-            turnFlow.seatedBySeat = { ...(turnFlow.seatedBySeat || {}), [seat]: true };
+            const shouldRestAtChair = !isHumanShooter;
+            let walkingToChair = false;
+            let seatedAtChair = false;
+            let chairFacing = null;
+            if (shouldRestAtChair) {
+              const lounge = loungeBySeat.get(seat);
+              const seatChair = lounge?.userData?.sharedSeatChairs?.[seat] || lounge?.userData || null;
+              const chairRoot = seatChair?.chairRoot;
+              if (chairRoot) {
+                walkRoot.copy(chairRoot);
+                const tableWatchPoint = cueWorld?.clone?.() || new THREE.Vector3(0, floorY, 0);
+                tableWatchPoint.y = floorY;
+                chairFacing = tableWatchPoint.sub(chairRoot);
+                chairFacing.y = 0;
+                if (chairFacing.lengthSq() < 1e-6) {
+                  chairFacing = new THREE.Vector3(-chairRoot.x, 0, -chairRoot.z);
+                }
+                chairFacing.normalize();
+                // Keep the off-turn player registered at the lounge entry point while seated.
+                // On the next turn, the shared rig eases out to this perimeter point instead of
+                // teleporting from a chair directly to an already-advanced walk-ring position.
+                human.walkPerimeterT = pointToPerimeterT(chairRoot);
+                human.perimeterT = human.walkPerimeterT;
+                walkingToChair = true;
+                seatedAtChair = (human.root?.position?.distanceTo?.(chairRoot) ?? Infinity) <= BALL_R * 5.5;
+              }
+            }
+            turnFlow.seatedBySeat = { ...(turnFlow.seatedBySeat || {}), [seat]: seatedAtChair };
             characterTurnFlowRef.current = turnFlow;
-            const state = mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
+            const state = seatedAtChair
+              ? 'seated'
+              : mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
             const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
             const strikingPower = Math.max(0, Math.min(1, shotPowerRef.current ?? draggingPower));
             const activePower = state === 'dragging' ? draggingPower : strikingPower;
@@ -27199,20 +27334,6 @@ const shotPowerRef = useRef(0);
             }
             const bridgeBackFromBall = human?.cfg?.bridgeHandBackFromBall ?? (behavior.bridgeBack ?? 0.072) * humanUnitScale;
             const bridgeSideOffset = human?.cfg?.bridgeHandSide ?? (behavior.bridgeSide ?? -0.024) * humanUnitScale;
-            const railDistance = Math.min(
-              Math.max(0, TABLE.W / 2 - Math.abs(cueWorld.x)),
-              Math.max(0, TABLE.H / 2 - Math.abs(cueWorld.z))
-            );
-            const bridgeReach = cueWorld.clone().sub(walkRoot).setY(0).length();
-            const shotType = railDistance <= BALL_R * 7
-              ? 'rail'
-              : bridgeReach >= humanUnitScale * 1.25
-                ? 'longReach'
-                : activePower >= 0.74
-                  ? 'power'
-                  : activePower > 0 && activePower <= 0.26
-                    ? 'softPrecision'
-                    : 'standard';
             const bridgeTarget = cueWorld
               .clone()
               // Put the left bridge hand on the cloth right beside the cue ball, like a real pool stance.
@@ -27242,7 +27363,7 @@ const shotPowerRef = useRef(0);
                 side: side.clone()
               };
             }
-            const poseForward = aimForward;
+            const poseForward = chairFacing?.lengthSq?.() > 1e-6 ? chairFacing.normalize() : aimForward;
             const standingYaw = Math.atan2(-poseForward.x, -poseForward.z);
             const idleRight = walkRoot
               .clone()
@@ -27283,11 +27404,7 @@ const shotPowerRef = useRef(0);
               cueBack,
               cueTip,
               power: activePower,
-              tableCenter: new THREE.Vector3(0, TABLE_Y + TABLE.THICK, 0),
-              railDistance,
-              bridgeReach,
-              shotType,
-              directRootTarget: false
+              directRootTarget: walkingToChair
             });
             if (rig.heldCue) {
               rig.heldCue.userData?.setFromBackTip?.(cueBack, cueTip);


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale game implementation to its previous working state as of 2026-05-11 11:00 UTC so gameplay visuals, seating/lounge behavior and Showood table finish mapping match the known-good snapshot.  
- Limit the change to only the Pool Royale game code so unrelated areas remain untouched.

### Description
- Restored `webapp/src/pages/Games/PoolRoyale.jsx` to the earlier snapshot and reintroduced the Murlan lounge/table import and chair asset URLs via `createMurlanStyleTable` and `POOL_ROYALE_MURLAN_CHAIR_URLS`.  
- Reinstated pool-side lounge features and shared seating utilities including `createPoolSideLounge`, `createFallbackPoolSideFurniture`, `createWaterServiceProps`, `fitAssetToSpan`, and the logic that spawns a shared lounge and registers lounge rigs for off-turn players.  
- Recovered Showood table finish and part-mapping logic changes (updated `getShowoodPartOption` mapping and `resolvePoolRoyaleShowoodTrianglePart` / external material remapping) so external GLB surfaces map to the expected `baseFoot`, `baseCornerBlock`, `verticalCornerRim`, etc. roles.  
- Restored human/pose/camera tuning and behavior changes (lounge/chair positioning constants, `POOL_ROYALE_HUMAN_VISUAL_YAW_FIX`, `HUMAN_EYE_CAMERA_*` offsets, `chinToCueHeight`, `kneeBendShot`, `rightHandShotLift`, seated-state handling in character update flow) and replaced the previous brand-plate texture logic with the carbon label flow used for the restored brand plate visuals.

### Testing
- Ran the targeted Jest suites via `npx jest --runInBand test/poolRoyaleSpinController.test.js test/poolRoyaleCueStrokeTimeline.test.js test/poolRoyaleShotState.test.js test/poolRoyaleAiAimCompensation.test.js test/poolRoyaleAimSuggestion.test.js`, and all suites passed.  
- Built the webapp with `npm --prefix webapp run build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e10e4c6c8329977de743e2384cdf)