### PR TITLE
Table Tennis: scale up scene, boost power, and fix net collision behavior

### DIFF
--- a/webapp/src/pages/Games/TableTennis.tsx
+++ b/webapp/src/pages/Games/TableTennis.tsx
@@ -125,51 +125,52 @@ const DEFAULT_HDRI_URLS = [
 const UP = new THREE.Vector3(0, 1, 0);
 const Y_AXIS = UP;
 
+const TABLE_TENNIS_SCENE_SCALE = 1.14;
+const tableUnit = (value: number) => value * TABLE_TENNIS_SCENE_SCALE;
+
 const CFG = {
-  // Match Pool Royale stage proportions so table footprint/height align in the same HDRI placement.
-  tableL: 6.45,
-  tableW: 3.55,
+  // Keep the procedural table, net, ball, paddles, and humans scaled as one set so
+  // the gameplay reads larger while preserving the current table-tennis proportions.
+  tableL: tableUnit(6.45),
+  tableW: tableUnit(3.55),
   tableY: 1.52,
-  tableTopThickness: 0.088,
-  netH: 0.19,
-  netPostOutside: 0.19,
-  ballR: 0.046,
+  tableTopThickness: tableUnit(0.088),
+  netH: tableUnit(0.19),
+  netPostOutside: tableUnit(0.19),
+  ballR: tableUnit(0.046),
   gravity: 9.81,
   airDrag: 0.22,
   magnus: 0.00125,
   tableRestitution: 0.9,
   tableFriction: 0.965,
   spinDecay: 0.72,
-  playerHeight: 3.12,
-  playerSpeed: 3.5,
-  aiSpeed: 6.15,
+  playerHeight: tableUnit(3.12),
+  playerSpeed: tableUnit(3.5),
+  aiSpeed: tableUnit(6.15),
   aiServeReceiveBoost: 1.24,
   aiOutBallConfidenceCutoff: 0.22,
-  reach: 1.04,
+  reach: tableUnit(1.04),
   swingDuration: 0.31,
   backhandDuration: 0.27,
   serveDuration: 0.82,
   hitWindowStart: 0.35,
   hitWindowEnd: 0.8,
   serveContactT: 0.68,
-  netTopRestitution: 0.42,
-  netFaceRestitution: 0.08,
-  netPowerRetention: 0.18,
-  netClipPowerRetention: 0.58,
-  netTangentDamping: 0.42,
+  netPowerRetention: 0.2,
+  netTangentDamping: 0.62,
   bodyPowerRetention: 0.2,
   floorRestitution: 0.56,
   floorFriction: 0.88,
   railRestitution: 0.5,
-  minShotSpeed: 3.7,
-  maxShotSpeed: 9.8,
+  minShotSpeed: 4.05,
+  maxShotSpeed: 10.75,
   playerVisualYawFix: Math.PI,
   paddlePalmOffset: 0.038,
 };
 
 const TABLE_REFERENCE_LENGTH = 2.74;
 const TABLE_SCALE_FACTOR = CFG.tableL / TABLE_REFERENCE_LENGTH;
-const PADDLE_SCALE_FACTOR = Math.max(1.18, TABLE_SCALE_FACTOR * 0.86);
+const PADDLE_SCALE_FACTOR = Math.max(1.18, TABLE_SCALE_FACTOR * 0.9);
 
 const TABLE_HALF_W = CFG.tableW / 2;
 const TABLE_HALF_L = CFG.tableL / 2;
@@ -1052,7 +1053,7 @@ function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, flight: n
 function makeUserHitFromSwipe(startX: number, startY: number, endX: number, endY: number, isServe: boolean): DesiredHit {
   const dx = endX - startX;
   const dy = endY - startY;
-  const power = clamp(Math.hypot(dx, dy) / 180, isServe ? 0.56 : 0.36, 1);
+  const power = clamp(Math.hypot(dx, dy) / 165, isServe ? 0.6 : 0.4, 1);
   const lateral = clamp(dx / 170, -1, 1);
   const depth = clamp((-dy + 42) / 255, 0, 1);
   const targetX = clamp(lateral * (TABLE_HALF_W - 0.13), -TABLE_HALF_W + 0.12, TABLE_HALF_W - 0.12);
@@ -1073,7 +1074,7 @@ function makeAiServeTarget(): DesiredHit {
   const z = shortServe ? lerp(0.32, 0.52, Math.random()) : lerp(TABLE_HALF_L - 0.35, TABLE_HALF_L - 0.16, Math.random());
   return {
     target: new THREE.Vector3(x, BALL_SURFACE_Y, z),
-    power: shortServe ? 0.48 + Math.random() * 0.12 : 0.62 + Math.random() * 0.18,
+    power: shortServe ? 0.52 + Math.random() * 0.12 : 0.68 + Math.random() * 0.18,
     topSpin: shortServe ? 0.24 + Math.random() * 0.28 : 0.62 + Math.random() * 0.35,
     sideSpin,
     tactic: "serve",
@@ -1172,7 +1173,7 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
     ball.pos.y = clamp(ball.pos.y, CFG.tableY + 0.08, CFG.tableY + 0.48);
     const dist = Math.hypot(target.x - ball.pos.x, target.z - ball.pos.z);
     const speedScale = Math.max(1, TABLE_SCALE_FACTOR * 0.85);
-    const flight = clamp(dist / ((4.2 + hit.power * 4.1) * speedScale), 0.14, 0.4);
+    const flight = clamp(dist / ((4.55 + hit.power * 4.45) * speedScale), 0.13, 0.36);
     ball.vel.copy(ballisticVelocity(ball.pos, target, flight));
     ball.spin.set(-dirZ * (68 + hit.topSpin * 102), hit.sideSpin * 118, hit.sideSpin * 14);
     ball.phase = { kind: "rally" };
@@ -1543,8 +1544,8 @@ export default function MobileRealisticTableTennisGame() {
       renderer.setSize(w, h, false);
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
       camera.aspect = w / h;
-      camera.fov = camera.aspect < 0.72 ? 44 : 39;
-      camera.position.set(0, camera.aspect < 0.72 ? 6.35 : 5.55, camera.aspect < 0.72 ? 7.65 : 6.75);
+      camera.fov = camera.aspect < 0.72 ? 45 : 40;
+      camera.position.set(0, camera.aspect < 0.72 ? 6.9 : 6.05, camera.aspect < 0.72 ? 8.35 : 7.35);
       camera.lookAt(cameraTarget);
       camera.updateProjectionMatrix();
     };
@@ -1693,24 +1694,16 @@ export default function MobileRealisticTableTennisGame() {
       if (netContact) {
         const travelDir = Math.sign(ball.vel.z || (ball.lastHitBy === "near" ? -1 : 1));
         const approachSide = travelDir === 0 ? (ball.lastHitBy === "near" ? 1 : -1) : -travelDir;
-        const clipDepth = clamp01((ball.pos.y + CFG.ballR - (netTopY - CFG.ballR * 0.25)) / (CFG.ballR * 1.6));
-        const topClip = clipDepth > 0.45 && Math.abs(ball.vel.z) > 0.35;
-        const lateralDeflect = clamp(ball.vel.x * 0.05 + ball.spin.y * 0.0009 + (Math.random() - 0.5) * 0.08, -0.22, 0.22);
+        const lateralDeflect = clamp(ball.spin.y * 0.0006 + (Math.random() - 0.5) * 0.035, -0.08, 0.08);
 
-        ball.pos.z = approachSide * 0.032;
-        if (topClip) {
-          const crawlsOver = ball.vel.y > -0.85 && Math.abs(ball.vel.z) > 1.1 && clipDepth > 0.58;
-          ball.vel.z = Math.abs(ball.vel.z) * (crawlsOver ? CFG.netClipPowerRetention : CFG.netTopRestitution) * (crawlsOver ? travelDir : approachSide);
-          ball.vel.y = Math.max(crawlsOver ? 0.055 : 0.02, Math.abs(ball.vel.y) * 0.18 + clipDepth * 0.08);
-          ball.vel.x = ball.vel.x * 0.62 + lateralDeflect;
-          reduceImpactPower(ball.vel, crawlsOver ? CFG.netClipPowerRetention : CFG.netPowerRetention, crawlsOver ? 0.42 : 0.24);
-        } else {
-          ball.vel.z = Math.abs(ball.vel.z) * CFG.netFaceRestitution * approachSide;
-          ball.vel.x = ball.vel.x * CFG.netTangentDamping + lateralDeflect;
-          ball.vel.y = Math.min(0.06, ball.vel.y * 0.18) - 0.06;
-          reduceImpactPower(ball.vel, CFG.netPowerRetention, 0.18);
-        }
-        ball.spin.multiplyScalar(topClip ? 0.55 : 0.35);
+        // Net contact should not reflect the ball back at the hitter. Preserve the
+        // incoming travel direction, remove 80% of the total velocity, then let
+        // gravity, spin decay, and normal table/floor bounce handling continue.
+        ball.pos.z = travelDir * Math.max(0.032, CFG.ballR * 0.55);
+        ball.vel.multiplyScalar(CFG.netPowerRetention);
+        ball.vel.z = Math.sign(ball.vel.z || travelDir) * Math.abs(ball.vel.z);
+        ball.vel.x = ball.vel.x * CFG.netTangentDamping + lateralDeflect;
+        ball.spin.multiplyScalar(0.4);
         netWobble.amount = 1;
         netWobble.side = approachSide;
         playFx(netFx);
@@ -1899,7 +1892,7 @@ export default function MobileRealisticTableTennisGame() {
         netObj.position.z = Math.sin(now * 0.02) * 0.012 * netWobble.amount * netWobble.side;
       }
 
-      const bPos = new THREE.Vector3(0, camera.aspect < 0.72 ? 6.35 : 5.55, camera.aspect < 0.72 ? 7.65 : 6.75);
+      const bPos = new THREE.Vector3(0, camera.aspect < 0.72 ? 6.9 : 6.05, camera.aspect < 0.72 ? 8.35 : 7.35);
       camera.position.lerp(bPos, 1 - Math.exp(-5 * dt));
       cameraTarget.lerp(new THREE.Vector3(0, CFG.tableY + 0.22, -0.08), 1 - Math.exp(-5 * dt));
       camera.lookAt(cameraTarget);


### PR DESCRIPTION
### Motivation
- Make the table, players, paddles, net and ball read larger in-game while preserving the existing portrait framing. 
- Increase shot responsiveness and top-end speed for a more energetic feel. 
- Fix incorrect net collisions that reflected the ball back toward the hitter instead of letting it lose most energy and continue naturally.

### Description
- Introduced a shared scene scale (`TABLE_TENNIS_SCENE_SCALE` + `tableUnit`) and applied it to the table, net, ball, player sizes, reach and paddle scale to enlarge the whole play set while retaining proportions (`webapp/src/pages/Games/TableTennis.tsx`).
- Tuned gameplay power and speed: increased swipe-to-power scaling, raised AI serve power, adjusted rally `flight` constants, and bumped `minShotSpeed`/`maxShotSpeed` to make hits feel stronger and faster.
- Adjusted camera parameters (`fov` and camera positions) to pull back/up so the new larger scene keeps the same type of framing in portrait layouts.
- Reworked net collision handling: net contact now removes ~80% of incoming velocity (keeps `20%`), preserves the travel direction, damps lateral/tangent components, reduces spin, and lets gravity and normal bounce handling continue instead of reflecting back at the hitter; replaced previous branchy top-clip/face reflection logic with a simple energy-reduction path using `CFG.netPowerRetention` and tangent damping.
- Minor related changes: increased `PADDLE_SCALE_FACTOR` formula and updated several CFG constants (e.g. `netPowerRetention`, `netTangentDamping`, `reach`) to match the new scale and behavior.

### Testing
- Type-checked the modified file with `npx tsc --noEmit --skipLibCheck --jsx react-jsx --moduleResolution bundler --module esnext --target es2020 --allowSyntheticDefaultImports --esModuleInterop webapp/src/pages/Games/TableTennis.tsx` (succeeded).
- Built the webapp with `npm --prefix webapp run build` to ensure bundling and minification passed (succeeded).
- Ran a local headless run and captured a Playwright screenshot of `/games/table-tennis` to confirm visual framing and runtime behavior (`/tmp/table-tennis-update.png`) (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ca993b6883299f5a70c510093e2b)