### PR TITLE
Fix Pool Royale shooter table-facing pose

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2437,7 +2437,7 @@ const POOL_ROYALE_HUMAN_LOGIC_PROFILES = Object.freeze({
     label: 'Classic Pro',
     summary: 'Original ReadyPlayer skeleton logic: table-edge stance, low cloth bridge, fixed cue grip, and classic follow-through.',
     bendMode: 'forward',
-    originalSkeletonLogic: true,
+    originalSkeletonLogic: false,
     desiredShootDistance: 1.25,
     edgeMargin: 0.68,
     stanceWidth: 0.52,
@@ -27110,7 +27110,7 @@ const shotPowerRef = useRef(0);
             // original rig forward axis, so the fallback bend sign folds belly/chest/head
             // toward the cue ball instead of bending the whole body backward.
             shootBendDirection: -1,
-            shootBendTowardCueStick: !behavior.originalSkeletonLogic,
+            shootBendTowardCueStick: true,
             shootBendMode: behavior.bendMode || 'forward',
             shootCounterLeanSide: behavior.shootCounterLeanSide ?? -1,
             shootUpperBodyCounterLean: behavior.shootUpperBodyCounterLean,
@@ -27118,7 +27118,7 @@ const shotPowerRef = useRef(0);
             standingShotStance: Boolean(behavior.standingShotStance),
             plantFeetDuringShot: true,
             bridgeArmStraightDown: false,
-            forceTableFacingAim: !behavior.originalSkeletonLogic,
+            forceTableFacingAim: true,
             addFaceDetails: false,
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,


### PR DESCRIPTION
### Motivation
- Pool Royale human avatar was using the legacy original-skeleton logic and could fold/point the bridge hand away from the table; the goal is to keep the shooter facing the table and place the bridge hand toward the cue ball during aiming.

### Description
- Changed the default `rpm-current` human profile to disable the legacy `originalSkeletonLogic` so the shared table-facing pose solver is used (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Forced table-facing shot behavior when creating the human rig by setting `shootBendTowardCueStick: true` and `forceTableFacingAim: true` in the `createBilardoHumanRig` options in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build output, no build errors). 
- Ran `git diff --check` (no whitespace or diff-check issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05560d5a1c8329a8a0c751f31ede91)