### PR TITLE
Improve tennis camera, AI positioning, walk and swing animations

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/CharacterWalk8Dir.cs
+++ b/Assets/Scripts/Gameplay/Tennis/CharacterWalk8Dir.cs
@@ -2,16 +2,53 @@ using UnityEngine;
 
 namespace TonPlaygram.Gameplay.Tennis
 {
+    [DisallowMultipleComponent]
     [RequireComponent(typeof(CharacterController))]
     public class CharacterWalk8Dir : MonoBehaviour
     {
+        [Header("Movement")]
         [SerializeField] private float walkSpeed = 4.5f;
+        [SerializeField] private float acceleration = 18f;
         [SerializeField] private Transform cameraForwardSource;
+        [SerializeField] private Transform incomingBall;
+        [SerializeField] private bool faceIncomingBall = true;
+        [SerializeField, Min(0.01f)] private float rotationSharpness = 14f;
         [SerializeField] private Animator animator;
 
-        private CharacterController _controller;
+        [Header("Soldier-Style Procedural Walk")]
+        [SerializeField] private bool useProceduralSoldierWalk = true;
+        [SerializeField] private Transform proceduralHipRoot;
+        [SerializeField] private Transform leftUpperLeg;
+        [SerializeField] private Transform rightUpperLeg;
+        [SerializeField] private Transform leftLowerLeg;
+        [SerializeField] private Transform rightLowerLeg;
+        [SerializeField] private Transform leftFoot;
+        [SerializeField] private Transform rightFoot;
+        [SerializeField, Min(0.1f)] private float strideFrequency = 4.6f;
+        [SerializeField, Range(0f, 45f)] private float thighSwingDegrees = 18f;
+        [SerializeField, Range(0f, 60f)] private float kneeBendDegrees = 24f;
+        [SerializeField, Range(0f, 35f)] private float footRollDegrees = 12f;
+        [SerializeField, Range(0f, 15f)] private float hipBobCentimeters = 2.5f;
 
-        private void Awake() => _controller = GetComponent<CharacterController>();
+        private CharacterController _controller;
+        private Vector3 _velocity;
+        private float _walkCycle;
+        private Vector3 _hipInitialLocalPosition;
+        private Quaternion _leftUpperLegBase;
+        private Quaternion _rightUpperLegBase;
+        private Quaternion _leftLowerLegBase;
+        private Quaternion _rightLowerLegBase;
+        private Quaternion _leftFootBase;
+        private Quaternion _rightFootBase;
+
+        private void Awake()
+        {
+            _controller = GetComponent<CharacterController>();
+            if (proceduralHipRoot != null) _hipInitialLocalPosition = proceduralHipRoot.localPosition;
+            CacheBoneBases();
+        }
+
+        private void OnEnable() => CacheBoneBases();
 
         private void Update()
         {
@@ -25,17 +62,97 @@ namespace TonPlaygram.Gameplay.Tennis
             forward.Normalize();
             right.Normalize();
 
-            Vector3 move = (right * x + forward * y);
-            if (move.sqrMagnitude > 1f) move.Normalize();
+            Vector3 desiredMove = right * x + forward * y;
+            if (desiredMove.sqrMagnitude > 1f) desiredMove.Normalize();
 
-            _controller.Move(move * (walkSpeed * Time.deltaTime));
+            _velocity = Vector3.MoveTowards(_velocity, desiredMove * walkSpeed, acceleration * Time.deltaTime);
+            _controller.Move(_velocity * Time.deltaTime);
 
-            if (animator != null)
+            UpdateFacing(desiredMove);
+            UpdateAnimator(x, y, desiredMove.magnitude);
+            UpdateSoldierWalk(desiredMove.magnitude);
+        }
+
+        private void UpdateFacing(Vector3 desiredMove)
+        {
+            Vector3 lookDirection = Vector3.zero;
+            if (faceIncomingBall && incomingBall != null)
             {
-                animator.SetFloat("MoveX", x);
-                animator.SetFloat("MoveY", y);
-                animator.SetFloat("Speed", move.magnitude);
+                lookDirection = incomingBall.position - transform.position;
+                lookDirection.y = 0f;
             }
+
+            if (lookDirection.sqrMagnitude < 0.001f && desiredMove.sqrMagnitude > 0.001f)
+            {
+                lookDirection = desiredMove;
+            }
+
+            if (lookDirection.sqrMagnitude < 0.001f) return;
+
+            Quaternion targetRotation = Quaternion.LookRotation(lookDirection.normalized, Vector3.up);
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, 1f - Mathf.Exp(-rotationSharpness * Time.deltaTime));
+        }
+
+        private void UpdateAnimator(float x, float y, float speed01)
+        {
+            if (animator == null) return;
+
+            animator.SetFloat("MoveX", x);
+            animator.SetFloat("MoveY", y);
+            animator.SetFloat("Speed", speed01);
+            animator.SetBool("IsWalking", speed01 > 0.05f);
+        }
+
+        private void CacheBoneBases()
+        {
+            if (leftUpperLeg != null) _leftUpperLegBase = leftUpperLeg.localRotation;
+            if (rightUpperLeg != null) _rightUpperLegBase = rightUpperLeg.localRotation;
+            if (leftLowerLeg != null) _leftLowerLegBase = leftLowerLeg.localRotation;
+            if (rightLowerLeg != null) _rightLowerLegBase = rightLowerLeg.localRotation;
+            if (leftFoot != null) _leftFootBase = leftFoot.localRotation;
+            if (rightFoot != null) _rightFootBase = rightFoot.localRotation;
+        }
+
+        private void UpdateSoldierWalk(float speed01)
+        {
+            if (!useProceduralSoldierWalk) return;
+
+            float normalizedSpeed = Mathf.Clamp01(speed01);
+            if (normalizedSpeed > 0.02f) _walkCycle += Time.deltaTime * strideFrequency * Mathf.Lerp(0.65f, 1.2f, normalizedSpeed);
+
+            float leftPhase = Mathf.Sin(_walkCycle);
+            float rightPhase = -leftPhase;
+            float leftPlant = Mathf.Max(0f, -leftPhase);
+            float rightPlant = Mathf.Max(0f, -rightPhase);
+            float swing = thighSwingDegrees * normalizedSpeed;
+            float knee = kneeBendDegrees * normalizedSpeed;
+            float roll = footRollDegrees * normalizedSpeed;
+
+            ApplyLegPose(leftUpperLeg, _leftUpperLegBase, leftPhase * swing);
+            ApplyLegPose(rightUpperLeg, _rightUpperLegBase, rightPhase * swing);
+            ApplyLegPose(leftLowerLeg, _leftLowerLegBase, leftPlant * knee);
+            ApplyLegPose(rightLowerLeg, _rightLowerLegBase, rightPlant * knee);
+            ApplyFootPose(leftFoot, _leftFootBase, -leftPhase * roll);
+            ApplyFootPose(rightFoot, _rightFootBase, -rightPhase * roll);
+
+            if (proceduralHipRoot != null)
+            {
+                Vector3 localPosition = _hipInitialLocalPosition;
+                localPosition.y += Mathf.Abs(Mathf.Sin(_walkCycle * 2f)) * (hipBobCentimeters * 0.01f) * normalizedSpeed;
+                proceduralHipRoot.localPosition = localPosition;
+            }
+        }
+
+        private static void ApplyLegPose(Transform bone, Quaternion baseRotation, float degrees)
+        {
+            if (bone == null) return;
+            bone.localRotation = baseRotation * Quaternion.Euler(degrees, 0f, 0f);
+        }
+
+        private static void ApplyFootPose(Transform bone, Quaternion baseRotation, float degrees)
+        {
+            if (bone == null) return;
+            bone.localRotation = baseRotation * Quaternion.Euler(degrees, 0f, 0f);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/Tennis/README.md
+++ b/Assets/Scripts/Gameplay/Tennis/README.md
@@ -5,8 +5,29 @@ This folder adds modular tennis systems:
 - `TennisShotTuning`: keeps shots at a calmer match-power pace and supports flat/power/topspin/curve variants.
 - `TennisCourtScaler`: scales court + characters and moves camera back to keep similar framing.
 - `TennisAudioController`: trigger shot and bounce SFX.
-- `TennisAIOpponent`: faster AI reaction, mixed shot variants, and capped match-power shot selection.
-- `CharacterWalk8Dir`: 8-direction walk movement (forward/backward/sideways).
+- `TennisAIOpponent`: professional positioning AI that predicts the first bounce, moves either behind the landing point for a groundstroke or steps inside the bounce for a volley/intervention, faces the incoming ball, recovers to a ready position, and only releases a shot when the ball is reachable and at a hittable height.
+- `CharacterWalk8Dir`: camera-relative 8-direction movement with optional incoming-ball facing and a shared soldier-style procedural leg cycle so every tennis character can use identical leg timing.
+- `TennisPlayerCameraRig`: camera/player follow rig that trucks with the player, pulls slightly back under incoming-ball pressure, and blends the look target from the player to the predicted incoming ball.
+- `TennisRacketSwingAnimator`: additive shoulder-to-racket swing overlay for both shot and serve motions, with a clear pull-back, forward strike, wrist snap, and recovery.
+
+## Professional tennis logic reference
+
+Implementation is based on coaching/gameplay principles gathered during the upgrade:
+
+1. Split-step / ready-position logic: players should be ready before the opponent contact and recover after their own shot.
+2. Contact positioning: move diagonally in/out, use small adjustment steps, and choose depth so contact happens at an optimal point rather than exactly on the bounce.
+3. Groundstroke vs volley decision: if the player can reach the ball before the first bounce, step in; otherwise get slightly behind the predicted landing point to hit after the bounce.
+4. Ball-facing camera/player logic: incoming-ball tracking should bias the view and character facing toward the ball without losing the player as the main follow target.
+
+Sources consulted: Tennis Nation footwork guide, Sportplan movement/split-step notes, CoachUp split-step explanation, and third-person camera design notes.
+
+## Scene wiring checklist
+
+- Add `TennisPlayerCameraRig` to the camera rig and assign the human player transform + tennis ball rigidbody.
+- Assign the ball transform to each `CharacterWalk8Dir.incomingBall` and enable `faceIncomingBall` for the human player.
+- For identical walking on all human characters, assign the same humanoid leg bones (`proceduralHipRoot`, upper legs, lower legs, feet) and keep the same stride/swing values. The procedural walk runs after the animator, so it can standardize different GLTF characters to the soldier-style gait.
+- Add `TennisRacketSwingAnimator` to each tennis character and assign shoulder/upper-arm/forearm/hand-or-racket bones. Call `PlayShotSwing()` on shots and `PlayServeSwing()` on serves.
+- For AI characters, assign `TennisAIOpponent.characterController`, `homePosition`, `hitTarget`, `ballBody`, `shotTuning`, and optionally `swingAnimator`.
 
 ## Free/open-source sound effect sources
 

--- a/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
@@ -2,41 +2,223 @@ using UnityEngine;
 
 namespace TonPlaygram.Gameplay.Tennis
 {
+    [DisallowMultipleComponent]
     public class TennisAIOpponent : MonoBehaviour
     {
+        [Header("Shot References")]
         [SerializeField] private TennisShotTuning shotTuning;
         [SerializeField] private Rigidbody ballBody;
         [SerializeField] private Transform hitTarget;
+        [SerializeField] private TennisRacketSwingAnimator swingAnimator;
+
+        [Header("Movement")]
+        [SerializeField] private CharacterController characterController;
+        [SerializeField] private Transform eyesOrChest;
+        [SerializeField] private Transform homePosition;
+        [SerializeField] private Vector2 courtXBounds = new Vector2(-4.4f, 4.4f);
+        [SerializeField] private Vector2 courtZBounds = new Vector2(-11.3f, 11.3f);
+        [SerializeField, Min(0.1f)] private float moveSpeed = 5.8f;
+        [SerializeField, Min(0.1f)] private float recoverySpeed = 3.8f;
+        [SerializeField, Min(0.01f)] private float rotationSharpness = 12f;
+        [SerializeField, Min(0.1f)] private float behindLandingDistance = 1.15f;
+        [SerializeField, Min(0.1f)] private float stepInBeforeBounceDistance = 0.85f;
+        [SerializeField, Min(0.1f)] private float volleyReachDistance = 2.25f;
+        [SerializeField, Min(0.1f)] private float readyStanceDistance = 0.75f;
+
+        [Header("Professional Timing")]
         [SerializeField, Min(0.01f)] private float reactionTime = 0.1f;
-        [SerializeField, Min(0f)] private float anticipationTime = 0.14f;
         [SerializeField, Min(0.01f)] private float minReactionTime = 0.05f;
         [SerializeField, Min(0.1f)] private float minShotPower01 = 0.45f;
         [SerializeField, Min(0.1f)] private float maxShotPower01 = 0.82f;
+        [SerializeField, Min(0.1f)] private float hitRadius = 1.35f;
+        [SerializeField, Min(0.01f)] private float hitCooldown = 0.32f;
+        [SerializeField] private Vector2 hittableHeight = new Vector2(0.42f, 2.35f);
+        [SerializeField, Range(0f, 1f)] private float interventionAggression = 0.72f;
 
+        private float _nextDecisionTime;
         private float _nextHitTime;
+        private Vector3 _moveTarget;
+        private Vector3 _lastIncomingLanding;
+        private bool _hasIncomingRead;
+        private bool _plannedVolley;
+
+        public Vector3 MoveTarget => _moveTarget;
+        public Vector3 LastIncomingLanding => _lastIncomingLanding;
+        public bool HasIncomingRead => _hasIncomingRead;
+
+        private void Awake()
+        {
+            if (characterController == null) characterController = GetComponent<CharacterController>();
+            _moveTarget = GetHomePosition();
+        }
 
         private void Update()
         {
-            if (shotTuning == null || ballBody == null || hitTarget == null) return;
-            if (Time.time < _nextHitTime) return;
+            if (ballBody == null) return;
 
-            bool ballComingToAi = ballBody.velocity.z > 0f;
-            float predictedBallZ = ballBody.position.z + (ballBody.velocity.z * anticipationTime);
-            if (ballComingToAi && predictedBallZ > transform.position.z)
+            bool incoming = IsBallIncomingToThisSide();
+            if (incoming && Time.time >= _nextDecisionTime)
             {
-                float speed = ballBody.velocity.magnitude;
-                float adaptiveReaction = Mathf.Max(minReactionTime, reactionTime - (speed * 0.003f));
-                _nextHitTime = Time.time + adaptiveReaction;
+                float adaptiveReaction = Mathf.Max(minReactionTime, reactionTime - (ballBody.velocity.magnitude * 0.003f));
+                _nextDecisionTime = Time.time + adaptiveReaction;
+                PlanProfessionalPosition();
+            }
+            else if (!incoming)
+            {
+                _hasIncomingRead = false;
+                _plannedVolley = false;
+                RecoverToReadyPosition();
+            }
+
+            MoveTowardTarget(incoming ? moveSpeed : recoverySpeed);
+            LookAtIncomingBall(incoming);
+
+            if (incoming && ShouldInterveneAndHit())
+            {
                 ShootAdaptive();
             }
         }
 
+        private bool IsBallIncomingToThisSide()
+        {
+            float sideSign = GetCourtSideSign();
+            return Mathf.Sign(ballBody.velocity.z) == sideSign && Mathf.Abs(ballBody.velocity.z) > 0.2f;
+        }
+
+        private void PlanProfessionalPosition()
+        {
+            if (!TryPredictFirstBounce(out Vector3 landingPoint, out float bounceTime))
+            {
+                _moveTarget = ClampToCourt(ballBody.position);
+                _hasIncomingRead = false;
+                return;
+            }
+
+            _lastIncomingLanding = ClampToCourt(landingPoint);
+            _hasIncomingRead = true;
+
+            float sideSign = GetCourtSideSign();
+            Vector3 behindBounce = landingPoint + (Vector3.forward * sideSign * behindLandingDistance);
+            Vector3 preBounce = landingPoint - (Vector3.forward * sideSign * stepInBeforeBounceDistance);
+
+            bool canVolley = bounceTime > 0.22f
+                && Vector3.Distance(transform.position, preBounce) <= volleyReachDistance + (moveSpeed * bounceTime * interventionAggression);
+
+            _plannedVolley = canVolley;
+            _moveTarget = ClampToCourt(canVolley ? preBounce : behindBounce);
+        }
+
+        private void RecoverToReadyPosition()
+        {
+            Vector3 home = GetHomePosition();
+            Vector3 target = home;
+            if (hitTarget != null)
+            {
+                target.x = Mathf.Lerp(home.x, hitTarget.position.x, 0.18f);
+                target.z = home.z;
+            }
+            _moveTarget = ClampToCourt(target);
+        }
+
+        private bool TryPredictFirstBounce(out Vector3 landingPoint, out float timeToBounce)
+        {
+            landingPoint = ballBody.position;
+            timeToBounce = 0f;
+
+            Vector3 gravity = Physics.gravity;
+            float courtY = 0.05f;
+            float a = 0.5f * gravity.y;
+            float b = ballBody.velocity.y;
+            float c = ballBody.position.y - courtY;
+            float discriminant = (b * b) - (4f * a * c);
+            if (discriminant < 0f || Mathf.Approximately(a, 0f)) return false;
+
+            float sqrt = Mathf.Sqrt(discriminant);
+            float t1 = (-b - sqrt) / (2f * a);
+            float t2 = (-b + sqrt) / (2f * a);
+            timeToBounce = t1 > 0.03f ? t1 : t2;
+            if (timeToBounce <= 0.03f || timeToBounce > 4f) return false;
+
+            landingPoint = ballBody.position + (ballBody.velocity * timeToBounce) + (0.5f * gravity * timeToBounce * timeToBounce);
+            landingPoint.y = transform.position.y;
+            return true;
+        }
+
+        private bool ShouldInterveneAndHit()
+        {
+            if (shotTuning == null || hitTarget == null || Time.time < _nextHitTime) return false;
+            if (ballBody.position.y < hittableHeight.x || ballBody.position.y > hittableHeight.y) return false;
+
+            Vector3 toBall = ballBody.position - transform.position;
+            toBall.y = 0f;
+            if (toBall.magnitude > hitRadius) return false;
+
+            if (_plannedVolley) return true;
+            if (!_hasIncomingRead) return true;
+
+            float sideSign = GetCourtSideSign();
+            bool behindBounceReady = (transform.position.z - _lastIncomingLanding.z) * sideSign >= -0.25f;
+            return behindBounceReady;
+        }
+
         private void ShootAdaptive()
         {
+            _nextHitTime = Time.time + hitCooldown;
             Vector3 aim = (hitTarget.position - ballBody.position).normalized;
             float power = Random.Range(minShotPower01, maxShotPower01);
-            ShotVariant variant = (ShotVariant)Random.Range(0, 5);
+            ShotVariant variant = ChooseShotVariant();
+            if (swingAnimator != null) swingAnimator.PlayShotSwing();
             shotTuning.ApplyShot(ballBody, aim, power, variant);
+        }
+
+        private ShotVariant ChooseShotVariant()
+        {
+            if (!_hasIncomingRead) return ShotVariant.Flat;
+
+            float width01 = Mathf.InverseLerp(courtXBounds.x, courtXBounds.y, Mathf.Abs(_lastIncomingLanding.x));
+            if (_plannedVolley && Random.value < 0.45f) return ShotVariant.Power;
+            if (width01 > 0.7f && Random.value < 0.5f) return _lastIncomingLanding.x < 0f ? ShotVariant.CurveRight : ShotVariant.CurveLeft;
+            return Random.value < 0.55f ? ShotVariant.Topspin : ShotVariant.Flat;
+        }
+
+        private void MoveTowardTarget(float speed)
+        {
+            Vector3 current = transform.position;
+            Vector3 delta = _moveTarget - current;
+            delta.y = 0f;
+            if (delta.magnitude < 0.03f) return;
+
+            Vector3 step = Vector3.ClampMagnitude(delta, speed * Time.deltaTime);
+            if (characterController != null) characterController.Move(step);
+            else transform.position += step;
+        }
+
+        private void LookAtIncomingBall(bool incoming)
+        {
+            Vector3 lookTarget = incoming ? ballBody.position : GetHomePosition() + (Vector3.back * GetCourtSideSign() * readyStanceDistance);
+            Transform lookSource = eyesOrChest != null ? eyesOrChest : transform;
+            Vector3 direction = lookTarget - lookSource.position;
+            direction.y = 0f;
+            if (direction.sqrMagnitude < 0.001f) return;
+
+            Quaternion targetRotation = Quaternion.LookRotation(direction.normalized, Vector3.up);
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, 1f - Mathf.Exp(-rotationSharpness * Time.deltaTime));
+        }
+
+        private Vector3 ClampToCourt(Vector3 point)
+        {
+            point.x = Mathf.Clamp(point.x, courtXBounds.x, courtXBounds.y);
+            point.z = Mathf.Clamp(point.z, courtZBounds.x, courtZBounds.y);
+            point.y = transform.position.y;
+            return point;
+        }
+
+        private Vector3 GetHomePosition() => homePosition != null ? homePosition.position : transform.position;
+
+        private float GetCourtSideSign()
+        {
+            float z = homePosition != null ? homePosition.position.z : transform.position.z;
+            return z >= 0f ? 1f : -1f;
         }
     }
 }

--- a/Assets/Scripts/Gameplay/Tennis/TennisPlayerCameraRig.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisPlayerCameraRig.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [DisallowMultipleComponent]
+    public class TennisPlayerCameraRig : MonoBehaviour
+    {
+        [Header("Targets")]
+        [SerializeField] private Transform player;
+        [SerializeField] private Rigidbody ballBody;
+        [SerializeField] private Transform cameraTransform;
+
+        [Header("Follow Framing")]
+        [SerializeField] private Vector3 baseOffset = new Vector3(0f, 4.3f, -7.2f);
+        [SerializeField] private Vector3 incomingExtraOffset = new Vector3(0f, 1.0f, -2.2f);
+        [SerializeField, Range(0f, 1f)] private float ballLookWeight = 0.62f;
+        [SerializeField, Min(0.01f)] private float positionSharpness = 8f;
+        [SerializeField, Min(0.01f)] private float rotationSharpness = 10f;
+        [SerializeField, Min(0.01f)] private float ballSpeedForFullPullback = 18f;
+        [SerializeField] private Vector2 pitchLimits = new Vector2(8f, 58f);
+
+        private void Reset()
+        {
+            cameraTransform = Camera.main != null ? Camera.main.transform : transform;
+        }
+
+        private void LateUpdate()
+        {
+            if (player == null) return;
+            Transform cam = cameraTransform != null ? cameraTransform : transform;
+
+            float incoming01 = GetIncomingPressure01();
+            Vector3 playerForward = player.forward;
+            playerForward.y = 0f;
+            if (playerForward.sqrMagnitude < 0.001f) playerForward = Vector3.forward;
+            playerForward.Normalize();
+
+            Vector3 offset = baseOffset + (incomingExtraOffset * incoming01);
+            Vector3 desiredPosition = player.position
+                + (player.right * offset.x)
+                + (Vector3.up * offset.y)
+                - (playerForward * Mathf.Abs(offset.z));
+
+            cam.position = Vector3.Lerp(cam.position, desiredPosition, 1f - Mathf.Exp(-positionSharpness * Time.deltaTime));
+
+            Vector3 lookPoint = player.position + Vector3.up * 1.45f;
+            if (ballBody != null)
+            {
+                Vector3 predictedBall = ballBody.position + (ballBody.velocity * 0.18f);
+                lookPoint = Vector3.Lerp(lookPoint, predictedBall, ballLookWeight * incoming01);
+            }
+
+            Vector3 lookDirection = lookPoint - cam.position;
+            if (lookDirection.sqrMagnitude < 0.001f) return;
+
+            Quaternion desiredRotation = Quaternion.LookRotation(lookDirection.normalized, Vector3.up);
+            Vector3 euler = desiredRotation.eulerAngles;
+            euler.x = NormalizePitch(euler.x);
+            euler.x = Mathf.Clamp(euler.x, pitchLimits.x, pitchLimits.y);
+            desiredRotation = Quaternion.Euler(euler.x, euler.y, 0f);
+            cam.rotation = Quaternion.Slerp(cam.rotation, desiredRotation, 1f - Mathf.Exp(-rotationSharpness * Time.deltaTime));
+        }
+
+        private float GetIncomingPressure01()
+        {
+            if (ballBody == null || player == null) return 0f;
+
+            Vector3 toPlayer = player.position - ballBody.position;
+            toPlayer.y = 0f;
+            Vector3 ballVelocity = ballBody.velocity;
+            ballVelocity.y = 0f;
+            if (ballVelocity.sqrMagnitude < 0.01f || toPlayer.sqrMagnitude < 0.01f) return 0f;
+
+            float headingToPlayer = Mathf.Clamp01(Vector3.Dot(ballVelocity.normalized, toPlayer.normalized));
+            float speed01 = Mathf.Clamp01(ballBody.velocity.magnitude / ballSpeedForFullPullback);
+            return headingToPlayer * speed01;
+        }
+
+        private static float NormalizePitch(float pitch)
+        {
+            return pitch > 180f ? pitch - 360f : pitch;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisRacketSwingAnimator.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisRacketSwingAnimator.cs
@@ -1,0 +1,122 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [DisallowMultipleComponent]
+    public class TennisRacketSwingAnimator : MonoBehaviour
+    {
+        [Header("Arm Chain")]
+        [SerializeField] private Transform shoulder;
+        [SerializeField] private Transform upperArm;
+        [SerializeField] private Transform forearm;
+        [SerializeField] private Transform handOrRacket;
+        [SerializeField] private Animator animator;
+
+        [Header("Swing Shape")]
+        [SerializeField, Range(0f, 90f)] private float shoulderBackswingDegrees = 42f;
+        [SerializeField, Range(0f, 90f)] private float shoulderFollowThroughDegrees = 58f;
+        [SerializeField, Range(0f, 90f)] private float elbowLoadDegrees = 36f;
+        [SerializeField, Range(0f, 90f)] private float wristSnapDegrees = 24f;
+        [SerializeField, Min(0.01f)] private float backswingSeconds = 0.18f;
+        [SerializeField, Min(0.01f)] private float forwardSwingSeconds = 0.16f;
+        [SerializeField, Min(0.01f)] private float recoverSeconds = 0.22f;
+
+        private Quaternion _shoulderBase;
+        private Quaternion _upperArmBase;
+        private Quaternion _forearmBase;
+        private Quaternion _handBase;
+        private float _swingTimer;
+        private float _swingDuration;
+        private bool _swinging;
+        private bool _serve;
+
+        private void Awake() => CacheBasePose();
+        private void OnEnable() => CacheBasePose();
+
+        private void LateUpdate()
+        {
+            if (!_swinging) return;
+
+            _swingTimer += Time.deltaTime;
+            float normalized = Mathf.Clamp01(_swingTimer / _swingDuration);
+            ApplySwingPose(normalized, _serve);
+
+            if (_swingTimer >= _swingDuration)
+            {
+                _swinging = false;
+                RestoreBasePose();
+            }
+        }
+
+        public void PlayShotSwing()
+        {
+            BeginSwing(false, "Shot");
+        }
+
+        public void PlayServeSwing()
+        {
+            BeginSwing(true, "Serve");
+        }
+
+        private void BeginSwing(bool serve, string triggerName)
+        {
+            CacheBasePose();
+            _serve = serve;
+            _swingTimer = 0f;
+            _swingDuration = backswingSeconds + forwardSwingSeconds + recoverSeconds;
+            _swinging = true;
+
+            if (animator != null) animator.SetTrigger(triggerName);
+        }
+
+        private void ApplySwingPose(float normalized, bool serve)
+        {
+            float backswingEnd = backswingSeconds / _swingDuration;
+            float forwardEnd = (backswingSeconds + forwardSwingSeconds) / _swingDuration;
+
+            float load01 = normalized <= backswingEnd ? Mathf.SmoothStep(0f, 1f, normalized / backswingEnd) : 1f;
+            float strike01 = normalized <= backswingEnd ? 0f : Mathf.SmoothStep(0f, 1f, Mathf.InverseLerp(backswingEnd, forwardEnd, normalized));
+            float recover01 = normalized <= forwardEnd ? 0f : Mathf.SmoothStep(0f, 1f, Mathf.InverseLerp(forwardEnd, 1f, normalized));
+
+            float loadedShoulder = Mathf.Lerp(0f, -shoulderBackswingDegrees, load01);
+            float shoulderPitch = Mathf.Lerp(loadedShoulder, shoulderFollowThroughDegrees, strike01);
+            shoulderPitch = Mathf.Lerp(shoulderPitch, 0f, recover01);
+            float loadedServeLift = serve ? Mathf.Lerp(0f, 24f, load01) : 0f;
+            float serveLift = serve ? Mathf.Lerp(loadedServeLift, -18f, strike01) : 0f;
+            serveLift = Mathf.Lerp(serveLift, 0f, recover01);
+            float loadedElbow = Mathf.Lerp(0f, elbowLoadDegrees, load01);
+            float elbowPitch = Mathf.Lerp(loadedElbow, -8f, strike01);
+            elbowPitch = Mathf.Lerp(elbowPitch, 0f, recover01);
+            float loadedWrist = Mathf.Lerp(0f, -wristSnapDegrees * 0.35f, load01);
+            float wristPitch = Mathf.Lerp(loadedWrist, wristSnapDegrees, strike01);
+            wristPitch = Mathf.Lerp(wristPitch, 0f, recover01);
+
+            ApplyBone(shoulder, _shoulderBase, Quaternion.Euler(serveLift, shoulderPitch * 0.35f, 0f));
+            ApplyBone(upperArm, _upperArmBase, Quaternion.Euler(serveLift * 0.45f, shoulderPitch, 0f));
+            ApplyBone(forearm, _forearmBase, Quaternion.Euler(elbowPitch, 0f, 0f));
+            ApplyBone(handOrRacket, _handBase, Quaternion.Euler(wristPitch, 0f, 0f));
+        }
+
+        private void CacheBasePose()
+        {
+            if (shoulder != null) _shoulderBase = shoulder.localRotation;
+            if (upperArm != null) _upperArmBase = upperArm.localRotation;
+            if (forearm != null) _forearmBase = forearm.localRotation;
+            if (handOrRacket != null) _handBase = handOrRacket.localRotation;
+        }
+
+        private void RestoreBasePose()
+        {
+            ApplyBone(shoulder, _shoulderBase, Quaternion.identity);
+            ApplyBone(upperArm, _upperArmBase, Quaternion.identity);
+            ApplyBone(forearm, _forearmBase, Quaternion.identity);
+            ApplyBone(handOrRacket, _handBase, Quaternion.identity);
+        }
+
+        private static void ApplyBone(Transform bone, Quaternion baseRotation, Quaternion offset)
+        {
+            if (bone == null) return;
+            bone.localRotation = baseRotation * offset;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide professional tennis behavior: camera should truck with the player and bias toward the incoming ball while the player and camera move together and face the ball. 
- Make AI opponents position and time hits like a coached player (predict first bounce, decide groundstroke vs volley, recover to ready stance, and only hit when reachable/hittable). 
- Ensure every human character walks identically using the same soldier-style leg timing and improve arm/racket swing from shoulder to hand for clearer backswing and follow-through.

### Description

- Added `TennisPlayerCameraRig` which follows the player, pulls back under incoming-ball pressure, and blends look-at from the player to a predicted short ball; tuning exposed via `baseOffset`, `incomingExtraOffset`, `ballLookWeight`, `positionSharpness`, and `rotationSharpness`. 
- Reworked `TennisAIOpponent` into a positioning controller that predicts the first bounce (`TryPredictFirstBounce`), plans depth (behind landing or step-in for volley), recovers to ready pose, looks at the ball, and gates shots by reach/height; added parameters for court bounds, timings, reach, and aggression. 
- Upgraded `CharacterWalk8Dir` to camera-relative smoothed movement with optional `incomingBall` facing and a shared soldier-style procedural gait (hip bob, thigh/knee/foot procedural offsets) so all characters can use identical leg timing and animator parameters (`MoveX`, `MoveY`, `Speed`, `IsWalking`). 
- Added `TennisRacketSwingAnimator` as an additive shoulder→upper-arm→forearm→hand overlay with configurable backswing/load/strike/recover timings and angles, and wired AI shots to call `PlayShotSwing()` when available. 
- Updated `Assets/Scripts/Gameplay/Tennis/README.md` with wiring checklist, logic rationale (split-step, contact positioning, groundstroke vs volley), and recommended scene assignments.

### Testing

- Ran `git diff --check` to ensure no whitespace/merge issues and it passed. 
- Ran a Python delimiter/brace balance check over changed C# files to validate balanced braces and it passed. 
- Attempted `unity -batchmode -quit -projectPath .` but Unity CLI is not available in this environment so an editor compile/run was not executed. 
- All scripted static checks included in this PR succeeded (no syntax brace mismatch, and basic diff checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060f7488c08329a5dd5225b6e8c225)