### PR TITLE
Tennis: enlarge court, soften shot power, and apply PolyHaven cloth materials to characters

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -183,6 +183,264 @@ function transparentMaterial(color: number, opacity: number, roughness = 0.72) {
   return new THREE.MeshStandardMaterial({ color, roughness, metalness: 0.02, transparent: true, opacity, depthWrite: false });
 }
 
+
+type TennisClothSlot = { material: keyof typeof POLYHAVEN_CLOTH_MATERIALS; tint: number; repeat: number };
+type TennisClothCombo = { upper: TennisClothSlot; lower: TennisClothSlot; accent: TennisClothSlot };
+type TennisClothTexture = {
+  source: string;
+  gltf: string;
+  color: string;
+  normal: string;
+  roughness: string;
+  tint: number;
+  repeat: number;
+};
+
+const POLYHAVEN_CLOTH_MATERIALS = Object.freeze({
+  denim: {
+    source: "Poly Haven denim_fabric 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/denim_fabric/denim_fabric_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/denim_fabric/denim_fabric_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/denim_fabric/denim_fabric_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/denim_fabric/denim_fabric_rough_1k.jpg",
+    tint: 0x314d86,
+  },
+  check: {
+    source: "Poly Haven gingham_check 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/gingham_check/gingham_check_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/gingham_check/gingham_check_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/gingham_check/gingham_check_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/gingham_check/gingham_check_rough_1k.jpg",
+    tint: 0x9f3651,
+  },
+  hessian: {
+    source: "Poly Haven hessian_230 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/hessian_230/hessian_230_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/hessian_230/hessian_230_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/hessian_230/hessian_230_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/hessian_230/hessian_230_rough_1k.jpg",
+    tint: 0xa27445,
+  },
+  floral: {
+    source: "Poly Haven floral_jacquard 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/floral_jacquard/floral_jacquard_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/floral_jacquard/floral_jacquard_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/floral_jacquard/floral_jacquard_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/floral_jacquard/floral_jacquard_rough_1k.jpg",
+    tint: 0x6d3f7f,
+  },
+  fleece: {
+    source: "Poly Haven knitted_fleece 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/knitted_fleece/knitted_fleece_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/knitted_fleece/knitted_fleece_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/knitted_fleece/knitted_fleece_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/knitted_fleece/knitted_fleece_rough_1k.jpg",
+    tint: 0x4b5563,
+  },
+  picnic: {
+    source: "Poly Haven fabric_pattern_07 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/fabric_pattern_07/fabric_pattern_07_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/fabric_pattern_07/fabric_pattern_07_col_1_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/fabric_pattern_07/fabric_pattern_07_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/fabric_pattern_07/fabric_pattern_07_rough_1k.jpg",
+    tint: 0xc44f42,
+  },
+} as const);
+
+const TENNIS_CHARACTER_CLOTH_COMBOS: Record<string, TennisClothCombo> = Object.freeze({
+  royalDenim: {
+    upper: { material: "denim", tint: 0x2f5f9f, repeat: 4.2 },
+    lower: { material: "hessian", tint: 0x9b6b3f, repeat: 3.4 },
+    accent: { material: "fleece", tint: 0xd8dee9, repeat: 5.0 },
+  },
+  casinoCheck: {
+    upper: { material: "check", tint: 0xb7375d, repeat: 3.8 },
+    lower: { material: "denim", tint: 0x243e70, repeat: 4.4 },
+    accent: { material: "hessian", tint: 0xf4d7a1, repeat: 3.2 },
+  },
+  linenStreet: {
+    upper: { material: "hessian", tint: 0xb68452, repeat: 3.6 },
+    lower: { material: "fleece", tint: 0x374151, repeat: 5.2 },
+    accent: { material: "denim", tint: 0x4a6fa4, repeat: 4.0 },
+  },
+  jacquardNight: {
+    upper: { material: "floral", tint: 0x7c3f88, repeat: 3.2 },
+    lower: { material: "denim", tint: 0x1f335f, repeat: 4.5 },
+    accent: { material: "check", tint: 0xe3c16f, repeat: 4.0 },
+  },
+  softFleece: {
+    upper: { material: "fleece", tint: 0x556070, repeat: 5.3 },
+    lower: { material: "hessian", tint: 0x8b633f, repeat: 3.7 },
+    accent: { material: "floral", tint: 0xb88ab8, repeat: 3.0 },
+  },
+  patternedRed: {
+    upper: { material: "picnic", tint: 0xc44f42, repeat: 3.4 },
+    lower: { material: "denim", tint: 0x263f73, repeat: 4.7 },
+    accent: { material: "fleece", tint: 0xf1f5f9, repeat: 5.0 },
+  },
+  mixedDenim: {
+    upper: { material: "denim", tint: 0x3b6ea8, repeat: 4.0 },
+    lower: { material: "check", tint: 0x4f6f93, repeat: 4.2 },
+    accent: { material: "hessian", tint: 0xd6a35f, repeat: 3.2 },
+  },
+});
+
+const tennisTextureLoader = new THREE.TextureLoader();
+tennisTextureLoader.setCrossOrigin("anonymous");
+const TENNIS_CHARACTER_TEXTURE_CACHE = new Map<string, THREE.Texture>();
+
+function loadTennisCharacterTexture(url: string, { isColor = false, repeat = 3 } = {}) {
+  const cacheKey = `${url}|${isColor ? "srgb" : "linear"}|${repeat}`;
+  const cached = TENNIS_CHARACTER_TEXTURE_CACHE.get(cacheKey);
+  if (cached) return cached;
+  const texture = tennisTextureLoader.load(
+    url,
+    (loaded) => {
+      loaded.wrapS = THREE.RepeatWrapping;
+      loaded.wrapT = THREE.RepeatWrapping;
+      loaded.repeat.set(repeat, repeat);
+      loaded.anisotropy = 8;
+      loaded.generateMipmaps = true;
+      loaded.minFilter = THREE.LinearMipmapLinearFilter;
+      loaded.magFilter = THREE.LinearFilter;
+      if (isColor) loaded.colorSpace = THREE.SRGBColorSpace;
+      loaded.needsUpdate = true;
+    },
+    undefined,
+    () => TENNIS_CHARACTER_TEXTURE_CACHE.delete(cacheKey)
+  );
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(repeat, repeat);
+  texture.anisotropy = 8;
+  texture.generateMipmaps = true;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+  TENNIS_CHARACTER_TEXTURE_CACHE.set(cacheKey, texture);
+  return texture;
+}
+
+function isNearlyWhiteCharacterMaterial(mat: THREE.MeshStandardMaterial) {
+  if (!mat.color) return false;
+  return mat.color.r > 0.82 && mat.color.g > 0.82 && mat.color.b > 0.82 && !mat.map;
+}
+
+function isLowSaturationLightCharacterMaterial(mat: THREE.MeshStandardMaterial) {
+  if (!mat.color || mat.map) return false;
+  const max = Math.max(mat.color.r, mat.color.g, mat.color.b);
+  const min = Math.min(mat.color.r, mat.color.g, mat.color.b);
+  return max > 0.72 && max - min < 0.18;
+}
+
+function classifyTennisHumanSurface(obj: THREE.Object3D, mat: THREE.MeshStandardMaterial) {
+  const name = `${obj.name || ""} ${mat.name || ""}`.toLowerCase();
+  if (/eye|iris|pupil|cornea|wolf3d_eyes/.test(name)) return "eye";
+  if (/hair|brow|beard|mustache|moustache|lash|wolf3d_hair|wolf3d_beard|wolf3d_eyebrow/.test(name)) return "hair";
+  if (/teeth|tooth|tongue|mouth|gum/.test(name)) return "mouth";
+  if (/shoe|boot|sole|sneaker|footwear|wolf3d_outfit_footwear/.test(name)) return "shoe";
+  if (/skin|head|face|neck|hand|finger|wolf3d_head|wolf3d_body|bodymesh/.test(name) && !/outfit|shirt|pants|trouser|shoe|sock|cloth|jacket|hood|dress|skirt|uniform|suit/.test(name)) return "skin";
+  if (/shirt|top|torso|chest|jacket|hood|dress|skirt|sleeve|upper|outfit_top|wolf3d_outfit_top/.test(name)) return "upperCloth";
+  if (/pants|trouser|jean|short|legging|bottom|outfit_bottom|wolf3d_outfit_bottom/.test(name)) return "lowerCloth";
+  if (/tie|scarf|belt|strap|bag|hat|cap|glove|sock|accessory|accent/.test(name)) return "accentCloth";
+  if (/cloth|clothing|uniform|outfit|suit/.test(name)) return "upperCloth";
+  if (isNearlyWhiteCharacterMaterial(mat) && /torso|chest|spine|pelvis|hip|leg|arm|body|mesh/.test(name)) return "upperCloth";
+  return "other";
+}
+
+function resolveTennisClothSlot(theme: CharacterTheme | undefined, slot: "upper" | "lower" | "accent", side: PlayerSide): TennisClothTexture {
+  const combo = TENNIS_CHARACTER_CLOTH_COMBOS[theme?.clothCombo || ""] || TENNIS_CHARACTER_CLOTH_COMBOS.royalDenim;
+  const slotConfig = combo[slot] || combo.upper;
+  const source = POLYHAVEN_CLOTH_MATERIALS[slotConfig.material] || POLYHAVEN_CLOTH_MATERIALS.denim;
+  return {
+    ...source,
+    tint: slotConfig.tint ?? source.tint,
+    repeat: slotConfig.repeat + (side === "near" ? 0.55 : 0),
+  };
+}
+
+function applyTennisClothMaterial(mat: THREE.MeshStandardMaterial, cloth: TennisClothTexture) {
+  mat.map = loadTennisCharacterTexture(cloth.color, { isColor: true, repeat: cloth.repeat });
+  mat.normalMap = loadTennisCharacterTexture(cloth.normal, { repeat: cloth.repeat });
+  mat.roughnessMap = loadTennisCharacterTexture(cloth.roughness, { repeat: cloth.repeat });
+  mat.color = new THREE.Color(cloth.tint ?? 0xffffff);
+  mat.normalScale = new THREE.Vector2(0.28, 0.28);
+  mat.roughness = 0.86;
+  mat.metalness = 0.015;
+  mat.userData = { ...(mat.userData || {}), polyhavenCloth: cloth.source, polyhavenGltf: cloth.gltf };
+}
+
+function normalizeTennisMaterialTextures(mat: THREE.MeshStandardMaterial) {
+  [mat.map, mat.normalMap, mat.roughnessMap, mat.metalnessMap, mat.aoMap, mat.emissiveMap].forEach((tex) => {
+    if (!tex) return;
+    tex.anisotropy = Math.max(tex.anisotropy ?? 1, 8);
+    tex.generateMipmaps = true;
+    tex.minFilter = THREE.LinearMipmapLinearFilter;
+    tex.magFilter = THREE.LinearFilter;
+    tex.needsUpdate = true;
+  });
+  if (mat.map) mat.map.colorSpace = THREE.SRGBColorSpace;
+}
+
+function enhanceTennisCharacterMaterials(instance: THREE.Object3D, theme: CharacterTheme | undefined, side: PlayerSide) {
+  const clothSlots = {
+    upperCloth: resolveTennisClothSlot(theme, "upper", side),
+    lowerCloth: resolveTennisClothSlot(theme, "lower", side),
+    accentCloth: resolveTennisClothSlot(theme, "accent", side),
+  } as const;
+  const skinColor = new THREE.Color(theme?.skinTone ?? 0xd2a07c);
+  const hairColor = new THREE.Color(theme?.hairColor ?? 0x21150f);
+  const eyeColor = new THREE.Color(theme?.eyeColor ?? 0x3f5f75);
+
+  instance.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!mesh.isMesh || !mesh.material) return;
+    const sourceMaterials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    const enhancedMaterials = sourceMaterials.map((sourceMat) => {
+      const mat = (sourceMat as THREE.MeshStandardMaterial).clone
+        ? (sourceMat as THREE.MeshStandardMaterial).clone()
+        : new THREE.MeshStandardMaterial();
+      const surface = classifyTennisHumanSurface(obj, mat);
+      if (surface === "upperCloth" || surface === "lowerCloth" || surface === "accentCloth") {
+        applyTennisClothMaterial(mat, clothSlots[surface]);
+      } else if (surface === "hair") {
+        mat.map = null;
+        mat.color = hairColor.clone();
+        mat.roughness = 0.56;
+        mat.metalness = 0.02;
+        mat.envMapIntensity = 0.28;
+      } else if (surface === "eye") {
+        mat.map = null;
+        mat.color = eyeColor.clone();
+        mat.roughness = 0.18;
+        mat.metalness = 0;
+        mat.envMapIntensity = 1.1;
+      } else if (surface === "skin") {
+        if (isLowSaturationLightCharacterMaterial(mat)) mat.color = skinColor.clone();
+        mat.roughness = Math.min(mat.roughness ?? 0.62, 0.62);
+        mat.metalness = 0;
+      } else if (surface === "shoe") {
+        if (isLowSaturationLightCharacterMaterial(mat)) mat.color = new THREE.Color(0x111827);
+        mat.roughness = 0.78;
+        mat.metalness = 0.02;
+      } else if (surface === "mouth") {
+        if (isNearlyWhiteCharacterMaterial(mat)) mat.color = new THREE.Color(0xf8fafc);
+        mat.roughness = 0.32;
+        mat.metalness = 0;
+      } else if (isNearlyWhiteCharacterMaterial(mat)) {
+        mat.color = skinColor.clone();
+        mat.roughness = 0.58;
+        mat.metalness = 0;
+      }
+      normalizeTennisMaterialTextures(mat);
+      mat.needsUpdate = true;
+      return mat;
+    });
+    mesh.material = Array.isArray(mesh.material) ? enhancedMaterials : enhancedMaterials[0];
+  });
+}
+
 function enableShadow(obj: THREE.Object3D) {
   obj.traverse((child) => {
     const mesh = child as THREE.Mesh;
@@ -498,61 +756,6 @@ function createFallbackHuman(color: number) {
   return g;
 }
 
-function clothPalette(combo?: string, accent = 0x2563eb) {
-  const palettes: Record<string, { top: number; trim: number; bottom: number; shoe: number }> = {
-    royalDenim: { top: 0x1d4ed8, trim: 0xf8d35b, bottom: 0x111827, shoe: 0xffffff },
-    casinoCheck: { top: 0x111827, trim: 0xe11d48, bottom: 0x2f3542, shoe: 0xf8fafc },
-    linenStreet: { top: 0xf4e7cf, trim: 0x0f766e, bottom: 0x334155, shoe: 0xffffff },
-    jacquardNight: { top: 0x4c1d95, trim: 0xf59e0b, bottom: 0x18181b, shoe: 0xe5e7eb },
-    softFleece: { top: 0xf9a8d4, trim: 0x7c2d12, bottom: 0x1e293b, shoe: 0xffffff },
-    patternedRed: { top: 0x991b1b, trim: 0xfacc15, bottom: 0x0f172a, shoe: 0xf8fafc },
-    mixedDenim: { top: 0x2563eb, trim: 0x38bdf8, bottom: 0x1e3a8a, shoe: 0xffffff },
-  };
-  return palettes[combo || ""] || { top: accent, trim: 0xfacc15, bottom: 0x20232a, shoe: 0xffffff };
-}
-
-function createRoyalTennisStyling(theme: CharacterTheme | undefined, accent: number) {
-  const scale = CFG.playerHeight / 1.82;
-  const g = new THREE.Group();
-  g.name = "domino-royal-tennis-hair-eyes-makeup-outfit";
-  g.scale.setScalar(scale);
-  const palette = clothPalette(theme?.clothCombo, accent);
-  const hairMat = material(theme?.hairColor ?? 0x1a100c, 0.58, 0.04);
-  const skinMat = material(theme?.skinTone ?? 0xe0ad86, 0.72, 0.02);
-  const eyeMat = material(theme?.eyeColor ?? 0x315a7c, 0.34, 0.02);
-  const linerMat = material(0x171014, 0.3, 0.01);
-  const lipMat = material(0xa83d55, 0.46, 0.02);
-  const topMat = material(palette.top, 0.64, 0.04);
-  const trimMat = material(palette.trim, 0.38, 0.18);
-  const bottomMat = material(palette.bottom, 0.68, 0.03);
-  const shoeMat = material(palette.shoe, 0.48, 0.05);
-
-  const hair = new THREE.Mesh(new THREE.SphereGeometry(0.181, 28, 16, 0, Math.PI * 2, 0, Math.PI * 0.56), hairMat);
-  hair.position.set(0, 1.68, -0.012);
-  hair.scale.set(1.08, 0.58, 0.98);
-  g.add(hair);
-  const pony = new THREE.Mesh(new THREE.SphereGeometry(0.075, 18, 12), hairMat);
-  pony.position.set(0, 1.56, 0.145);
-  pony.scale.set(0.9, 1.25, 0.72);
-  g.add(pony);
-  addBox(g, [0.11, 0.018, 0.014], [-0.062, 1.63, -0.155], linerMat);
-  addBox(g, [0.11, 0.018, 0.014], [0.062, 1.63, -0.155], linerMat);
-  addCylinder(g, 0.018, 0.018, 0.008, [-0.062, 1.628, -0.166], eyeMat, 12);
-  addCylinder(g, 0.018, 0.018, 0.008, [0.062, 1.628, -0.166], eyeMat, 12);
-  addBox(g, [0.08, 0.014, 0.012], [0, 1.57, -0.168], lipMat);
-  addCylinder(g, 0.18, 0.22, 0.24, [0, 1.1, -0.003], topMat, 28);
-  addBox(g, [0.46, 0.038, 0.032], [0, 1.235, -0.01], trimMat);
-  addBox(g, [0.34, 0.035, 0.03], [0, 0.92, -0.012], trimMat);
-  addCylinder(g, 0.218, 0.235, 0.2, [0, 0.66, 0], bottomMat, 24);
-  addBox(g, [0.18, 0.05, 0.3], [-0.13, 0.035, -0.04], shoeMat);
-  addBox(g, [0.18, 0.05, 0.3], [0.13, 0.035, -0.04], shoeMat);
-  addCylinder(g, 0.052, 0.055, 0.2, [-0.31, 1.13, 0], skinMat, 14);
-  addCylinder(g, 0.052, 0.055, 0.2, [0.31, 1.13, 0], skinMat, 14);
-  g.traverse((obj) => { obj.renderOrder = 2; });
-  enableShadow(g);
-  return g;
-}
-
 
 function createRacket(color: number) {
   const g = new THREE.Group();
@@ -721,12 +924,11 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
   const root = new THREE.Group();
   const modelRoot = new THREE.Group();
   const fallback = createFallbackHuman(accent);
-  const royalStyling = createRoyalTennisStyling(theme, accent);
   const racket = createRacket(accent);
 
   root.position.copy(start);
   modelRoot.position.copy(start);
-  modelRoot.add(fallback, royalStyling);
+  modelRoot.add(fallback);
   scene.add(root, modelRoot, racket);
 
   const rig: HumanRig = {
@@ -763,22 +965,12 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
     (gltf) => {
       const model = gltf.scene;
       normalizeHuman(model, CFG.playerHeight);
-      model.traverse((obj) => {
-        const mesh = obj as THREE.Mesh;
-        if (!mesh.isMesh || !mesh.material) return;
-        const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-        materials.forEach((m) => {
-          const mat = m as THREE.MeshStandardMaterial;
-          if ((mat as any).map) (mat as any).map.colorSpace = THREE.SRGBColorSpace;
-          mat.needsUpdate = true;
-        });
-      });
+      enhanceTennisCharacterMaterials(model, theme, side);
       enableShadow(model);
       rig.model = model;
       rig.bones = findHumanBones(model);
       rig.rest = captureRestPose(rig.bones);
       rig.fallback.visible = false;
-      royalStyling.visible = true;
       rig.modelRoot.add(model);
       rig.modelRoot.updateMatrixWorld(true);
       rig.rightArmChain = makeArmChain(rig.bones.rightShoulder, rig.bones.rightUpperArm, rig.bones.rightForeArm, rig.bones.rightHand);
@@ -788,7 +980,6 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
     undefined,
     () => {
       rig.fallback.visible = true;
-      royalStyling.visible = true;
       rig.racket.visible = false;
     }
   );
@@ -1003,7 +1194,7 @@ function updatePoseAndRacket(player: HumanRig, ball: BallState) {
 function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: number, serve = false) {
   const flatDist = Math.hypot(target.x - from.x, target.z - from.z);
   const speedScale = CFG.worldScale * 1.48;
-  const shotPowerTrim = 0.95;
+  const shotPowerTrim = 0.88;
   const baseSpeed = (serve ? 24.5 + power * 15.2 : 18.6 + power * 12.8) * speedScale * shotPowerTrim;
   const flight = clamp(flatDist / baseSpeed, serve ? 0.34 : 0.46, serve ? 0.78 : 1.04);
   const velocity = new THREE.Vector3(
@@ -1034,7 +1225,7 @@ function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, e
   const duration = Math.max(durationMs, 16);
   const swipeSpeed = (dist / duration) * 1000;
   const speedBoost = clamp01((swipeSpeed - 240) / 1100);
-  const power = clamp((dist / 145) * 0.58 + speedBoost * 1.08 + (isServe ? 0.66 : 0.43), isServe ? 0.78 : 0.42, 1);
+  const power = clamp((dist / 145) * 0.5 + speedBoost * 0.92 + (isServe ? 0.58 : 0.36), isServe ? CFG.servePower.min : CFG.shotPower.min, isServe ? CFG.servePower.max : CFG.shotPower.max);
   const dir = new THREE.Vector2(dx, -dy);
   if (dir.lengthSq() > 1e-6) dir.normalize();
   const rawAimX = (dx / 120) * (CFG.courtW / 2);
@@ -1052,7 +1243,7 @@ function makeAiTarget(near: HumanRig, ball: BallState): DesiredHit {
   const attackToOpen = farDefendingWide ? -Math.sign(ball.pos.x || 1) * (CFG.courtW * 0.36) : near.pos.x * 0.72;
   const x = clamp(attackToOpen + sideRead + (Math.random() - 0.5) * 0.58, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
   const z = lerp(1.2, CFG.courtL / 2 - 0.7, 0.42 + pressure * 0.5);
-  const power = clamp(0.72 + pressure * 0.55 + Math.random() * 0.22, 0.62, 1);
+  const power = clamp(0.64 + pressure * 0.46 + Math.random() * 0.16, CFG.shotPower.min, CFG.shotPower.max);
   const roll = Math.random();
   const technique: ShotTechnique = pressure > 0.72 ? "topspin" : roll > 0.62 ? "slice" : "flat";
   return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique };
@@ -1650,7 +1841,7 @@ export default function MobileThreeTennisPrototype() {
         {menuOpen && (
           <div style={{ position: "absolute", right: 10, top: 108, width: 230, maxHeight: 330, overflow: "auto", background: "rgba(8,16,24,0.94)", border: "1px solid rgba(255,255,255,0.22)", borderRadius: 12, padding: 8, pointerEvents: "auto" }}>
             <div style={{ color: "#fff", fontSize: 12, fontWeight: 700, marginBottom: 6 }}>Domino Royal Characters</div>
-            <div style={{ color: "rgba(255,255,255,.7)", fontSize: 10, marginBottom: 8 }}>HDRIs removed: training court uses built-in lights, sky, fence, hair, eyes, makeup, and outfit styling.</div>
+            <div style={{ color: "rgba(255,255,255,.7)", fontSize: 10, marginBottom: 8 }}>HDRIs removed: training court uses built-in lights, sky, fence, Poly Haven mapped cloth textures and model-native hair/eyes styling.</div>
             {MURLAN_CHARACTER_THEMES.slice(0, 7).map((opt) => (
               <button key={opt.id} type="button" onClick={() => setSelectedHumanCharacterId(opt.id)} style={{ width: "100%", display: "flex", gap: 8, alignItems: "center", marginBottom: 6, borderRadius: 10, border: selectedHumanCharacterId === opt.id ? "1px solid #7dd3fc" : "1px solid rgba(255,255,255,.18)", background: "rgba(255,255,255,0.08)", padding: 6, color: "#fff" }}>
                 <span style={{ width: 42, height: 24, borderRadius: 6, background: `linear-gradient(135deg,#${(opt.hairColor ?? 0x24150f).toString(16).padStart(6, "0")},#${(opt.eyeColor ?? 0x2f5d7c).toString(16).padStart(6, "0")})`, border: "1px solid rgba(255,255,255,.2)" }} />

--- a/webapp/src/pages/Games/tennis/AIController.ts
+++ b/webapp/src/pages/Games/tennis/AIController.ts
@@ -32,7 +32,7 @@ export class AIController {
     const z = lerp(gameConfig.serviceLineZ * 0.42, gameConfig.courtL / 2 - 1.05, 0.36 + pressure * 0.54);
     const roll = Math.random();
     const technique: ShotTechnique = pressure > 0.72 ? "topspin" : roll > 0.9 ? "lob" : roll > 0.7 ? "slice" : "flat";
-    return { target: new THREE.Vector3(x, gameConfig.ballR, z), power: clamp(0.64 + pressure * 0.38 + gameConfig.aiDifficulty.power * 0.2, 0.62, 1), technique };
+    return { target: new THREE.Vector3(x, gameConfig.ballR, z), power: clamp(0.58 + pressure * 0.32 + gameConfig.aiDifficulty.power * 0.16, gameConfig.shotPower.min, gameConfig.shotPower.max), technique };
   }
 
   chooseServeTarget(side: ServeSide, server: PlayerSide = "far") {
@@ -43,7 +43,7 @@ export class AIController {
     const targetX = laneSign * lerp(gameConfig.courtW * 0.16, gameConfig.courtW * 0.36, Math.random());
     return {
       target: new THREE.Vector3(targetX, gameConfig.ballR, targetZ),
-      power: clamp(0.8 + gameConfig.aiDifficulty.serveQuality * 0.22 + Math.random() * 0.06, 0.78, 1),
+      power: clamp(0.72 + gameConfig.aiDifficulty.serveQuality * 0.18 + Math.random() * 0.05, gameConfig.servePower.min, gameConfig.servePower.max),
       technique: "topspin" as ShotTechnique,
     };
   }

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -29,7 +29,7 @@ export enum TennisBallState {
 }
 
 const BASE_WORLD_SCALE = 1.72;
-const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.3;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.42;
 const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
 // Keep the camera at its prior pullback distance so the enlarged court and
 // players read about 30% bigger in the actual gameplay view.
@@ -74,8 +74,8 @@ export const gameConfig = {
   serveDuration: 0.86,
   serveContactT: 0.72,
   serveTossMinHeight: 1.85 * PLAYER_SCALE,
-  servePower: { min: 0.68, max: 0.96 },
-  shotPower: { min: 0.33, max: 0.96 },
+  servePower: { min: 0.64, max: 0.9 },
+  shotPower: { min: 0.3, max: 0.88 },
   spinAmount: { flat: 0.8, topspin: 1.6, slice: -1.4, lob: 1.1, drop: -0.7, block: 0.25 },
   playerVisualYawFix: Math.PI,
   serveNearBaselineZ: (23.77 / 2 + 0.92) * WORLD_SCALE,
@@ -87,10 +87,10 @@ export const gameConfig = {
     moveSpeed: 11.2 * PLAYER_SCALE,
     reachRadius: 1.7 * PLAYER_SCALE,
     accuracy: 0.88,
-    power: 0.94,
+    power: 0.86,
     spin: 0.72,
     mistakeChance: 0.045,
-    serveQuality: 0.84,
+    serveQuality: 0.78,
   },
 } as const;
 


### PR DESCRIPTION
### Motivation
- Make the Tennis playfield and characters read larger in-game while keeping the same layout and camera framing. 
- Soften serve/shot power to produce gentler rallies that better match the enlarged visual scale. 
- Replace the procedural outfit/makeup overlay with model-native mapping using PolyHaven PBR textures (same approach used for Domino Royal) so character clothing uses real scanned textures instead of procedurals.

### Description
- Increased court/character scale by changing `COURT_AND_CHARACTER_SIZE_MULTIPLIER` from `1.3` to `1.42` in `webapp/src/pages/Games/tennis/gameConfig.ts`. 
- Reduced maximum/minimum `servePower` and `shotPower` and tuned `aiDifficulty` power/serveQuality to respect the softer ranges (adjusted `servePower`, `shotPower`, `aiDifficulty.power`, and `aiDifficulty.serveQuality`).
- Lowered `shotPowerTrim` used by `ballisticVelocity` and updated user swipe and AI power calculations to use `gameConfig.servePower`/`gameConfig.shotPower` ranges in `webapp/src/pages/Games/Tennis.tsx` and `webapp/src/pages/Games/tennis/AIController.ts`.
- Added a re-usable PolyHaven cloth material system to `Tennis.tsx` including `POLYHAVEN_CLOTH_MATERIALS`, `TENNIS_CHARACTER_CLOTH_COMBOS`, a texture loader/cache (`tennisTextureLoader`/`TENNIS_CHARACTER_TEXTURE_CACHE`), and helper functions `enhanceTennisCharacterMaterials`, `applyTennisClothMaterial`, and `normalizeTennisMaterialTextures` which map PolyHaven textures onto loaded GLB character meshes.
- Removed the old procedural `royalStyling` outfit overlay and instead call `enhanceTennisCharacterMaterials(model, theme, side)` during GLTF load to apply PolyHaven textures directly to the model materials (fallback behavior unchanged). 

### Testing
- Ran `npm --prefix webapp run build` successfully to produce production build artifacts. 
- Started the dev server (`vite --host`) and executed Playwright checks including `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully. 
- Launched a headless Playwright session to load `/games/tennis` and captured a verification screenshot saved as `/tmp/tennis-court-update.png` (page logged some external asset fetch warnings/errors but the tennis scene and character material mapping code paths were exercised).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0599ec9f548329b52294991e13bfdb)