### PR TITLE
Tune Pool Royale stance, furniture, and shot power

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2272,8 +2272,8 @@ const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
-const SHOT_POWER_BOOST = 1.16; // add more cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.76; // keep Pool Royale stronger than before without over-speeding the table
+const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
+const SHOT_GLOBAL_POWER_SCALE = 0.82; // raise Pool Royale strike speed so full shots feel powerful
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -2402,21 +2402,21 @@ const POOL_ROYALE_HUMAN_LOGIC_PROFILES = Object.freeze({
     label: 'Classic Pro',
     summary: 'Forward bend: balanced orthodox pool stance with a stable bridge and medium follow-through.',
     bendMode: 'forward',
-    desiredShootDistance: 1.58,
-    edgeMargin: 0.82,
+    desiredShootDistance: 1.72,
+    edgeMargin: 0.9,
     stanceWidth: 0.62,
     bridgeBack: 0.095,
     bridgeSide: -0.024,
     bridgeLift: 0.006,
-    gripFromBack: 0.58,
-    rightElbowRise: 0.32,
-    rightElbowSide: -0.52,
-    rightElbowBack: -0.94,
-    forearmOutward: 0.42,
-    forearmBack: 0.56,
-    forearmDown: 0.58,
-    strokePull: 0.42,
-    strokePush: 0.18,
+    gripFromBack: 0.64,
+    rightElbowRise: 0.36,
+    rightElbowSide: -0.5,
+    rightElbowBack: -1.02,
+    forearmOutward: 0.34,
+    forearmBack: 0.48,
+    forearmDown: 0.54,
+    strokePull: 0.5,
+    strokePush: 0.24,
     practiceStroke: 0.035,
     cueGap: 0.012,
     strikeMs: 120,
@@ -2671,14 +2671,14 @@ const resolvePoolRoyaleHumanCharacter = (id) =>
   POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0];
 const POOL_ROYALE_HUMAN_UNIT_SCALE = BALL_R / 0.0525;
 const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.85 * POOL_ROYALE_HUMAN_UNIT_SCALE; // make the shooter larger again without returning to the oversized direct scale
-const POOL_ROYALE_LOUNGE_TABLE_RADIUS = BALL_R * 38; // larger pool-side player table matching the Showood table's bigger stage presence.
-const POOL_ROYALE_LOUNGE_TABLE_HEIGHT = BALL_R * 20.5;
-const POOL_ROYALE_LOUNGE_CHAIR_SPAN = BALL_R * 84; // larger, taller portrait-readable chairs for each player lounge.
+const POOL_ROYALE_LOUNGE_TABLE_RADIUS = BALL_R * 30; // smaller pool-side Murlan table so it no longer competes with the Showood table.
+const POOL_ROYALE_LOUNGE_TABLE_HEIGHT = BALL_R * 17.5;
+const POOL_ROYALE_LOUNGE_CHAIR_SPAN = BALL_R * 62; // smaller side chairs keep the lounge secondary to the main table.
 const POOL_ROYALE_LOUNGE_DISTANCE = BALL_R * 82;
-const POOL_ROYALE_LOUNGE_CHAIR_OFFSET = BALL_R * 82;
-// Soldier.glb already faces the billiards rig forward axis; keep the child model unflipped so
-// the visible player faces inward toward the table instead of showing their back in portrait play.
-const POOL_ROYALE_HUMAN_VISUAL_YAW_FIX = 0;
+const POOL_ROYALE_LOUNGE_CHAIR_OFFSET = BALL_R * 62;
+// Pool Royale's loaded human avatars use the shared billiards rig forward axis,
+// which needs the same 180° visual correction as the core rig so they face the table.
+const POOL_ROYALE_HUMAN_VISUAL_YAW_FIX = Math.PI;
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
 const HUMAN_PLAYER_AIM_LEAN = 0.2;
@@ -2686,21 +2686,21 @@ const HUMAN_PLAYER_REACT_LEAN = 0.12;
 const HUMAN_POSE_LAMBDA = 9.0;
 const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
-const HUMAN_EDGE_MARGIN = 2.18; // push the shooter farther outward so the avatar stays clear of the table edge in portrait
-const HUMAN_DESIRED_SHOOT_DISTANCE = 2.42; // keep the shooter much farther back on the cue-butt side like a real pool stance
+const HUMAN_EDGE_MARGIN = 2.34; // push the shooter farther outward so the avatar stays clear of the table edge in portrait
+const HUMAN_DESIRED_SHOOT_DISTANCE = 2.62; // keep the shooter farther back on the cue-butt side like a real pool stance
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.96; // enter shooting pose immediately when the portrait cue camera starts lowering
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 4.55; // widen the perimeter walk ring so feet never step onto the table mesh
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
 const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.032; // lower the low cue camera close to cloth height for portrait aiming
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
-const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 3.15; // move the low cue camera closer toward the bridge hand/cue ball while staying behind the shot line
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 4.35; // move the low cue camera closer toward the bridge hand/cue ball while staying behind the shot line
 const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 0.22; // preserve subtle right-eye bias without exposing too much of the avatar body
 const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
 const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
-const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.34; // set the bridge farther behind the cue ball to match real pool hand placement
-const HUMAN_BRIDGE_HAND_SIDE = -0.008; // match Bilardo Shqip bridge hand lateral placement
-const HUMAN_BRIDGE_CUE_LIFT = 0.018; // flatten the cue closer to the cloth like the reference shooting photos
-const HUMAN_GRIP_RATIO = 0.9; // anchor right-hand grip much closer to the cue butt so the hand no longer drifts toward the tip
+const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.26; // keep the bridge roughly 6-10 inches behind the cue ball for a real pool stance
+const HUMAN_BRIDGE_HAND_SIDE = -0.014; // small lateral offset keeps the bridge hand beside the shot line instead of under the cue ball
+const HUMAN_BRIDGE_CUE_LIFT = 0.012; // flatten the cue closer to the cloth like a real level stroke
+const HUMAN_GRIP_RATIO = 0.78; // place the grip where the forearm can hang near vertical at cue-ball address
 const HUMAN_CUE_LENGTH = 1.46; // match Bilardo Shqip cue length used for hand/cue alignment
 const HUMAN_BRIDGE_DIST = 0.24; // match Bilardo Shqip bridge-to-tip section used by cue placement
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -1074,7 +1074,14 @@ export function updateHumanPose(human, dt, frameData) {
     ? tableForward
     : resolveTableFacingForward(frameData.aimForward, rootGoal, frameData, cfg);
   const targetRootYaw = yawFromForward(facingForward) - (cfg.humanVisualYawFix || 0);
-  human.yaw = dampAngle(human.yaw, targetRootYaw, shootingPoseActive ? cfg.rotLambda * 1.35 : cfg.rotLambda, dt);
+  if (shootingPoseActive) {
+    // Lock aiming/striking frames exactly onto the table-facing shot line. A slow
+    // damp here can leave the avatar visibly aimed at the opposite rail for a few
+    // frames after the cue camera drops.
+    human.yaw = targetRootYaw;
+  } else {
+    human.yaw = dampAngle(human.yaw, targetRootYaw, cfg.rotLambda, dt);
+  }
   ensureHumanFacingTable(human, frameData, cfg);
 
   const t = easeInOut(human.poseT);


### PR DESCRIPTION
### Motivation
- Make the Murlan/lounge table and chairs visually smaller so they don’t compete with the Showood pool table in Pool Royale scenes.
- Increase shot strength so strikes feel more powerful while preserving existing slider/physics pipeline behavior.
- Move and retune the human shooter (stance, bridge, grip) and bring the cue camera closer so the avatar and camera align with realistic pool shooting posture, and ensure the avatar faces the table when aiming/striking.

### Description
- Increased global shot scaling by changing `SHOT_POWER_BOOST` and `SHOT_GLOBAL_POWER_SCALE` to raise cue-drive while keeping the rest of the slider/physics chain unchanged (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Reduced lounge furniture footprint by lowering `POOL_ROYALE_LOUNGE_TABLE_RADIUS`, `POOL_ROYALE_LOUNGE_TABLE_HEIGHT`, `POOL_ROYALE_LOUNGE_CHAIR_SPAN`, and `POOL_ROYALE_LOUNGE_CHAIR_OFFSET` so side table and chairs read smaller beside the Showood table (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Retuned the shooter and stance profiles (e.g. `desiredShootDistance`, `edgeMargin`, `gripFromBack`, elbow/forearm and stroke parameters) and adjusted human-placement constants (`HUMAN_EDGE_MARGIN`, `HUMAN_DESIRED_SHOOT_DISTANCE`, `HUMAN_EYE_CAMERA_FORWARD_OFFSET`, `HUMAN_BRIDGE_*`, `HUMAN_GRIP_RATIO`) to move the avatar slightly farther back and produce a more realistic bridge/grip (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Fix for model facing and aiming: set `POOL_ROYALE_HUMAN_VISUAL_YAW_FIX` for loaded human models and change the shared human rig so when `shootingPoseActive` the avatar yaw is locked directly to the table-facing shot line (replace damped yaw with an immediate alignment during aiming/striking) to avoid the avatar briefly looking the wrong way (file: `webapp/src/pages/Games/shared/humanRigCore.js`).

### Testing
- Ran unit/play-mode related suites with `npm test -- --runInBand test/poolRoyaleShotState.test.js test/cueShotImpact.test.js test/poolRoyaleCueStrokeTimeline.test.js` and all tests passed.
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.
- Attempted an automated Playwright screenshot of the running dev site (after installing Playwright deps) but the canvas screenshot timed out in this environment; the build and headless browser install steps ran as automated tasks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ebc913a88329a784863da4e4229d)