### PR TITLE
Refactor table tennis game into modular Three.js architecture

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import ChessBattleRoyaleStore from './ChessBattleRoyaleStore';
+import { UIOverlay } from './table-tennis/UIOverlay';
 
 export function App() {
-  return <ChessBattleRoyaleStore />;
+  return <UIOverlay />;
 }

--- a/frontend/src/table-tennis/AIController.ts
+++ b/frontend/src/table-tennis/AIController.ts
@@ -1,0 +1,50 @@
+import * as THREE from 'three';
+import { BallPhysics } from './BallPhysics';
+import { GAME_CONFIG, ShotType } from './gameConfig';
+
+export class AIController {
+  readonly targetX = { value: 0 };
+  currentShot: ShotType = 'forehand drive';
+  private reactionTimer = 0;
+  private committedLanding: THREE.Vector3 | null = null;
+
+  constructor(private root: THREE.Group, private hand: THREE.Object3D, private paddle: THREE.Object3D) {}
+
+  update(dt: number, ball: BallPhysics) {
+    const cfg = GAME_CONFIG.ai.difficulty;
+    this.reactionTimer -= dt;
+    if (this.reactionTimer <= 0) {
+      this.committedLanding = ball.predictLandingPoint('ai');
+      if (this.committedLanding) {
+        const noise = (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(0.55);
+        this.targetX.value = THREE.MathUtils.clamp(this.committedLanding.x + noise, GAME_CONFIG.ai.minX, GAME_CONFIG.ai.maxX);
+      }
+      this.reactionTimer = cfg.reactionTime;
+    }
+
+    this.root.position.x = THREE.MathUtils.damp(this.root.position.x, this.targetX.value, cfg.moveSpeed, dt);
+    this.root.position.z = GAME_CONFIG.ai.z;
+    this.currentShot = ball.position.x > this.root.position.x ? 'forehand drive' : 'backhand drive';
+    const yaw = THREE.MathUtils.clamp((ball.position.x - this.root.position.x) * 0.4, -0.5, 0.5);
+    this.root.rotation.y = Math.PI + yaw;
+    this.hand.position.set(this.currentShot === 'forehand drive' ? -0.16 : 0.16, 0.92, -0.28);
+    this.paddle.position.set(0, -0.02, -0.12);
+    this.paddle.rotation.set(-0.25, 0, this.currentShot === 'forehand drive' ? -0.16 : 0.16);
+  }
+
+  canReach(ballPosition: THREE.Vector3) {
+    return Math.abs(ballPosition.x - this.root.position.x) <= GAME_CONFIG.ai.maxReach && ballPosition.z < -1.18 && ballPosition.z > -2.45;
+  }
+
+  shouldMiss() {
+    return Math.random() < GAME_CONFIG.ai.difficulty.mistakeChance;
+  }
+
+  getPaddleWorldPosition() {
+    return this.paddle.getWorldPosition(new THREE.Vector3());
+  }
+
+  getPaddleForward() {
+    return new THREE.Vector3(0, 0, 1).applyQuaternion(this.paddle.getWorldQuaternion(new THREE.Quaternion())).normalize();
+  }
+}

--- a/frontend/src/table-tennis/BallPhysics.ts
+++ b/frontend/src/table-tennis/BallPhysics.ts
@@ -1,0 +1,187 @@
+import * as THREE from 'three';
+import { GAME_CONFIG, NET_BOUNDS, Side, TABLE_BOUNDS } from './gameConfig';
+
+export type BallStateName =
+  | 'idle'
+  | 'serve'
+  | 'flying'
+  | 'tableBouncePlayer'
+  | 'tableBounceAI'
+  | 'paddleHitPlayer'
+  | 'paddleHitAI'
+  | 'netHit'
+  | 'out'
+  | 'pointEnded';
+
+export interface BallSnapshot {
+  position: THREE.Vector3;
+  velocity: THREE.Vector3;
+  spin: THREE.Vector3;
+  state: BallStateName;
+  bounces: Record<Side, number>;
+  lastTouch: Side | null;
+}
+
+export interface BallEvent {
+  type: 'bounce' | 'net' | 'out';
+  side?: Side;
+  position: THREE.Vector3;
+  state: BallStateName;
+}
+
+const tmp = new THREE.Vector3();
+
+export class BallPhysics {
+  readonly position = new THREE.Vector3();
+  readonly velocity = new THREE.Vector3();
+  readonly spin = new THREE.Vector3();
+  state: BallStateName = 'idle';
+  lastTouch: Side | null = null;
+  bounces: Record<Side, number> = { player: 0, ai: 0 };
+  private accumulator = 0;
+
+  resetForServe(server: Side) {
+    this.position.set(server === 'player' ? -0.16 : 0.16, GAME_CONFIG.table.topY + GAME_CONFIG.serveHeight, server === 'player' ? 1.08 : -1.08);
+    this.velocity.set(0, 0, 0);
+    this.spin.set(0, 0, 0);
+    this.lastTouch = server;
+    this.bounces = { player: 0, ai: 0 };
+    this.state = 'serve';
+    this.accumulator = 0;
+  }
+
+  serve(server: Side) {
+    this.resetBouncesAfterHit(server);
+    this.velocity.set(server === 'player' ? 0.08 : -0.08, 1.25, server === 'player' ? -2.9 : 2.9);
+    this.spin.set(server === 'player' ? 0.2 : -0.2, 0, server === 'player' ? -1.2 : 1.2);
+    this.state = 'flying';
+  }
+
+  applyPaddleHit(side: Side, velocity: THREE.Vector3, spin: THREE.Vector3) {
+    this.velocity.copy(velocity);
+    this.spin.copy(spin);
+    this.lastTouch = side;
+    this.resetBouncesAfterHit(side);
+    this.state = side === 'player' ? 'paddleHitPlayer' : 'paddleHitAI';
+  }
+
+  update(deltaSeconds: number): BallEvent[] {
+    const events: BallEvent[] = [];
+    this.accumulator += Math.min(deltaSeconds, 0.05);
+    while (this.accumulator >= GAME_CONFIG.fixedDt) {
+      events.push(...this.step(GAME_CONFIG.fixedDt));
+      this.accumulator -= GAME_CONFIG.fixedDt;
+    }
+    return events;
+  }
+
+  private step(dt: number): BallEvent[] {
+    if (this.state === 'idle' || this.state === 'serve' || this.state === 'pointEnded') return [];
+
+    const events: BallEvent[] = [];
+    const previous = this.position.clone();
+    const acceleration = tmp.set(this.spin.z * GAME_CONFIG.spinCurve, GAME_CONFIG.gravity, -this.spin.x * GAME_CONFIG.spinCurve);
+    this.velocity.addScaledVector(acceleration, dt);
+    this.velocity.multiplyScalar(1 - GAME_CONFIG.drag * dt);
+    this.position.addScaledVector(this.velocity, dt);
+
+    const tableEvent = this.resolveTableCollision(previous);
+    if (tableEvent) events.push(tableEvent);
+
+    const netEvent = this.resolveNetCollision(previous);
+    if (netEvent) events.push(netEvent);
+
+    if (this.isClearlyOut()) {
+      this.state = 'out';
+      events.push({ type: 'out', position: this.position.clone(), state: this.state });
+    } else if (this.state !== 'netHit' && this.state !== 'out') {
+      this.state = 'flying';
+    }
+
+    return events;
+  }
+
+  private resolveTableCollision(previous: THREE.Vector3): BallEvent | null {
+    const top = GAME_CONFIG.table.topY + GAME_CONFIG.ballRadius;
+    const crossedTop = previous.y >= top && this.position.y <= top;
+    if (!crossedTop || this.velocity.y >= 0) return null;
+
+    const t = (previous.y - top) / Math.max(previous.y - this.position.y, 0.0001);
+    const xAtImpact = THREE.MathUtils.lerp(previous.x, this.position.x, t);
+    const zAtImpact = THREE.MathUtils.lerp(previous.z, this.position.z, t);
+    const inside = xAtImpact >= TABLE_BOUNDS.minX && xAtImpact <= TABLE_BOUNDS.maxX && zAtImpact >= TABLE_BOUNDS.minZ && zAtImpact <= TABLE_BOUNDS.maxZ;
+    if (!inside) return null;
+
+    this.position.set(xAtImpact, top, zAtImpact);
+    this.velocity.y = Math.abs(this.velocity.y) * 0.88;
+    this.velocity.x += this.spin.z * 0.018;
+    this.velocity.z -= this.spin.x * 0.018;
+    this.spin.multiplyScalar(0.84);
+
+    const side: Side = zAtImpact > 0 ? 'player' : 'ai';
+    this.bounces[side] += 1;
+    this.state = side === 'player' ? 'tableBouncePlayer' : 'tableBounceAI';
+    return { type: 'bounce', side, position: this.position.clone(), state: this.state };
+  }
+
+  private resolveNetCollision(previous: THREE.Vector3): BallEvent | null {
+    const radius = GAME_CONFIG.ballRadius;
+    const crossesNet = (previous.z - NET_BOUNDS.minZ) * (this.position.z - NET_BOUNDS.minZ) <= 0 || (previous.z - NET_BOUNDS.maxZ) * (this.position.z - NET_BOUNDS.maxZ) <= 0;
+    const insideX = this.position.x + radius >= NET_BOUNDS.minX && this.position.x - radius <= NET_BOUNDS.maxX;
+    const insideY = this.position.y - radius <= NET_BOUNDS.maxY && this.position.y + radius >= NET_BOUNDS.minY;
+    const insideZ = this.position.z + radius >= NET_BOUNDS.minZ && this.position.z - radius <= NET_BOUNDS.maxZ;
+    if (!crossesNet || !insideX || !insideY || !insideZ) return null;
+
+    this.position.z = previous.z > 0 ? NET_BOUNDS.maxZ + radius : NET_BOUNDS.minZ - radius;
+    this.velocity.z *= -0.42;
+    this.velocity.y = Math.max(this.velocity.y, 0.35);
+    this.spin.multiplyScalar(0.55);
+    this.state = 'netHit';
+    return { type: 'net', position: this.position.clone(), state: this.state };
+  }
+
+  private isClearlyOut() {
+    const margin = 0.44;
+    return this.position.y < GAME_CONFIG.table.topY - 0.42 || Math.abs(this.position.x) > TABLE_BOUNDS.maxX + margin || Math.abs(this.position.z) > TABLE_BOUNDS.maxZ + 1.0;
+  }
+
+  private resetBouncesAfterHit(side: Side) {
+    this.lastTouch = side;
+    this.bounces = { player: 0, ai: 0 };
+  }
+
+  predictLandingPoint(targetSide?: Side): THREE.Vector3 | null {
+    const simPos = this.position.clone();
+    const simVel = this.velocity.clone();
+    const simSpin = this.spin.clone();
+    const top = GAME_CONFIG.table.topY + GAME_CONFIG.ballRadius;
+
+    for (let i = 0; i < 240; i += 1) {
+      const prev = simPos.clone();
+      simVel.addScaledVector(new THREE.Vector3(simSpin.z * GAME_CONFIG.spinCurve, GAME_CONFIG.gravity, -simSpin.x * GAME_CONFIG.spinCurve), GAME_CONFIG.fixedDt);
+      simVel.multiplyScalar(1 - GAME_CONFIG.drag * GAME_CONFIG.fixedDt);
+      simPos.addScaledVector(simVel, GAME_CONFIG.fixedDt);
+      if (prev.y >= top && simPos.y <= top && simVel.y < 0) {
+        const t = (prev.y - top) / Math.max(prev.y - simPos.y, 0.0001);
+        const x = THREE.MathUtils.lerp(prev.x, simPos.x, t);
+        const z = THREE.MathUtils.lerp(prev.z, simPos.z, t);
+        const side: Side = z > 0 ? 'player' : 'ai';
+        if (x >= TABLE_BOUNDS.minX && x <= TABLE_BOUNDS.maxX && z >= TABLE_BOUNDS.minZ && z <= TABLE_BOUNDS.maxZ && (!targetSide || side === targetSide)) {
+          return new THREE.Vector3(x, top, z);
+        }
+      }
+    }
+    return null;
+  }
+
+  snapshot(): BallSnapshot {
+    return {
+      position: this.position.clone(),
+      velocity: this.velocity.clone(),
+      spin: this.spin.clone(),
+      state: this.state,
+      bounces: { ...this.bounces },
+      lastTouch: this.lastTouch,
+    };
+  }
+}

--- a/frontend/src/table-tennis/CameraController.ts
+++ b/frontend/src/table-tennis/CameraController.ts
@@ -1,0 +1,20 @@
+import * as THREE from 'three';
+import { GAME_CONFIG } from './gameConfig';
+
+export class CameraController {
+  private desired = new THREE.Vector3();
+  private target = new THREE.Vector3();
+
+  constructor(private camera: THREE.PerspectiveCamera) {
+    this.camera.position.copy(GAME_CONFIG.camera.position);
+  }
+
+  update(dt: number, ballPosition: THREE.Vector3, playerPosition: THREE.Vector3) {
+    const nearPlayer = ballPosition.z > 0.85;
+    const lateralOffset = nearPlayer ? THREE.MathUtils.clamp((ballPosition.x - playerPosition.x) * 0.55, -0.32, 0.32) : 0;
+    this.desired.set(lateralOffset, GAME_CONFIG.camera.position.y + (nearPlayer ? 0.18 : 0), GAME_CONFIG.camera.position.z);
+    this.target.set(ballPosition.x * 0.14, GAME_CONFIG.camera.target.y + ballPosition.y * 0.08, GAME_CONFIG.camera.target.z);
+    this.camera.position.lerp(this.desired, 1 - Math.exp(-GAME_CONFIG.camera.damping * dt));
+    this.camera.lookAt(this.target);
+  }
+}

--- a/frontend/src/table-tennis/GameManager.ts
+++ b/frontend/src/table-tennis/GameManager.ts
@@ -1,0 +1,313 @@
+import * as THREE from 'three';
+import { AIController } from './AIController';
+import { BallPhysics } from './BallPhysics';
+import { CameraController } from './CameraController';
+import { GAME_CONFIG, ShotType } from './gameConfig';
+import { PaddleHitDetector } from './PaddleHitDetector';
+import { PlayerController } from './PlayerController';
+import { ReplayManager } from './ReplayManager';
+import { ScoreManager } from './ScoreManager';
+
+export interface GameHudState {
+  playerScore: number;
+  aiScore: number;
+  server: string;
+  lastShot: string;
+  lastReason: string;
+  replaying: boolean;
+  debug: {
+    ballState: string;
+    bounces: string;
+    hitValidity: string;
+    predictedLanding: string;
+  };
+}
+
+export class GameManager {
+  readonly scene = new THREE.Scene();
+  readonly camera: THREE.PerspectiveCamera;
+  readonly renderer: THREE.WebGLRenderer;
+  readonly ball = new BallPhysics();
+  readonly score = new ScoreManager();
+  readonly replay = new ReplayManager();
+  private readonly hitDetector = new PaddleHitDetector();
+  private readonly cameraController: CameraController;
+  private readonly player: PlayerController;
+  private readonly ai: AIController;
+  private readonly clock = new THREE.Clock();
+  private readonly ballMesh: THREE.Mesh;
+  private readonly predictedMarker: THREE.Mesh;
+  private animationId = 0;
+  private rallyTime = 0;
+  private pointResetTimer = 0;
+  private lastShot = '';
+  private lastHitValidity = 'waiting';
+  private onHud?: (hud: GameHudState) => void;
+
+  constructor(private mount: HTMLElement) {
+    this.camera = new THREE.PerspectiveCamera(48, mount.clientWidth / mount.clientHeight, 0.1, 100);
+    this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.setSize(mount.clientWidth, mount.clientHeight);
+    this.renderer.shadowMap.enabled = true;
+    this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    mount.appendChild(this.renderer.domElement);
+
+    this.scene.background = new THREE.Color('#07162e');
+    this.scene.fog = new THREE.Fog('#07162e', 5.5, 9.5);
+    this.cameraController = new CameraController(this.camera);
+    this.createLights();
+    this.createTable();
+    const playerVisuals = this.createAvatar('player');
+    const aiVisuals = this.createAvatar('ai');
+    this.player = new PlayerController(playerVisuals);
+    this.ai = new AIController(aiVisuals.root, aiVisuals.hand, aiVisuals.paddle);
+    this.ballMesh = this.createBall();
+    this.predictedMarker = this.createPredictionMarker();
+    this.resetPoint();
+  }
+
+  start(onHud: (hud: GameHudState) => void) {
+    this.onHud = onHud;
+    this.clock.start();
+    const loop = () => {
+      this.animationId = requestAnimationFrame(loop);
+      this.update(Math.min(this.clock.getDelta(), 0.05));
+    };
+    loop();
+  }
+
+  dispose() {
+    cancelAnimationFrame(this.animationId);
+    this.renderer.dispose();
+    this.mount.removeChild(this.renderer.domElement);
+  }
+
+  setPointer(normalizedX: number) {
+    if (!this.replay.isReplaying) this.player.setInput(normalizedX);
+  }
+
+  replayLastRally() {
+    this.replay.beginReplay();
+  }
+
+  resetMatch() {
+    this.score.resetMatch();
+    this.resetPoint();
+  }
+
+  private update(dt: number) {
+    if (this.replay.isReplaying) {
+      const replayBall = this.replay.update(dt);
+      if (replayBall) this.ballMesh.position.copy(replayBall);
+      this.cameraController.update(dt, this.ballMesh.position, new THREE.Vector3(0, 0, GAME_CONFIG.player.z));
+      this.renderer.render(this.scene, this.camera);
+      this.emitHud();
+      return;
+    }
+
+    this.rallyTime += dt;
+    this.player.update(dt, this.ball.position);
+    this.ai.update(dt, this.ball);
+
+    if (this.ball.state === 'serve') this.ball.serve(this.score.state.server);
+    const events = this.ball.update(dt);
+    events.filter((event) => event.type === 'bounce').forEach((event) => this.replay.recordBounce(this.rallyTime, event.side, event.position));
+
+    this.tryPlayerHit();
+    this.tryAiHit();
+
+    const pointWinner = this.score.evaluate(events, this.ball);
+    if (pointWinner) {
+      this.replay.recordScore(this.rallyTime, pointWinner, { player: this.score.state.player, ai: this.score.state.ai }, this.score.state.lastReason);
+      this.pointResetTimer = 1.35;
+    }
+
+    if (this.ball.state === 'pointEnded') {
+      this.pointResetTimer -= dt;
+      if (this.pointResetTimer <= 0 && !this.score.state.winner) this.resetPoint();
+    }
+
+    this.ballMesh.position.copy(this.ball.position);
+    this.updatePredictionMarker();
+    this.replay.recordBall(this.rallyTime, this.ball.position, this.ball.state);
+    this.cameraController.update(dt, this.ball.position, new THREE.Vector3(this.playerPositionX(), 0, GAME_CONFIG.player.z));
+    this.renderer.render(this.scene, this.camera);
+    this.emitHud();
+  }
+
+  private tryPlayerHit() {
+    if (this.ball.lastTouch === 'player' || this.ball.bounces.player < 1 || this.ball.bounces.player > 1) return;
+    const result = this.hitDetector.detect({
+      side: 'player',
+      paddlePosition: this.player.getPaddleWorldPosition(),
+      paddleForward: this.player.getPaddleForward(),
+      ballPosition: this.ball.position,
+      ballVelocity: this.ball.velocity,
+      ballSpin: this.ball.spin,
+      requestedShot: this.player.currentShot,
+    });
+    this.lastHitValidity = result.valid ? 'valid player hit' : result.reason ?? 'invalid';
+    if (result.valid && result.velocity && result.spin && result.shotType) {
+      this.ball.applyPaddleHit('player', result.velocity, result.spin);
+      this.player.triggerHit();
+      this.lastShot = result.shotType;
+      this.replay.recordHit(this.rallyTime, 'player', result.shotType, this.ball.position);
+    }
+  }
+
+  private tryAiHit() {
+    if (this.ball.lastTouch === 'ai' || this.ball.bounces.ai < 1 || this.ball.bounces.ai > 1 || !this.ai.canReach(this.ball.position) || this.ai.shouldMiss()) return;
+    const shot = this.ai.currentShot as ShotType;
+    const result = this.hitDetector.detect({
+      side: 'ai',
+      paddlePosition: this.ai.getPaddleWorldPosition(),
+      paddleForward: this.ai.getPaddleForward(),
+      ballPosition: this.ball.position,
+      ballVelocity: this.ball.velocity,
+      ballSpin: this.ball.spin,
+      requestedShot: shot,
+      accuracy: GAME_CONFIG.ai.difficulty.accuracy,
+      powerScale: GAME_CONFIG.ai.difficulty.shotPower,
+    });
+    this.lastHitValidity = result.valid ? 'valid AI hit' : result.reason ?? 'invalid';
+    if (result.valid && result.velocity && result.spin && result.shotType) {
+      this.ball.applyPaddleHit('ai', result.velocity, result.spin);
+      this.lastShot = result.shotType;
+      this.replay.recordHit(this.rallyTime, 'ai', result.shotType, this.ball.position);
+    }
+  }
+
+  private resetPoint() {
+    this.rallyTime = 0;
+    this.lastShot = '';
+    this.lastHitValidity = 'waiting';
+    this.replay.startRecording();
+    this.ball.resetForServe(this.score.state.server);
+  }
+
+  private emitHud() {
+    const landing = this.ball.predictLandingPoint();
+    this.onHud?.({
+      playerScore: this.score.state.player,
+      aiScore: this.score.state.ai,
+      server: this.score.state.server === 'player' ? 'YOU' : 'AI',
+      lastShot: this.lastShot,
+      lastReason: this.score.state.lastReason,
+      replaying: this.replay.isReplaying,
+      debug: {
+        ballState: this.ball.state,
+        bounces: `P:${this.ball.bounces.player} AI:${this.ball.bounces.ai}`,
+        hitValidity: this.lastHitValidity,
+        predictedLanding: landing ? `${landing.x.toFixed(2)}, ${landing.z.toFixed(2)}` : 'none',
+      },
+    });
+  }
+
+  private playerPositionX() {
+    return this.player.getPaddleWorldPosition().x;
+  }
+
+  private updatePredictionMarker() {
+    const landing = this.ball.predictLandingPoint();
+    this.predictedMarker.visible = Boolean(landing);
+    if (landing) this.predictedMarker.position.set(landing.x, GAME_CONFIG.table.topY + 0.006, landing.z);
+  }
+
+  private createLights() {
+    this.scene.add(new THREE.HemisphereLight('#dbeafe', '#0f172a', 1.15));
+    const key = new THREE.DirectionalLight('#ffffff', 2.25);
+    key.position.set(2.8, 5.2, 3.4);
+    key.castShadow = true;
+    key.shadow.mapSize.set(1024, 1024);
+    key.shadow.camera.near = 0.5;
+    key.shadow.camera.far = 12;
+    this.scene.add(key);
+  }
+
+  private createTable() {
+    const table = new THREE.Group();
+    const top = new THREE.Mesh(
+      new THREE.BoxGeometry(GAME_CONFIG.table.width, GAME_CONFIG.table.thickness, GAME_CONFIG.table.length),
+      new THREE.MeshStandardMaterial({ color: GAME_CONFIG.table.color, roughness: 0.58, metalness: 0.05 }),
+    );
+    top.position.y = GAME_CONFIG.table.topY - GAME_CONFIG.table.thickness / 2;
+    top.receiveShadow = true;
+    table.add(top);
+
+    const lineMat = new THREE.MeshBasicMaterial({ color: GAME_CONFIG.table.lineColor });
+    const addLine = (w: number, l: number, x: number, z: number) => {
+      const line = new THREE.Mesh(new THREE.BoxGeometry(w, 0.006, l), lineMat);
+      line.position.set(x, GAME_CONFIG.table.topY + 0.004, z);
+      table.add(line);
+    };
+    addLine(GAME_CONFIG.table.width, 0.012, 0, 0);
+    addLine(0.012, GAME_CONFIG.table.length, 0, 0);
+    addLine(GAME_CONFIG.table.width, 0.016, 0, GAME_CONFIG.table.length / 2 - 0.01);
+    addLine(GAME_CONFIG.table.width, 0.016, 0, -GAME_CONFIG.table.length / 2 + 0.01);
+    addLine(0.016, GAME_CONFIG.table.length, GAME_CONFIG.table.width / 2 - 0.01, 0);
+    addLine(0.016, GAME_CONFIG.table.length, -GAME_CONFIG.table.width / 2 + 0.01, 0);
+
+    const net = new THREE.Mesh(
+      new THREE.BoxGeometry(GAME_CONFIG.table.width + GAME_CONFIG.net.overhang * 2, GAME_CONFIG.net.height, GAME_CONFIG.net.thickness),
+      new THREE.MeshStandardMaterial({ color: '#dbeafe', transparent: true, opacity: 0.72, roughness: 0.35 }),
+    );
+    net.position.y = GAME_CONFIG.table.topY + GAME_CONFIG.net.height / 2;
+    net.castShadow = true;
+    table.add(net);
+
+    const floor = new THREE.Mesh(new THREE.PlaneGeometry(5, 7), new THREE.ShadowMaterial({ opacity: 0.22 }));
+    floor.rotation.x = -Math.PI / 2;
+    floor.receiveShadow = true;
+    this.scene.add(floor, table);
+  }
+
+  private createAvatar(side: 'player' | 'ai') {
+    const root = new THREE.Group();
+    root.position.set(0, 0, side === 'player' ? GAME_CONFIG.player.z : GAME_CONFIG.ai.z);
+    root.rotation.y = side === 'player' ? 0 : Math.PI;
+    const material = new THREE.MeshStandardMaterial({ color: '#f1f5f9', roughness: 0.72, metalness: 0.02 });
+    const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.18, 0.44, 5, 12), material);
+    torso.position.y = 0.72;
+    torso.castShadow = true;
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.15, 20, 16), material);
+    head.position.y = 1.16;
+    head.castShadow = true;
+    const hand = new THREE.Group();
+    const arm = new THREE.Mesh(new THREE.CapsuleGeometry(0.045, 0.34, 4, 8), material);
+    arm.rotation.x = Math.PI / 2;
+    arm.castShadow = true;
+    hand.add(arm);
+    const paddle = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.115, 0.115, 0.018, 28),
+      new THREE.MeshStandardMaterial({ color: '#d72638', roughness: 0.48 }),
+    );
+    paddle.rotation.x = Math.PI / 2;
+    paddle.castShadow = true;
+    hand.add(paddle);
+    root.add(torso, head, hand);
+    this.scene.add(root);
+    return { root, torso, head, hand, paddle };
+  }
+
+  private createBall() {
+    const ball = new THREE.Mesh(
+      new THREE.SphereGeometry(GAME_CONFIG.ballRadius, 24, 18),
+      new THREE.MeshStandardMaterial({ color: '#fff8b5', emissive: '#facc15', emissiveIntensity: 0.22, roughness: 0.36 }),
+    );
+    ball.castShadow = true;
+    this.scene.add(ball);
+    return ball;
+  }
+
+  private createPredictionMarker() {
+    const marker = new THREE.Mesh(
+      new THREE.RingGeometry(0.09, 0.12, 32),
+      new THREE.MeshBasicMaterial({ color: '#fef08a', transparent: true, opacity: 0.65, side: THREE.DoubleSide }),
+    );
+    marker.rotation.x = -Math.PI / 2;
+    marker.visible = false;
+    this.scene.add(marker);
+    return marker;
+  }
+}

