### PR TITLE
Reduce tennis shot power

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/README.md
+++ b/Assets/Scripts/Gameplay/Tennis/README.md
@@ -2,10 +2,10 @@
 
 This folder adds modular tennis systems:
 
-- `TennisShotTuning`: boosts shot power and supports flat/power/topspin/curve variants.
+- `TennisShotTuning`: keeps shots at a calmer match-power pace and supports flat/power/topspin/curve variants.
 - `TennisCourtScaler`: scales court + characters and moves camera back to keep similar framing.
 - `TennisAudioController`: trigger shot and bounce SFX.
-- `TennisAIOpponent`: faster AI reaction and mixed shot variants.
+- `TennisAIOpponent`: faster AI reaction, mixed shot variants, and capped match-power shot selection.
 - `CharacterWalk8Dir`: 8-direction walk movement (forward/backward/sideways).
 
 ## Free/open-source sound effect sources

--- a/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
@@ -10,8 +10,8 @@ namespace TonPlaygram.Gameplay.Tennis
         [SerializeField, Min(0.01f)] private float reactionTime = 0.1f;
         [SerializeField, Min(0f)] private float anticipationTime = 0.14f;
         [SerializeField, Min(0.01f)] private float minReactionTime = 0.05f;
-        [SerializeField, Min(0.1f)] private float minShotPower01 = 0.55f;
-        [SerializeField, Min(0.1f)] private float maxShotPower01 = 1f;
+        [SerializeField, Min(0.1f)] private float minShotPower01 = 0.45f;
+        [SerializeField, Min(0.1f)] private float maxShotPower01 = 0.82f;
 
         private float _nextHitTime;
 

--- a/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
@@ -6,7 +6,8 @@ namespace TonPlaygram.Gameplay.Tennis
     public class TennisShotTuning : MonoBehaviour
     {
         [Header("Power")]
-        [Min(1f)] public float baseShotPower = 23.25f;
+        [Min(1f)] public float baseShotPower = 17.5f;
+        [Range(0.1f, 1f)] public float maxMatchPower01 = 0.82f;
         [Range(0f, 2f)] public float topspin = 0.35f;
         [Range(0f, 2f)] public float sidespin = 0.2f;
         [Range(0f, 2f)] public float curvePower = 0.5f;
@@ -16,9 +17,10 @@ namespace TonPlaygram.Gameplay.Tennis
             if (ballBody == null) return;
 
             var dir = aimDirection.sqrMagnitude > 0.0001f ? aimDirection.normalized : transform.forward;
-            float power = baseShotPower * Mathf.Clamp01(normalizedPower);
+            float matchPower = Mathf.Clamp(normalizedPower, 0f, maxMatchPower01);
+            float power = baseShotPower * matchPower;
 
-            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.28f : 1.06f;
+            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.08f : 1f;
             float finalPower = power * variantPowerMultiplier;
 
             ballBody.AddForce(dir * finalPower, ForceMode.Impulse);
@@ -30,7 +32,7 @@ namespace TonPlaygram.Gameplay.Tennis
             ballBody.AddTorque((Vector3.right * spinY) + (right * side * sidespin * finalPower), ForceMode.Impulse);
             if (Mathf.Abs(side) > 0f)
             {
-                ballBody.AddForce(right * side * curvePower * normalizedPower, ForceMode.Impulse);
+                ballBody.AddForce(right * side * curvePower * matchPower, ForceMode.Impulse);
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Bring tennis shots down to a calmer, match-appropriate pace by preventing full-strength normalized power from producing overly strong impulses.
- Prevent special variants (Power/Curve) from bypassing the intended power cap and making shots unexpectedly aggressive.
- Ensure AI selects shots within the same capped match-power envelope so gameplay feels consistent.

### Description
- Lowered `baseShotPower` and added a `maxMatchPower01` clamp in `TennisShotTuning` and use `matchPower = Mathf.Clamp(normalizedPower, 0f, maxMatchPower01)` when computing shot force and curve impulse in `ApplyShot`.
- Reduced the `Power` variant multiplier to `1.08f` and set the default variant multiplier to `1f`, and make curve forces scale with `matchPower` instead of raw `normalizedPower` in `Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs`.
- Tuned AI shot selection min/max to `0.45`–`0.82` in `Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs` so AI chooses shots inside the new match-power range.
- Updated `Assets/Scripts/Gameplay/Tennis/README.md` to document the calmer match-power tuning and the AI cap.

### Testing
- Ran `git diff --check` to validate diffs and whitespace issues, which completed successfully.
- Changes were committed successfully (no automated unit tests were executed as part of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c209cdc8832984844cfa49c6026d)