### PR TITLE
Add Shooting Range game

### DIFF
--- a/webapp/public/assets/icons/shooting-range.svg
+++ b/webapp/public/assets/icons/shooting-range.svg
@@ -1,0 +1,16 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="112" fill="#111827"/>
+  <path d="M68 376H444" stroke="#334155" stroke-width="28" stroke-linecap="round"/>
+  <path d="M96 376L148 168H364L416 376" fill="#1f2937"/>
+  <path d="M148 168H364L416 376H96L148 168Z" stroke="#64748b" stroke-width="18" stroke-linejoin="round"/>
+  <circle cx="256" cy="238" r="88" fill="#f8fafc" stroke="#0f172a" stroke-width="14"/>
+  <circle cx="256" cy="238" r="62" stroke="#ef4444" stroke-width="14"/>
+  <circle cx="256" cy="238" r="34" stroke="#0ea5e9" stroke-width="14"/>
+  <circle cx="256" cy="238" r="10" fill="#f97316"/>
+  <path d="M166 334H314C329.464 334 342 346.536 342 362V377H196C179.431 377 166 363.569 166 347V334Z" fill="#f59e0b"/>
+  <path d="M224 302H398C413.464 302 426 314.536 426 330V334H224V302Z" fill="#94a3b8"/>
+  <path d="M341 334L381 391H329L298 334H341Z" fill="#78350f"/>
+  <path d="M196 334H426" stroke="#f8fafc" stroke-width="10" stroke-linecap="round"/>
+  <path d="M390 288L446 268" stroke="#fde68a" stroke-width="12" stroke-linecap="round"/>
+  <path d="M402 302L458 302" stroke="#fde68a" stroke-width="12" stroke-linecap="round"/>
+</svg>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -113,6 +113,9 @@ const BowlingRealistic = React.lazy(
 const FreeKickArena = React.lazy(
   () => import('./pages/Games/FreeKickArena.tsx')
 );
+const ShootingRange = React.lazy(
+  () => import('./pages/Games/ShootingRange.tsx')
+);
 const StoreThumbnailStudioPoolRoyale = React.lazy(
   () => import('./pages/Tools/StoreThumbnailStudioPoolRoyale.jsx')
 );
@@ -438,6 +441,18 @@ export default function App() {
                 element={
                   <GameLiveAvatarOverlay gameSlug="bowling">
                     <BowlingRealistic />
+                  </GameLiveAvatarOverlay>
+                }
+              />
+              <Route
+                path="/games/shootingrange/lobby"
+                element={<Navigate to="/games/shootingrange" replace />}
+              />
+              <Route
+                path="/games/shootingrange"
+                element={
+                  <GameLiveAvatarOverlay gameSlug="shootingrange">
+                    <ShootingRange />
                   </GameLiveAvatarOverlay>
                 }
               />

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -26,6 +26,7 @@ export const gameThumbnails = {
   ludobattleroyal: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png',
   tennis: '/assets/icons/tennis-icon.svg',
   tabletennis: '/assets/icons/Goal%20rush%20logo.png',
+  shootingrange: '/assets/icons/shooting-range.svg',
 };
 
 const buildLobbyIconSet = (keys, icon) =>

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -112,6 +112,15 @@ const gamesCatalog = [
   },
 
   {
+    name: 'Shooting Range',
+    route: '/games/shootingrange',
+    slug: 'shootingrange',
+    image: '/assets/icons/shooting-range.svg',
+    description:
+      'Pick a 3D weapon, take your lane, and outscore three AI shooters.'
+  },
+
+  {
     name: 'Free Kick Arena',
     route: '/games/freekickarena/lobby',
     slug: 'freekickarena',

--- a/webapp/src/config/onlineContract.js
+++ b/webapp/src/config/onlineContract.js
@@ -59,6 +59,10 @@ export const ONLINE_READINESS_BY_GAME = Object.freeze({
   murlanroyale: {
     checks: { lobby: true, runtime: true, backend: true, security: true },
     label: 'Online Ready'
+  },
+  shootingrange: {
+    checks: { lobby: false, runtime: true, backend: false, security: false },
+    label: 'Beta'
   }
 });
 

--- a/webapp/src/pages/Games/ShootingRange.tsx
+++ b/webapp/src/pages/Games/ShootingRange.tsx
@@ -1,0 +1,1844 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import { clone as cloneScene } from 'three/examples/jsm/utils/SkeletonUtils.js';
+
+type WeaponClass = 'pistol' | 'revolver' | 'shotgun' | 'rifle' | 'smg' | 'sniper';
+type GamePhase = 'loading' | 'pick' | 'shoot' | 'results';
+type ViewMode = 'tables' | 'range' | 'results';
+type ControllerType = 'USER' | 'AI';
+
+type WeaponEntry = {
+  id: string;
+  name: string;
+  shortName: string;
+  urls: string[];
+  weaponClass: WeaponClass;
+};
+
+type WeaponStats = {
+  mag: number;
+  fireDelay: number;
+  reloadMs: number;
+  recoil: number;
+  spread: number;
+  damage: number;
+  pellets: number;
+  bulletSpeed: number;
+  shellPower: number;
+};
+
+type CharacterSpec = {
+  name: string;
+  urls: string[];
+  scale: number;
+  yaw: number;
+  fallbackColor: string;
+};
+
+type LaneRuntime = {
+  laneIndex: number;
+  playerId: number;
+  controller: ControllerType;
+  root: THREE.Group;
+  visual: THREE.Object3D | null;
+  mixer: THREE.AnimationMixer | null;
+  weaponMount: THREE.Group;
+  tableGroup: THREE.Group;
+  heldWeapon: THREE.Object3D | null;
+  muzzle: THREE.Object3D | null;
+  shellPort: THREE.Object3D | null;
+  aiNextShotAt: number;
+  aiAim: THREE.Vector2;
+  activeWeaponIndex: number;
+  pickupLift: number;
+};
+
+type TableWeaponRuntime = {
+  root: THREE.Group;
+  model: THREE.Object3D;
+  card: THREE.Mesh;
+  weaponIndex: number;
+};
+
+type BulletHole = {
+  mesh: THREE.Mesh;
+  points: number;
+};
+
+type PaperTargetRuntime = {
+  laneIndex: number;
+  root: THREE.Group;
+  paper: THREE.Mesh;
+  score: number;
+  hits: number;
+  holes: BulletHole[];
+  labelSprite: THREE.Sprite;
+  winnerRing: THREE.Mesh;
+  startX: number;
+  startY: number;
+  startZ: number;
+  resultZ: number;
+};
+
+type BulletRuntime = {
+  mesh: THREE.Mesh;
+  trail: THREE.Mesh;
+  start: THREE.Vector3;
+  end: THREE.Vector3;
+  t: number;
+  speed: number;
+  cinematic: boolean;
+};
+
+type ShellRuntime = {
+  mesh: THREE.Mesh;
+  vel: THREE.Vector3;
+  spin: THREE.Vector3;
+  life: number;
+};
+
+const USER_LANE = 0;
+const LANE_COUNT = 4;
+const SHOTS_PER_PLAYER = 5;
+const PICK_SECONDS = 5;
+const LANE_X = [-4.9, -1.65, 1.65, 4.9];
+const TABLE_Z = 2.35;
+const TABLE_TOP_Y = 0.94;
+const TARGET_Z = -21.8;
+
+const OVER_SHOULDER_OFFSET = new THREE.Vector3(0.5, 1.72, 4.1);
+const OVER_SHOULDER_LOOK = new THREE.Vector3(0.05, 1.38, -12.5);
+
+const HDRI_URL = 'https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/studio_small_09_1k.hdr';
+
+const TEXTURES = {
+  floor: {
+    diff: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_diff_4k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_nor_gl_4k.jpg',
+    rough: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_rough_4k.jpg',
+    ao: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_ao_4k.jpg'
+  },
+  wall: {
+    diff: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_diff_4k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_nor_gl_4k.jpg',
+    rough: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_rough_4k.jpg',
+    ao: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_ao_4k.jpg'
+  },
+  metal: {
+    diff: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_diff_4k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_nor_gl_4k.jpg',
+    rough: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_rough_4k.jpg',
+    metal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_metal_4k.jpg'
+  },
+  table: {
+    diff: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_diff_4k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_nor_gl_4k.jpg',
+    rough: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_rough_4k.jpg',
+    ao: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_ao_4k.jpg'
+  }
+};
+
+const KNOWN = {
+  fps: 'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
+  fpsRaw: 'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
+  awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
+  awpRaw: 'https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb',
+  mrtk: 'https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  mrtkRaw: 'https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  mrtkMaster: 'https://cdn.jsdelivr.net/gh/Microsoft/MixedRealityToolkit@master/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  pistolHolster: 'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
+  pistolHolsterRaw: 'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb'
+};
+
+function polyGlb(uuid: string) {
+  return `https://static.poly.pizza/${uuid}.glb`;
+}
+
+const WEAPONS: WeaponEntry[] = [
+  { id: 'q-shotgun-1', name: 'Quaternius Shotgun', shortName: 'Shotgun', weaponClass: 'shotgun', urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')] },
+  { id: 'q-assault', name: 'Quaternius Assault Rifle', shortName: 'Assault', weaponClass: 'rifle', urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')] },
+  { id: 'q-pistol', name: 'Quaternius Pistol', shortName: 'Pistol', weaponClass: 'pistol', urls: [polyGlb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc')] },
+  { id: 'q-heavy-revolver', name: 'Quaternius Heavy Revolver', shortName: 'Heavy Rev', weaponClass: 'revolver', urls: [polyGlb('9e728565-67a3-44db-9567-982320abff09')] },
+  { id: 'q-sawed-off', name: 'Quaternius Sawed-Off Shotgun', shortName: 'Sawed-Off', weaponClass: 'shotgun', urls: [polyGlb('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e')] },
+  { id: 'q-silver-revolver', name: 'Quaternius Revolver Silver', shortName: 'Silver Rev', weaponClass: 'revolver', urls: [polyGlb('7951b3b9-d3a5-4ec8-81b7-11111f1c8e88')] },
+  { id: 'q-long-shotgun', name: 'Quaternius Long Shotgun', shortName: 'Long Shotgun', weaponClass: 'shotgun', urls: [polyGlb('f71d6771-f512-4374-bd23-ba00b564db68')] },
+  { id: 'q-pump-shotgun', name: 'Quaternius Pump Shotgun', shortName: 'Pump', weaponClass: 'shotgun', urls: [polyGlb('08f27141-8e64-425a-9161-1bbd6956dfca')] },
+  { id: 'q-smg', name: 'Quaternius Submachine Gun', shortName: 'SMG', weaponClass: 'smg', urls: [polyGlb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710')] },
+  { id: 'ak47', name: 'AK47 GLTF', shortName: 'AK47', weaponClass: 'rifle', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf', KNOWN.awp, KNOWN.awpRaw] },
+  { id: 'krsv', name: 'KRSV GLTF', shortName: 'KRSV', weaponClass: 'rifle', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf', KNOWN.mrtk, KNOWN.mrtkRaw] },
+  { id: 'smith', name: 'Smith GLTF', shortName: 'Smith', weaponClass: 'pistol', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf', KNOWN.pistolHolster, KNOWN.pistolHolsterRaw] },
+  { id: 'mosin', name: 'Mosin GLTF', shortName: 'Mosin', weaponClass: 'sniper', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf', KNOWN.awp, KNOWN.awpRaw] },
+  { id: 'uzi', name: 'Uzi GLTF', shortName: 'Uzi', weaponClass: 'smg', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf', KNOWN.mrtk, KNOWN.mrtkMaster] },
+  { id: 'sigsauer', name: 'SigSauer GLTF', shortName: 'SigSauer', weaponClass: 'pistol', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf', KNOWN.pistolHolster, KNOWN.pistolHolsterRaw] },
+  { id: 'awp', name: 'AWP Sniper GLB', shortName: 'AWP', weaponClass: 'sniper', urls: [KNOWN.awp, KNOWN.awpRaw] },
+  { id: 'mrtk', name: 'MRTK Gun GLB', shortName: 'MRTK', weaponClass: 'rifle', urls: [KNOWN.mrtk, KNOWN.mrtkRaw, KNOWN.mrtkMaster] },
+  { id: 'fps', name: 'FPS Gun GLTF', shortName: 'FPS Shotgun', weaponClass: 'shotgun', urls: [KNOWN.fps, KNOWN.fpsRaw, KNOWN.awp, KNOWN.awpRaw] }
+];
+
+const STATS: Record<WeaponClass, WeaponStats> = {
+  pistol: { mag: 12, fireDelay: 210, reloadMs: 950, recoil: 0.35, spread: 0.013, damage: 34, pellets: 1, bulletSpeed: 5.2, shellPower: 0.95 },
+  revolver: { mag: 6, fireDelay: 430, reloadMs: 1150, recoil: 0.55, spread: 0.011, damage: 60, pellets: 1, bulletSpeed: 5.4, shellPower: 1.05 },
+  shotgun: { mag: 7, fireDelay: 670, reloadMs: 1300, recoil: 0.85, spread: 0.05, damage: 18, pellets: 8, bulletSpeed: 4.2, shellPower: 1.3 },
+  rifle: { mag: 30, fireDelay: 115, reloadMs: 1180, recoil: 0.28, spread: 0.017, damage: 27, pellets: 1, bulletSpeed: 5.6, shellPower: 1.0 },
+  smg: { mag: 34, fireDelay: 85, reloadMs: 1000, recoil: 0.2, spread: 0.024, damage: 20, pellets: 1, bulletSpeed: 5.0, shellPower: 0.82 },
+  sniper: { mag: 5, fireDelay: 900, reloadMs: 1500, recoil: 1.05, spread: 0.005, damage: 100, pellets: 1, bulletSpeed: 6.6, shellPower: 1.25 }
+};
+
+const CHARACTERS: CharacterSpec[] = [
+  { name: 'Soldier', urls: ['https://threejs.org/examples/models/gltf/Soldier.glb'], scale: 1.7, yaw: Math.PI, fallbackColor: '#e5e7eb' },
+  { name: 'Cesium Man', urls: ['https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb', 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb'], scale: 1.68, yaw: Math.PI, fallbackColor: '#93c5fd' },
+  { name: 'Robot Expressive', urls: ['https://threejs.org/examples/models/gltf/RobotExpressive/RobotExpressive.glb'], scale: 1.62, yaw: Math.PI, fallbackColor: '#fca5a5' },
+  { name: 'Xbot', urls: ['https://threejs.org/examples/models/gltf/Xbot.glb'], scale: 1.7, yaw: Math.PI, fallbackColor: '#86efac' }
+];
+
+function statsFor(entry: WeaponEntry) {
+  return STATS[entry.weaponClass];
+}
+
+function parentFolder(url: string) {
+  return url.slice(0, url.lastIndexOf('/') + 1);
+}
+
+function isAbsoluteOrDataUrl(url: string) {
+  return /^(https?:)?\/\//i.test(url) || url.startsWith('data:') || url.startsWith('blob:');
+}
+
+function shuffle<T>(items: T[]) {
+  const a = [...items];
+  for (let i = a.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function makeLoaderForUrl(modelUrl: string) {
+  const baseFolder = parentFolder(modelUrl);
+  const manager = new THREE.LoadingManager();
+  manager.setURLModifier((resourceUrl) =>
+    isAbsoluteOrDataUrl(resourceUrl) ? resourceUrl : new URL(resourceUrl, baseFolder).toString()
+  );
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin('anonymous');
+  return loader;
+}
+
+async function loadGLTF(name: string, urls: string[]): Promise<GLTF> {
+  let lastError: unknown = null;
+  for (const url of urls) {
+    try {
+      const loader = makeLoaderForUrl(url);
+      const gltf = await new Promise<GLTF>((resolve, reject) => {
+        const timer = window.setTimeout(() => reject(new Error(`Timeout loading ${name}`)), 24000);
+        loader.load(
+          url,
+          (loaded) => {
+            window.clearTimeout(timer);
+            resolve(loaded);
+          },
+          undefined,
+          (error) => {
+            window.clearTimeout(timer);
+            reject(error);
+          }
+        );
+      });
+      return gltf;
+    } catch (error) {
+      lastError = error;
+      console.warn('GLTF source failed:', name, url, error);
+    }
+  }
+  throw lastError ?? new Error(`All URLs failed for ${name}`);
+}
+
+function loadTexture(loader: THREE.TextureLoader, url: string, color = false, repeat: [number, number] = [1, 1]) {
+  const tex = loader.load(url, undefined, undefined, () => console.warn('Texture failed:', url));
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(repeat[0], repeat[1]);
+  tex.anisotropy = 8;
+  if (color) tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+function makePbrMaterial(
+  loader: THREE.TextureLoader,
+  maps: { diff: string; normal: string; rough: string; ao?: string; metal?: string },
+  repeat: [number, number],
+  fallback: string,
+  metalness = 0
+) {
+  const mat = new THREE.MeshStandardMaterial({ color: fallback, roughness: 0.78, metalness });
+  mat.map = loadTexture(loader, maps.diff, true, repeat);
+  mat.normalMap = loadTexture(loader, maps.normal, false, repeat);
+  mat.roughnessMap = loadTexture(loader, maps.rough, false, repeat);
+  if (maps.ao) mat.aoMap = loadTexture(loader, maps.ao, false, repeat);
+  if (maps.metal) {
+    mat.metalnessMap = loadTexture(loader, maps.metal, false, repeat);
+    mat.metalness = 1;
+  }
+  return mat;
+}
+
+function configureModel(root: THREE.Object3D, renderer: THREE.WebGLRenderer) {
+  root.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh) return;
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    mesh.frustumCulled = false;
+
+    const materials = Array.isArray((mesh as any).material)
+      ? (mesh as any).material
+      : (mesh as any).material
+      ? [(mesh as any).material]
+      : [];
+
+    materials.forEach((material: any) => {
+      const keys = ['map', 'emissiveMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'alphaMap'];
+      keys.forEach((key) => {
+        const tex = material[key] as THREE.Texture | undefined;
+        if (!tex?.isTexture) return;
+        if (key === 'map' || key === 'emissiveMap') tex.colorSpace = THREE.SRGBColorSpace;
+        tex.anisotropy = renderer.capabilities.getMaxAnisotropy();
+        tex.needsUpdate = true;
+      });
+      material.needsUpdate = true;
+    });
+  });
+}
+
+function getRenderableBounds(root: THREE.Object3D) {
+  root.updateMatrixWorld(true);
+  const box = new THREE.Box3();
+  let has = false;
+  root.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh) return;
+    const b = new THREE.Box3().setFromObject(obj);
+    if (!Number.isFinite(b.min.x)) return;
+    box.union(b);
+    has = true;
+  });
+  return has ? box : null;
+}
+
+function centerRoot(root: THREE.Object3D) {
+  root.updateMatrixWorld(true);
+  const box = getRenderableBounds(root);
+  if (!box) return;
+  const center = box.getCenter(new THREE.Vector3());
+  root.position.x -= center.x;
+  root.position.y -= center.y;
+  root.position.z -= center.z;
+  root.updateMatrixWorld(true);
+}
+
+function normalizeToLength(root: THREE.Object3D, targetLength: number) {
+  root.updateMatrixWorld(true);
+  const box = getRenderableBounds(root);
+  if (!box) return;
+  const size = box.getSize(new THREE.Vector3());
+  const max = Math.max(size.x, size.y, size.z);
+  if (!Number.isFinite(max) || max <= 0) return;
+  root.scale.setScalar(targetLength / max);
+  root.updateMatrixWorld(true);
+  centerRoot(root);
+}
+
+function groundObject(root: THREE.Object3D, groundY = 0) {
+  root.updateMatrixWorld(true);
+  const box = getRenderableBounds(root);
+  if (!box) return;
+  root.position.y += groundY - box.min.y;
+  root.updateMatrixWorld(true);
+}
+
+function orientWeaponForward(root: THREE.Object3D) {
+  centerRoot(root);
+  root.rotation.set(0, Math.PI, 0);
+  root.rotation.x += -0.035;
+  root.rotation.z += 0.012;
+  root.updateMatrixWorld(true);
+  centerRoot(root);
+}
+
+function layWeaponFlatOnTable(root: THREE.Object3D) {
+  centerRoot(root);
+  root.rotation.set(Math.PI / 2, Math.PI / 2, 0);
+  root.updateMatrixWorld(true);
+  const box = getRenderableBounds(root);
+  if (!box) return;
+  root.position.y += 0.025 - box.min.y;
+  root.updateMatrixWorld(true);
+}
+
+function makeFallbackCharacter(color = '#e5e7eb') {
+  const g = new THREE.Group();
+  const skinMat = new THREE.MeshStandardMaterial({ color: '#9ca3af', roughness: 0.82, metalness: 0.06 });
+  const shirtMat = new THREE.MeshStandardMaterial({ color, roughness: 0.95, metalness: 0.02 });
+  const pantsMat = new THREE.MeshStandardMaterial({ color: '#111827', roughness: 0.9, metalness: 0.02 });
+
+  const torso = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.72, 0.24), shirtMat);
+  torso.position.y = 1.2;
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.16, 16, 16), skinMat);
+  head.position.y = 1.72;
+  const armL = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.58, 0.12), skinMat);
+  armL.position.set(-0.28, 1.2, 0);
+  const armR = armL.clone();
+  armR.position.x = 0.28;
+  const legL = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.84, 0.16), pantsMat);
+  legL.position.set(-0.1, 0.42, 0);
+  const legR = legL.clone();
+  legR.position.x = 0.1;
+
+  g.add(torso, head, armL, armR, legL, legR);
+  g.traverse((o) => {
+    const m = o as THREE.Mesh;
+    if (m.isMesh) {
+      m.castShadow = true;
+      m.receiveShadow = true;
+    }
+  });
+  groundObject(g, 0);
+  return g;
+}
+
+function createSilhouetteTargetTexture() {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 768;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return new THREE.CanvasTexture(canvas);
+
+  ctx.fillStyle = '#faf7f2';
+  ctx.fillRect(0, 0, 512, 768);
+  ctx.strokeStyle = 'rgba(30,30,30,.4)';
+  ctx.lineWidth = 8;
+  ctx.strokeRect(8, 8, 496, 752);
+
+  ctx.fillStyle = '#222222';
+  ctx.beginPath();
+  ctx.arc(256, 160, 68, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.moveTo(162, 246);
+  ctx.lineTo(350, 246);
+  ctx.lineTo(390, 442);
+  ctx.lineTo(330, 690);
+  ctx.lineTo(286, 690);
+  ctx.lineTo(256, 560);
+  ctx.lineTo(226, 690);
+  ctx.lineTo(182, 690);
+  ctx.lineTo(122, 442);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.moveTo(166, 286);
+  ctx.lineTo(84, 420);
+  ctx.lineTo(122, 446);
+  ctx.lineTo(204, 340);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.moveTo(346, 286);
+  ctx.lineTo(428, 420);
+  ctx.lineTo(390, 446);
+  ctx.lineTo(308, 340);
+  ctx.closePath();
+  ctx.fill();
+
+  const rings = [
+    { r: 92, color: '#6b7280', w: 14 },
+    { r: 68, color: '#d1d5db', w: 10 },
+    { r: 44, color: '#9ca3af', w: 8 },
+    { r: 22, color: '#ef4444', w: 10 }
+  ];
+  rings.forEach((ring) => {
+    ctx.beginPath();
+    ctx.arc(256, 356, ring.r, 0, Math.PI * 2);
+    ctx.strokeStyle = ring.color;
+    ctx.lineWidth = ring.w;
+    ctx.stroke();
+  });
+  ctx.fillStyle = '#f97316';
+  ctx.fillRect(240, 340, 32, 32);
+
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+function createLabelSprite(text: string) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 160;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return new THREE.Sprite();
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = 'rgba(0,0,0,.72)';
+  ctx.fillRect(16, 18, 480, 124);
+  ctx.strokeStyle = 'rgba(255,255,255,.22)';
+  ctx.lineWidth = 4;
+  ctx.strokeRect(16, 18, 480, 124);
+  ctx.fillStyle = 'white';
+  ctx.font = 'bold 42px system-ui';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, 256, 80);
+
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false });
+  const sprite = new THREE.Sprite(mat);
+  sprite.scale.set(2.1, 0.65, 1);
+  return sprite;
+}
+
+function updateLabelSprite(sprite: THREE.Sprite, text: string) {
+  const tex = (sprite.material as THREE.SpriteMaterial).map as THREE.CanvasTexture | undefined;
+  const canvas = tex?.image as HTMLCanvasElement | undefined;
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = 'rgba(0,0,0,.72)';
+  ctx.fillRect(16, 18, 480, 124);
+  ctx.strokeStyle = 'rgba(255,255,255,.22)';
+  ctx.lineWidth = 4;
+  ctx.strokeRect(16, 18, 480, 124);
+  ctx.fillStyle = 'white';
+  ctx.font = 'bold 42px system-ui';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, 256, 80);
+  tex.needsUpdate = true;
+}
+
+function createPaperTarget(laneIndex: number): PaperTargetRuntime {
+  const root = new THREE.Group();
+  const railMat = new THREE.MeshStandardMaterial({ color: '#555f69', roughness: 0.7, metalness: 0.28 });
+
+  const topBar = new THREE.Mesh(new THREE.BoxGeometry(0.9, 0.06, 0.07), railMat);
+  topBar.position.set(0, 2.56, 0);
+  topBar.castShadow = true;
+  root.add(topBar);
+
+  const hanger = new THREE.Mesh(new THREE.BoxGeometry(0.06, 1.0, 0.06), railMat);
+  hanger.position.set(0, 2.02, 0);
+  hanger.castShadow = true;
+  root.add(hanger);
+
+  const clip = new THREE.Mesh(new THREE.BoxGeometry(0.62, 0.06, 0.06), railMat);
+  clip.position.set(0, 1.56, 0);
+  clip.castShadow = true;
+  root.add(clip);
+
+  const paper = new THREE.Mesh(
+    new THREE.PlaneGeometry(1.05, 1.58),
+    new THREE.MeshStandardMaterial({
+      map: createSilhouetteTargetTexture(),
+      roughness: 0.88,
+      metalness: 0.02,
+      side: THREE.DoubleSide
+    })
+  );
+  paper.position.set(0, 0.84, 0);
+  paper.castShadow = true;
+  paper.receiveShadow = true;
+  root.add(paper);
+
+  const winnerRing = new THREE.Mesh(
+    new THREE.TorusGeometry(0.92, 0.03, 12, 48),
+    new THREE.MeshBasicMaterial({ color: '#facc15', transparent: true, opacity: 0 })
+  );
+  winnerRing.position.set(0, 0.84, 0.04);
+  root.add(winnerRing);
+
+  const labelSprite = createLabelSprite(`Lane ${laneIndex + 1}`);
+  labelSprite.position.set(0, 2.95, 0);
+  root.add(labelSprite);
+
+  root.position.set(LANE_X[laneIndex], 0.65, TARGET_Z);
+
+  return {
+    laneIndex,
+    root,
+    paper,
+    score: 0,
+    hits: 0,
+    holes: [],
+    labelSprite,
+    winnerRing,
+    startX: LANE_X[laneIndex],
+    startY: 0.65,
+    startZ: TARGET_Z,
+    resultZ: -4.1
+  };
+}
+
+function createBulletHole(localPoint: THREE.Vector3, points: number) {
+  const size = 0.03 + Math.random() * 0.018;
+  const mesh = new THREE.Mesh(
+    new THREE.CircleGeometry(size, 18),
+    new THREE.MeshBasicMaterial({
+      color: points >= 9 ? '#3f0a0a' : '#111111',
+      transparent: true,
+      opacity: 0.95,
+      side: THREE.DoubleSide,
+      depthWrite: false
+    })
+  );
+  mesh.position.set(localPoint.x, localPoint.y, 0.006 + Math.random() * 0.002);
+  return mesh;
+}
+
+function createBullet(scene: THREE.Scene, start: THREE.Vector3, end: THREE.Vector3, cinematic: boolean, speed: number) {
+  const bullet = new THREE.Mesh(
+    new THREE.SphereGeometry(0.027, 10, 10),
+    new THREE.MeshBasicMaterial({ color: '#ffe8a3' })
+  );
+  const length = Math.min(1.2, start.distanceTo(end));
+  const trail = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.007, 0.007, length, 8),
+    new THREE.MeshBasicMaterial({ color: '#ffb84d', transparent: true, opacity: 0.58 })
+  );
+
+  bullet.position.copy(start);
+  trail.position.copy(start);
+  trail.rotation.x = Math.PI / 2;
+  scene.add(bullet, trail);
+
+  return { mesh: bullet, trail, start, end, t: 0, speed, cinematic } as BulletRuntime;
+}
+
+function createShell(scene: THREE.Scene, position: THREE.Vector3, power: number) {
+  const mesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.025, 0.025, 0.12, 16),
+    new THREE.MeshStandardMaterial({ color: '#c0892f', roughness: 0.34, metalness: 0.92 })
+  );
+  mesh.rotation.z = Math.PI / 2;
+  mesh.position.copy(position);
+  mesh.castShadow = true;
+  scene.add(mesh);
+
+  return {
+    mesh,
+    vel: new THREE.Vector3(0.72 * power, 0.45 * power, 0.16),
+    spin: new THREE.Vector3(Math.random() * 7, Math.random() * 12, Math.random() * 8),
+    life: 2.4
+  } as ShellRuntime;
+}
+
+function disposeObject(object: THREE.Object3D) {
+  object.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh) return;
+    mesh.geometry?.dispose?.();
+    const materials = Array.isArray((mesh as any).material)
+      ? (mesh as any).material
+      : (mesh as any).material
+      ? [(mesh as any).material]
+      : [];
+    materials.forEach((mat: any) => mat?.dispose?.());
+  });
+}
+
+export default function ShootingRange() {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+
+  const [phase, setPhase] = useState<GamePhase>('loading');
+  const [viewMode, setViewMode] = useState<ViewMode>('tables');
+  const [status, setStatus] = useState('Loading...');
+  const [pickTimer, setPickTimer] = useState(PICK_SECONDS);
+  const [selectedWeapon, setSelectedWeapon] = useState(0);
+  const [ammo, setAmmo] = useState(STATS[WEAPONS[0].weaponClass].mag);
+  const [laneScores, setLaneScores] = useState([0, 0, 0, 0]);
+  const [shotsLeft, setShotsLeft] = useState([SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER]);
+  const [winnerText, setWinnerText] = useState('');
+
+  const phaseRef = useRef<GamePhase>('loading');
+  const viewModeRef = useRef<ViewMode>('tables');
+  const selectedWeaponRef = useRef(0);
+  const ammoRef = useRef(STATS[WEAPONS[0].weaponClass].mag);
+  const shotsLeftRef = useRef([SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER]);
+  const laneScoresRef = useRef([0, 0, 0, 0]);
+
+  const aimRef = useRef(new THREE.Vector2(0, 0));
+  const fireLockRef = useRef(0);
+  const recoilRef = useRef(0);
+  const reloadRef = useRef(false);
+  const followUntilRef = useRef(0);
+
+  const lanesRef = useRef<LaneRuntime[]>([]);
+  const paperTargetsRef = useRef<PaperTargetRuntime[]>([]);
+  const bulletsRef = useRef<BulletRuntime[]>([]);
+  const shellsRef = useRef<ShellRuntime[]>([]);
+  const weaponSourcesRef = useRef<(THREE.Object3D | null)[]>([]);
+  const tableWeaponsRef = useRef<TableWeaponRuntime[]>([]);
+  const pickTargetsRef = useRef<THREE.Object3D[]>([]);
+
+  const actionsRef = useRef({
+    fire: () => {},
+    reload: () => {},
+    next: () => {},
+    prev: () => {},
+    tables: () => {},
+    range: () => {},
+    restart: () => {}
+  });
+
+  const selectedEntry = useMemo(() => WEAPONS[selectedWeapon], [selectedWeapon]);
+  const selectedStats = useMemo(() => statsFor(selectedEntry), [selectedEntry]);
+
+  useEffect(() => { phaseRef.current = phase; }, [phase]);
+  useEffect(() => { viewModeRef.current = viewMode; }, [viewMode]);
+  useEffect(() => { selectedWeaponRef.current = selectedWeapon; }, [selectedWeapon]);
+  useEffect(() => { ammoRef.current = ammo; }, [ammo]);
+
+  function setPhaseSafe(next: GamePhase) {
+    phaseRef.current = next;
+    setPhase(next);
+  }
+
+  function playShot(power: number) {
+    try {
+      const Ctx = window.AudioContext || (window as any).webkitAudioContext;
+      if (!Ctx) return;
+      const ctx = new Ctx();
+
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'square';
+      osc.frequency.setValueAtTime(90 * power, ctx.currentTime);
+      osc.frequency.exponentialRampToValueAtTime(34, ctx.currentTime + 0.12);
+
+      gain.gain.setValueAtTime(0.2 * power, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.12);
+
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start();
+      osc.stop(ctx.currentTime + 0.13);
+    } catch {}
+  }
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    let disposed = false;
+    let raf = 0;
+    let pickInterval: number | null = null;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#111827');
+    scene.fog = new THREE.Fog('#111827', 18, 76);
+
+    const camera = new THREE.PerspectiveCamera(62, mount.clientWidth / Math.max(1, mount.clientHeight), 0.05, 200);
+    camera.position.set(LANE_X[USER_LANE] + OVER_SHOULDER_OFFSET.x, OVER_SHOULDER_OFFSET.y, OVER_SHOULDER_OFFSET.z);
+    camera.lookAt(new THREE.Vector3(LANE_X[USER_LANE] + OVER_SHOULDER_LOOK.x, OVER_SHOULDER_LOOK.y, OVER_SHOULDER_LOOK.z));
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.setSize(mount.clientWidth, mount.clientHeight);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.26;
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+    mount.innerHTML = '';
+    mount.appendChild(renderer.domElement);
+
+    const hdr = new RGBELoader();
+    hdr.setDataType(THREE.HalfFloatType);
+    hdr.load(
+      HDRI_URL,
+      (map) => {
+        map.mapping = THREE.EquirectangularReflectionMapping;
+        scene.environment = map;
+      },
+      undefined,
+      () => {
+        console.warn('HDRI failed');
+      }
+    );
+
+    scene.add(new THREE.AmbientLight(0xa8c6ff, 0.54));
+    scene.add(new THREE.HemisphereLight(0xe7f2ff, 0x33271d, 1.05));
+
+    const keyLight = new THREE.DirectionalLight(0xffffff, 4.4);
+    keyLight.position.set(8, 10, 8);
+    keyLight.castShadow = true;
+    keyLight.shadow.mapSize.set(2048, 2048);
+    scene.add(keyLight);
+
+    const fillLight = new THREE.DirectionalLight(0x9cc8ff, 0.72);
+    fillLight.position.set(-7, 5, -6);
+    scene.add(fillLight);
+
+    const textureLoader = new THREE.TextureLoader();
+    const floorMat = makePbrMaterial(textureLoader, TEXTURES.floor, [7, 20], '#5b5e63', 0.02);
+    const wallMat = makePbrMaterial(textureLoader, TEXTURES.wall, [4, 10], '#7b786e', 0.03);
+    const laneMat = makePbrMaterial(textureLoader, TEXTURES.metal, [3, 8], '#202833', 1);
+    const tableMat = makePbrMaterial(textureLoader, TEXTURES.table, [2, 1], '#0d1117', 0.08);
+    const metalMat = makePbrMaterial(textureLoader, TEXTURES.metal, [2, 6], '#48515a', 1);
+
+    const floor = new THREE.Mesh(new THREE.PlaneGeometry(18, 58), floorMat);
+    floor.rotation.x = -Math.PI / 2;
+    floor.position.z = -16;
+    floor.receiveShadow = true;
+    scene.add(floor);
+
+    const leftWall = new THREE.Mesh(new THREE.BoxGeometry(0.25, 4.2, 52), wallMat);
+    leftWall.position.set(-7.6, 2.1, -16);
+    leftWall.receiveShadow = true;
+    scene.add(leftWall);
+
+    const rightWall = leftWall.clone();
+    rightWall.position.x = 7.6;
+    scene.add(rightWall);
+
+    const backWall = new THREE.Mesh(new THREE.BoxGeometry(15.2, 6.2, 0.25), wallMat);
+    backWall.position.set(0, 3.05, TARGET_Z - 10.4);
+    backWall.receiveShadow = true;
+    scene.add(backWall);
+
+    const roof = new THREE.Mesh(new THREE.BoxGeometry(15.2, 0.2, 52), wallMat);
+    roof.position.set(0, 5.2, -16);
+    roof.receiveShadow = true;
+    roof.castShadow = true;
+    scene.add(roof);
+
+    const darkBackstop = new THREE.Mesh(new THREE.BoxGeometry(14, 2.6, 1.2), laneMat);
+    darkBackstop.position.set(0, 1.3, TARGET_Z - 8.9);
+    darkBackstop.rotation.x = -0.25;
+    darkBackstop.receiveShadow = true;
+    darkBackstop.castShadow = true;
+    scene.add(darkBackstop);
+
+    for (let lane = 0; lane < LANE_COUNT; lane += 1) {
+      const x = LANE_X[lane];
+
+      const boothBench = new THREE.Mesh(new THREE.BoxGeometry(2.55, 0.16, 1.15), tableMat);
+      boothBench.position.set(x, TABLE_TOP_Y, TABLE_Z);
+      boothBench.castShadow = true;
+      boothBench.receiveShadow = true;
+      scene.add(boothBench);
+
+      const boothShelf = new THREE.Mesh(new THREE.BoxGeometry(2.55, 0.11, 0.78), metalMat);
+      boothShelf.position.set(x, 0.55, TABLE_Z);
+      boothShelf.castShadow = true;
+      boothShelf.receiveShadow = true;
+      scene.add(boothShelf);
+
+      const leftDivider = new THREE.Mesh(new THREE.BoxGeometry(0.12, 2.15, 1.26), laneMat);
+      leftDivider.position.set(x - 1.48, 1.36, TABLE_Z);
+      leftDivider.castShadow = true;
+      leftDivider.receiveShadow = true;
+      scene.add(leftDivider);
+
+      const rightDivider = leftDivider.clone();
+      rightDivider.position.x = x + 1.48;
+      scene.add(rightDivider);
+
+      const boothHead = new THREE.Mesh(new THREE.BoxGeometry(2.55, 0.14, 0.95), metalMat);
+      boothHead.position.set(x, 4.45, 1.1);
+      boothHead.castShadow = true;
+      scene.add(boothHead);
+
+      const targetRail = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.12, 50), metalMat);
+      targetRail.position.set(x, 4.72, -16.6);
+      targetRail.castShadow = true;
+      scene.add(targetRail);
+
+      const leftLine = new THREE.Mesh(
+        new THREE.BoxGeometry(0.05, 0.012, 48),
+        new THREE.MeshStandardMaterial({ color: '#f8fafc', roughness: 0.8 })
+      );
+      leftLine.position.set(x - 1.48, 0.02, -16.4);
+      scene.add(leftLine);
+
+      const rightLine = leftLine.clone();
+      rightLine.position.x = x + 1.48;
+      scene.add(rightLine);
+
+      const redCenter = new THREE.Mesh(
+        new THREE.BoxGeometry(0.05, 0.012, 48),
+        new THREE.MeshStandardMaterial({ color: '#b91c1c', roughness: 0.8 })
+      );
+      redCenter.position.set(x, 0.022, -16.2);
+      scene.add(redCenter);
+
+      const yellowFireLine = new THREE.Mesh(
+        new THREE.BoxGeometry(2.45, 0.014, 0.12),
+        new THREE.MeshStandardMaterial({ color: '#facc15', roughness: 0.82 })
+      );
+      yellowFireLine.position.set(x, 0.024, 1.95);
+      scene.add(yellowFireLine);
+    }
+
+    for (let i = 0; i < 7; i += 1) {
+      const z = 1.6 - i * 6.3;
+      const lampBar = new THREE.Mesh(new THREE.BoxGeometry(13.8, 0.08, 0.28), metalMat);
+      lampBar.position.set(0, 4.56, z);
+      lampBar.castShadow = true;
+      scene.add(lampBar);
+
+      const glow = new THREE.Mesh(
+        new THREE.BoxGeometry(12.7, 0.02, 0.12),
+        new THREE.MeshBasicMaterial({ color: '#eef6ff' })
+      );
+      glow.position.set(0, 4.49, z);
+      scene.add(glow);
+
+      const light = new THREE.PointLight(0xf7fbff, 4.2, 12, 1.4);
+      light.position.set(0, 4.34, z);
+      scene.add(light);
+    }
+
+    const targets = Array.from({ length: LANE_COUNT }, (_, i) => createPaperTarget(i));
+    targets.forEach((t) => scene.add(t.root));
+    paperTargetsRef.current = targets;
+
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+
+    async function buildCharacters() {
+      const randomizedLanes = shuffle([0, 1, 2, 3]);
+      const characterResults = await Promise.all(
+        CHARACTERS.map((spec) => loadGLTF(spec.name, spec.urls).catch(() => null))
+      );
+
+      const lanes: LaneRuntime[] = [];
+
+      for (let playerId = 0; playerId < LANE_COUNT; playerId += 1) {
+        const laneIndex = randomizedLanes[playerId];
+        const x = LANE_X[laneIndex];
+        const root = new THREE.Group();
+        root.position.set(x, 0, 3.05);
+        scene.add(root);
+
+        let visual: THREE.Object3D | null = null;
+        let mixer: THREE.AnimationMixer | null = null;
+
+        const spec = CHARACTERS[playerId];
+        const loaded = characterResults[playerId];
+
+        if (loaded) {
+          visual = cloneScene(loaded.scene);
+          configureModel(visual, renderer);
+          normalizeToLength(visual, spec.scale);
+          groundObject(visual, 0);
+          visual.rotation.y = spec.yaw;
+          root.add(visual);
+
+          if (loaded.animations?.length) {
+            mixer = new THREE.AnimationMixer(visual);
+            const idle =
+              loaded.animations.find((a) => /idle/i.test(a.name)) ||
+              loaded.animations.find((a) => /walk|run/i.test(a.name)) ||
+              loaded.animations[0];
+            mixer.clipAction(idle).play();
+          }
+        } else {
+          visual = makeFallbackCharacter(spec.fallbackColor);
+          visual.rotation.y = Math.PI;
+          root.add(visual);
+        }
+
+        const weaponMount = new THREE.Group();
+        weaponMount.position.set(0.34, 1.27, -0.12);
+        weaponMount.rotation.set(0.02, -0.03, 0.1);
+        root.add(weaponMount);
+
+        lanes[laneIndex] = {
+          laneIndex,
+          playerId,
+          controller: laneIndex === USER_LANE ? 'USER' : 'AI',
+          root,
+          visual,
+          mixer,
+          weaponMount,
+          tableGroup: new THREE.Group(),
+          heldWeapon: null,
+          muzzle: null,
+          shellPort: null,
+          aiNextShotAt: 0,
+          aiAim: new THREE.Vector2(0, 0),
+          activeWeaponIndex: laneIndex,
+          pickupLift: 0
+        };
+      }
+
+      lanesRef.current = lanes;
+    }
+
+    function setHeldWeapon(laneIndex: number, weaponIndex: number, lift = true) {
+      const lane = lanesRef.current[laneIndex];
+      const source = weaponSourcesRef.current[weaponIndex];
+      if (!lane || !source) return;
+
+      if (lane.heldWeapon) {
+        lane.weaponMount.remove(lane.heldWeapon);
+        disposeObject(lane.heldWeapon);
+      }
+
+      const held = cloneScene(source);
+      configureModel(held, renderer);
+      normalizeToLength(held, 1.14);
+      orientWeaponForward(held);
+      held.position.set(-0.03, -0.02, -0.2);
+      held.rotation.x += -0.05;
+      held.rotation.z += 0.02;
+
+      lane.weaponMount.add(held);
+      lane.heldWeapon = held;
+      lane.activeWeaponIndex = weaponIndex;
+      lane.pickupLift = lift ? 1 : 0;
+
+      const muzzle = new THREE.Object3D();
+      muzzle.position.set(0.02, 0.02, -0.95);
+      held.add(muzzle);
+
+      const shellPort = new THREE.Object3D();
+      shellPort.position.set(0.12, 0.03, -0.42);
+      held.add(shellPort);
+
+      lane.muzzle = muzzle;
+      lane.shellPort = shellPort;
+
+      if (laneIndex === USER_LANE) {
+        selectedWeaponRef.current = weaponIndex;
+        setSelectedWeapon(weaponIndex);
+        const st = statsFor(WEAPONS[weaponIndex]);
+        ammoRef.current = st.mag;
+        setAmmo(st.mag);
+      }
+    }
+
+    function highlightTableSelection() {
+      tableWeaponsRef.current.forEach((tw) => {
+        const selected = tw.weaponIndex === selectedWeaponRef.current;
+        tw.root.position.y = selected ? TABLE_TOP_Y + 0.05 : TABLE_TOP_Y + 0.03;
+        ((tw.card.material as THREE.MeshStandardMaterial).color).set(selected ? '#38506d' : '#1c1c1c');
+      });
+    }
+
+    async function loadWeaponsAndTables() {
+      weaponSourcesRef.current = new Array(WEAPONS.length).fill(null);
+      tableWeaponsRef.current = [];
+      pickTargetsRef.current = [];
+
+      await buildCharacters();
+
+      await Promise.allSettled(
+        WEAPONS.map(async (entry, index) => {
+          const gltf = await loadGLTF(entry.name, entry.urls);
+          if (disposed) return;
+
+          configureModel(gltf.scene, renderer);
+          weaponSourcesRef.current[index] = gltf.scene;
+
+          const tableIndex = index % LANE_COUNT;
+          const group = new THREE.Group();
+          group.userData.pickWeaponIndex = index;
+
+          const model = cloneScene(gltf.scene);
+          configureModel(model, renderer);
+          normalizeToLength(model, 0.62);
+          layWeaponFlatOnTable(model);
+          group.add(model);
+
+          const card = new THREE.Mesh(
+            new THREE.BoxGeometry(0.92, 0.035, 0.42),
+            new THREE.MeshStandardMaterial({ color: '#1c1c1c', roughness: 0.84, metalness: 0.14 })
+          );
+          card.position.y = -0.018;
+          card.receiveShadow = true;
+          group.add(card);
+
+          const localIndex = Math.floor(index / LANE_COUNT);
+          const col = localIndex % 2;
+          const row = Math.floor(localIndex / 2);
+
+          group.position.set(
+            LANE_X[tableIndex] + (col === 0 ? -0.46 : 0.46),
+            TABLE_TOP_Y + 0.03,
+            TABLE_Z - 0.28 + row * 0.25
+          );
+
+          scene.add(group);
+          tableWeaponsRef.current.push({ root: group, card, model, weaponIndex: index });
+          pickTargetsRef.current.push(group);
+        })
+      );
+
+      setHeldWeapon(USER_LANE, 0, false);
+      highlightTableSelection();
+
+      [1, 2, 3].forEach((laneIndex) => {
+        const possible = Array.from({ length: WEAPONS.length }, (_, i) => i);
+        const chosen = possible[(laneIndex * 3) % possible.length];
+        setHeldWeapon(laneIndex, chosen, false);
+      });
+
+      startPickPhase();
+    }
+
+    function startPickPhase() {
+      setPhaseSafe('pick');
+      setViewMode('tables');
+      setStatus('Pick any weapon from any table');
+      setPickTimer(PICK_SECONDS);
+
+      let left = PICK_SECONDS;
+
+      if (pickInterval) window.clearInterval(pickInterval);
+
+      pickInterval = window.setInterval(() => {
+        left -= 1;
+        setPickTimer(left);
+
+        if (left > 0) {
+          setStatus(`Pick any weapon from the tables · ${left}s`);
+        } else {
+          if (pickInterval) window.clearInterval(pickInterval);
+          pickInterval = null;
+          startShootPhase();
+        }
+      }, 1000);
+
+      [1, 2, 3].forEach((laneIndex, idx) => {
+        window.setTimeout(() => {
+          if (disposed || phaseRef.current !== 'pick') return;
+          const aiPick = (laneIndex * 5 + idx * 2 + 1) % WEAPONS.length;
+          setHeldWeapon(laneIndex, aiPick, true);
+        }, 850 + idx * 650);
+      });
+    }
+
+    function startShootPhase() {
+      setPhaseSafe('shoot');
+      setViewMode('range');
+      setStatus('Shoot phase started');
+
+      const shots = [SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER];
+      shotsLeftRef.current = shots;
+      setShotsLeft([...shots]);
+
+      const scores = [0, 0, 0, 0];
+      laneScoresRef.current = scores;
+      setLaneScores([...scores]);
+
+      paperTargetsRef.current.forEach((target) => {
+        target.score = 0;
+        target.hits = 0;
+        target.holes.forEach((h) => {
+          target.paper.remove(h.mesh);
+          h.mesh.geometry.dispose();
+          (h.mesh.material as THREE.Material).dispose();
+        });
+        target.holes = [];
+        updateLabelSprite(target.labelSprite, `Lane ${target.laneIndex + 1} · 0`);
+        (target.winnerRing.material as THREE.MeshBasicMaterial).opacity = 0;
+      });
+
+      lanesRef.current.forEach((lane, laneIndex) => {
+        if (lane.controller === 'AI') {
+          lane.aiNextShotAt = performance.now() + 900 + laneIndex * 420;
+        }
+      });
+    }
+
+    function finishRound() {
+      setPhaseSafe('results');
+      setViewMode('results');
+
+      const scores = laneScoresRef.current;
+      const best = Math.max(...scores);
+      const winnerLane = scores.findIndex((s) => s === best);
+
+      setWinnerText(`Winner: Lane ${winnerLane + 1} · ${best} pts`);
+      setStatus(`Winner: Lane ${winnerLane + 1} · ${best} pts`);
+
+      paperTargetsRef.current.forEach((target, i) => {
+        (target.winnerRing.material as THREE.MeshBasicMaterial).opacity = i === winnerLane ? 1 : 0;
+        updateLabelSprite(target.labelSprite, `Lane ${i + 1} · ${target.score}`);
+      });
+    }
+
+    function addLaneScore(laneIndex: number, points: number) {
+      const next = [...laneScoresRef.current];
+      next[laneIndex] += points;
+      laneScoresRef.current = next;
+      setLaneScores(next);
+
+      const target = paperTargetsRef.current[laneIndex];
+      if (target) {
+        target.score = next[laneIndex];
+        updateLabelSprite(target.labelSprite, `Lane ${laneIndex + 1} · ${target.score}`);
+      }
+    }
+
+    function setShotCount(laneIndex: number, value: number) {
+      const next = [...shotsLeftRef.current];
+      next[laneIndex] = value;
+      shotsLeftRef.current = next;
+      setShotsLeft(next);
+    }
+
+    function scoreHit(local: THREE.Vector3) {
+      const dx = local.x;
+      const dy = local.y - 0.04;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      if (d < 0.055) return 10;
+      if (d < 0.1) return 9;
+      if (d < 0.16) return 8;
+      if (d < 0.24) return 7;
+      if (d < 0.33) return 6;
+      return 5;
+    }
+
+    function addBulletHole(target: PaperTargetRuntime, localPoint: THREE.Vector3, points: number) {
+      const hole = createBulletHole(localPoint, points);
+      target.paper.add(hole);
+      target.holes.push({ mesh: hole, points });
+      target.hits += 1;
+      if (target.holes.length > 36) {
+        const old = target.holes.shift();
+        if (old) {
+          target.paper.remove(old.mesh);
+          old.mesh.geometry.dispose();
+          (old.mesh.material as THREE.Material).dispose();
+        }
+      }
+    }
+
+    function resolveShotForLane(laneIndex: number, spread: number, aiAim?: THREE.Vector2) {
+      const target = paperTargetsRef.current[laneIndex];
+      const baseAim = aiAim ?? aimRef.current;
+
+      pointer.set(
+        baseAim.x + (Math.random() - 0.5) * spread,
+        baseAim.y + (Math.random() - 0.5) * spread
+      );
+
+      raycaster.setFromCamera(pointer, camera);
+      const hit = raycaster.intersectObject(target.paper, false)[0];
+
+      if (!hit) {
+        const far = raycaster.ray.origin.clone().addScaledVector(raycaster.ray.direction, 70);
+        return { point: far, local: null as THREE.Vector3 | null, target };
+      }
+
+      const local = target.paper.worldToLocal(hit.point.clone());
+      return { point: hit.point.clone(), local, target };
+    }
+
+    function executeShot(laneIndex: number, isAI: boolean) {
+      if (phaseRef.current !== 'shoot') return;
+      if (shotsLeftRef.current[laneIndex] <= 0) return;
+
+      const lane = lanesRef.current[laneIndex];
+      if (!lane?.muzzle || !lane.shellPort) return;
+
+      const weapon = WEAPONS[lane.activeWeaponIndex];
+      const stats = statsFor(weapon);
+      const now = performance.now();
+
+      if (!isAI && now < fireLockRef.current) return;
+      if (!isAI) fireLockRef.current = now + stats.fireDelay;
+
+      if (!isAI && ammoRef.current <= 0) {
+        setStatus('Reload first');
+        return;
+      }
+
+      if (!isAI) {
+        ammoRef.current -= 1;
+        setAmmo(ammoRef.current);
+      }
+
+      setShotCount(laneIndex, shotsLeftRef.current[laneIndex] - 1);
+
+      if (!isAI) {
+        recoilRef.current = stats.recoil;
+        followUntilRef.current = performance.now() + 500;
+      }
+
+      playShot(Math.max(0.6, stats.recoil));
+      lane.pickupLift = 0.35;
+
+      const muzzlePos = new THREE.Vector3();
+      lane.muzzle.getWorldPosition(muzzlePos);
+
+      const shellPos = new THREE.Vector3();
+      lane.shellPort.getWorldPosition(shellPos);
+      shellsRef.current.push(createShell(scene, shellPos, stats.shellPower));
+
+      let bestPoints = 0;
+
+      for (let i = 0; i < stats.pellets; i += 1) {
+        const result = resolveShotForLane(laneIndex, stats.spread * (isAI ? 1.28 : 1), lane.aiAim);
+        const cinematic = !isAI && i === 0;
+        bulletsRef.current.push(
+          createBullet(scene, muzzlePos.clone(), result.point.clone(), cinematic, stats.bulletSpeed)
+        );
+
+        if (result.local) {
+          const points = scoreHit(result.local);
+          addBulletHole(result.target, result.local, points);
+          if (i === 0) bestPoints = points;
+        }
+      }
+
+      addLaneScore(laneIndex, bestPoints);
+
+      const allDone = shotsLeftRef.current.every((s) => s <= 0);
+      if (allDone) {
+        window.setTimeout(() => {
+          if (!disposed) finishRound();
+        }, 850);
+      }
+    }
+
+    function fireUser() {
+      if (phaseRef.current !== 'shoot') return;
+      executeShot(USER_LANE, false);
+    }
+
+    function reloadUser() {
+      if (phaseRef.current !== 'shoot' || reloadRef.current) return;
+      const weapon = WEAPONS[selectedWeaponRef.current];
+      const stats = statsFor(weapon);
+      reloadRef.current = true;
+      setStatus('Reloading...');
+      window.setTimeout(() => {
+        if (disposed) return;
+        ammoRef.current = stats.mag;
+        setAmmo(stats.mag);
+        reloadRef.current = false;
+        setStatus('Ready');
+      }, stats.reloadMs);
+    }
+
+    function nextWeapon() {
+      if (phaseRef.current !== 'pick') return;
+      const next = (selectedWeaponRef.current + 1) % WEAPONS.length;
+      selectedWeaponRef.current = next;
+      setSelectedWeapon(next);
+      setHeldWeapon(USER_LANE, next, true);
+      highlightTableSelection();
+    }
+
+    function prevWeapon() {
+      if (phaseRef.current !== 'pick') return;
+      const next = (selectedWeaponRef.current - 1 + WEAPONS.length) % WEAPONS.length;
+      selectedWeaponRef.current = next;
+      setSelectedWeapon(next);
+      setHeldWeapon(USER_LANE, next, true);
+      highlightTableSelection();
+    }
+
+    function pickWeapon(index: number) {
+      if (phaseRef.current !== 'pick') return;
+      selectedWeaponRef.current = index;
+      setSelectedWeapon(index);
+      setHeldWeapon(USER_LANE, index, true);
+      highlightTableSelection();
+      setStatus(`Picked ${WEAPONS[index].shortName}`);
+    }
+
+    function updateAI(now: number) {
+      if (phaseRef.current !== 'shoot') return;
+      lanesRef.current.forEach((lane) => {
+        if (!lane || lane.controller !== 'AI') return;
+        if (shotsLeftRef.current[lane.laneIndex] <= 0) return;
+        if (now < lane.aiNextShotAt) return;
+
+        const difficulty = lane.laneIndex === 1 ? 0.05 : lane.laneIndex === 2 ? 0.072 : 0.09;
+        lane.aiAim.set((Math.random() - 0.5) * difficulty, (Math.random() - 0.5) * difficulty);
+
+        executeShot(lane.laneIndex, true);
+        lane.aiNextShotAt = now + 850 + Math.random() * 800;
+      });
+    }
+
+    void loadWeaponsAndTables();
+
+    const activePointers = new Set<number>();
+
+    function updateAim(event: PointerEvent) {
+      const rect = renderer.domElement.getBoundingClientRect();
+      const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      const y = -(((event.clientY - rect.top) / rect.height) * 2 - 1);
+      aimRef.current.set(
+        THREE.MathUtils.clamp(x * 0.86, -0.95, 0.95),
+        THREE.MathUtils.clamp(y * 0.7, -0.7, 0.7)
+      );
+    }
+
+    function tryPick(event: PointerEvent) {
+      const rect = renderer.domElement.getBoundingClientRect();
+      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -(((event.clientY - rect.top) / rect.height) * 2 - 1);
+
+      raycaster.setFromCamera(pointer, camera);
+      const hit = raycaster.intersectObjects(pickTargetsRef.current, true)[0];
+      if (!hit) return false;
+
+      let cur: THREE.Object3D | null = hit.object;
+      while (cur) {
+        if (typeof cur.userData.pickWeaponIndex === 'number') {
+          pickWeapon(cur.userData.pickWeaponIndex);
+          return true;
+        }
+        cur = cur.parent;
+      }
+      return false;
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      activePointers.add(event.pointerId);
+      renderer.domElement.setPointerCapture?.(event.pointerId);
+
+      if (phaseRef.current === 'pick' && viewModeRef.current === 'tables') {
+        tryPick(event);
+      } else {
+        updateAim(event);
+      }
+    }
+
+    function onPointerMove(event: PointerEvent) {
+      if (!activePointers.has(event.pointerId)) return;
+      if (viewModeRef.current === 'range') updateAim(event);
+    }
+
+    function onPointerUp(event: PointerEvent) {
+      activePointers.delete(event.pointerId);
+      renderer.domElement.releasePointerCapture?.(event.pointerId);
+    }
+
+    renderer.domElement.addEventListener('pointerdown', onPointerDown);
+    renderer.domElement.addEventListener('pointermove', onPointerMove);
+    renderer.domElement.addEventListener('pointerup', onPointerUp);
+    renderer.domElement.addEventListener('pointercancel', onPointerUp);
+
+    function updateBullets(dt: number) {
+      for (let i = bulletsRef.current.length - 1; i >= 0; i -= 1) {
+        const bullet = bulletsRef.current[i];
+        bullet.t += dt * bullet.speed;
+        const p = THREE.MathUtils.smoothstep(Math.min(1, bullet.t), 0, 1);
+        bullet.mesh.position.lerpVectors(bullet.start, bullet.end, p);
+        bullet.trail.position.copy(bullet.mesh.position).lerp(bullet.start, 0.15);
+        bullet.trail.lookAt(bullet.end);
+
+        if (bullet.t >= 1) {
+          scene.remove(bullet.mesh, bullet.trail);
+          bullet.mesh.geometry.dispose();
+          (bullet.mesh.material as THREE.Material).dispose();
+          bullet.trail.geometry.dispose();
+          (bullet.trail.material as THREE.Material).dispose();
+          bulletsRef.current.splice(i, 1);
+        }
+      }
+    }
+
+    function updateShells(dt: number) {
+      for (let i = shellsRef.current.length - 1; i >= 0; i -= 1) {
+        const shell = shellsRef.current[i];
+        shell.life -= dt;
+        shell.vel.y -= dt * 1.8;
+        shell.mesh.position.addScaledVector(shell.vel, dt);
+        shell.mesh.rotation.x += shell.spin.x * dt;
+        shell.mesh.rotation.y += shell.spin.y * dt;
+        shell.mesh.rotation.z += shell.spin.z * dt;
+
+        if (shell.life <= 0) {
+          scene.remove(shell.mesh);
+          shell.mesh.geometry.dispose();
+          (shell.mesh.material as THREE.Material).dispose();
+          shellsRef.current.splice(i, 1);
+        }
+      }
+    }
+
+    function updateCharacters(dt: number) {
+      lanesRef.current.forEach((lane) => {
+        lane.mixer?.update(dt);
+        lane.pickupLift = Math.max(0, lane.pickupLift - dt * 2.3);
+
+        const isUser = lane.laneIndex === USER_LANE;
+        const aim = isUser ? aimRef.current : lane.aiAim;
+        const recoil = isUser ? recoilRef.current : 0;
+
+        lane.weaponMount.position.x = THREE.MathUtils.lerp(lane.weaponMount.position.x, 0.34 + aim.x * 0.1, 0.16);
+        lane.weaponMount.position.y = THREE.MathUtils.lerp(
+          lane.weaponMount.position.y,
+          1.27 + lane.pickupLift * 0.18 + aim.y * 0.06 - recoil * 0.05,
+          0.16
+        );
+        lane.weaponMount.position.z = THREE.MathUtils.lerp(lane.weaponMount.position.z, -0.12 + recoil * 0.18, 0.16);
+
+        lane.weaponMount.rotation.x = THREE.MathUtils.lerp(
+          lane.weaponMount.rotation.x,
+          0.02 - recoil * 0.2 + aim.y * 0.05,
+          0.16
+        );
+        lane.weaponMount.rotation.y = THREE.MathUtils.lerp(
+          lane.weaponMount.rotation.y,
+          -0.03 - aim.x * 0.08,
+          0.16
+        );
+        lane.weaponMount.rotation.z = THREE.MathUtils.lerp(
+          lane.weaponMount.rotation.z,
+          0.1 + aim.x * 0.05,
+          0.16
+        );
+      });
+
+      recoilRef.current = Math.max(0, recoilRef.current - dt * 6.4);
+    }
+
+    function updateTargets() {
+      if (phaseRef.current === 'results') {
+        const best = Math.max(...laneScoresRef.current);
+        const winnerLane = laneScoresRef.current.findIndex((s) => s === best);
+
+        paperTargetsRef.current.forEach((target, i) => {
+          const wantedZ = i === winnerLane ? -4.1 : -7.2;
+          const wantedX = i === winnerLane ? 0 : LANE_X[i] * 0.75;
+          target.root.position.z = THREE.MathUtils.lerp(target.root.position.z, wantedZ, 0.05);
+          target.root.position.x = THREE.MathUtils.lerp(target.root.position.x, wantedX, 0.05);
+          target.root.position.y = THREE.MathUtils.lerp(target.root.position.y, i === winnerLane ? 0.92 : 0.76, 0.05);
+          target.root.rotation.y = THREE.MathUtils.lerp(target.root.rotation.y, 0, 0.08);
+        });
+      }
+    }
+
+    const tempPos = new THREE.Vector3();
+    const tempLook = new THREE.Vector3();
+
+    function updateCamera() {
+      if (viewModeRef.current === 'tables') {
+        tempPos.set(0, 5.3, 7.5);
+        tempLook.set(0, 1.05, 1.9);
+        camera.position.lerp(tempPos, 0.08);
+        camera.lookAt(tempLook);
+        return;
+      }
+
+      if (viewModeRef.current === 'results') {
+        const best = Math.max(...laneScoresRef.current);
+        const winnerLane = laneScoresRef.current.findIndex((s) => s === best);
+        const target = paperTargetsRef.current[winnerLane];
+        if (target) {
+          tempPos.set(0, 2.25, 3.45);
+          tempLook.copy(target.root.position).add(new THREE.Vector3(0, 1.0, 0));
+          camera.position.lerp(tempPos, 0.07);
+          camera.lookAt(tempLook);
+        }
+        return;
+      }
+
+      const cinematicBullet = bulletsRef.current.find((b) => b.cinematic && performance.now() < followUntilRef.current);
+      if (cinematicBullet) {
+        const dir = cinematicBullet.end.clone().sub(cinematicBullet.start).normalize();
+        tempPos.copy(cinematicBullet.mesh.position).addScaledVector(dir, -0.7).add(new THREE.Vector3(0.18, 0.14, 0.28));
+        tempLook.copy(cinematicBullet.mesh.position).addScaledVector(dir, 0.9);
+        camera.position.lerp(tempPos, 0.22);
+        camera.lookAt(tempLook);
+        return;
+      }
+
+      tempPos.set(
+        LANE_X[USER_LANE] + OVER_SHOULDER_OFFSET.x + aimRef.current.x * 0.24,
+        OVER_SHOULDER_OFFSET.y + aimRef.current.y * 0.12 + recoilRef.current * 0.04,
+        OVER_SHOULDER_OFFSET.z
+      );
+      tempLook.set(
+        LANE_X[USER_LANE] + OVER_SHOULDER_LOOK.x + aimRef.current.x * 1.35,
+        OVER_SHOULDER_LOOK.y + aimRef.current.y * 0.95,
+        OVER_SHOULDER_LOOK.z
+      );
+
+      camera.position.lerp(tempPos, 0.09);
+      camera.lookAt(tempLook);
+    }
+
+    const clock = new THREE.Clock();
+
+    function resize() {
+      const w = Math.max(1, mount.clientWidth);
+      const h = Math.max(1, mount.clientHeight);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+    }
+
+    function animate() {
+      if (disposed) return;
+      raf = requestAnimationFrame(animate);
+
+      const dt = Math.min(clock.getDelta(), 0.05);
+
+      updateAI(performance.now());
+      updateBullets(dt);
+      updateShells(dt);
+      updateCharacters(dt);
+      updateTargets();
+      updateCamera();
+
+      renderer.render(scene, camera);
+    }
+
+    actionsRef.current.fire = () => {
+      if (phaseRef.current === 'results') {
+        window.location.reload();
+        return;
+      }
+      fireUser();
+    };
+    actionsRef.current.reload = () => reloadUser();
+    actionsRef.current.next = () => nextWeapon();
+    actionsRef.current.prev = () => prevWeapon();
+    actionsRef.current.tables = () => {
+      if (phaseRef.current === 'pick') setViewMode('tables');
+    };
+    actionsRef.current.range = () => {
+      if (phaseRef.current === 'pick') setViewMode('range');
+    };
+    actionsRef.current.restart = () => window.location.reload();
+
+    resize();
+    animate();
+
+    window.addEventListener('resize', resize);
+
+    return () => {
+      disposed = true;
+      if (pickInterval) window.clearInterval(pickInterval);
+
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+
+      renderer.domElement.removeEventListener('pointerdown', onPointerDown);
+      renderer.domElement.removeEventListener('pointermove', onPointerMove);
+      renderer.domElement.removeEventListener('pointerup', onPointerUp);
+      renderer.domElement.removeEventListener('pointercancel', onPointerUp);
+
+      disposeObject(scene);
+      renderer.dispose();
+      if (renderer.domElement.parentElement === mount) {
+        mount.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  const panelStyle: React.CSSProperties = {
+    background: 'rgba(8,14,24,.74)',
+    border: '1px solid rgba(255,255,255,.12)',
+    borderRadius: 16,
+    padding: '10px 12px',
+    color: 'white',
+    boxShadow: '0 12px 30px rgba(0,0,0,.24)',
+    backdropFilter: 'blur(10px)'
+  };
+
+  const buttonStyle: React.CSSProperties = {
+    border: '1px solid rgba(255,255,255,.16)',
+    borderRadius: 14,
+    padding: '10px 12px',
+    background: 'rgba(255,255,255,.08)',
+    color: 'white',
+    fontSize: 12,
+    fontWeight: 800,
+    boxShadow: '0 10px 22px rgba(0,0,0,.18)',
+    cursor: 'pointer'
+  };
+
+  const fireStyle: React.CSSProperties = {
+    height: 90,
+    borderRadius: 999,
+    border: '1px solid rgba(255,230,230,.25)',
+    background: phase === 'results' ? 'rgba(34,197,94,.92)' : 'rgba(220,38,38,.92)',
+    color: 'white',
+    fontWeight: 900,
+    fontSize: 18,
+    boxShadow: '0 18px 40px rgba(0,0,0,.28)',
+    cursor: 'pointer'
+  };
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100vh',
+        position: 'relative',
+        overflow: 'hidden',
+        background: '#0a0d13',
+        fontFamily: 'system-ui, sans-serif',
+        userSelect: 'none',
+        touchAction: 'none'
+      }}
+    >
+      <div ref={mountRef} style={{ position: 'absolute', inset: 0 }} />
+
+      <div
+        style={{
+          position: 'absolute',
+          top: 12,
+          left: 12,
+          right: 12,
+          display: 'grid',
+          gap: 10,
+          zIndex: 10
+        }}
+      >
+        <div style={panelStyle}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'start' }}>
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 900, color: '#fde68a' }}>
+                User vs 3 AI Shooting Match
+              </div>
+              <div style={{ marginTop: 3, fontSize: 11, opacity: 0.88 }}>
+                {phase === 'pick'
+                  ? `Pick any weapon from any table · ${pickTimer}s`
+                  : phase === 'shoot'
+                  ? 'Lane 1 is yours · bullet holes are saved on targets'
+                  : phase === 'results'
+                  ? winnerText
+                  : 'Loading range...'}
+              </div>
+            </div>
+            <div style={{ textAlign: 'right', fontSize: 12, fontWeight: 900 }}>
+              <div>{phase.toUpperCase()}</div>
+              <div>{viewMode.toUpperCase()}</div>
+            </div>
+          </div>
+
+          <div
+            style={{
+              marginTop: 8,
+              display: 'grid',
+              gridTemplateColumns: 'repeat(4, 1fr)',
+              gap: 6,
+              fontSize: 11,
+              fontWeight: 800,
+              opacity: 0.96
+            }}
+          >
+            {laneScores.map((s, i) => (
+              <div
+                key={i}
+                style={{
+                  padding: '6px 8px',
+                  borderRadius: 12,
+                  background: i === USER_LANE ? 'rgba(250,204,21,.16)' : 'rgba(255,255,255,.05)',
+                  color: i === USER_LANE ? '#fde68a' : '#d1d5db'
+                }}
+              >
+                <div>{i === USER_LANE ? 'YOU' : `AI ${i}`}</div>
+                <div>Score: {s}</div>
+                <div>Shots: {shotsLeft[i]}</div>
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{
+              marginTop: 6,
+              display: 'flex',
+              justifyContent: 'space-between',
+              gap: 8,
+              fontSize: 11,
+              fontWeight: 700,
+              opacity: 0.9,
+              flexWrap: 'wrap'
+            }}
+          >
+            <span>Weapon: {selectedEntry.shortName}</span>
+            <span>Type: {selectedEntry.weaponClass.toUpperCase()}</span>
+            <span>Ammo: {ammo}/{selectedStats.mag}</span>
+            <span>{status}</span>
+          </div>
+        </div>
+      </div>
+
+      {viewMode === 'range' && (
+        <div
+          style={{
+            position: 'absolute',
+            left: '50%',
+            top: '50%',
+            width: 40,
+            height: 40,
+            transform: 'translate(-50%,-50%)',
+            borderRadius: 999,
+            border: '1px solid rgba(255,255,255,.8)',
+            boxShadow: '0 0 22px rgba(255,255,255,.16)',
+            pointerEvents: 'none',
+            zIndex: 10
+          }}
+        >
+          <div style={{ position: 'absolute', left: '50%', top: -12, width: 1, height: 12, background: 'rgba(255,255,255,.8)', transform: 'translateX(-50%)' }} />
+          <div style={{ position: 'absolute', left: '50%', bottom: -12, width: 1, height: 12, background: 'rgba(255,255,255,.8)', transform: 'translateX(-50%)' }} />
+          <div style={{ position: 'absolute', top: '50%', left: -12, width: 12, height: 1, background: 'rgba(255,255,255,.8)', transform: 'translateY(-50%)' }} />
+          <div style={{ position: 'absolute', top: '50%', right: -12, width: 12, height: 1, background: 'rgba(255,255,255,.8)', transform: 'translateY(-50%)' }} />
+          <div style={{ position: 'absolute', left: '50%', top: '50%', width: 6, height: 6, borderRadius: 999, background: '#f87171', transform: 'translate(-50%,-50%)' }} />
+        </div>
+      )}
+
+      <div
+        style={{
+          position: 'absolute',
+          left: 12,
+          right: 12,
+          bottom: 12,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1.4fr 1fr',
+          gap: 10,
+          alignItems: 'end',
+          zIndex: 10
+        }}
+      >
+        <div style={{ display: 'grid', gap: 8 }}>
+          <button onClick={() => actionsRef.current.tables()} style={buttonStyle}>Tables</button>
+          <button onClick={() => actionsRef.current.prev()} style={buttonStyle}>Prev Gun</button>
+          <button onClick={() => actionsRef.current.next()} style={buttonStyle}>Next Gun</button>
+        </div>
+
+        <button onClick={() => actionsRef.current.fire()} style={fireStyle}>
+          {phase === 'results' ? 'RESTART' : 'FIRE'}
+        </button>
+
+        <div style={{ display: 'grid', gap: 8 }}>
+          <button
+            onClick={() => actionsRef.current.reload()}
+            style={{ ...buttonStyle, background: 'rgba(234,179,8,.92)', color: '#111827' }}
+          >
+            Reload
+          </button>
+          <button onClick={() => actionsRef.current.range()} style={buttonStyle}>Range View</button>
+          <div style={panelStyle}>
+            <div style={{ fontSize: 11, fontWeight: 800, opacity: 0.86 }}>
+              During pick phase you can click any weapon lying on the tables.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a new interactive 3D Shooting Range game on the Games page so users can pick weapons, compete against 3 AI lanes, and view per-lane scoring and results.

### Description
- Added a full Three.js-based game page at `webapp/src/pages/Games/ShootingRange.tsx` implementing GLTF/HDRI loading, weapon/table pickups, character lanes, AI firing, scoring, bullet/shell visuals, ammo/reload, and end-of-round results and camera views.
- Registered the new route and lazy-loaded component in `webapp/src/App.jsx` and added a `/games/shootingrange/lobby` redirect to the game route.
- Added the game catalog entry in `webapp/src/config/gamesCatalog.js`, a thumbnail mapping in `webapp/src/config/gameAssets.js`, and Beta readiness metadata in `webapp/src/config/onlineContract.js`.
- Included a vector icon `webapp/public/assets/icons/shooting-range.svg` and committed all changes (commit message: "Add shooting range game").

### Testing
- Ran `npm run build` in the webapp and the production build completed successfully.
- Started the dev server (`npm run dev`) and Vite reported the dev server ready (dev server start succeeded).
- Exercised a Playwright-based smoke check: `npx playwright install chromium` and `npx playwright install-deps chromium` were executed to provision browsers and system deps; the headless screenshot attempt of `/games` was attempted but experienced environment-specific headless runtime issues in this containerized session (browser provisioning succeeded, screenshot run had intermittent failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04499311548329b9c66176dec8e9ae)