--- a/frontend/src/table-tennis/PaddleHitDetector.ts
+++ b/frontend/src/table-tennis/PaddleHitDetector.ts
@@ -1,0 +1,58 @@
+import * as THREE from 'three';
+import { GAME_CONFIG, ShotType, Side, TABLE_BOUNDS } from './gameConfig';
+
+export interface PaddleHitInput {
+  side: Side;
+  paddlePosition: THREE.Vector3;
+  paddleForward: THREE.Vector3;
+  ballPosition: THREE.Vector3;
+  ballVelocity: THREE.Vector3;
+  ballSpin: THREE.Vector3;
+  requestedShot: ShotType;
+  accuracy?: number;
+  powerScale?: number;
+}
+
+export interface PaddleHitResult {
+  valid: boolean;
+  shotType?: ShotType;
+  velocity?: THREE.Vector3;
+  spin?: THREE.Vector3;
+  reason?: string;
+}
+
+const shotProfiles: Record<ShotType, { lift: number; speed: number; spin: number; arc: number }> = {
+  'forehand drive': { lift: 1.55, speed: GAME_CONFIG.paddle.drivePower, spin: 2.2, arc: 0.18 },
+  'backhand drive': { lift: 1.45, speed: GAME_CONFIG.paddle.drivePower * 0.95, spin: 1.9, arc: 0.12 },
+  push: { lift: 1.15, speed: GAME_CONFIG.paddle.pushPower, spin: -1.6, arc: 0.24 },
+  'brush/topspin': { lift: 1.75, speed: GAME_CONFIG.paddle.drivePower * 0.92, spin: GAME_CONFIG.paddle.spin, arc: 0.04 },
+  lob: { lift: 2.75, speed: GAME_CONFIG.paddle.lobPower, spin: 0.7, arc: 0.42 },
+};
+
+export class PaddleHitDetector {
+  detect(input: PaddleHitInput): PaddleHitResult {
+    const distance = input.paddlePosition.distanceTo(input.ballPosition);
+    if (distance > GAME_CONFIG.paddle.hitRadius) return { valid: false, reason: 'outside hit radius' };
+
+    const incoming = input.ballVelocity.clone().normalize();
+    const facingDot = input.paddleForward.clone().normalize().dot(incoming.clone().multiplyScalar(-1));
+    if (facingDot < GAME_CONFIG.paddle.minFacingDot) return { valid: false, reason: 'paddle face angle' };
+
+    const ballComingToPaddle = input.side === 'player' ? input.ballVelocity.z > 0.4 : input.ballVelocity.z < -0.4;
+    if (!ballComingToPaddle) return { valid: false, reason: 'ball moving away' };
+
+    const profile = shotProfiles[input.requestedShot];
+    const targetZ = input.side === 'player' ? THREE.MathUtils.randFloat(-1.08, -0.42) : THREE.MathUtils.randFloat(0.42, 1.08);
+    const targetXBase = THREE.MathUtils.clamp(-input.ballPosition.x * 0.55, TABLE_BOUNDS.minX + 0.12, TABLE_BOUNDS.maxX - 0.12);
+    const error = (1 - (input.accuracy ?? GAME_CONFIG.paddle.accuracy)) * 0.42;
+    const target = new THREE.Vector3(targetXBase + THREE.MathUtils.randFloatSpread(error), GAME_CONFIG.table.topY + profile.arc, targetZ);
+    const direction = target.sub(input.ballPosition).normalize();
+    const power = profile.speed * (input.powerScale ?? 1);
+    const velocity = direction.multiplyScalar(power);
+    velocity.y = Math.max(velocity.y + profile.lift, input.requestedShot === 'lob' ? 2.2 : 1.05);
+
+    const sideSign = input.side === 'player' ? -1 : 1;
+    const spin = new THREE.Vector3(profile.spin * sideSign, 0, -input.paddleForward.x * 1.2);
+    return { valid: true, shotType: input.requestedShot, velocity, spin };
+  }
+}

