### PR TITLE
Increase tennis court size and improve camera tracking & auto-chase

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -1740,6 +1740,30 @@ export default function MobileThreeTennisPrototype() {
       ball.mesh.position.copy(ball.pos);
     }
 
+    function updateNearAutoChase(landing: THREE.Vector3, dt: number) {
+      if (!CFG.playerAutoChase.enabled || controlRef.current.active || pointLock) return;
+      if (ball.lastHitBy === null) return;
+      if (nearPlayer.swingT > 0) return;
+
+      const ballComingToHuman = ball.lastHitBy === "far" && (ball.pos.z > -0.35 * CFG.worldScale || landing.z > 0);
+      if (!ballComingToHuman) {
+        const home = new THREE.Vector3(0, 0, CFG.courtL / 2 - 1.18 * CFG.worldScale);
+        nearPlayer.target.lerp(home, 1 - Math.exp(-1.45 * dt));
+        PlayerController.clampMovement(nearPlayer.target, "near");
+        return;
+      }
+
+      const autoTarget = landing.clone();
+      autoTarget.x = clamp(autoTarget.x, -CFG.courtW / 2 + 0.35 * CFG.worldScale, CFG.courtW / 2 - 0.35 * CFG.worldScale);
+      autoTarget.z = clamp(
+        autoTarget.z + CFG.playerAutoChase.anticipation * CFG.worldScale,
+        0.82 * CFG.worldScale,
+        CFG.courtL / 2 - 0.58 * CFG.worldScale
+      );
+      nearPlayer.target.lerp(autoTarget, 1 - Math.exp(-CFG.playerAutoChase.maxBlendPerSecond * dt));
+      PlayerController.clampMovement(nearPlayer.target, "near");
+    }
+
     function updateAi() {
       const landing = predictLanding(ball);
       const aiHomeZ = scoreManager.snapshot().server === "far" && ball.lastHitBy === null ? -CFG.serveNearBaselineZ : -CFG.courtL / 2 + 1.2 * CFG.worldScale;
@@ -1836,6 +1860,9 @@ export default function MobileThreeTennisPrototype() {
         }
       }
 
+      const predictedLanding = predictLanding(ball);
+      updateNearAutoChase(predictedLanding, dt);
+
       updatePlayerMotion(nearPlayer, ball, dt);
       updatePlayerMotion(farPlayer, ball, dt);
       updatePoseAndRacket(nearPlayer, ball);
@@ -1856,13 +1883,15 @@ export default function MobileThreeTennisPrototype() {
       ghost.position.z += (nearPlayer.target.z - ghost.position.z) * (1 - Math.exp(-12 * dt));
       (ghost.material as THREE.MeshBasicMaterial).opacity = controlRef.current.active ? 0.62 : 0.28;
 
-      const predictedLanding = predictLanding(ball);
       const landingUseful = ball.lastHitBy !== null && ball.vel.lengthSq() > 0.25 && predictedLanding.y <= CFG.ballR + 0.05 && Math.abs(predictedLanding.x) <= CFG.courtW / 2 + 0.6 && Math.abs(predictedLanding.z) <= CFG.courtL / 2 + 0.8;
       landingMarker.position.set(clamp(predictedLanding.x, -CFG.courtW / 2, CFG.courtW / 2), 0.078, clamp(predictedLanding.z, -CFG.courtL / 2, CFG.courtL / 2));
       (landingMarker.material as THREE.MeshBasicMaterial).opacity += ((landingUseful ? 0.55 : 0) - (landingMarker.material as THREE.MeshBasicMaterial).opacity) * (1 - Math.exp(-10 * dt));
 
       const preServe = ball.lastHitBy === null;
-      cameraController.update(camera, cameraTarget, cameraPosTarget, nearPlayer.target, ball.pos, cameraOffset, preServe, dt);
+      cameraController.update(camera, cameraTarget, cameraPosTarget, nearPlayer.target, ball.pos, cameraOffset, preServe, dt, {
+        incomingSide: ball.lastHitBy === "far" ? "near" : ball.lastHitBy === "near" ? "far" : null,
+        predictedLanding,
+      });
       updateBillboards();
       renderer.render(scene, camera);
     }

--- a/webapp/src/pages/Games/tennis/CameraController.ts
+++ b/webapp/src/pages/Games/tennis/CameraController.ts
@@ -1,18 +1,60 @@
 import * as THREE from "three";
