### PR TITLE
Remake Pool Royale shooting positions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2400,10 +2400,12 @@ const POOL_ROYALE_HUMAN_CHARACTER_IDS = Object.freeze([
 ]);
 const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
   Object.freeze({
-    id: 'open-bridge-table-low',
-    label: 'Attempt 1 • Open Bridge Low',
-    menuLabel: '1 Open Bridge Low',
-    sourceNote: 'Open bridge: palm flat, fingers spread, chest and chin lowered over cue.',
+    id: 'front-open-bridge-low',
+    label: 'Attempt 1 • Front Bend Open Bridge',
+    menuLabel: '1 Front • Open Bridge Low',
+    directionLabel: 'Front bend',
+    techniqueLabel: 'Open bridge',
+    sourceNote: 'Front bend/open bridge: palm flat, fingers spread, chest and chin lowered over cue.',
     shotType: 'standard',
     bridgeBack: 0.082,
     bridgeSide: -0.016,
@@ -2418,15 +2420,20 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     forearmDown: 0.5,
     strokePull: 0.38,
     strokePush: 0.16,
-    shootForwardBendScale: 0.82,
+    shootForwardBendScale: 1.02,
     shootUpperBodyCounterLean: 0.46,
+    shootSideBendScale: 0.08,
+    shootSideBendDirection: -1,
+    shootCounterLeanSide: -1,
     cueGap: 0.009
   }),
   Object.freeze({
-    id: 'closed-bridge-power-line',
-    label: 'Attempt 2 • Closed Bridge Power',
-    menuLabel: '2 Closed Bridge Power',
-    sourceNote: 'Closed bridge/grip: stronger back arm, wider planted feet, elbow high over the cue.',
+    id: 'right-closed-bridge-power-line',
+    label: 'Attempt 2 • Right Bend Closed Bridge Power',
+    menuLabel: '2 Right • Closed Power',
+    directionLabel: 'Right bend',
+    techniqueLabel: 'Closed bridge power',
+    sourceNote: 'Right-side power bend: closed bridge/grip, wider planted feet, elbow high over the cue.',
     shotType: 'power',
     bridgeBack: 0.07,
     bridgeSide: -0.028,
@@ -2441,15 +2448,20 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     forearmDown: 0.43,
     strokePull: 0.58,
     strokePush: 0.28,
-    shootForwardBendScale: 0.58,
-    shootUpperBodyCounterLean: 0.86,
+    shootForwardBendScale: 0.72,
+    shootUpperBodyCounterLean: 0.82,
+    shootSideBendScale: 0.86,
+    shootSideBendDirection: 1,
+    shootCounterLeanSide: 1,
     cueGap: 0.015
   }),
   Object.freeze({
-    id: 'rail-bridge-near-cushion',
-    label: 'Attempt 3 • Rail Bridge',
-    menuLabel: '3 Rail Bridge',
-    sourceNote: 'Rail bridge: raised bridge hand for balls near cushion while keeping palm/table contact.',
+    id: 'back-rail-bridge-near-cushion',
+    label: 'Attempt 3 • Back-Weighted Rail Bridge',
+    menuLabel: '3 Back • Rail Bridge',
+    directionLabel: 'Back weight',
+    techniqueLabel: 'Rail bridge',
+    sourceNote: 'Back-weighted rail bridge: raised hand near cushion with hips sitting back for control.',
     shotType: 'rail',
     bridgeBack: 0.06,
     bridgeSide: -0.02,
@@ -2464,15 +2476,20 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     forearmDown: 0.46,
     strokePull: 0.3,
     strokePush: 0.11,
-    shootForwardBendScale: 0.72,
-    shootUpperBodyCounterLean: 0.58,
+    shootForwardBendScale: 0.42,
+    shootUpperBodyCounterLean: 0.72,
+    shootSideBendScale: 0.12,
+    shootSideBendDirection: -1,
+    shootCounterLeanSide: -1,
     cueGap: 0.012
   }),
   Object.freeze({
-    id: 'long-reach-snooker-stretch',
-    label: 'Attempt 4 • Long Reach Stretch',
-    menuLabel: '4 Long Reach Stretch',
-    sourceNote: 'Long reach: extended bridge arm, back foot anchored, upper body stretched toward cue ball.',
+    id: 'left-long-reach-snooker-stretch',
+    label: 'Attempt 4 • Left Bend Long Reach',
+    menuLabel: '4 Left • Long Reach',
+    directionLabel: 'Left bend',
+    techniqueLabel: 'Long reach',
+    sourceNote: 'Left-side long reach: extended bridge arm, back foot anchored, torso stretched to cue ball.',
     shotType: 'longReach',
     bridgeBack: 0.105,
     bridgeSide: -0.024,
@@ -2487,15 +2504,20 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     forearmDown: 0.54,
     strokePull: 0.42,
     strokePush: 0.15,
-    shootForwardBendScale: 0.9,
+    shootForwardBendScale: 0.88,
     shootUpperBodyCounterLean: 0.5,
+    shootSideBendScale: 0.78,
+    shootSideBendDirection: -1,
+    shootCounterLeanSide: -1,
     cueGap: 0.008
   }),
   Object.freeze({
-    id: 'compact-soft-touch',
-    label: 'Attempt 5 • Compact Soft Touch',
-    menuLabel: '5 Compact Soft Touch',
-    sourceNote: 'Soft precision: compact stance, shorter cue travel, stable open bridge close to cue ball.',
+    id: 'front-compact-soft-touch',
+    label: 'Attempt 5 • Front Compact Soft Touch',
+    menuLabel: '5 Front • Soft Touch',
+    directionLabel: 'Front bend',
+    techniqueLabel: 'Soft touch',
+    sourceNote: 'Front compact precision: shorter cue travel and stable open bridge close to cue ball.',
     shotType: 'softPrecision',
     bridgeBack: 0.055,
     bridgeSide: -0.014,
@@ -2510,15 +2532,20 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     forearmDown: 0.56,
     strokePull: 0.22,
     strokePush: 0.08,
-    shootForwardBendScale: 0.7,
+    shootForwardBendScale: 0.78,
     shootUpperBodyCounterLean: 0.34,
+    shootSideBendScale: 0.2,
+    shootSideBendDirection: 1,
+    shootCounterLeanSide: 1,
     cueGap: 0.006
   }),
   Object.freeze({
-    id: 'chin-over-cue-line',
-    label: 'Attempt 6 • Chin Over Cue',
-    menuLabel: '6 Chin Over Cue',
-    sourceNote: 'Low sight line: head/chin follows cue axis with forward torso bend and planted shoes.',
+    id: 'back-chin-over-cue-line',
+    label: 'Attempt 6 • Back-Balanced Chin Over Cue',
+    menuLabel: '6 Back • Chin Over Cue',
+    directionLabel: 'Back balance',
+    techniqueLabel: 'Chin-over-cue sighting',
+    sourceNote: 'Back-balanced sight line: chin follows cue axis while weight stays over the rear shoe.',
     shotType: 'standard',
     bridgeBack: 0.074,
     bridgeSide: -0.01,
@@ -2533,15 +2560,20 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     forearmDown: 0.55,
     strokePull: 0.32,
     strokePush: 0.13,
-    shootForwardBendScale: 1.02,
-    shootUpperBodyCounterLean: 0.4,
+    shootForwardBendScale: 0.56,
+    shootUpperBodyCounterLean: 0.62,
+    shootSideBendScale: 0.1,
+    shootSideBendDirection: 1,
+    shootCounterLeanSide: 1,
     cueGap: 0.008
   }),
   Object.freeze({
-    id: 'side-cut-open-stance',
-    label: 'Attempt 7 • Side Cut Stance',
-    menuLabel: '7 Side Cut Stance',
-    sourceNote: 'Difficult cut: bridge shifts slightly off line while hips counter-lean and feet stay grounded.',
+    id: 'right-side-cut-open-stance',
+    label: 'Attempt 7 • Right Bend Side Cut',
+    menuLabel: '7 Right • Side Cut',
+    directionLabel: 'Right bend',
+    techniqueLabel: 'Side cut stance',
+    sourceNote: 'Right-side cut stance: bridge shifts off line while hips counter-lean and feet stay grounded.',
     shotType: 'difficultAngle',
     bridgeBack: 0.078,
     bridgeSide: 0.044,
@@ -2558,13 +2590,18 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     strokePush: 0.12,
     shootForwardBendScale: 0.78,
     shootUpperBodyCounterLean: 0.74,
+    shootSideBendScale: 0.9,
+    shootSideBendDirection: 1,
+    shootCounterLeanSide: 1,
     cueGap: 0.011
   }),
   Object.freeze({
-    id: 'bridge-hand-flat-table',
-    label: 'Attempt 8 • Flat Palm Bridge',
-    menuLabel: '8 Flat Palm Bridge',
-    sourceNote: 'Palm-down bridge: emphasizes left hand glued to cloth and cue sliding over thumb/index groove.',
+    id: 'left-bridge-hand-flat-table',
+    label: 'Attempt 8 • Left Bend Flat Palm Bridge',
+    menuLabel: '8 Left • Flat Palm',
+    directionLabel: 'Left bend',
+    techniqueLabel: 'Flat palm bridge',
+    sourceNote: 'Left-side flat-palm bridge: hand glued to cloth with cue sliding over thumb/index groove.',
     shotType: 'standard',
     bridgeBack: 0.048,
     bridgeSide: -0.006,
@@ -2579,15 +2616,20 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     forearmDown: 0.58,
     strokePull: 0.28,
     strokePush: 0.1,
-    shootForwardBendScale: 0.86,
+    shootForwardBendScale: 0.84,
     shootUpperBodyCounterLean: 0.36,
+    shootSideBendScale: 0.72,
+    shootSideBendDirection: -1,
+    shootCounterLeanSide: -1,
     cueGap: 0.006
   }),
   Object.freeze({
-    id: 'upright-elbow-90',
-    label: 'Attempt 9 • Back Arm 90°',
-    menuLabel: '9 Back Arm 90°',
-    sourceNote: 'Dominant arm: recreates the vertical forearm/near-90-degree elbow shown in coaching diagrams.',
+    id: 'back-upright-elbow-90',
+    label: 'Attempt 9 • Back Upright 90° Elbow',
+    menuLabel: '9 Back • 90° Elbow',
+    directionLabel: 'Back upright',
+    techniqueLabel: '90-degree back arm',
+    sourceNote: 'Back-upright arm: vertical forearm/near-90-degree elbow with less chest drop.',
     shotType: 'power',
     bridgeBack: 0.088,
     bridgeSide: -0.018,
@@ -2602,15 +2644,20 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     forearmDown: 0.62,
     strokePull: 0.4,
     strokePush: 0.18,
-    shootForwardBendScale: 0.66,
-    shootUpperBodyCounterLean: 0.66,
+    shootForwardBendScale: 0.38,
+    shootUpperBodyCounterLean: 0.86,
+    shootSideBendScale: 0.18,
+    shootSideBendDirection: 1,
+    shootCounterLeanSide: 1,
     cueGap: 0.012
   }),
   Object.freeze({
-    id: 'beginner-balanced-guide',
-    label: 'Attempt 10 • Balanced Beginner',
-    menuLabel: '10 Balanced Beginner',
-    sourceNote: 'Beginner guide: medium stance width, comfortable reach, flat bridge and easy follow-through.',
+    id: 'front-beginner-balanced-guide',
+    label: 'Attempt 10 • Front Balanced Beginner',
+    menuLabel: '10 Front • Beginner',
+    directionLabel: 'Front bend',
+    techniqueLabel: 'Balanced beginner',
+    sourceNote: 'Front balanced guide: medium stance width, comfortable reach, flat bridge and easy follow-through.',
     shotType: 'standard',
     bridgeBack: 0.092,
     bridgeSide: -0.018,
@@ -2625,8 +2672,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     forearmDown: 0.5,
     strokePull: 0.34,
     strokePush: 0.14,
-    shootForwardBendScale: 0.74,
+    shootForwardBendScale: 0.92,
     shootUpperBodyCounterLean: 0.52,
+    shootSideBendScale: 0.06,
+    shootSideBendDirection: -1,
+    shootCounterLeanSide: -1,
     cueGap: 0.009
   })
 ]);
