### PR TITLE
Revamp Pool Royale shooting positions — 4‑sided stances & bend-aware placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2403,7 +2403,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'open-bridge-table-low',
     label: 'Attempt 1 • Open Bridge Low',
     menuLabel: '1 Open Bridge Low',
-    sourceNote: 'Open bridge: palm flat, fingers spread, chest and chin lowered over cue.',
+    sourceNote: 'West rail forward bend: open bridge, palm flat, chest/chin lowered over cue.',
+    stanceSide: 'west',
+    bendDirectionLabel: 'forward',
+    shootCounterLeanSide: -1,
+    originalSkeletonLogic: false,
     shotType: 'standard',
     bridgeBack: 0.082,
     bridgeSide: -0.016,
@@ -2426,7 +2430,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'closed-bridge-power-line',
     label: 'Attempt 2 • Closed Bridge Power',
     menuLabel: '2 Closed Bridge Power',
-    sourceNote: 'Closed bridge/grip: stronger back arm, wider planted feet, elbow high over the cue.',
+    sourceNote: 'North rail right-side bend: closed grip, wide feet, high elbow power line.',
+    stanceSide: 'north',
+    bendDirectionLabel: 'right',
+    shootCounterLeanSide: 1,
+    originalSkeletonLogic: false,
     shotType: 'power',
     bridgeBack: 0.07,
     bridgeSide: -0.028,
@@ -2449,7 +2457,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'rail-bridge-near-cushion',
     label: 'Attempt 3 • Rail Bridge',
     menuLabel: '3 Rail Bridge',
-    sourceNote: 'Rail bridge: raised bridge hand for balls near cushion while keeping palm/table contact.',
+    sourceNote: 'East rail left-side bend: raised rail bridge while the palm stays in table contact.',
+    stanceSide: 'east',
+    bendDirectionLabel: 'left',
+    shootCounterLeanSide: -1,
+    originalSkeletonLogic: false,
     shotType: 'rail',
     bridgeBack: 0.06,
     bridgeSide: -0.02,
@@ -2472,7 +2484,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'long-reach-snooker-stretch',
     label: 'Attempt 4 • Long Reach Stretch',
     menuLabel: '4 Long Reach Stretch',
-    sourceNote: 'Long reach: extended bridge arm, back foot anchored, upper body stretched toward cue ball.',
+    sourceNote: 'South rail deep forward bend: long bridge reach, anchored back foot, stretched torso.',
+    stanceSide: 'south',
+    bendDirectionLabel: 'forward',
+    shootCounterLeanSide: -1,
+    originalSkeletonLogic: false,
     shotType: 'longReach',
     bridgeBack: 0.105,
     bridgeSide: -0.024,
@@ -2495,7 +2511,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'compact-soft-touch',
     label: 'Attempt 5 • Compact Soft Touch',
     menuLabel: '5 Compact Soft Touch',
-    sourceNote: 'Soft precision: compact stance, shorter cue travel, stable open bridge close to cue ball.',
+    sourceNote: 'West rail compact bend: soft-touch short stroke with stable open bridge near cue ball.',
+    stanceSide: 'west',
+    bendDirectionLabel: 'compact',
+    shootCounterLeanSide: 1,
+    originalSkeletonLogic: false,
     shotType: 'softPrecision',
     bridgeBack: 0.055,
     bridgeSide: -0.014,
@@ -2518,7 +2538,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'chin-over-cue-line',
     label: 'Attempt 6 • Chin Over Cue',
     menuLabel: '6 Chin Over Cue',
-    sourceNote: 'Low sight line: head/chin follows cue axis with forward torso bend and planted shoes.',
+    sourceNote: 'North rail low sight-line bend: chin tracks the cue axis with planted shoes.',
+    stanceSide: 'north',
+    bendDirectionLabel: 'low',
+    shootCounterLeanSide: -1,
+    originalSkeletonLogic: false,
     shotType: 'standard',
     bridgeBack: 0.074,
     bridgeSide: -0.01,
@@ -2541,7 +2565,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'side-cut-open-stance',
     label: 'Attempt 7 • Side Cut Stance',
     menuLabel: '7 Side Cut Stance',
-    sourceNote: 'Difficult cut: bridge shifts slightly off line while hips counter-lean and feet stay grounded.',
+    sourceNote: 'East rail side-cut bend: bridge shifts off line while hips counter-lean and feet stay grounded.',
+    stanceSide: 'east',
+    bendDirectionLabel: 'side-cut',
+    shootCounterLeanSide: 1,
+    originalSkeletonLogic: false,
     shotType: 'difficultAngle',
     bridgeBack: 0.078,
     bridgeSide: 0.044,
