### PR TITLE
Reduce tennis shot power

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -1258,7 +1258,7 @@ function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: nu
   const speedScale = CFG.worldScale * 1.48;
   const shotPowerTrim = serve ? 0.8 : 0.76;
   const matchPower = power * CFG.matchPowerMultiplier;
-  const baseSpeed = (serve ? 22.2 + matchPower * 12.6 : 15.8 + matchPower * 10.4) * speedScale * shotPowerTrim;
+  const baseSpeed = (serve ? 22.2 + power * 12.6 : 15.8 + power * 10.4) * speedScale * shotPowerTrim * CFG.matchPowerMultiplier;
   const flight = clamp(flatDist / baseSpeed, serve ? 0.34 : 0.46, serve ? 0.78 : 1.04);
   const velocity = new THREE.Vector3(
     (target.x - from.x) / flight,
@@ -1331,8 +1331,8 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
   ball.vel.copy(ballisticVelocity(ball.pos, target, hit.power, serve));
   if (hit.swipeDir && hit.swipeDir.lengthSq() > 0) {
     const swipePower = hit.power * CFG.matchPowerMultiplier;
-    ball.vel.x += hit.swipeDir.x * (2.2 + swipePower * 1.85) * CFG.worldScale;
-    ball.vel.z += -hit.swipeDir.y * (0.94 + swipePower * 1.18) * CFG.worldScale;
+    ball.vel.x += hit.swipeDir.x * (2.2 + swipePower * 1.85) * CFG.worldScale * CFG.matchPowerMultiplier;
+    ball.vel.z += -hit.swipeDir.y * (0.94 + swipePower * 1.18) * CFG.worldScale * CFG.matchPowerMultiplier;
   }
   const technique = hit.technique || "flat";
   if (technique === "lob") {

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -74,7 +74,7 @@ export const gameConfig = {
   serveDuration: 0.86,
   serveContactT: 0.72,
   serveTossMinHeight: 1.85 * PLAYER_SCALE,
-  // Scales match shot force so player and AI strokes share a calmer 80% power ceiling.
+  // Scales the full match shot force so player and AI strokes share a calmer 80% power ceiling.
   matchPowerMultiplier: 0.8,
   servePower: { min: 0.56, max: 0.82 },
   shotPower: { min: 0.24, max: 0.78 },


### PR DESCRIPTION
### Motivation
- Reduce the felt strength of tennis shots so in-game shot power better matches the intended pacing and `power` inputs.

### Description
- In `webapp/src/pages/Games/Tennis.tsx` apply `CFG.matchPowerMultiplier` to the full ballistic speed calculation in `ballisticVelocity` so base shot speed is scaled by the match-wide multiplier.
- In `webapp/src/pages/Games/Tennis.tsx` scale swipe-added directional velocity by `CFG.matchPowerMultiplier` to keep lateral/depth impulse consistent with the lowered overall power.
- Clarified the comment for `matchPowerMultiplier` in `webapp/src/pages/Games/tennis/gameConfig.ts` to indicate it scales the full match shot force.

### Testing
- Ran the production build with `npm --prefix webapp run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05d2475b7083298941bd993e744f3e)