@@ -15767,7 +15817,7 @@ function PoolRoyaleGame({
         return stored;
       }
     }
-    return POOL_ROYALE_SHOOTING_POSITION_OPTIONS[0]?.id || 'open-bridge-table-low';
+    return POOL_ROYALE_SHOOTING_POSITION_OPTIONS[0]?.id || 'front-open-bridge-low';
   });
   const activeShootingPosition = useMemo(
     () => resolvePoolRoyaleShootingPosition(shootingPositionId),
@@ -27310,12 +27360,14 @@ const shotPowerRef = useRef(0);
             // as the portrait camera lowers into the ready-to-shoot view. Local -Z is the
             // original rig forward axis, so the fallback bend sign folds belly/chest/head
             // toward the cue ball instead of bending the whole body backward.
-            shootBendDirection: -1,
-            shootBendTowardCueStick: !behavior.originalSkeletonLogic,
+            shootBendDirection: behavior.shootBendDirection ?? -1,
+            shootBendTowardCueStick: behavior.shootBendTowardCueStick ?? !behavior.originalSkeletonLogic,
             shootBendMode: behavior.bendMode || 'forward',
-            shootCounterLeanSide: -1,
+            shootCounterLeanSide: behavior.shootCounterLeanSide ?? -1,
             shootUpperBodyCounterLean: behavior.shootUpperBodyCounterLean,
             shootForwardBendScale: behavior.shootForwardBendScale,
+            shootSideBendScale: behavior.shootSideBendScale ?? 0,
+            shootSideBendDirection: behavior.shootSideBendDirection ?? -1,
             plantFeetDuringShot: true,
             bridgeArmStraightDown: false,
             forceTableFacingAim: !behavior.originalSkeletonLogic,
@@ -37479,7 +37531,7 @@ const shotPowerRef = useRef(0);
                       Shooting Positions
                     </h3>
                     <p className="mt-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-white/60">
-                      10 attempts • feet grounded • left bridge on table • right hand grips cue
+                      10 attempts • 4 bend directions • feet grounded • bridge hand on table
                     </p>
                   </div>
                   <span className="rounded-full border border-amber-200/40 bg-amber-200/15 px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] text-amber-100">
@@ -37505,6 +37557,9 @@ const shotPowerRef = useRef(0);
                           {option.menuLabel || option.label}
                         </span>
                         <span className={`mt-1 block text-[9px] font-semibold uppercase tracking-[0.12em] ${active ? 'text-black/70' : 'text-white/50'}`}>
+                          {option.directionLabel ? `${option.directionLabel} • ${option.techniqueLabel}` : option.sourceNote}
+                        </span>
+                        <span className={`mt-1 block text-[9px] font-medium leading-relaxed ${active ? 'text-black/65' : 'text-white/45'}`}>
                           {option.sourceNote}
                         </span>
                       </button>

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -247,6 +247,11 @@ const BASE_CFG = {
   shootCounterLeanSide: -1,
   shootUpperBodyCounterLean: 1,
   shootForwardBendScale: 1,
+  // Optional side-bend layer lets individual Pool Royale shooting positions
+  // bias the fold to the left or right while the main chest/head bend still
+  // tracks the live cue line.
+  shootSideBendScale: 0,
+  shootSideBendDirection: -1,
   plantFeetDuringShot: true,
   bridgeArmStraightDown: false,
   forceTableFacingAim: true,
@@ -1286,9 +1291,14 @@ export function updateHumanPose(human, dt, frameData) {
   const forwardBendScale = Number.isFinite(cfg.shootForwardBendScale)
     ? Math.max(0, cfg.shootForwardBendScale)
     : 1;
+  const sideBendScale = Number.isFinite(cfg.shootSideBendScale)
+    ? Math.max(0, cfg.shootSideBendScale)
+    : 0;
+  const sideBendDirection = cfg.shootSideBendDirection >= 0 ? 1 : -1;
   const plantFeetDuringShot = cfg.plantFeetDuringShot !== false;
   const shotBendZ = (value) => Math.abs(value) * bendDirection * forwardBendScale * poseProfile.lean;
   const shotCounterLeanX = (value) => (value + (poseProfile.hipSide || 0) * t) * counterLeanSide * upperBodyCounterLean;
+  const shotSideBendX = (value) => Math.abs(value) * sideBendDirection * sideBendScale * poseProfile.lean;
   const rootWorld = human.root.position.clone();
   rootWorld.y = cfg.groundY;
   if (activeState === 'striking' && poseProfile.recoil) rootWorld.addScaledVector(forward, -poseProfile.recoil * cfg.unit * strikeFollow);
@@ -1296,12 +1306,12 @@ export function updateHumanPose(human, dt, frameData) {
   // Real pool stance: feet/hips stay grounded and carry the weight; the fold is
   // from the belly upward, lowering the head toward the cue line without pushing
   // the entire body backward or off the floor.
-  const torso = local(new THREE.Vector3(shotCounterLeanX(0.012 * t) * cfg.unit, lerp(1.3, 1.16, t) * cfg.unit + breath, shotBendZ(lerp(0.01, -0.12, t) - 0.008 * powerLean) * cfg.unit));
-  const chest = local(new THREE.Vector3(shotCounterLeanX(0.038 * t + 0.006 * powerLean) * cfg.unit, lerp(1.52, 1.25, t) * cfg.unit + breath, shotBendZ(lerp(0.015, -0.36, t) - 0.014 * powerLean) * cfg.unit));
-  const neck = local(new THREE.Vector3(shotCounterLeanX(0.055 * t + 0.008 * powerLean) * cfg.unit, lerp(1.68, 1.32, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.52, t) - 0.016 * powerLean) * cfg.unit));
-  const head = local(new THREE.Vector3(shotCounterLeanX(0.066 * t + 0.01 * powerLean) * cfg.unit, lerp(1.84, 1.39, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.42 * t, shotBendZ(lerp(0.03, -0.62, t) - 0.018 * powerLean) * cfg.unit));
-  const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.048 * t)) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.43, t) - 0.012 * human.settleT) * cfg.unit));
-  const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.034 * t)) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.36, t) - 0.012 * human.settleT) * cfg.unit));
+  const torso = local(new THREE.Vector3((shotCounterLeanX(0.012 * t) + shotSideBendX(0.01 * t)) * cfg.unit, lerp(1.3, 1.16, t) * cfg.unit + breath, shotBendZ(lerp(0.01, -0.12, t) - 0.008 * powerLean) * cfg.unit));
+  const chest = local(new THREE.Vector3((shotCounterLeanX(0.038 * t + 0.006 * powerLean) + shotSideBendX(0.032 * t)) * cfg.unit, lerp(1.52, 1.25, t) * cfg.unit + breath, shotBendZ(lerp(0.015, -0.36, t) - 0.014 * powerLean) * cfg.unit));
+  const neck = local(new THREE.Vector3((shotCounterLeanX(0.055 * t + 0.008 * powerLean) + shotSideBendX(0.048 * t)) * cfg.unit, lerp(1.68, 1.32, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.52, t) - 0.016 * powerLean) * cfg.unit));
+  const head = local(new THREE.Vector3((shotCounterLeanX(0.066 * t + 0.01 * powerLean) + shotSideBendX(0.06 * t)) * cfg.unit, lerp(1.84, 1.39, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.42 * t, shotBendZ(lerp(0.03, -0.62, t) - 0.018 * powerLean) * cfg.unit));
+  const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.048 * t) + shotSideBendX(0.026 * t)) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.43, t) - 0.012 * human.settleT) * cfg.unit));
+  const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.034 * t) + shotSideBendX(0.022 * t)) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.36, t) - 0.012 * human.settleT) * cfg.unit));
   const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const footWalkBlend = plantFeetDuringShot ? idle : 1;


