### PR TITLE
Add 9mm/service-pistol ammo templates, cinematic bullet/shell visuals, and weapon handling improvements

### DIFF
--- a/webapp/src/pages/Games/ShootingRange.tsx
+++ b/webapp/src/pages/Games/ShootingRange.tsx
@@ -99,20 +99,54 @@ type PaperTargetRuntime = {
 };
 
 type BulletRuntime = {
-  mesh: THREE.Mesh;
-  trail: THREE.Mesh;
+  root: THREE.Object3D;
+  spinGroup: THREE.Object3D;
+  trail: THREE.Object3D;
+  wake: THREE.Object3D | null;
   start: THREE.Vector3;
   end: THREE.Vector3;
+  muzzle: THREE.Vector3;
+  inside: THREE.Vector3;
+  dir: THREE.Vector3;
+  right: THREE.Vector3;
+  pos: THREE.Vector3;
   t: number;
+  age: number;
   speed: number;
+  spin: number;
   cinematic: boolean;
+  launched: boolean;
+  prelaunch: number;
+  life: number;
+  flightQuat: THREE.Quaternion;
 };
 
 type ShellRuntime = {
-  mesh: THREE.Mesh;
+  root: THREE.Object3D;
+  pos: THREE.Vector3;
+  start: THREE.Vector3;
+  end: THREE.Vector3;
   vel: THREE.Vector3;
   spin: THREE.Vector3;
   life: number;
+  age: number;
+  launched: boolean;
+  grounded: boolean;
+  pre: number;
+};
+
+type ServicePistolTextureMaps = {
+  diff: THREE.Texture;
+  normal: THREE.Texture;
+  rough: THREE.Texture;
+  metal: THREE.Texture;
+  ao: THREE.Texture;
+};
+
+type AmmoTemplates = {
+  bullet: THREE.Object3D;
+  shell: THREE.Object3D;
+  source: string;
 };
 
 const USER_LANE = 0;
@@ -125,6 +159,13 @@ const LANE_X = [-4.9, -1.65, 1.65, 4.9];
 const TABLE_Z = 2.35;
 const TABLE_TOP_Y = 0.94;
 const TARGET_Z = -21.8;
+const PRELAUNCH = 1.25;
+const BULLET_SPIN = 245;
+const SERVICE_PISTOL_AIM = {
+  mount: new THREE.Vector3(0.34, 1.27, -0.12),
+  muzzle: new THREE.Vector3(0.01, -0.035, -1.21),
+  shellPort: new THREE.Vector3(0.46, 0.04, -0.44)
+};
 
 const RANGE_DISTANCE_CONFIG: Record<
   RangeDistance,
