### PR TITLE
Improve table tennis shot power

### DIFF
--- a/webapp/src/pages/Games/TableTennis.tsx
+++ b/webapp/src/pages/Games/TableTennis.tsx
@@ -159,8 +159,9 @@ const CFG = {
   floorRestitution: 0.56,
   floorFriction: 0.88,
   railRestitution: 0.5,
-  minShotSpeed: 4.05,
-  maxShotSpeed: 10.9,
+  minShotSpeed: 5.25,
+  maxShotSpeed: 15.75,
+  netClearance: 0.085,
   playerVisualYawFix: Math.PI,
   paddlePalmOffset: 0.038,
 };
@@ -1054,10 +1055,27 @@ function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, flight: n
   );
 }
 
+function flightWithNetClearance(from: THREE.Vector3, target: THREE.Vector3, baseFlight: number, minFlight: number, maxFlight: number) {
+  if ((from.z > 0 && target.z < 0) || (from.z < 0 && target.z > 0)) {
+    const netAlpha = clamp01((0 - from.z) / (target.z - from.z));
+    const netArcWeight = netAlpha * (1 - netAlpha);
+    if (netArcWeight > 0.0001) {
+      const linearNetY = lerp(from.y, target.y, netAlpha);
+      const requiredCenterY = CFG.tableY + CFG.netH + CFG.ballR + CFG.netClearance;
+      const requiredLift = requiredCenterY - linearNetY;
+      if (requiredLift > 0) {
+        const clearanceFlight = Math.sqrt((requiredLift * 2) / (CFG.gravity * netArcWeight));
+        return clamp(Math.max(baseFlight, clearanceFlight), minFlight, maxFlight);
+      }
+    }
+  }
+  return clamp(baseFlight, minFlight, maxFlight);
+}
+
 function makeUserHitFromSwipe(startX: number, startY: number, endX: number, endY: number, isServe: boolean): DesiredHit {
   const dx = endX - startX;
   const dy = endY - startY;
-  const power = clamp(Math.hypot(dx, dy) / 180, isServe ? 0.56 : 0.36, 1);
+  const power = clamp(Math.hypot(dx, dy) / 140, isServe ? 0.68 : 0.5, 1);
   const lateral = clamp(dx / 170, -1, 1);
   const depth = clamp((-dy + 42) / 255, 0, 1);
   const targetX = clamp(lateral * (TABLE_HALF_W - 0.13), -TABLE_HALF_W + 0.12, TABLE_HALF_W - 0.12);
@@ -1168,8 +1186,8 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
 
   if (serve) {
     ball.pos.copy(serveContactPosition(player));
-    const ownBounce = new THREE.Vector3(clamp(target.x * 0.45, -TABLE_HALF_W + 0.12, TABLE_HALF_W - 0.12), BALL_SURFACE_Y, dirZ * -0.56);
-    const flight = clamp(0.18 + (1 - hit.power) * 0.075, 0.17, 0.28);
+    const ownBounce = new THREE.Vector3(clamp(target.x * 0.45, -TABLE_HALF_W + 0.12, TABLE_HALF_W - 0.12), BALL_SURFACE_Y, dirZ * -0.82);
+    const flight = clamp(0.2 + (1 - hit.power) * 0.085, 0.18, 0.31);
     ball.vel.copy(ballisticVelocity(ball.pos, ownBounce, flight));
     ball.spin.set(-dirZ * (52 + hit.topSpin * 50), hit.sideSpin * 86, hit.sideSpin * 9);
     ball.phase = { kind: "serve", server: player.side, stage: "own" };
@@ -1177,7 +1195,8 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
     ball.pos.y = clamp(ball.pos.y, CFG.tableY + 0.08, CFG.tableY + 0.48);
     const dist = Math.hypot(target.x - ball.pos.x, target.z - ball.pos.z);
     const speedScale = Math.max(1, TABLE_SCALE_FACTOR * 0.85);
-    const flight = clamp(dist / ((4.55 + hit.power * 4.45) * speedScale), 0.14, 0.4);
+    const baseFlight = dist / ((5.2 + hit.power * 5.35) * speedScale);
+    const flight = flightWithNetClearance(ball.pos, target, baseFlight, 0.18, 0.52);
     ball.vel.copy(ballisticVelocity(ball.pos, target, flight));
     ball.spin.set(-dirZ * (68 + hit.topSpin * 102), hit.sideSpin * 118, hit.sideSpin * 14);
     ball.phase = { kind: "rally" };


### PR DESCRIPTION
### Motivation
- Players reported that table tennis shots lacked carry and often failed to clear the net, so hits need to feel stronger and cross-table shots should arc higher.

### Description
- Increased shot speed limits by raising `minShotSpeed` and `maxShotSpeed` and added a configurable `netClearance` to `CFG` to tune net safety margins.
- Reduced swipe distance required for full power in `makeUserHitFromSwipe` to make user swipes feel stronger by adjusting the swipe-to-power scaling.
- Added a new helper `flightWithNetClearance(from, target, baseFlight, minFlight, maxFlight)` and applied it in `performHit` to raise rally trajectories that cross the net so they clear reliably.
- Tweaked serve behavior by pushing the server-side own-bounce deeper and slightly extending serve flight timing so legal serves carry more predictably.

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e11b98b08329b9c5b66390bff539)