### PR TITLE
Tune tennis scale and shot power

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
@@ -11,8 +11,8 @@ namespace TonPlaygram.Gameplay.Tennis
         [SerializeField] private Transform netRoot;
         [SerializeField] private Camera targetCamera;
         [SerializeField] private Transform framingPivot;
-        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 2.15f;
-        [SerializeField, Min(1f)] private float framingDistanceScale = 2.05f;
+        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 2.45f;
+        [SerializeField, Min(1f)] private float framingDistanceScale = 2.15f;
 
         private bool _initialized;
         private Vector3 _initialCourtScale;

--- a/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
@@ -6,8 +6,8 @@ namespace TonPlaygram.Gameplay.Tennis
     public class TennisShotTuning : MonoBehaviour
     {
         [Header("Power")]
-        [Min(1f)] public float baseShotPower = 17.5f;
-        [Range(0.1f, 1f)] public float maxMatchPower01 = 0.82f;
+        [Min(1f)] public float baseShotPower = 14.25f;
+        [Range(0.1f, 1f)] public float maxMatchPower01 = 0.68f;
         [Range(0f, 2f)] public float topspin = 0.35f;
         [Range(0f, 2f)] public float sidespin = 0.2f;
         [Range(0f, 2f)] public float curvePower = 0.5f;
@@ -20,7 +20,7 @@ namespace TonPlaygram.Gameplay.Tennis
             float matchPower = Mathf.Clamp(normalizedPower, 0f, maxMatchPower01);
             float power = baseShotPower * matchPower;
 
-            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.08f : 1f;
+            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.02f : 1f;
             float finalPower = power * variantPowerMultiplier;
 
             ballBody.AddForce(dir * finalPower, ForceMode.Impulse);

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -29,13 +29,13 @@ export enum TennisBallState {
 }
 
 const BASE_WORLD_SCALE = 1.72;
-const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.55;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.8;
 const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
 // Keep the camera at its prior pullback distance so the enlarged court and
 // players read clearly bigger in the actual gameplay view.
 const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE;
 // Extra character scale keeps human avatars visibly bigger than the court uplift.
-const PLAYER_CHARACTER_SCALE = 1.2;
+const PLAYER_CHARACTER_SCALE = 1.35;
 const PLAYER_SCALE = WORLD_SCALE * PLAYER_CHARACTER_SCALE;
 
 export const gameConfig = {
@@ -74,10 +74,10 @@ export const gameConfig = {
   serveDuration: 0.86,
   serveContactT: 0.72,
   serveTossMinHeight: 1.85 * PLAYER_SCALE,
-  // Scales the full match shot force so player and AI strokes share a calmer, lower power ceiling.
-  matchPowerMultiplier: 0.68,
-  servePower: { min: 0.48, max: 0.72 },
-  shotPower: { min: 0.2, max: 0.66 },
+  // Scales the full match shot force so player and AI strokes share a softer, lower power ceiling.
+  matchPowerMultiplier: 0.55,
+  servePower: { min: 0.42, max: 0.62 },
+  shotPower: { min: 0.16, max: 0.56 },
   spinAmount: { flat: 0.8, topspin: 1.6, slice: -1.4, lob: 1.1, drop: -0.7, block: 0.25 },
   playerVisualYawFix: Math.PI,
   serveNearBaselineZ: (23.77 / 2 + 0.92) * WORLD_SCALE,
@@ -89,7 +89,7 @@ export const gameConfig = {
     moveSpeed: 12.8 * PLAYER_SCALE,
     reachRadius: 1.95 * PLAYER_SCALE,
     accuracy: 0.94,
-    power: 0.62,
+    power: 0.54,
     spin: 0.88,
     mistakeChance: 0.018,
     serveQuality: 0.84,


### PR DESCRIPTION
### Motivation
- Make the tennis court and human characters read larger in both web and Unity gameplay views. 
- Reduce the perceived ball/shot power so rallies feel calmer and less overpowering for both player and AI.

### Description
- Increased web world/court scale and player size by changing `COURT_AND_CHARACTER_SIZE_MULTIPLIER` from `1.55` to `1.8` and `PLAYER_CHARACTER_SCALE` from `1.2` to `1.35` in `webapp/src/pages/Games/tennis/gameConfig.ts`.
- Lowered web shot power ceilings by updating `matchPowerMultiplier` to `0.55`, `servePower` to `{ min: 0.42, max: 0.62 }`, `shotPower` to `{ min: 0.16, max: 0.56 }`, and reduced AI `power` to `0.54` in `gameConfig.ts`.
- Reduced Unity shot force by lowering `baseShotPower` to `14.25f`, clamped `maxMatchPower01` to `0.68f`, and reduced the Power-variant multiplier from `1.08f` to `1.02f` in `Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs`.
- Increased Unity scene scaling/framing by bumping `worldScaleMultiplier` to `2.45f` and `framingDistanceScale` to `2.15f` in `Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs`.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Installed Playwright browsers with `npx playwright install chromium` and system deps with `npx playwright install-deps chromium` successfully.
- Executed a Playwright screenshot smoke test for `/games/tennis`; initial run failed due to missing browser binaries but succeeded after installing browsers and deps and saved a screenshot (`artifacts-tennis-scale.png`).
- Started the dev server (`npm --prefix webapp run dev`) during verification and it responded as expected.

All automated steps listed above completed successfully. Note: `webapp/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json` had an unrelated local modification and was not included in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e75e2498832990562e3e65c05b3c)