### PR TITLE
Add SnookerRoyal human player model, loader, posing and runtime integration

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -71,6 +71,7 @@ import {
   SNOOKER_ROYALE_OPTION_LABELS
 } from '../../config/snookerRoyalInventoryConfig.js';
 import { SNOOKER_ROYALE_CLOTH_VARIANTS } from '../../config/snookerRoyalClothPresets.js';
+import { MURLAN_CHARACTER_THEMES } from '../../config/murlanCharacterThemes.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 import {
   getCachedSnookerRoyalInventory,
@@ -1657,6 +1658,493 @@ const CUE_BUTT_LIFT = BALL_R * 0.52; // keep the butt elevated for clearance whi
 const CUE_BUTT_CUSHION_CLEARANCE = BALL_R * 0.11; // keep the cue butt from dipping below the cushion top surface
 const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.06; // lift the cue slightly more as cushions rise so it never touches
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
+
+
+const SNOOKER_HUMAN_CHARACTER_THEME =
+  MURLAN_CHARACTER_THEMES.find((theme) => theme.id === 'rpm-current') ||
+  MURLAN_CHARACTER_THEMES[0];
+const SNOOKER_HUMAN_UP = new THREE.Vector3(0, 1, 0);
+const SNOOKER_HUMAN_FORWARD_LOCAL = new THREE.Vector3(0, 0, 1);
+const SNOOKER_HUMAN_WORLD_SCALE = BALL_R / 0.0525;
+const SNOOKER_HUMAN_CFG = Object.freeze({
+  targetHeight: 1.72 * SNOOKER_HUMAN_WORLD_SCALE,
+  floorY: FLOOR_Y - TABLE_Y,
+  idleDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeBackFromBall: 0.27 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeSide: -0.025 * SNOOKER_HUMAN_WORLD_SCALE,
+  stanceSide: 0.25 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightFootBack: 0.38 * SNOOKER_HUMAN_WORLD_SCALE,
+  leftFootForward: 0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+  chinCueOffsetY: 0.12 * SNOOKER_HUMAN_WORLD_SCALE,
+  chestCueOffsetY: 0.22 * SNOOKER_HUMAN_WORLD_SCALE,
+  rootLambda: 7.5,
+  poseLambda: 10,
+  yawFix: 0
+});
+const cleanSnookerHumanBoneName = (name = '') => name.toLowerCase().replace(/[^a-z0-9]/g, '');
+const snookerHumanClamp01 = (value) => Math.max(0, Math.min(1, value));
+const snookerHumanDamp = (current, target, lambda, dt) =>
+  THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+const snookerHumanDampAngle = (current, target, lambda, dt) => {
+  const delta = THREE.MathUtils.euclideanModulo(target - current + Math.PI, Math.PI * 2) - Math.PI;
+  return current + delta * (1 - Math.exp(-lambda * dt));
+};
+
+function makeSnookerHumanSegment(radius, color, metalness = 0.02) {
+  return new THREE.Mesh(
+    new THREE.CylinderGeometry(radius, radius, 1, 14),
+    new THREE.MeshStandardMaterial({ color, roughness: 0.72, metalness })
+  );
+}
+
+function createSnookerHumanFallbackRig() {
+  const rig = new THREE.Group();
+  rig.name = 'SnookerRoyalFallbackHumanPoseRig';
+  const skin = new THREE.MeshStandardMaterial({ color: 0xd9a27d, roughness: 0.68 });
+  const vest = new THREE.MeshStandardMaterial({ color: 0x111827, roughness: 0.64 });
+  const shirt = new THREE.MeshStandardMaterial({ color: 0xf8fafc, roughness: 0.7 });
+  const trouser = new THREE.MeshStandardMaterial({ color: 0x1f2937, roughness: 0.75 });
+  const shoe = new THREE.MeshStandardMaterial({ color: 0x050505, roughness: 0.6 });
+  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.135, 0.34, 5, 12), vest);
+  const chest = new THREE.Mesh(new THREE.CapsuleGeometry(0.105, 0.22, 5, 12), shirt);
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.078, 18, 14), skin);
+  const neck = makeSnookerHumanSegment(0.032, 0xd9a27d);
+  const leftHand = new THREE.Mesh(new THREE.SphereGeometry(0.036, 14, 10), skin);
+  const rightHand = new THREE.Mesh(new THREE.SphereGeometry(0.034, 14, 10), skin);
+  const leftFoot = new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.045, 0.25), shoe);
+  const rightFoot = leftFoot.clone();
+  const segments = {
+    leftUpperArm: makeSnookerHumanSegment(0.032, 0xf8fafc),
+    leftForearm: makeSnookerHumanSegment(0.027, 0xd9a27d),
+    rightUpperArm: makeSnookerHumanSegment(0.033, 0xf8fafc),
+    rightForearm: makeSnookerHumanSegment(0.027, 0xd9a27d),
+    leftThigh: makeSnookerHumanSegment(0.043, 0x1f2937),
+    leftShin: makeSnookerHumanSegment(0.036, 0x1f2937),
+    rightThigh: makeSnookerHumanSegment(0.043, 0x1f2937),
+    rightShin: makeSnookerHumanSegment(0.036, 0x1f2937)
+  };
+  rig.add(torso, chest, head, neck, leftHand, rightHand, leftFoot, rightFoot, ...Object.values(segments));
+  rig.userData.parts = { torso, chest, head, neck, leftHand, rightHand, leftFoot, rightFoot, ...segments };
+  rig.traverse((obj) => {
+    if (obj?.isMesh) {
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+    }
+  });
+  return rig;
+}
+
+function placeSnookerHumanSegment(segment, a, b) {
+  if (!segment || !a || !b) return;
+  const mid = a.clone().add(b).multiplyScalar(0.5);
+  const delta = b.clone().sub(a);
+  const len = delta.length();
+  segment.position.copy(mid);
+  segment.scale.set(1, Math.max(len, 1e-4), 1);
+  if (len > 1e-5) {
+    segment.quaternion.setFromUnitVectors(SNOOKER_HUMAN_UP, delta.normalize());
+  }
+}
+
+function poseSnookerHumanFallback(human, points) {
+  const parts = human?.fallback?.userData?.parts;
+  if (!parts) return;
+  const {
+    root, torso, chest, head, neck, leftShoulder, rightShoulder,
+    leftElbow, rightElbow, leftHand, rightHand, leftHip, rightHip,
+    leftKnee, rightKnee, leftFoot, rightFoot
+  } = points;
+  parts.torso.position.copy(torso);
+  parts.torso.rotation.set(THREE.MathUtils.degToRad(71), 0, 0);
+  parts.chest.position.copy(chest);
+  parts.chest.rotation.copy(parts.torso.rotation);
+  parts.head.position.copy(head);
+  parts.neck.position.copy(neck);
+  parts.leftHand.position.copy(leftHand);
+  parts.rightHand.position.copy(rightHand);
+  parts.leftFoot.position.copy(leftFoot);
+  parts.rightFoot.position.copy(rightFoot);
+  parts.leftFoot.rotation.y = 0.15;
+  parts.rightFoot.rotation.y = -0.12;
+  placeSnookerHumanSegment(parts.leftUpperArm, leftShoulder, leftElbow);
+  placeSnookerHumanSegment(parts.leftForearm, leftElbow, leftHand);
+  placeSnookerHumanSegment(parts.rightUpperArm, rightShoulder, rightElbow);
+  placeSnookerHumanSegment(parts.rightForearm, rightElbow, rightHand);
+  placeSnookerHumanSegment(parts.leftThigh, leftHip, leftKnee);
+  placeSnookerHumanSegment(parts.leftShin, leftKnee, leftFoot);
+  placeSnookerHumanSegment(parts.rightThigh, rightHip, rightKnee);
+  placeSnookerHumanSegment(parts.rightShin, rightKnee, rightFoot);
+  root.updateMatrixWorld(true);
+}
+
+function normalizeSnookerHumanModel(model, targetHeight = SNOOKER_HUMAN_CFG.targetHeight) {
+  model.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const height = Math.max(size.y, 1e-4);
+  const scale = targetHeight / height;
+  model.scale.multiplyScalar(scale);
+  model.updateMatrixWorld(true);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.sub(center);
+  model.position.y -= scaledBox.min.y - center.y;
+  model.rotation.y += SNOOKER_HUMAN_CFG.yawFix;
+}
+
+function findSnookerHumanBone(root, ...names) {
+  const wanted = names.map(cleanSnookerHumanBoneName);
+  let found = null;
+  root.traverse((obj) => {
+    if (found || !obj?.isBone) return;
+    const n = cleanSnookerHumanBoneName(obj.name);
+    if (wanted.some((needle) => n === needle || n.includes(needle))) found = obj;
+  });
+  return found;
+}
+
+function buildSnookerHumanBones(model) {
+  return {
+    hips: findSnookerHumanBone(model, 'hips', 'pelvis'),
+    spine: findSnookerHumanBone(model, 'spine'),
+    chest: findSnookerHumanBone(model, 'spine2', 'chest', 'upperchest'),
+    neck: findSnookerHumanBone(model, 'neck'),
+    head: findSnookerHumanBone(model, 'head'),
+    leftUpperArm: findSnookerHumanBone(model, 'leftarm', 'leftupperarm', 'mixamorigleftarm'),
+    leftLowerArm: findSnookerHumanBone(model, 'leftforearm', 'leftlowerarm'),
+    leftHand: findSnookerHumanBone(model, 'lefthand'),
+    rightUpperArm: findSnookerHumanBone(model, 'rightarm', 'rightupperarm', 'mixamorigrightarm'),
+    rightLowerArm: findSnookerHumanBone(model, 'rightforearm', 'rightlowerarm'),
+    rightHand: findSnookerHumanBone(model, 'righthand'),
+    leftUpperLeg: findSnookerHumanBone(model, 'leftupleg', 'leftupperleg'),
+    leftLowerLeg: findSnookerHumanBone(model, 'leftleg', 'leftlowerleg'),
+    rightUpperLeg: findSnookerHumanBone(model, 'rightupleg', 'rightupperleg'),
+    rightLowerLeg: findSnookerHumanBone(model, 'rightleg', 'rightlowerleg')
+  };
+}
+
+
+function disposeSnookerHumanGLTFLoader(loader) {
+  loader?.userData?.draco?.dispose?.();
+  loader?.userData?.ktx2?.dispose?.();
+}
+
+function createSnookerHumanGLTFLoader(renderer = null) {
+  const loader = new GLTFLoader();
+  loader.setCrossOrigin('anonymous');
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(DRACO_DECODER_PATH);
+  loader.setDRACOLoader(draco);
+  const ktx2 = new KTX2Loader();
+  ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  if (renderer) {
+    try {
+      ktx2.detectSupport(renderer);
+    } catch (error) {
+      console.warn('Snooker Royal human KTX2 support detection failed', error);
+    }
+  }
+  loader.setKTX2Loader(ktx2);
+  loader.setMeshoptDecoder?.(MeshoptDecoder);
+  loader.userData = { draco, ktx2 };
+  return loader;
+}
+
+function loadSnookerHumanModel(loader, url) {
+  return new Promise((resolve, reject) => {
+    loader.load(
+      url,
+      (gltf) => resolve(gltf?.scene || gltf?.scenes?.[0] || null),
+      undefined,
+      async (loaderError) => {
+        try {
+          const response = await fetch(url, { mode: 'cors', cache: 'reload' });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          const buffer = await response.arrayBuffer();
+          const basePath = url.slice(0, url.lastIndexOf('/') + 1);
+          loader.parse(
+            buffer,
+            basePath,
+            (gltf) => resolve(gltf?.scene || gltf?.scenes?.[0] || null),
+            reject
+          );
+        } catch (fetchError) {
+          reject(fetchError || loaderError);
+        }
+      }
+    );
+  });
+}
+
+function buildSnookerHumanModelUrls(theme = SNOOKER_HUMAN_CHARACTER_THEME) {
+  const urls = [
+    ...(theme?.modelUrls || []),
+    theme?.url,
+    ...MURLAN_CHARACTER_THEMES.flatMap((entry) => [
+      ...(entry?.modelUrls || []),
+      entry?.url
+    ]),
+    'https://threejs.org/examples/models/gltf/Xbot.glb',
+    'https://threejs.org/examples/models/gltf/Soldier.glb'
+  ].filter(Boolean);
+  return [...new Set(urls)];
+}
+
+async function loadSnookerHumanModelFromCatalog(loader, urls = buildSnookerHumanModelUrls()) {
+  let lastError = null;
+  for (const url of urls) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const model = await loadSnookerHumanModel(loader, url);
+      if (model) return { model, url };
+    } catch (error) {
+      lastError = error;
+      console.warn('Snooker Royal human model failed, trying fallback', url, error);
+    }
+  }
+  throw lastError || new Error('No Snooker Royal human models configured');
+}
+
+function resetSnookerHumanRestPose(human) {
+  if (!human?.restQuats) return;
+  human.restQuats.forEach((quat, bone) => {
+    if (bone?.quaternion) bone.quaternion.copy(quat);
+  });
+}
+
+function setSnookerHumanBoneWorldQuaternion(bone, q) {
+  if (!bone || !q) return;
+  const parentQ = new THREE.Quaternion();
+  bone.parent?.getWorldQuaternion(parentQ);
+  bone.quaternion.copy(parentQ.invert().multiply(q));
+  bone.updateMatrixWorld(true);
+}
+
+function firstSnookerHumanBoneChild(bone) {
+  return bone?.children.find((child) => child?.isBone);
+}
+
+function rotateSnookerHumanBoneToward(bone, targetWorld, strength = 0.72, fallbackDir = SNOOKER_HUMAN_UP) {
+  if (!bone || !targetWorld || strength <= 0) return;
+  const bonePos = bone.getWorldPosition(new THREE.Vector3());
+  const child = firstSnookerHumanBoneChild(bone);
+  const childPos = child?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir, 0.2);
+  const current = childPos.sub(bonePos).normalize();
+  const desired = targetWorld.clone().sub(bonePos);
+  if (current.lengthSq() < 1e-8 || desired.lengthSq() < 1e-8) return;
+  const delta = new THREE.Quaternion().setFromUnitVectors(current, desired.normalize());
+  const blended = new THREE.Quaternion().slerpQuaternions(new THREE.Quaternion(), delta, snookerHumanClamp01(strength));
+  setSnookerHumanBoneWorldQuaternion(bone, blended.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+
+function poseSnookerHumanGlb(human, targetsLocal) {
+  if (!human?.activeGlb || !human.modelRoot?.parent) return;
+  const tableGroup = human.modelRoot.parent;
+  if (!tableGroup) return;
+  resetSnookerHumanRestPose(human);
+  const toWorld = (local) => tableGroup.localToWorld(local.clone());
+  const bones = human.bones || {};
+  human.modelRoot.updateMatrixWorld(true);
+  const leftHand = toWorld(targetsLocal.leftHandWorld);
+  const rightHand = toWorld(targetsLocal.rightHandWorld);
+  const leftElbow = toWorld(targetsLocal.leftElbowWorld);
+  const rightElbow = toWorld(targetsLocal.rightElbowWorld);
+  const head = toWorld(targetsLocal.headWorld);
+  const chest = toWorld(targetsLocal.chestWorld);
+  rotateSnookerHumanBoneToward(bones.spine, chest, 0.4, SNOOKER_HUMAN_UP);
+  rotateSnookerHumanBoneToward(bones.chest, head, 0.45, SNOOKER_HUMAN_UP);
+  rotateSnookerHumanBoneToward(bones.neck, head, 0.55, SNOOKER_HUMAN_UP);
+  rotateSnookerHumanBoneToward(bones.head, toWorld(targetsLocal.cueTipWorld), 0.32, SNOOKER_HUMAN_FORWARD_LOCAL);
+  for (let i = 0; i < 3; i += 1) {
+    rotateSnookerHumanBoneToward(bones.leftUpperArm, leftElbow, 0.75, SNOOKER_HUMAN_UP);
+    rotateSnookerHumanBoneToward(bones.leftLowerArm, leftHand, 0.78, SNOOKER_HUMAN_UP);
+    rotateSnookerHumanBoneToward(bones.rightUpperArm, rightElbow, 0.76, SNOOKER_HUMAN_UP);
+    rotateSnookerHumanBoneToward(bones.rightLowerArm, rightHand, 0.8, SNOOKER_HUMAN_UP);
+  }
+}
+
+function createSnookerRoyalHumanPlayer(parent, renderer) {
+  const human = {
+    root: new THREE.Group(),
+    modelRoot: new THREE.Group(),
+    fallback: createSnookerHumanFallbackRig(),
+    bones: {},
+    activeGlb: false,
+    yaw: 0,
+    poseT: 0,
+    loaded: false,
+    disabled: false,
+    loadFailed: false,
+    lastRootPosition: new THREE.Vector3(),
+    walkPhase: 0,
+    walkAmount: 0,
+    restQuats: new Map(),
+    theme: SNOOKER_HUMAN_CHARACTER_THEME
+  };
+  human.root.name = 'SnookerRoyalHumanPlayerRoot';
+  human.modelRoot.name = 'SnookerRoyalDominoCharacterRoot';
+  human.root.visible = false;
+  human.modelRoot.visible = false;
+  human.root.add(human.fallback);
+  parent.add(human.root, human.modelRoot);
+  const urls = buildSnookerHumanModelUrls(human.theme);
+  const loader = createSnookerHumanGLTFLoader(renderer);
+  loadSnookerHumanModelFromCatalog(loader, urls)
+    .then(({ model, url }) => {
+      normalizeSnookerHumanModel(model);
+      model.traverse((obj) => {
+        if (obj?.isBone) human.restQuats.set(obj, obj.quaternion.clone());
+        if (!obj?.isMesh) return;
+        obj.castShadow = true;
+        obj.receiveShadow = true;
+        obj.frustumCulled = false;
+        const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+        mats.forEach((mat) => {
+          if (mat?.map) {
+            applySRGBColorSpace(mat.map);
+            mat.map.needsUpdate = true;
+          }
+          if (mat) mat.needsUpdate = true;
+        });
+      });
+      human.bones = buildSnookerHumanBones(model);
+      human.activeGlb = Boolean(
+        human.bones.head &&
+        human.bones.spine &&
+        human.bones.leftUpperArm &&
+        human.bones.leftLowerArm &&
+        human.bones.rightUpperArm &&
+        human.bones.rightLowerArm
+      );
+      human.modelUrl = url;
+      human.modelRoot.add(model);
+      human.modelRoot.visible = human.root.visible && human.activeGlb;
+      human.fallback.visible = !human.activeGlb;
+      human.loaded = true;
+    })
+    .catch((error) => {
+      human.loadFailed = true;
+      human.activeGlb = false;
+      human.fallback.visible = true;
+      console.warn('Snooker Royal human GLB catalog failed; using fallback pose rig.', error);
+    })
+    .finally(() => disposeSnookerHumanGLTFLoader(loader));
+  return human;
+}
+
+function getSnookerCueEndpoints(cueStick, cueLen) {
+  if (!cueStick) return null;
+  cueStick.updateMatrixWorld(true);
+  const tip = new THREE.Vector3(0, 0, -cueLen / 2).applyMatrix4(cueStick.matrixWorld);
+  const butt = new THREE.Vector3(0, 0, cueLen / 2).applyMatrix4(cueStick.matrixWorld);
+  const parent = cueStick.parent;
+  if (parent) {
+    parent.worldToLocal(tip);
+    parent.worldToLocal(butt);
+  }
+  return { tip, butt };
+}
+
+function updateSnookerRoyalHumanPlayer(human, dt, options) {
+  if (!human?.root || human.disabled) return;
+  const { cue, cueStick, cueLen, aimDir, visible, power = 0, shooting = false, cueAnimating = false } = options || {};
+  const cuePos = cue?.pos;
+  if (!cuePos || !cue?.active || !visible) {
+    human.root.visible = false;
+    human.modelRoot.visible = false;
+    return;
+  }
+  const dir = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
+  if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
+  dir.normalize();
+  const side = new THREE.Vector3(-dir.z, 0, dir.x).normalize();
+  const cueBall = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
+  const cueEndpoints = getSnookerCueEndpoints(cueStick, cueLen) || {
+    tip: cueBall.clone().addScaledVector(dir, -CUE_TIP_GAP),
+    butt: cueBall.clone().addScaledVector(dir, -(cueLen + CUE_TIP_GAP))
+  };
+  const pullPose = THREE.MathUtils.clamp((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0), 0, 1);
+  // Orientation is driven from the actual shot line: the root stands behind
+  // the cue ball on -dir, then faces +dir back through cue ball/object ball.
+  // Keeping local +Z on the shot line prevents mirrored cue/hand placement.
+  const rootTarget = cueBall.clone()
+    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.idleDistance - pullPose * BALL_R * 1.8)
+    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceSide * 0.32);
+  rootTarget.y = SNOOKER_HUMAN_CFG.floorY;
+  const yawTarget = Math.atan2(dir.x, dir.z);
+  human.root.visible = true;
+  human.modelRoot.visible = human.loaded && human.activeGlb;
+  const travel = human.lastRootPosition.distanceTo(rootTarget);
+  human.walkAmount = snookerHumanDamp(human.walkAmount, snookerHumanClamp01(travel / Math.max(BALL_R * 4, 1e-4)), 8, dt);
+  human.walkPhase += dt * (4.5 + human.walkAmount * 5.5);
+  human.root.position.lerp(rootTarget, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
+  human.lastRootPosition.copy(human.root.position);
+  human.yaw = snookerHumanDampAngle(human.yaw, yawTarget, SNOOKER_HUMAN_CFG.rootLambda, dt);
+  human.root.rotation.set(0, human.yaw, 0);
+  human.modelRoot.position.copy(human.root.position);
+  human.modelRoot.rotation.copy(human.root.rotation);
+  human.poseT = snookerHumanDamp(human.poseT, 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
+  const invRoot = new THREE.Matrix4().copy(human.root.matrixWorld).invert();
+  const toRootLocal = (v) => v.clone().applyMatrix4(invRoot);
+  const bridge = cueBall.clone()
+    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
+    .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
+    .setY(CUE_Y + BALL_R * 0.08);
+  const grip = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
+  const chestWorld = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
+  const headWorld = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
+  const torso = toRootLocal(chestWorld).add(new THREE.Vector3(0, 0.16 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
+  const chest = toRootLocal(chestWorld);
+  const head = toRootLocal(headWorld);
+  const neck = chest.clone().lerp(head, 0.68);
+  const leftShoulder = chest.clone().add(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, -0.025 * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightShoulder = chest.clone().add(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.055 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
+  const leftHand = toRootLocal(bridge);
+  const rightHand = toRootLocal(grip);
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.58).add(new THREE.Vector3(-0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.03 * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightElbow = rightShoulder.clone().lerp(rightHand, 0.42).add(new THREE.Vector3(0.22 * SNOOKER_HUMAN_WORLD_SCALE, 0.20 * SNOOKER_HUMAN_WORLD_SCALE, -0.20 * SNOOKER_HUMAN_WORLD_SCALE));
+  const leftHip = new THREE.Vector3(-0.07 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE);
+  const rightHip = new THREE.Vector3(0.08 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.12 * SNOOKER_HUMAN_WORLD_SCALE);
+  const walkLift = Math.sin(human.walkPhase) * 0.028 * SNOOKER_HUMAN_WORLD_SCALE * human.walkAmount;
+  const leftFoot = new THREE.Vector3(-SNOOKER_HUMAN_CFG.stanceSide, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, walkLift), SNOOKER_HUMAN_CFG.leftFootForward);
+  const rightFoot = new THREE.Vector3(SNOOKER_HUMAN_CFG.stanceSide * 0.62, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, -walkLift), -SNOOKER_HUMAN_CFG.rightFootBack);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.55).add(new THREE.Vector3(-0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.12 * SNOOKER_HUMAN_WORLD_SCALE, 0.04 * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).add(new THREE.Vector3(0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.14 * SNOOKER_HUMAN_WORLD_SCALE, -0.03 * SNOOKER_HUMAN_WORLD_SCALE));
+  poseSnookerHumanFallback(human, {
+    root: human.root,
+    torso,
+    chest,
+    head,
+    neck,
+    leftShoulder,
+    rightShoulder,
+    leftElbow,
+    rightElbow,
+    leftHand,
+    rightHand,
+    leftHip,
+    rightHip,
+    leftKnee,
+    rightKnee,
+    leftFoot,
+    rightFoot
+  });
+  const leftElbowTable = human.root.parent
+    ? human.root.parent.worldToLocal(human.root.localToWorld(leftElbow.clone()))
+    : leftElbow.clone();
+  const rightElbowTable = human.root.parent
+    ? human.root.parent.worldToLocal(human.root.localToWorld(rightElbow.clone()))
+    : rightElbow.clone();
+  poseSnookerHumanGlb(human, {
+    leftHandWorld: bridge,
+    rightHandWorld: grip,
+    leftElbowWorld: leftElbowTable,
+    rightElbowWorld: rightElbowTable,
+    headWorld: headWorld,
+    chestWorld: chestWorld,
+    cueTipWorld: cueEndpoints.tip
+  });
+}
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_LIFT_DRAG_SCALE = 0.0048;
 const CUE_LIFT_MAX_TILT = THREE.MathUtils.degToRad(12.5);
@@ -21402,6 +21890,7 @@ const powerRef = useRef(hud.power);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
+      const snookerHumanPlayer = createSnookerRoyalHumanPlayer(table, renderer);
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
       const closeCueGallery = () => {
@@ -25863,6 +26352,26 @@ const powerRef = useRef(hud.power);
           updateChalkVisibility(null);
         }
 
+        try {
+          updateSnookerRoyalHumanPlayer(snookerHumanPlayer, deltaSeconds, {
+            cue,
+            cueStick,
+            cueLen,
+            aimDir: showingRemoteAim
+              ? new THREE.Vector2(remoteAimState?.dir?.x ?? 0, remoteAimState?.dir?.y ?? 1)
+              : activeAiPlan?.aimDir || aimDir,
+            visible: cueStick.visible || cueAnimating || shooting,
+            power: powerRef.current ?? activeAiPlan?.power ?? 0,
+            shooting,
+            cueAnimating
+          });
+        } catch (error) {
+          snookerHumanPlayer.disabled = true;
+          snookerHumanPlayer.root.visible = false;
+          snookerHumanPlayer.modelRoot.visible = false;
+          console.warn('Snooker Royal human player disabled after pose error', error);
+        }
+
         if (!shouldSlowAim) {
           const precisionArea = chalkAreaRef.current;
           if (precisionArea) precisionArea.visible = false;
@@ -26770,6 +27279,8 @@ const powerRef = useRef(hud.power);
         lightingRigRef.current = null;
         worldRef.current = null;
         activeRenderCameraRef.current = null;
+        snookerHumanPlayer?.root?.removeFromParent?.();
+        snookerHumanPlayer?.modelRoot?.removeFromParent?.();
         cueBodyRef.current = null;
         tipGroupRef.current = null;
         try {


### PR DESCRIPTION
### Motivation
- Introduce an in-scene human character to visually represent players during shots for Snooker Royale, using configured character themes and fallbacks.
- Provide a robust loading pipeline with DRACO/KTX2 support and graceful fallback to a simple rig when GLB assets fail.

### Description
- Added imports for character themes and introduced constants and configuration for snooker human scale, pose, and damping (`SNOOKER_HUMAN_CFG`, helpers, and utility functions).
- Implemented a simple fallback rig generator (`createSnookerHumanFallbackRig`) and helper utilities for placing and posing body segments and bones (`placeSnookerHumanSegment`, `poseSnookerHumanFallback`, `normalizeSnookerHumanModel`, `buildSnookerHumanBones`, `findSnookerHumanBone`, etc.).
- Added GLTF loading helpers with DRACO and KTX2 integration and disposal (`createSnookerHumanGLTFLoader`, `loadSnookerHumanModel`, `loadSnookerHumanModelFromCatalog`, `disposeSnookerHumanGLTFLoader`).
- Implemented runtime pose application for GLB models (`poseSnookerHumanGlb`, bone rotation helpers) and a full update loop for the human player (`createSnookerRoyalHumanPlayer`, `updateSnookerRoyalHumanPlayer`) that computes target positions from cue state and blends between fallback and GLB-based poses.
- Integrated the human player into the main SnookerRoyal rendering lifecycle by creating the player when the table is setup, calling `updateSnookerRoyalHumanPlayer` each tick (with error-protection that disables the player on pose errors), and cleaning up model nodes and loaders on teardown.

### Testing
- Ran the project test suite with `yarn test`; all tests passed.
- Built the application with `yarn build` to verify asset pipeline integration and loader code; build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0689a791ec83299e58547727a8a411)