### PR TITLE
Enlarge tennis court and characters

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -1050,9 +1050,9 @@ export default function MobileThreeTennisPrototype() {
     let activeEnvMap: THREE.Texture | null = null;
     scene.fog = null;
 
-    const camera = new THREE.PerspectiveCamera(44, 1, 0.05, 70);
-    const cameraTarget = new THREE.Vector3(0, 0.95 * CFG.worldScale, -1.45 * CFG.worldScale);
-    const cameraOffset = new THREE.Vector3(0, 4.95 * CFG.worldScale, 7.7 * CFG.worldScale);
+    const camera = new THREE.PerspectiveCamera(44, 1, 0.05, Math.max(70, CFG.courtL * 1.8));
+    const cameraTarget = new THREE.Vector3(0, 0.95 * CFG.cameraViewScale, -1.45 * CFG.cameraViewScale);
+    const cameraOffset = new THREE.Vector3(0, 4.95 * CFG.cameraViewScale, 7.7 * CFG.cameraViewScale);
     const cameraPosTarget = new THREE.Vector3();
 
     scene.add(new THREE.AmbientLight(0xffffff, 0.62));
@@ -1183,8 +1183,8 @@ export default function MobileThreeTennisPrototype() {
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
       camera.aspect = w / h;
       camera.fov = camera.aspect < 0.72 ? 52 : 46;
-      if (camera.aspect < 0.72) cameraOffset.set(0, 5.45 * CFG.worldScale, 8.55 * CFG.worldScale);
-      else cameraOffset.set(0, 4.95 * CFG.worldScale, 7.7 * CFG.worldScale);
+      if (camera.aspect < 0.72) cameraOffset.set(0, 5.45 * CFG.cameraViewScale, 8.55 * CFG.cameraViewScale);
+      else cameraOffset.set(0, 4.95 * CFG.cameraViewScale, 7.7 * CFG.cameraViewScale);
       cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
       camera.position.copy(cameraPosTarget);
       camera.lookAt(cameraTarget);

--- a/webapp/src/pages/Games/tennis/CameraController.ts
+++ b/webapp/src/pages/Games/tennis/CameraController.ts
@@ -5,13 +5,13 @@ export class CameraController {
   update(camera: THREE.PerspectiveCamera, cameraTarget: THREE.Vector3, cameraPosTarget: THREE.Vector3, playerTarget: THREE.Vector3, ballPos: THREE.Vector3, cameraOffset: THREE.Vector3, preServe: boolean, dt: number) {
     const lateral = Math.max(-0.45, Math.min(0.45, ballPos.x * 0.08));
     if (preServe) {
-      cameraPosTarget.copy(playerTarget).add(new THREE.Vector3(playerTarget.x * 0.08 + lateral, 6.25 * gameConfig.worldScale, 10.4 * gameConfig.worldScale));
+      cameraPosTarget.copy(playerTarget).add(new THREE.Vector3(playerTarget.x * 0.08 + lateral, 6.25 * gameConfig.cameraViewScale, 10.4 * gameConfig.cameraViewScale));
       cameraTarget.x += (playerTarget.x * 0.2 + lateral - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
       cameraTarget.z += ((-gameConfig.courtL * 0.24) - cameraTarget.z) * (1 - Math.exp(-5.1 * dt));
     } else {
       cameraPosTarget.copy(playerTarget).add(cameraOffset).add(new THREE.Vector3(lateral, 0, 0));
       cameraTarget.x += (playerTarget.x + lateral - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
-      cameraTarget.z += ((playerTarget.z - 6.9 * gameConfig.worldScale) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
+      cameraTarget.z += ((playerTarget.z - 6.9 * gameConfig.cameraViewScale) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
     }
     camera.position.lerp(cameraPosTarget, 1 - Math.exp(-gameConfig.cameraDamping * dt));
     camera.lookAt(cameraTarget);

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -28,13 +28,20 @@ export enum TennisBallState {
   PointEnded = "PointEnded",
 }
 
-const WORLD_SCALE = 1.72;
+const BASE_WORLD_SCALE = 1.72;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.3;
+const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
+// Keep the camera at its prior pullback distance so the enlarged court and
+// players read about 30% bigger in the actual gameplay view.
+const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE;
 // Extra character scale keeps human avatars visibly bigger than the court uplift.
 const PLAYER_CHARACTER_SCALE = 1.12;
 const PLAYER_SCALE = WORLD_SCALE * PLAYER_CHARACTER_SCALE;
 
 export const gameConfig = {
   worldScale: WORLD_SCALE,
+  courtAndCharacterSizeMultiplier: COURT_AND_CHARACTER_SIZE_MULTIPLIER,
+  cameraViewScale: CAMERA_VIEW_SCALE,
   fixedTimeStep: 1 / 90,
   maxPhysicsSteps: 5,
   // Regulation court proportions in world metres, scaled as a single unit so


### PR DESCRIPTION
### Motivation
- Increase perceived size of the tennis play area and human characters by ~30% so players and court read larger in-scene. 
- Preserve the original gameplay camera framing so the larger models feel bigger without pushing the camera farther back. 

### Description
- Added `COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.3` and computed `WORLD_SCALE` from it in `tennis/gameConfig.ts`, and exposed `cameraViewScale` and `courtAndCharacterSizeMultiplier` on the exported `gameConfig`. 
- Kept the camera view at the previous scale by introducing `CAMERA_VIEW_SCALE` and updated camera targets/offsets in `webapp/src/pages/Games/Tennis.tsx` to use `CFG.cameraViewScale`, and expanded the camera far plane to `Math.max(70, CFG.courtL * 1.8)`. 
- Updated `webapp/src/pages/Games/tennis/CameraController.ts` to use `gameConfig.cameraViewScale` for pre-serve and rally camera positioning so the camera maintains prior pullback while the court and humans are larger. 

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully. 
- Installed Playwright and dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium`, and the installs completed. 
- Started the dev server and performed a Playwright smoke screenshot of `/games/tennis`, which produced a saved preview image for visual verification (noting some network resource fetch warnings during the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05732b6b08832990e0f8035bbbe2ef)