@@ -158,6 +199,17 @@ const POLYHAVEN_ASSETS = {
     'https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/security_camera_01/security_camera_01_1k.gltf',
   servicePistol:
     'https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/service_pistol/service_pistol_1k.gltf'
+};
+
+const SERVICE_PISTOL_TEXTURES = {
+  diff: 'https://dl.polyhaven.org/file/ph-assets/Models/jpg/2k/service_pistol/service_pistol_diff_2k.jpg',
+  normal:
+    'https://dl.polyhaven.org/file/ph-assets/Models/jpg/2k/service_pistol/service_pistol_nor_gl_2k.jpg',
+  rough:
+    'https://dl.polyhaven.org/file/ph-assets/Models/jpg/2k/service_pistol/service_pistol_rough_2k.jpg',
+  metal:
+    'https://dl.polyhaven.org/file/ph-assets/Models/jpg/2k/service_pistol/service_pistol_metal_2k.jpg',
+  ao: 'https://dl.polyhaven.org/file/ph-assets/Models/jpg/2k/service_pistol/service_pistol_ao_2k.jpg'
 };
 
 const TEXTURES = {
@@ -582,6 +634,67 @@ function loadTexture(
   return tex;
 }
 
+function loadServicePistolTexture(
+  loader: THREE.TextureLoader,
+  url: string,
+  colorSpace: THREE.ColorSpace = THREE.NoColorSpace
+) {
+  const tex = loader.load(url, undefined, undefined, () =>
+    console.warn('Service pistol texture failed:', url)
+  );
+  tex.colorSpace = colorSpace;
+  tex.flipY = false;
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.anisotropy = 8;
+  tex.needsUpdate = true;
+  return tex;
+}
+
+function makeServicePistolTextureMaps(loader: THREE.TextureLoader): ServicePistolTextureMaps {
+  return {
+    diff: loadServicePistolTexture(loader, SERVICE_PISTOL_TEXTURES.diff, THREE.SRGBColorSpace),
+    normal: loadServicePistolTexture(loader, SERVICE_PISTOL_TEXTURES.normal),
+    rough: loadServicePistolTexture(loader, SERVICE_PISTOL_TEXTURES.rough),
+    metal: loadServicePistolTexture(loader, SERVICE_PISTOL_TEXTURES.metal),
+    ao: loadServicePistolTexture(loader, SERVICE_PISTOL_TEXTURES.ao)
+  };
+}
+
+function applyServicePistolTextureMaps(
+  root: THREE.Object3D,
+  maps: ServicePistolTextureMaps | null
+) {
+  if (!maps) return;
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh) return;
+    if (mesh.geometry?.attributes?.uv && !mesh.geometry.attributes.uv2) {
+      mesh.geometry.setAttribute('uv2', mesh.geometry.attributes.uv.clone());
+    }
+    const sourceMaterials = Array.isArray((mesh as any).material)
+      ? (mesh as any).material
+      : (mesh as any).material
+        ? [(mesh as any).material]
+        : [new THREE.MeshStandardMaterial()];
+    const texturedMaterials = sourceMaterials.map((material: THREE.Material) => {
+      const mat = material.clone() as THREE.MeshStandardMaterial;
+      mat.map = maps.diff;
+      mat.normalMap = maps.normal;
+      mat.roughnessMap = maps.rough;
+      mat.metalnessMap = maps.metal;
+      mat.aoMap = maps.ao;
+      mat.metalness = Math.max(mat.metalness ?? 0.55, 0.48);
+      mat.roughness = Math.min(Math.max(mat.roughness ?? 0.38, 0.24), 0.68);
+      mat.needsUpdate = true;
+      return mat;
+    });
+    (mesh as any).material = Array.isArray((mesh as any).material)
+      ? texturedMaterials
+      : texturedMaterials[0];
+  });
+}
+
 function makePbrMaterial(
   loader: THREE.TextureLoader,
   maps: {
@@ -701,6 +814,432 @@ function orientWeaponForward(root: THREE.Object3D) {
   root.rotation.z += 0.012;
   root.updateMatrixWorld(true);
   centerRoot(root);
+}
+
+
+function cloneRenderable(root: THREE.Object3D) {
+  const cloned = cloneScene(root);
+  cloned.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh) return;
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    mesh.frustumCulled = false;
+  });
+  return cloned;
+}
+
+function isNineMmWeapon(entry: WeaponEntry) {
+  return (
+    entry.weaponClass === 'pistol' ||
+    entry.weaponClass === 'smg' ||
+    entry.id === 'q-pistol' ||
+    entry.id === 'service-pistol' ||
+    entry.id === 'smith' ||
+    entry.id === 'sigsauer' ||
+    entry.id === 'uzi'
+  );
+}
+
+function usesRifleCinematic(entry: WeaponEntry) {
+  return entry.weaponClass === 'rifle' || entry.weaponClass === 'sniper';
+}
+
+function labelOf(object: THREE.Object3D) {
+  const mesh = object as THREE.Mesh;
+  const materials = Array.isArray((mesh as any).material)
+    ? (mesh as any).material
+    : (mesh as any).material
+      ? [(mesh as any).material]
+      : [];
+  return `${object.name || ''} ${materials.map((m: any) => m?.name || '').join(' ')}`.toLowerCase();
+}
+
+function scoreLabel(label: string, words: string[], reject: string[] = []) {
+  if (reject.some((word) => label.includes(word))) return -999;
+  return words.reduce(
+    (sum, word, index) => sum + (label.includes(word) ? 24 - index : 0),
+    0
+  );
+}
+
+function bestMesh(
+  root: THREE.Object3D,
+  words: string[],
+  reject: string[] = []
+) {
+  let best: THREE.Mesh | null = null;
+  let bestScore = -Infinity;
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh || !child.visible)
+      return;
+    const score = scoreLabel(labelOf(child), words, reject);
+    if (score > bestScore) {
+      best = mesh;
+      bestScore = score;
+    }
+  });
+  return bestScore > 0 ? best : null;
+}
+
+function materialFrom(
+  object: THREE.Object3D | null,
+  fallback = 0xc48a35,
+  maps: ServicePistolTextureMaps | null = null
+) {
+  let found: THREE.Material | null = null;
+  object?.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (found || (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh)) return;
+    found = Array.isArray((mesh as any).material)
+      ? (mesh as any).material.find(Boolean)
+      : (mesh as any).material;
+  });
+  const foundMaterial = found as (THREE.Material & { clone?: () => THREE.Material }) | null;
+  const mat = foundMaterial?.clone
+    ? (foundMaterial.clone() as THREE.MeshStandardMaterial)
+    : new THREE.MeshStandardMaterial({ color: fallback });
+  if (maps) {
+    mat.map = maps.diff;
+    mat.normalMap = maps.normal;
+    mat.roughnessMap = maps.rough;
+    mat.metalnessMap = maps.metal;
+    mat.aoMap = maps.ao;
+  }
+  mat.metalness = Math.max(mat.metalness ?? 0.5, 0.48);
+  mat.roughness = Math.min(Math.max(mat.roughness ?? 0.38, 0.24), 0.68);
+  mat.needsUpdate = true;
+  return mat;
+}
+
+function splitMesh(
+  mesh: THREE.Mesh | null,
+  keep: 'front' | 'back',
+  size: number,
+  maps: ServicePistolTextureMaps | null = null
+) {
+  if (!mesh?.geometry?.attributes?.position) return null;
+  const source = mesh.geometry.index ? mesh.geometry.toNonIndexed() : mesh.geometry.clone();
+  const pos = source.attributes.position;
+  const nor = source.attributes.normal;
+  const uv = source.attributes.uv;
+  const box = new THREE.Box3().setFromBufferAttribute(pos as THREE.BufferAttribute);
+  const dims = box.getSize(new THREE.Vector3());
+  const axis = dims.x >= dims.y && dims.x >= dims.z ? 0 : dims.y >= dims.z ? 1 : 2;
+  const min = axis === 0 ? box.min.x : axis === 1 ? box.min.y : box.min.z;
+  const max = axis === 0 ? box.max.x : axis === 1 ? box.max.y : box.max.z;
+  const cut = min + (max - min) * 0.52;
+  const p: number[] = [];
+  const n: number[] = [];
+  const u: number[] = [];
+  const v = new THREE.Vector3();
+
+  for (let i = 0; i < pos.count; i += 3) {
+    let avg = 0;
+    for (let j = 0; j < 3; j += 1) {
+      v.fromBufferAttribute(pos as THREE.BufferAttribute, i + j);
+      avg += axis === 0 ? v.x : axis === 1 ? v.y : v.z;
+    }
+    avg /= 3;
+    const choose = keep === 'front' ? avg >= cut : avg < cut;
+    if (!choose) continue;
+    for (let j = 0; j < 3; j += 1) {
+      p.push(pos.getX(i + j), pos.getY(i + j), pos.getZ(i + j));
+      if (nor) n.push(nor.getX(i + j), nor.getY(i + j), nor.getZ(i + j));
+      if (uv) u.push(uv.getX(i + j), uv.getY(i + j));
+    }
+  }
+
+  if (p.length < 9) return null;
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(p, 3));
+  if (n.length) geo.setAttribute('normal', new THREE.Float32BufferAttribute(n, 3));
+  else geo.computeVertexNormals();
+  if (u.length) geo.setAttribute('uv', new THREE.Float32BufferAttribute(u, 2));
+  geo.computeBoundingBox();
+  geo.computeBoundingSphere();
+  const group = new THREE.Group();
+  group.add(new THREE.Mesh(geo, materialFrom(mesh, keep === 'front' ? 0xb66b35 : 0xc48a35, maps)));
+  normalizeToLength(group, size);
+  return group;
+}
+
+function findAmmoCarrier(root: THREE.Object3D) {
+  const modelBox = getRenderableBounds(root);
+  if (!modelBox) return null;
+  const diag = modelBox.getSize(new THREE.Vector3()).length() || 1;
+  const modelCenter = modelBox.getCenter(new THREE.Vector3());
+  const candidates: { child: THREE.Mesh; score: number }[] = [];
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh || !child.visible)
+      return;
+    const label = labelOf(child);
+    if (/magazine|\bmag\b|slide|grip|trigger|barrel|frame|receiver|sight|rail|screw|bolt/.test(label))
+      return;
+    const box = new THREE.Box3().setFromObject(child);
+    const size = box.getSize(new THREE.Vector3());
+    const center = box.getCenter(new THREE.Vector3());
+    const sorted = [size.x, size.y, size.z].sort((a, b) => a - b);
+    const rel = sorted[2] / diag;
+    if (rel > 0.38 || rel < 0.018) return;
+    const longRatio = sorted[2] / Math.max(sorted[0], 0.0001);
+    const score =
+      scoreLabel(label, ['cartridge', 'round', 'ammo', 'bullet', 'shell', 'casing', 'case', 'brass', 'projectile']) +
+      Math.min(longRatio, 8) * 2.2 +
+      (center.distanceTo(modelCenter) / diag) * 12;
+    candidates.push({ child: mesh, score });
+  });
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates[0]?.child ?? null;
+}
+
+function addRoundedRearCap(root: THREE.Object3D) {
+  root.updateMatrixWorld(true);
+  const box = getRenderableBounds(root);
+  if (!box) return;
+  const size = box.getSize(new THREE.Vector3());
+  const radius = Math.max(size.x, size.y) * 0.36;
+  const mat = new THREE.MeshStandardMaterial({
+    color: 0x59616a,
+    roughness: 0.36,
+    metalness: 0.78
+  });
+  const base = new THREE.Mesh(new THREE.CylinderGeometry(radius * 0.82, radius * 0.72, radius * 0.32, 44), mat.clone());
+  base.rotation.x = Math.PI / 2;
+  base.position.z = box.max.z - radius * 0.48;
+  const dome = new THREE.Mesh(new THREE.SphereGeometry(radius, 48, 28), mat);
+  dome.scale.set(1, 1, 0.58);
+  dome.position.z = box.max.z - radius * 0.28;
+  root.add(base, dome);
+  centerRoot(root);
+}
+
+function bulletTipIsAtPositiveZ(root: THREE.Object3D) {
+  root.updateMatrixWorld(true);
+  const vertices: THREE.Vector3[] = [];
+  const inverseRoot = new THREE.Matrix4().copy(root.matrixWorld).invert();
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    const position = mesh.geometry?.attributes?.position as THREE.BufferAttribute | undefined;
+    if (!(mesh as any).isMesh || !position) return;
+    const matrix = new THREE.Matrix4().multiplyMatrices(inverseRoot, mesh.matrixWorld);
+    const v = new THREE.Vector3();
+    for (let i = 0; i < position.count; i += 1) {
+      v.fromBufferAttribute(position, i).applyMatrix4(matrix);
+      vertices.push(v.clone());
+    }
+  });
+  if (vertices.length < 8) return false;
+  let minZ = Infinity;
+  let maxZ = -Infinity;
+  vertices.forEach((v) => {
+    minZ = Math.min(minZ, v.z);
+    maxZ = Math.max(maxZ, v.z);
+  });
+  const span = Math.max(maxZ - minZ, 0.0001);
+  const slice = span * 0.28;
+  let minRadius = 0;
+  let minCount = 0;
+  let maxRadius = 0;
+  let maxCount = 0;
+  vertices.forEach((v) => {
+    const radius = Math.hypot(v.x, v.y);
+    if (v.z <= minZ + slice) {
+      minRadius += radius;
+      minCount += 1;
+    }
+    if (v.z >= maxZ - slice) {
+      maxRadius += radius;
+      maxCount += 1;
+    }
+  });
+  if (!minCount || !maxCount) return false;
+  return maxRadius / maxCount < minRadius / minCount;
+}
+
+function orientBulletTipForward(root: THREE.Object3D) {
+  centerRoot(root);
+  root.updateMatrixWorld(true);
+  if (bulletTipIsAtPositiveZ(root)) {
+    root.rotateY(Math.PI);
+    centerRoot(root);
+  }
+}
+
+function makeFallbackBulletHead(maps: ServicePistolTextureMaps | null = null) {
+  const mat = materialFrom(null, 0xb66b35, maps);
+  const group = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.03, 0.06, 48), mat);
+  body.rotation.x = Math.PI / 2;
+  body.position.z = 0.012;
+  const tip = new THREE.Mesh(new THREE.ConeGeometry(0.03, 0.06, 48), mat.clone());
+  tip.rotation.x = -Math.PI / 2;
+  tip.position.z = -0.048;
+  group.add(body, tip);
+  addRoundedRearCap(group);
+  return group;
+}
+
+function makeBulletHead(
+  source: THREE.Object3D | null,
+  maps: ServicePistolTextureMaps | null = null
+) {
+  if (!source) return makeFallbackBulletHead(maps);
+  const group = new THREE.Group();
+  group.add(cloneRenderable(source));
+  applyServicePistolTextureMaps(group, maps);
+  centerRoot(group);
+  group.updateMatrixWorld(true);
+  const size = new THREE.Box3().setFromObject(group).getSize(new THREE.Vector3());
+  const axis = size.x >= size.y && size.x >= size.z ? 'x' : size.y >= size.z ? 'y' : 'z';
+  if (axis === 'x') group.rotation.y = -Math.PI / 2;
+  if (axis === 'y') group.rotation.x = Math.PI / 2;
+  orientBulletTipForward(group);
+  normalizeToLength(group, 0.135);
+  orientBulletTipForward(group);
+  addRoundedRearCap(group);
+  return group;
+}
+
+function makeShell(source: THREE.Mesh | null, maps: ServicePistolTextureMaps | null = null) {
+  const split = splitMesh(source, 'back', 0.22, maps);
+  if (split) return split;
+  const group = new THREE.Group();
+  const mat = materialFrom(source, 0xc9953d, maps);
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.062, 0.074, 0.28, 48), mat);
+  body.rotation.x = Math.PI / 2;
+  const rim = new THREE.Mesh(new THREE.CylinderGeometry(0.082, 0.082, 0.03, 48), mat.clone());
+  rim.rotation.x = Math.PI / 2;
+  rim.position.z = 0.155;
+  const primer = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.035, 0.035, 0.008, 32),
+    new THREE.MeshStandardMaterial({ color: 0x1c1711, roughness: 0.65, metalness: 0.18 })
+  );
+  primer.rotation.x = Math.PI / 2;
+  primer.position.z = -0.146;
+  group.add(body, rim, primer);
+  return group;
+}
+
+function extractServicePistolAmmo(
+  root: THREE.Object3D,
+  maps: ServicePistolTextureMaps | null = null
+): AmmoTemplates {
+  applyServicePistolTextureMaps(root, maps);
+  const explicitBullet = bestMesh(
+    root,
+    ['bullet_head', 'bullet head', 'projectile', 'bullet', 'round'],
+    ['shell', 'casing', 'case', 'magazine', 'mag', 'slide', 'grip', 'barrel', 'trigger']
+  );
+  const explicitShell = bestMesh(
+    root,
+    ['shell', 'casing', 'case', 'brass'],
+    ['bullet_head', 'bullet head', 'projectile', 'magazine', 'mag', 'slide', 'grip', 'barrel', 'trigger']
+  );
+
+  if (explicitBullet && explicitShell) {
+    return {
+      bullet: makeBulletHead(explicitBullet, maps),
+      shell: makeShell(explicitShell, maps),
+      source: 'service pistol GLB bullet head + shell'
+    };
+  }
+
+  const carrier = findAmmoCarrier(root);
+  if (carrier) {
+    const splitBullet = splitMesh(carrier, 'front', 0.135, maps);
+    return {
+      bullet: makeBulletHead(splitBullet || carrier, maps),
+      shell: makeShell(carrier, maps),
+      source: 'service pistol GLB split cartridge'
+    };
+  }
+
+  return {
+    bullet: makeFallbackBulletHead(maps),
+    shell: makeShell(null, maps),
+    source: 'fallback 9mm cartridge'
+  };
+}
+
+function createFallbackAmmoTemplates(
+  maps: ServicePistolTextureMaps | null = null
+): AmmoTemplates {
+  return {
+    bullet: makeFallbackBulletHead(maps),
+    shell: makeShell(null, maps),
+    source: 'fallback 9mm cartridge'
+  };
+}
+
+function alignToDirection(object: THREE.Object3D, dir: THREE.Vector3) {
+  object.quaternion.setFromUnitVectors(
+    new THREE.Vector3(0, 0, -1),
+    dir.clone().normalize()
+  );
+}
+
+function makeWake() {
+  const group = new THREE.Group();
+  const cone = new THREE.Mesh(
+    new THREE.ConeGeometry(0.15, 0.62, 48, 1, true),
+    new THREE.MeshBasicMaterial({
+      color: 0xbff5ff,
+      transparent: true,
+      opacity: 0.1,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide
+    })
+  );
+  cone.rotation.x = Math.PI / 2;
+  cone.position.z = 0.34;
+  group.add(cone);
+
+  for (let strand = 0; strand < 4; strand += 1) {
+    const points: THREE.Vector3[] = [];
+    const phase = (strand / 4) * Math.PI * 2;
+    for (let i = 0; i < 32; i += 1) {
+      const t = i / 31;
+      const radius = 0.024 + t * 0.09;
+      const angle = phase + t * Math.PI * 4.4;
+      points.push(new THREE.Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0.04 + t * 0.62));
+    }
+    group.add(
+      new THREE.Line(
+        new THREE.BufferGeometry().setFromPoints(points),
+        new THREE.LineBasicMaterial({
+          color: 0xe8fcff,
+          transparent: true,
+          opacity: 0.22,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending
+        })
+      )
+    );
+  }
+
+  for (let i = 0; i < 2; i += 1) {
+    const shock = new THREE.Mesh(
+      new THREE.TorusGeometry(0.105 + i * 0.085, 0.0035, 8, 56),
+      new THREE.MeshBasicMaterial({
+        color: 0xd7fbff,
+        transparent: true,
+        opacity: 0.11,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+        side: THREE.DoubleSide
+      })
+    );
+    shock.rotation.x = Math.PI / 2;
+    shock.position.z = 0.14 + i * 0.16;
+    group.add(shock);
+  }
+
+  group.visible = false;
+  return group;
 }
 
 function layWeaponFlatOnTable(root: THREE.Object3D) {
@@ -1056,8 +1595,9 @@ function updateLabelSprite(sprite: THREE.Sprite, text: string) {
     | undefined;
   const canvas = tex?.image as HTMLCanvasElement | undefined;
   if (!canvas) return;
+  const texture = tex;
   const ctx = canvas.getContext('2d');
-  if (!ctx) return;
+  if (!ctx || !texture) return;
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = 'rgba(0,0,0,.72)';
@@ -1070,7 +1610,7 @@ function updateLabelSprite(sprite: THREE.Sprite, text: string) {
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillText(text, 256, 80);
-  tex.needsUpdate = true;
+  texture.needsUpdate = true;
 }
 
 function createPaperTarget(
@@ -1174,56 +1714,86 @@ function createBullet(
   end: THREE.Vector3,
   cinematic: boolean,
   speed: number,
-  weapon: WeaponEntry
+  weapon: WeaponEntry,
+  ammoTemplates: AmmoTemplates
 ) {
-  const handgun =
-    weapon.weaponClass === 'pistol' || weapon.weaponClass === 'revolver';
-  const longGun =
-    weapon.weaponClass === 'rifle' || weapon.weaponClass === 'sniper';
+  const dir = end.clone().sub(start).normalize();
+  const right = new THREE.Vector3(1, 0, 0);
+  const inside = start.clone().addScaledVector(dir, -0.53);
+  const nineMm = isNineMmWeapon(weapon);
+  const longGun = usesRifleCinematic(weapon);
   const shotgun = weapon.weaponClass === 'shotgun';
-  const bulletGeometry = shotgun
-    ? new THREE.SphereGeometry(0.034, 10, 10)
-    : new THREE.CapsuleGeometry(
-        handgun ? 0.018 : longGun ? 0.015 : 0.016,
-        handgun ? 0.085 : longGun ? 0.13 : 0.1,
-        4,
-        10
-      );
-  const bullet = new THREE.Mesh(
-    bulletGeometry,
-    new THREE.MeshStandardMaterial({
-      color: handgun ? '#c9c2b8' : shotgun ? '#d9b56d' : '#e7d7a2',
-      roughness: handgun ? 0.24 : 0.32,
-      metalness: 0.86,
-      emissive: '#3b2508',
-      emissiveIntensity: cinematic ? 0.16 : 0.06
-    })
-  );
+  const root = new THREE.Group();
+  const spinGroup = new THREE.Group();
+
+  let visual: THREE.Object3D;
+  if (nineMm) {
+    visual = cloneRenderable(ammoTemplates.bullet);
+    visual.scale.multiplyScalar(cinematic ? 1.08 : 1);
+  } else {
+    const bulletGeometry = shotgun
+      ? new THREE.SphereGeometry(0.034, 10, 10)
+      : new THREE.CapsuleGeometry(longGun ? 0.015 : 0.016, longGun ? 0.13 : 0.1, 4, 10);
+    visual = new THREE.Mesh(
+      bulletGeometry,
+      new THREE.MeshStandardMaterial({
+        color: shotgun ? '#d9b56d' : '#e7d7a2',
+        roughness: 0.32,
+        metalness: 0.86,
+        emissive: '#3b2508',
+        emissiveIntensity: cinematic ? 0.16 : 0.06
+      })
+    );
+  }
+
+  spinGroup.add(visual);
+  root.add(spinGroup);
+  alignToDirection(root, dir);
+  root.position.copy(cinematic && nineMm ? inside : start);
+
   const length = Math.min(1.2, start.distanceTo(end));
   const trail = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.007, 0.007, length, 8),
+    new THREE.CylinderGeometry(nineMm ? 0.005 : 0.007, nineMm ? 0.005 : 0.007, length, 8),
     new THREE.MeshBasicMaterial({
-      color: '#ffb84d',
+      color: nineMm ? '#e8fcff' : '#ffb84d',
       transparent: true,
-      opacity: 0.58
+      opacity: nineMm ? 0.38 : 0.58,
+      depthWrite: false,
+      blending: nineMm ? THREE.AdditiveBlending : THREE.NormalBlending
     })
   );
-
-  bullet.position.copy(start);
-  bullet.lookAt(end);
-  bullet.rotateX(Math.PI / 2);
   trail.position.copy(start);
   trail.rotation.x = Math.PI / 2;
-  scene.add(bullet, trail);
+  const wake = nineMm || longGun ? makeWake() : null;
+  if (wake) {
+    wake.position.copy(root.position);
+    wake.quaternion.copy(root.quaternion);
+  }
+
+  scene.add(root, trail);
+  if (wake) scene.add(wake);
 
   return {
-    mesh: bullet,
+    root,
+    spinGroup,
     trail,
+    wake,
     start,
     end,
+    muzzle: start.clone(),
+    inside,
+    dir,
+    right,
+    pos: root.position.clone(),
     t: 0,
+    age: 0,
     speed,
-    cinematic
+    spin: 0,
+    cinematic,
+    launched: !(cinematic && nineMm),
+    prelaunch: nineMm ? PRELAUNCH : 0,
+    life: cinematic ? 4.2 : 1.2,
+    flightQuat: root.quaternion.clone()
   } as BulletRuntime;
 }
 
@@ -1231,35 +1801,54 @@ function createShell(
   scene: THREE.Scene,
   position: THREE.Vector3,
   power: number,
-  weapon: WeaponEntry
+  weapon: WeaponEntry,
+  ammoTemplates: AmmoTemplates,
+  dir = new THREE.Vector3(0, 0, -1),
+  right = new THREE.Vector3(1, 0, 0),
+  up = new THREE.Vector3(0, 1, 0),
+  cinematic = false
 ) {
-  const handgun =
-    weapon.weaponClass === 'pistol' || weapon.weaponClass === 'revolver';
-  const shotgun = weapon.weaponClass === 'shotgun';
-  const shellRadius = handgun ? 0.022 : shotgun ? 0.04 : 0.026;
-  const shellLength = handgun ? 0.115 : shotgun ? 0.22 : 0.145;
-  const mesh = new THREE.Mesh(
-    new THREE.CylinderGeometry(shellRadius, shellRadius, shellLength, 18),
-    new THREE.MeshStandardMaterial({
-      color: handgun ? '#b9822f' : shotgun ? '#8b1e24' : '#d0a044',
-      roughness: handgun ? 0.28 : 0.36,
-      metalness: shotgun ? 0.46 : 0.92
-    })
-  );
-  mesh.rotation.z = Math.PI / 2;
-  mesh.position.copy(position);
-  mesh.castShadow = true;
-  scene.add(mesh);
+  const nineMm = isNineMmWeapon(weapon);
+  let root: THREE.Object3D;
+  if (nineMm) {
+    root = cloneRenderable(ammoTemplates.shell);
+    root.scale.multiplyScalar(cinematic ? 3 : 2.2);
+  } else {
+    const shotgun = weapon.weaponClass === 'shotgun';
+    const shellRadius = shotgun ? 0.04 : 0.026;
+    const shellLength = shotgun ? 0.22 : 0.145;
+    root = new THREE.Mesh(
+      new THREE.CylinderGeometry(shellRadius, shellRadius, shellLength, 18),
+      new THREE.MeshStandardMaterial({
+        color: shotgun ? '#8b1e24' : '#d0a044',
+        roughness: shotgun ? 0.36 : 0.34,
+        metalness: shotgun ? 0.46 : 0.92
+      })
+    );
+    root.rotation.z = Math.PI / 2;
+  }
+
+  const shellStart = position.clone().addScaledVector(right, -0.1).addScaledVector(up, -0.01).addScaledVector(dir, 0.02);
+  const shellOut = position.clone().addScaledVector(right, 0.5 * power).addScaledVector(up, 0.22 * power).addScaledVector(dir, 0.08);
+  root.position.copy(cinematic && nineMm ? shellStart : shellOut);
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (mesh.isMesh) mesh.castShadow = true;
+  });
+  scene.add(root);
 
   return {
-    mesh,
-    vel: new THREE.Vector3(0.72 * power, 0.45 * power, 0.16),
-    spin: new THREE.Vector3(
-      Math.random() * 7,
-      Math.random() * 12,
-      Math.random() * 8
-    ),
-    life: 2.4
+    root,
+    pos: root.position.clone(),
+    start: shellStart,
+    end: shellOut,
+    vel: right.clone().multiplyScalar(1.25 * power).add(up.clone().multiplyScalar(0.82 * power)).add(dir.clone().multiplyScalar(0.12)),
+    spin: new THREE.Vector3(4 + Math.random() * 2, 6 + Math.random() * 2, 4 + Math.random() * 2),
+    life: nineMm ? 7.5 : 2.4,
+    age: 0,
+    launched: !(cinematic && nineMm),
+    grounded: false,
+    pre: nineMm ? 0.18 : 0
   } as ShellRuntime;
 }
 
