### PR TITLE
Restore Snooker Royal cue follow-through

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -22685,25 +22685,35 @@ const powerRef = useRef(hud.power);
           };
           const idlePos = buildCuePosition(0);
           const pullPos = buildCuePosition(visualPull);
-          cueStick.position.copy(idlePos);
+          // Start the visible release from the player's pulled cue depth so the
+          // stick drives forward on its own, matching the former human-shot
+          // follow-through without needing to render the human character.
+          cueStick.position.copy(pullPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
           const pullbackDuration = 0;
-          const strikeDuration = 110;
-          const holdDuration = 45;
+          const strikeDuration = 130;
+          const holdDuration = 120;
           const returnDuration = 0;
-          // Stop exactly at the original address position after the forward stroke.
           const impactPos = buildCuePosition(0);
-          const followExtra = 0;
-          TMP_VEC3_FOLLOW_DIR.copy(impactPos).sub(pullPos);
-          if (TMP_VEC3_FOLLOW_DIR.lengthSq() > 1e-8) {
-            TMP_VEC3_FOLLOW_DIR.normalize();
-          }
-          const settlePos = impactPos
+          const contactAdvance = THREE.MathUtils.lerp(
+            BALL_R * 0.28,
+            BALL_R * 0.62,
+            clampedPower
+          );
+          const contactPos = impactPos
             .clone()
-            .addScaledVector(TMP_VEC3_FOLLOW_DIR, followExtra);
+            .addScaledVector(dir, contactAdvance);
+          const followExtra = THREE.MathUtils.lerp(
+            CUE_FOLLOW_THROUGH_MIN,
+            CUE_FOLLOW_THROUGH_MAX,
+            clampedPower
+          );
+          const settlePos = contactPos
+            .clone()
+            .addScaledVector(dir, followExtra);
           cueStick.visible = true;
-          cueStick.position.copy(idlePos);
+          cueStick.position.copy(pullPos);
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
           const impactTime = pullEndTime + strikeDuration;
@@ -22753,7 +22763,7 @@ const powerRef = useRef(hud.power);
             shotRecording.cueStroke = {
               warmup: serializeVector3Snapshot(idlePos),
               start: serializeVector3Snapshot(pullPos),
-              impact: serializeVector3Snapshot(impactPos),
+              impact: serializeVector3Snapshot(contactPos),
               settle: serializeVector3Snapshot(settlePos),
               idle: serializeVector3Snapshot(idlePos),
               rotationX: cueStick.rotation.x,
@@ -22787,14 +22797,9 @@ const powerRef = useRef(hud.power);
               cueStick.position.lerpVectors(idlePos, pullPos, easeInOutQuad(sample.t));
             } else if (sample.phase === 'release' || sample.phase === 'strike') {
               const strikeEase = easeOutCubic(sample.t);
-              const dynamicFollow =
-                followExtra * (0.55 + 0.45 * Math.sin(sample.t * Math.PI));
-              cueStick.position.lerpVectors(pullPos, impactPos, strikeEase);
-              if (dynamicFollow > 1e-6) {
-                cueStick.position.addScaledVector(TMP_VEC3_FOLLOW_DIR, dynamicFollow);
-              }
+              cueStick.position.lerpVectors(pullPos, contactPos, strikeEase);
             } else if (sample.phase === 'hold') {
-              cueStick.position.lerpVectors(impactPos, settlePos, easeInOutQuad(sample.t));
+              cueStick.position.lerpVectors(contactPos, settlePos, easeInOutQuad(sample.t));
             } else if (now <= returnTime && returnDuration > 0) {
               const t = THREE.MathUtils.clamp((now - holdEndTime) / returnDuration, 0, 1);
               cueStick.position.lerpVectors(settlePos, idlePos, easeInOutQuad(t));


### PR DESCRIPTION
### Motivation
- Restore the visual cue-stick follow-through so shots read like the previous human-character stroke while removing the need to render the human avatar.

### Description
- Start the visible release from the pulled-back cue depth by copying `pullPos` into the cue group instead of the idle pose and keep the cue visible during the forward stroke (`webapp/src/pages/Games/SnookerRoyal.jsx`).
- Compute a power-scaled `contactAdvance` and derive a `contactPos` (impact position) and `settlePos` (follow-through) from it, then drive the live animation toward `contactPos` and from `contactPos` to `settlePos`.
- Use `contactPos` for replay/recorded stroke data (`shotRecording.cueStroke.impact`) and update the runtime interpolation to lerp from `pullPos`→`contactPos`→`settlePos` during the stroke timeline.
- Adjust stroke timing parameters (increase `strikeDuration` and `holdDuration`) and simplify the dynamic follow code so the cue stick visibly pushes forward without relying on the human character.

### Testing
- Ran `npm run build` in `webapp` and the production build completed successfully.
- Ran `git diff --check` on the modified file and no whitespace/patch errors were reported.
- Attempted an automated Playwright screenshot of the dev route to visually validate the stroke, but Chromium could not launch in this environment due to a missing system library (`libatk-1.0.so.0`), so browser screenshot capture failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05aefa53c48329894802b917691375)