### PR TITLE
Tweak table-tennis: larger court & avatars, reduce ball power

### DIFF
--- a/frontend/src/table-tennis/AIController.ts
+++ b/frontend/src/table-tennis/AIController.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { BallPhysics } from './BallPhysics';
-import { GAME_CONFIG, ShotType } from './gameConfig';
+import { GAME_CONFIG, ShotType, TABLE_BOUNDS } from './gameConfig';
 
 export class AIController {
   readonly targetX = { value: 0 };
@@ -8,7 +8,11 @@ export class AIController {
   private reactionTimer = 0;
   private committedLanding: THREE.Vector3 | null = null;
 
-  constructor(private root: THREE.Group, private hand: THREE.Object3D, private paddle: THREE.Object3D) {}
+  constructor(
+    private root: THREE.Group,
+    private hand: THREE.Object3D,
+    private paddle: THREE.Object3D
+  ) {}
 
   update(dt: number, ball: BallPhysics) {
     const cfg = GAME_CONFIG.ai.difficulty;
@@ -16,24 +20,54 @@ export class AIController {
     if (this.reactionTimer <= 0) {
       this.committedLanding = ball.predictLandingPoint('ai');
       if (this.committedLanding) {
-        const noise = (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(0.55);
-        this.targetX.value = THREE.MathUtils.clamp(this.committedLanding.x + noise, GAME_CONFIG.ai.minX, GAME_CONFIG.ai.maxX);
+        const noise =
+          (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(0.55);
+        this.targetX.value = THREE.MathUtils.clamp(
+          this.committedLanding.x + noise,
+          GAME_CONFIG.ai.minX,
+          GAME_CONFIG.ai.maxX
+        );
       }
       this.reactionTimer = cfg.reactionTime;
     }
 
-    this.root.position.x = THREE.MathUtils.damp(this.root.position.x, this.targetX.value, cfg.moveSpeed, dt);
+    this.root.position.x = THREE.MathUtils.damp(
+      this.root.position.x,
+      this.targetX.value,
+      cfg.moveSpeed,
+      dt
+    );
     this.root.position.z = GAME_CONFIG.ai.z;
-    this.currentShot = ball.position.x > this.root.position.x ? 'forehand drive' : 'backhand drive';
-    const yaw = THREE.MathUtils.clamp((ball.position.x - this.root.position.x) * 0.4, -0.5, 0.5);
+    this.currentShot =
+      ball.position.x > this.root.position.x
+        ? 'forehand drive'
+        : 'backhand drive';
+    const yaw = THREE.MathUtils.clamp(
+      (ball.position.x - this.root.position.x) * 0.4,
+      -0.5,
+      0.5
+    );
     this.root.rotation.y = Math.PI + yaw;
-    this.hand.position.set(this.currentShot === 'forehand drive' ? -0.16 : 0.16, 0.92, -0.28);
+    this.hand.position.set(
+      this.currentShot === 'forehand drive' ? -0.16 : 0.16,
+      0.92,
+      -0.28
+    );
     this.paddle.position.set(0, -0.02, -0.12);
-    this.paddle.rotation.set(-0.25, 0, this.currentShot === 'forehand drive' ? -0.16 : 0.16);
+    this.paddle.rotation.set(
+      -0.25,
+      0,
+      this.currentShot === 'forehand drive' ? -0.16 : 0.16
+    );
   }
 
   canReach(ballPosition: THREE.Vector3) {
-    return Math.abs(ballPosition.x - this.root.position.x) <= GAME_CONFIG.ai.maxReach && ballPosition.z < -1.3 && ballPosition.z > -2.68;
+    return (
+      Math.abs(ballPosition.x - this.root.position.x) <=
+        GAME_CONFIG.ai.maxReach &&
+      ballPosition.z < TABLE_BOUNDS.minZ * 0.7 &&
+      ballPosition.z > GAME_CONFIG.ai.z - 0.32
+    );
   }
 
   shouldMiss() {
@@ -45,6 +79,8 @@ export class AIController {
   }
 
   getPaddleForward() {
-    return new THREE.Vector3(0, 0, 1).applyQuaternion(this.paddle.getWorldQuaternion(new THREE.Quaternion())).normalize();
+    return new THREE.Vector3(0, 0, 1)
+      .applyQuaternion(this.paddle.getWorldQuaternion(new THREE.Quaternion()))
+      .normalize();
   }
 }

--- a/frontend/src/table-tennis/BallPhysics.ts
+++ b/frontend/src/table-tennis/BallPhysics.ts
@@ -41,7 +41,11 @@ export class BallPhysics {
   private accumulator = 0;
 
   resetForServe(server: Side) {
-    this.position.set(server === 'player' ? -0.16 : 0.16, GAME_CONFIG.table.topY + GAME_CONFIG.serveHeight, server === 'player' ? 1.08 : -1.08);
+    this.position.set(
+      server === 'player' ? -0.16 : 0.16,
+      GAME_CONFIG.table.topY + GAME_CONFIG.serveHeight,
+      server === 'player' ? 1.08 : -1.08
+    );
     this.velocity.set(0, 0, 0);
     this.spin.set(0, 0, 0);
     this.lastTouch = server;
@@ -52,8 +56,16 @@ export class BallPhysics {
 
   serve(server: Side) {
     this.resetBouncesAfterHit(server);
-    this.velocity.set(server === 'player' ? 0.08 : -0.08, 1.25, server === 'player' ? -2.9 : 2.9);
-    this.spin.set(server === 'player' ? 0.2 : -0.2, 0, server === 'player' ? -1.2 : 1.2);
+    this.velocity.set(
+      server === 'player' ? 0.06 : -0.06,
+      1.12,
+      server === 'player' ? -2.35 : 2.35
+    );
+    this.spin.set(
+      server === 'player' ? 0.16 : -0.16,
+      0,
+      server === 'player' ? -0.95 : 0.95
+    );
     this.state = 'flying';
   }
 
@@ -76,11 +88,20 @@ export class BallPhysics {
   }
 
   private step(dt: number): BallEvent[] {
-    if (this.state === 'idle' || this.state === 'serve' || this.state === 'pointEnded') return [];
+    if (
+      this.state === 'idle' ||
+      this.state === 'serve' ||
+      this.state === 'pointEnded'
+    )
+      return [];
 
     const events: BallEvent[] = [];
     const previous = this.position.clone();
-    const acceleration = tmp.set(this.spin.z * GAME_CONFIG.spinCurve, GAME_CONFIG.gravity, -this.spin.x * GAME_CONFIG.spinCurve);
+    const acceleration = tmp.set(
+      this.spin.z * GAME_CONFIG.spinCurve,
+      GAME_CONFIG.gravity,
+      -this.spin.x * GAME_CONFIG.spinCurve
+    );
     this.velocity.addScaledVector(acceleration, dt);
     this.velocity.multiplyScalar(1 - GAME_CONFIG.drag * dt);
     this.position.addScaledVector(this.velocity, dt);
@@ -93,7 +114,11 @@ export class BallPhysics {
 
     if (this.isClearlyOut()) {
       this.state = 'out';
-      events.push({ type: 'out', position: this.position.clone(), state: this.state });
+      events.push({
+        type: 'out',
+        position: this.position.clone(),
+        state: this.state
+      });
     } else if (this.state !== 'netHit' && this.state !== 'out') {
       this.state = 'flying';
     }
@@ -106,10 +131,15 @@ export class BallPhysics {
     const crossedTop = previous.y >= top && this.position.y <= top;
     if (!crossedTop || this.velocity.y >= 0) return null;
 
-    const t = (previous.y - top) / Math.max(previous.y - this.position.y, 0.0001);
+    const t =
+      (previous.y - top) / Math.max(previous.y - this.position.y, 0.0001);
     const xAtImpact = THREE.MathUtils.lerp(previous.x, this.position.x, t);
     const zAtImpact = THREE.MathUtils.lerp(previous.z, this.position.z, t);
-    const inside = xAtImpact >= TABLE_BOUNDS.minX && xAtImpact <= TABLE_BOUNDS.maxX && zAtImpact >= TABLE_BOUNDS.minZ && zAtImpact <= TABLE_BOUNDS.maxZ;
+    const inside =
+      xAtImpact >= TABLE_BOUNDS.minX &&
+      xAtImpact <= TABLE_BOUNDS.maxX &&
+      zAtImpact >= TABLE_BOUNDS.minZ &&
+      zAtImpact <= TABLE_BOUNDS.maxZ;
     if (!inside) return null;
 
     this.position.set(xAtImpact, top, zAtImpact);
@@ -121,18 +151,33 @@ export class BallPhysics {
     const side: Side = zAtImpact > 0 ? 'player' : 'ai';
     this.bounces[side] += 1;
     this.state = side === 'player' ? 'tableBouncePlayer' : 'tableBounceAI';
-    return { type: 'bounce', side, position: this.position.clone(), state: this.state };
+    return {
+      type: 'bounce',
+      side,
+      position: this.position.clone(),
+      state: this.state
+    };
   }
 
   private resolveNetCollision(previous: THREE.Vector3): BallEvent | null {
     const radius = GAME_CONFIG.ballRadius;
-    const crossesNet = (previous.z - NET_BOUNDS.minZ) * (this.position.z - NET_BOUNDS.minZ) <= 0 || (previous.z - NET_BOUNDS.maxZ) * (this.position.z - NET_BOUNDS.maxZ) <= 0;
-    const insideX = this.position.x + radius >= NET_BOUNDS.minX && this.position.x - radius <= NET_BOUNDS.maxX;
-    const insideY = this.position.y - radius <= NET_BOUNDS.maxY && this.position.y + radius >= NET_BOUNDS.minY;
-    const insideZ = this.position.z + radius >= NET_BOUNDS.minZ && this.position.z - radius <= NET_BOUNDS.maxZ;
+    const crossesNet =
+      (previous.z - NET_BOUNDS.minZ) * (this.position.z - NET_BOUNDS.minZ) <=
+        0 ||
+      (previous.z - NET_BOUNDS.maxZ) * (this.position.z - NET_BOUNDS.maxZ) <= 0;
+    const insideX =
+      this.position.x + radius >= NET_BOUNDS.minX &&
+      this.position.x - radius <= NET_BOUNDS.maxX;
+    const insideY =
+      this.position.y - radius <= NET_BOUNDS.maxY &&
+      this.position.y + radius >= NET_BOUNDS.minY;
+    const insideZ =
+      this.position.z + radius >= NET_BOUNDS.minZ &&
+      this.position.z - radius <= NET_BOUNDS.maxZ;
     if (!crossesNet || !insideX || !insideY || !insideZ) return null;
 
-    this.position.z = previous.z > 0 ? NET_BOUNDS.maxZ + radius : NET_BOUNDS.minZ - radius;
+    this.position.z =
+      previous.z > 0 ? NET_BOUNDS.maxZ + radius : NET_BOUNDS.minZ - radius;
     this.velocity.z *= -0.42;
     this.velocity.y = Math.max(this.velocity.y, 0.35);
     this.spin.multiplyScalar(0.55);
@@ -142,7 +187,11 @@ export class BallPhysics {
 
   private isClearlyOut() {
     const margin = 0.44;
-    return this.position.y < GAME_CONFIG.table.topY - 0.42 || Math.abs(this.position.x) > TABLE_BOUNDS.maxX + margin || Math.abs(this.position.z) > TABLE_BOUNDS.maxZ + 1.0;
+    return (
+      this.position.y < GAME_CONFIG.table.topY - 0.42 ||
+      Math.abs(this.position.x) > TABLE_BOUNDS.maxX + margin ||
+      Math.abs(this.position.z) > TABLE_BOUNDS.maxZ + 1.0
+    );
   }
 
   private resetBouncesAfterHit(side: Side) {
@@ -158,7 +207,14 @@ export class BallPhysics {
 
     for (let i = 0; i < 240; i += 1) {
       const prev = simPos.clone();
-      simVel.addScaledVector(new THREE.Vector3(simSpin.z * GAME_CONFIG.spinCurve, GAME_CONFIG.gravity, -simSpin.x * GAME_CONFIG.spinCurve), GAME_CONFIG.fixedDt);
+      simVel.addScaledVector(
+        new THREE.Vector3(
+          simSpin.z * GAME_CONFIG.spinCurve,
+          GAME_CONFIG.gravity,
+          -simSpin.x * GAME_CONFIG.spinCurve
+        ),
+        GAME_CONFIG.fixedDt
+      );
       simVel.multiplyScalar(1 - GAME_CONFIG.drag * GAME_CONFIG.fixedDt);
       simPos.addScaledVector(simVel, GAME_CONFIG.fixedDt);
       if (prev.y >= top && simPos.y <= top && simVel.y < 0) {
@@ -166,7 +222,13 @@ export class BallPhysics {
         const x = THREE.MathUtils.lerp(prev.x, simPos.x, t);
         const z = THREE.MathUtils.lerp(prev.z, simPos.z, t);
         const side: Side = z > 0 ? 'player' : 'ai';
-        if (x >= TABLE_BOUNDS.minX && x <= TABLE_BOUNDS.maxX && z >= TABLE_BOUNDS.minZ && z <= TABLE_BOUNDS.maxZ && (!targetSide || side === targetSide)) {
+        if (
+          x >= TABLE_BOUNDS.minX &&
+          x <= TABLE_BOUNDS.maxX &&
+          z >= TABLE_BOUNDS.minZ &&
+          z <= TABLE_BOUNDS.maxZ &&
+          (!targetSide || side === targetSide)
+        ) {
           return new THREE.Vector3(x, top, z);
         }
       }
@@ -181,7 +243,7 @@ export class BallPhysics {
       spin: this.spin.clone(),
       state: this.state,
       bounces: { ...this.bounces },
-      lastTouch: this.lastTouch,
+      lastTouch: this.lastTouch
     };
   }
 }

--- a/frontend/src/table-tennis/PaddleHitDetector.ts
+++ b/frontend/src/table-tennis/PaddleHitDetector.ts
@@ -21,38 +21,94 @@ export interface PaddleHitResult {
   reason?: string;
 }
 
-const shotProfiles: Record<ShotType, { lift: number; speed: number; spin: number; arc: number }> = {
-  'forehand drive': { lift: 1.55, speed: GAME_CONFIG.paddle.drivePower, spin: 2.2, arc: 0.18 },
-  'backhand drive': { lift: 1.45, speed: GAME_CONFIG.paddle.drivePower * 0.95, spin: 1.9, arc: 0.12 },
-  push: { lift: 1.15, speed: GAME_CONFIG.paddle.pushPower, spin: -1.6, arc: 0.24 },
-  'brush/topspin': { lift: 1.75, speed: GAME_CONFIG.paddle.drivePower * 0.92, spin: GAME_CONFIG.paddle.spin, arc: 0.04 },
-  lob: { lift: 2.75, speed: GAME_CONFIG.paddle.lobPower, spin: 0.7, arc: 0.42 },
+const shotProfiles: Record<
+  ShotType,
+  { lift: number; speed: number; spin: number; arc: number }
+> = {
+  'forehand drive': {
+    lift: 1.55,
+    speed: GAME_CONFIG.paddle.drivePower,
+    spin: 2.2,
+    arc: 0.18
+  },
+  'backhand drive': {
+    lift: 1.45,
+    speed: GAME_CONFIG.paddle.drivePower * 0.95,
+    spin: 1.9,
+    arc: 0.12
+  },
+  push: {
+    lift: 1.15,
+    speed: GAME_CONFIG.paddle.pushPower,
+    spin: -1.6,
+    arc: 0.24
+  },
+  'brush/topspin': {
+    lift: 1.75,
+    speed: GAME_CONFIG.paddle.drivePower * 0.92,
+    spin: GAME_CONFIG.paddle.spin,
+    arc: 0.04
+  },
+  lob: { lift: 2.75, speed: GAME_CONFIG.paddle.lobPower, spin: 0.7, arc: 0.42 }
 };
 
 export class PaddleHitDetector {
   detect(input: PaddleHitInput): PaddleHitResult {
     const distance = input.paddlePosition.distanceTo(input.ballPosition);
-    if (distance > GAME_CONFIG.paddle.hitRadius) return { valid: false, reason: 'outside hit radius' };
+    if (distance > GAME_CONFIG.paddle.hitRadius)
+      return { valid: false, reason: 'outside hit radius' };
 
     const incoming = input.ballVelocity.clone().normalize();
-    const facingDot = input.paddleForward.clone().normalize().dot(incoming.clone().multiplyScalar(-1));
-    if (facingDot < GAME_CONFIG.paddle.minFacingDot) return { valid: false, reason: 'paddle face angle' };
+    const facingDot = input.paddleForward
+      .clone()
+      .normalize()
+      .dot(incoming.clone().multiplyScalar(-1));
+    if (facingDot < GAME_CONFIG.paddle.minFacingDot)
+      return { valid: false, reason: 'paddle face angle' };
 
-    const ballComingToPaddle = input.side === 'player' ? input.ballVelocity.z > 0.4 : input.ballVelocity.z < -0.4;
-    if (!ballComingToPaddle) return { valid: false, reason: 'ball moving away' };
+    const ballComingToPaddle =
+      input.side === 'player'
+        ? input.ballVelocity.z > 0.4
+        : input.ballVelocity.z < -0.4;
+    if (!ballComingToPaddle)
+      return { valid: false, reason: 'ball moving away' };
 
     const profile = shotProfiles[input.requestedShot];
-    const targetZ = input.side === 'player' ? THREE.MathUtils.randFloat(-1.08, -0.42) : THREE.MathUtils.randFloat(0.42, 1.08);
-    const targetXBase = THREE.MathUtils.clamp(-input.ballPosition.x * 0.55, TABLE_BOUNDS.minX + 0.12, TABLE_BOUNDS.maxX - 0.12);
+    const targetZ =
+      input.side === 'player'
+        ? THREE.MathUtils.randFloat(
+            TABLE_BOUNDS.minZ * 0.7,
+            TABLE_BOUNDS.minZ * 0.28
+          )
+        : THREE.MathUtils.randFloat(
+            TABLE_BOUNDS.maxZ * 0.28,
+            TABLE_BOUNDS.maxZ * 0.7
+          );
+    const targetXBase = THREE.MathUtils.clamp(
+      -input.ballPosition.x * 0.55,
+      TABLE_BOUNDS.minX + 0.12,
+      TABLE_BOUNDS.maxX - 0.12
+    );
     const error = (1 - (input.accuracy ?? GAME_CONFIG.paddle.accuracy)) * 0.42;
-    const target = new THREE.Vector3(targetXBase + THREE.MathUtils.randFloatSpread(error), GAME_CONFIG.table.topY + profile.arc, targetZ);
+    const target = new THREE.Vector3(
+      targetXBase + THREE.MathUtils.randFloatSpread(error),
+      GAME_CONFIG.table.topY + profile.arc,
+      targetZ
+    );
     const direction = target.sub(input.ballPosition).normalize();
     const power = profile.speed * (input.powerScale ?? 1);
     const velocity = direction.multiplyScalar(power);
-    velocity.y = Math.max(velocity.y + profile.lift, input.requestedShot === 'lob' ? 2.2 : 1.05);
+    velocity.y = Math.max(
+      velocity.y + profile.lift,
+      input.requestedShot === 'lob' ? 2.2 : 1.05
+    );
 
     const sideSign = input.side === 'player' ? -1 : 1;
-    const spin = new THREE.Vector3(profile.spin * sideSign, 0, -input.paddleForward.x * 1.2);
+    const spin = new THREE.Vector3(
+      profile.spin * sideSign,
+      0,
+      -input.paddleForward.x * 1.2
+    );
     return { valid: true, shotType: input.requestedShot, velocity, spin };
   }
 }

--- a/frontend/src/table-tennis/gameConfig.ts
+++ b/frontend/src/table-tennis/gameConfig.ts
@@ -1,7 +1,12 @@
 import * as THREE from 'three';
 
 export type Side = 'player' | 'ai';
-export type ShotType = 'forehand drive' | 'backhand drive' | 'push' | 'brush/topspin' | 'lob';
+export type ShotType =
+  | 'forehand drive'
+  | 'backhand drive'
+  | 'push'
+  | 'brush/topspin'
+  | 'lob';
 
 export interface DifficultyConfig {
   reactionTime: number;
@@ -19,68 +24,68 @@ export const GAME_CONFIG = {
   ballRadius: 0.055,
   serveHeight: 0.34,
   table: {
-    width: 1.8,
-    length: 3.08,
+    width: 2.16,
+    length: 3.7,
     topY: 0.76,
     thickness: 0.08,
     color: '#1266c3',
-    lineColor: '#e8f4ff',
+    lineColor: '#e8f4ff'
   },
   net: {
     height: 0.18,
     thickness: 0.028,
-    overhang: 0.1,
+    overhang: 0.1
   },
   player: {
-    z: 2.38,
-    minX: -1.02,
-    maxX: 1.02,
-    safeZ: 2.22,
+    z: 2.76,
+    minX: -1.24,
+    maxX: 1.24,
+    safeZ: 2.58,
     moveSpeed: 2.55,
     reach: 0.52,
     recoveryTime: 0.28,
-    avatarScale: 1.42,
+    avatarScale: 1.72
   },
   ai: {
-    z: -2.38,
-    minX: -1.02,
-    maxX: 1.02,
-    maxReach: 0.66,
-    avatarScale: 1.42,
+    z: -2.76,
+    minX: -1.24,
+    maxX: 1.24,
+    maxReach: 0.78,
+    avatarScale: 1.72,
     difficulty: {
       reactionTime: 0.24,
       moveSpeed: 2.05,
       accuracy: 0.78,
-      shotPower: 1,
-      mistakeChance: 0.14,
-    } satisfies DifficultyConfig,
+      shotPower: 0.86,
+      mistakeChance: 0.14
+    } satisfies DifficultyConfig
   },
   paddle: {
     hitRadius: 0.21,
     timingWindow: 0.12,
     minFacingDot: 0.22,
-    drivePower: 3.75,
-    pushPower: 2.85,
-    lobPower: 2.95,
+    drivePower: 3.15,
+    pushPower: 2.42,
+    lobPower: 2.55,
     spin: 3.6,
-    accuracy: 0.9,
+    accuracy: 0.9
   },
   camera: {
-    position: new THREE.Vector3(0, 2.2, 4.7),
-    target: new THREE.Vector3(0, 0.94, 0.15),
-    damping: 8,
+    position: new THREE.Vector3(0, 2.55, 5.35),
+    target: new THREE.Vector3(0, 1.02, 0.15),
+    damping: 8
   },
   score: {
     gamePoint: 11,
-    winBy: 2,
-  },
+    winBy: 2
+  }
 } as const;
 
 export const TABLE_BOUNDS = {
   minX: -GAME_CONFIG.table.width / 2,
   maxX: GAME_CONFIG.table.width / 2,
   minZ: -GAME_CONFIG.table.length / 2,
-  maxZ: GAME_CONFIG.table.length / 2,
+  maxZ: GAME_CONFIG.table.length / 2
 };
 
 export const NET_BOUNDS = {
@@ -89,5 +94,5 @@ export const NET_BOUNDS = {
   minY: GAME_CONFIG.table.topY,
   maxY: GAME_CONFIG.table.topY + GAME_CONFIG.net.height,
   minZ: -GAME_CONFIG.net.thickness / 2,
-  maxZ: GAME_CONFIG.net.thickness / 2,
+  maxZ: GAME_CONFIG.net.thickness / 2
 };


### PR DESCRIPTION
### Motivation
- Make the human characters and court visually larger so gameplay feels more spacious and readable. 
- Reduce ball/shot power so rallies are less aggressive and timing/placement matter more. 
- Adjust AI/paddle target logic so behavior and reach scale with the larger table.

### Description
- Increased table size and bounds by changing `table.width` and `table.length` and updated `TABLE_BOUNDS` in `frontend/src/table-tennis/gameConfig.ts` and widened player/AI movement ranges and `avatarScale` for both sides. 
- Adjusted camera `position` and `target` in `frontend/src/table-tennis/gameConfig.ts` to keep the enlarged scene framed. 
- Reduced serve velocity and spin in `frontend/src/table-tennis/BallPhysics.ts` and decreased paddle shot powers and AI `shotPower` in `frontend/src/table-tennis/gameConfig.ts` so the ball has less force. 
- Scaled shot targeting and reach checks to use `TABLE_BOUNDS` by updating `frontend/src/table-tennis/PaddleHitDetector.ts` target Z ranges and `frontend/src/table-tennis/AIController.ts` `canReach` logic so AI/paddle targets respect the new table dimensions.

### Testing
- Ran code formatting with `npx prettier --write frontend/src/table-tennis/*` which completed successfully. 
- Built the frontend with `npm --prefix frontend run build` which completed successfully (build emitted size warnings but succeeded). 
- Performed a visual smoke test by launching the local dev server and capturing a screenshot via Playwright after installing browsers/deps (`npx playwright install` / `npx playwright install-deps chromium`), and a screenshot of the updated scene was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e75e2498832990562e3e65c05b3c)