@@ -2564,7 +2592,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'bridge-hand-flat-table',
     label: 'Attempt 8 • Flat Palm Bridge',
     menuLabel: '8 Flat Palm Bridge',
-    sourceNote: 'Palm-down bridge: emphasizes left hand glued to cloth and cue sliding over thumb/index groove.',
+    sourceNote: 'South rail flat-palm bend: left hand glued to cloth with cue in thumb/index groove.',
+    stanceSide: 'south',
+    bendDirectionLabel: 'flat-palm',
+    shootCounterLeanSide: -1,
+    originalSkeletonLogic: false,
     shotType: 'standard',
     bridgeBack: 0.048,
     bridgeSide: -0.006,
@@ -2587,7 +2619,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'upright-elbow-90',
     label: 'Attempt 9 • Back Arm 90°',
     menuLabel: '9 Back Arm 90°',
-    sourceNote: 'Dominant arm: recreates the vertical forearm/near-90-degree elbow shown in coaching diagrams.',
+    sourceNote: 'West rail upright-elbow bend: vertical forearm near 90 degrees for a coached strike.',
+    stanceSide: 'west',
+    bendDirectionLabel: 'upright',
+    shootCounterLeanSide: 1,
+    originalSkeletonLogic: false,
     shotType: 'power',
     bridgeBack: 0.088,
     bridgeSide: -0.018,
@@ -2610,7 +2646,11 @@ const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
     id: 'beginner-balanced-guide',
     label: 'Attempt 10 • Balanced Beginner',
     menuLabel: '10 Balanced Beginner',
-    sourceNote: 'Beginner guide: medium stance width, comfortable reach, flat bridge and easy follow-through.',
+    sourceNote: 'North rail balanced bend: medium stance, comfortable reach, flat bridge and easy follow-through.',
+    stanceSide: 'north',
+    bendDirectionLabel: 'balanced',
+    shootCounterLeanSide: -1,
+    originalSkeletonLogic: false,
     shotType: 'standard',
     bridgeBack: 0.092,
     bridgeSide: -0.018,
@@ -27313,7 +27353,7 @@ const shotPowerRef = useRef(0);
             shootBendDirection: -1,
             shootBendTowardCueStick: !behavior.originalSkeletonLogic,
             shootBendMode: behavior.bendMode || 'forward',
-            shootCounterLeanSide: -1,
+            shootCounterLeanSide: behavior.shootCounterLeanSide ?? -1,
             shootUpperBodyCounterLean: behavior.shootUpperBodyCounterLean,
             shootForwardBendScale: behavior.shootForwardBendScale,
             plantFeetDuringShot: true,
@@ -27576,7 +27616,8 @@ const shotPowerRef = useRef(0);
                   tableW: TABLE.W,
                   tableL: TABLE.H,
                   edgeMargin: humanEdgeMargin,
-                  desiredShootDistance: humanShootDistance
+                  desiredShootDistance: humanShootDistance,
+                  preferredTableSide: behavior.stanceSide
                 }).setY(floorY);
             const perimeterRoot = behavior.originalSkeletonLogic
               ? desiredRoot.clone()
@@ -37479,7 +37520,7 @@ const shotPowerRef = useRef(0);
                       Shooting Positions
                     </h3>
                     <p className="mt-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-white/60">
-                      10 attempts • feet grounded • left bridge on table • right hand grips cue
+                      10 attempts • all 4 table sides • distinct body bends • unique cue techniques
                     </p>
                   </div>
                   <span className="rounded-full border border-amber-200/40 bg-amber-200/15 px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] text-amber-100">
@@ -37506,6 +37547,9 @@ const shotPowerRef = useRef(0);
                         </span>
                         <span className={`mt-1 block text-[9px] font-semibold uppercase tracking-[0.12em] ${active ? 'text-black/70' : 'text-white/50'}`}>
                           {option.sourceNote}
+                        </span>
+                        <span className={`mt-1 block text-[8px] font-black uppercase tracking-[0.16em] ${active ? 'text-black/60' : 'text-amber-100/60'}`}>
+                          {(option.stanceSide || 'auto')} side • {(option.bendDirectionLabel || option.shotType || 'standard')} bend
                         </span>
                       </button>
                     );

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -1436,12 +1436,24 @@ export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
   const zEdge = tableL / 2 + cfg.edgeMargin;
   const groundY = cfg.groundY || 0;
   const behind = shotDir.clone().multiplyScalar(-1);
