### PR TITLE
Add Snooker Royal human player stance and GLB/fallback rig

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -71,6 +71,7 @@ import {
   SNOOKER_ROYALE_OPTION_LABELS
 } from '../../config/snookerRoyalInventoryConfig.js';
 import { SNOOKER_ROYALE_CLOTH_VARIANTS } from '../../config/snookerRoyalClothPresets.js';
+import { MURLAN_CHARACTER_THEMES } from '../../config/murlanCharacterThemes.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 import {
   getCachedSnookerRoyalInventory,
@@ -1657,6 +1658,382 @@ const CUE_BUTT_LIFT = BALL_R * 0.52; // keep the butt elevated for clearance whi
 const CUE_BUTT_CUSHION_CLEARANCE = BALL_R * 0.11; // keep the cue butt from dipping below the cushion top surface
 const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.06; // lift the cue slightly more as cushions rise so it never touches
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
+
+
+const SNOOKER_HUMAN_CHARACTER_THEME =
+  MURLAN_CHARACTER_THEMES.find((theme) => theme.id === 'rpm-current') ||
+  MURLAN_CHARACTER_THEMES[0];
+const SNOOKER_HUMAN_UP = new THREE.Vector3(0, 1, 0);
+const SNOOKER_HUMAN_FORWARD_LOCAL = new THREE.Vector3(0, 0, 1);
+const SNOOKER_HUMAN_WORLD_SCALE = BALL_R / 0.0525;
+const SNOOKER_HUMAN_CFG = Object.freeze({
+  targetHeight: 1.72 * SNOOKER_HUMAN_WORLD_SCALE,
+  floorY: FLOOR_Y - TABLE_Y,
+  idleDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeBackFromBall: 0.27 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeSide: -0.025 * SNOOKER_HUMAN_WORLD_SCALE,
+  stanceSide: 0.25 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightFootBack: 0.38 * SNOOKER_HUMAN_WORLD_SCALE,
+  leftFootForward: 0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+  chinCueOffsetY: 0.12 * SNOOKER_HUMAN_WORLD_SCALE,
+  chestCueOffsetY: 0.22 * SNOOKER_HUMAN_WORLD_SCALE,
+  rootLambda: 7.5,
+  poseLambda: 10,
+  yawFix: 0
+});
+const cleanSnookerHumanBoneName = (name = '') => name.toLowerCase().replace(/[^a-z0-9]/g, '');
+const snookerHumanClamp01 = (value) => Math.max(0, Math.min(1, value));
+const snookerHumanDamp = (current, target, lambda, dt) =>
+  THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+const snookerHumanDampAngle = (current, target, lambda, dt) => {
+  const delta = THREE.MathUtils.euclideanModulo(target - current + Math.PI, Math.PI * 2) - Math.PI;
+  return current + delta * (1 - Math.exp(-lambda * dt));
+};
+
+function makeSnookerHumanSegment(radius, color, metalness = 0.02) {
+  return new THREE.Mesh(
+    new THREE.CylinderGeometry(radius, radius, 1, 14),
+    new THREE.MeshStandardMaterial({ color, roughness: 0.72, metalness })
+  );
+}
+
+function createSnookerHumanFallbackRig() {
+  const rig = new THREE.Group();
+  rig.name = 'SnookerRoyalFallbackHumanPoseRig';
+  const skin = new THREE.MeshStandardMaterial({ color: 0xd9a27d, roughness: 0.68 });
+  const vest = new THREE.MeshStandardMaterial({ color: 0x111827, roughness: 0.64 });
+  const shirt = new THREE.MeshStandardMaterial({ color: 0xf8fafc, roughness: 0.7 });
+  const trouser = new THREE.MeshStandardMaterial({ color: 0x1f2937, roughness: 0.75 });
+  const shoe = new THREE.MeshStandardMaterial({ color: 0x050505, roughness: 0.6 });
+  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.135, 0.34, 5, 12), vest);
+  const chest = new THREE.Mesh(new THREE.CapsuleGeometry(0.105, 0.22, 5, 12), shirt);
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.078, 18, 14), skin);
+  const neck = makeSnookerHumanSegment(0.032, 0xd9a27d);
+  const leftHand = new THREE.Mesh(new THREE.SphereGeometry(0.036, 14, 10), skin);
+  const rightHand = new THREE.Mesh(new THREE.SphereGeometry(0.034, 14, 10), skin);
+  const leftFoot = new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.045, 0.25), shoe);
+  const rightFoot = leftFoot.clone();
+  const segments = {
+    leftUpperArm: makeSnookerHumanSegment(0.032, 0xf8fafc),
+    leftForearm: makeSnookerHumanSegment(0.027, 0xd9a27d),
+    rightUpperArm: makeSnookerHumanSegment(0.033, 0xf8fafc),
+    rightForearm: makeSnookerHumanSegment(0.027, 0xd9a27d),
+    leftThigh: makeSnookerHumanSegment(0.043, 0x1f2937),
+    leftShin: makeSnookerHumanSegment(0.036, 0x1f2937),
+    rightThigh: makeSnookerHumanSegment(0.043, 0x1f2937),
+    rightShin: makeSnookerHumanSegment(0.036, 0x1f2937)
+  };
+  rig.add(torso, chest, head, neck, leftHand, rightHand, leftFoot, rightFoot, ...Object.values(segments));
+  rig.userData.parts = { torso, chest, head, neck, leftHand, rightHand, leftFoot, rightFoot, ...segments };
+  rig.traverse((obj) => {
+    if (obj?.isMesh) {
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+    }
+  });
+  return rig;
+}
+
+function placeSnookerHumanSegment(segment, a, b) {
+  if (!segment || !a || !b) return;
+  const mid = a.clone().add(b).multiplyScalar(0.5);
+  const delta = b.clone().sub(a);
+  const len = delta.length();
+  segment.position.copy(mid);
+  segment.scale.set(1, Math.max(len, 1e-4), 1);
+  if (len > 1e-5) {
+    segment.quaternion.setFromUnitVectors(SNOOKER_HUMAN_UP, delta.normalize());
+  }
+}
+
+function poseSnookerHumanFallback(human, points) {
+  const parts = human?.fallback?.userData?.parts;
+  if (!parts) return;
+  const {
+    root, torso, chest, head, neck, leftShoulder, rightShoulder,
+    leftElbow, rightElbow, leftHand, rightHand, leftHip, rightHip,
+    leftKnee, rightKnee, leftFoot, rightFoot
+  } = points;
+  parts.torso.position.copy(torso);
+  parts.torso.rotation.set(THREE.MathUtils.degToRad(71), 0, 0);
+  parts.chest.position.copy(chest);
+  parts.chest.rotation.copy(parts.torso.rotation);
+  parts.head.position.copy(head);
+  parts.neck.position.copy(neck);
+  parts.leftHand.position.copy(leftHand);
+  parts.rightHand.position.copy(rightHand);
+  parts.leftFoot.position.copy(leftFoot);
+  parts.rightFoot.position.copy(rightFoot);
+  parts.leftFoot.rotation.y = 0.15;
+  parts.rightFoot.rotation.y = -0.12;
+  placeSnookerHumanSegment(parts.leftUpperArm, leftShoulder, leftElbow);
+  placeSnookerHumanSegment(parts.leftForearm, leftElbow, leftHand);
+  placeSnookerHumanSegment(parts.rightUpperArm, rightShoulder, rightElbow);
+  placeSnookerHumanSegment(parts.rightForearm, rightElbow, rightHand);
+  placeSnookerHumanSegment(parts.leftThigh, leftHip, leftKnee);
+  placeSnookerHumanSegment(parts.leftShin, leftKnee, leftFoot);
+  placeSnookerHumanSegment(parts.rightThigh, rightHip, rightKnee);
+  placeSnookerHumanSegment(parts.rightShin, rightKnee, rightFoot);
+  root.updateMatrixWorld(true);
+}
+
+function normalizeSnookerHumanModel(model, targetHeight = SNOOKER_HUMAN_CFG.targetHeight) {
+  model.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const height = Math.max(size.y, 1e-4);
+  const scale = targetHeight / height;
+  model.scale.multiplyScalar(scale);
+  model.updateMatrixWorld(true);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.sub(center);
+  model.position.y -= scaledBox.min.y - center.y;
+  model.rotation.y += SNOOKER_HUMAN_CFG.yawFix;
+}
+
+function findSnookerHumanBone(root, ...names) {
+  const wanted = names.map(cleanSnookerHumanBoneName);
+  let found = null;
+  root.traverse((obj) => {
+    if (found || !obj?.isBone) return;
+    const n = cleanSnookerHumanBoneName(obj.name);
+    if (wanted.some((needle) => n === needle || n.includes(needle))) found = obj;
+  });
+  return found;
+}
+
+function buildSnookerHumanBones(model) {
+  return {
+    hips: findSnookerHumanBone(model, 'hips', 'pelvis'),
+    spine: findSnookerHumanBone(model, 'spine'),
+    chest: findSnookerHumanBone(model, 'spine2', 'chest', 'upperchest'),
+    neck: findSnookerHumanBone(model, 'neck'),
+    head: findSnookerHumanBone(model, 'head'),
+    leftUpperArm: findSnookerHumanBone(model, 'leftarm', 'leftupperarm', 'mixamorigleftarm'),
+    leftLowerArm: findSnookerHumanBone(model, 'leftforearm', 'leftlowerarm'),
+    leftHand: findSnookerHumanBone(model, 'lefthand'),
+    rightUpperArm: findSnookerHumanBone(model, 'rightarm', 'rightupperarm', 'mixamorigrightarm'),
+    rightLowerArm: findSnookerHumanBone(model, 'rightforearm', 'rightlowerarm'),
+    rightHand: findSnookerHumanBone(model, 'righthand'),
+    leftUpperLeg: findSnookerHumanBone(model, 'leftupleg', 'leftupperleg'),
+    leftLowerLeg: findSnookerHumanBone(model, 'leftleg', 'leftlowerleg'),
+    rightUpperLeg: findSnookerHumanBone(model, 'rightupleg', 'rightupperleg'),
+    rightLowerLeg: findSnookerHumanBone(model, 'rightleg', 'rightlowerleg')
+  };
+}
+
+function setSnookerHumanBoneWorldQuaternion(bone, q) {
+  if (!bone || !q) return;
+  const parentQ = new THREE.Quaternion();
+  bone.parent?.getWorldQuaternion(parentQ);
+  bone.quaternion.copy(parentQ.invert().multiply(q));
+  bone.updateMatrixWorld(true);
+}
+
+function firstSnookerHumanBoneChild(bone) {
+  return bone?.children.find((child) => child?.isBone);
+}
+
+function rotateSnookerHumanBoneToward(bone, targetWorld, strength = 0.72, fallbackDir = SNOOKER_HUMAN_UP) {
+  if (!bone || !targetWorld || strength <= 0) return;
+  const bonePos = bone.getWorldPosition(new THREE.Vector3());
+  const child = firstSnookerHumanBoneChild(bone);
+  const childPos = child?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir, 0.2);
+  const current = childPos.sub(bonePos).normalize();
+  const desired = targetWorld.clone().sub(bonePos);
+  if (current.lengthSq() < 1e-8 || desired.lengthSq() < 1e-8) return;
+  const delta = new THREE.Quaternion().setFromUnitVectors(current, desired.normalize());
+  const blended = new THREE.Quaternion().slerpQuaternions(new THREE.Quaternion(), delta, snookerHumanClamp01(strength));
+  setSnookerHumanBoneWorldQuaternion(bone, blended.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+
+function poseSnookerHumanGlb(human, targetsLocal) {
+  if (!human?.activeGlb || !human.modelRoot?.parent) return;
+  const tableGroup = human.modelRoot.parent;
+  const toWorld = (local) => tableGroup.localToWorld(local.clone());
+  const bones = human.bones || {};
+  human.modelRoot.updateMatrixWorld(true);
+  const leftHand = toWorld(targetsLocal.leftHandWorld);
+  const rightHand = toWorld(targetsLocal.rightHandWorld);
+  const leftElbow = toWorld(targetsLocal.leftElbowWorld);
+  const rightElbow = toWorld(targetsLocal.rightElbowWorld);
+  const head = toWorld(targetsLocal.headWorld);
+  const chest = toWorld(targetsLocal.chestWorld);
+  rotateSnookerHumanBoneToward(bones.spine, chest, 0.4, SNOOKER_HUMAN_UP);
+  rotateSnookerHumanBoneToward(bones.chest, head, 0.45, SNOOKER_HUMAN_UP);
+  rotateSnookerHumanBoneToward(bones.neck, head, 0.55, SNOOKER_HUMAN_UP);
+  rotateSnookerHumanBoneToward(bones.head, toWorld(targetsLocal.cueTipWorld), 0.32, SNOOKER_HUMAN_FORWARD_LOCAL);
+  for (let i = 0; i < 3; i += 1) {
+    rotateSnookerHumanBoneToward(bones.leftUpperArm, leftElbow, 0.75, SNOOKER_HUMAN_UP);
+    rotateSnookerHumanBoneToward(bones.leftLowerArm, leftHand, 0.78, SNOOKER_HUMAN_UP);
+    rotateSnookerHumanBoneToward(bones.rightUpperArm, rightElbow, 0.76, SNOOKER_HUMAN_UP);
+    rotateSnookerHumanBoneToward(bones.rightLowerArm, rightHand, 0.8, SNOOKER_HUMAN_UP);
+  }
+}
+
+function createSnookerRoyalHumanPlayer(parent, renderer, createLoader) {
+  const human = {
+    root: new THREE.Group(),
+    modelRoot: new THREE.Group(),
+    fallback: createSnookerHumanFallbackRig(),
+    bones: {},
+    activeGlb: false,
+    yaw: 0,
+    poseT: 0,
+    loaded: false,
+    theme: SNOOKER_HUMAN_CHARACTER_THEME
+  };
+  human.root.name = 'SnookerRoyalHumanPlayerRoot';
+  human.modelRoot.name = 'SnookerRoyalDominoCharacterRoot';
+  human.root.visible = false;
+  human.modelRoot.visible = false;
+  human.root.add(human.fallback);
+  parent.add(human.root, human.modelRoot);
+  const urls = [
+    ...(human.theme?.modelUrls || []),
+    human.theme?.url
+  ].filter(Boolean);
+  if (urls.length && typeof createLoader === 'function') {
+    const loader = createLoader(renderer);
+    (async () => {
+      let loaded = null;
+      let loadedUrl = null;
+      for (const url of urls) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const gltf = await loader.loadAsync(url);
+          loaded = gltf?.scene || gltf?.scenes?.[0] || null;
+          loadedUrl = url;
+          if (loaded) break;
+        } catch (error) {
+          console.warn('Snooker Royal human character load failed, trying fallback URL', url, error);
+        }
+      }
+      if (!loaded) return;
+      normalizeSnookerHumanModel(loaded);
+      loaded.traverse((obj) => {
+        if (!obj?.isMesh) return;
+        obj.castShadow = true;
+        obj.receiveShadow = true;
+        obj.frustumCulled = false;
+        const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+        mats.forEach((mat) => {
+          if (mat?.map) applySRGBColorSpace(mat.map);
+          if (mat) mat.needsUpdate = true;
+        });
+      });
+      human.bones = buildSnookerHumanBones(loaded);
+      human.activeGlb = Boolean(human.bones.head && human.bones.leftUpperArm && human.bones.rightUpperArm);
+      human.modelUrl = loadedUrl;
+      human.modelRoot.add(loaded);
+      human.modelRoot.visible = human.root.visible;
+      human.fallback.visible = !human.activeGlb;
+      human.loaded = true;
+    })();
+  }
+  return human;
+}
+
+function getSnookerCueEndpoints(cueStick, cueLen) {
+  if (!cueStick) return null;
+  cueStick.updateMatrixWorld(true);
+  const tip = new THREE.Vector3(0, 0, -cueLen / 2).applyMatrix4(cueStick.matrixWorld);
+  const butt = new THREE.Vector3(0, 0, cueLen / 2).applyMatrix4(cueStick.matrixWorld);
+  const parent = cueStick.parent;
+  if (parent) {
+    parent.worldToLocal(tip);
+    parent.worldToLocal(butt);
+  }
+  return { tip, butt };
+}
+
+function updateSnookerRoyalHumanPlayer(human, dt, options) {
+  if (!human?.root) return;
+  const { cue, cueStick, cueLen, aimDir, visible, power = 0, shooting = false, cueAnimating = false } = options || {};
+  const cuePos = cue?.pos;
+  if (!cuePos || !cue?.active || !visible) {
+    human.root.visible = false;
+    human.modelRoot.visible = false;
+    return;
+  }
+  const dir = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
+  if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
+  dir.normalize();
+  const side = new THREE.Vector3(-dir.z, 0, dir.x).normalize();
+  const cueBall = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
+  const cueEndpoints = getSnookerCueEndpoints(cueStick, cueLen) || {
+    tip: cueBall.clone().addScaledVector(dir, -CUE_TIP_GAP),
+    butt: cueBall.clone().addScaledVector(dir, -(cueLen + CUE_TIP_GAP))
+  };
+  const pullPose = THREE.MathUtils.clamp((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0), 0, 1);
+  const rootTarget = cueBall.clone()
+    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.idleDistance - pullPose * BALL_R * 1.8)
+    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceSide * 0.32);
+  rootTarget.y = SNOOKER_HUMAN_CFG.floorY;
+  const yawTarget = Math.atan2(dir.x, dir.z);
+  human.root.visible = true;
+  human.modelRoot.visible = human.loaded;
+  human.root.position.lerp(rootTarget, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
+  human.yaw = snookerHumanDampAngle(human.yaw, yawTarget, SNOOKER_HUMAN_CFG.rootLambda, dt);
+  human.root.rotation.set(0, human.yaw, 0);
+  human.modelRoot.position.copy(human.root.position);
+  human.modelRoot.rotation.copy(human.root.rotation);
+  human.poseT = snookerHumanDamp(human.poseT, 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
+  const invRoot = new THREE.Matrix4().copy(human.root.matrixWorld).invert();
+  const toRootLocal = (v) => v.clone().applyMatrix4(invRoot);
+  const bridge = cueBall.clone()
+    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
+    .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
+    .setY(CUE_Y + BALL_R * 0.08);
+  const grip = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
+  const chestWorld = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
+  const headWorld = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
+  const torso = toRootLocal(chestWorld).add(new THREE.Vector3(0, 0.16 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
+  const chest = toRootLocal(chestWorld);
+  const head = toRootLocal(headWorld);
+  const neck = chest.clone().lerp(head, 0.68);
+  const leftShoulder = chest.clone().add(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, -0.025 * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightShoulder = chest.clone().add(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.055 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
+  const leftHand = toRootLocal(bridge);
+  const rightHand = toRootLocal(grip);
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.58).add(new THREE.Vector3(-0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.03 * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightElbow = rightShoulder.clone().lerp(rightHand, 0.42).add(new THREE.Vector3(0.22 * SNOOKER_HUMAN_WORLD_SCALE, 0.20 * SNOOKER_HUMAN_WORLD_SCALE, -0.20 * SNOOKER_HUMAN_WORLD_SCALE));
+  const leftHip = new THREE.Vector3(-0.07 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE);
+  const rightHip = new THREE.Vector3(0.08 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.12 * SNOOKER_HUMAN_WORLD_SCALE);
+  const leftFoot = new THREE.Vector3(-SNOOKER_HUMAN_CFG.stanceSide, 0.03 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.leftFootForward);
+  const rightFoot = new THREE.Vector3(SNOOKER_HUMAN_CFG.stanceSide * 0.62, 0.03 * SNOOKER_HUMAN_WORLD_SCALE, -SNOOKER_HUMAN_CFG.rightFootBack);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.55).add(new THREE.Vector3(-0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.12 * SNOOKER_HUMAN_WORLD_SCALE, 0.04 * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).add(new THREE.Vector3(0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.14 * SNOOKER_HUMAN_WORLD_SCALE, -0.03 * SNOOKER_HUMAN_WORLD_SCALE));
+  poseSnookerHumanFallback(human, {
+    root: human.root,
+    torso,
+    chest,
+    head,
+    neck,
+    leftShoulder,
+    rightShoulder,
+    leftElbow,
+    rightElbow,
+    leftHand,
+    rightHand,
+    leftHip,
+    rightHip,
+    leftKnee,
+    rightKnee,
+    leftFoot,
+    rightFoot
+  });
+  poseSnookerHumanGlb(human, {
+    leftHandWorld: bridge,
+    rightHandWorld: grip,
+    leftElbowWorld: human.root.parent.worldToLocal(human.root.localToWorld(leftElbow.clone())),
+    rightElbowWorld: human.root.parent.worldToLocal(human.root.localToWorld(rightElbow.clone())),
+    headWorld: headWorld,
+    chestWorld: chestWorld,
+    cueTipWorld: cueEndpoints.tip
+  });
+}
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_LIFT_DRAG_SCALE = 0.0048;
 const CUE_LIFT_MAX_TILT = THREE.MathUtils.degToRad(12.5);
@@ -21402,6 +21779,11 @@ const powerRef = useRef(hud.power);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
+      const snookerHumanPlayer = createSnookerRoyalHumanPlayer(
+        table,
+        renderer,
+        createConfiguredGLTFLoader
+      );
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
       const closeCueGallery = () => {
@@ -25863,6 +26245,19 @@ const powerRef = useRef(hud.power);
           updateChalkVisibility(null);
         }
 
+        updateSnookerRoyalHumanPlayer(snookerHumanPlayer, deltaSeconds, {
+          cue,
+          cueStick,
+          cueLen,
+          aimDir: showingRemoteAim
+            ? new THREE.Vector2(remoteAimState?.dir?.x ?? 0, remoteAimState?.dir?.y ?? 1)
+            : activeAiPlan?.aimDir || aimDir,
+          visible: cueStick.visible || cueAnimating || shooting,
+          power: powerRef.current ?? activeAiPlan?.power ?? 0,
+          shooting,
+          cueAnimating
+        });
+
         if (!shouldSlowAim) {
           const precisionArea = chalkAreaRef.current;
           if (precisionArea) precisionArea.visible = false;
@@ -26770,6 +27165,8 @@ const powerRef = useRef(hud.power);
         lightingRigRef.current = null;
         worldRef.current = null;
         activeRenderCameraRef.current = null;
+        snookerHumanPlayer?.root?.removeFromParent?.();
+        snookerHumanPlayer?.modelRoot?.removeFromParent?.();
         cueBodyRef.current = null;
         tipGroupRef.current = null;
         try {


### PR DESCRIPTION
### Motivation
- Reuse the existing Domino/Murlan human character catalog so Snooker Royal can display a full-body player using the same ReadyPlayerMe / shared GLB sources. 
- Provide accurate shot-line orientation, bridge/grip hand placement and stance logic so the character lines up with the cue and cue-ball before a shot. 
- Ensure a visible player is available even if the GLB fails to load by adding a simple procedural fallback rig and lightweight bone-targeting pose logic. 

### Description
- Added imports and a new snooker character configuration and constants based on table/ball scales and cue geometry in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Implemented a procedural fallback rig (`createSnookerHumanFallbackRig`, helpers to place/pose segments) and GLB-loadable rig support (`createSnookerRoyalHumanPlayer`, `buildSnookerHumanBones`, `normalizeSnookerHumanModel`, `poseSnookerHumanGlb`) to map target world positions into bone orientations.
- Integrated character creation into the Snooker scene near the cue-stick setup and wired `updateSnookerRoyalHumanPlayer(...)` into the main render/aim loop so the player root follows the cue/aim state, handles pull/shot/preview state and updates model/fallback visibility.
- Added cleanup logic to remove the character roots on scene dispose and adjusted a few local/world transforms when computing elbow/hand targets so the GLB and fallback both align correctly with the cue-tip and bridge target. 

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully and produced the app assets. 
- Ran `git diff --check` (no whitespace/errors reported) as a quick static-change sanity check. 
- Attempted an automated Playwright screenshot to validate the in-browser pose but the headless Chromium run failed in this environment due to missing system library `libatk-1.0.so.0`, so runtime visual verification could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0689a791ec83299e58547727a8a411)