-import { gameConfig } from "./gameConfig";
+import { gameConfig, PlayerSide } from "./gameConfig";
+
+type CameraUpdateOptions = {
+  incomingSide?: PlayerSide | null;
+  predictedLanding?: THREE.Vector3 | null;
+};
+
+const tempIncomingTarget = new THREE.Vector3();
+const tempBallBias = new THREE.Vector3();
+const tempBaseTarget = new THREE.Vector3();
+const tempLookTarget = new THREE.Vector3();
+const tempFollowAnchor = new THREE.Vector3();
+const tempOffset = new THREE.Vector3();
 
 export class CameraController {
-  update(camera: THREE.PerspectiveCamera, cameraTarget: THREE.Vector3, cameraPosTarget: THREE.Vector3, playerTarget: THREE.Vector3, ballPos: THREE.Vector3, cameraOffset: THREE.Vector3, preServe: boolean, dt: number) {
+  update(
+    camera: THREE.PerspectiveCamera,
+    cameraTarget: THREE.Vector3,
+    cameraPosTarget: THREE.Vector3,
+    playerTarget: THREE.Vector3,
+    ballPos: THREE.Vector3,
+    cameraOffset: THREE.Vector3,
+    preServe: boolean,
+    dt: number,
+    options: CameraUpdateOptions = {}
+  ) {
+    const incomingToPlayer = options.incomingSide === "near";
+    const targetDamping = 1 - Math.exp(-5.2 * dt);
+    const zDamping = 1 - Math.exp(-4.3 * dt);
     const lateral = Math.max(-0.45, Math.min(0.45, ballPos.x * 0.08));
+
     if (preServe) {
-      cameraPosTarget.copy(playerTarget).add(new THREE.Vector3(playerTarget.x * 0.08 + lateral, 6.25 * gameConfig.cameraViewScale, 10.4 * gameConfig.cameraViewScale));
-      cameraTarget.x += (playerTarget.x * 0.2 + lateral - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
-      cameraTarget.z += ((-gameConfig.courtL * 0.24) - cameraTarget.z) * (1 - Math.exp(-5.1 * dt));
+      cameraPosTarget.copy(playerTarget).add(tempOffset.set(playerTarget.x * 0.08 + lateral, 6.25 * gameConfig.cameraViewScale, 10.4 * gameConfig.cameraViewScale));
+      tempLookTarget.set(playerTarget.x * 0.2 + lateral, 0.95 * gameConfig.cameraViewScale, -gameConfig.courtL * 0.24);
+      cameraTarget.lerp(tempLookTarget, targetDamping);
     } else {
-      cameraPosTarget.copy(playerTarget).add(cameraOffset).add(new THREE.Vector3(lateral, 0, 0));
-      cameraTarget.x += (playerTarget.x + lateral - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
-      cameraTarget.z += ((playerTarget.z - 6.9 * gameConfig.cameraViewScale) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
+      tempFollowAnchor.copy(playerTarget);
+      tempBaseTarget.set(playerTarget.x + lateral, 0.95 * gameConfig.cameraViewScale, playerTarget.z - 6.9 * gameConfig.cameraViewScale);
+
+      if (incomingToPlayer) {
+        tempIncomingTarget.copy(options.predictedLanding || ballPos);
+        tempIncomingTarget.x = THREE.MathUtils.clamp(tempIncomingTarget.x, -gameConfig.courtW / 2, gameConfig.courtW / 2);
+        tempIncomingTarget.z = THREE.MathUtils.clamp(tempIncomingTarget.z, 0.25 * gameConfig.worldScale, gameConfig.courtL / 2);
+        tempFollowAnchor.lerp(tempIncomingTarget, gameConfig.cameraPlayerFollowBlend);
+
+        tempBallBias.copy(ballPos).lerp(tempIncomingTarget, 0.45);
+        tempBallBias.y = Math.max(0.9 * gameConfig.cameraViewScale, ballPos.y * 0.32 + 0.85 * gameConfig.cameraViewScale);
+        tempBaseTarget.lerp(tempBallBias, gameConfig.cameraBallLookAhead);
+      }
+
+      cameraPosTarget.copy(tempFollowAnchor).add(cameraOffset).add(tempOffset.set(lateral, 0, 0));
+      cameraTarget.x += (tempBaseTarget.x - cameraTarget.x) * targetDamping;
+      cameraTarget.y += (tempBaseTarget.y - cameraTarget.y) * targetDamping;
+      cameraTarget.z += (tempBaseTarget.z - cameraTarget.z) * zDamping;
     }
+
     camera.position.lerp(cameraPosTarget, 1 - Math.exp(-gameConfig.cameraDamping * dt));
     camera.lookAt(cameraTarget);
   }

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -29,7 +29,7 @@ export enum TennisBallState {
 }
 
 const BASE_WORLD_SCALE = 1.72;
-const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.8;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 1.95;
 const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
 // Keep the camera at its prior pullback distance so the enlarged court and
 // players read clearly bigger in the actual gameplay view.
@@ -83,6 +83,13 @@ export const gameConfig = {
   serveNearBaselineZ: (23.77 / 2 + 0.92) * WORLD_SCALE,
   serviceBuffer: 0.28 * WORLD_SCALE,
   cameraDamping: 5.5,
+  cameraBallLookAhead: 0.58,
+  cameraPlayerFollowBlend: 0.72,
+  playerAutoChase: {
+    enabled: true,
+    anticipation: 0.74,
+    maxBlendPerSecond: 5.8,
+  },
   scoring: { gamesPerSet: 6, winByTwoGames: true },
   aiDifficulty: {
     reactionTime: 0.07,


### PR DESCRIPTION
### Motivation
- Make the playable tennis court and characters read larger and more arena-like by increasing world scaling.  
- Improve the camera so it anticipates and looks toward incoming balls and their predicted landing spots for clearer action framing.  
- Help the human character automatically move toward incoming returns when the player is not actively dragging so gameplay feels more responsive.

### Description
- Increased the court/character scale by changing `COURT_AND_CHARACTER_SIZE_MULTIPLIER` from `1.8` to `1.95` in `tennis/gameConfig.ts`.  
- Added camera tuning values `cameraBallLookAhead`, `cameraPlayerFollowBlend` and `playerAutoChase` config to `gameConfig` to control look-ahead and auto-chase behaviour.  
- Reworked `CameraController.update` to accept options (`incomingSide`, `predictedLanding`), blend the camera follow anchor toward the predicted landing and bias the look target toward the incoming ball, and preserve smooth damping.  
- Implemented `updateNearAutoChase` in `Tennis.tsx` to lerp the near-player `target` toward the predicted landing when appropriate, and wired the per-frame `predictedLanding` into camera updates and the landing marker logic.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully.  
- Installed Playwright browsers with `npx --prefix webapp playwright install chromium`, which downloaded the browser binaries successfully.  
- Attempted an automated Playwright screenshot of the running dev server, but Chromium could not launch in this environment due to a missing system library (`libatk-1.0.so.0`), so headless screenshot capture failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069267d22c8329b98779b12ed6a191)