-  const candidate = (x, z) => new THREE.Vector3(clamp(x, -xEdge, xEdge), groundY, clamp(z, -zEdge, zEdge));
+  const normalizePreferredSide = (side) => {
+    const value = String(side || '').toLowerCase();
+    if (['west', 'left', '-x'].includes(value)) return 'west';
+    if (['east', 'right', '+x'].includes(value)) return 'east';
+    if (['north', 'top', '-z'].includes(value)) return 'north';
+    if (['south', 'bottom', '+z'].includes(value)) return 'south';
+    return null;
+  };
+  const preferredTableSide = normalizePreferredSide(opts.preferredTableSide || opts.stanceSide);
+  const candidate = (x, z, sideName = null) => ({
+    point: new THREE.Vector3(clamp(x, -xEdge, xEdge), groundY, clamp(z, -zEdge, zEdge)),
+    sideName
+  });
   const candidates = [
-    candidate(-xEdge, desired.z),
-    candidate(xEdge, desired.z),
-    candidate(desired.x, -zEdge),
-    candidate(desired.x, zEdge),
+    candidate(-xEdge, desired.z, 'west'),
+    candidate(xEdge, desired.z, 'east'),
+    candidate(desired.x, -zEdge, 'north'),
+    candidate(desired.x, zEdge, 'south'),
     candidate(cueBallWorld.x + behind.x * cfg.desiredShootDistance, cueBallWorld.z + behind.z * cfg.desiredShootDistance),
     candidate(cueBallWorld.x + behind.x * (cfg.desiredShootDistance + cfg.edgeMargin * 0.5), cueBallWorld.z + behind.z * (cfg.desiredShootDistance + cfg.edgeMargin * 0.5))
   ];
@@ -1453,23 +1465,28 @@ export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
 
   const unique = [];
   const seen = new Set();
-  for (const point of candidates) {
+  for (const entry of candidates) {
+    const point = entry.point || entry;
     const key = `${point.x.toFixed(3)}:${point.z.toFixed(3)}`;
     if (!seen.has(key)) {
       seen.add(key);
-      unique.push(point);
+      unique.push({ point, sideName: entry.sideName || null });
     }
   }
 
-  const score = (point) => {
+  const score = (entry) => {
+    const point = entry.point || entry;
     const cueToPoint = point.clone().sub(cueBallWorld).setY(0);
     const behindScore = cueToPoint.lengthSq() > 1e-8 ? Math.max(0, cueToPoint.normalize().dot(behind)) : 0;
     const sidePenalty = Math.abs(point.clone().sub(desired).dot(new THREE.Vector3(shotDir.z, 0, -shotDir.x)));
     const blockedPenalty = isBlockedStandingPoint(point, opts, cfg) ? 100000 : 0;
     const behindPenalty = (1 - behindScore) * cfg.desiredShootDistance * cfg.desiredShootDistance * 18;
-    return blockedPenalty + behindPenalty + point.distanceToSquared(desired) + sidePenalty * 0.35;
+    const sidePreferencePenalty = preferredTableSide && entry.sideName && entry.sideName !== preferredTableSide
+      ? cfg.desiredShootDistance * cfg.desiredShootDistance * 28
+      : 0;
+    return blockedPenalty + behindPenalty + sidePreferencePenalty + point.distanceToSquared(desired) + sidePenalty * 0.35;
   };
 
   const sorted = unique.sort((a, b) => score(a) - score(b));
-  return (sorted[0] || desired).clone().setY(groundY);
+  return ((sorted[0] && sorted[0].point) || desired).clone().setY(groundY);
 }


### PR DESCRIPTION
### Motivation
- Provide 10 distinct shooting-position presets that cover all four table sides and expose different body-bend/technique variants so the avatar can present visibly different poses and placement around the table.
- Let the human rig use per-position metadata (counter-lean + preferred side) so pose solving and root placement reflect the selected shooting technique instead of a single hard-coded behavior.

### Description
- Added per-preset metadata to the Pool Royale shooting options (`stanceSide`, `bendDirectionLabel`, `shootCounterLeanSide`, `originalSkeletonLogic: false`) and updated option copy/UI to advertise side/bend details in the Shooting Positions panel (changes in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Propagated the selected shooting position into the rig runtime so `shootCounterLeanSide` is used instead of a constant and `preferredTableSide` is passed to the edge placement logic when computing the avatar root position (changes in the rig creation and placement call sites in `PoolRoyale.jsx`).
- Extended the shared human rig edge chooser (`chooseHumanEdgePosition`) to normalize preferred side tokens, annotate candidate edge points with side names, and bias scoring toward the requested `preferredTableSide` while keeping blocked-point and behind-shot scoring intact (changes in `webapp/src/pages/Games/shared/humanRigCore.js`).
- Small UI update to the Shooting Positions panel to show each option’s side and bend in the option card.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.
- Installed Playwright and its system deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully.
- Ran a Playwright screenshot script against the running dev site to verify the updated UI and avatar placement, and captured `/tmp/pool-royale-shooting-positions.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a053744d4688329a7a1be8cd5f643b2)