### PR TITLE
Pool Royale: replace 10 shooting presets with automatic table-facing standing stance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2400,274 +2400,33 @@ const POOL_ROYALE_HUMAN_CHARACTER_IDS = Object.freeze([
 ]);
 const POOL_ROYALE_SHOOTING_POSITION_OPTIONS = Object.freeze([
   Object.freeze({
-    id: 'open-bridge-table-low',
-    label: 'Attempt 1 • Open Bridge Low',
-    menuLabel: '1 Open Bridge Low',
-    sourceNote: 'West rail forward bend: open bridge, palm flat, chest/chin lowered over cue.',
-    stanceSide: 'west',
-    bendDirectionLabel: 'forward',
-    shootCounterLeanSide: -1,
-    originalSkeletonLogic: false,
-    shotType: 'standard',
-    bridgeBack: 0.082,
-    bridgeSide: -0.016,
-    bridgeLift: 0.002,
-    desiredShootDistance: 1.38,
-    stanceWidth: 0.56,
-    rightElbowRise: 0.16,
-    rightElbowSide: -0.44,
-    rightElbowBack: -0.84,
-    forearmOutward: 0.34,
-    forearmBack: 0.52,
-    forearmDown: 0.5,
-    strokePull: 0.38,
-    strokePush: 0.16,
-    shootForwardBendScale: 0.82,
-    shootUpperBodyCounterLean: 0.46,
-    cueGap: 0.009
-  }),
-  Object.freeze({
-    id: 'closed-bridge-power-line',
-    label: 'Attempt 2 • Closed Bridge Power',
-    menuLabel: '2 Closed Bridge Power',
-    sourceNote: 'North rail right-side bend: closed grip, wide feet, high elbow power line.',
-    stanceSide: 'north',
-    bendDirectionLabel: 'right',
-    shootCounterLeanSide: 1,
-    originalSkeletonLogic: false,
-    shotType: 'power',
-    bridgeBack: 0.07,
-    bridgeSide: -0.028,
-    bridgeLift: 0.008,
-    desiredShootDistance: 1.48,
-    stanceWidth: 0.68,
-    rightElbowRise: 0.29,
-    rightElbowSide: -0.54,
-    rightElbowBack: -0.92,
-    forearmOutward: 0.45,
-    forearmBack: 0.58,
-    forearmDown: 0.43,
-    strokePull: 0.58,
-    strokePush: 0.28,
-    shootForwardBendScale: 0.58,
-    shootUpperBodyCounterLean: 0.86,
-    cueGap: 0.015
-  }),
-  Object.freeze({
-    id: 'rail-bridge-near-cushion',
-    label: 'Attempt 3 • Rail Bridge',
-    menuLabel: '3 Rail Bridge',
-    sourceNote: 'East rail left-side bend: raised rail bridge while the palm stays in table contact.',
-    stanceSide: 'east',
-    bendDirectionLabel: 'left',
-    shootCounterLeanSide: -1,
-    originalSkeletonLogic: false,
-    shotType: 'rail',
-    bridgeBack: 0.06,
-    bridgeSide: -0.02,
-    bridgeLift: 0.036,
-    desiredShootDistance: 1.32,
-    stanceWidth: 0.54,
-    rightElbowRise: 0.2,
-    rightElbowSide: -0.42,
-    rightElbowBack: -0.78,
-    forearmOutward: 0.32,
-    forearmBack: 0.46,
-    forearmDown: 0.46,
-    strokePull: 0.3,
-    strokePush: 0.11,
-    shootForwardBendScale: 0.72,
-    shootUpperBodyCounterLean: 0.58,
-    cueGap: 0.012
-  }),
-  Object.freeze({
-    id: 'long-reach-snooker-stretch',
-    label: 'Attempt 4 • Long Reach Stretch',
-    menuLabel: '4 Long Reach Stretch',
-    sourceNote: 'South rail deep forward bend: long bridge reach, anchored back foot, stretched torso.',
-    stanceSide: 'south',
-    bendDirectionLabel: 'forward',
-    shootCounterLeanSide: -1,
-    originalSkeletonLogic: false,
-    shotType: 'longReach',
-    bridgeBack: 0.105,
-    bridgeSide: -0.024,
-    bridgeLift: 0.001,
-    desiredShootDistance: 1.56,
-    stanceWidth: 0.62,
-    rightElbowRise: 0.14,
-    rightElbowSide: -0.39,
-    rightElbowBack: -0.9,
-    forearmOutward: 0.3,
-    forearmBack: 0.54,
-    forearmDown: 0.54,
-    strokePull: 0.42,
-    strokePush: 0.15,
-    shootForwardBendScale: 0.9,
-    shootUpperBodyCounterLean: 0.5,
-    cueGap: 0.008
-  }),
-  Object.freeze({
-    id: 'compact-soft-touch',
-    label: 'Attempt 5 • Compact Soft Touch',
-    menuLabel: '5 Compact Soft Touch',
-    sourceNote: 'West rail compact bend: soft-touch short stroke with stable open bridge near cue ball.',
-    stanceSide: 'west',
-    bendDirectionLabel: 'compact',
-    shootCounterLeanSide: 1,
-    originalSkeletonLogic: false,
-    shotType: 'softPrecision',
-    bridgeBack: 0.055,
-    bridgeSide: -0.014,
-    bridgeLift: 0.005,
-    desiredShootDistance: 1.22,
-    stanceWidth: 0.46,
-    rightElbowRise: 0.12,
-    rightElbowSide: -0.34,
-    rightElbowBack: -0.64,
-    forearmOutward: 0.24,
-    forearmBack: 0.34,
-    forearmDown: 0.56,
-    strokePull: 0.22,
-    strokePush: 0.08,
-    shootForwardBendScale: 0.7,
-    shootUpperBodyCounterLean: 0.34,
-    cueGap: 0.006
-  }),
-  Object.freeze({
-    id: 'chin-over-cue-line',
-    label: 'Attempt 6 • Chin Over Cue',
-    menuLabel: '6 Chin Over Cue',
-    sourceNote: 'North rail low sight-line bend: chin tracks the cue axis with planted shoes.',
-    stanceSide: 'north',
-    bendDirectionLabel: 'low',
+    id: 'automatic-standing-table-facing',
+    label: 'Automatic Standing Table-Facing Shot',
+    menuLabel: 'Automatic Shot Position',
+    sourceNote: 'Auto maps the shooter around the table, keeps the body upright, faces the table, and plants the left bridge hand toward the cue ball.',
+    stanceSide: null,
+    bendDirectionLabel: 'upright',
     shootCounterLeanSide: -1,
     originalSkeletonLogic: false,
     shotType: 'standard',
     bridgeBack: 0.074,
-    bridgeSide: -0.01,
-    bridgeLift: 0.003,
-    desiredShootDistance: 1.34,
-    stanceWidth: 0.52,
-    rightElbowRise: 0.17,
-    rightElbowSide: -0.38,
-    rightElbowBack: -0.76,
-    forearmOutward: 0.28,
-    forearmBack: 0.42,
-    forearmDown: 0.55,
-    strokePull: 0.32,
-    strokePush: 0.13,
-    shootForwardBendScale: 1.02,
-    shootUpperBodyCounterLean: 0.4,
-    cueGap: 0.008
-  }),
-  Object.freeze({
-    id: 'side-cut-open-stance',
-    label: 'Attempt 7 • Side Cut Stance',
-    menuLabel: '7 Side Cut Stance',
-    sourceNote: 'East rail side-cut bend: bridge shifts off line while hips counter-lean and feet stay grounded.',
-    stanceSide: 'east',
-    bendDirectionLabel: 'side-cut',
-    shootCounterLeanSide: 1,
-    originalSkeletonLogic: false,
-    shotType: 'difficultAngle',
-    bridgeBack: 0.078,
-    bridgeSide: 0.044,
-    bridgeLift: 0.006,
-    desiredShootDistance: 1.36,
-    stanceWidth: 0.58,
-    rightElbowRise: 0.2,
-    rightElbowSide: -0.48,
-    rightElbowBack: -0.8,
-    forearmOutward: 0.36,
-    forearmBack: 0.44,
-    forearmDown: 0.48,
-    strokePull: 0.34,
-    strokePush: 0.12,
-    shootForwardBendScale: 0.78,
-    shootUpperBodyCounterLean: 0.74,
-    cueGap: 0.011
-  }),
-  Object.freeze({
-    id: 'bridge-hand-flat-table',
-    label: 'Attempt 8 • Flat Palm Bridge',
-    menuLabel: '8 Flat Palm Bridge',
-    sourceNote: 'South rail flat-palm bend: left hand glued to cloth with cue in thumb/index groove.',
-    stanceSide: 'south',
-    bendDirectionLabel: 'flat-palm',
-    shootCounterLeanSide: -1,
-    originalSkeletonLogic: false,
-    shotType: 'standard',
-    bridgeBack: 0.048,
-    bridgeSide: -0.006,
+    bridgeSide: -0.012,
     bridgeLift: 0,
-    desiredShootDistance: 1.3,
-    stanceWidth: 0.5,
-    rightElbowRise: 0.15,
-    rightElbowSide: -0.36,
-    rightElbowBack: -0.74,
-    forearmOutward: 0.26,
-    forearmBack: 0.4,
-    forearmDown: 0.58,
+    desiredShootDistance: 1.34,
+    stanceWidth: 0.48,
+    rightElbowRise: 0.12,
+    rightElbowSide: -0.32,
+    rightElbowBack: -0.58,
+    forearmOutward: 0.25,
+    forearmBack: 0.3,
+    forearmDown: 0.36,
     strokePull: 0.28,
     strokePush: 0.1,
-    shootForwardBendScale: 0.86,
-    shootUpperBodyCounterLean: 0.36,
-    cueGap: 0.006
-  }),
-  Object.freeze({
-    id: 'upright-elbow-90',
-    label: 'Attempt 9 • Back Arm 90°',
-    menuLabel: '9 Back Arm 90°',
-    sourceNote: 'West rail upright-elbow bend: vertical forearm near 90 degrees for a coached strike.',
-    stanceSide: 'west',
-    bendDirectionLabel: 'upright',
-    shootCounterLeanSide: 1,
-    originalSkeletonLogic: false,
-    shotType: 'power',
-    bridgeBack: 0.088,
-    bridgeSide: -0.018,
-    bridgeLift: 0.007,
-    desiredShootDistance: 1.42,
-    stanceWidth: 0.6,
-    rightElbowRise: 0.34,
-    rightElbowSide: -0.5,
-    rightElbowBack: -0.72,
-    forearmOutward: 0.38,
-    forearmBack: 0.36,
-    forearmDown: 0.62,
-    strokePull: 0.4,
-    strokePush: 0.18,
-    shootForwardBendScale: 0.66,
-    shootUpperBodyCounterLean: 0.66,
-    cueGap: 0.012
-  }),
-  Object.freeze({
-    id: 'beginner-balanced-guide',
-    label: 'Attempt 10 • Balanced Beginner',
-    menuLabel: '10 Balanced Beginner',
-    sourceNote: 'North rail balanced bend: medium stance, comfortable reach, flat bridge and easy follow-through.',
-    stanceSide: 'north',
-    bendDirectionLabel: 'balanced',
-    shootCounterLeanSide: -1,
-    originalSkeletonLogic: false,
-    shotType: 'standard',
-    bridgeBack: 0.092,
-    bridgeSide: -0.018,
-    bridgeLift: 0.004,
-    desiredShootDistance: 1.36,
-    stanceWidth: 0.55,
-    rightElbowRise: 0.18,
-    rightElbowSide: -0.42,
-    rightElbowBack: -0.78,
-    forearmOutward: 0.33,
-    forearmBack: 0.46,
-    forearmDown: 0.5,
-    strokePull: 0.34,
-    strokePush: 0.14,
-    shootForwardBendScale: 0.74,
-    shootUpperBodyCounterLean: 0.52,
-    cueGap: 0.009
+    shootForwardBendScale: 0,
+    shootUpperBodyCounterLean: 0,
+    standingShotStance: true,
+    cueGap: 0.008,
+    walkSpeed: 4.2
   })
 ]);
 const resolvePoolRoyaleShootingPosition = (id) =>
