### PR TITLE
Adjust tennis court scale and camera framing

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -1514,7 +1514,7 @@ export default function MobileThreeTennisPrototype() {
 
     const camera = new THREE.PerspectiveCamera(44, 1, 0.05, Math.max(70, CFG.courtL * 1.8));
     const cameraTarget = new THREE.Vector3(0, 1.12 * CFG.cameraViewScale, -1.7 * CFG.cameraViewScale);
-    const cameraOffset = new THREE.Vector3(0, 5.9 * CFG.cameraViewScale, 9.1 * CFG.cameraViewScale);
+    const cameraOffset = new THREE.Vector3(0, 7.35 * CFG.cameraViewScale, 11.85 * CFG.cameraViewScale);
     const cameraPosTarget = new THREE.Vector3();
 
     addTrainingCourtLighting(scene);
@@ -1606,9 +1606,9 @@ export default function MobileThreeTennisPrototype() {
       renderer.setSize(w, h, false);
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
       camera.aspect = w / h;
-      camera.fov = camera.aspect < 0.72 ? 50 : 44;
-      if (camera.aspect < 0.72) cameraOffset.set(0, 6.35 * CFG.cameraViewScale, 9.95 * CFG.cameraViewScale);
-      else cameraOffset.set(0, 5.9 * CFG.cameraViewScale, 9.1 * CFG.cameraViewScale);
+      camera.fov = camera.aspect < 0.72 ? 52 : 46;
+      if (camera.aspect < 0.72) cameraOffset.set(0, 7.95 * CFG.cameraViewScale, 12.95 * CFG.cameraViewScale);
+      else cameraOffset.set(0, 7.35 * CFG.cameraViewScale, 11.85 * CFG.cameraViewScale);
       cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
       camera.position.copy(cameraPosTarget);
       camera.lookAt(cameraTarget);

--- a/webapp/src/pages/Games/tennis/CameraController.ts
+++ b/webapp/src/pages/Games/tennis/CameraController.ts
@@ -31,12 +31,12 @@ export class CameraController {
     const lateral = Math.max(-0.45, Math.min(0.45, ballPos.x * 0.08));
 
     if (preServe) {
-      cameraPosTarget.copy(playerTarget).add(tempOffset.set(playerTarget.x * 0.08 + lateral, 7.15 * gameConfig.cameraViewScale, 11.85 * gameConfig.cameraViewScale));
-      tempLookTarget.set(playerTarget.x * 0.2 + lateral, 1.15 * gameConfig.cameraViewScale, -gameConfig.courtL * 0.27);
+      cameraPosTarget.copy(playerTarget).add(tempOffset.set(playerTarget.x * 0.08 + lateral, 8.85 * gameConfig.cameraViewScale, 14.65 * gameConfig.cameraViewScale));
+      tempLookTarget.set(playerTarget.x * 0.2 + lateral, 1.55 * gameConfig.cameraViewScale, -gameConfig.courtL * 0.31);
       cameraTarget.lerp(tempLookTarget, targetDamping);
     } else {
       tempFollowAnchor.copy(playerTarget);
-      tempBaseTarget.set(playerTarget.x + lateral, 1.12 * gameConfig.cameraViewScale, playerTarget.z - 7.65 * gameConfig.cameraViewScale);
+      tempBaseTarget.set(playerTarget.x + lateral, 1.52 * gameConfig.cameraViewScale, playerTarget.z - 9.35 * gameConfig.cameraViewScale);
 
       if (incomingToPlayer) {
         tempIncomingTarget.copy(options.predictedLanding || ballPos);
@@ -45,7 +45,7 @@ export class CameraController {
         tempFollowAnchor.lerp(tempIncomingTarget, gameConfig.cameraPlayerFollowBlend);
 
         tempBallBias.copy(ballPos).lerp(tempIncomingTarget, 0.45);
-        tempBallBias.y = Math.max(1.08 * gameConfig.cameraViewScale, ballPos.y * 0.3 + 1.02 * gameConfig.cameraViewScale);
+        tempBallBias.y = Math.max(1.45 * gameConfig.cameraViewScale, ballPos.y * 0.3 + 1.35 * gameConfig.cameraViewScale);
         tempBaseTarget.lerp(tempBallBias, gameConfig.cameraBallLookAhead);
       }
 

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -29,11 +29,11 @@ export enum TennisBallState {
 }
 
 const BASE_WORLD_SCALE = 1.72;
-const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 2.15;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 2.38;
 const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
 // Keep camera scaling independent from world scale so camera framing can be
 // tuned precisely while the enlarged court keeps its regulation proportions.
-const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE * 1.08;
+const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE * 1.18;
 // Extra character scale keeps human avatars visibly bigger than the court uplift.
 const PLAYER_CHARACTER_SCALE = 1.35;
 const PLAYER_SCALE = WORLD_SCALE * PLAYER_CHARACTER_SCALE;


### PR DESCRIPTION
### Motivation
- Make the tennis camera sit further back and higher so the match reads more like a broadcast shot. 
- Increase the apparent play area by enlarging the court/world scale while keeping camera framing tunable. 
- Ensure both default and pre-serve/follow cameras use higher/deeper targets so gameplay remains readable with the larger court. 

### Description
- Increased the court/character scale by changing `COURT_AND_CHARACTER_SIZE_MULTIPLIER` from `2.15` to `2.38` and bumped `CAMERA_VIEW_SCALE` from `BASE_WORLD_SCALE * 1.08` to `BASE_WORLD_SCALE * 1.18` in `webapp/src/pages/Games/tennis/gameConfig.ts` so the visual court is larger while camera scale stays independent. 
- Pulled the default camera farther back and up and widened responsive offsets/FOV in `webapp/src/pages/Games/Tennis.tsx` by adjusting the initial `cameraOffset`, responsive `cameraOffset.set(...)` values, and the small-FOV branch to `52/46` so the view is higher and deeper across aspect ratios. 
- Raised/pre-pulled live and pre-serve camera targets and bias in `webapp/src/pages/Games/tennis/CameraController.ts` by updating pre-serve offsets, look target height, base target height/depth and `tempBallBias.y` so runtime camera updates follow from a higher, more distant vantage. 

### Testing
- Ran `npm run build` which completed successfully and produced the production bundle. 
- Ran `npx playwright install chromium` which completed and downloaded Chromium successfully. 
- Attempted an automated Playwright headless screenshot run but Chromium could not be launched in the current environment due to a missing system library (`libatk-1.0.so.0`), so the capture step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069ec85c4083299c54f1c2f7fad64a)