### PR DESCRIPTION
### Motivation
- Provide ten distinct shooting-position presets that cover front/back/left/right body‑bend directions and expose technique metadata so players can choose stylistic stance options.
- Surface per‑position pose parameters to the human rig so each preset visibly biases the avatar’s upper‑body fold and bridge/grip technique.

### Description
- Reworked the shooting presets in `webapp/src/pages/Games/PoolRoyale.jsx` to a new `POOL_ROYALE_SHOOTING_POSITION_OPTIONS` list of 10 options that include `directionLabel`, `techniqueLabel`, and per‑option parameters such as `shootSideBendScale`, `shootSideBendDirection`, and `shootCounterLeanSide`.
- Wired the selected shooting position into the human rig config passed to `createBilardoHumanRig`, forwarding `shootSideBendScale`, `shootSideBendDirection`, `shootCounterLeanSide`, and related settings so the runtime rig receives per‑preset behavior.
- Extended the shared pose solver in `webapp/src/pages/Games/shared/humanRigCore.js` to add config defaults `shootSideBendScale`/`shootSideBendDirection` and a `shotSideBendX` term that biases torso/chest/neck/head/shoulder X offsets while preserving the main cue‑aligned fold.
- Updated the Pool Royale settings UI to show “4 bend directions” and present each preset’s bend direction and technique in the Shooting Positions menu.

### Testing
- Ran `npm --prefix webapp run build` and a full `vite build` from `webapp/`; both completed successfully.
- Executed a small Node validation script that checks there are exactly 10 shooting positions and that Front/Back/Left/Right directions are represented; the validation passed.
- Ran `git diff --check` to ensure no diff issues; check passed.
- Attempted an automated headless UI capture with Playwright to verify the live menu; Playwright and native browser deps were installed, but the in‑scene 3D route did not show the menu within the headless timeout (menu capture timed out), so the runtime visual smoke test failed to complete within the environment timeout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a053744d4688329a7a1be8cd5f643b2)