@@ -15800,14 +15559,14 @@ function PoolRoyaleGame({
     () => resolvePoolRoyaleHumanCharacter(humanCharacterId),
     [humanCharacterId]
   );
-  const [shootingPositionId, setShootingPositionId] = useState(() => {
+  const [shootingPositionId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(POOL_ROYALE_SHOOTING_POSITION_STORAGE_KEY);
       if (stored && POOL_ROYALE_SHOOTING_POSITION_OPTIONS.some((option) => option.id === stored)) {
         return stored;
       }
     }
-    return POOL_ROYALE_SHOOTING_POSITION_OPTIONS[0]?.id || 'open-bridge-table-low';
+    return POOL_ROYALE_SHOOTING_POSITION_OPTIONS[0]?.id || 'automatic-standing-table-facing';
   });
   const activeShootingPosition = useMemo(
     () => resolvePoolRoyaleShootingPosition(shootingPositionId),
@@ -27356,6 +27115,7 @@ const shotPowerRef = useRef(0);
             shootCounterLeanSide: behavior.shootCounterLeanSide ?? -1,
             shootUpperBodyCounterLean: behavior.shootUpperBodyCounterLean,
             shootForwardBendScale: behavior.shootForwardBendScale,
+            standingShotStance: Boolean(behavior.standingShotStance),
             plantFeetDuringShot: true,
             bridgeArmStraightDown: false,
             forceTableFacingAim: !behavior.originalSkeletonLogic,
@@ -27617,7 +27377,7 @@ const shotPowerRef = useRef(0);
                   tableL: TABLE.H,
                   edgeMargin: humanEdgeMargin,
                   desiredShootDistance: humanShootDistance,
-                  preferredTableSide: behavior.stanceSide
+                  preferredTableSide: behavior.stanceSide || null
                 }).setY(floorY);
             const perimeterRoot = behavior.originalSkeletonLogic
               ? desiredRoot.clone()