@@ -1409,6 +1998,7 @@ export default function ShootingRange() {
   const bulletsRef = useRef<BulletRuntime[]>([]);
   const shellsRef = useRef<ShellRuntime[]>([]);
   const weaponSourcesRef = useRef<(THREE.Object3D | null)[]>([]);
+  const ammoTemplatesRef = useRef<AmmoTemplates | null>(null);
   const tableWeaponsRef = useRef<TableWeaponRuntime[]>([]);
   const pickTargetsRef = useRef<THREE.Object3D[]>([]);
 
@@ -1483,6 +2073,8 @@ export default function ShootingRange() {
     const rangeConfig = RANGE_DISTANCE_CONFIG[queryConfig.distance];
     const activeTargetZ = rangeConfig.targetZ;
 
+    ammoTemplatesRef.current = createFallbackAmmoTemplates();
+
     const scene = new THREE.Scene();
     scene.background = new THREE.Color('#111827');
     scene.fog = new THREE.Fog(
@@ -1553,6 +2145,9 @@ export default function ShootingRange() {
     scene.add(fillLight);
 
     const textureLoader = new THREE.TextureLoader();
+    textureLoader.setCrossOrigin('anonymous');
+    const servicePistolTextureMaps = makeServicePistolTextureMaps(textureLoader);
+    ammoTemplatesRef.current = createFallbackAmmoTemplates(servicePistolTextureMaps);
     const floorMat = makePbrMaterial(
       textureLoader,
       TEXTURES.floor,
@@ -1649,7 +2244,7 @@ export default function ShootingRange() {
         lookAt: new THREE.Vector3(3.9, 1.65, activeTargetZ + 1.7)
       }
     ];
-    const securityCameras = securityCameraAnchors.map(({ position, lookAt }) => {
+    const securityCameras: { root: THREE.Object3D; position: THREE.Vector3; lookAt: THREE.Vector3 }[] = securityCameraAnchors.map(({ position, lookAt }) => {
       const cameraObject = createFallbackSecurityCamera();
       cameraObject.position.copy(position);
       cameraObject.lookAt(lookAt);
@@ -1910,13 +2505,21 @@ export default function ShootingRange() {
         disposeObject(lane.heldWeapon);
       }
 
-      const held = cloneScene(source);
+      const entry = WEAPONS[weaponIndex];
+      const nineMm = isNineMmWeapon(entry);
+      const held = cloneRenderable(source);
       configureModel(held, renderer);
-      normalizeToLength(held, 1.14);
-      orientWeaponForward(held);
-      held.position.set(-0.03, -0.02, -0.2);
-      held.rotation.x += -0.05;
-      held.rotation.z += 0.02;
+      normalizeToLength(held, nineMm ? 1.95 : 1.14);
+      if (nineMm) {
+        orientWeaponForward(held);
+        held.rotation.y += Math.PI / 2;
+        held.position.set(0, -0.12, -0.02);
+      } else {
+        orientWeaponForward(held);
+        held.position.set(-0.03, -0.02, -0.2);
+        held.rotation.x += -0.05;
+        held.rotation.z += 0.02;
+      }
 
       lane.weaponMount.add(held);
       lane.heldWeapon = held;
@@ -1924,11 +2527,11 @@ export default function ShootingRange() {
       lane.pickupLift = lift ? 1 : 0;
 
       const muzzle = new THREE.Object3D();
-      muzzle.position.set(0.02, 0.02, -0.95);
+      muzzle.position.copy(nineMm ? SERVICE_PISTOL_AIM.muzzle : new THREE.Vector3(0.02, 0.02, -0.95));
       held.add(muzzle);
 
       const shellPort = new THREE.Object3D();
-      shellPort.position.set(0.12, 0.03, -0.42);
+      shellPort.position.copy(nineMm ? SERVICE_PISTOL_AIM.shellPort : new THREE.Vector3(0.12, 0.03, -0.42));
       held.add(shellPort);
 
       lane.muzzle = muzzle;
@@ -2040,6 +2643,9 @@ export default function ShootingRange() {
           .then((gltf) => {
             if (disposed) return;
             configureModel(gltf.scene, renderer);
+            if (entry.id === 'service-pistol') {
+              ammoTemplatesRef.current = extractServicePistolAmmo(gltf.scene, servicePistolTextureMaps);
+            }
             weaponSourcesRef.current[index] = gltf.scene;
 
             const tableWeapon = tableWeaponsRef.current.find(
@@ -2363,7 +2969,7 @@ export default function ShootingRange() {
 
       if (!isAI) {
         recoilRef.current = stats.recoil;
-        followUntilRef.current = performance.now() + 500;
+        followUntilRef.current = performance.now() + (isNineMmWeapon(weapon) ? 4200 : usesRifleCinematic(weapon) ? 2300 : 500);
       }
 
       playShot(Math.max(0.6, stats.recoil));
@@ -2374,8 +2980,24 @@ export default function ShootingRange() {
 
       const shellPos = new THREE.Vector3();
       lane.shellPort.getWorldPosition(shellPos);
+      const weaponQuat = lane.muzzle.getWorldQuaternion(new THREE.Quaternion());
+      const muzzleDir = new THREE.Vector3(0, 0, -1).applyQuaternion(weaponQuat).normalize();
+      const weaponRight = new THREE.Vector3(1, 0, 0).applyQuaternion(weaponQuat).normalize();
+      const weaponUp = new THREE.Vector3(0, 1, 0).applyQuaternion(weaponQuat).normalize();
+      const ammoTemplates = ammoTemplatesRef.current ?? createFallbackAmmoTemplates();
+      const shotCinematic = !isAI && (isNineMmWeapon(weapon) || usesRifleCinematic(weapon));
       shellsRef.current.push(
-        createShell(scene, shellPos, stats.shellPower, weapon)
+        createShell(
+          scene,
+          shellPos,
+          stats.shellPower,
+          weapon,
+          ammoTemplates,
+          muzzleDir,
+          weaponRight,
+          weaponUp,
+          shotCinematic
+        )
       );
 
       let bestPoints = 0;
@@ -2386,7 +3008,7 @@ export default function ShootingRange() {
         const result = isAI
           ? resolveShotForLane(laneIndex, stats.spread * 1.08, lane.aiAim)
           : resolveUserShotFromCrosshair(laneIndex);
-        const cinematic = !isAI && i === 0;
+        const cinematic = shotCinematic && i === 0;
         bulletsRef.current.push(
           createBullet(
             scene,
@@ -2394,7 +3016,8 @@ export default function ShootingRange() {
             result.point.clone(),
             cinematic,
             stats.bulletSpeed,
-            weapon
+            weapon,
+            ammoTemplates
           )
         );
 
@@ -2600,20 +3223,47 @@ export default function ShootingRange() {
     function updateBullets(dt: number) {
       for (let i = bulletsRef.current.length - 1; i >= 0; i -= 1) {
         const bullet = bulletsRef.current[i];
-        bullet.t += dt * bullet.speed;
-        const p = THREE.MathUtils.smoothstep(Math.min(1, bullet.t), 0, 1);
-        bullet.mesh.position.lerpVectors(bullet.start, bullet.end, p);
-        bullet.trail.position
-          .copy(bullet.mesh.position)
-          .lerp(bullet.start, 0.15);
-        bullet.trail.lookAt(bullet.end);
+        bullet.age += dt;
 
-        if (bullet.t >= 1) {
-          scene.remove(bullet.mesh, bullet.trail);
-          bullet.mesh.geometry.dispose();
-          (bullet.mesh.material as THREE.Material).dispose();
-          bullet.trail.geometry.dispose();
-          (bullet.trail.material as THREE.Material).dispose();
+        if (bullet.cinematic && bullet.prelaunch > 0 && !bullet.launched) {
+          const p = THREE.MathUtils.smoothstep(
+            Math.min(1, bullet.age / bullet.prelaunch),
+            0,
+            1
+          );
+          bullet.pos.copy(bullet.inside).lerp(bullet.muzzle, p);
+          if (bullet.age >= bullet.prelaunch) {
+            bullet.launched = true;
+            bullet.pos.copy(bullet.muzzle);
+            bullet.t = 0;
+          }
+        } else {
+          bullet.t += dt * bullet.speed;
+          const p = THREE.MathUtils.smoothstep(Math.min(1, bullet.t), 0, 1);
+          bullet.pos.lerpVectors(bullet.muzzle, bullet.end, p);
+        }
+
+        bullet.root.position.copy(bullet.pos);
+        bullet.root.quaternion.copy(bullet.flightQuat);
+        bullet.spin += BULLET_SPIN * dt;
+        bullet.spinGroup.rotation.set(0, 0, bullet.spin);
+
+        bullet.trail.position.copy(bullet.pos).lerp(bullet.muzzle, 0.15);
+        bullet.trail.lookAt(bullet.end);
+        bullet.trail.visible = bullet.launched;
+
+        if (bullet.wake) {
+          bullet.wake.visible = bullet.launched;
+          bullet.wake.position.copy(bullet.pos);
+          bullet.wake.quaternion.copy(bullet.flightQuat);
+        }
+
+        if (bullet.t >= 1 || bullet.age >= bullet.life) {
+          scene.remove(bullet.root, bullet.trail);
+          if (bullet.wake) scene.remove(bullet.wake);
+          disposeObject(bullet.root);
+          disposeObject(bullet.trail);
+          if (bullet.wake) disposeObject(bullet.wake);
           bulletsRef.current.splice(i, 1);
         }
       }
@@ -2622,17 +3272,37 @@ export default function ShootingRange() {
     function updateShells(dt: number) {
       for (let i = shellsRef.current.length - 1; i >= 0; i -= 1) {
         const shell = shellsRef.current[i];
+        shell.age += dt;
         shell.life -= dt;
-        shell.vel.y -= dt * 1.8;
-        shell.mesh.position.addScaledVector(shell.vel, dt);
-        shell.mesh.rotation.x += shell.spin.x * dt;
-        shell.mesh.rotation.y += shell.spin.y * dt;
-        shell.mesh.rotation.z += shell.spin.z * dt;
+
+        if (!shell.launched) {
+          shell.pos.copy(shell.start).lerp(
+            shell.end,
+            THREE.MathUtils.smoothstep(Math.min(1, shell.age / shell.pre), 0, 1)
+          );
+          if (shell.age >= shell.pre) shell.launched = true;
+        } else if (!shell.grounded) {
+          shell.vel.y -= dt * 2.8;
+          shell.pos.addScaledVector(shell.vel, dt);
+          if (shell.pos.y < 0.08) {
+            shell.pos.y = 0.08;
+            shell.vel.y *= -0.18;
+            shell.vel.x *= 0.82;
+            shell.vel.z *= 0.82;
+            if (Math.abs(shell.vel.y) < 0.08) shell.grounded = true;
+          }
+        } else {
+          shell.vel.multiplyScalar(Math.exp(-1.2 * dt));
+        }
+
+        shell.root.position.copy(shell.pos);
+        shell.root.rotation.x += shell.spin.x * dt;
+        shell.root.rotation.y += shell.spin.y * dt;
+        shell.root.rotation.z += shell.spin.z * dt;
 
         if (shell.life <= 0) {
-          scene.remove(shell.mesh);
-          shell.mesh.geometry.dispose();
-          (shell.mesh.material as THREE.Material).dispose();
+          scene.remove(shell.root);
+          disposeObject(shell.root);
           shellsRef.current.splice(i, 1);
         }
       }
@@ -2646,37 +3316,41 @@ export default function ShootingRange() {
         const isUser = lane.controller === 'USER';
         const aim = isUser ? aimRef.current : lane.aiAim;
         const recoil = isUser ? recoilRef.current : 0;
+        const weapon = WEAPONS[lane.activeWeaponIndex];
+        const nineMm = isNineMmWeapon(weapon);
+        const kick = Math.sin(Math.max(0, Math.min(1, recoil)) * Math.PI) * (nineMm ? 0.09 : recoil);
+        const baseMount = nineMm ? SERVICE_PISTOL_AIM.mount : new THREE.Vector3(0.34, 1.27, -0.12);
 
         lane.weaponMount.position.x = THREE.MathUtils.lerp(
           lane.weaponMount.position.x,
-          0.34 + aim.x * 0.1,
-          0.16
+          baseMount.x + aim.x * (nineMm ? 0.04 : 0.1),
+          nineMm ? 0.22 : 0.16
         );
         lane.weaponMount.position.y = THREE.MathUtils.lerp(
           lane.weaponMount.position.y,
-          1.27 + lane.pickupLift * 0.18 + aim.y * 0.06 - recoil * 0.05,
-          0.16
+          baseMount.y + lane.pickupLift * 0.18 + aim.y * (nineMm ? 0.03 : 0.06) - kick * (nineMm ? 0.09 : 0.05),
+          nineMm ? 0.22 : 0.16
         );
         lane.weaponMount.position.z = THREE.MathUtils.lerp(
           lane.weaponMount.position.z,
-          -0.12 + recoil * 0.18,
-          0.16
+          baseMount.z + kick * (nineMm ? 0.045 : 0.18),
+          nineMm ? 0.22 : 0.16
         );
 
         lane.weaponMount.rotation.x = THREE.MathUtils.lerp(
           lane.weaponMount.rotation.x,
-          0.02 - recoil * 0.2 + aim.y * 0.05,
-          0.16
+          (nineMm ? -0.02 : 0.02) - kick * (nineMm ? 0.44 : 0.2) + aim.y * 0.05,
+          nineMm ? 0.22 : 0.16
         );
         lane.weaponMount.rotation.y = THREE.MathUtils.lerp(
           lane.weaponMount.rotation.y,
-          -0.03 - aim.x * 0.08,
-          0.16
+          (nineMm ? 0.01 : -0.03) - aim.x * 0.08 + kick * (nineMm ? 0.08 : 0),
+          nineMm ? 0.22 : 0.16
         );
         lane.weaponMount.rotation.z = THREE.MathUtils.lerp(
           lane.weaponMount.rotation.z,
-          0.1 + aim.x * 0.05,
-          0.16
+          (nineMm ? 0.005 : 0.1) + aim.x * 0.05 + kick * (nineMm ? 0.12 : 0),
+          nineMm ? 0.22 : 0.16
         );
       });
 
@@ -2793,11 +3467,23 @@ export default function ShootingRange() {
           .clone()
           .sub(cinematicBullet.start)
           .normalize();
-        tempPos
-          .copy(cinematicBullet.mesh.position)
-          .addScaledVector(dir, -0.7)
-          .add(new THREE.Vector3(0.18, 0.14, 0.28));
-        tempLook.copy(cinematicBullet.mesh.position).addScaledVector(dir, 0.9);
+        if (!cinematicBullet.launched && cinematicBullet.prelaunch > 0) {
+          tempPos
+            .copy(cinematicBullet.muzzle)
+            .addScaledVector(dir, -1.3)
+            .addScaledVector(cinematicBullet.right, 0.52)
+            .add(new THREE.Vector3(0, 0.52, 0));
+          tempLook
+            .copy(cinematicBullet.muzzle)
+            .addScaledVector(dir, 0.46)
+            .addScaledVector(cinematicBullet.right, 0.15);
+        } else {
+          tempPos
+            .copy(cinematicBullet.root.position)
+            .addScaledVector(dir, -0.7)
+            .add(new THREE.Vector3(0.18, 0.14, 0.28));
+          tempLook.copy(cinematicBullet.root.position).addScaledVector(dir, 0.9);
+        }
         camera.position.lerp(tempPos, 0.22);
         camera.lookAt(tempLook);
         return;
@@ -2827,6 +3513,7 @@ export default function ShootingRange() {
     const clock = new THREE.Clock();
 
     function resize() {
+      if (!mount) return;
       const w = Math.max(1, mount.clientWidth);
       const h = Math.max(1, mount.clientHeight);
       camera.aspect = w / h;


### PR DESCRIPTION
### Motivation
- Improve visual fidelity and realism for small-arms (9mm/service pistol) by extracting and applying dedicated bullet and shell meshes and textures, and enable cinematic prelaunch/follow-camera behavior for certain weapons.
- Centralize service-pistol texture handling and ammo template creation so loaded GLTF models can provide accurate projectile visuals instead of fallback primitives.
- Make bullet and shell flight, spin, wake, and ejection behavior more physically plausible and consistent across weapon classes.

### Description
- Introduced new runtime types and ammo template types: `BulletRuntime`, `ShellRuntime`, `ServicePistolTextureMaps`, and `AmmoTemplates` and added constants for `PRELAUNCH`, `BULLET_SPIN`, and `SERVICE_PISTOL_AIM`.
- Added texture helpers `makeServicePistolTextureMaps`, `loadServicePistolTexture`, and `applyServicePistolTextureMaps`, plus numerous model utilities (`cloneRenderable`, `bestMesh`, `splitMesh`, `findAmmoCarrier`, `extractServicePistolAmmo`, etc.) to detect and build bullet and shell meshes from the `service-pistol` GLTF.
- Reworked projectile creation to use ammo templates: `createBullet` now produces a `root`/`spinGroup` visual for bullets (using extracted bullet meshes for 9mm), creates wakes for small fast rounds, supports cinematic `prelaunch` behavior and spin, and returns expanded `BulletRuntime`; `createShell` uses extracted shell meshes for 9mm and updates shell trajectory, life and grounded behavior.
- Adjusted weapon mounting/positioning for 9mm weapons (special mount/muzzle/shellPort positions via `SERVICE_PISTOL_AIM`), set `textureLoader.setCrossOrigin('anonymous')`, and extract ammo templates when the `service-pistol` model is loaded, with a fallback created at startup.
- Updated runtime updates: `updateBullets`, `updateShells`, `updateCharacters`, and camera follow logic to support cinematic prelaunch, spin/wake visuals, delayed launch, and improved camera framing for cinematic shots.
- Minor fixes: ensure canvas texture update uses local `texture` variable in `updateLabelSprite`, and improved disposal/scene cleanup calls by using `disposeObject` helpers for grouped objects.

### Testing
- Ran the project's type-check and development build (`yarn build` / `npm run build`) to validate TypeScript and bundling, and the build completed successfully with no compile errors.
- Executed the test suite (`yarn test`) and the automated tests passed locally without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b8a0a9808329923620a8e0e239c8)