### PR TITLE
Adjust player-hand domino placement and character pose; bump script version

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6715,8 +6715,8 @@ const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.0025; // keep chain tiles touching without visible overlap
 const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
-// May 10, 2026: keep player-hand dominoes compact while placing them farther
-// beyond the rail and higher above the tabletop for clearer Battle Royal seating.
+// Keep player-hand dominoes compact, raised above the lowered character hands,
+// and far enough beyond the rail for clearer Battle Royal seating.
 const PLAYER_HAND_TILE_SCALE = 0.9;
 const PLAYER_HAND_GAP_SCALE = 0.5;
 const PLAYER_HAND_MIN_GAP_SCALE = 0.76;
@@ -7975,8 +7975,8 @@ const DOMINO_CHARACTER_PROPORTION_SCALE = 2.55;
 const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.55;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
-const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.1;
-const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.04;
+const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.02;
+const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0;
 const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 1.76;
 const DOMINO_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = -0.08;
 const ENABLE_DOMINO_CHARACTER_HELD_RACKS = false;
@@ -8003,11 +8003,11 @@ function buildDominoFallbackCharacterTemplate() {
   torso.rotation.x = THREE.MathUtils.degToRad(-7);
   const makeLimb = (radius, depth, material) => new THREE.Mesh(new THREE.CapsuleGeometry(radius, depth, 6, 12), material);
   const leftArm = makeLimb(0.045, 0.46, suit);
-  leftArm.position.set(-0.22, 0.93, 0.18);
-  leftArm.rotation.set(THREE.MathUtils.degToRad(62), 0, THREE.MathUtils.degToRad(-18));
+  leftArm.position.set(-0.22, 0.8, 0.24);
+  leftArm.rotation.set(THREE.MathUtils.degToRad(62), 0, THREE.MathUtils.degToRad(-14));
   const rightArm = makeLimb(0.045, 0.46, suit);
-  rightArm.position.set(0.22, 0.93, 0.18);
-  rightArm.rotation.set(THREE.MathUtils.degToRad(62), 0, THREE.MathUtils.degToRad(18));
+  rightArm.position.set(0.22, 0.8, 0.24);
+  rightArm.rotation.set(THREE.MathUtils.degToRad(62), 0, THREE.MathUtils.degToRad(14));
   const leftLeg = makeLimb(0.055, 0.56, dark);
   leftLeg.position.set(-0.1, 0.48, 0.27);
   leftLeg.rotation.set(THREE.MathUtils.degToRad(86), 0, THREE.MathUtils.degToRad(-4));
@@ -8344,7 +8344,7 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));
   addDominoBoneOffset(bones.rightCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(-1.1), THREE.MathUtils.degToRad(-0.6));
   rig.seatedPose = captureDominoPose(bones);
-  instance.position.y -= 0.09 * MODEL_SCALE;
+  instance.position.y -= 0.24 * MODEL_SCALE;
   refreshDominoRigRack(rig, player?.hand || []);
   return rig;
 }

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-10-domino-player-hand-gap-v36';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-15-raised-player-dominoes-v39';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Improve Battle Royal seating clarity by compacting and raising player-hand dominoes relative to character hands and moving them further beyond the rail. 
- Align seated avatar visuals with updated hand positions by lowering character trunks and adjusting arm placement and chair offsets. 

### Description
- Updated inline script version to `2026-05-15-raised-player-dominoes-v39` in `DominoRoyalArena.jsx`. 
- Clarified player-hand behavior in a comment and kept `PLAYER_HAND_*` scaling constants while shifting commentary to note raising above lowered character hands. 
- Reduced chair-seat outward bias by changing `DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS` from `0.1` to `0.02` and `DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS` from `0.04` to `0`. 
- Adjusted fallback character pose in `buildDominoFallbackCharacterTemplate()` by lowering both arms (`position.y` from `0.93` to `0.8`), moving arms slightly outward (`position.z` to `0.24`), and easing the wrist rotation angles (`-18/18`° to `-14/14`°). 
- Lowered the instantiated character root by increasing `instance.position.y` offset from `-0.09 * MODEL_SCALE` to `-0.24 * MODEL_SCALE` so hands sit lower relative to tiles. 

### Testing
- Ran the repository's automated test suite with `npm test`; the tests completed successfully. 
- Ran the linter with `npm run lint`; no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05fce358bc8329a7e40b694a718348)