--- a/frontend/src/table-tennis/PlayerController.ts
+++ b/frontend/src/table-tennis/PlayerController.ts
@@ -1,0 +1,77 @@
+import * as THREE from 'three';
+import { GAME_CONFIG, ShotType } from './gameConfig';
+
+export interface PlayerVisuals {
+  root: THREE.Group;
+  torso: THREE.Object3D;
+  head: THREE.Object3D;
+  hand: THREE.Object3D;
+  paddle: THREE.Object3D;
+}
+
+export class PlayerController {
+  readonly targetX = { value: 0 };
+  currentShot: ShotType = 'forehand drive';
+  isRecovering = false;
+  private recoveryTimer = 0;
+  private pointerX = 0;
+
+  constructor(private visuals: PlayerVisuals) {}
+
+  setInput(normalizedX: number) {
+    this.pointerX = THREE.MathUtils.clamp(normalizedX, -1, 1);
+    this.targetX.value = THREE.MathUtils.lerp(GAME_CONFIG.player.minX, GAME_CONFIG.player.maxX, (this.pointerX + 1) / 2);
+  }
+
+  update(dt: number, ballPosition: THREE.Vector3) {
+    const root = this.visuals.root;
+    root.position.x = THREE.MathUtils.damp(root.position.x, this.targetX.value, GAME_CONFIG.player.moveSpeed, dt);
+    root.position.x = THREE.MathUtils.clamp(root.position.x, GAME_CONFIG.player.minX, GAME_CONFIG.player.maxX);
+    root.position.z = GAME_CONFIG.player.z;
+
+    const acrossBody = ballPosition.x < root.position.x - 0.05;
+    this.currentShot = acrossBody ? 'backhand drive' : this.chooseForehandVariant(ballPosition);
+
+    const lookYaw = THREE.MathUtils.clamp((ballPosition.x - root.position.x) * 0.45, -0.45, 0.45);
+    this.visuals.torso.rotation.y = THREE.MathUtils.damp(this.visuals.torso.rotation.y, lookYaw, 9, dt);
+    this.visuals.head.rotation.y = THREE.MathUtils.damp(this.visuals.head.rotation.y, lookYaw * 0.8, 10, dt);
+
+    if (this.isRecovering) {
+      this.recoveryTimer -= dt;
+      if (this.recoveryTimer <= 0) this.isRecovering = false;
+    }
+    this.updatePaddleAttachment(dt, ballPosition);
+  }
+
+  triggerHit() {
+    this.isRecovering = true;
+    this.recoveryTimer = GAME_CONFIG.player.recoveryTime;
+  }
+
+  getPaddleWorldPosition() {
+    return this.visuals.paddle.getWorldPosition(new THREE.Vector3());
+  }
+
+  getPaddleForward() {
+    return new THREE.Vector3(0, 0, -1).applyQuaternion(this.visuals.paddle.getWorldQuaternion(new THREE.Quaternion())).normalize();
+  }
+
+  private chooseForehandVariant(ballPosition: THREE.Vector3): ShotType {
+    if (ballPosition.y > GAME_CONFIG.table.topY + 0.55) return 'lob';
+    if (ballPosition.y < GAME_CONFIG.table.topY + 0.18) return 'push';
+    if (Math.abs(ballPosition.x - this.visuals.root.position.x) > 0.32) return 'brush/topspin';
+    return 'forehand drive';
+  }
+
+  private updatePaddleAttachment(dt: number, ballPosition: THREE.Vector3) {
+    const hand = this.visuals.hand;
+    const paddle = this.visuals.paddle;
+    const side = this.currentShot === 'backhand drive' ? -1 : 1;
+    const reach = this.isRecovering ? 0.34 : THREE.MathUtils.clamp((GAME_CONFIG.player.z - ballPosition.z) * 0.24, 0.08, 0.38);
+    hand.position.set(0.16 * side, 0.92, -0.12 - reach);
+    hand.rotation.y = THREE.MathUtils.damp(hand.rotation.y, side * 0.28, 12, dt);
+    hand.rotation.x = THREE.MathUtils.damp(hand.rotation.x, this.isRecovering ? -0.45 : -0.2, 12, dt);
+    paddle.position.set(0, -0.02, -0.12);
+    paddle.rotation.set(-0.25, 0, side * 0.16);
+  }
+}