@@ -27727,7 +27487,10 @@ const shotPowerRef = useRef(0);
                 side: side.clone()
               };
             }
-            const poseForward = chairFacing?.lengthSq?.() > 1e-6 ? chairFacing.normalize() : aimForward;
+            const tableFacingForward = cueWorld.clone().sub(walkRoot).setY(0);
+            if (tableFacingForward.lengthSq() < 1e-6) tableFacingForward.copy(aimForward);
+            tableFacingForward.normalize();
+            const poseForward = chairFacing?.lengthSq?.() > 1e-6 ? chairFacing.normalize() : tableFacingForward;
             const standingYaw = Math.atan2(-poseForward.x, -poseForward.z);
             const idleRight = walkRoot
               .clone()
@@ -27771,6 +27534,7 @@ const shotPowerRef = useRef(0);
               shotType: behavior.shotType || activeShootingPositionRef.current?.shotType || 'standard',
               railDistance: behavior.shotType === 'rail' ? 0 : undefined,
               bridgeReach: behavior.shotType === 'longReach' ? 1 : undefined,
+              tableCenter: new THREE.Vector3(0, TABLE_Y + TABLE.THICK, 0),
               directRootTarget: walkingToChair
             });
             if (rig.heldCue) {
@@ -37517,44 +37281,19 @@ const shotPowerRef = useRef(0);
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <h3 className="text-[11px] font-black uppercase tracking-[0.28em] text-amber-100">
-                      Shooting Positions
+                      Shooting Logic
                     </h3>
                     <p className="mt-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-white/60">
-                      10 attempts • all 4 table sides • distinct body bends • unique cue techniques
+                      Auto table walk • table-facing human • upright bridge-hand shot
                     </p>
                   </div>
                   <span className="rounded-full border border-amber-200/40 bg-amber-200/15 px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] text-amber-100">
-                    First
+                    Auto
                   </span>
                 </div>
-                <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  {POOL_ROYALE_SHOOTING_POSITION_OPTIONS.map((option) => {
-                    const active = option.id === shootingPositionId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setShootingPositionId(option.id)}
-                        aria-pressed={active}
-                        className={`rounded-2xl border px-3 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 ${
-                          active
-                            ? 'border-amber-200 bg-amber-300 text-black shadow-[0_0_18px_rgba(251,191,36,0.5)]'
-                            : 'border-white/15 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="block text-[10px] font-black uppercase tracking-[0.2em]">
-                          {option.menuLabel || option.label}
-                        </span>
-                        <span className={`mt-1 block text-[9px] font-semibold uppercase tracking-[0.12em] ${active ? 'text-black/70' : 'text-white/50'}`}>
-                          {option.sourceNote}
-                        </span>
-                        <span className={`mt-1 block text-[8px] font-black uppercase tracking-[0.16em] ${active ? 'text-black/60' : 'text-amber-100/60'}`}>
-                          {(option.stanceSide || 'auto')} side • {(option.bendDirectionLabel || option.shotType || 'standard')} bend
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
+                <p className="mt-3 text-[11px] font-semibold leading-relaxed text-amber-50/75">
+                  The old 10 shooting-position buttons were removed. The player now walks around the table automatically, keeps facing the table, stands upright with both feet grounded, holds the cue in the right hand, and places the left bridge hand on the cloth toward the cue ball.
+                </p>
               </div>
               <div className="rounded-3xl border border-emerald-300/30 bg-white/[0.05] p-3">
                 <div className="flex items-center justify-between gap-3">

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -248,6 +248,7 @@ const BASE_CFG = {
   shootUpperBodyCounterLean: 1,
   shootForwardBendScale: 1,
   plantFeetDuringShot: true,
+  standingShotStance: false,
   bridgeArmStraightDown: false,
   forceTableFacingAim: true,
   showDebugArrows: true,
@@ -1134,31 +1135,31 @@ function updateOriginalSkeletonHumanPose(human, dt, frameData) {
     .addScaledVector(side, -0.012 * cfg.unit * t)
     .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
     .addScaledVector(UP, -0.01 * cfg.unit * human.settleT);
-  const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);
+  const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, handPoseT);
   const cueDirForHand = frameData.cueTip.clone().sub(frameData.cueBack).normalize();
-  const handIk = easeInOut(clamp01(t));
+  const handIk = easeInOut(clamp01(handPoseT));
   const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
   const idleGripUp = UP.clone().multiplyScalar(-1.0).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
   const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
   const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
   const lockedRightElbow = rightShoulder.clone()
-    .addScaledVector(UP, lerp(0.04 * cfg.unit, cfg.rightElbowShotRise, t))
-    .addScaledVector(side, lerp(-0.18 * cfg.unit, cfg.rightElbowShotSide, t))
-    .addScaledVector(forward, lerp(-0.04 * cfg.unit, cfg.rightElbowShotBack, t));
+    .addScaledVector(UP, lerp(0.04 * cfg.unit, cfg.rightElbowShotRise, handPoseT))
+    .addScaledVector(side, lerp(-0.18 * cfg.unit, cfg.rightElbowShotSide, handPoseT))
+    .addScaledVector(forward, lerp(-0.04 * cfg.unit, cfg.rightElbowShotBack, handPoseT));
   const pullBack = activeState === 'dragging' ? -cfg.rightStrokePull * easeOutCubic(frameData.power || 0) : 0;
   const pushForward = activeState === 'striking' ? cfg.rightStrokePush * strikeFollow : 0;
   const smallPractice = activeState === 'dragging' ? dragStroke * 0.035 * cfg.unit : 0;
   const forearmStroke = pullBack + pushForward + smallPractice;
   const forearmBase = lockedRightElbow.clone()
-    .addScaledVector(side, cfg.rightForearmOutward * t)
-    .addScaledVector(UP, -cfg.rightForearmDown * t)
-    .addScaledVector(UP, cfg.rightHandShotLift * t)
-    .addScaledVector(forward, -cfg.rightForearmBack * t)
+    .addScaledVector(side, cfg.rightForearmOutward * handPoseT)
+    .addScaledVector(UP, -cfg.rightForearmDown * handPoseT)
+    .addScaledVector(UP, cfg.rightHandShotLift * handPoseT)
+    .addScaledVector(forward, -cfg.rightForearmBack * handPoseT)
     .addScaledVector(cueDirForHand, cfg.rightForearmLength);
   const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
   const idleWristTarget = frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal));
   const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - cfg.rightHandDownPose, handIk), cfg.rightHandCueSocketLocal));
-  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, handPoseT);
   const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * cfg.unit * t).addScaledVector(side, -0.044 * cfg.unit * t).addScaledVector(forward, 0.065 * cfg.unit * t);
   const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * cfg.unit * t).addScaledVector(side, -0.012 * cfg.unit * t);
   const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * cfg.unit * t).addScaledVector(side, 0.014 * cfg.unit * t);
@@ -1287,6 +1288,10 @@ export function updateHumanPose(human, dt, frameData) {
     ? Math.max(0, cfg.shootForwardBendScale)
     : 1;
   const plantFeetDuringShot = cfg.plantFeetDuringShot !== false;
+  const standingShotStance = cfg.standingShotStance === true;
+  const bodyPoseT = standingShotStance ? 0 : t;
+  const footPoseT = standingShotStance ? 0 : t;
+  const handPoseT = t;
   const shotBendZ = (value) => Math.abs(value) * bendDirection * forwardBendScale * poseProfile.lean;
   const shotCounterLeanX = (value) => (value + (poseProfile.hipSide || 0) * t) * counterLeanSide * upperBodyCounterLean;
   const rootWorld = human.root.position.clone();
@@ -1296,12 +1301,12 @@ export function updateHumanPose(human, dt, frameData) {
   // Real pool stance: feet/hips stay grounded and carry the weight; the fold is
   // from the belly upward, lowering the head toward the cue line without pushing
   // the entire body backward or off the floor.
-  const torso = local(new THREE.Vector3(shotCounterLeanX(0.012 * t) * cfg.unit, lerp(1.3, 1.16, t) * cfg.unit + breath, shotBendZ(lerp(0.01, -0.12, t) - 0.008 * powerLean) * cfg.unit));
-  const chest = local(new THREE.Vector3(shotCounterLeanX(0.038 * t + 0.006 * powerLean) * cfg.unit, lerp(1.52, 1.25, t) * cfg.unit + breath, shotBendZ(lerp(0.015, -0.36, t) - 0.014 * powerLean) * cfg.unit));
-  const neck = local(new THREE.Vector3(shotCounterLeanX(0.055 * t + 0.008 * powerLean) * cfg.unit, lerp(1.68, 1.32, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.52, t) - 0.016 * powerLean) * cfg.unit));
-  const head = local(new THREE.Vector3(shotCounterLeanX(0.066 * t + 0.01 * powerLean) * cfg.unit, lerp(1.84, 1.39, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.42 * t, shotBendZ(lerp(0.03, -0.62, t) - 0.018 * powerLean) * cfg.unit));
-  const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.048 * t)) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.43, t) - 0.012 * human.settleT) * cfg.unit));
-  const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.034 * t)) * cfg.unit, lerp(1.58, 1.34, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.36, t) - 0.012 * human.settleT) * cfg.unit));
+  const torso = local(new THREE.Vector3(shotCounterLeanX(0.012 * bodyPoseT) * cfg.unit, lerp(1.3, 1.16, bodyPoseT) * cfg.unit + breath, shotBendZ(lerp(0.01, -0.12, bodyPoseT) - 0.008 * powerLean) * cfg.unit));
+  const chest = local(new THREE.Vector3(shotCounterLeanX(0.038 * bodyPoseT + 0.006 * powerLean) * cfg.unit, lerp(1.52, 1.25, bodyPoseT) * cfg.unit + breath, shotBendZ(lerp(0.015, -0.36, bodyPoseT) - 0.014 * powerLean) * cfg.unit));
+  const neck = local(new THREE.Vector3(shotCounterLeanX(0.055 * bodyPoseT + 0.008 * powerLean) * cfg.unit, lerp(1.68, 1.32, bodyPoseT) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.52, bodyPoseT) - 0.016 * powerLean) * cfg.unit));
+  const head = local(new THREE.Vector3(shotCounterLeanX(0.066 * bodyPoseT + 0.01 * powerLean) * cfg.unit, lerp(1.84, 1.39, bodyPoseT) * cfg.unit + breath - cfg.chinToCueHeight * 0.42 * bodyPoseT, shotBendZ(lerp(0.03, -0.62, bodyPoseT) - 0.018 * powerLean) * cfg.unit));
+  const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.048 * bodyPoseT)) * cfg.unit, lerp(1.58, 1.34, bodyPoseT) * cfg.unit + breath, shotBendZ(lerp(0, -0.43, bodyPoseT) - 0.012 * human.settleT) * cfg.unit));
+  const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.034 * bodyPoseT)) * cfg.unit, lerp(1.58, 1.34, bodyPoseT) * cfg.unit + breath, shotBendZ(lerp(0, -0.36, bodyPoseT) - 0.012 * human.settleT) * cfg.unit));
   const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
   const footWalkBlend = plantFeetDuringShot ? idle : 1;
@@ -1320,61 +1325,61 @@ export function updateHumanPose(human, dt, frameData) {
     -0.13 * cfg.unit,
     cfg.footGroundY,
     0.03 * cfg.unit + walk * 0.018 * cfg.unit * footWalkBlend
-  ).lerp(plantedLeftFootLocal, t));
+  ).lerp(plantedLeftFootLocal, footPoseT));
   const rightFoot = local(new THREE.Vector3(
     0.13 * cfg.unit,
     cfg.footGroundY,
     -0.03 * cfg.unit - walk * 0.018 * cfg.unit * footWalkBlend
-  ).lerp(plantedRightFootLocal, t));
+  ).lerp(plantedRightFootLocal, footPoseT));
 
   const bridgePalmSide = (cfg.bridgePoseUsesConfiguredSide
     ? cfg.bridgeHandSide
     : -0.012 * cfg.unit) + (poseProfile.bridgeSide || 0) * cfg.unit;
   const bridgePalmTarget = frameData.bridgeTarget.clone()
-    .addScaledVector(forward, (-0.006 + poseProfile.bridgeReach) * cfg.unit * t)
-    .addScaledVector(side, bridgePalmSide * t)
+    .addScaledVector(forward, (-0.006 + poseProfile.bridgeReach) * cfg.unit * handPoseT)
+    .addScaledVector(side, bridgePalmSide * handPoseT)
     .setY(cfg.tableTopY + cfg.bridgePalmTableLift + poseProfile.bridgeLift * cfg.unit)
     .addScaledVector(UP, -0.01 * cfg.unit * human.settleT);
-  const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);
+  const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, handPoseT);
   const cueDirForHand = frameData.cueTip.clone().sub(frameData.cueBack).normalize();
-  const handIk = easeInOut(clamp01(t));
+  const handIk = easeInOut(clamp01(handPoseT));
   const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
   const idleGripUp = UP.clone().multiplyScalar(-1.0).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
   const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
   const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
   const lockedRightElbow = rightShoulder.clone()
-    .addScaledVector(UP, lerp(0.04 * cfg.unit, cfg.rightElbowShotRise, t))
-    .addScaledVector(side, lerp(-0.18 * cfg.unit, cfg.rightElbowShotSide, t))
-    .addScaledVector(forward, lerp(-0.04 * cfg.unit, cfg.rightElbowShotBack, t));
+    .addScaledVector(UP, lerp(0.04 * cfg.unit, cfg.rightElbowShotRise, handPoseT))
+    .addScaledVector(side, lerp(-0.18 * cfg.unit, cfg.rightElbowShotSide, handPoseT))
+    .addScaledVector(forward, lerp(-0.04 * cfg.unit, cfg.rightElbowShotBack, handPoseT));
   const pullBack = activeState === 'dragging' ? -(cfg.rightStrokePull + poseProfile.gripBack * cfg.unit) * easeOutCubic(frameData.power || 0) : 0;
   const pushForward = activeState === 'striking' ? cfg.rightStrokePush * poseProfile.followScale * strikeFollow : 0;
   const smallPractice = activeState === 'dragging' ? dragStroke * 0.035 * cfg.unit : 0;
   const forearmStroke = pullBack + pushForward + smallPractice;
   const forearmBase = lockedRightElbow.clone()
-    .addScaledVector(side, cfg.rightForearmOutward * t)
-    .addScaledVector(UP, -cfg.rightForearmDown * t)
-    .addScaledVector(UP, cfg.rightHandShotLift * t)
-    .addScaledVector(forward, -cfg.rightForearmBack * t)
+    .addScaledVector(side, cfg.rightForearmOutward * handPoseT)
+    .addScaledVector(UP, -cfg.rightForearmDown * handPoseT)
+    .addScaledVector(UP, cfg.rightHandShotLift * handPoseT)
+    .addScaledVector(forward, -cfg.rightForearmBack * handPoseT)
     .addScaledVector(cueDirForHand, cfg.rightForearmLength);
   const liveCueGripPoint = forearmBase.clone()
-    .addScaledVector(cueDirForHand, forearmStroke + poseProfile.gripBack * cfg.unit * t)
-    .addScaledVector(UP, poseProfile.cueLift * cfg.unit * t);
-  if (frameData.gripTarget) liveCueGripPoint.lerp(frameData.gripTarget, 0.72 * t);
+    .addScaledVector(cueDirForHand, forearmStroke + poseProfile.gripBack * cfg.unit * handPoseT)
+    .addScaledVector(UP, poseProfile.cueLift * cfg.unit * handPoseT);
+  if (frameData.gripTarget) liveCueGripPoint.lerp(frameData.gripTarget, 0.72 * handPoseT);
   const idleWristTarget = frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal));
   const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - cfg.rightHandDownPose, handIk), cfg.rightHandCueSocketLocal));
-  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, handPoseT);
   const bridgeArmDownElbow = leftHand.clone()
     .addScaledVector(UP, 0.39 * cfg.unit)
     .addScaledVector(side, -0.01 * cfg.unit)
     .addScaledVector(forward, 0.012 * cfg.unit);
   const extendedBridgeElbow = leftShoulder.clone()
     .lerp(leftHand, 0.58)
-    .addScaledVector(UP, -0.035 * cfg.unit * t)
-    .addScaledVector(side, -0.028 * cfg.unit * t)
-    .addScaledVector(forward, -0.055 * cfg.unit * t);
-  const leftElbow = extendedBridgeElbow.lerp(bridgeArmDownElbow, cfg.bridgeArmStraightDown ? t : 0);
-  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * cfg.unit * t).addScaledVector(side, -0.012 * cfg.unit * t);
-  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot * 1.02, t)).addScaledVector(forward, -0.03 * cfg.unit * t).addScaledVector(side, 0.014 * cfg.unit * t);
+    .addScaledVector(UP, -0.035 * cfg.unit * handPoseT)
+    .addScaledVector(side, -0.028 * cfg.unit * handPoseT)
+    .addScaledVector(forward, -0.055 * cfg.unit * handPoseT);
+  const leftElbow = extendedBridgeElbow.lerp(bridgeArmDownElbow, cfg.bridgeArmStraightDown ? handPoseT : 0);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot, footPoseT)).addScaledVector(forward, 0.04 * cfg.unit * footPoseT).addScaledVector(side, -0.012 * cfg.unit * footPoseT);
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot * 1.02, footPoseT)).addScaledVector(forward, -0.03 * cfg.unit * footPoseT).addScaledVector(side, 0.014 * cfg.unit * footPoseT);
 
   human.root.visible = true;
   driveHuman(human, {


### PR DESCRIPTION
### Motivation
- Simplify and modernize shooter behavior by removing the legacy 10 preset shooting positions and replace them with an automatic table-facing, standing-shot workflow that keeps the avatar facing the table and standing with feet planted.
- Make the human rig behave consistently while walking around the table perimeter and during shots so the bridge hand is placed on the cloth toward the cue ball and the right hand holds the cue.

### Description
- Replaced `POOL_ROYALE_SHOOTING_POSITION_OPTIONS` (10 presets) with a single `automatic-standing-table-facing` profile and removed the selectable buttons from the config UI, replacing them with an explanatory summary. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Set the default shooting position id to the new automatic profile and stopped exposing the old `setShootingPositionId` UI flow. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Routed shooter placement to use `chooseBilardoHumanEdgePosition` around the table perimeter and compute a table-facing `poseForward` so the avatar consistently faces the table/cue while walking and when arriving at the shot position. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Added `standingShotStance` flag to the rig config and introduced separate pose blend scalars (`bodyPoseT`, `footPoseT`, `handPoseT`) so the torso/feet can remain upright while hands still perform bridge/grip movement, and updated numerous IK/pose interpolations to use these pose blends. (`webapp/src/pages/Games/shared/humanRigCore.js`)
- Passed a `tableCenter` into `updateBilardoHumanPose` and adjusted behavior merging so the standing/automatic logic integrates with the existing perimeter-walk and chair/idle behavior. (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/pages/Games/shared/humanRigCore.js`)

### Testing
- Built the webapp bundle with `npm --prefix webapp run build` and the production build completed successfully (Vite build passed and assets emitted). (success)
- Attempted an automated Playwright screenshot of the `/games/poolroyale` route after installing Playwright and `npx playwright install` plus `npx playwright install-deps chromium`, however the full headless browser route did not produce a reliable capture in this container due to runtime environment/network errors (certificate and resource loading failures), so the screenshot attempt did not complete successfully (partial / failed).
- No unit tests were changed; existing test suite was not run as part of this change beyond the build verification step. (build-only)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05501b83b88329a3852e3afa334ed0)