### PR TITLE
Scale up tennis court and human characters

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -266,8 +266,8 @@ function addCourt(scene: THREE.Scene, options: { hideFloor?: boolean } = {}) {
     addBox(group, [CFG.courtW - 0.2, 0.043, CFG.serviceLineZ * 2], [0, 0.012, 0], serviceMat);
   }
 
-  const y = 0.045;
-  const thick = 0.045;
+  const y = 0.045 * CFG.worldScale;
+  const thick = 0.045 * CFG.worldScale;
   const halfW = CFG.courtW / 2;
   const halfL = CFG.courtL / 2;
 
@@ -278,8 +278,8 @@ function addCourt(scene: THREE.Scene, options: { hideFloor?: boolean } = {}) {
   addBox(group, [CFG.courtW, thick, thick], [0, y, -CFG.serviceLineZ], lineMat);
   addBox(group, [CFG.courtW, thick, thick], [0, y, CFG.serviceLineZ], lineMat);
   addBox(group, [thick, thick, CFG.serviceLineZ * 2], [0, y, 0], lineMat);
-  addBox(group, [thick, thick, 0.38], [0, y, -halfL + 0.18], lineMat);
-  addBox(group, [thick, thick, 0.38], [0, y, halfL - 0.18], lineMat);
+  addBox(group, [thick, thick, 0.38 * CFG.worldScale], [0, y, -halfL + 0.18 * CFG.worldScale], lineMat);
+  addBox(group, [thick, thick, 0.38 * CFG.worldScale], [0, y, halfL - 0.18 * CFG.worldScale], lineMat);
   addBox(group, [thick, thick, CFG.courtL + thick], [-CFG.doublesW / 2, y, 0], transparentMaterial(0xffffff, 0.34));
   addBox(group, [thick, thick, CFG.courtL + thick], [CFG.doublesW / 2, y, 0], transparentMaterial(0xffffff, 0.34));
 
@@ -1063,11 +1063,13 @@ export default function MobileThreeTennisPrototype() {
     sun.shadow.mapSize.width = 2048;
     sun.shadow.mapSize.height = 2048;
     sun.shadow.camera.near = 0.5;
-    sun.shadow.camera.far = 25;
-    sun.shadow.camera.left = -8;
-    sun.shadow.camera.right = 8;
-    sun.shadow.camera.top = 9;
-    sun.shadow.camera.bottom = -9;
+    sun.shadow.camera.far = Math.max(25, CFG.courtL * 1.45);
+    const shadowHalfW = CFG.doublesW / 2 + 5.2 * CFG.worldScale;
+    const shadowHalfL = CFG.courtL / 2 + 5.8 * CFG.worldScale;
+    sun.shadow.camera.left = -shadowHalfW;
+    sun.shadow.camera.right = shadowHalfW;
+    sun.shadow.camera.top = shadowHalfL;
+    sun.shadow.camera.bottom = -shadowHalfL;
     scene.add(sun);
 
 

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -28,14 +28,17 @@ export enum TennisBallState {
   PointEnded = "PointEnded",
 }
 
-const WORLD_SCALE = 1.55;
+const WORLD_SCALE = 1.72;
+// Extra character scale keeps human avatars visibly bigger than the court uplift.
+const PLAYER_CHARACTER_SCALE = 1.12;
+const PLAYER_SCALE = WORLD_SCALE * PLAYER_CHARACTER_SCALE;
 
 export const gameConfig = {
   worldScale: WORLD_SCALE,
   fixedTimeStep: 1 / 90,
   maxPhysicsSteps: 5,
   // Regulation court proportions in world metres, scaled as a single unit so
-  // the court, net, players, rackets and ball read correctly against HDRIs.
+  // the tennis play area reads larger and more arena-like against HDRIs.
   courtW: 8.23 * WORLD_SCALE,
   doublesW: 10.97 * WORLD_SCALE,
   courtL: 23.77 * WORLD_SCALE,
@@ -48,22 +51,22 @@ export const gameConfig = {
   groundFriction: 0.86,
   minBallSpeed: 0.12 * WORLD_SCALE,
   courtFriction: 0.86,
-  playerHeight: 1.88 * WORLD_SCALE,
-  playerSpeed: 8.4 * WORLD_SCALE,
-  playerAcceleration: 28 * WORLD_SCALE,
-  playerDeceleration: 34 * WORLD_SCALE,
-  aiSpeed: 11.2 * WORLD_SCALE,
-  reach: 1.62 * WORLD_SCALE,
-  racketHitRadius: 0.56 * WORLD_SCALE,
+  playerHeight: 1.88 * PLAYER_SCALE,
+  playerSpeed: 8.4 * PLAYER_SCALE,
+  playerAcceleration: 28 * PLAYER_SCALE,
+  playerDeceleration: 34 * PLAYER_SCALE,
+  aiSpeed: 11.2 * PLAYER_SCALE,
+  reach: 1.62 * PLAYER_SCALE,
+  racketHitRadius: 0.56 * PLAYER_SCALE,
   contactAngleTolerance: 0.18,
   timingWindow: { start: 0.42, end: 0.72 },
-  minContactHeight: 0.25 * WORLD_SCALE,
-  maxContactHeight: 1.85 * WORLD_SCALE,
-  maxReachDistance: 1.62 * WORLD_SCALE,
+  minContactHeight: 0.25 * PLAYER_SCALE,
+  maxContactHeight: 1.85 * PLAYER_SCALE,
+  maxReachDistance: 1.62 * PLAYER_SCALE,
   swingDuration: 0.38,
   serveDuration: 0.86,
   serveContactT: 0.72,
-  serveTossMinHeight: 1.85 * WORLD_SCALE,
+  serveTossMinHeight: 1.85 * PLAYER_SCALE,
   servePower: { min: 0.72, max: 1 },
   shotPower: { min: 0.35, max: 1 },
   spinAmount: { flat: 0.8, topspin: 1.6, slice: -1.4, lob: 1.1, drop: -0.7, block: 0.25 },
@@ -74,8 +77,8 @@ export const gameConfig = {
   scoring: { gamesPerSet: 6, winByTwoGames: true },
   aiDifficulty: {
     reactionTime: 0.14,
-    moveSpeed: 11.2 * WORLD_SCALE,
-    reachRadius: 1.7 * WORLD_SCALE,
+    moveSpeed: 11.2 * PLAYER_SCALE,
+    reachRadius: 1.7 * PLAYER_SCALE,
     accuracy: 0.88,
     power: 0.94,
     spin: 0.72,


### PR DESCRIPTION
### Motivation
- Make the tennis scene read larger and the players more visually prominent in the 3D prototype so avatars and court proportions feel more arena-like.
- Keep gameplay reach, contact heights and physics consistent with the visual scale so mechanics remain playable after the upscale.

### Description
- Increased `WORLD_SCALE` from `1.55` to `1.72` and added `PLAYER_CHARACTER_SCALE` plus derived `PLAYER_SCALE` in `webapp/src/pages/Games/tennis/gameConfig.ts` to make the court and environment larger while letting characters scale independently.
- Applied `PLAYER_SCALE` to player and AI parameters including `playerHeight`, movement/acceleration (`playerSpeed`, `playerAcceleration`, `playerDeceleration`), `aiSpeed`, `reach`, `racketHitRadius`, contact height limits, `serveTossMinHeight` and AI difficulty `moveSpeed`/`reachRadius` to keep interactions aligned with visuals.
- Scaled court visual primitives in `webapp/src/pages/Games/Tennis.tsx` (line thickness/notches and baseline offsets) by `CFG.worldScale` so markings and small geometry remain proportional to the enlarged court.
- Expanded directional light shadow camera bounds to cover the larger play area so lighting and shadows remain correct for the updated court size.

### Testing
- Ran `npm --prefix webapp run build` to produce a production build and verify no type/runtime build regressions, and the build completed successfully.
- Ran `git diff --check` which reported no whitespace/errors in diffs.
- Installed Playwright browsers with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully to enable headless verification.
- Launched a dev server and captured a headless screenshot of `/games/tennis` with Playwright, producing `artifacts/tennis-court-scale.png` to verify the court/character sizing visually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0562fc4204832997e2043d0f4a0be6)