--- a/frontend/src/table-tennis/ReplayManager.ts
+++ b/frontend/src/table-tennis/ReplayManager.ts
@@ -1,0 +1,73 @@
+import * as THREE from 'three';
+import { BallStateName } from './BallPhysics';
+import { ShotType, Side } from './gameConfig';
+
+export type ReplayEvent =
+  | { type: 'ball'; time: number; position: THREE.Vector3; state: BallStateName }
+  | { type: 'hit'; time: number; side: Side; shotType: ShotType; position: THREE.Vector3 }
+  | { type: 'bounce'; time: number; side?: Side; position: THREE.Vector3 }
+  | { type: 'score'; time: number; winner: Side; score: { player: number; ai: number }; reason: string };
+
+export class ReplayManager {
+  events: ReplayEvent[] = [];
+  isReplaying = false;
+  private replayTime = 0;
+  private duration = 0;
+
+  startRecording() {
+    this.events = [];
+    this.isReplaying = false;
+    this.replayTime = 0;
+    this.duration = 0;
+  }
+
+  recordBall(time: number, position: THREE.Vector3, state: BallStateName) {
+    if (this.isReplaying) return;
+    this.events.push({ type: 'ball', time, position: position.clone(), state });
+    this.duration = Math.max(this.duration, time);
+  }
+
+  recordHit(time: number, side: Side, shotType: ShotType, position: THREE.Vector3) {
+    this.events.push({ type: 'hit', time, side, shotType, position: position.clone() });
+  }
+
+  recordBounce(time: number, side: Side | undefined, position: THREE.Vector3) {
+    this.events.push({ type: 'bounce', time, side, position: position.clone() });
+  }
+
+  recordScore(time: number, winner: Side, score: { player: number; ai: number }, reason: string) {
+    this.events.push({ type: 'score', time, winner, score: { ...score }, reason });
+  }
+
+  beginReplay() {
+    if (this.events.length < 2) return false;
+    this.isReplaying = true;
+    this.replayTime = 0;
+    return true;
+  }
+
+  update(dt: number) {
+    if (!this.isReplaying) return null;
+    this.replayTime += dt * 0.42;
+    if (this.replayTime >= this.duration) {
+      this.isReplaying = false;
+      return null;
+    }
+    return this.sampleBall(this.replayTime);
+  }
+
+  private sampleBall(time: number) {
+    const balls = this.events.filter((event): event is Extract<ReplayEvent, { type: 'ball' }> => event.type === 'ball');
+    let prev = balls[0];
+    let next = balls[balls.length - 1];
+    for (let i = 1; i < balls.length; i += 1) {
+      if (balls[i].time >= time) {
+        next = balls[i];
+        prev = balls[i - 1];
+        break;
+      }
+    }
+    const t = next.time === prev.time ? 0 : (time - prev.time) / (next.time - prev.time);
+    return prev.position.clone().lerp(next.position, THREE.MathUtils.clamp(t, 0, 1));
+  }
+}

