### PR TITLE
Lower Domino Royal arms and hand tiles

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6715,18 +6715,18 @@ const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.0025; // keep chain tiles touching without visible overlap
 const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
-// May 10, 2026: keep player-hand dominoes compact while placing them farther
-// beyond the rail and higher above the tabletop for clearer Battle Royal seating.
+// May 14, 2026: keep player-hand dominoes compact but lower and closer to
+// the seated human reach so the arms/hands visually meet the domino rack.
 const PLAYER_HAND_TILE_SCALE = 0.9;
 const PLAYER_HAND_GAP_SCALE = 0.5;
 const PLAYER_HAND_MIN_GAP_SCALE = 0.76;
 const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 10.6;
-const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 7.8;
-const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 5.2;
-const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 6.7;
-const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.0;
-const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 1.45;
-const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 5.7;
+const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 6.2;
+const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 3.8;
+const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 5.6;
+const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.35;
+const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 0.85;
+const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 3.65;
 // Keep the bottom player's upright tiles separated by a small visible gap.
 const HUMAN_BOTTOM_HAND_GAP_SCALE = 1.04;
 const DOMINO_DOUBLE_NEIGHBOR_EXTRA_GAP = 0;
@@ -8003,10 +8003,10 @@ function buildDominoFallbackCharacterTemplate() {
   torso.rotation.x = THREE.MathUtils.degToRad(-7);
   const makeLimb = (radius, depth, material) => new THREE.Mesh(new THREE.CapsuleGeometry(radius, depth, 6, 12), material);
   const leftArm = makeLimb(0.045, 0.46, suit);
-  leftArm.position.set(-0.22, 0.93, 0.18);
+  leftArm.position.set(-0.22, 0.87, 0.24);
   leftArm.rotation.set(THREE.MathUtils.degToRad(62), 0, THREE.MathUtils.degToRad(-18));
   const rightArm = makeLimb(0.045, 0.46, suit);
-  rightArm.position.set(0.22, 0.93, 0.18);
+  rightArm.position.set(0.22, 0.87, 0.24);
   rightArm.rotation.set(THREE.MathUtils.degToRad(62), 0, THREE.MathUtils.degToRad(18));
   const leftLeg = makeLimb(0.055, 0.56, dark);
   leftLeg.position.set(-0.1, 0.48, 0.27);
@@ -8333,12 +8333,14 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-65), THREE.MathUtils.degToRad(-5), THREE.MathUtils.degToRad(-2));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(39), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(11), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-72), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(41), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(12), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
+  // Lower both resting arms and bend the forearms farther toward the in-front
+  // dominoes so hands sit closer to the player's rack instead of hovering high.
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-82), THREE.MathUtils.degToRad(-8), THREE.MathUtils.degToRad(-3));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(54), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(7), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-88), THREE.MathUtils.degToRad(13), THREE.MathUtils.degToRad(6));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(56), THREE.MathUtils.degToRad(7), THREE.MathUtils.degToRad(3));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(8), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(3));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-10-domino-player-hand-gap-v36';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-14-domino-arms-hand-lower-v37';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Make seated human characters' arms and hands sit closer to their domino racks and lower the player-hand dominoes so the hands visually contact the tiles. 

### Description
- Lowered player-hand layout by reducing `PLAYER_HAND_VERTICAL_RAISE` and inward/outward offsets (`HUMAN_PLAYER_HAND_OUTWARD_OFFSET`, `HUMAN_HAND_OUTWARD_OFFSET`, `HUMAN_HAND_VERTICAL_OFFSET`, `HUMAN_BOTTOM_EXTRA_OUTWARD`, `HUMAN_BOTTOM_EXTRA_RAISE`) in `webapp/public/domino-royal-game.js` so hand tiles appear lower and closer to the characters.  
- Adjusted fallback procedural character limb positions (fallback `leftArm`/`rightArm` positions) so placeholder humans match the lowered hands.  
- Tuned seated character rig offsets in `createDominoCharacterRig` to lower upper-arm/forearm and rotate hands inward so fingers/hand pose read closer to the domino rack.  
- Bumped the Domino Royal runtime cache version (`DOMINO_ROYAL_SCRIPT_VERSION`) in `webapp/src/pages/Games/DominoRoyalArena.jsx` so clients load the updated `domino-royal-game.js` bundle. 

### Testing
- Ran `npm --prefix webapp run build` to produce a production build for the webapp and the build completed successfully.  
- Ran `git diff --check` (no whitespace / diff issues reported).  
- Attempted an automated visual check using Playwright to capture a screenshot, but the capture timed out due to remote asset/font fetch failures and headless Chromium environment issues (installed Playwright browsers and deps during the run); the screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05fce358bc8329a7e40b694a718348)