### PR TITLE
Tune tennis scale and shot power

### DIFF
--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -29,13 +29,13 @@ export enum TennisBallState {
 }
 
 const BASE_WORLD_SCALE = 1.72;
-const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.42;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.55;
 const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
 // Keep the camera at its prior pullback distance so the enlarged court and
-// players read about 30% bigger in the actual gameplay view.
+// players read clearly bigger in the actual gameplay view.
 const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE;
 // Extra character scale keeps human avatars visibly bigger than the court uplift.
-const PLAYER_CHARACTER_SCALE = 1.12;
+const PLAYER_CHARACTER_SCALE = 1.2;
 const PLAYER_SCALE = WORLD_SCALE * PLAYER_CHARACTER_SCALE;
 
 export const gameConfig = {
@@ -74,10 +74,10 @@ export const gameConfig = {
   serveDuration: 0.86,
   serveContactT: 0.72,
   serveTossMinHeight: 1.85 * PLAYER_SCALE,
-  // Scales the full match shot force so player and AI strokes share a calmer 80% power ceiling.
-  matchPowerMultiplier: 0.8,
-  servePower: { min: 0.56, max: 0.82 },
-  shotPower: { min: 0.24, max: 0.78 },
+  // Scales the full match shot force so player and AI strokes share a calmer, lower power ceiling.
+  matchPowerMultiplier: 0.68,
+  servePower: { min: 0.48, max: 0.72 },
+  shotPower: { min: 0.2, max: 0.66 },
   spinAmount: { flat: 0.8, topspin: 1.6, slice: -1.4, lob: 1.1, drop: -0.7, block: 0.25 },
   playerVisualYawFix: Math.PI,
   serveNearBaselineZ: (23.77 / 2 + 0.92) * WORLD_SCALE,
@@ -89,7 +89,7 @@ export const gameConfig = {
     moveSpeed: 12.8 * PLAYER_SCALE,
     reachRadius: 1.95 * PLAYER_SCALE,
     accuracy: 0.94,
-    power: 0.74,
+    power: 0.62,
     spin: 0.88,
     mistakeChance: 0.018,
     serveQuality: 0.84,


### PR DESCRIPTION
### Motivation

- Make the tennis gameplay read and feel larger by increasing court/world and human character scale, and reduce the felt power of serves and strokes so rallies feel calmer and less overpowering.

### Description

- Increased the global court/world scale multiplier from `1.42` to `1.55` and raised `PLAYER_CHARACTER_SCALE` from `1.12` to `1.2` so characters and court render bigger (`webapp/src/pages/Games/tennis/gameConfig.ts`).
- Lowered overall shot strength by reducing `matchPowerMultiplier` from `0.8` to `0.68`, tightening `servePower` to `{ min: 0.48, max: 0.72 }` and `shotPower` to `{ min: 0.2, max: 0.66 }` (`webapp/src/pages/Games/tennis/gameConfig.ts`).
- Reduced AI aggressiveness by lowering AI `power` from `0.74` to `0.62` to match the new, softer shot tuning (`webapp/src/pages/Games/tennis/gameConfig.ts`).

### Testing

- Ran `npm run build` in the webapp and the production build completed successfully (Vite build finished without fatal errors). 
- Installed Playwright and platform dependencies via `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully. 
- Executed a Playwright headless smoke screenshot test against `/games/tennis`; the run completed and produced a screenshot, though the headless environment produced multiple network/resource fetch console errors that are expected in CI-like sandboxed runs and did not prevent the smoke test from finishing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e15c4f7c8329a77742b5014f3886)