### PR TITLE
Add legacy ReadyPlayer skeleton mode, improve cloth-edge material handling, and increase Pool Royale shot power

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2273,7 +2273,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.82; // raise Pool Royale strike speed so full shots feel powerful
+const SHOT_GLOBAL_POWER_SCALE = 1.06; // stronger Pool Royale strike speed so shots carry more power
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -2400,29 +2400,30 @@ const POOL_ROYALE_HUMAN_CHARACTER_IDS = Object.freeze([
 const POOL_ROYALE_HUMAN_LOGIC_PROFILES = Object.freeze({
   'rpm-current': Object.freeze({
     label: 'Classic Pro',
-    summary: 'Forward bend: balanced orthodox pool stance with a stable bridge and medium follow-through.',
+    summary: 'Original ReadyPlayer skeleton logic: table-edge stance, low cloth bridge, fixed cue grip, and classic follow-through.',
     bendMode: 'forward',
-    desiredShootDistance: 1.72,
-    edgeMargin: 0.9,
-    stanceWidth: 0.62,
-    bridgeBack: 0.095,
-    bridgeSide: -0.024,
+    originalSkeletonLogic: true,
+    desiredShootDistance: 1.25,
+    edgeMargin: 0.68,
+    stanceWidth: 0.52,
+    bridgeBack: 0.235,
+    bridgeSide: -0.012,
     bridgeLift: 0.006,
-    gripFromBack: 0.64,
-    rightElbowRise: 0.36,
-    rightElbowSide: -0.5,
-    rightElbowBack: -1.02,
-    forearmOutward: 0.34,
-    forearmBack: 0.48,
-    forearmDown: 0.54,
-    strokePull: 0.5,
+    gripFromBack: 0.58,
+    rightElbowRise: 0.18,
+    rightElbowSide: -0.46,
+    rightElbowBack: -0.78,
+    forearmOutward: 0.36,
+    forearmBack: 0.44,
+    forearmDown: 0.48,
+    strokePull: 0.30,
     strokePush: 0.24,
     practiceStroke: 0.035,
     cueGap: 0.012,
     strikeMs: 120,
     walkSpeed: 4.0,
-    shootForwardBendScale: 0.92,
-    shootUpperBodyCounterLean: 0.48
+    shootForwardBendScale: 1,
+    shootUpperBodyCounterLean: 0
   }),
   'rpm-67d411': Object.freeze({
     label: 'Sniper Rail',
@@ -5803,12 +5804,39 @@ function updateClothTexturesForFinish (
         edgeColor.clone().multiplyScalar(CLOTH_EDGE_EMISSIVE_MULTIPLIER)
       );
     }
-    finishInfo.clothEdgeMat.map = null;
-    finishInfo.clothEdgeMat.bumpMap = null;
-    finishInfo.clothEdgeMat.normalMap = null;
-    finishInfo.clothEdgeMat.roughnessMap = null;
-    finishInfo.clothEdgeMat.bumpScale = 0;
-    finishInfo.clothEdgeMat.roughness = 1;
+    replaceMaterialTexture(finishInfo.clothEdgeMat, 'map', textures.map, fallbackRepeat, {
+      preserveExisting: true
+    });
+    replaceMaterialTexture(
+      finishInfo.clothEdgeMat,
+      'normalMap',
+      textures.normal,
+      fallbackRepeat,
+      { preserveExisting: true }
+    );
+    replaceMaterialTexture(
+      finishInfo.clothEdgeMat,
+      'roughnessMap',
+      textures.roughness,
+      fallbackRepeat,
+      { preserveExisting: true }
+    );
+    if (textures.normal) {
+      finishInfo.clothEdgeMat.normalScale = targetNormalScale.clone();
+      replaceMaterialTexture(finishInfo.clothEdgeMat, 'bumpMap', null, fallbackRepeat);
+    } else {
+      replaceMaterialTexture(
+        finishInfo.clothEdgeMat,
+        'bumpMap',
+        textures.bump,
+        fallbackRepeat,
+        { preserveExisting: true }
+      );
+    }
+    finishInfo.clothEdgeMat.bumpScale = Number.isFinite(finishInfo.clothBase?.baseBumpScale)
+      ? finishInfo.clothBase.baseBumpScale
+      : finishInfo.clothMat.bumpScale;
+    finishInfo.clothEdgeMat.roughness = Math.max(finishInfo.clothMat.roughness ?? roughnessBase, 0.9);
     finishInfo.clothEdgeMat.clearcoat = 0;
     finishInfo.clothEdgeMat.clearcoatRoughness = 1;
     finishInfo.clothEdgeMat.envMapIntensity = 0;
@@ -9697,11 +9725,7 @@ export function Table3D(
   const clothEdgeMat = clothMat.clone();
   clothEdgeMat.color.copy(clothColor);
   clothEdgeMat.emissive.set(0x000000);
-  clothEdgeMat.map = null;
-  clothEdgeMat.bumpMap = null;
-  clothEdgeMat.normalMap = null;
-  clothEdgeMat.roughnessMap = null;
-  clothEdgeMat.bumpScale = 0;
+  clothEdgeMat.bumpScale = clothMat.bumpScale;
   clothEdgeMat.side = THREE.DoubleSide;
   clothEdgeMat.envMapIntensity = 0;
   clothEdgeMat.emissiveIntensity = CLOTH_EDGE_EMISSIVE_INTENSITY;
@@ -9802,10 +9826,8 @@ export function Table3D(
     }
   };
   applyClothDetail(resolvedFinish?.clothDetail);
-  clothEdgeMat.map = null;
-  clothEdgeMat.bumpMap = null;
-  clothEdgeMat.bumpScale = 0;
-  clothEdgeMat.roughness = 1;
+  clothEdgeMat.bumpScale = clothMat.bumpScale;
+  clothEdgeMat.roughness = Math.max(clothMat.roughness ?? 0.82, 0.9);
   clothEdgeMat.clearcoat = 0;
   clothEdgeMat.clearcoatRoughness = 1;
   clothEdgeMat.envMapIntensity = 0;
@@ -10069,6 +10091,13 @@ export function Table3D(
       clothEdgeMat.bumpMap.rotation = clothEdgeMat.map?.rotation ?? clothEdgeMat.bumpMap.rotation ?? 0;
       clothEdgeMat.bumpMap.needsUpdate = true;
     }
+    [clothEdgeMat.normalMap, clothEdgeMat.roughnessMap].forEach((texture) => {
+      if (!texture) return;
+      texture.repeat.set(Math.max(repeatAround, 1), Math.max(repeatHeight, 0.5));
+      texture.center.set(0.5, 0.5);
+      texture.rotation = clothEdgeMat.map?.rotation ?? texture.rotation ?? 0;
+      texture.needsUpdate = true;
+    });
     clothEdgeMat.needsUpdate = true;
   }
 
@@ -15063,10 +15092,8 @@ function applyTableFinishToTable(table, finish) {
   if (finishInfo.clothEdgeMat) {
     const clothEdgeColor = clothColor.clone().lerp(new THREE.Color(0x000000), CLOTH_EDGE_TINT);
     finishInfo.clothEdgeMat.color.copy(clothEdgeColor);
-    finishInfo.clothEdgeMat.map = null;
-    finishInfo.clothEdgeMat.bumpMap = null;
-    finishInfo.clothEdgeMat.bumpScale = 0;
-    finishInfo.clothEdgeMat.roughness = 1;
+    finishInfo.clothEdgeMat.bumpScale = finishInfo.clothMat?.bumpScale ?? finishInfo.clothEdgeMat.bumpScale;
+    finishInfo.clothEdgeMat.roughness = Math.max(finishInfo.clothMat?.roughness ?? 0.82, 0.9);
     finishInfo.clothEdgeMat.clearcoat = 0;
     finishInfo.clothEdgeMat.clearcoatRoughness = 1;
     finishInfo.clothEdgeMat.envMapIntensity = 0;
@@ -27015,19 +27042,20 @@ const shotPowerRef = useRef(0);
             unit: POOL_ROYALE_HUMAN_UNIT_SCALE,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER * (selectedCharacter?.scale || 1),
             humanVisualYawFix: behavior.visualYawFix ?? POOL_ROYALE_HUMAN_VISUAL_YAW_FIX,
+            originalSkeletonLogic: Boolean(behavior.originalSkeletonLogic),
             // Drop the bridge hand to the cloth while keeping the cue aligned with the aim line
             // as the portrait camera lowers into the ready-to-shoot view. Local -Z is the
             // original rig forward axis, so the fallback bend sign folds belly/chest/head
             // toward the cue ball instead of bending the whole body backward.
             shootBendDirection: -1,
-            shootBendTowardCueStick: true,
+            shootBendTowardCueStick: !behavior.originalSkeletonLogic,
             shootBendMode: behavior.bendMode || 'forward',
             shootCounterLeanSide: -1,
             shootUpperBodyCounterLean: behavior.shootUpperBodyCounterLean,
             shootForwardBendScale: behavior.shootForwardBendScale,
             plantFeetDuringShot: true,
             bridgeArmStraightDown: false,
-            forceTableFacingAim: true,
+            forceTableFacingAim: !behavior.originalSkeletonLogic,
             addFaceDetails: false,
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,
@@ -27257,30 +27285,60 @@ const shotPowerRef = useRef(0);
             const behavior = human.userData?.poolRoyaleLogic || activeHumanCharacterRef.current?.logic || POOL_ROYALE_HUMAN_LOGIC_PROFILES['rpm-current'];
             const aimForward = new THREE.Vector3(normalizedAim.x, 0, normalizedAim.y).normalize();
             const side = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
-            const desiredRoot = chooseBilardoHumanEdgePosition(cueWorld, aimForward, {
-              tableW: TABLE.W,
-              tableL: TABLE.H,
-              edgeMargin: (behavior.edgeMargin ?? 0.68) * POOL_ROYALE_HUMAN_UNIT_SCALE,
-              desiredShootDistance: (behavior.desiredShootDistance ?? 1.32) * POOL_ROYALE_HUMAN_UNIT_SCALE
-            }).setY(floorY);
-            const perimeterRoot = clampToWalkPerimeter(desiredRoot);
-            if (isInsideTableBlocker(perimeterRoot)) {
+            // Original-skeleton profile values come from the standalone ReadyPlayer demo scale.
+            // Root placement in this scene must stay in Pool Royale table units, otherwise the
+            // shooter is pushed far past the rail instead of taking the playable cue-side stance.
+            const humanEdgeMargin = behavior.originalSkeletonLogic
+              ? HUMAN_EDGE_MARGIN
+              : (behavior.edgeMargin ?? 0.68) * POOL_ROYALE_HUMAN_UNIT_SCALE;
+            const humanShootDistance = behavior.originalSkeletonLogic
+              ? HUMAN_DESIRED_SHOOT_DISTANCE
+              : (behavior.desiredShootDistance ?? 1.32) * POOL_ROYALE_HUMAN_UNIT_SCALE;
+            const desiredRoot = behavior.originalSkeletonLogic
+              ? (() => {
+                  const desired = cueWorld.clone().addScaledVector(aimForward, -humanShootDistance);
+                  const xEdge = TABLE.W / 2 + humanEdgeMargin;
+                  const zEdge = TABLE.H / 2 + humanEdgeMargin;
+                  const candidates = [
+                    new THREE.Vector3(-xEdge, floorY, THREE.MathUtils.clamp(desired.z, -zEdge, zEdge)),
+                    new THREE.Vector3(xEdge, floorY, THREE.MathUtils.clamp(desired.z, -zEdge, zEdge)),
+                    new THREE.Vector3(THREE.MathUtils.clamp(desired.x, -xEdge, xEdge), floorY, -zEdge),
+                    new THREE.Vector3(THREE.MathUtils.clamp(desired.x, -xEdge, xEdge), floorY, zEdge)
+                  ];
+                  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+                })()
+              : chooseBilardoHumanEdgePosition(cueWorld, aimForward, {
+                  tableW: TABLE.W,
+                  tableL: TABLE.H,
+                  edgeMargin: humanEdgeMargin,
+                  desiredShootDistance: humanShootDistance
+                }).setY(floorY);
+            const perimeterRoot = behavior.originalSkeletonLogic
+              ? desiredRoot.clone()
+              : clampToWalkPerimeter(desiredRoot);
+            if (!behavior.originalSkeletonLogic && isInsideTableBlocker(perimeterRoot)) {
               perimeterRoot.copy(clampToWalkPerimeter(perimeterRoot));
             }
             if (!Number.isFinite(human.walkPerimeterT)) {
               human.walkPerimeterT = pointToPerimeterT(human.root?.position ?? perimeterRoot);
             }
-            const humanTargetT = pointToPerimeterT(perimeterRoot);
-            const humanLoopDelta =
-              THREE.MathUtils.euclideanModulo(humanTargetT - human.walkPerimeterT + 0.5, 1) - 0.5;
-            const humanMaxStepT =
-              ((behavior.walkSpeed ?? 4.0) * POOL_ROYALE_HUMAN_UNIT_SCALE * Math.max(dtSeconds, 1 / 240)) /
-              (4 * (walkHalfX + walkHalfZ));
-            human.walkPerimeterT = THREE.MathUtils.euclideanModulo(
-              human.walkPerimeterT + THREE.MathUtils.clamp(humanLoopDelta, -humanMaxStepT, humanMaxStepT),
-              1
-            );
-            const walkRoot = perimeterTToPoint(human.walkPerimeterT);
+            let walkRoot;
+            if (behavior.originalSkeletonLogic) {
+              walkRoot = perimeterRoot.clone();
+              human.walkPerimeterT = pointToPerimeterT(walkRoot);
+            } else {
+              const humanTargetT = pointToPerimeterT(perimeterRoot);
+              const humanLoopDelta =
+                THREE.MathUtils.euclideanModulo(humanTargetT - human.walkPerimeterT + 0.5, 1) - 0.5;
+              const humanMaxStepT =
+                ((behavior.walkSpeed ?? 4.0) * POOL_ROYALE_HUMAN_UNIT_SCALE * Math.max(dtSeconds, 1 / 240)) /
+                (4 * (walkHalfX + walkHalfZ));
+              human.walkPerimeterT = THREE.MathUtils.euclideanModulo(
+                human.walkPerimeterT + THREE.MathUtils.clamp(humanLoopDelta, -humanMaxStepT, humanMaxStepT),
+                1
+              );
+              walkRoot = perimeterTToPoint(human.walkPerimeterT);
+            }
             const shouldRestAtChair = !isHumanShooter;
             let walkingToChair = false;
             let seatedAtChair = false;

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -257,7 +257,8 @@ const BASE_CFG = {
   closeCueBallDistance: 0.28,
   powerShotThreshold: 0.74,
   softShotThreshold: 0.26,
-  addFaceDetails: true
+  addFaceDetails: true,
+  originalSkeletonLogic: false
 };
 
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
@@ -1019,8 +1020,148 @@ function driveHuman(human, frame) {
   setHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, cfg.footLockStrength * ik);
 }
 
+
+function updateOriginalSkeletonHumanPose(human, dt, frameData) {
+  const cfg = human.cfg;
+  const state = frameData.state || 'idle';
+  const activeState = state === 'rolling' || state === 'turnEnd' || state === 'gameOver' ? 'idle' : state;
+  human.poolPlayerState = activeState === 'idle'
+    ? 'ReturnToIdle'
+    : activeState === 'dragging'
+      ? 'AimAdjust'
+      : activeState === 'striking'
+        ? (human.strikeClock < cfg.strikeTime * 0.42 ? 'CuePullBack' : human.strikeClock < cfg.strikeTime ? 'CueStrike' : 'FollowThrough')
+        : 'WatchBalls';
+  human.poseT = dampScalar(human.poseT, activeState === 'idle' ? 0 : 1, cfg.poseLambda, dt);
+  human.breathT += dt * (activeState === 'idle' ? 1.05 : 0.5);
+  human.settleT = dampScalar(human.settleT, activeState === 'dragging' ? 1 : 0, 5.5, dt);
+  if (activeState === 'striking') {
+    if (human.strikeClock === 0) {
+      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : frameData.rootTarget);
+      human.strikeYaw = human.yaw;
+    }
+    human.strikeClock += dt;
+  } else {
+    human.strikeClock = 0;
+  }
+
+  const rootGoal = activeState === 'striking' ? human.strikeRoot : frameData.rootTarget;
+  const moveAmountRaw = (() => {
+    dampVector(human.root.position, rootGoal, activeState === 'striking' ? 12 : cfg.moveLambda, dt);
+    human.root.position.y = cfg.groundY;
+    return human.root.position.distanceTo(rootGoal);
+  })();
+  human.walkT += dt * (2 + Math.min(7, (moveAmountRaw * 10) / cfg.unit));
+
+  const targetYaw = activeState === 'striking' ? human.strikeYaw : yawFromForward(frameData.aimForward);
+  human.yaw = activeState === 'dragging' || activeState === 'striking'
+    ? targetYaw
+    : dampAngle(human.yaw, targetYaw, cfg.rotLambda, dt);
+
+  const t = easeInOut(human.poseT);
+  const idle = 1 - t;
+  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * cfg.unit);
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, (moveAmountRaw * 12) / cfg.unit);
+  const walkAmount = clamp01((moveAmountRaw * 18) / cfg.unit) * idle;
+  const dragStroke = activeState === 'dragging'
+    ? Math.sin(performance.now() * 0.011) * (0.25 + (frameData.power || 0) * 0.75)
+    : 0;
+  const strikeFollow = activeState === 'striking'
+    ? Math.sin(clamp01(human.strikeClock / (cfg.strikeTime + cfg.holdTime)) * Math.PI)
+    : 0;
+  // The loaded ReadyPlayer model keeps its own visual yaw fix on the model child.
+  // Drive the original skeleton bend/stance from that visible direction so the
+  // avatar leans over the cue line instead of folding toward the opposite side.
+  const visualYaw = human.yaw + (cfg.humanVisualYawFix || 0);
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, visualYaw).normalize();
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, visualYaw).add(human.root.position);
+  const powerLean = (frameData.power || 0) * t;
+  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * cfg.unit);
+  rootWorld.y = cfg.groundY;
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) * cfg.unit + breath, (lerp(0.02, -0.16, t) - 0.014 * powerLean) * cfg.unit));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) * cfg.unit + breath, (lerp(0.02, -0.42, t) - 0.024 * powerLean) * cfg.unit));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) * cfg.unit + breath, (lerp(0.02, -0.61, t) - 0.028 * powerLean) * cfg.unit));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.72, t) - 0.028 * powerLean) * cfg.unit));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * cfg.unit));
+  const rightShoulder = local(new THREE.Vector3(0.23 * cfg.unit, lerp(1.58, 1.36, t) * cfg.unit + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.unit));
+  const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
+  const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
+  const leftFoot = local(new THREE.Vector3(-0.13 * cfg.unit, cfg.footGroundY, 0.03 * cfg.unit + walk * 0.018 * cfg.unit).lerp(new THREE.Vector3(-cfg.stanceWidth * 0.42, cfg.footGroundY, -0.34 * cfg.unit), t));
+  const rightFoot = local(new THREE.Vector3(0.13 * cfg.unit, cfg.footGroundY, -0.03 * cfg.unit - walk * 0.018 * cfg.unit).lerp(new THREE.Vector3(cfg.stanceWidth * 0.5, cfg.footGroundY, 0.34 * cfg.unit), t));
+  const bridgePalmTarget = frameData.bridgeTarget.clone()
+    .addScaledVector(forward, -0.006 * cfg.unit * t)
+    .addScaledVector(side, -0.012 * cfg.unit * t)
+    .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
+    .addScaledVector(UP, -0.01 * cfg.unit * human.settleT);
+  const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);
+  const cueDirForHand = frameData.cueTip.clone().sub(frameData.cueBack).normalize();
+  const handIk = easeInOut(clamp01(t));
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = UP.clone().multiplyScalar(-1.0).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
+  const lockedRightElbow = rightShoulder.clone()
+    .addScaledVector(UP, lerp(0.04 * cfg.unit, cfg.rightElbowShotRise, t))
+    .addScaledVector(side, lerp(-0.18 * cfg.unit, cfg.rightElbowShotSide, t))
+    .addScaledVector(forward, lerp(-0.04 * cfg.unit, cfg.rightElbowShotBack, t));
+  const pullBack = activeState === 'dragging' ? -cfg.rightStrokePull * easeOutCubic(frameData.power || 0) : 0;
+  const pushForward = activeState === 'striking' ? cfg.rightStrokePush * strikeFollow : 0;
+  const smallPractice = activeState === 'dragging' ? dragStroke * 0.035 * cfg.unit : 0;
+  const forearmStroke = pullBack + pushForward + smallPractice;
+  const forearmBase = lockedRightElbow.clone()
+    .addScaledVector(side, cfg.rightForearmOutward * t)
+    .addScaledVector(UP, -cfg.rightForearmDown * t)
+    .addScaledVector(UP, cfg.rightHandShotLift * t)
+    .addScaledVector(forward, -cfg.rightForearmBack * t)
+    .addScaledVector(cueDirForHand, cfg.rightForearmLength);
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
+  const idleWristTarget = frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal));
+  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - cfg.rightHandDownPose, handIk), cfg.rightHandCueSocketLocal));
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * cfg.unit * t).addScaledVector(side, -0.044 * cfg.unit * t).addScaledVector(forward, 0.065 * cfg.unit * t);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * cfg.unit * t).addScaledVector(side, -0.012 * cfg.unit * t);
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * cfg.unit * t).addScaledVector(side, 0.014 * cfg.unit * t);
+
+  human.root.visible = true;
+  human.lastMoveAmountRaw = moveAmountRaw;
+  driveHuman(human, {
+    t,
+    dt,
+    stroke: forearmStroke / cfg.unit,
+    follow: strikeFollow,
+    walkAmount,
+    forward,
+    side,
+    up: UP,
+    rootWorld,
+    torsoCenterWorld: torso,
+    chestCenterWorld: chest,
+    neckWorld: neck,
+    headCenterWorld: head,
+    leftElbow,
+    rightElbow: lockedRightElbow,
+    leftHandWorld: leftHand,
+    rightHandWorld: rightHand,
+    leftKnee,
+    rightKnee,
+    leftFootWorld: leftFoot,
+    rightFootWorld: rightFoot,
+    cueBackWorld: frameData.cueBack,
+    cueTipWorld: frameData.cueTip,
+    seated: false,
+    seatedBlend: 0,
+    standTransition: 1
+  });
+  updateHumanDebugArrows(human, frameData, forward, cueDirForHand, cfg);
+}
+
 export function updateHumanPose(human, dt, frameData) {
   if (!human || !frameData || !Number.isFinite(dt) || dt < 0 || !frameData.rootTarget || !frameData.aimForward) return;
+  if (human.cfg?.originalSkeletonLogic && (frameData.state || 'idle') !== 'seated') {
+    updateOriginalSkeletonHumanPose(human, dt, frameData);
+    return;
+  }
   const cfg = human.cfg;
   const state = frameData.state || 'idle';
   const activeState = state === 'rolling' || state === 'turnEnd' || state === 'gameOver' ? 'idle' : state;


### PR DESCRIPTION
### Motivation

- Restore compatibility with the original ReadyPlayer human skeleton for a legacy character profile while keeping Pool Royale placement and animations coherent with table units.
- Improve visual fidelity of table cloth edge materials by preserving and correctly applying normal/roughness maps and bump scales.
- Adjust Pool Royale global shot power to make full strikes feel stronger and more consistent with tuning changes.

### Description

- Increase shot strength by changing `SHOT_GLOBAL_POWER_SCALE` from `0.82` to `1.06`, which flows through `SHOT_FORCE_BOOST` and `SHOT_BASE_SPEED` calculations.
- Add an `originalSkeletonLogic` flag to the `rpm-current` profile and update many stance/bridge/arm parameters for that profile to match the ReadyPlayer demo scale.
- Propagate `originalSkeletonLogic` into `createBilardoHumanRig` options and toggle `shootBendTowardCueStick` and `forceTableFacingAim` accordingly when creating player rigs.
- Implement custom placement and walk/perimeter logic for original-skeleton characters in `PoolRoyale.jsx` so root placement uses table-edge candidate points and avoids the normal perimeter clamping used by the new rigs.
- Introduce `updateOriginalSkeletonHumanPose` in `humanRigCore.js` and short-circuit `updateHumanPose` to call it when `human.cfg.originalSkeletonLogic` is enabled, preserving the legacy pose/animation flow.
- Replace ad-hoc cloth-edge material clearing with `replaceMaterialTexture` usage, preserve existing textures when appropriate, set `bumpScale` to match the primary cloth, ensure `roughness` is at least `0.9`, and add handling for `normalMap`/`roughnessMap` repeat/rotation updates.
- Minor changes: set initial `clothEdgeMat.bumpScale` from `clothMat.bumpScale` and ensure `clothEdgeMat.roughness` is tightened on table creation and finish application.

### Testing

- Ran the automated unit test suite with `yarn test`, and all tests passed.
- Performed a production build with `yarn build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045fd17f4c83298936ae0ef5a11663)