### PR TITLE
Add Shooting Range lobby, simplify HUD controls, fix shot placement and improve AI

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -116,6 +116,9 @@ const FreeKickArena = React.lazy(
 const ShootingRange = React.lazy(
   () => import('./pages/Games/ShootingRange.tsx')
 );
+const ShootingRangeLobby = React.lazy(
+  () => import('./pages/Games/ShootingRangeLobby.jsx')
+);
 const StoreThumbnailStudioPoolRoyale = React.lazy(
   () => import('./pages/Tools/StoreThumbnailStudioPoolRoyale.jsx')
 );
@@ -446,7 +449,7 @@ export default function App() {
               />
               <Route
                 path="/games/shootingrange/lobby"
-                element={<Navigate to="/games/shootingrange" replace />}
+                element={<ShootingRangeLobby />}
               />
               <Route
                 path="/games/shootingrange"

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -113,7 +113,7 @@ const gamesCatalog = [
 
   {
     name: 'Shooting Range',
-    route: '/games/shootingrange',
+    route: '/games/shootingrange/lobby',
     slug: 'shootingrange',
     image: '/assets/icons/shooting-range.svg',
     description:

--- a/webapp/src/config/onlineContract.js
+++ b/webapp/src/config/onlineContract.js
@@ -61,8 +61,8 @@ export const ONLINE_READINESS_BY_GAME = Object.freeze({
     label: 'Online Ready'
   },
   shootingrange: {
-    checks: { lobby: false, runtime: true, backend: false, security: false },
-    label: 'Beta'
+    checks: { lobby: true, runtime: true, backend: false, security: false },
+    label: 'Lobby Ready'
   }
 });
 
@@ -71,7 +71,10 @@ const FALLBACK_STATE = Object.freeze({
   label: 'Coming Soon'
 });
 
-export function getOnlineReadiness(slug = '', source = ONLINE_READINESS_BY_GAME) {
+export function getOnlineReadiness(
+  slug = '',
+  source = ONLINE_READINESS_BY_GAME
+) {
   const state = source[slug] || FALLBACK_STATE;
   const checks = {
     lobby: Boolean(state.checks?.lobby),
@@ -79,7 +82,8 @@ export function getOnlineReadiness(slug = '', source = ONLINE_READINESS_BY_GAME)
     backend: Boolean(state.checks?.backend),
     security: Boolean(state.checks?.security)
   };
-  const ready = checks.lobby && checks.runtime && checks.backend && checks.security;
+  const ready =
+    checks.lobby && checks.runtime && checks.backend && checks.security;
   return {
     slug,
     checks,

--- a/webapp/src/pages/Games/ShootingRange.tsx
+++ b/webapp/src/pages/Games/ShootingRange.tsx
@@ -2,14 +2,24 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
-import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import {
+  GLTFLoader,
+  type GLTF
+} from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { clone as cloneScene } from 'three/examples/jsm/utils/SkeletonUtils.js';
 
-type WeaponClass = 'pistol' | 'revolver' | 'shotgun' | 'rifle' | 'smg' | 'sniper';
+type WeaponClass =
+  | 'pistol'
+  | 'revolver'
+  | 'shotgun'
+  | 'rifle'
+  | 'smg'
+  | 'sniper';
 type GamePhase = 'loading' | 'pick' | 'shoot' | 'results';
 type ViewMode = 'tables' | 'range' | 'results';
 type ControllerType = 'USER' | 'AI';
+type MatchMode = 'ai' | 'online';
 
 type WeaponEntry = {
   id: string;
@@ -107,6 +117,8 @@ const USER_LANE = 0;
 const LANE_COUNT = 4;
 const SHOTS_PER_PLAYER = 5;
 const PICK_SECONDS = 5;
+const TARGET_HALF_WIDTH = 1.05 / 2;
+const TARGET_HALF_HEIGHT = 1.58 / 2;
 const LANE_X = [-4.9, -1.65, 1.65, 4.9];
 const TABLE_Z = 2.35;
 const TABLE_TOP_Y = 0.94;
@@ -115,45 +127,61 @@ const TARGET_Z = -21.8;
 const OVER_SHOULDER_OFFSET = new THREE.Vector3(0.5, 1.72, 4.85);
 const OVER_SHOULDER_LOOK = new THREE.Vector3(0.05, 1.38, -12.5);
 
-const HDRI_URL = 'https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/studio_small_09_1k.hdr';
+const HDRI_URL =
+  'https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/studio_small_09_1k.hdr';
 
 const TEXTURES = {
   floor: {
     diff: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_diff_4k.jpg',
-    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_nor_gl_4k.jpg',
-    rough: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_rough_4k.jpg',
+    normal:
+      'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_nor_gl_4k.jpg',
+    rough:
+      'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_rough_4k.jpg',
     ao: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete_floor_02/concrete_floor_02_ao_4k.jpg'
   },
   wall: {
     diff: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_diff_4k.jpg',
-    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_nor_gl_4k.jpg',
-    rough: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_rough_4k.jpg',
+    normal:
+      'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_nor_gl_4k.jpg',
+    rough:
+      'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_rough_4k.jpg',
     ao: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/concrete/concrete_ao_4k.jpg'
   },
   metal: {
     diff: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_diff_4k.jpg',
-    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_nor_gl_4k.jpg',
-    rough: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_rough_4k.jpg',
-    metal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_metal_4k.jpg'
+    normal:
+      'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_nor_gl_4k.jpg',
+    rough:
+      'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_rough_4k.jpg',
+    metal:
+      'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/metal_plate/metal_plate_metal_4k.jpg'
   },
   table: {
     diff: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_diff_4k.jpg',
-    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_nor_gl_4k.jpg',
-    rough: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_rough_4k.jpg',
+    normal:
+      'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_nor_gl_4k.jpg',
+    rough:
+      'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_rough_4k.jpg',
     ao: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/4k/dark_wood/dark_wood_ao_4k.jpg'
   }
 };
 
 const KNOWN = {
   fps: 'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
-  fpsRaw: 'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
+  fpsRaw:
+    'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
   awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
-  awpRaw: 'https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb',
+  awpRaw:
+    'https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb',
   mrtk: 'https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
-  mrtkRaw: 'https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
-  mrtkMaster: 'https://cdn.jsdelivr.net/gh/Microsoft/MixedRealityToolkit@master/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
-  pistolHolster: 'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
-  pistolHolsterRaw: 'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb'
+  mrtkRaw:
+    'https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  mrtkMaster:
+    'https://cdn.jsdelivr.net/gh/Microsoft/MixedRealityToolkit@master/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  pistolHolster:
+    'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
+  pistolHolsterRaw:
+    'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb'
 };
 
 function polyGlb(uuid: string) {
@@ -161,40 +189,273 @@ function polyGlb(uuid: string) {
 }
 
 const WEAPONS: WeaponEntry[] = [
-  { id: 'q-shotgun-1', name: 'Quaternius Shotgun', shortName: 'Shotgun', weaponClass: 'shotgun', urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')] },
-  { id: 'q-assault', name: 'Quaternius Assault Rifle', shortName: 'Assault', weaponClass: 'rifle', urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')] },
-  { id: 'q-pistol', name: 'Quaternius Pistol', shortName: 'Pistol', weaponClass: 'pistol', urls: [polyGlb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc')] },
-  { id: 'q-heavy-revolver', name: 'Quaternius Heavy Revolver', shortName: 'Heavy Rev', weaponClass: 'revolver', urls: [polyGlb('9e728565-67a3-44db-9567-982320abff09')] },
-  { id: 'q-sawed-off', name: 'Quaternius Sawed-Off Shotgun', shortName: 'Sawed-Off', weaponClass: 'shotgun', urls: [polyGlb('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e')] },
-  { id: 'q-silver-revolver', name: 'Quaternius Revolver Silver', shortName: 'Silver Rev', weaponClass: 'revolver', urls: [polyGlb('7951b3b9-d3a5-4ec8-81b7-11111f1c8e88')] },
-  { id: 'q-long-shotgun', name: 'Quaternius Long Shotgun', shortName: 'Long Shotgun', weaponClass: 'shotgun', urls: [polyGlb('f71d6771-f512-4374-bd23-ba00b564db68')] },
-  { id: 'q-pump-shotgun', name: 'Quaternius Pump Shotgun', shortName: 'Pump', weaponClass: 'shotgun', urls: [polyGlb('08f27141-8e64-425a-9161-1bbd6956dfca')] },
-  { id: 'q-smg', name: 'Quaternius Submachine Gun', shortName: 'SMG', weaponClass: 'smg', urls: [polyGlb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710')] },
-  { id: 'ak47', name: 'AK47 GLTF', shortName: 'AK47', weaponClass: 'rifle', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf', KNOWN.awp, KNOWN.awpRaw] },
-  { id: 'krsv', name: 'KRSV GLTF', shortName: 'KRSV', weaponClass: 'rifle', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf', KNOWN.mrtk, KNOWN.mrtkRaw] },
-  { id: 'smith', name: 'Smith GLTF', shortName: 'Smith', weaponClass: 'pistol', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf', KNOWN.pistolHolster, KNOWN.pistolHolsterRaw] },
-  { id: 'mosin', name: 'Mosin GLTF', shortName: 'Mosin', weaponClass: 'sniper', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf', KNOWN.awp, KNOWN.awpRaw] },
-  { id: 'uzi', name: 'Uzi GLTF', shortName: 'Uzi', weaponClass: 'smg', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf', KNOWN.mrtk, KNOWN.mrtkMaster] },
-  { id: 'sigsauer', name: 'SigSauer GLTF', shortName: 'SigSauer', weaponClass: 'pistol', urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf', KNOWN.pistolHolster, KNOWN.pistolHolsterRaw] },
-  { id: 'awp', name: 'AWP Sniper GLB', shortName: 'AWP', weaponClass: 'sniper', urls: [KNOWN.awp, KNOWN.awpRaw] },
-  { id: 'mrtk', name: 'MRTK Gun GLB', shortName: 'MRTK', weaponClass: 'rifle', urls: [KNOWN.mrtk, KNOWN.mrtkRaw, KNOWN.mrtkMaster] },
-  { id: 'fps', name: 'FPS Gun GLTF', shortName: 'FPS Shotgun', weaponClass: 'shotgun', urls: [KNOWN.fps, KNOWN.fpsRaw, KNOWN.awp, KNOWN.awpRaw] }
+  {
+    id: 'q-shotgun-1',
+    name: 'Quaternius Shotgun',
+    shortName: 'Shotgun',
+    weaponClass: 'shotgun',
+    urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')]
+  },
+  {
+    id: 'q-assault',
+    name: 'Quaternius Assault Rifle',
+    shortName: 'Assault',
+    weaponClass: 'rifle',
+    urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')]
+  },
+  {
+    id: 'q-pistol',
+    name: 'Quaternius Pistol',
+    shortName: 'Pistol',
+    weaponClass: 'pistol',
+    urls: [polyGlb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc')]
+  },
+  {
+    id: 'q-heavy-revolver',
+    name: 'Quaternius Heavy Revolver',
+    shortName: 'Heavy Rev',
+    weaponClass: 'revolver',
+    urls: [polyGlb('9e728565-67a3-44db-9567-982320abff09')]
+  },
+  {
+    id: 'q-sawed-off',
+    name: 'Quaternius Sawed-Off Shotgun',
+    shortName: 'Sawed-Off',
+    weaponClass: 'shotgun',
+    urls: [polyGlb('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e')]
+  },
+  {
+    id: 'q-silver-revolver',
+    name: 'Quaternius Revolver Silver',
+    shortName: 'Silver Rev',
+    weaponClass: 'revolver',
+    urls: [polyGlb('7951b3b9-d3a5-4ec8-81b7-11111f1c8e88')]
+  },
+  {
+    id: 'q-long-shotgun',
+    name: 'Quaternius Long Shotgun',
+    shortName: 'Long Shotgun',
+    weaponClass: 'shotgun',
+    urls: [polyGlb('f71d6771-f512-4374-bd23-ba00b564db68')]
+  },
+  {
+    id: 'q-pump-shotgun',
+    name: 'Quaternius Pump Shotgun',
+    shortName: 'Pump',
+    weaponClass: 'shotgun',
+    urls: [polyGlb('08f27141-8e64-425a-9161-1bbd6956dfca')]
+  },
+  {
+    id: 'q-smg',
+    name: 'Quaternius Submachine Gun',
+    shortName: 'SMG',
+    weaponClass: 'smg',
+    urls: [polyGlb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710')]
+  },
+  {
+    id: 'ak47',
+    name: 'AK47 GLTF',
+    shortName: 'AK47',
+    weaponClass: 'rifle',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
+      KNOWN.awp,
+      KNOWN.awpRaw
+    ]
+  },
+  {
+    id: 'krsv',
+    name: 'KRSV GLTF',
+    shortName: 'KRSV',
+    weaponClass: 'rifle',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf',
+      KNOWN.mrtk,
+      KNOWN.mrtkRaw
+    ]
+  },
+  {
+    id: 'smith',
+    name: 'Smith GLTF',
+    shortName: 'Smith',
+    weaponClass: 'pistol',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
+      KNOWN.pistolHolster,
+      KNOWN.pistolHolsterRaw
+    ]
+  },
+  {
+    id: 'mosin',
+    name: 'Mosin GLTF',
+    shortName: 'Mosin',
+    weaponClass: 'sniper',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
+      KNOWN.awp,
+      KNOWN.awpRaw
+    ]
+  },
+  {
+    id: 'uzi',
+    name: 'Uzi GLTF',
+    shortName: 'Uzi',
+    weaponClass: 'smg',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf',
+      KNOWN.mrtk,
+      KNOWN.mrtkMaster
+    ]
+  },
+  {
+    id: 'sigsauer',
+    name: 'SigSauer GLTF',
+    shortName: 'SigSauer',
+    weaponClass: 'pistol',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf',
+      KNOWN.pistolHolster,
+      KNOWN.pistolHolsterRaw
+    ]
+  },
+  {
+    id: 'awp',
+    name: 'AWP Sniper GLB',
+    shortName: 'AWP',
+    weaponClass: 'sniper',
+    urls: [KNOWN.awp, KNOWN.awpRaw]
+  },
+  {
+    id: 'mrtk',
+    name: 'MRTK Gun GLB',
+    shortName: 'MRTK',
+    weaponClass: 'rifle',
+    urls: [KNOWN.mrtk, KNOWN.mrtkRaw, KNOWN.mrtkMaster]
+  },
+  {
+    id: 'fps',
+    name: 'FPS Gun GLTF',
+    shortName: 'FPS Shotgun',
+    weaponClass: 'shotgun',
+    urls: [KNOWN.fps, KNOWN.fpsRaw, KNOWN.awp, KNOWN.awpRaw]
+  }
 ];
 
 const STATS: Record<WeaponClass, WeaponStats> = {
-  pistol: { mag: 12, fireDelay: 210, reloadMs: 950, recoil: 0.35, spread: 0.013, damage: 34, pellets: 1, fairPellets: 1, bulletSpeed: 5.2, shellPower: 0.95 },
-  revolver: { mag: 6, fireDelay: 430, reloadMs: 1150, recoil: 0.55, spread: 0.011, damage: 60, pellets: 1, fairPellets: 1, bulletSpeed: 5.4, shellPower: 1.05 },
-  shotgun: { mag: 7, fireDelay: 670, reloadMs: 1300, recoil: 0.85, spread: 0.05, damage: 18, pellets: 1, fairPellets: 1, bulletSpeed: 4.2, shellPower: 1.3 },
-  rifle: { mag: 30, fireDelay: 115, reloadMs: 1180, recoil: 0.28, spread: 0.017, damage: 27, pellets: 1, fairPellets: 1, bulletSpeed: 5.6, shellPower: 1.0 },
-  smg: { mag: 34, fireDelay: 85, reloadMs: 1000, recoil: 0.2, spread: 0.024, damage: 20, pellets: 1, fairPellets: 1, bulletSpeed: 5.0, shellPower: 0.82 },
-  sniper: { mag: 5, fireDelay: 900, reloadMs: 1500, recoil: 1.05, spread: 0.005, damage: 100, pellets: 1, fairPellets: 1, bulletSpeed: 6.6, shellPower: 1.25 }
+  pistol: {
+    mag: 12,
+    fireDelay: 210,
+    reloadMs: 950,
+    recoil: 0.35,
+    spread: 0.013,
+    damage: 34,
+    pellets: 1,
+    fairPellets: 1,
+    bulletSpeed: 5.2,
+    shellPower: 0.95
+  },
+  revolver: {
+    mag: 6,
+    fireDelay: 430,
+    reloadMs: 1150,
+    recoil: 0.55,
+    spread: 0.011,
+    damage: 60,
+    pellets: 1,
+    fairPellets: 1,
+    bulletSpeed: 5.4,
+    shellPower: 1.05
+  },
+  shotgun: {
+    mag: 7,
+    fireDelay: 670,
+    reloadMs: 1300,
+    recoil: 0.85,
+    spread: 0.05,
+    damage: 18,
+    pellets: 1,
+    fairPellets: 1,
+    bulletSpeed: 4.2,
+    shellPower: 1.3
+  },
+  rifle: {
+    mag: 30,
+    fireDelay: 115,
+    reloadMs: 1180,
+    recoil: 0.28,
+    spread: 0.017,
+    damage: 27,
+    pellets: 1,
+    fairPellets: 1,
+    bulletSpeed: 5.6,
+    shellPower: 1.0
+  },
+  smg: {
+    mag: 34,
+    fireDelay: 85,
+    reloadMs: 1000,
+    recoil: 0.2,
+    spread: 0.024,
+    damage: 20,
+    pellets: 1,
+    fairPellets: 1,
+    bulletSpeed: 5.0,
+    shellPower: 0.82
+  },
+  sniper: {
+    mag: 5,
+    fireDelay: 900,
+    reloadMs: 1500,
+    recoil: 1.05,
+    spread: 0.005,
+    damage: 100,
+    pellets: 1,
+    fairPellets: 1,
+    bulletSpeed: 6.6,
+    shellPower: 1.25
+  }
 };
 
 const CHARACTERS: CharacterSpec[] = [
-  { name: 'Soldier', urls: ['https://threejs.org/examples/models/gltf/Soldier.glb'], scale: 1.7, yaw: Math.PI, fallbackColor: '#e5e7eb' },
-  { name: 'Cesium Man', urls: ['https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb', 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb'], scale: 1.68, yaw: Math.PI, fallbackColor: '#93c5fd' },
-  { name: 'Robot Expressive', urls: ['https://threejs.org/examples/models/gltf/RobotExpressive/RobotExpressive.glb'], scale: 1.62, yaw: Math.PI, fallbackColor: '#fca5a5' },
-  { name: 'Xbot', urls: ['https://threejs.org/examples/models/gltf/Xbot.glb'], scale: 1.7, yaw: Math.PI, fallbackColor: '#86efac' }
+  {
+    name: 'Soldier',
+    urls: ['https://threejs.org/examples/models/gltf/Soldier.glb'],
+    scale: 1.7,
+    yaw: Math.PI,
+    fallbackColor: '#e5e7eb'
+  },
+  {
+    name: 'Cesium Man',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb',
+      'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb'
+    ],
+    scale: 1.68,
+    yaw: Math.PI,
+    fallbackColor: '#93c5fd'
+  },
+  {
+    name: 'Robot Expressive',
+    urls: [
+      'https://threejs.org/examples/models/gltf/RobotExpressive/RobotExpressive.glb'
+    ],
+    scale: 1.62,
+    yaw: Math.PI,
+    fallbackColor: '#fca5a5'
+  },
+  {
+    name: 'Xbot',
+    urls: ['https://threejs.org/examples/models/gltf/Xbot.glb'],
+    scale: 1.7,
+    yaw: Math.PI,
+    fallbackColor: '#86efac'
+  }
 ];
 
 function statsFor(entry: WeaponEntry) {
@@ -206,7 +467,11 @@ function parentFolder(url: string) {
 }
 
 function isAbsoluteOrDataUrl(url: string) {
-  return /^(https?:)?\/\//i.test(url) || url.startsWith('data:') || url.startsWith('blob:');
+  return (
+    /^(https?:)?\/\//i.test(url) ||
+    url.startsWith('data:') ||
+    url.startsWith('blob:')
+  );
 }
 
 function shuffle<T>(items: T[]) {
@@ -222,7 +487,9 @@ function makeLoaderForUrl(modelUrl: string) {
   const baseFolder = parentFolder(modelUrl);
   const manager = new THREE.LoadingManager();
   manager.setURLModifier((resourceUrl) =>
-    isAbsoluteOrDataUrl(resourceUrl) ? resourceUrl : new URL(resourceUrl, baseFolder).toString()
+    isAbsoluteOrDataUrl(resourceUrl)
+      ? resourceUrl
+      : new URL(resourceUrl, baseFolder).toString()
   );
   const loader = new GLTFLoader(manager);
   loader.setCrossOrigin('anonymous');
@@ -235,7 +502,10 @@ async function loadGLTF(name: string, urls: string[]): Promise<GLTF> {
     try {
       const loader = makeLoaderForUrl(url);
       const gltf = await new Promise<GLTF>((resolve, reject) => {
-        const timer = window.setTimeout(() => reject(new Error(`Timeout loading ${name}`)), 24000);
+        const timer = window.setTimeout(
+          () => reject(new Error(`Timeout loading ${name}`)),
+          24000
+        );
         loader.load(
           url,
           (loaded) => {
@@ -258,8 +528,15 @@ async function loadGLTF(name: string, urls: string[]): Promise<GLTF> {
   throw lastError ?? new Error(`All URLs failed for ${name}`);
 }
 
-function loadTexture(loader: THREE.TextureLoader, url: string, color = false, repeat: [number, number] = [1, 1]) {
-  const tex = loader.load(url, undefined, undefined, () => console.warn('Texture failed:', url));
+function loadTexture(
+  loader: THREE.TextureLoader,
+  url: string,
+  color = false,
+  repeat: [number, number] = [1, 1]
+) {
+  const tex = loader.load(url, undefined, undefined, () =>
+    console.warn('Texture failed:', url)
+  );
   tex.wrapS = THREE.RepeatWrapping;
   tex.wrapT = THREE.RepeatWrapping;
   tex.repeat.set(repeat[0], repeat[1]);
@@ -270,12 +547,22 @@ function loadTexture(loader: THREE.TextureLoader, url: string, color = false, re
 
 function makePbrMaterial(
   loader: THREE.TextureLoader,
-  maps: { diff: string; normal: string; rough: string; ao?: string; metal?: string },
+  maps: {
+    diff: string;
+    normal: string;
+    rough: string;
+    ao?: string;
+    metal?: string;
+  },
   repeat: [number, number],
   fallback: string,
   metalness = 0
 ) {
-  const mat = new THREE.MeshStandardMaterial({ color: fallback, roughness: 0.78, metalness });
+  const mat = new THREE.MeshStandardMaterial({
+    color: fallback,
+    roughness: 0.78,
+    metalness
+  });
   mat.map = loadTexture(loader, maps.diff, true, repeat);
   mat.normalMap = loadTexture(loader, maps.normal, false, repeat);
   mat.roughnessMap = loadTexture(loader, maps.rough, false, repeat);
@@ -298,15 +585,24 @@ function configureModel(root: THREE.Object3D, renderer: THREE.WebGLRenderer) {
     const materials = Array.isArray((mesh as any).material)
       ? (mesh as any).material
       : (mesh as any).material
-      ? [(mesh as any).material]
-      : [];
+        ? [(mesh as any).material]
+        : [];
 
     materials.forEach((material: any) => {
-      const keys = ['map', 'emissiveMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'alphaMap'];
+      const keys = [
+        'map',
+        'emissiveMap',
+        'normalMap',
+        'roughnessMap',
+        'metalnessMap',
+        'aoMap',
+        'alphaMap'
+      ];
       keys.forEach((key) => {
         const tex = material[key] as THREE.Texture | undefined;
         if (!tex?.isTexture) return;
-        if (key === 'map' || key === 'emissiveMap') tex.colorSpace = THREE.SRGBColorSpace;
+        if (key === 'map' || key === 'emissiveMap')
+          tex.colorSpace = THREE.SRGBColorSpace;
         tex.anisotropy = renderer.capabilities.getMaxAnisotropy();
         tex.needsUpdate = true;
       });
@@ -387,20 +683,37 @@ function pickAiWeaponIndex(aiOrder: number) {
     ['pistol', 'revolver', 'shotgun']
   ];
   const classes = preferred[aiOrder % preferred.length];
-  const candidates = WEAPONS
-    .map((weapon, index) => ({ weapon, index }))
-    .filter(({ weapon }) => classes.includes(weapon.weaponClass));
-  const pool = candidates.length ? candidates : WEAPONS.map((weapon, index) => ({ weapon, index }));
+  const candidates = WEAPONS.map((weapon, index) => ({ weapon, index })).filter(
+    ({ weapon }) => classes.includes(weapon.weaponClass)
+  );
+  const pool = candidates.length
+    ? candidates
+    : WEAPONS.map((weapon, index) => ({ weapon, index }));
   return pool[Math.floor(Math.random() * pool.length)].index;
 }
 
 function makeFallbackCharacter(color = '#e5e7eb') {
   const g = new THREE.Group();
-  const skinMat = new THREE.MeshStandardMaterial({ color: '#9ca3af', roughness: 0.82, metalness: 0.06 });
-  const shirtMat = new THREE.MeshStandardMaterial({ color, roughness: 0.95, metalness: 0.02 });
-  const pantsMat = new THREE.MeshStandardMaterial({ color: '#111827', roughness: 0.9, metalness: 0.02 });
+  const skinMat = new THREE.MeshStandardMaterial({
+    color: '#9ca3af',
+    roughness: 0.82,
+    metalness: 0.06
+  });
+  const shirtMat = new THREE.MeshStandardMaterial({
+    color,
+    roughness: 0.95,
+    metalness: 0.02
+  });
+  const pantsMat = new THREE.MeshStandardMaterial({
+    color: '#111827',
+    roughness: 0.9,
+    metalness: 0.02
+  });
 
-  const torso = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.72, 0.24), shirtMat);
+  const torso = new THREE.Mesh(
+    new THREE.BoxGeometry(0.42, 0.72, 0.24),
+    shirtMat
+  );
   torso.position.y = 1.2;
   const head = new THREE.Mesh(new THREE.SphereGeometry(0.16, 16, 16), skinMat);
   head.position.y = 1.72;
@@ -408,7 +721,10 @@ function makeFallbackCharacter(color = '#e5e7eb') {
   armL.position.set(-0.28, 1.2, 0);
   const armR = armL.clone();
   armR.position.x = 0.28;
-  const legL = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.84, 0.16), pantsMat);
+  const legL = new THREE.Mesh(
+    new THREE.BoxGeometry(0.16, 0.84, 0.16),
+    pantsMat
+  );
   legL.position.set(-0.1, 0.42, 0);
   const legR = legL.clone();
   legR.position.x = 0.1;
@@ -425,7 +741,6 @@ function makeFallbackCharacter(color = '#e5e7eb') {
   return g;
 }
 
-
 function makeFallbackWeapon(entry: WeaponEntry) {
   const group = new THREE.Group();
   const accentByClass: Record<WeaponClass, string> = {
@@ -436,36 +751,74 @@ function makeFallbackWeapon(entry: WeaponEntry) {
     smg: '#22c55e',
     sniper: '#facc15'
   };
-  const bodyMat = new THREE.MeshStandardMaterial({ color: '#171923', roughness: 0.55, metalness: 0.55 });
-  const gripMat = new THREE.MeshStandardMaterial({ color: '#0f172a', roughness: 0.86, metalness: 0.1 });
-  const accentMat = new THREE.MeshStandardMaterial({ color: accentByClass[entry.weaponClass], roughness: 0.42, metalness: 0.45 });
+  const bodyMat = new THREE.MeshStandardMaterial({
+    color: '#171923',
+    roughness: 0.55,
+    metalness: 0.55
+  });
+  const gripMat = new THREE.MeshStandardMaterial({
+    color: '#0f172a',
+    roughness: 0.86,
+    metalness: 0.1
+  });
+  const accentMat = new THREE.MeshStandardMaterial({
+    color: accentByClass[entry.weaponClass],
+    roughness: 0.42,
+    metalness: 0.45
+  });
 
-  const longGun = entry.weaponClass === 'rifle' || entry.weaponClass === 'shotgun' || entry.weaponClass === 'sniper';
-  const bodyLength = longGun ? (entry.weaponClass === 'sniper' ? 1.25 : 0.98) : 0.54;
-  const barrelLength = longGun ? (entry.weaponClass === 'shotgun' ? 0.68 : 0.86) : 0.34;
+  const longGun =
+    entry.weaponClass === 'rifle' ||
+    entry.weaponClass === 'shotgun' ||
+    entry.weaponClass === 'sniper';
+  const bodyLength = longGun
+    ? entry.weaponClass === 'sniper'
+      ? 1.25
+      : 0.98
+    : 0.54;
+  const barrelLength = longGun
+    ? entry.weaponClass === 'shotgun'
+      ? 0.68
+      : 0.86
+    : 0.34;
 
-  const body = new THREE.Mesh(new THREE.BoxGeometry(0.22, 0.18, bodyLength), bodyMat);
+  const body = new THREE.Mesh(
+    new THREE.BoxGeometry(0.22, 0.18, bodyLength),
+    bodyMat
+  );
   body.position.z = -0.18;
-  const barrel = new THREE.Mesh(new THREE.CylinderGeometry(0.035, 0.035, barrelLength, 16), accentMat);
+  const barrel = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.035, 0.035, barrelLength, 16),
+    accentMat
+  );
   barrel.rotation.x = Math.PI / 2;
   barrel.position.z = -bodyLength / 2 - barrelLength / 2 + 0.05;
   const grip = new THREE.Mesh(new THREE.BoxGeometry(0.13, 0.36, 0.16), gripMat);
   grip.position.set(0, -0.25, 0.08);
   grip.rotation.x = -0.34;
-  const trigger = new THREE.Mesh(new THREE.TorusGeometry(0.075, 0.012, 8, 18), accentMat);
+  const trigger = new THREE.Mesh(
+    new THREE.TorusGeometry(0.075, 0.012, 8, 18),
+    accentMat
+  );
   trigger.rotation.x = Math.PI / 2;
   trigger.position.set(0, -0.11, -0.03);
 
   group.add(body, barrel, grip, trigger);
 
   if (longGun) {
-    const stock = new THREE.Mesh(new THREE.BoxGeometry(0.26, 0.18, 0.34), gripMat);
+    const stock = new THREE.Mesh(
+      new THREE.BoxGeometry(0.26, 0.18, 0.34),
+      gripMat
+    );
     stock.position.z = bodyLength / 2 + 0.1;
     group.add(stock);
   }
 
   if (entry.weaponClass === 'sniper') {
-    const scope = new THREE.Mesh(new THREE.CylinderGeometry(0.055, 0.055, 0.42, 16), accentMat);
+    const scope = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.055, 0.055, 0.42, 16),
+      accentMat
+    );
     scope.rotation.z = Math.PI / 2;
     scope.position.set(0, 0.16, -0.2);
     group.add(scope);
@@ -581,14 +934,20 @@ function createLabelSprite(text: string) {
 
   const tex = new THREE.CanvasTexture(canvas);
   tex.colorSpace = THREE.SRGBColorSpace;
-  const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false });
+  const mat = new THREE.SpriteMaterial({
+    map: tex,
+    transparent: true,
+    depthWrite: false
+  });
   const sprite = new THREE.Sprite(mat);
   sprite.scale.set(2.1, 0.65, 1);
   return sprite;
 }
 
 function updateLabelSprite(sprite: THREE.Sprite, text: string) {
-  const tex = (sprite.material as THREE.SpriteMaterial).map as THREE.CanvasTexture | undefined;
+  const tex = (sprite.material as THREE.SpriteMaterial).map as
+    | THREE.CanvasTexture
+    | undefined;
   const canvas = tex?.image as HTMLCanvasElement | undefined;
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
@@ -610,14 +969,24 @@ function updateLabelSprite(sprite: THREE.Sprite, text: string) {
 
 function createPaperTarget(laneIndex: number): PaperTargetRuntime {
   const root = new THREE.Group();
-  const railMat = new THREE.MeshStandardMaterial({ color: '#555f69', roughness: 0.7, metalness: 0.28 });
+  const railMat = new THREE.MeshStandardMaterial({
+    color: '#555f69',
+    roughness: 0.7,
+    metalness: 0.28
+  });
 
-  const topBar = new THREE.Mesh(new THREE.BoxGeometry(0.9, 0.06, 0.07), railMat);
+  const topBar = new THREE.Mesh(
+    new THREE.BoxGeometry(0.9, 0.06, 0.07),
+    railMat
+  );
   topBar.position.set(0, 2.56, 0);
   topBar.castShadow = true;
   root.add(topBar);
 
-  const hanger = new THREE.Mesh(new THREE.BoxGeometry(0.06, 1.0, 0.06), railMat);
+  const hanger = new THREE.Mesh(
+    new THREE.BoxGeometry(0.06, 1.0, 0.06),
+    railMat
+  );
   hanger.position.set(0, 2.02, 0);
   hanger.castShadow = true;
   root.add(hanger);
@@ -643,7 +1012,11 @@ function createPaperTarget(laneIndex: number): PaperTargetRuntime {
 
   const winnerRing = new THREE.Mesh(
     new THREE.TorusGeometry(0.92, 0.03, 12, 48),
-    new THREE.MeshBasicMaterial({ color: '#facc15', transparent: true, opacity: 0 })
+    new THREE.MeshBasicMaterial({
+      color: '#facc15',
+      transparent: true,
+      opacity: 0
+    })
   );
   winnerRing.position.set(0, 0.84, 0.04);
   root.add(winnerRing);
@@ -686,7 +1059,13 @@ function createBulletHole(localPoint: THREE.Vector3, points: number) {
   return mesh;
 }
 
-function createBullet(scene: THREE.Scene, start: THREE.Vector3, end: THREE.Vector3, cinematic: boolean, speed: number) {
+function createBullet(
+  scene: THREE.Scene,
+  start: THREE.Vector3,
+  end: THREE.Vector3,
+  cinematic: boolean,
+  speed: number
+) {
   const bullet = new THREE.Mesh(
     new THREE.SphereGeometry(0.027, 10, 10),
     new THREE.MeshBasicMaterial({ color: '#ffe8a3' })
@@ -694,7 +1073,11 @@ function createBullet(scene: THREE.Scene, start: THREE.Vector3, end: THREE.Vecto
   const length = Math.min(1.2, start.distanceTo(end));
   const trail = new THREE.Mesh(
     new THREE.CylinderGeometry(0.007, 0.007, length, 8),
-    new THREE.MeshBasicMaterial({ color: '#ffb84d', transparent: true, opacity: 0.58 })
+    new THREE.MeshBasicMaterial({
+      color: '#ffb84d',
+      transparent: true,
+      opacity: 0.58
+    })
   );
 
   bullet.position.copy(start);
@@ -702,13 +1085,29 @@ function createBullet(scene: THREE.Scene, start: THREE.Vector3, end: THREE.Vecto
   trail.rotation.x = Math.PI / 2;
   scene.add(bullet, trail);
 
-  return { mesh: bullet, trail, start, end, t: 0, speed, cinematic } as BulletRuntime;
+  return {
+    mesh: bullet,
+    trail,
+    start,
+    end,
+    t: 0,
+    speed,
+    cinematic
+  } as BulletRuntime;
 }
 
-function createShell(scene: THREE.Scene, position: THREE.Vector3, power: number) {
+function createShell(
+  scene: THREE.Scene,
+  position: THREE.Vector3,
+  power: number
+) {
   const mesh = new THREE.Mesh(
     new THREE.CylinderGeometry(0.025, 0.025, 0.12, 16),
-    new THREE.MeshStandardMaterial({ color: '#c0892f', roughness: 0.34, metalness: 0.92 })
+    new THREE.MeshStandardMaterial({
+      color: '#c0892f',
+      roughness: 0.34,
+      metalness: 0.92
+    })
   );
   mesh.rotation.z = Math.PI / 2;
   mesh.position.copy(position);
@@ -718,7 +1117,11 @@ function createShell(scene: THREE.Scene, position: THREE.Vector3, power: number)
   return {
     mesh,
     vel: new THREE.Vector3(0.72 * power, 0.45 * power, 0.16),
-    spin: new THREE.Vector3(Math.random() * 7, Math.random() * 12, Math.random() * 8),
+    spin: new THREE.Vector3(
+      Math.random() * 7,
+      Math.random() * 12,
+      Math.random() * 8
+    ),
     life: 2.4
   } as ShellRuntime;
 }
@@ -731,8 +1134,8 @@ function disposeObject(object: THREE.Object3D) {
     const materials = Array.isArray((mesh as any).material)
       ? (mesh as any).material
       : (mesh as any).material
-      ? [(mesh as any).material]
-      : [];
+        ? [(mesh as any).material]
+        : [];
     materials.forEach((mat: any) => mat?.dispose?.());
   });
 }
@@ -747,16 +1150,52 @@ export default function ShootingRange() {
   const [selectedWeapon, setSelectedWeapon] = useState(0);
   const [ammo, setAmmo] = useState(STATS[WEAPONS[0].weaponClass].mag);
   const [laneScores, setLaneScores] = useState([0, 0, 0, 0]);
-  const [shotsLeft, setShotsLeft] = useState([SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER]);
+  const [shotsLeft, setShotsLeft] = useState([
+    SHOTS_PER_PLAYER,
+    SHOTS_PER_PLAYER,
+    SHOTS_PER_PLAYER,
+    SHOTS_PER_PLAYER
+  ]);
   const [winnerText, setWinnerText] = useState('');
   const [userLane, setUserLane] = useState(USER_LANE);
   const [lastHitText, setLastHitText] = useState('');
+
+  const queryConfig = useMemo(() => {
+    if (typeof window === 'undefined')
+      return {
+        mode: 'ai' as MatchMode,
+        playerCount: LANE_COUNT,
+        playerName: 'Player',
+        playerFlag: '',
+        aiFlag: ''
+      };
+    const params = new URLSearchParams(window.location.search);
+    const parsedPlayers = Number(params.get('players') || LANE_COUNT);
+    return {
+      mode:
+        params.get('mode') === 'online'
+          ? ('online' as MatchMode)
+          : ('ai' as MatchMode),
+      playerCount: Math.min(
+        LANE_COUNT,
+        Math.max(2, Number.isFinite(parsedPlayers) ? parsedPlayers : LANE_COUNT)
+      ),
+      playerName: params.get('name') || 'Player',
+      playerFlag: params.get('flag') || '',
+      aiFlag: params.get('aiFlag') || ''
+    };
+  }, []);
 
   const phaseRef = useRef<GamePhase>('loading');
   const viewModeRef = useRef<ViewMode>('tables');
   const selectedWeaponRef = useRef(0);
   const ammoRef = useRef(STATS[WEAPONS[0].weaponClass].mag);
-  const shotsLeftRef = useRef([SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER]);
+  const shotsLeftRef = useRef([
+    SHOTS_PER_PLAYER,
+    SHOTS_PER_PLAYER,
+    SHOTS_PER_PLAYER,
+    SHOTS_PER_PLAYER
+  ]);
   const laneScoresRef = useRef([0, 0, 0, 0]);
   const userLaneRef = useRef(USER_LANE);
   const winnerLaneRef = useRef<number | null>(null);
@@ -785,13 +1224,24 @@ export default function ShootingRange() {
     restart: () => {}
   });
 
-  const selectedEntry = useMemo(() => WEAPONS[selectedWeapon], [selectedWeapon]);
+  const selectedEntry = useMemo(
+    () => WEAPONS[selectedWeapon],
+    [selectedWeapon]
+  );
   const selectedStats = useMemo(() => statsFor(selectedEntry), [selectedEntry]);
 
-  useEffect(() => { phaseRef.current = phase; }, [phase]);
-  useEffect(() => { viewModeRef.current = viewMode; }, [viewMode]);
-  useEffect(() => { selectedWeaponRef.current = selectedWeapon; }, [selectedWeapon]);
-  useEffect(() => { ammoRef.current = ammo; }, [ammo]);
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+  useEffect(() => {
+    viewModeRef.current = viewMode;
+  }, [viewMode]);
+  useEffect(() => {
+    selectedWeaponRef.current = selectedWeapon;
+  }, [selectedWeapon]);
+  useEffect(() => {
+    ammoRef.current = ammo;
+  }, [ammo]);
 
   function setPhaseSafe(next: GamePhase) {
     phaseRef.current = next;
@@ -832,11 +1282,29 @@ export default function ShootingRange() {
     scene.background = new THREE.Color('#111827');
     scene.fog = new THREE.Fog('#111827', 18, 76);
 
-    const camera = new THREE.PerspectiveCamera(62, mount.clientWidth / Math.max(1, mount.clientHeight), 0.05, 200);
-    camera.position.set(LANE_X[USER_LANE] + OVER_SHOULDER_OFFSET.x, OVER_SHOULDER_OFFSET.y, OVER_SHOULDER_OFFSET.z);
-    camera.lookAt(new THREE.Vector3(LANE_X[USER_LANE] + OVER_SHOULDER_LOOK.x, OVER_SHOULDER_LOOK.y, OVER_SHOULDER_LOOK.z));
+    const camera = new THREE.PerspectiveCamera(
+      62,
+      mount.clientWidth / Math.max(1, mount.clientHeight),
+      0.05,
+      200
+    );
+    camera.position.set(
+      LANE_X[USER_LANE] + OVER_SHOULDER_OFFSET.x,
+      OVER_SHOULDER_OFFSET.y,
+      OVER_SHOULDER_OFFSET.z
+    );
+    camera.lookAt(
+      new THREE.Vector3(
+        LANE_X[USER_LANE] + OVER_SHOULDER_LOOK.x,
+        OVER_SHOULDER_LOOK.y,
+        OVER_SHOULDER_LOOK.z
+      )
+    );
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      powerPreference: 'high-performance'
+    });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     renderer.setSize(mount.clientWidth, mount.clientHeight);
     renderer.outputColorSpace = THREE.SRGBColorSpace;
@@ -876,11 +1344,41 @@ export default function ShootingRange() {
     scene.add(fillLight);
 
     const textureLoader = new THREE.TextureLoader();
-    const floorMat = makePbrMaterial(textureLoader, TEXTURES.floor, [7, 20], '#5b5e63', 0.02);
-    const wallMat = makePbrMaterial(textureLoader, TEXTURES.wall, [4, 10], '#7b786e', 0.03);
-    const laneMat = makePbrMaterial(textureLoader, TEXTURES.metal, [3, 8], '#202833', 1);
-    const tableMat = makePbrMaterial(textureLoader, TEXTURES.table, [2, 1], '#0d1117', 0.08);
-    const metalMat = makePbrMaterial(textureLoader, TEXTURES.metal, [2, 6], '#48515a', 1);
+    const floorMat = makePbrMaterial(
+      textureLoader,
+      TEXTURES.floor,
+      [7, 20],
+      '#5b5e63',
+      0.02
+    );
+    const wallMat = makePbrMaterial(
+      textureLoader,
+      TEXTURES.wall,
+      [4, 10],
+      '#7b786e',
+      0.03
+    );
+    const laneMat = makePbrMaterial(
+      textureLoader,
+      TEXTURES.metal,
+      [3, 8],
+      '#202833',
+      1
+    );
+    const tableMat = makePbrMaterial(
+      textureLoader,
+      TEXTURES.table,
+      [2, 1],
+      '#0d1117',
+      0.08
+    );
+    const metalMat = makePbrMaterial(
+      textureLoader,
+      TEXTURES.metal,
+      [2, 6],
+      '#48515a',
+      1
+    );
 
     const floor = new THREE.Mesh(new THREE.PlaneGeometry(18, 58), floorMat);
     floor.rotation.x = -Math.PI / 2;
@@ -888,7 +1386,10 @@ export default function ShootingRange() {
     floor.receiveShadow = true;
     scene.add(floor);
 
-    const leftWall = new THREE.Mesh(new THREE.BoxGeometry(0.25, 4.2, 52), wallMat);
+    const leftWall = new THREE.Mesh(
+      new THREE.BoxGeometry(0.25, 4.2, 52),
+      wallMat
+    );
     leftWall.position.set(-7.6, 2.1, -16);
     leftWall.receiveShadow = true;
     scene.add(leftWall);
@@ -897,7 +1398,10 @@ export default function ShootingRange() {
     rightWall.position.x = 7.6;
     scene.add(rightWall);
 
-    const backWall = new THREE.Mesh(new THREE.BoxGeometry(15.2, 6.2, 0.25), wallMat);
+    const backWall = new THREE.Mesh(
+      new THREE.BoxGeometry(15.2, 6.2, 0.25),
+      wallMat
+    );
     backWall.position.set(0, 3.05, TARGET_Z - 10.4);
     backWall.receiveShadow = true;
     scene.add(backWall);
@@ -908,7 +1412,10 @@ export default function ShootingRange() {
     roof.castShadow = true;
     scene.add(roof);
 
-    const darkBackstop = new THREE.Mesh(new THREE.BoxGeometry(14, 2.6, 1.2), laneMat);
+    const darkBackstop = new THREE.Mesh(
+      new THREE.BoxGeometry(14, 2.6, 1.2),
+      laneMat
+    );
     darkBackstop.position.set(0, 1.3, TARGET_Z - 8.9);
     darkBackstop.rotation.x = -0.25;
     darkBackstop.receiveShadow = true;
@@ -918,19 +1425,28 @@ export default function ShootingRange() {
     for (let lane = 0; lane < LANE_COUNT; lane += 1) {
       const x = LANE_X[lane];
 
-      const boothBench = new THREE.Mesh(new THREE.BoxGeometry(2.55, 0.16, 1.15), tableMat);
+      const boothBench = new THREE.Mesh(
+        new THREE.BoxGeometry(2.55, 0.16, 1.15),
+        tableMat
+      );
       boothBench.position.set(x, TABLE_TOP_Y, TABLE_Z);
       boothBench.castShadow = true;
       boothBench.receiveShadow = true;
       scene.add(boothBench);
 
-      const boothShelf = new THREE.Mesh(new THREE.BoxGeometry(2.55, 0.11, 0.78), metalMat);
+      const boothShelf = new THREE.Mesh(
+        new THREE.BoxGeometry(2.55, 0.11, 0.78),
+        metalMat
+      );
       boothShelf.position.set(x, 0.55, TABLE_Z);
       boothShelf.castShadow = true;
       boothShelf.receiveShadow = true;
       scene.add(boothShelf);
 
-      const leftDivider = new THREE.Mesh(new THREE.BoxGeometry(0.12, 2.15, 1.26), laneMat);
+      const leftDivider = new THREE.Mesh(
+        new THREE.BoxGeometry(0.12, 2.15, 1.26),
+        laneMat
+      );
       leftDivider.position.set(x - 1.48, 1.36, TABLE_Z);
       leftDivider.castShadow = true;
       leftDivider.receiveShadow = true;
@@ -940,12 +1456,18 @@ export default function ShootingRange() {
       rightDivider.position.x = x + 1.48;
       scene.add(rightDivider);
 
-      const boothHead = new THREE.Mesh(new THREE.BoxGeometry(2.55, 0.14, 0.95), metalMat);
+      const boothHead = new THREE.Mesh(
+        new THREE.BoxGeometry(2.55, 0.14, 0.95),
+        metalMat
+      );
       boothHead.position.set(x, 4.45, 1.1);
       boothHead.castShadow = true;
       scene.add(boothHead);
 
-      const targetRail = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.12, 50), metalMat);
+      const targetRail = new THREE.Mesh(
+        new THREE.BoxGeometry(0.12, 0.12, 50),
+        metalMat
+      );
       targetRail.position.set(x, 4.72, -16.6);
       targetRail.castShadow = true;
       scene.add(targetRail);
@@ -978,7 +1500,10 @@ export default function ShootingRange() {
 
     for (let i = 0; i < 7; i += 1) {
       const z = 1.6 - i * 6.3;
-      const lampBar = new THREE.Mesh(new THREE.BoxGeometry(13.8, 0.08, 0.28), metalMat);
+      const lampBar = new THREE.Mesh(
+        new THREE.BoxGeometry(13.8, 0.08, 0.28),
+        metalMat
+      );
       lampBar.position.set(0, 4.56, z);
       lampBar.castShadow = true;
       scene.add(lampBar);
@@ -995,13 +1520,24 @@ export default function ShootingRange() {
       scene.add(light);
     }
 
-    const targets = Array.from({ length: LANE_COUNT }, (_, i) => createPaperTarget(i));
+    const targets = Array.from({ length: LANE_COUNT }, (_, i) =>
+      createPaperTarget(i)
+    );
     targets.forEach((t) => scene.add(t.root));
     paperTargetsRef.current = targets;
 
-    const tpcCoinMaterial = new THREE.MeshStandardMaterial({ color: '#facc15', emissive: '#f59e0b', emissiveIntensity: 0.48, roughness: 0.32, metalness: 0.8 });
+    const tpcCoinMaterial = new THREE.MeshStandardMaterial({
+      color: '#facc15',
+      emissive: '#f59e0b',
+      emissiveIntensity: 0.48,
+      roughness: 0.32,
+      metalness: 0.8
+    });
     const tpcCoins = Array.from({ length: 44 }, () => {
-      const mesh = new THREE.Mesh(new THREE.CylinderGeometry(0.075, 0.075, 0.025, 24), tpcCoinMaterial.clone());
+      const mesh = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.075, 0.075, 0.025, 24),
+        tpcCoinMaterial.clone()
+      );
       mesh.visible = false;
       mesh.castShadow = true;
       scene.add(mesh);
@@ -1018,7 +1554,11 @@ export default function ShootingRange() {
       setUserLane(humanLaneIndex);
       const lanes: LaneRuntime[] = [];
 
-      for (let playerId = 0; playerId < LANE_COUNT; playerId += 1) {
+      for (
+        let playerId = 0;
+        playerId < queryConfig.playerCount;
+        playerId += 1
+      ) {
         const laneIndex = randomizedLanes[playerId];
         const x = LANE_X[laneIndex];
         const root = new THREE.Group();
@@ -1060,7 +1600,9 @@ export default function ShootingRange() {
         void loadGLTF(spec.name, spec.urls)
           .then((loaded) => {
             if (disposed) return;
-            const lane = lanesRef.current.find((candidate) => candidate?.playerId === playerId);
+            const lane = lanesRef.current.find(
+              (candidate) => candidate?.playerId === playerId
+            );
             if (!lane) return;
 
             const loadedVisual = cloneScene(loaded.scene);
@@ -1087,12 +1629,20 @@ export default function ShootingRange() {
             }
           })
           .catch((error) => {
-            console.warn('Character model failed, keeping fallback:', spec.name, error);
+            console.warn(
+              'Character model failed, keeping fallback:',
+              spec.name,
+              error
+            );
           });
       });
     }
 
-    function setHeldWeapon(laneIndex: number, weaponIndex: number, lift = true) {
+    function setHeldWeapon(
+      laneIndex: number,
+      weaponIndex: number,
+      lift = true
+    ) {
       const lane = lanesRef.current[laneIndex];
       const source = weaponSourcesRef.current[weaponIndex];
       if (!lane || !source) return;
@@ -1139,12 +1689,16 @@ export default function ShootingRange() {
       tableWeaponsRef.current.forEach((tw) => {
         const selected = tw.weaponIndex === selectedWeaponRef.current;
         tw.root.position.y = selected ? TABLE_TOP_Y + 0.05 : TABLE_TOP_Y + 0.03;
-        ((tw.card.material as THREE.MeshStandardMaterial).color).set(selected ? '#38506d' : '#1c1c1c');
+        (tw.card.material as THREE.MeshStandardMaterial).color.set(
+          selected ? '#38506d' : '#1c1c1c'
+        );
       });
     }
 
     function loadWeaponsAndTables() {
-      weaponSourcesRef.current = WEAPONS.map((entry) => makeFallbackWeapon(entry));
+      weaponSourcesRef.current = WEAPONS.map((entry) =>
+        makeFallbackWeapon(entry)
+      );
       tableWeaponsRef.current = [];
       pickTargetsRef.current = [];
 
@@ -1155,7 +1709,9 @@ export default function ShootingRange() {
         const group = new THREE.Group();
         group.userData.pickWeaponIndex = index;
 
-        const model = cloneScene(weaponSourcesRef.current[index] as THREE.Object3D);
+        const model = cloneScene(
+          weaponSourcesRef.current[index] as THREE.Object3D
+        );
         configureModel(model, renderer);
         normalizeToLength(model, 0.72);
         layWeaponFlatOnTable(model);
@@ -1163,7 +1719,11 @@ export default function ShootingRange() {
 
         const card = new THREE.Mesh(
           new THREE.BoxGeometry(1.08, 0.035, 0.5),
-          new THREE.MeshStandardMaterial({ color: '#1c1c1c', roughness: 0.84, metalness: 0.14 })
+          new THREE.MeshStandardMaterial({
+            color: '#1c1c1c',
+            roughness: 0.84,
+            metalness: 0.14
+          })
         );
         card.position.y = -0.018;
         card.receiveShadow = true;
@@ -1180,7 +1740,12 @@ export default function ShootingRange() {
         );
 
         scene.add(group);
-        tableWeaponsRef.current.push({ root: group, card, model, weaponIndex: index });
+        tableWeaponsRef.current.push({
+          root: group,
+          card,
+          model,
+          weaponIndex: index
+        });
         pickTargetsRef.current.push(group);
 
         void loadGLTF(entry.name, entry.urls)
@@ -1189,7 +1754,9 @@ export default function ShootingRange() {
             configureModel(gltf.scene, renderer);
             weaponSourcesRef.current[index] = gltf.scene;
 
-            const tableWeapon = tableWeaponsRef.current.find((tw) => tw.weaponIndex === index);
+            const tableWeapon = tableWeaponsRef.current.find(
+              (tw) => tw.weaponIndex === index
+            );
             if (tableWeapon) {
               tableWeapon.root.remove(tableWeapon.model);
               disposeObject(tableWeapon.model);
@@ -1208,7 +1775,11 @@ export default function ShootingRange() {
             });
           })
           .catch((error) => {
-            console.warn('Weapon model failed, keeping fallback:', entry.name, error);
+            console.warn(
+              'Weapon model failed, keeping fallback:',
+              entry.name,
+              error
+            );
           });
       });
 
@@ -1250,11 +1821,14 @@ export default function ShootingRange() {
       lanesRef.current
         .filter((lane) => lane?.controller === 'AI')
         .forEach((lane, idx) => {
-          window.setTimeout(() => {
-            if (disposed || phaseRef.current !== 'pick') return;
-            const aiPick = pickAiWeaponIndex(idx);
-            setHeldWeapon(lane.laneIndex, aiPick, true);
-          }, 850 + idx * 650);
+          window.setTimeout(
+            () => {
+              if (disposed || phaseRef.current !== 'pick') return;
+              const aiPick = pickAiWeaponIndex(idx);
+              setHeldWeapon(lane.laneIndex, aiPick, true);
+            },
+            850 + idx * 650
+          );
         });
     }
 
@@ -1263,7 +1837,9 @@ export default function ShootingRange() {
       setViewMode('range');
       setStatus('Shoot phase started');
 
-      const shots = [SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER, SHOTS_PER_PLAYER];
+      const shots = Array.from({ length: LANE_COUNT }, (_, laneIndex) =>
+        lanesRef.current[laneIndex] ? SHOTS_PER_PLAYER : 0
+      );
       shotsLeftRef.current = shots;
       setShotsLeft([...shots]);
 
@@ -1283,12 +1859,15 @@ export default function ShootingRange() {
           (h.mesh.material as THREE.Material).dispose();
         });
         target.holes = [];
-        updateLabelSprite(target.labelSprite, `Lane ${target.laneIndex + 1} · 0`);
+        updateLabelSprite(
+          target.labelSprite,
+          `Lane ${target.laneIndex + 1} · 0`
+        );
         (target.winnerRing.material as THREE.MeshBasicMaterial).opacity = 0;
       });
 
       lanesRef.current.forEach((lane, laneIndex) => {
-        if (lane.controller === 'AI') {
+        if (lane?.controller === 'AI') {
           lane.aiNextShotAt = performance.now() + 900 + laneIndex * 420;
         }
       });
@@ -1299,26 +1878,52 @@ export default function ShootingRange() {
       setViewMode('results');
 
       const scores = laneScoresRef.current;
-      const best = Math.max(...scores);
-      const winnerLane = scores.findIndex((score) => score === best);
+      const activeLaneIndexes = lanesRef.current
+        .map((lane, index) => (lane ? index : -1))
+        .filter((index) => index >= 0);
+      const best = Math.max(...activeLaneIndexes.map((index) => scores[index]));
+      const winnerLane =
+        activeLaneIndexes.find((index) => scores[index] === best) ??
+        userLaneRef.current;
       const winnerLaneRuntime = lanesRef.current[winnerLane];
-      const winnerName = winnerLane === userLaneRef.current ? 'YOU' : `AI ${winnerLaneRuntime?.playerId ?? winnerLane}`;
+      const winnerName =
+        winnerLane === userLaneRef.current
+          ? 'YOU'
+          : `AI ${winnerLaneRuntime?.playerId ?? winnerLane}`;
       winnerLaneRef.current = winnerLane;
 
-      setWinnerText(`Winner: ${winnerName} · Lane ${winnerLane + 1} · ${best} pts`);
+      setWinnerText(
+        `Winner: ${winnerName} · Lane ${winnerLane + 1} · ${best} pts`
+      );
       setStatus(`${winnerName} wins! Winner target reveal + TPC coin burst.`);
 
       tpcCoins.forEach((coin) => {
         coin.mesh.visible = true;
-        coin.mesh.position.set(THREE.MathUtils.randFloatSpread(0.9), 1.85 + THREE.MathUtils.randFloatSpread(0.42), -3.72 + THREE.MathUtils.randFloatSpread(0.35));
-        coin.mesh.rotation.set(Math.random() * Math.PI, Math.random() * Math.PI, Math.random() * Math.PI);
-        coin.velocity.set(THREE.MathUtils.randFloatSpread(2.3), THREE.MathUtils.randFloat(1.65, 3.45), THREE.MathUtils.randFloat(-0.7, 1.45));
+        coin.mesh.position.set(
+          THREE.MathUtils.randFloatSpread(0.9),
+          1.85 + THREE.MathUtils.randFloatSpread(0.42),
+          -3.72 + THREE.MathUtils.randFloatSpread(0.35)
+        );
+        coin.mesh.rotation.set(
+          Math.random() * Math.PI,
+          Math.random() * Math.PI,
+          Math.random() * Math.PI
+        );
+        coin.velocity.set(
+          THREE.MathUtils.randFloatSpread(2.3),
+          THREE.MathUtils.randFloat(1.65, 3.45),
+          THREE.MathUtils.randFloat(-0.7, 1.45)
+        );
         coin.life = 3.2 + Math.random() * 1.4;
       });
 
       paperTargetsRef.current.forEach((target, i) => {
-        (target.winnerRing.material as THREE.MeshBasicMaterial).opacity = i === winnerLane ? 1 : 0;
-        updateLabelSprite(target.labelSprite, `Lane ${i + 1} · ${target.score}`);
+        (target.winnerRing.material as THREE.MeshBasicMaterial).opacity =
+          i === winnerLane ? 1 : 0;
+        updateLabelSprite(
+          target.labelSprite,
+          `Lane ${i + 1} · ${target.score}`
+        );
       });
     }
 
@@ -1331,7 +1936,10 @@ export default function ShootingRange() {
       const target = paperTargetsRef.current[laneIndex];
       if (target) {
         target.score = next[laneIndex];
-        updateLabelSprite(target.labelSprite, `Lane ${laneIndex + 1} · ${target.score}`);
+        updateLabelSprite(
+          target.labelSprite,
+          `Lane ${laneIndex + 1} · ${target.score}`
+        );
       }
     }
 
@@ -1351,11 +1959,17 @@ export default function ShootingRange() {
       if (heartDistance < 0.13) return { points: 88, label: 'Center chest' };
       if (heartDistance < 0.2) return { points: 70, label: 'Inner ring' };
       if (heartDistance < 0.3) return { points: 48, label: 'Outer ring' };
-      if (Math.abs(local.x) < 0.43 && local.y > -0.64 && local.y < 0.48) return { points: 20, label: 'Body hit' };
+      if (Math.abs(local.x) < 0.43 && local.y > -0.64 && local.y < 0.48)
+        return { points: 20, label: 'Body hit' };
       return { points: 5, label: 'Paper edge' };
     }
 
-    function addBulletHole(target: PaperTargetRuntime, localPoint: THREE.Vector3, points: number, label: string) {
+    function addBulletHole(
+      target: PaperTargetRuntime,
+      localPoint: THREE.Vector3,
+      points: number,
+      label: string
+    ) {
       const hole = createBulletHole(localPoint, points);
       target.paper.add(hole);
       target.holes.push({ mesh: hole, points, label });
@@ -1370,25 +1984,28 @@ export default function ShootingRange() {
       }
     }
 
-    function resolveShotForLane(laneIndex: number, spread: number, aiAim?: THREE.Vector2) {
+    function resolveShotForLane(
+      laneIndex: number,
+      spread: number,
+      aiAim?: THREE.Vector2
+    ) {
       const target = paperTargetsRef.current[laneIndex];
       const baseAim = aiAim ?? aimRef.current;
-
-      pointer.set(
-        baseAim.x + (Math.random() - 0.5) * spread,
-        baseAim.y + (Math.random() - 0.5) * spread
+      const local = new THREE.Vector3(
+        THREE.MathUtils.clamp(
+          baseAim.x + THREE.MathUtils.randFloatSpread(spread),
+          -1,
+          1
+        ) * TARGET_HALF_WIDTH,
+        THREE.MathUtils.clamp(
+          baseAim.y + THREE.MathUtils.randFloatSpread(spread),
+          -1,
+          1
+        ) * TARGET_HALF_HEIGHT,
+        0
       );
-
-      raycaster.setFromCamera(pointer, camera);
-      const hit = raycaster.intersectObject(target.paper, false)[0];
-
-      if (!hit) {
-        const far = raycaster.ray.origin.clone().addScaledVector(raycaster.ray.direction, 70);
-        return { point: far, local: null as THREE.Vector3 | null, target };
-      }
-
-      const local = target.paper.worldToLocal(hit.point.clone());
-      return { point: hit.point.clone(), local, target };
+      const point = target.paper.localToWorld(local.clone());
+      return { point, local, target };
     }
 
     function executeShot(laneIndex: number, isAI: boolean) {
@@ -1437,10 +2054,20 @@ export default function ShootingRange() {
       const pelletCount = stats.fairPellets;
 
       for (let i = 0; i < pelletCount; i += 1) {
-        const result = resolveShotForLane(laneIndex, stats.spread * (isAI ? 1.18 : 1), lane.aiAim);
+        const result = resolveShotForLane(
+          laneIndex,
+          stats.spread * (isAI ? 1.08 : 1),
+          isAI ? lane.aiAim : undefined
+        );
         const cinematic = !isAI && i === 0;
         bulletsRef.current.push(
-          createBullet(scene, muzzlePos.clone(), result.point.clone(), cinematic, stats.bulletSpeed)
+          createBullet(
+            scene,
+            muzzlePos.clone(),
+            result.point.clone(),
+            cinematic,
+            stats.bulletSpeed
+          )
         );
 
         if (result.local) {
@@ -1454,9 +2081,12 @@ export default function ShootingRange() {
       }
 
       addLaneScore(laneIndex, bestPoints);
-      const shooterName = laneIndex === userLaneRef.current ? 'YOU' : `AI ${lane.playerId}`;
-      setLastHitText(`${shooterName}: ${bestLabel} · +${bestPoints} (${weapon.weaponClass === 'shotgun' ? 'single fair shotgun pellet' : 'single scored shot'})`);
-      setStatus(`${shooterName} fired ${weapon.shortName}: ${bestLabel} +${bestPoints}`);
+      const shooterName =
+        laneIndex === userLaneRef.current ? 'YOU' : `AI ${lane.playerId}`;
+      setLastHitText(`${shooterName}: ${bestLabel} · +${bestPoints}`);
+      setStatus(
+        `${shooterName} fired ${weapon.shortName}: ${bestLabel} +${bestPoints}`
+      );
 
       const allDone = shotsLeftRef.current.every((s) => s <= 0);
       if (allDone) {
@@ -1486,18 +2116,34 @@ export default function ShootingRange() {
       }, stats.reloadMs);
     }
 
+    function tableWeaponIndicesForUser() {
+      const laneX = LANE_X[userLaneRef.current];
+      const indices = tableWeaponsRef.current
+        .filter((tw) => Math.abs(tw.root.position.x - laneX) < 1.35)
+        .map((tw) => tw.weaponIndex)
+        .sort((a, b) => a - b);
+      return indices.length ? indices : WEAPONS.map((_, index) => index);
+    }
+
     function nextWeapon() {
       if (phaseRef.current !== 'pick') return;
-      const next = (selectedWeaponRef.current + 1) % WEAPONS.length;
+      const visibleOnTable = tableWeaponIndicesForUser();
+      const currentSlot = visibleOnTable.indexOf(selectedWeaponRef.current);
+      const next =
+        visibleOnTable[
+          (currentSlot + 1 + visibleOnTable.length) % visibleOnTable.length
+        ];
       selectedWeaponRef.current = next;
       setSelectedWeapon(next);
       setHeldWeapon(userLaneRef.current, next, true);
       highlightTableSelection();
+      setStatus(`Switched to ${WEAPONS[next].shortName}`);
     }
 
     function prevWeapon() {
       if (phaseRef.current !== 'pick') return;
-      const next = (selectedWeaponRef.current - 1 + WEAPONS.length) % WEAPONS.length;
+      const next =
+        (selectedWeaponRef.current - 1 + WEAPONS.length) % WEAPONS.length;
       selectedWeaponRef.current = next;
       setSelectedWeapon(next);
       setHeldWeapon(userLaneRef.current, next, true);
@@ -1520,8 +2166,17 @@ export default function ShootingRange() {
         if (shotsLeftRef.current[lane.laneIndex] <= 0) return;
         if (now < lane.aiNextShotAt) return;
 
-        const difficulty = lane.laneIndex === 1 ? 0.05 : lane.laneIndex === 2 ? 0.072 : 0.09;
-        lane.aiAim.set((Math.random() - 0.5) * difficulty, (Math.random() - 0.5) * difficulty);
+        const skill =
+          lane.playerId === 1 ? 0.13 : lane.playerId === 2 ? 0.18 : 0.23;
+        const targetPreference =
+          Math.random() < 0.72
+            ? new THREE.Vector2(0, 0.08 / TARGET_HALF_HEIGHT)
+            : new THREE.Vector2(0, 0.46 / TARGET_HALF_HEIGHT);
+        lane.aiAim.lerp(targetPreference, 0.68);
+        lane.aiAim.x += THREE.MathUtils.randFloatSpread(skill);
+        lane.aiAim.y += THREE.MathUtils.randFloatSpread(skill * 0.82);
+        lane.aiAim.x = THREE.MathUtils.clamp(lane.aiAim.x, -0.82, 0.82);
+        lane.aiAim.y = THREE.MathUtils.clamp(lane.aiAim.y, -0.7, 0.72);
 
         executeShot(lane.laneIndex, true);
         lane.aiNextShotAt = now + 850 + Math.random() * 800;
@@ -1594,7 +2249,9 @@ export default function ShootingRange() {
         bullet.t += dt * bullet.speed;
         const p = THREE.MathUtils.smoothstep(Math.min(1, bullet.t), 0, 1);
         bullet.mesh.position.lerpVectors(bullet.start, bullet.end, p);
-        bullet.trail.position.copy(bullet.mesh.position).lerp(bullet.start, 0.15);
+        bullet.trail.position
+          .copy(bullet.mesh.position)
+          .lerp(bullet.start, 0.15);
         bullet.trail.lookAt(bullet.end);
 
         if (bullet.t >= 1) {
@@ -1636,13 +2293,21 @@ export default function ShootingRange() {
         const aim = isUser ? aimRef.current : lane.aiAim;
         const recoil = isUser ? recoilRef.current : 0;
 
-        lane.weaponMount.position.x = THREE.MathUtils.lerp(lane.weaponMount.position.x, 0.34 + aim.x * 0.1, 0.16);
+        lane.weaponMount.position.x = THREE.MathUtils.lerp(
+          lane.weaponMount.position.x,
+          0.34 + aim.x * 0.1,
+          0.16
+        );
         lane.weaponMount.position.y = THREE.MathUtils.lerp(
           lane.weaponMount.position.y,
           1.27 + lane.pickupLift * 0.18 + aim.y * 0.06 - recoil * 0.05,
           0.16
         );
-        lane.weaponMount.position.z = THREE.MathUtils.lerp(lane.weaponMount.position.z, -0.12 + recoil * 0.18, 0.16);
+        lane.weaponMount.position.z = THREE.MathUtils.lerp(
+          lane.weaponMount.position.z,
+          -0.12 + recoil * 0.18,
+          0.16
+        );
 
         lane.weaponMount.rotation.x = THREE.MathUtils.lerp(
           lane.weaponMount.rotation.x,
@@ -1667,15 +2332,33 @@ export default function ShootingRange() {
     function updateTargets() {
       if (phaseRef.current === 'results') {
         const best = Math.max(...laneScoresRef.current);
-        const winnerLane = winnerLaneRef.current ?? laneScoresRef.current.findIndex((score) => score === best);
+        const winnerLane =
+          winnerLaneRef.current ??
+          laneScoresRef.current.findIndex((score) => score === best);
 
         paperTargetsRef.current.forEach((target, i) => {
           const wantedZ = i === winnerLane ? -4.1 : -7.2;
           const wantedX = i === winnerLane ? 0 : LANE_X[i] * 0.75;
-          target.root.position.z = THREE.MathUtils.lerp(target.root.position.z, wantedZ, 0.05);
-          target.root.position.x = THREE.MathUtils.lerp(target.root.position.x, wantedX, 0.05);
-          target.root.position.y = THREE.MathUtils.lerp(target.root.position.y, i === winnerLane ? 0.92 : 0.76, 0.05);
-          target.root.rotation.y = THREE.MathUtils.lerp(target.root.rotation.y, 0, 0.08);
+          target.root.position.z = THREE.MathUtils.lerp(
+            target.root.position.z,
+            wantedZ,
+            0.05
+          );
+          target.root.position.x = THREE.MathUtils.lerp(
+            target.root.position.x,
+            wantedX,
+            0.05
+          );
+          target.root.position.y = THREE.MathUtils.lerp(
+            target.root.position.y,
+            i === winnerLane ? 0.92 : 0.76,
+            0.05
+          );
+          target.root.rotation.y = THREE.MathUtils.lerp(
+            target.root.rotation.y,
+            0,
+            0.08
+          );
         });
 
         lanesRef.current.forEach((lane) => {
@@ -1683,9 +2366,21 @@ export default function ShootingRange() {
           const winningLane = lane.laneIndex === winnerLane;
           const targetX = winningLane ? -1.18 : LANE_X[lane.laneIndex];
           const targetZ = winningLane ? -3.95 : 3.05;
-          lane.root.position.x = THREE.MathUtils.lerp(lane.root.position.x, targetX, 0.045);
-          lane.root.position.z = THREE.MathUtils.lerp(lane.root.position.z, targetZ, 0.045);
-          lane.root.rotation.y = THREE.MathUtils.lerp(lane.root.rotation.y, winningLane ? 0.18 : 0, 0.05);
+          lane.root.position.x = THREE.MathUtils.lerp(
+            lane.root.position.x,
+            targetX,
+            0.045
+          );
+          lane.root.position.z = THREE.MathUtils.lerp(
+            lane.root.position.z,
+            targetZ,
+            0.045
+          );
+          lane.root.rotation.y = THREE.MathUtils.lerp(
+            lane.root.rotation.y,
+            winningLane ? 0.18 : 0,
+            0.05
+          );
         });
       }
     }
@@ -1698,7 +2393,8 @@ export default function ShootingRange() {
         coin.mesh.position.addScaledVector(coin.velocity, dt);
         coin.mesh.rotation.x += 8.5 * dt;
         coin.mesh.rotation.y += 5.8 * dt;
-        if (coin.life <= 0 || coin.mesh.position.y < 0.32) coin.mesh.visible = false;
+        if (coin.life <= 0 || coin.mesh.position.y < 0.32)
+          coin.mesh.visible = false;
       });
     }
 
@@ -1715,8 +2411,16 @@ export default function ShootingRange() {
       }
 
       if (viewModeRef.current === 'results') {
-        const best = Math.max(...laneScoresRef.current);
-        const winnerLane = laneScoresRef.current.findIndex((s) => s === best);
+        const activeLaneIndexes = lanesRef.current
+          .map((lane, index) => (lane ? index : -1))
+          .filter((index) => index >= 0);
+        const best = Math.max(
+          ...activeLaneIndexes.map((index) => laneScoresRef.current[index])
+        );
+        const winnerLane =
+          activeLaneIndexes.find(
+            (index) => laneScoresRef.current[index] === best
+          ) ?? userLaneRef.current;
         const target = paperTargetsRef.current[winnerLane];
         if (target) {
           tempPos.set(0, 2.5, 4.45);
@@ -1727,10 +2431,18 @@ export default function ShootingRange() {
         return;
       }
 
-      const cinematicBullet = bulletsRef.current.find((b) => b.cinematic && performance.now() < followUntilRef.current);
+      const cinematicBullet = bulletsRef.current.find(
+        (b) => b.cinematic && performance.now() < followUntilRef.current
+      );
       if (cinematicBullet) {
-        const dir = cinematicBullet.end.clone().sub(cinematicBullet.start).normalize();
-        tempPos.copy(cinematicBullet.mesh.position).addScaledVector(dir, -0.7).add(new THREE.Vector3(0.18, 0.14, 0.28));
+        const dir = cinematicBullet.end
+          .clone()
+          .sub(cinematicBullet.start)
+          .normalize();
+        tempPos
+          .copy(cinematicBullet.mesh.position)
+          .addScaledVector(dir, -0.7)
+          .add(new THREE.Vector3(0.18, 0.14, 0.28));
         tempLook.copy(cinematicBullet.mesh.position).addScaledVector(dir, 0.9);
         camera.position.lerp(tempPos, 0.22);
         camera.lookAt(tempLook);
@@ -1738,12 +2450,18 @@ export default function ShootingRange() {
       }
 
       tempPos.set(
-        LANE_X[userLaneRef.current] + OVER_SHOULDER_OFFSET.x + aimRef.current.x * 0.24,
-        OVER_SHOULDER_OFFSET.y + aimRef.current.y * 0.12 + recoilRef.current * 0.04,
+        LANE_X[userLaneRef.current] +
+          OVER_SHOULDER_OFFSET.x +
+          aimRef.current.x * 0.24,
+        OVER_SHOULDER_OFFSET.y +
+          aimRef.current.y * 0.12 +
+          recoilRef.current * 0.04,
         OVER_SHOULDER_OFFSET.z
       );
       tempLook.set(
-        LANE_X[userLaneRef.current] + OVER_SHOULDER_LOOK.x + aimRef.current.x * 1.35,
+        LANE_X[userLaneRef.current] +
+          OVER_SHOULDER_LOOK.x +
+          aimRef.current.x * 1.35,
         OVER_SHOULDER_LOOK.y + aimRef.current.y * 0.95,
         OVER_SHOULDER_LOOK.z
       );
@@ -1848,7 +2566,8 @@ export default function ShootingRange() {
     height: 90,
     borderRadius: 999,
     border: '1px solid rgba(255,230,230,.25)',
-    background: phase === 'results' ? 'rgba(34,197,94,.92)' : 'rgba(220,38,38,.92)',
+    background:
+      phase === 'results' ? 'rgba(34,197,94,.92)' : 'rgba(220,38,38,.92)',
     color: 'white',
     fontWeight: 900,
     fontSize: 18,
@@ -1883,19 +2602,28 @@ export default function ShootingRange() {
         }}
       >
         <div style={panelStyle}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'start' }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              gap: 10,
+              alignItems: 'start'
+            }}
+          >
             <div style={{ minWidth: 0 }}>
               <div style={{ fontSize: 13, fontWeight: 900, color: '#fde68a' }}>
-                User vs 3 AI Shooting Match
+                {queryConfig.mode === 'online'
+                  ? 'Online Shooting Range'
+                  : `${queryConfig.playerName}${queryConfig.playerFlag ? ` ${queryConfig.playerFlag}` : ''} vs AI`}
               </div>
               <div style={{ marginTop: 3, fontSize: 11, opacity: 0.88 }}>
                 {phase === 'pick'
                   ? `Pick any weapon from any table · ${pickTimer}s`
                   : phase === 'shoot'
-                  ? `Lane ${userLane + 1} is yours · bullet holes are saved on targets`
-                  : phase === 'results'
-                  ? winnerText
-                  : 'Loading range...'}
+                    ? `Lane ${userLane + 1} is yours · ${queryConfig.playerCount} players · bullet holes are saved on targets`
+                    : phase === 'results'
+                      ? winnerText
+                      : 'Loading range...'}
               </div>
             </div>
             <div style={{ textAlign: 'right', fontSize: 12, fontWeight: 900 }}>
@@ -1915,21 +2643,30 @@ export default function ShootingRange() {
               opacity: 0.96
             }}
           >
-            {laneScores.map((s, i) => (
-              <div
-                key={i}
-                style={{
-                  padding: '6px 8px',
-                  borderRadius: 12,
-                  background: i === userLane ? 'rgba(250,204,21,.16)' : 'rgba(255,255,255,.05)',
-                  color: i === userLane ? '#fde68a' : '#d1d5db'
-                }}
-              >
-                <div>{i === userLane ? 'YOU' : `AI ${lanesRef.current[i]?.playerId ?? i}`}</div>
-                <div>Score: {s}</div>
-                <div>Shots: {shotsLeft[i]}</div>
-              </div>
-            ))}
+            {laneScores.map((s, i) =>
+              !lanesRef.current[i] ? null : (
+                <div
+                  key={i}
+                  style={{
+                    padding: '6px 8px',
+                    borderRadius: 12,
+                    background:
+                      i === userLane
+                        ? 'rgba(250,204,21,.16)'
+                        : 'rgba(255,255,255,.05)',
+                    color: i === userLane ? '#fde68a' : '#d1d5db'
+                  }}
+                >
+                  <div>
+                    {i === userLane
+                      ? 'YOU'
+                      : `AI ${lanesRef.current[i]?.playerId ?? i}`}
+                  </div>
+                  <div>Score: {s}</div>
+                  <div>Shots: {shotsLeft[i]}</div>
+                </div>
+              )
+            )}
           </div>
 
           <div
@@ -1946,10 +2683,18 @@ export default function ShootingRange() {
           >
             <span>Weapon: {selectedEntry.shortName}</span>
             <span>Type: {selectedEntry.weaponClass.toUpperCase()}</span>
-            <span>Ammo: {ammo}/{selectedStats.mag}</span>
-            <span>{selectedEntry.weaponClass === 'shotgun' ? 'Shotgun fairness: 1 pellet' : 'Single scored shot'}</span>
+            <span>
+              Ammo: {ammo}/{selectedStats.mag}
+            </span>
+            <span>
+              {queryConfig.mode === 'online'
+                ? 'Online stake match'
+                : 'Free vs AI'}
+            </span>
             <span>{status}</span>
-            {lastHitText && <span style={{ color: '#86efac' }}>{lastHitText}</span>}
+            {lastHitText && (
+              <span style={{ color: '#86efac' }}>{lastHitText}</span>
+            )}
           </div>
         </div>
       </div>
@@ -1970,11 +2715,62 @@ export default function ShootingRange() {
             zIndex: 10
           }}
         >
-          <div style={{ position: 'absolute', left: '50%', top: -12, width: 1, height: 12, background: 'rgba(255,255,255,.8)', transform: 'translateX(-50%)' }} />
-          <div style={{ position: 'absolute', left: '50%', bottom: -12, width: 1, height: 12, background: 'rgba(255,255,255,.8)', transform: 'translateX(-50%)' }} />
-          <div style={{ position: 'absolute', top: '50%', left: -12, width: 12, height: 1, background: 'rgba(255,255,255,.8)', transform: 'translateY(-50%)' }} />
-          <div style={{ position: 'absolute', top: '50%', right: -12, width: 12, height: 1, background: 'rgba(255,255,255,.8)', transform: 'translateY(-50%)' }} />
-          <div style={{ position: 'absolute', left: '50%', top: '50%', width: 6, height: 6, borderRadius: 999, background: '#f87171', transform: 'translate(-50%,-50%)' }} />
+          <div
+            style={{
+              position: 'absolute',
+              left: '50%',
+              top: -12,
+              width: 1,
+              height: 12,
+              background: 'rgba(255,255,255,.8)',
+              transform: 'translateX(-50%)'
+            }}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              left: '50%',
+              bottom: -12,
+              width: 1,
+              height: 12,
+              background: 'rgba(255,255,255,.8)',
+              transform: 'translateX(-50%)'
+            }}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              top: '50%',
+              left: -12,
+              width: 12,
+              height: 1,
+              background: 'rgba(255,255,255,.8)',
+              transform: 'translateY(-50%)'
+            }}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              top: '50%',
+              right: -12,
+              width: 12,
+              height: 1,
+              background: 'rgba(255,255,255,.8)',
+              transform: 'translateY(-50%)'
+            }}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              left: '50%',
+              top: '50%',
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: '#f87171',
+              transform: 'translate(-50%,-50%)'
+            }}
+          />
         </div>
       )}
 
@@ -1985,36 +2781,36 @@ export default function ShootingRange() {
           right: 12,
           bottom: 12,
           display: 'grid',
-          gridTemplateColumns: '1fr 1.4fr 1fr',
+          gridTemplateColumns: '1fr 1fr 1fr',
           gap: 10,
-          alignItems: 'end',
+          alignItems: 'center',
           zIndex: 10
         }}
       >
-        <div style={{ display: 'grid', gap: 8 }}>
-          <button onClick={() => actionsRef.current.tables()} style={buttonStyle}>Tables</button>
-          <button onClick={() => actionsRef.current.prev()} style={buttonStyle}>Prev Gun</button>
-          <button onClick={() => actionsRef.current.next()} style={buttonStyle}>Next Gun</button>
-        </div>
-
-        <button onClick={() => actionsRef.current.fire()} style={fireStyle}>
-          {phase === 'results' ? 'RESTART' : 'FIRE'}
+        <button
+          onClick={() => actionsRef.current.next()}
+          style={buttonStyle}
+          disabled={phase !== 'pick'}
+        >
+          Switch
         </button>
-
-        <div style={{ display: 'grid', gap: 8 }}>
-          <button
-            onClick={() => actionsRef.current.reload()}
-            style={{ ...buttonStyle, background: 'rgba(234,179,8,.92)', color: '#111827' }}
-          >
-            Reload
-          </button>
-          <button onClick={() => actionsRef.current.range()} style={buttonStyle}>Range View</button>
-          <div style={panelStyle}>
-            <div style={{ fontSize: 11, fontWeight: 800, opacity: 0.86 }}>
-              During pick phase you can click any weapon lying flat on the tables.
-            </div>
-          </div>
-        </div>
+        <button
+          onClick={() => actionsRef.current.reload()}
+          style={{
+            ...buttonStyle,
+            background: 'rgba(234,179,8,.92)',
+            color: '#111827'
+          }}
+          disabled={phase !== 'shoot'}
+        >
+          Reload
+        </button>
+        <button
+          onClick={() => actionsRef.current.fire()}
+          style={{ ...fireStyle, height: 64 }}
+        >
+          {phase === 'results' ? 'RESTART' : 'SHOOT'}
+        </button>
       </div>
     </div>
   );

--- a/webapp/src/pages/Games/ShootingRangeLobby.jsx
+++ b/webapp/src/pages/Games/ShootingRangeLobby.jsx
@@ -1,0 +1,350 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
+import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  ensureAccountId,
+  getTelegramFirstName,
+  getTelegramId,
+  getTelegramPhotoUrl
+} from '../../utils/telegram.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { runSimpleOnlineFlow } from '../../utils/simpleOnlineFlow.js';
+
+const PLAYER_FLAG_STORAGE_KEY = 'shootingRangePlayerFlag';
+const AI_FLAG_STORAGE_KEY = 'shootingRangeAiFlag';
+
+export default function ShootingRangeLobby() {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  useTelegramBackButton();
+
+  const [mode, setMode] = useState('ai');
+  const [players, setPlayers] = useState(4);
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [avatar, setAvatar] = useState('');
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
+  const [aiFlagIndex, setAiFlagIndex] = useState(null);
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
+  const [matching, setMatching] = useState(false);
+  const [matchStatus, setMatchStatus] = useState('');
+  const [matchError, setMatchError] = useState('');
+
+  const selectedFlag =
+    playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+  const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+
+  useEffect(() => {
+    import('./ShootingRange.tsx').catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    try {
+      setAvatar(loadAvatar() || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(PLAYER_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setPlayerFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setAiFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  const launchGame = ({ tableId = '', accountId = '' } = {}) => {
+    const params = new URLSearchParams(search);
+    params.set('mode', mode);
+    params.set('players', String(players));
+    if (avatar) params.set('avatar', avatar);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (tableId) params.set('tableId', tableId);
+    if (accountId) params.set('accountId', accountId);
+    if (mode === 'online') {
+      params.set('token', stake.token);
+      params.set('amount', String(stake.amount));
+    }
+    navigate(`/games/shootingrange?${params.toString()}`);
+  };
+
+  const startGame = async () => {
+    if (mode === 'online') {
+      await runSimpleOnlineFlow({
+        gameType: 'shootingrange',
+        stake,
+        maxPlayers: players,
+        avatar,
+        playerName: getTelegramFirstName() || 'Player',
+        matchMeta: { flag: selectedFlag, aiFlag: selectedAiFlag },
+        state: { setMatching, setMatchStatus, setMatchError },
+        onMatched: ({ accountId, tableId }) =>
+          launchGame({ accountId, tableId })
+      });
+      return;
+    }
+
+    try {
+      await ensureAccountId();
+      getTelegramId();
+    } catch {}
+    launchGame();
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <GameLobbyHeader
+          slug="shootingrange"
+          title="Shooting Range Lobby"
+          badge="2-4 players"
+        />
+
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">
+            Player Profile
+          </p>
+          <div className="mt-3 flex items-center gap-3">
+            <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+              {avatar ? (
+                <img
+                  src={avatar}
+                  alt="Your avatar"
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-lg">
+                  🙂
+                </div>
+              )}
+            </div>
+            <div className="text-sm text-white/80">
+              <p className="font-semibold">
+                {getTelegramFirstName() || 'Player'} ready
+              </p>
+              <p className="text-xs text-white/50">
+                Flag: {selectedFlag || 'Auto'}
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            <button
+              type="button"
+              onClick={() => setShowFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">
+                Your world flag
+              </div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedFlag || '🌐'}</span>
+                <span>
+                  {selectedFlag ? 'Custom flag' : 'Auto-detect & save'}
+                </span>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAiFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">
+                AI flag
+              </div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                <span>
+                  {selectedAiFlag ? 'Custom AI flag' : 'Auto-pick rival'}
+                </span>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Match Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+              Free or stake
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              {
+                id: 'ai',
+                label: 'Vs AI',
+                desc: 'Free practice match',
+                icon: '🤖'
+              },
+              {
+                id: 'online',
+                label: 'Online',
+                desc: 'TPC staking queue',
+                icon: '⚔️'
+              }
+            ].map(({ id, label, desc, icon }) => {
+              const active = mode === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setMode(id)}
+                  className={`lobby-option-card ${active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-sky-400/20 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src=""
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Players</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+              2 to 4
+            </span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {[2, 3, 4].map((count) => (
+              <button
+                key={count}
+                type="button"
+                onClick={() => setPlayers(count)}
+                className={`lobby-option-card ${players === count ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
+              >
+                <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent">
+                  <div className="lobby-option-thumb-inner">
+                    <span className="text-2xl font-semibold">{count}</span>
+                  </div>
+                </div>
+                <div className="text-center">
+                  <p className="lobby-option-label">{count} Players</p>
+                  <p className="lobby-option-subtitle">
+                    {mode === 'ai' ? 'You + AI' : 'Online table'}
+                  </p>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {mode === 'online' ? (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-cyan-400/40 to-blue-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  💎
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Stake</h3>
+                <p className="text-xs text-white/60">
+                  Online Shooting Range uses the same TPC staking flow as other
+                  games.
+                </p>
+              </div>
+            </div>
+            <div className="mt-3">
+              <RoomSelector
+                selected={stake}
+                onSelect={setStake}
+                tokens={['TPC']}
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/70">
+            Vs AI is free. Pick 2-4 total players and the remaining seats are
+            filled by competitive AI shooters.
+          </div>
+        )}
+
+        {(matchStatus || matchError) && (
+          <div className="rounded-xl border border-white/10 bg-white/5 p-3 text-center text-sm text-white/70">
+            <span className={matchError ? 'text-red-400' : ''}>
+              {matchError || matchStatus}
+            </span>
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={startGame}
+          disabled={matching}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:opacity-60"
+        >
+          {matching
+            ? 'MATCHING…'
+            : mode === 'online'
+              ? 'START ONLINE'
+              : 'START FREE VS AI'}
+        </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setPlayerFlagIndex(idx);
+            try {
+              if (idx != null)
+                window.localStorage?.setItem(
+                  PLAYER_FLAG_STORAGE_KEY,
+                  FLAG_EMOJIS[idx]
+                );
+            } catch {}
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
+        <FlagPickerModal
+          open={showAiFlagPicker}
+          count={1}
+          selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setAiFlagIndex(idx);
+            try {
+              if (idx != null)
+                window.localStorage?.setItem(
+                  AI_FLAG_STORAGE_KEY,
+                  FLAG_EMOJIS[idx]
+                );
+            } catch {}
+          }}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a proper Shooting Range lobby matching other games (avatar/flag, 2–4 players, free vs AI and online/TPC staking). 
- Remove cluttered bottom controls and expose a compact Switch/Reload/Shoot UI for mobile-friendly gameplay. 
- Fix a bug where multiple shots collapsed to the same place by resolving impacts per-target in local coordinates. 
- Make AI shooters more competitive by steering aim toward high-value zones with per-AI skill variance.

### Description

- Added a new lobby page at `webapp/src/pages/Games/ShootingRangeLobby.jsx` and wired the route `/games/shootingrange/lobby` to the lobby in `webapp/src/App.jsx` while updating the catalog entry in `webapp/src/config/gamesCatalog.js`. 
- Updated `webapp/src/config/onlineContract.js` to mark the Shooting Range lobby as ready while keeping backend/security readiness flags until backend contract work is completed. 
- Updated `webapp/src/pages/Games/ShootingRange.tsx` to read lobby query parameters (mode, players, name/flag), support variable player counts (2–4) and only allocate shots to active lanes. 
- Fixed shot resolution by computing a target-local hit point and converting it to world coordinates (`resolveShotForLane` now returns a proper `local` point per target), adjusted bullet creation to use that per-shot point, and removed reuse of a shared lane aim for user shots. 
- Improved AI aiming in `updateAI` by biasing aim toward head/heart regions and adding per-AI skill randomness, and tuned spread multipliers for AI shots. 
- Simplified the in-game bottom controls to three actions (`Switch` cycles visible weapons on the user’s table, `Reload`, and `SHOOT/RESTART`) and added `tableWeaponIndicesForUser` logic to cycle only weapons on the user’s table side. 
- Various formatting and small refactors/defensive checks in `ShootingRange.tsx` (minor code style/structural changes to improve readability and reliability).

### Testing

- Ran a production build with `cd webapp && npm run build` and the build completed successfully (Vite build output without fatal errors). 
- Ran a validation check via `git diff --check -- webapp/src/App.jsx webapp/src/config/gamesCatalog.js webapp/src/config/onlineContract.js webapp/src/pages/Games/ShootingRange.tsx webapp/src/pages/Games/ShootingRangeLobby.jsx` which returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049815e9f4832998318acc9d676efc)