--- a/frontend/src/table-tennis/ScoreManager.ts
+++ b/frontend/src/table-tennis/ScoreManager.ts
@@ -1,0 +1,67 @@
+import { BallEvent, BallPhysics } from './BallPhysics';
+import { GAME_CONFIG, Side } from './gameConfig';
+
+export interface ScoreState {
+  player: number;
+  ai: number;
+  server: Side;
+  winner: Side | null;
+  lastReason: string;
+}
+
+export class ScoreManager {
+  state: ScoreState = { player: 0, ai: 0, server: 'player', winner: null, lastReason: 'Serve' };
+  private ralliesSinceServeSwitch = 0;
+
+  evaluate(events: BallEvent[], ball: BallPhysics): Side | null {
+    if (ball.state === 'pointEnded') return null;
+    let winner: Side | null = null;
+    let reason = '';
+
+    if (events.some((event) => event.type === 'net')) {
+      winner = ball.lastTouch === 'player' ? 'ai' : 'player';
+      reason = 'net fault';
+    } else if (ball.bounces.player > 1) {
+      winner = 'ai';
+      reason = 'double bounce on player side';
+    } else if (ball.bounces.ai > 1) {
+      winner = 'player';
+      reason = 'double bounce on AI side';
+    } else if (events.some((event) => event.type === 'out')) {
+      winner = this.scoreOutOrMiss(ball);
+      reason = 'missed return / out';
+    }
+
+    if (!winner) return null;
+    this.awardPoint(winner, reason);
+    ball.state = 'pointEnded';
+    return winner;
+  }
+
+  private scoreOutOrMiss(ball: BallPhysics): Side {
+    if (ball.lastTouch === 'player') {
+      return ball.bounces.ai === 0 ? 'ai' : 'player';
+    }
+    return ball.bounces.player === 0 ? 'player' : 'ai';
+  }
+
+  private awardPoint(winner: Side, reason: string) {
+    this.state[winner] += 1;
+    this.ralliesSinceServeSwitch += 1;
+    const serveInterval = this.state.player >= 10 && this.state.ai >= 10 ? 1 : 2;
+    if (this.ralliesSinceServeSwitch >= serveInterval) {
+      this.state.server = this.state.server === 'player' ? 'ai' : 'player';
+      this.ralliesSinceServeSwitch = 0;
+    }
+    this.state.lastReason = reason;
+    const leading = this.state.player > this.state.ai ? 'player' : 'ai';
+    const high = Math.max(this.state.player, this.state.ai);
+    const gap = Math.abs(this.state.player - this.state.ai);
+    this.state.winner = high >= GAME_CONFIG.score.gamePoint && gap >= GAME_CONFIG.score.winBy ? leading : null;
+  }
+
+  resetMatch() {
+    this.state = { player: 0, ai: 0, server: 'player', winner: null, lastReason: 'Serve' };
+    this.ralliesSinceServeSwitch = 0;
+  }
+}

