### PR TITLE
Restore Snooker Royal classic arena shell

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -6,7 +6,6 @@ import React, {
   useRef,
   useState
 } from 'react';
-import SnookerRoyalProvided from './SnookerRoyalProvided.jsx';
 import * as THREE from 'three';
 import polygonClipping from 'polygon-clipping';
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
@@ -29961,5 +29960,22 @@ export default function SnookerRoyal() {
     const params = new URLSearchParams(location.search);
     return params.get('opponentAvatar') || '';
   }, [location.search]);
-  return <SnookerRoyalProvided />;
+  return (
+    <SnookerRoyalGame
+      variantKey={variantKey}
+      ballSetKey={ballSetKey}
+      tableSizeKey={tableSizeKey}
+      tableModel={tableModel}
+      playType={playType}
+      mode={mode}
+      trainingMode={trainingMode}
+      trainingRulesEnabled={trainingRulesEnabled}
+      accountId={accountId}
+      tgId={tgId}
+      playerName={playerName}
+      playerAvatar={playerAvatar}
+      opponentName={opponentName}
+      opponentAvatar={opponentAvatar}
+    />
+  );
 }


### PR DESCRIPTION
### Motivation
- Bring the full Snooker Royal game shell (classic table, HDRI/inventory handling, UI and camera stack) back into the main route while preserving the newly provided human character and existing cue/power behavior. 
- Route the app through the canonical `SnookerRoyalGame` so the prior table/cameras/HDRI UX and inventory flow are available again.

### Description
- Replace the demo-only return with the full game entry by returning `<SnookerRoyalGame ... />` from `webapp/src/pages/Games/SnookerRoyal.jsx` and remove the unused `SnookerRoyalProvided` import. 
- Keep all existing human player integration and pose/update logic in `SnookerRoyal.jsx` (loader, fallback rig, `createSnookerRoyalHumanPlayer`, `updateSnookerRoyalHumanPlayer`).
- Preserve the current cue stick and drag-down power slider logic embedded in the `SnookerRoyalGame` flow (power compute, pull → impulse mapping and UI handlers remain unchanged).

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully. 
- Ran unit tests with `npm test -- --runInBand test/snookerTableModel.test.js test/snookerRoyalInventoryRoutes.test.js`, where `test/snookerTableModel.test.js` passed and `test/snookerRoyalInventoryRoutes.test.js` failed due to a timeout caused by a missing server dependency (`compression`).
- Installed Playwright runtimes with `npx playwright install chromium` and `npx playwright install-deps chromium` successfully, and attempted an automated headless screenshot of `/games/snookerroyale`, but headless WebGL/page screenshot attempts timed out / closed in this container environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06bb4688e48329be411aed253d7f40)