### PR TITLE
Table tennis: add swipe-driven shot commands, stronger shots & AI parity

### DIFF
--- a/frontend/src/table-tennis/AIController.ts
+++ b/frontend/src/table-tennis/AIController.ts
@@ -1,12 +1,13 @@
 import * as THREE from 'three';
 import { BallPhysics } from './BallPhysics';
-import { GAME_CONFIG, ShotType } from './gameConfig';
+import { GAME_CONFIG, ShotCommand, ShotType } from './gameConfig';
 
 export class AIController {
   readonly targetX = { value: 0 };
   currentShot: ShotType = 'forehand drive';
   private reactionTimer = 0;
   private committedLanding: THREE.Vector3 | null = null;
+  private shotCommand: ShotCommand = { aimX: 0, power: 0.62, lift: 0.42, curve: 0, spin: 0.2 };
 
   constructor(private root: THREE.Group, private hand: THREE.Object3D, private paddle: THREE.Object3D) {}
 
@@ -18,18 +19,20 @@ export class AIController {
       if (this.committedLanding) {
         const noise = (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(0.55);
         this.targetX.value = THREE.MathUtils.clamp(this.committedLanding.x + noise, GAME_CONFIG.ai.minX, GAME_CONFIG.ai.maxX);
+        this.shotCommand = this.planShot(ball, cfg.accuracy);
       }
       this.reactionTimer = cfg.reactionTime;
     }
 
     this.root.position.x = THREE.MathUtils.damp(this.root.position.x, this.targetX.value, cfg.moveSpeed, dt);
     this.root.position.z = GAME_CONFIG.ai.z;
-    this.currentShot = ball.position.x > this.root.position.x ? 'forehand drive' : 'backhand drive';
-    const yaw = THREE.MathUtils.clamp((ball.position.x - this.root.position.x) * 0.4, -0.5, 0.5);
+    this.currentShot = this.chooseShot(ball.position);
+    const yaw = THREE.MathUtils.clamp((ball.position.x - this.root.position.x) * 0.4 + this.shotCommand.curve * 0.1, -0.55, 0.55);
     this.root.rotation.y = Math.PI + yaw;
-    this.hand.position.set(this.currentShot === 'forehand drive' ? -0.16 : 0.16, 0.92, -0.28);
+    const side = this.currentShot === 'forehand drive' ? -1 : 1;
+    this.hand.position.set(side * (0.16 + Math.abs(this.shotCommand.curve) * 0.05), 0.92 + this.shotCommand.lift * 0.08, -0.22 - this.shotCommand.power * 0.12);
     this.paddle.position.set(0, -0.02, -0.12);
-    this.paddle.rotation.set(-0.25, 0, this.currentShot === 'forehand drive' ? -0.16 : 0.16);
+    this.paddle.rotation.set(-0.25 - this.shotCommand.lift * 0.16, this.shotCommand.curve * -0.2, side * (0.12 + this.shotCommand.power * 0.1));
   }
 
   canReach(ballPosition: THREE.Vector3) {
@@ -40,11 +43,33 @@ export class AIController {
     return Math.random() < GAME_CONFIG.ai.difficulty.mistakeChance;
   }
 
+  getShotCommand() {
+    return this.shotCommand;
+  }
+
   getPaddleWorldPosition() {
     return this.paddle.getWorldPosition(new THREE.Vector3());
   }
 
   getPaddleForward() {
     return new THREE.Vector3(0, 0, 1).applyQuaternion(this.paddle.getWorldQuaternion(new THREE.Quaternion())).normalize();
+  }
+
+  private planShot(ball: BallPhysics, accuracy: number): ShotCommand {
+    const crossCourt = ball.position.x > 0 ? -0.62 : 0.62;
+    const openTable = THREE.MathUtils.clamp(crossCourt + THREE.MathUtils.randFloatSpread((1 - accuracy) * 0.5), -1, 1);
+    const power = THREE.MathUtils.clamp(THREE.MathUtils.randFloat(0.48, 0.92) * GAME_CONFIG.ai.difficulty.shotPower, 0, 1);
+    const lift = THREE.MathUtils.clamp(ball.position.y > GAME_CONFIG.table.topY + 0.42 ? 0.72 : THREE.MathUtils.randFloat(0.22, 0.58), 0, 1);
+    const curve = THREE.MathUtils.randFloatSpread(0.9) * accuracy;
+    const spin = power > 0.72 ? THREE.MathUtils.randFloat(0.35, 0.85) : THREE.MathUtils.randFloat(-0.28, 0.45);
+    return { aimX: openTable, power, lift, curve, spin };
+  }
+
+  private chooseShot(ballPosition: THREE.Vector3): ShotType {
+    if (this.shotCommand.power > 0.8 && Math.abs(this.shotCommand.curve) > 0.32) return 'swerve power';
+    if (this.shotCommand.lift > 0.72 || ballPosition.y > GAME_CONFIG.table.topY + 0.55) return 'lob';
+    if (this.shotCommand.power < 0.34 || ballPosition.y < GAME_CONFIG.table.topY + 0.18) return 'push';
+    if (this.shotCommand.spin > 0.45 || Math.abs(this.shotCommand.curve) > 0.22) return 'brush/topspin';
+    return ballPosition.x > this.root.position.x ? 'forehand drive' : 'backhand drive';
   }
 }

--- a/frontend/src/table-tennis/GameManager.ts
+++ b/frontend/src/table-tennis/GameManager.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { AIController } from './AIController';
 import { BallPhysics } from './BallPhysics';
 import { CameraController } from './CameraController';
-import { GAME_CONFIG, ShotType } from './gameConfig';
+import { GAME_CONFIG, ShotCommand, ShotType } from './gameConfig';
 import { PaddleHitDetector } from './PaddleHitDetector';
 import { PlayerController } from './PlayerController';
 import { ReplayManager } from './ReplayManager';
@@ -83,8 +83,13 @@ export class GameManager {
     this.mount.removeChild(this.renderer.domElement);
   }
 
-  setPointer(normalizedX: number) {
-    if (!this.replay.isReplaying) this.player.setInput(normalizedX);
+  setPointer(_normalizedX: number) {
+    // Player movement is auto-tracked now; pointer movement is reserved for swipe shooting.
+  }
+
+  shootSwipe(start: { x: number; y: number }, end: { x: number; y: number }, durationMs: number) {
+    if (this.replay.isReplaying) return;
+    this.player.queueShot(this.buildShotCommandFromSwipe(start, end, durationMs));
   }
 
   replayLastRally() {
@@ -107,7 +112,7 @@ export class GameManager {
     }
 
     this.rallyTime += dt;
-    this.player.update(dt, this.ball.position);
+    this.player.update(dt, this.ball.position, this.ball.predictLandingPoint('player'));
     this.ai.update(dt, this.ball);
 
     if (this.ball.state === 'serve') this.ball.serve(this.score.state.server);
@@ -146,9 +151,11 @@ export class GameManager {
       ballVelocity: this.ball.velocity,
       ballSpin: this.ball.spin,
       requestedShot: this.player.currentShot,
+      shotCommand: this.player.peekShotCommand(),
     });
     this.lastHitValidity = result.valid ? 'valid player hit' : result.reason ?? 'invalid';
     if (result.valid && result.velocity && result.spin && result.shotType) {
+      this.player.consumeShotCommand();
       this.ball.applyPaddleHit('player', result.velocity, result.spin);
       this.player.triggerHit();
       this.lastShot = result.shotType;
@@ -167,6 +174,7 @@ export class GameManager {
       ballVelocity: this.ball.velocity,
       ballSpin: this.ball.spin,
       requestedShot: shot,
+      shotCommand: this.ai.getShotCommand(),
       accuracy: GAME_CONFIG.ai.difficulty.accuracy,
       powerScale: GAME_CONFIG.ai.difficulty.shotPower,
     });
@@ -176,6 +184,20 @@ export class GameManager {
       this.lastShot = result.shotType;
       this.replay.recordHit(this.rallyTime, 'ai', result.shotType, this.ball.position);
     }
+  }
+
+
+  private buildShotCommandFromSwipe(start: { x: number; y: number }, end: { x: number; y: number }, durationMs: number): ShotCommand {
+    const dx = end.x - start.x;
+    const dy = start.y - end.y;
+    const distance = Math.hypot(dx, dy);
+    const fastSwipeBonus = THREE.MathUtils.clamp(320 / Math.max(durationMs, 80), 0, 1);
+    const aimX = THREE.MathUtils.clamp(end.x * 1.08, -1, 1);
+    const power = THREE.MathUtils.clamp(distance * 0.64 + fastSwipeBonus * 0.42, 0.16, 1);
+    const lift = THREE.MathUtils.clamp(0.28 + dy * 0.58, 0, 1);
+    const curve = THREE.MathUtils.clamp(dx * 0.92, -1, 1);
+    const spin = THREE.MathUtils.clamp(dy * 0.92 + power * 0.22 - Math.abs(curve) * 0.1, -1, 1);
+    return { aimX, power, lift, curve, spin };
   }
 
   private resetPoint() {

--- a/frontend/src/table-tennis/PaddleHitDetector.ts
+++ b/frontend/src/table-tennis/PaddleHitDetector.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { GAME_CONFIG, ShotType, Side, TABLE_BOUNDS } from './gameConfig';
+import { GAME_CONFIG, ShotCommand, ShotType, Side, TABLE_BOUNDS } from './gameConfig';
 
 export interface PaddleHitInput {
   side: Side;
@@ -9,6 +9,7 @@ export interface PaddleHitInput {
   ballVelocity: THREE.Vector3;
   ballSpin: THREE.Vector3;
   requestedShot: ShotType;
+  shotCommand?: ShotCommand;
   accuracy?: number;
   powerScale?: number;
 }
@@ -22,12 +23,15 @@ export interface PaddleHitResult {
 }
 
 const shotProfiles: Record<ShotType, { lift: number; speed: number; spin: number; arc: number }> = {
-  'forehand drive': { lift: 1.55, speed: GAME_CONFIG.paddle.drivePower, spin: 2.2, arc: 0.18 },
-  'backhand drive': { lift: 1.45, speed: GAME_CONFIG.paddle.drivePower * 0.95, spin: 1.9, arc: 0.12 },
-  push: { lift: 1.15, speed: GAME_CONFIG.paddle.pushPower, spin: -1.6, arc: 0.24 },
-  'brush/topspin': { lift: 1.75, speed: GAME_CONFIG.paddle.drivePower * 0.92, spin: GAME_CONFIG.paddle.spin, arc: 0.04 },
-  lob: { lift: 2.75, speed: GAME_CONFIG.paddle.lobPower, spin: 0.7, arc: 0.42 },
+  'forehand drive': { lift: 1.68, speed: GAME_CONFIG.paddle.drivePower, spin: 2.35, arc: 0.16 },
+  'backhand drive': { lift: 1.58, speed: GAME_CONFIG.paddle.drivePower * 0.96, spin: 2.05, arc: 0.12 },
+  push: { lift: 1.12, speed: GAME_CONFIG.paddle.pushPower, spin: -1.85, arc: 0.2 },
+  'brush/topspin': { lift: 1.78, speed: GAME_CONFIG.paddle.drivePower * 0.98, spin: GAME_CONFIG.paddle.spin, arc: 0.05 },
+  lob: { lift: 2.85, speed: GAME_CONFIG.paddle.lobPower, spin: 0.75, arc: 0.46 },
+  'swerve power': { lift: 1.62, speed: GAME_CONFIG.paddle.drivePower * GAME_CONFIG.paddle.powerShotMultiplier, spin: GAME_CONFIG.paddle.spin * 0.9, arc: 0.08 },
 };
+
+const DEFAULT_COMMAND: ShotCommand = { aimX: 0, power: 0.58, lift: 0.45, curve: 0, spin: 0.25 };
 
 export class PaddleHitDetector {
   detect(input: PaddleHitInput): PaddleHitResult {
@@ -41,18 +45,28 @@ export class PaddleHitDetector {
     const ballComingToPaddle = input.side === 'player' ? input.ballVelocity.z > 0.4 : input.ballVelocity.z < -0.4;
     if (!ballComingToPaddle) return { valid: false, reason: 'ball moving away' };
 
+    const command = input.shotCommand ?? DEFAULT_COMMAND;
     const profile = shotProfiles[input.requestedShot];
-    const targetZ = input.side === 'player' ? THREE.MathUtils.randFloat(-1.08, -0.42) : THREE.MathUtils.randFloat(0.42, 1.08);
-    const targetXBase = THREE.MathUtils.clamp(-input.ballPosition.x * 0.55, TABLE_BOUNDS.minX + 0.12, TABLE_BOUNDS.maxX - 0.12);
-    const error = (1 - (input.accuracy ?? GAME_CONFIG.paddle.accuracy)) * 0.42;
-    const target = new THREE.Vector3(targetXBase + THREE.MathUtils.randFloatSpread(error), GAME_CONFIG.table.topY + profile.arc, targetZ);
+    const targetZ = input.side === 'player' ? THREE.MathUtils.randFloat(-1.2, -0.34) : THREE.MathUtils.randFloat(0.34, 1.2);
+    const screenAim = input.side === 'player' ? command.aimX : -command.aimX;
+    const targetXBase = THREE.MathUtils.lerp(TABLE_BOUNDS.minX + 0.1, TABLE_BOUNDS.maxX - 0.1, (screenAim + 1) / 2);
+    const error = (1 - (input.accuracy ?? GAME_CONFIG.paddle.accuracy)) * THREE.MathUtils.lerp(0.48, 0.22, command.power);
+    const target = new THREE.Vector3(
+      THREE.MathUtils.clamp(targetXBase + THREE.MathUtils.randFloatSpread(error), TABLE_BOUNDS.minX + 0.08, TABLE_BOUNDS.maxX - 0.08),
+      GAME_CONFIG.table.topY + profile.arc + command.lift * 0.32,
+      targetZ,
+    );
     const direction = target.sub(input.ballPosition).normalize();
-    const power = profile.speed * (input.powerScale ?? 1);
+    const commandPower = THREE.MathUtils.lerp(0.72, 1.28, command.power);
+    const power = profile.speed * commandPower * (input.powerScale ?? 1);
     const velocity = direction.multiplyScalar(power);
-    velocity.y = Math.max(velocity.y + profile.lift, input.requestedShot === 'lob' ? 2.2 : 1.05);
+    const minLift = input.requestedShot === 'lob' ? 2.18 : THREE.MathUtils.lerp(0.9, 1.24, command.lift);
+    velocity.y = Math.max(velocity.y + profile.lift + command.lift * 0.58, minLift);
 
     const sideSign = input.side === 'player' ? -1 : 1;
-    const spin = new THREE.Vector3(profile.spin * sideSign, 0, -input.paddleForward.x * 1.2);
+    const topOrBackSpin = profile.spin + command.spin * GAME_CONFIG.paddle.spin;
+    const sideSpin = command.curve * GAME_CONFIG.paddle.sideSpin;
+    const spin = new THREE.Vector3(topOrBackSpin * sideSign, 0, sideSpin * sideSign - input.paddleForward.x * 1.1);
     return { valid: true, shotType: input.requestedShot, velocity, spin };
   }
 }

--- a/frontend/src/table-tennis/PlayerController.ts
+++ b/frontend/src/table-tennis/PlayerController.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { GAME_CONFIG, ShotType } from './gameConfig';
+import { GAME_CONFIG, ShotCommand, ShotType } from './gameConfig';
 
 export interface PlayerVisuals {
   root: THREE.Group;
@@ -9,30 +9,61 @@ export interface PlayerVisuals {
   paddle: THREE.Object3D;
 }
 
+const DEFAULT_SHOT: ShotCommand = { aimX: 0, power: 0.58, lift: 0.45, curve: 0, spin: 0.25 };
+
 export class PlayerController {
   readonly targetX = { value: 0 };
   currentShot: ShotType = 'forehand drive';
   isRecovering = false;
   private recoveryTimer = 0;
-  private pointerX = 0;
+  private queuedShot: ShotCommand | null = null;
+  private queuedShotAge = 0;
+  private readonly maxQueuedShotAge = 1.6;
 
   constructor(private visuals: PlayerVisuals) {}
 
-  setInput(normalizedX: number) {
-    this.pointerX = THREE.MathUtils.clamp(normalizedX, -1, 1);
-    this.targetX.value = THREE.MathUtils.lerp(GAME_CONFIG.player.minX, GAME_CONFIG.player.maxX, (this.pointerX + 1) / 2);
+  queueShot(command: ShotCommand) {
+    this.queuedShot = {
+      aimX: THREE.MathUtils.clamp(command.aimX, -1, 1),
+      power: THREE.MathUtils.clamp(command.power, 0, 1),
+      lift: THREE.MathUtils.clamp(command.lift, 0, 1),
+      curve: THREE.MathUtils.clamp(command.curve, -1, 1),
+      spin: THREE.MathUtils.clamp(command.spin, -1, 1),
+    };
+    this.queuedShotAge = 0;
   }
 
-  update(dt: number, ballPosition: THREE.Vector3) {
+  peekShotCommand(): ShotCommand {
+    return this.queuedShot ?? DEFAULT_SHOT;
+  }
+
+  consumeShotCommand(): ShotCommand {
+    const shot = this.peekShotCommand();
+    this.queuedShot = null;
+    return shot;
+  }
+
+  update(dt: number, ballPosition: THREE.Vector3, predictedLanding: THREE.Vector3 | null) {
+    if (this.queuedShot) {
+      this.queuedShotAge += dt;
+      if (this.queuedShotAge > this.maxQueuedShotAge) this.queuedShot = null;
+    }
+
     const root = this.visuals.root;
+    const isIncoming = ballPosition.z > 0.12;
+    const trackX = predictedLanding && predictedLanding.z > 0
+      ? predictedLanding.x
+      : ballPosition.x + THREE.MathUtils.clamp(ballPosition.x - root.position.x, -GAME_CONFIG.player.autoTrackLead, GAME_CONFIG.player.autoTrackLead);
+    this.targetX.value = THREE.MathUtils.clamp(isIncoming ? trackX : ballPosition.x * 0.42, GAME_CONFIG.player.minX, GAME_CONFIG.player.maxX);
     root.position.x = THREE.MathUtils.damp(root.position.x, this.targetX.value, GAME_CONFIG.player.moveSpeed, dt);
     root.position.x = THREE.MathUtils.clamp(root.position.x, GAME_CONFIG.player.minX, GAME_CONFIG.player.maxX);
     root.position.z = GAME_CONFIG.player.z;
 
+    const command = this.peekShotCommand();
     const acrossBody = ballPosition.x < root.position.x - 0.05;
-    this.currentShot = acrossBody ? 'backhand drive' : this.chooseForehandVariant(ballPosition);
+    this.currentShot = this.chooseShotVariant(ballPosition, acrossBody, command);
 
-    const lookYaw = THREE.MathUtils.clamp((ballPosition.x - root.position.x) * 0.45, -0.45, 0.45);
+    const lookYaw = THREE.MathUtils.clamp((ballPosition.x - root.position.x) * 0.45 + command.curve * 0.1, -0.52, 0.52);
     this.visuals.torso.rotation.y = THREE.MathUtils.damp(this.visuals.torso.rotation.y, lookYaw, 9, dt);
     this.visuals.head.rotation.y = THREE.MathUtils.damp(this.visuals.head.rotation.y, lookYaw * 0.8, 10, dt);
 
@@ -40,7 +71,7 @@ export class PlayerController {
       this.recoveryTimer -= dt;
       if (this.recoveryTimer <= 0) this.isRecovering = false;
     }
-    this.updatePaddleAttachment(dt, ballPosition);
+    this.updatePaddleAttachment(dt, ballPosition, command);
   }
 
   triggerHit() {
@@ -56,22 +87,24 @@ export class PlayerController {
     return new THREE.Vector3(0, 0, -1).applyQuaternion(this.visuals.paddle.getWorldQuaternion(new THREE.Quaternion())).normalize();
   }
 
-  private chooseForehandVariant(ballPosition: THREE.Vector3): ShotType {
-    if (ballPosition.y > GAME_CONFIG.table.topY + 0.55) return 'lob';
-    if (ballPosition.y < GAME_CONFIG.table.topY + 0.18) return 'push';
-    if (Math.abs(ballPosition.x - this.visuals.root.position.x) > 0.32) return 'brush/topspin';
-    return 'forehand drive';
+  private chooseShotVariant(ballPosition: THREE.Vector3, acrossBody: boolean, command: ShotCommand): ShotType {
+    if (command.power > 0.82 && Math.abs(command.curve) > 0.34) return 'swerve power';
+    if (command.lift > 0.76 || ballPosition.y > GAME_CONFIG.table.topY + 0.55) return 'lob';
+    if (command.power < 0.34 || ballPosition.y < GAME_CONFIG.table.topY + 0.18) return 'push';
+    if (command.spin > 0.45 || Math.abs(command.curve) > 0.22) return 'brush/topspin';
+    return acrossBody ? 'backhand drive' : 'forehand drive';
   }
 
-  private updatePaddleAttachment(dt: number, ballPosition: THREE.Vector3) {
+  private updatePaddleAttachment(dt: number, ballPosition: THREE.Vector3, command: ShotCommand) {
     const hand = this.visuals.hand;
     const paddle = this.visuals.paddle;
     const side = this.currentShot === 'backhand drive' ? -1 : 1;
-    const reach = this.isRecovering ? 0.34 : THREE.MathUtils.clamp((GAME_CONFIG.player.z - ballPosition.z) * 0.24, 0.08, 0.38);
-    hand.position.set(0.16 * side, 0.92, -0.12 - reach);
-    hand.rotation.y = THREE.MathUtils.damp(hand.rotation.y, side * 0.28, 12, dt);
-    hand.rotation.x = THREE.MathUtils.damp(hand.rotation.x, this.isRecovering ? -0.45 : -0.2, 12, dt);
+    const reach = this.isRecovering ? 0.34 : THREE.MathUtils.clamp((GAME_CONFIG.player.z - ballPosition.z) * 0.28, 0.12, 0.48);
+    const powerLoad = THREE.MathUtils.lerp(-0.08, -0.2, command.power);
+    hand.position.set((0.16 + Math.abs(command.curve) * 0.05) * side, 0.92 + command.lift * 0.08, powerLoad - reach);
+    hand.rotation.y = THREE.MathUtils.damp(hand.rotation.y, side * (0.22 + Math.abs(command.curve) * 0.28), 12, dt);
+    hand.rotation.x = THREE.MathUtils.damp(hand.rotation.x, this.isRecovering ? -0.48 : -0.16 - command.lift * 0.24, 12, dt);
     paddle.position.set(0, -0.02, -0.12);
-    paddle.rotation.set(-0.25, 0, side * 0.16);
+    paddle.rotation.set(-0.25 - command.lift * 0.18, command.curve * 0.22, side * (0.12 + command.power * 0.1));
   }
 }

--- a/frontend/src/table-tennis/UIOverlay.tsx
+++ b/frontend/src/table-tennis/UIOverlay.tsx
@@ -17,6 +17,7 @@ export function UIOverlay() {
   const managerRef = useRef<GameManager | null>(null);
   const [hud, setHud] = useState(initialHud);
   const [debug, setDebug] = useState(false);
+  const swipeStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
 
   useEffect(() => {
     if (!mountRef.current) return undefined;
@@ -32,19 +33,50 @@ export function UIOverlay() {
       managerRef.current.renderer.setSize(mount.clientWidth, mount.clientHeight);
     };
 
-    const onPointerMove = (event: PointerEvent) => {
+    const normalizePointer = (event: PointerEvent) => {
       const bounds = mountRef.current?.getBoundingClientRect();
-      if (!bounds) return;
-      manager.setPointer(((event.clientX - bounds.left) / bounds.width) * 2 - 1);
+      if (!bounds) return null;
+      return {
+        x: ((event.clientX - bounds.left) / bounds.width) * 2 - 1,
+        y: ((event.clientY - bounds.top) / bounds.height) * 2 - 1,
+      };
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      const point = normalizePointer(event);
+      if (!point) return;
+      manager.setPointer(point.x);
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      const point = normalizePointer(event);
+      if (!point) return;
+      swipeStartRef.current = { ...point, time: performance.now() };
+      manager.renderer.domElement.setPointerCapture(event.pointerId);
+    };
+
+    const onPointerUp = (event: PointerEvent) => {
+      const point = normalizePointer(event);
+      const start = swipeStartRef.current;
+      swipeStartRef.current = null;
+      if (!point || !start) return;
+      manager.shootSwipe({ x: start.x, y: start.y }, point, performance.now() - start.time);
+      if (manager.renderer.domElement.hasPointerCapture(event.pointerId)) {
+        manager.renderer.domElement.releasePointerCapture(event.pointerId);
+      }
     };
 
     window.addEventListener('resize', onResize);
     manager.renderer.domElement.addEventListener('pointermove', onPointerMove);
-    manager.renderer.domElement.addEventListener('pointerdown', onPointerMove);
+    manager.renderer.domElement.addEventListener('pointerdown', onPointerDown);
+    manager.renderer.domElement.addEventListener('pointerup', onPointerUp);
+    manager.renderer.domElement.addEventListener('pointercancel', onPointerUp);
     return () => {
       window.removeEventListener('resize', onResize);
       manager.renderer.domElement.removeEventListener('pointermove', onPointerMove);
-      manager.renderer.domElement.removeEventListener('pointerdown', onPointerMove);
+      manager.renderer.domElement.removeEventListener('pointerdown', onPointerDown);
+      manager.renderer.domElement.removeEventListener('pointerup', onPointerUp);
+      manager.renderer.domElement.removeEventListener('pointercancel', onPointerUp);
       manager.dispose();
       managerRef.current = null;
     };
@@ -67,6 +99,7 @@ export function UIOverlay() {
         </section>
 
         {hud.lastShot && !hud.replaying ? <div className="tt-shot-label">{hud.lastShot}</div> : null}
+        <div className="tt-swipe-hint">Swipe to shoot · aim sideways · flick up for lift · bend for curve</div>
         {hud.replaying ? <div className="tt-replay-banner">VAR Replay: slow motion review</div> : null}
 
         <section className="tt-controls">

--- a/frontend/src/table-tennis/gameConfig.ts
+++ b/frontend/src/table-tennis/gameConfig.ts
@@ -1,7 +1,20 @@
 import * as THREE from 'three';
 
 export type Side = 'player' | 'ai';
-export type ShotType = 'forehand drive' | 'backhand drive' | 'push' | 'brush/topspin' | 'lob';
+export type ShotType = 'forehand drive' | 'backhand drive' | 'push' | 'brush/topspin' | 'lob' | 'swerve power';
+
+export interface ShotCommand {
+  /** -1 aims to the left sideline, +1 aims to the right sideline from the striker's screen perspective. */
+  aimX: number;
+  /** 0 is a soft touch, 1 is the strongest drive. */
+  power: number;
+  /** 0 is a flat/low shot, 1 is a higher clearance arc. */
+  lift: number;
+  /** -1 bends left, +1 bends right with side spin. */
+  curve: number;
+  /** -1 slices/backspins, +1 brushes heavy topspin. */
+  spin: number;
+}
 
 export interface DifficultyConfig {
   reactionTime: number;
@@ -15,7 +28,7 @@ export const GAME_CONFIG = {
   fixedDt: 1 / 120,
   gravity: -9.8,
   drag: 0.09,
-  spinCurve: 0.08,
+  spinCurve: 0.11,
   ballRadius: 0.055,
   serveHeight: 0.34,
   table: {
@@ -36,8 +49,9 @@ export const GAME_CONFIG = {
     minX: -1.02,
     maxX: 1.02,
     safeZ: 2.22,
-    moveSpeed: 2.55,
-    reach: 0.52,
+    moveSpeed: 4.25,
+    reach: 0.66,
+    autoTrackLead: 0.34,
     recoveryTime: 0.28,
     avatarScale: 1.42,
   },
@@ -48,21 +62,23 @@ export const GAME_CONFIG = {
     maxReach: 0.66,
     avatarScale: 1.42,
     difficulty: {
-      reactionTime: 0.24,
-      moveSpeed: 2.05,
-      accuracy: 0.78,
-      shotPower: 1,
+      reactionTime: 0.18,
+      moveSpeed: 2.85,
+      accuracy: 0.8,
+      shotPower: 1.08,
       mistakeChance: 0.14,
     } satisfies DifficultyConfig,
   },
   paddle: {
-    hitRadius: 0.21,
+    hitRadius: 0.28,
     timingWindow: 0.12,
-    minFacingDot: 0.22,
-    drivePower: 3.75,
-    pushPower: 2.85,
-    lobPower: 2.95,
-    spin: 3.6,
+    minFacingDot: 0.1,
+    drivePower: 4.35,
+    pushPower: 3.15,
+    lobPower: 3.25,
+    powerShotMultiplier: 1.34,
+    spin: 4.6,
+    sideSpin: 5.2,
     accuracy: 0.9,
   },
   camera: {

--- a/frontend/src/table-tennis/tableTennis.css
+++ b/frontend/src/table-tennis/tableTennis.css
@@ -126,3 +126,23 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 11px;
 }
+
+.tt-swipe-hint {
+  position: absolute;
+  left: 50%;
+  bottom: max(74px, calc(env(safe-area-inset-bottom) + 74px));
+  width: min(calc(100% - 32px), 360px);
+  transform: translateX(-50%);
+  padding: 10px 13px;
+  border: 1px solid rgba(125, 211, 252, 0.2);
+  border-radius: 999px;
+  background: rgba(8, 47, 73, 0.48);
+  color: #dff7ff;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-align: center;
+  text-shadow: 0 1px 10px rgba(14, 165, 233, 0.38);
+  backdrop-filter: blur(12px);
+  pointer-events: none;
+}


### PR DESCRIPTION
### Motivation
- Introduce a swipe-based shooting control so the player can aim, vary power, lift, curve and spin with a single gesture. 
- Make the player auto-track incoming balls so users only need to swipe to shoot, and give AI the same richer shot capabilities for parity and realism. 
- Increase overall shot power, spin responsiveness and paddle reach to enable more satisfying power/curve shots and varied shot outcomes. 

### Description
- Added a `ShotCommand` model and new shot type `swerve power` and tuned physics in `frontend/src/table-tennis/gameConfig.ts` to increase `drivePower`, `spin`, `hitRadius`, `moveSpeed`, and `spinCurve`. 
- Player input now queues a shot command instead of raw pointer movement via `PlayerController` (`queueShot`/`peekShotCommand`/`consumeShotCommand`), and the player auto-tracks the predicted landing point; paddle pose uses the queued command for visual loading. 
- `PaddleHitDetector` was rewritten to resolve hits from `ShotCommand` parameters (screen aim → table target, command power → velocity scaling, lift → arc, and curve/spin → side/top spin) so human and AI use the same realistic hit resolution. 
- `AIController` now plans `ShotCommand` values and exposes them to the hit detector and paddle animation so the AI can perform lifts, curves and power shots like the player. 
- `GameManager` and `UIOverlay` implement swipe capture (`shootSwipe` + `buildShotCommandFromSwipe`) and pointer handlers (down/up/move) and a small UI hint; styling added to `tableTennis.css`. 

### Testing
- Built the frontend with `npm run build` and the build completed successfully. 
- Installed browsers and dependencies for headless tests with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully. 
- Started the dev server with `npm run dev -- --host 127.0.0.1` and used Playwright to load the page and capture a screenshot, which succeeded. 
- Ran a basic repository consistency check (`git diff --check`) during the workflow and no errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e91bc4308329a4ee3a09e7ed13a7)