--- a/frontend/src/table-tennis/UIOverlay.tsx
+++ b/frontend/src/table-tennis/UIOverlay.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from 'react';
+import { GameHudState, GameManager } from './GameManager';
+import './tableTennis.css';
+
+const initialHud: GameHudState = {
+  playerScore: 0,
+  aiScore: 0,
+  server: 'YOU',
+  lastShot: '',
+  lastReason: 'Serve',
+  replaying: false,
+  debug: { ballState: 'idle', bounces: 'P:0 AI:0', hitValidity: 'waiting', predictedLanding: 'none' },
+};
+
+export function UIOverlay() {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const managerRef = useRef<GameManager | null>(null);
+  const [hud, setHud] = useState(initialHud);
+  const [debug, setDebug] = useState(false);
+
+  useEffect(() => {
+    if (!mountRef.current) return undefined;
+    const manager = new GameManager(mountRef.current);
+    managerRef.current = manager;
+    manager.start(setHud);
+
+    const onResize = () => {
+      const mount = mountRef.current;
+      if (!mount || !managerRef.current) return;
+      managerRef.current.camera.aspect = mount.clientWidth / mount.clientHeight;
+      managerRef.current.camera.updateProjectionMatrix();
+      managerRef.current.renderer.setSize(mount.clientWidth, mount.clientHeight);
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      const bounds = mountRef.current?.getBoundingClientRect();
+      if (!bounds) return;
+      manager.setPointer(((event.clientX - bounds.left) / bounds.width) * 2 - 1);
+    };
+
+    window.addEventListener('resize', onResize);
+    manager.renderer.domElement.addEventListener('pointermove', onPointerMove);
+    manager.renderer.domElement.addEventListener('pointerdown', onPointerMove);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      manager.renderer.domElement.removeEventListener('pointermove', onPointerMove);
+      manager.renderer.domElement.removeEventListener('pointerdown', onPointerMove);
+      manager.dispose();
+      managerRef.current = null;
+    };
+  }, []);
+
+  return (
+    <main className="tt-shell">
+      <div className="tt-phone-frame">
+        <div ref={mountRef} className="tt-canvas" />
+        <section className="tt-score-panel" aria-label="Score">
+          <div>
+            <span className="tt-name">YOU</span>
+            <strong>{hud.playerScore}</strong>
+          </div>
+          <div className="tt-serve">SERVE: {hud.server}</div>
+          <div>
+            <span className="tt-name">AI</span>
+            <strong>{hud.aiScore}</strong>
+          </div>
+        </section>
+
+        {hud.lastShot && !hud.replaying ? <div className="tt-shot-label">{hud.lastShot}</div> : null}
+        {hud.replaying ? <div className="tt-replay-banner">VAR Replay: slow motion review</div> : null}
+
+        <section className="tt-controls">
+          <button type="button" onClick={() => managerRef.current?.replayLastRally()}>Replay</button>
+          <button type="button" onClick={() => managerRef.current?.resetMatch()}>Reset</button>
+          <button type="button" onClick={() => setDebug((value) => !value)}>{debug ? 'Hide debug' : 'Debug'}</button>
+        </section>
+
+        {debug ? (
+          <aside className="tt-debug">
+            <span>state: {hud.debug.ballState}</span>
+            <span>bounces: {hud.debug.bounces}</span>
+            <span>hit: {hud.debug.hitValidity}</span>
+            <span>landing: {hud.debug.predictedLanding}</span>
+            <span>last point: {hud.lastReason}</span>
+          </aside>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/table-tennis/gameConfig.ts
+++ b/frontend/src/table-tennis/gameConfig.ts
@@ -1,0 +1,91 @@
+import * as THREE from 'three';
+
+export type Side = 'player' | 'ai';
+export type ShotType = 'forehand drive' | 'backhand drive' | 'push' | 'brush/topspin' | 'lob';
+
+export interface DifficultyConfig {
+  reactionTime: number;
+  moveSpeed: number;
+  accuracy: number;
+  shotPower: number;
+  mistakeChance: number;
+}
+
+export const GAME_CONFIG = {
+  fixedDt: 1 / 120,
+  gravity: -9.8,
+  drag: 0.09,
+  spinCurve: 0.08,
+  ballRadius: 0.055,
+  serveHeight: 0.34,
+  table: {
+    width: 1.55,
+    length: 2.74,
+    topY: 0.76,
+    thickness: 0.08,
+    color: '#1266c3',
+    lineColor: '#e8f4ff',
+  },
+  net: {
+    height: 0.155,
+    thickness: 0.025,
+    overhang: 0.08,
+  },
+  player: {
+    z: 2.18,
+    minX: -0.88,
+    maxX: 0.88,
+    safeZ: 2.04,
+    moveSpeed: 2.55,
+    reach: 0.48,
+    recoveryTime: 0.28,
+  },
+  ai: {
+    z: -2.18,
+    minX: -0.88,
+    maxX: 0.88,
+    maxReach: 0.58,
+    difficulty: {
+      reactionTime: 0.24,
+      moveSpeed: 2.05,
+      accuracy: 0.78,
+      shotPower: 1.0,
+      mistakeChance: 0.14,
+    } satisfies DifficultyConfig,
+  },
+  paddle: {
+    hitRadius: 0.18,
+    timingWindow: 0.12,
+    minFacingDot: 0.22,
+    drivePower: 3.35,
+    pushPower: 2.55,
+    lobPower: 2.65,
+    spin: 3.6,
+    accuracy: 0.9,
+  },
+  camera: {
+    position: new THREE.Vector3(0, 2.0, 4.25),
+    target: new THREE.Vector3(0, 0.86, 0.15),
+    damping: 8,
+  },
+  score: {
+    gamePoint: 11,
+    winBy: 2,
+  },
+} as const;
+
+export const TABLE_BOUNDS = {
+  minX: -GAME_CONFIG.table.width / 2,
+  maxX: GAME_CONFIG.table.width / 2,
+  minZ: -GAME_CONFIG.table.length / 2,
+  maxZ: GAME_CONFIG.table.length / 2,
+};
+
+export const NET_BOUNDS = {
+  minX: -GAME_CONFIG.table.width / 2 - GAME_CONFIG.net.overhang,
+  maxX: GAME_CONFIG.table.width / 2 + GAME_CONFIG.net.overhang,
+  minY: GAME_CONFIG.table.topY,
+  maxY: GAME_CONFIG.table.topY + GAME_CONFIG.net.height,
+  minZ: -GAME_CONFIG.net.thickness / 2,
+  maxZ: GAME_CONFIG.net.thickness / 2,
+};

--- a/frontend/src/table-tennis/tableTennis.css
+++ b/frontend/src/table-tennis/tableTennis.css
@@ -1,0 +1,128 @@
+.tt-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, #123466, #020617 72%);
+  color: white;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  overflow: hidden;
+}
+
+.tt-phone-frame {
+  position: relative;
+  width: min(100vw, 430px);
+  height: 100vh;
+  max-height: 932px;
+  overflow: hidden;
+  background: #07162e;
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45);
+}
+
+.tt-canvas,
+.tt-canvas canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  touch-action: none;
+}
+
+.tt-score-panel {
+  position: absolute;
+  top: max(14px, env(safe-area-inset-top));
+  left: 16px;
+  right: 16px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 20px;
+  background: rgba(3, 7, 18, 0.56);
+  backdrop-filter: blur(14px);
+}
+
+.tt-score-panel > div:not(.tt-serve) {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tt-score-panel strong {
+  font-size: clamp(24px, 7vw, 36px);
+  line-height: 1;
+}
+
+.tt-name,
+.tt-serve {
+  color: #bfdbfe;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.tt-serve {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.35);
+  white-space: nowrap;
+}
+
+.tt-shot-label,
+.tt-replay-banner {
+  position: absolute;
+  left: 50%;
+  top: 102px;
+  transform: translateX(-50%);
+  padding: 9px 14px;
+  border-radius: 999px;
+  background: rgba(250, 204, 21, 0.92);
+  color: #111827;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  box-shadow: 0 10px 30px rgba(250, 204, 21, 0.25);
+}
+
+.tt-replay-banner {
+  background: rgba(37, 99, 235, 0.92);
+  color: white;
+}
+
+.tt-controls {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: max(18px, env(safe-area-inset-bottom));
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.tt-controls button {
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 14px;
+  color: white;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(12px);
+  font-weight: 800;
+}
+
+.tt-debug {
+  position: absolute;
+  right: 12px;
+  bottom: 76px;
+  display: grid;
+  gap: 3px;
+  padding: 10px;
+  max-width: 230px;
+  border-radius: 14px;
+  color: #dbeafe;
+  background: rgba(2, 6, 23, 0.7);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+}


### PR DESCRIPTION
### Motivation
- Provide a clean, modular architecture for the in-browser table tennis demo so physics, input, AI, camera, scoring and replay are isolated and easier to tune and extend.
- Fix core simulation and visual issues observed in the reference video by moving to fixed-timestep physics, swept collisions, explicit bounce/net/out state handling, and by attaching paddles/hands to avatar visuals.
- Preserve the current mobile portrait presentation, blue table, two avatars, paddles, ball, top score UI, and replay UI style while improving visibility, shadows and hit timing.

### Description
- Added a single-source `gameConfig.ts` with tuned constants for fixed timestep physics, table/net bounds, paddle tuning, AI difficulty and camera parameters.
- Implemented `BallPhysics.ts` using a fixed timestep integrator, explicit ball states (`idle`, `serve`, `flying`, `tableBouncePlayer`, `tableBounceAI`, `paddleHitPlayer`, `paddleHitAI`, `netHit`, `out`, `pointEnded`), swept table/net collision checks to avoid tunneling, spin/drag/curve, side bounce tracking and a `predictLandingPoint` helper.
- Implemented `PaddleHitDetector.ts` that validates hits by distance and paddle facing, prevents ghost hits, computes shot-specific velocity+spin for `forehand/backhand/push/brush/topspin/lob`, and accepts configurable accuracy/power parameters.
- Implemented `PlayerController.ts` and `AIController.ts` to constrain lateral movement, attach paddle visuals to the hand, select correct shot animations/variants, handle recovery after hits, predict landing for AI with reaction delay/mistake chance and reach limits.
- Implemented `CameraController.ts` for a portrait mobile camera behind the player with smooth damping and slight offset when the ball is near the player to avoid occlusion.
- Implemented `ScoreManager.ts` applying table-tennis scoring rules, serve-switching (including deuce behavior), and point awarding only after net faults, double bounces, out or missed returns.
- Implemented `ReplayManager.ts` to record ball positions, hits, bounces and score events and play them back in slow motion while disabling input; UI shows the "VAR Replay: slow motion review" banner only during replay.
- Implemented `GameManager.ts` to wire scene setup, lighting, table/net visuals, avatars, ball rendering, orchestration of physics/inputs/AI/hud/replay and prediction marker; added soft shadows and material tweaks to improve ball/character readability.
- Added `UIOverlay.tsx` and `tableTennis.css` to replace the app entry with the new mobile UI overlay (score panel, shot label, replay banner, Replay/Reset/Debug controls and an optional debug overlay hidden by default).

### Testing
- Ran the production build using `npm --prefix frontend run build`, which runs `tsc -b && vite build`, and it completed successfully (Vite emitted existing dependency/chunk-size warnings but the build finished).
- Installed Playwright browsers with `npx playwright install chromium` and completed the download and installation steps successfully.
- Performed a dev-server smoke test using Vite and Playwright by starting the dev server and running a headless navigation to `http://127.0.0.1:5173/` and capturing a mobile-sized screenshot; the smoke test completed (initial failure due to missing host libs was resolved by installing required system packages and Playwright browsers).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0559e04fd08329805690eeee99f111)