### PR TITLE
Add 9mm/service-pistol ammo visuals, texture loading, and cinematic bullet/shell behavior

### DIFF
--- a/webapp/src/pages/Games/ShootingRange.tsx
+++ b/webapp/src/pages/Games/ShootingRange.tsx
@@ -99,20 +99,54 @@ type PaperTargetRuntime = {
 };
 
 type BulletRuntime = {
-  mesh: THREE.Mesh;
-  trail: THREE.Mesh;
+  root: THREE.Object3D;
+  spinGroup: THREE.Object3D;
+  trail: THREE.Object3D;
+  wake: THREE.Object3D | null;
   start: THREE.Vector3;
   end: THREE.Vector3;
+  muzzle: THREE.Vector3;
+  inside: THREE.Vector3;
+  dir: THREE.Vector3;
+  right: THREE.Vector3;
+  pos: THREE.Vector3;
   t: number;
+  age: number;
   speed: number;
+  spin: number;
   cinematic: boolean;
+  launched: boolean;
+  prelaunch: number;
+  life: number;
+  flightQuat: THREE.Quaternion;
 };
 
 type ShellRuntime = {
-  mesh: THREE.Mesh;
+  root: THREE.Object3D;
+  pos: THREE.Vector3;
+  start: THREE.Vector3;
+  end: THREE.Vector3;
   vel: THREE.Vector3;
   spin: THREE.Vector3;
   life: number;
+  age: number;
+  launched: boolean;
+  grounded: boolean;
+  pre: number;
+};
+
+type AmmoTemplates = {
+  bullet: THREE.Object3D;
+  shell: THREE.Object3D;
+  source: string;
+};
+
+type ServicePistolTextureMaps = {
+  diff: THREE.Texture | null;
+  normal: THREE.Texture | null;
+  rough: THREE.Texture | null;
+  metal: THREE.Texture | null;
+  ao: THREE.Texture | null;
 };
 
 const USER_LANE = 0;
@@ -125,6 +159,13 @@ const LANE_X = [-4.9, -1.65, 1.65, 4.9];
 const TABLE_Z = 2.35;
 const TABLE_TOP_Y = 0.94;
 const TARGET_Z = -21.8;
+const PRELAUNCH = 1.25;
+const BULLET_SPIN = 245;
+const SERVICE_PISTOL_AIM = {
+  mount: new THREE.Vector3(0.34, 1.27, -0.12),
+  muzzle: new THREE.Vector3(0.01, -0.035, -1.21),
+  shellPort: new THREE.Vector3(0.46, 0.04, -0.44)
+};
 
 const RANGE_DISTANCE_CONFIG: Record<
   RangeDistance,
@@ -158,6 +199,17 @@ const POLYHAVEN_ASSETS = {
     'https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/security_camera_01/security_camera_01_1k.gltf',
   servicePistol:
     'https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/service_pistol/service_pistol_1k.gltf'
+};
+
+const servicePistolTexture = (res: '1k' | '2k' | '4k', name: string) =>
+  `https://dl.polyhaven.org/file/ph-assets/Models/jpg/${res}/service_pistol/service_pistol_${name}_${res}.jpg`;
+
+const SERVICE_PISTOL_TEXTURE_URLS = {
+  diff: [servicePistolTexture('2k', 'diff'), servicePistolTexture('1k', 'diff'), servicePistolTexture('4k', 'diff')],
+  normal: [servicePistolTexture('2k', 'nor_gl'), servicePistolTexture('1k', 'nor_gl'), servicePistolTexture('4k', 'nor_gl')],
+  rough: [servicePistolTexture('2k', 'rough'), servicePistolTexture('1k', 'rough'), servicePistolTexture('4k', 'rough')],
+  metal: [servicePistolTexture('2k', 'metal'), servicePistolTexture('1k', 'metal'), servicePistolTexture('4k', 'metal')],
+  ao: [servicePistolTexture('2k', 'ao'), servicePistolTexture('1k', 'ao'), servicePistolTexture('4k', 'ao')]
 };
 
 const TEXTURES = {
@@ -582,6 +634,90 @@ function loadTexture(
   return tex;
 }
 
+function loadTextureAny(
+  textureLoader: THREE.TextureLoader,
+  urls: string[],
+  colorSpace: THREE.ColorSpace = THREE.NoColorSpace
+) {
+  return new Promise<THREE.Texture | null>((resolve) => {
+    let index = 0;
+    const next = () => {
+      if (index >= urls.length) {
+        resolve(null);
+        return;
+      }
+      textureLoader.load(
+        urls[index++],
+        (tex) => {
+          tex.colorSpace = colorSpace;
+          tex.flipY = false;
+          tex.wrapS = THREE.RepeatWrapping;
+          tex.wrapT = THREE.RepeatWrapping;
+          tex.anisotropy = 8;
+          tex.needsUpdate = true;
+          resolve(tex);
+        },
+        undefined,
+        next
+      );
+    };
+    next();
+  });
+}
+
+async function loadServicePistolTextureMaps() {
+  const loader = new THREE.TextureLoader();
+  loader.setCrossOrigin('anonymous');
+  const [diff, normal, rough, metal, ao] = await Promise.all([
+    loadTextureAny(loader, SERVICE_PISTOL_TEXTURE_URLS.diff, THREE.SRGBColorSpace),
+    loadTextureAny(loader, SERVICE_PISTOL_TEXTURE_URLS.normal),
+    loadTextureAny(loader, SERVICE_PISTOL_TEXTURE_URLS.rough),
+    loadTextureAny(loader, SERVICE_PISTOL_TEXTURE_URLS.metal),
+    loadTextureAny(loader, SERVICE_PISTOL_TEXTURE_URLS.ao)
+  ]);
+  return { diff, normal, rough, metal, ao } as ServicePistolTextureMaps;
+}
+
+function applyServicePistolMaps(
+  material: THREE.MeshStandardMaterial,
+  maps: ServicePistolTextureMaps | null
+) {
+  if (!maps) return;
+  if (maps.diff) material.map = maps.diff;
+  if (maps.normal) material.normalMap = maps.normal;
+  if (maps.rough) material.roughnessMap = maps.rough;
+  if (maps.metal) material.metalnessMap = maps.metal;
+  if (maps.ao) material.aoMap = maps.ao;
+  material.metalness = Math.max(material.metalness ?? 0.5, 0.48);
+  material.roughness = Math.min(Math.max(material.roughness ?? 0.38, 0.24), 0.68);
+  material.needsUpdate = true;
+}
+
+function applyServicePistolMapsToObject(
+  root: THREE.Object3D,
+  maps: ServicePistolTextureMaps | null
+) {
+  if (!maps) return;
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh) return;
+    if (mesh.geometry?.attributes?.uv && !mesh.geometry.attributes.uv2) {
+      mesh.geometry.setAttribute('uv2', mesh.geometry.attributes.uv.clone());
+    }
+    const materials = Array.isArray((mesh as any).material)
+      ? (mesh as any).material
+      : (mesh as any).material
+        ? [(mesh as any).material]
+        : [];
+    const next = materials.map((material: THREE.Material) => {
+      const cloned = material.clone() as THREE.MeshStandardMaterial;
+      applyServicePistolMaps(cloned, maps);
+      return cloned;
+    });
+    if (next.length) (mesh as any).material = Array.isArray((mesh as any).material) ? next : next[0];
+  });
+}
+
 function makePbrMaterial(
   loader: THREE.TextureLoader,
   maps: {
@@ -701,6 +837,381 @@ function orientWeaponForward(root: THREE.Object3D) {
   root.rotation.z += 0.012;
   root.updateMatrixWorld(true);
   centerRoot(root);
+}
+
+
+function cloneRenderable(root: THREE.Object3D) {
+  const cloned = cloneScene(root);
+  cloned.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh) return;
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    mesh.frustumCulled = false;
+  });
+  return cloned;
+}
+
+function isNineMmWeapon(entry: WeaponEntry) {
+  return (
+    entry.weaponClass === 'pistol' ||
+    entry.weaponClass === 'smg' ||
+    entry.id === 'q-pistol' ||
+    entry.id === 'service-pistol' ||
+    entry.id === 'smith' ||
+    entry.id === 'sigsauer' ||
+    entry.id === 'uzi'
+  );
+}
+
+function usesRifleCinematic(entry: WeaponEntry) {
+  return entry.weaponClass === 'rifle' || entry.weaponClass === 'sniper';
+}
+
+function labelOf(object: THREE.Object3D) {
+  const mesh = object as THREE.Mesh;
+  const materials = Array.isArray((mesh as any).material)
+    ? (mesh as any).material
+    : (mesh as any).material
+      ? [(mesh as any).material]
+      : [];
+  return `${object.name || ''} ${materials.map((m: any) => m?.name || '').join(' ')}`.toLowerCase();
+}
+
+function scoreLabel(label: string, words: string[], reject: string[] = []) {
+  if (reject.some((word) => label.includes(word))) return -999;
+  return words.reduce(
+    (sum, word, index) => sum + (label.includes(word) ? 24 - index : 0),
+    0
+  );
+}
+
+function bestMesh(
+  root: THREE.Object3D,
+  words: string[],
+  reject: string[] = []
+) {
+  let best: THREE.Mesh | null = null;
+  let bestScore = -Infinity;
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh || !child.visible)
+      return;
+    const score = scoreLabel(labelOf(child), words, reject);
+    if (score > bestScore) {
+      best = mesh;
+      bestScore = score;
+    }
+  });
+  return bestScore > 0 ? best : null;
+}
+
+function materialFrom(
+  object: THREE.Object3D | null,
+  fallback = 0xc48a35,
+  maps: ServicePistolTextureMaps | null = null
+) {
+  let found: THREE.Material | null = null;
+  object?.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (found || (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh)) return;
+    found = Array.isArray((mesh as any).material)
+      ? (mesh as any).material.find(Boolean)
+      : (mesh as any).material;
+  });
+  const foundMaterial = found as (THREE.Material & { clone?: () => THREE.Material }) | null;
+  const mat = foundMaterial?.clone
+    ? (foundMaterial.clone() as THREE.MeshStandardMaterial)
+    : new THREE.MeshStandardMaterial({ color: fallback });
+  applyServicePistolMaps(mat, maps);
+  mat.metalness = Math.max(mat.metalness ?? 0.5, 0.48);
+  mat.roughness = Math.min(Math.max(mat.roughness ?? 0.38, 0.24), 0.68);
+  mat.needsUpdate = true;
+  return mat;
+}
+
+function splitMesh(
+  mesh: THREE.Mesh | null,
+  keep: 'front' | 'back',
+  size: number,
+  maps: ServicePistolTextureMaps | null = null
+) {
+  if (!mesh?.geometry?.attributes?.position) return null;
+  const source = mesh.geometry.index ? mesh.geometry.toNonIndexed() : mesh.geometry.clone();
+  const pos = source.attributes.position;
+  const nor = source.attributes.normal;
+  const uv = source.attributes.uv;
+  const box = new THREE.Box3().setFromBufferAttribute(pos as THREE.BufferAttribute);
+  const dims = box.getSize(new THREE.Vector3());
+  const axis = dims.x >= dims.y && dims.x >= dims.z ? 0 : dims.y >= dims.z ? 1 : 2;
+  const min = axis === 0 ? box.min.x : axis === 1 ? box.min.y : box.min.z;
+  const max = axis === 0 ? box.max.x : axis === 1 ? box.max.y : box.max.z;
+  const cut = min + (max - min) * 0.52;
+  const p: number[] = [];
+  const n: number[] = [];
+  const u: number[] = [];
+  const v = new THREE.Vector3();
+
+  for (let i = 0; i < pos.count; i += 3) {
+    let avg = 0;
+    for (let j = 0; j < 3; j += 1) {
+      v.fromBufferAttribute(pos as THREE.BufferAttribute, i + j);
+      avg += axis === 0 ? v.x : axis === 1 ? v.y : v.z;
+    }
+    avg /= 3;
+    const choose = keep === 'front' ? avg >= cut : avg < cut;
+    if (!choose) continue;
+    for (let j = 0; j < 3; j += 1) {
+      p.push(pos.getX(i + j), pos.getY(i + j), pos.getZ(i + j));
+      if (nor) n.push(nor.getX(i + j), nor.getY(i + j), nor.getZ(i + j));
+      if (uv) u.push(uv.getX(i + j), uv.getY(i + j));
+    }
+  }
+
+  if (p.length < 9) return null;
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(p, 3));
+  if (n.length) geo.setAttribute('normal', new THREE.Float32BufferAttribute(n, 3));
+  else geo.computeVertexNormals();
+  if (u.length) geo.setAttribute('uv', new THREE.Float32BufferAttribute(u, 2));
+  geo.computeBoundingBox();
+  geo.computeBoundingSphere();
+  const group = new THREE.Group();
+  group.add(new THREE.Mesh(geo, materialFrom(mesh, keep === 'front' ? 0xb66b35 : 0xc48a35, maps)));
+  normalizeToLength(group, size);
+  return group;
+}
+
+function findAmmoCarrier(root: THREE.Object3D) {
+  const modelBox = getRenderableBounds(root);
+  if (!modelBox) return null;
+  const diag = modelBox.getSize(new THREE.Vector3()).length() || 1;
+  const modelCenter = modelBox.getCenter(new THREE.Vector3());
+  const candidates: { child: THREE.Mesh; score: number }[] = [];
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!(mesh as any).isMesh && !(mesh as any).isSkinnedMesh || !child.visible)
+      return;
+    const label = labelOf(child);
+    if (/magazine|\bmag\b|slide|grip|trigger|barrel|frame|receiver|sight|rail|screw|bolt/.test(label))
+      return;
+    const box = new THREE.Box3().setFromObject(child);
+    const size = box.getSize(new THREE.Vector3());
+    const center = box.getCenter(new THREE.Vector3());
+    const sorted = [size.x, size.y, size.z].sort((a, b) => a - b);
+    const rel = sorted[2] / diag;
+    if (rel > 0.38 || rel < 0.018) return;
+    const longRatio = sorted[2] / Math.max(sorted[0], 0.0001);
+    const score =
+      scoreLabel(label, ['cartridge', 'round', 'ammo', 'bullet', 'shell', 'casing', 'case', 'brass', 'projectile']) +
+      Math.min(longRatio, 8) * 2.2 +
+      (center.distanceTo(modelCenter) / diag) * 12;
+    candidates.push({ child: mesh, score });
+  });
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates[0]?.child ?? null;
+}
+
+function addRoundedRearCap(
+  root: THREE.Object3D,
+  maps: ServicePistolTextureMaps | null = null
+) {
+  root.updateMatrixWorld(true);
+  const box = getRenderableBounds(root);
+  if (!box) return;
+  const size = box.getSize(new THREE.Vector3());
+  const radius = Math.max(size.x, size.y) * 0.36;
+  const mat = new THREE.MeshStandardMaterial({
+    color: 0x59616a,
+    roughness: 0.36,
+    metalness: 0.78
+  });
+  applyServicePistolMaps(mat, maps);
+  const base = new THREE.Mesh(new THREE.CylinderGeometry(radius * 0.82, radius * 0.72, radius * 0.32, 44), mat.clone());
+  base.rotation.x = Math.PI / 2;
+  base.position.z = box.max.z - radius * 0.48;
+  const dome = new THREE.Mesh(new THREE.SphereGeometry(radius, 48, 28), mat);
+  dome.scale.set(1, 1, 0.58);
+  dome.position.z = box.max.z - radius * 0.28;
+  root.add(base, dome);
+  centerRoot(root);
+}
+
+function makeFallbackBulletHead(maps: ServicePistolTextureMaps | null = null) {
+  const mat = materialFrom(null, 0xb66b35, maps);
+  const group = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.03, 0.06, 48), mat);
+  body.rotation.x = Math.PI / 2;
+  body.position.z = 0.012;
+  const tip = new THREE.Mesh(new THREE.ConeGeometry(0.03, 0.06, 48), mat.clone());
+  tip.rotation.x = -Math.PI / 2;
+  tip.position.z = -0.048;
+  group.add(body, tip);
+  addRoundedRearCap(group, maps);
+  return group;
+}
+
+function makeBulletHead(
+  source: THREE.Object3D | null,
+  maps: ServicePistolTextureMaps | null = null
+) {
+  if (!source) return makeFallbackBulletHead(maps);
+  const group = new THREE.Group();
+  group.add(cloneRenderable(source));
+  applyServicePistolMapsToObject(group, maps);
+  centerRoot(group);
+  group.updateMatrixWorld(true);
+  const size = new THREE.Box3().setFromObject(group).getSize(new THREE.Vector3());
+  const axis = size.x >= size.y && size.x >= size.z ? 'x' : size.y >= size.z ? 'y' : 'z';
+  if (axis === 'x') group.rotation.y = -Math.PI / 2;
+  if (axis === 'y') group.rotation.x = Math.PI / 2;
+  // Keep the extracted GLB projectile nose on local -Z so alignToDirection()
+  // launches it tip-first instead of flipping it backwards.
+  centerRoot(group);
+  normalizeToLength(group, 0.135);
+  addRoundedRearCap(group, maps);
+  return group;
+}
+
+function makeShell(
+  source: THREE.Mesh | null,
+  maps: ServicePistolTextureMaps | null = null
+) {
+  const split = splitMesh(source, 'back', 0.22, maps);
+  if (split) return split;
+  const group = new THREE.Group();
+  const mat = materialFrom(source, 0xc9953d, maps);
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.062, 0.074, 0.28, 48), mat);
+  body.rotation.x = Math.PI / 2;
+  const rim = new THREE.Mesh(new THREE.CylinderGeometry(0.082, 0.082, 0.03, 48), mat.clone());
+  rim.rotation.x = Math.PI / 2;
+  rim.position.z = 0.155;
+  const primer = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.035, 0.035, 0.008, 32),
+    new THREE.MeshStandardMaterial({ color: 0x1c1711, roughness: 0.65, metalness: 0.18 })
+  );
+  primer.rotation.x = Math.PI / 2;
+  primer.position.z = -0.146;
+  group.add(body, rim, primer);
+  return group;
+}
+
+function extractServicePistolAmmo(
+  root: THREE.Object3D,
+  maps: ServicePistolTextureMaps | null = null
+): AmmoTemplates {
+  const explicitBullet = bestMesh(
+    root,
+    ['bullet_head', 'bullet head', 'projectile', 'bullet', 'round'],
+    ['shell', 'casing', 'case', 'magazine', 'mag', 'slide', 'grip', 'barrel', 'trigger']
+  );
+  const explicitShell = bestMesh(
+    root,
+    ['shell', 'casing', 'case', 'brass'],
+    ['bullet_head', 'bullet head', 'projectile', 'magazine', 'mag', 'slide', 'grip', 'barrel', 'trigger']
+  );
+
+  if (explicitBullet && explicitShell) {
+    return {
+      bullet: makeBulletHead(explicitBullet, maps),
+      shell: makeShell(explicitShell, maps),
+      source: 'service pistol GLB bullet head + shell'
+    };
+  }
+
+  const carrier = findAmmoCarrier(root);
+  if (carrier) {
+    const splitBullet = splitMesh(carrier, 'front', 0.135, maps);
+    return {
+      bullet: makeBulletHead(splitBullet || carrier, maps),
+      shell: makeShell(carrier, maps),
+      source: 'service pistol GLB split cartridge'
+    };
+  }
+
+  return {
+    bullet: makeFallbackBulletHead(maps),
+    shell: makeShell(null, maps),
+    source: 'fallback 9mm cartridge'
+  };
+}
+
+function createFallbackAmmoTemplates(
+  maps: ServicePistolTextureMaps | null = null
+): AmmoTemplates {
+  return {
+    bullet: makeFallbackBulletHead(maps),
+    shell: makeShell(null, maps),
+    source: 'fallback 9mm cartridge'
+  };
+}
+
+function alignToDirection(object: THREE.Object3D, dir: THREE.Vector3) {
+  object.quaternion.setFromUnitVectors(
+    new THREE.Vector3(0, 0, -1),
+    dir.clone().normalize()
+  );
+}
+
+function makeWake() {
+  const group = new THREE.Group();
+  const cone = new THREE.Mesh(
+    new THREE.ConeGeometry(0.15, 0.62, 48, 1, true),
+    new THREE.MeshBasicMaterial({
+      color: 0xbff5ff,
+      transparent: true,
+      opacity: 0.1,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide
+    })
+  );
+  cone.rotation.x = Math.PI / 2;
+  cone.position.z = 0.34;
+  group.add(cone);
+
+  for (let strand = 0; strand < 4; strand += 1) {
+    const points: THREE.Vector3[] = [];
+    const phase = (strand / 4) * Math.PI * 2;
+    for (let i = 0; i < 32; i += 1) {
+      const t = i / 31;
+      const radius = 0.024 + t * 0.09;
+      const angle = phase + t * Math.PI * 4.4;
+      points.push(new THREE.Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0.04 + t * 0.62));
+    }
+    group.add(
+      new THREE.Line(
+        new THREE.BufferGeometry().setFromPoints(points),
+        new THREE.LineBasicMaterial({
+          color: 0xe8fcff,
+          transparent: true,
+          opacity: 0.22,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending
+        })
+      )
+    );
+  }
+
+  for (let i = 0; i < 2; i += 1) {
+    const shock = new THREE.Mesh(
+      new THREE.TorusGeometry(0.105 + i * 0.085, 0.0035, 8, 56),
+      new THREE.MeshBasicMaterial({
+        color: 0xd7fbff,
+        transparent: true,
+        opacity: 0.11,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+        side: THREE.DoubleSide
+      })
+    );
+    shock.rotation.x = Math.PI / 2;
+    shock.position.z = 0.14 + i * 0.16;
+    group.add(shock);
+  }
+
+  group.visible = false;
+  return group;
 }
 
 function layWeaponFlatOnTable(root: THREE.Object3D) {
@@ -1056,8 +1567,9 @@ function updateLabelSprite(sprite: THREE.Sprite, text: string) {
     | undefined;
   const canvas = tex?.image as HTMLCanvasElement | undefined;
   if (!canvas) return;
+  const texture = tex;
   const ctx = canvas.getContext('2d');
-  if (!ctx) return;
+  if (!ctx || !texture) return;
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = 'rgba(0,0,0,.72)';
@@ -1070,7 +1582,7 @@ function updateLabelSprite(sprite: THREE.Sprite, text: string) {
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillText(text, 256, 80);
-  tex.needsUpdate = true;
+  texture.needsUpdate = true;
 }
 
 function createPaperTarget(
@@ -1174,56 +1686,86 @@ function createBullet(
   end: THREE.Vector3,
   cinematic: boolean,
   speed: number,
-  weapon: WeaponEntry
+  weapon: WeaponEntry,
+  ammoTemplates: AmmoTemplates
 ) {
-  const handgun =
-    weapon.weaponClass === 'pistol' || weapon.weaponClass === 'revolver';
-  const longGun =
-    weapon.weaponClass === 'rifle' || weapon.weaponClass === 'sniper';
+  const dir = end.clone().sub(start).normalize();
+  const right = new THREE.Vector3(1, 0, 0);
+  const inside = start.clone().addScaledVector(dir, -0.53);
+  const nineMm = isNineMmWeapon(weapon);
+  const longGun = usesRifleCinematic(weapon);
   const shotgun = weapon.weaponClass === 'shotgun';
-  const bulletGeometry = shotgun
-    ? new THREE.SphereGeometry(0.034, 10, 10)
-    : new THREE.CapsuleGeometry(
-        handgun ? 0.018 : longGun ? 0.015 : 0.016,
-        handgun ? 0.085 : longGun ? 0.13 : 0.1,
-        4,
-        10
-      );
-  const bullet = new THREE.Mesh(
-    bulletGeometry,
-    new THREE.MeshStandardMaterial({
-      color: handgun ? '#c9c2b8' : shotgun ? '#d9b56d' : '#e7d7a2',
-      roughness: handgun ? 0.24 : 0.32,
-      metalness: 0.86,
-      emissive: '#3b2508',
-      emissiveIntensity: cinematic ? 0.16 : 0.06
-    })
-  );
+  const root = new THREE.Group();
+  const spinGroup = new THREE.Group();
+
+  let visual: THREE.Object3D;
+  if (nineMm) {
+    visual = cloneRenderable(ammoTemplates.bullet);
+    visual.scale.multiplyScalar(cinematic ? 1.08 : 1);
+  } else {
+    const bulletGeometry = shotgun
+      ? new THREE.SphereGeometry(0.034, 10, 10)
+      : new THREE.CapsuleGeometry(longGun ? 0.015 : 0.016, longGun ? 0.13 : 0.1, 4, 10);
+    visual = new THREE.Mesh(
+      bulletGeometry,
+      new THREE.MeshStandardMaterial({
+        color: shotgun ? '#d9b56d' : '#e7d7a2',
+        roughness: 0.32,
+        metalness: 0.86,
+        emissive: '#3b2508',
+        emissiveIntensity: cinematic ? 0.16 : 0.06
+      })
+    );
+  }
+
+  spinGroup.add(visual);
+  root.add(spinGroup);
+  alignToDirection(root, dir);
+  root.position.copy(cinematic && nineMm ? inside : start);
+
   const length = Math.min(1.2, start.distanceTo(end));
   const trail = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.007, 0.007, length, 8),
+    new THREE.CylinderGeometry(nineMm ? 0.005 : 0.007, nineMm ? 0.005 : 0.007, length, 8),
     new THREE.MeshBasicMaterial({
-      color: '#ffb84d',
+      color: nineMm ? '#e8fcff' : '#ffb84d',
       transparent: true,
-      opacity: 0.58
+      opacity: nineMm ? 0.38 : 0.58,
+      depthWrite: false,
+      blending: nineMm ? THREE.AdditiveBlending : THREE.NormalBlending
     })
   );
-
-  bullet.position.copy(start);
-  bullet.lookAt(end);
-  bullet.rotateX(Math.PI / 2);
   trail.position.copy(start);
   trail.rotation.x = Math.PI / 2;
-  scene.add(bullet, trail);
+  const wake = nineMm || longGun ? makeWake() : null;
+  if (wake) {
+    wake.position.copy(root.position);
+    wake.quaternion.copy(root.quaternion);
+  }
+
+  scene.add(root, trail);
+  if (wake) scene.add(wake);
 
   return {
-    mesh: bullet,
+    root,
+    spinGroup,
     trail,
+    wake,
     start,
     end,
+    muzzle: start.clone(),
+    inside,
+    dir,
+    right,
+    pos: root.position.clone(),
     t: 0,
+    age: 0,
     speed,
-    cinematic
+    spin: 0,
+    cinematic,
+    launched: !(cinematic && nineMm),
+    prelaunch: nineMm ? PRELAUNCH : 0,
+    life: cinematic ? 4.2 : 1.2,
+    flightQuat: root.quaternion.clone()
   } as BulletRuntime;
 }
 
@@ -1231,35 +1773,54 @@ function createShell(
   scene: THREE.Scene,
   position: THREE.Vector3,
   power: number,
-  weapon: WeaponEntry
+  weapon: WeaponEntry,
+  ammoTemplates: AmmoTemplates,
+  dir = new THREE.Vector3(0, 0, -1),
+  right = new THREE.Vector3(1, 0, 0),
+  up = new THREE.Vector3(0, 1, 0),
+  cinematic = false
 ) {
-  const handgun =
-    weapon.weaponClass === 'pistol' || weapon.weaponClass === 'revolver';
-  const shotgun = weapon.weaponClass === 'shotgun';
-  const shellRadius = handgun ? 0.022 : shotgun ? 0.04 : 0.026;
-  const shellLength = handgun ? 0.115 : shotgun ? 0.22 : 0.145;
-  const mesh = new THREE.Mesh(
-    new THREE.CylinderGeometry(shellRadius, shellRadius, shellLength, 18),
-    new THREE.MeshStandardMaterial({
-      color: handgun ? '#b9822f' : shotgun ? '#8b1e24' : '#d0a044',
-      roughness: handgun ? 0.28 : 0.36,
-      metalness: shotgun ? 0.46 : 0.92
-    })
-  );
-  mesh.rotation.z = Math.PI / 2;
-  mesh.position.copy(position);
-  mesh.castShadow = true;
-  scene.add(mesh);
+  const nineMm = isNineMmWeapon(weapon);
+  let root: THREE.Object3D;
+  if (nineMm) {
+    root = cloneRenderable(ammoTemplates.shell);
+    root.scale.multiplyScalar(cinematic ? 3 : 2.2);
+  } else {
+    const shotgun = weapon.weaponClass === 'shotgun';
+    const shellRadius = shotgun ? 0.04 : 0.026;
+    const shellLength = shotgun ? 0.22 : 0.145;
+    root = new THREE.Mesh(
+      new THREE.CylinderGeometry(shellRadius, shellRadius, shellLength, 18),
+      new THREE.MeshStandardMaterial({
+        color: shotgun ? '#8b1e24' : '#d0a044',
+        roughness: shotgun ? 0.36 : 0.34,
+        metalness: shotgun ? 0.46 : 0.92
+      })
+    );
+    root.rotation.z = Math.PI / 2;
+  }
+
+  const shellStart = position.clone().addScaledVector(right, -0.1).addScaledVector(up, -0.01).addScaledVector(dir, 0.02);
+  const shellOut = position.clone().addScaledVector(right, 0.5 * power).addScaledVector(up, 0.22 * power).addScaledVector(dir, 0.08);
+  root.position.copy(cinematic && nineMm ? shellStart : shellOut);
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (mesh.isMesh) mesh.castShadow = true;
+  });
+  scene.add(root);
 
   return {
-    mesh,
-    vel: new THREE.Vector3(0.72 * power, 0.45 * power, 0.16),
-    spin: new THREE.Vector3(
-      Math.random() * 7,
-      Math.random() * 12,
-      Math.random() * 8
-    ),
-    life: 2.4
+    root,
+    pos: root.position.clone(),
+    start: shellStart,
+    end: shellOut,
+    vel: right.clone().multiplyScalar(1.25 * power).add(up.clone().multiplyScalar(0.82 * power)).add(dir.clone().multiplyScalar(0.12)),
+    spin: new THREE.Vector3(4 + Math.random() * 2, 6 + Math.random() * 2, 4 + Math.random() * 2),
+    life: nineMm ? 7.5 : 2.4,
+    age: 0,
+    launched: !(cinematic && nineMm),
+    grounded: false,
+    pre: nineMm ? 0.18 : 0
   } as ShellRuntime;
 }
 
@@ -1409,6 +1970,7 @@ export default function ShootingRange() {
   const bulletsRef = useRef<BulletRuntime[]>([]);
   const shellsRef = useRef<ShellRuntime[]>([]);
   const weaponSourcesRef = useRef<(THREE.Object3D | null)[]>([]);
+  const ammoTemplatesRef = useRef<AmmoTemplates | null>(null);
   const tableWeaponsRef = useRef<TableWeaponRuntime[]>([]);
   const pickTargetsRef = useRef<THREE.Object3D[]>([]);
 
@@ -1482,6 +2044,8 @@ export default function ShootingRange() {
     let pickInterval: number | null = null;
     const rangeConfig = RANGE_DISTANCE_CONFIG[queryConfig.distance];
     const activeTargetZ = rangeConfig.targetZ;
+
+    ammoTemplatesRef.current = createFallbackAmmoTemplates();
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color('#111827');
@@ -1649,7 +2213,7 @@ export default function ShootingRange() {
         lookAt: new THREE.Vector3(3.9, 1.65, activeTargetZ + 1.7)
       }
     ];
-    const securityCameras = securityCameraAnchors.map(({ position, lookAt }) => {
+    const securityCameras: { root: THREE.Object3D; position: THREE.Vector3; lookAt: THREE.Vector3 }[] = securityCameraAnchors.map(({ position, lookAt }) => {
       const cameraObject = createFallbackSecurityCamera();
       cameraObject.position.copy(position);
       cameraObject.lookAt(lookAt);
@@ -1910,13 +2474,21 @@ export default function ShootingRange() {
         disposeObject(lane.heldWeapon);
       }
 
-      const held = cloneScene(source);
+      const entry = WEAPONS[weaponIndex];
+      const nineMm = isNineMmWeapon(entry);
+      const held = cloneRenderable(source);
       configureModel(held, renderer);
-      normalizeToLength(held, 1.14);
-      orientWeaponForward(held);
-      held.position.set(-0.03, -0.02, -0.2);
-      held.rotation.x += -0.05;
-      held.rotation.z += 0.02;
+      normalizeToLength(held, nineMm ? 1.95 : 1.14);
+      if (nineMm) {
+        orientWeaponForward(held);
+        held.rotation.y += Math.PI / 2;
+        held.position.set(0, -0.12, -0.02);
+      } else {
+        orientWeaponForward(held);
+        held.position.set(-0.03, -0.02, -0.2);
+        held.rotation.x += -0.05;
+        held.rotation.z += 0.02;
+      }
 
       lane.weaponMount.add(held);
       lane.heldWeapon = held;
@@ -1924,11 +2496,11 @@ export default function ShootingRange() {
       lane.pickupLift = lift ? 1 : 0;
 
       const muzzle = new THREE.Object3D();
-      muzzle.position.set(0.02, 0.02, -0.95);
+      muzzle.position.copy(nineMm ? SERVICE_PISTOL_AIM.muzzle : new THREE.Vector3(0.02, 0.02, -0.95));
       held.add(muzzle);
 
       const shellPort = new THREE.Object3D();
-      shellPort.position.set(0.12, 0.03, -0.42);
+      shellPort.position.copy(nineMm ? SERVICE_PISTOL_AIM.shellPort : new THREE.Vector3(0.12, 0.03, -0.42));
       held.add(shellPort);
 
       lane.muzzle = muzzle;
@@ -2037,9 +2609,19 @@ export default function ShootingRange() {
         pickTargetsRef.current.push(group);
 
         void loadGLTF(entry.name, entry.urls)
-          .then((gltf) => {
+          .then(async (gltf) => {
             if (disposed) return;
             configureModel(gltf.scene, renderer);
+            let servicePistolMaps: ServicePistolTextureMaps | null = null;
+            if (entry.id === 'service-pistol') {
+              servicePistolMaps = await loadServicePistolTextureMaps().catch((error) => {
+                console.warn('Service pistol texture set failed, using model materials:', error);
+                return null;
+              });
+              if (disposed) return;
+              ammoTemplatesRef.current = extractServicePistolAmmo(gltf.scene, servicePistolMaps);
+              applyServicePistolMapsToObject(gltf.scene, servicePistolMaps);
+            }
             weaponSourcesRef.current[index] = gltf.scene;
 
             const tableWeapon = tableWeaponsRef.current.find(
@@ -2363,7 +2945,7 @@ export default function ShootingRange() {
 
       if (!isAI) {
         recoilRef.current = stats.recoil;
-        followUntilRef.current = performance.now() + 500;
+        followUntilRef.current = performance.now() + (isNineMmWeapon(weapon) ? 4200 : usesRifleCinematic(weapon) ? 2300 : 500);
       }
 
       playShot(Math.max(0.6, stats.recoil));
@@ -2374,8 +2956,24 @@ export default function ShootingRange() {
 
       const shellPos = new THREE.Vector3();
       lane.shellPort.getWorldPosition(shellPos);
+      const weaponQuat = lane.muzzle.getWorldQuaternion(new THREE.Quaternion());
+      const muzzleDir = new THREE.Vector3(0, 0, -1).applyQuaternion(weaponQuat).normalize();
+      const weaponRight = new THREE.Vector3(1, 0, 0).applyQuaternion(weaponQuat).normalize();
+      const weaponUp = new THREE.Vector3(0, 1, 0).applyQuaternion(weaponQuat).normalize();
+      const ammoTemplates = ammoTemplatesRef.current ?? createFallbackAmmoTemplates();
+      const shotCinematic = !isAI && (isNineMmWeapon(weapon) || usesRifleCinematic(weapon));
       shellsRef.current.push(
-        createShell(scene, shellPos, stats.shellPower, weapon)
+        createShell(
+          scene,
+          shellPos,
+          stats.shellPower,
+          weapon,
+          ammoTemplates,
+          muzzleDir,
+          weaponRight,
+          weaponUp,
+          shotCinematic
+        )
       );
 
       let bestPoints = 0;
@@ -2386,7 +2984,7 @@ export default function ShootingRange() {
         const result = isAI
           ? resolveShotForLane(laneIndex, stats.spread * 1.08, lane.aiAim)
           : resolveUserShotFromCrosshair(laneIndex);
-        const cinematic = !isAI && i === 0;
+        const cinematic = shotCinematic && i === 0;
         bulletsRef.current.push(
           createBullet(
             scene,
@@ -2394,7 +2992,8 @@ export default function ShootingRange() {
             result.point.clone(),
             cinematic,
             stats.bulletSpeed,
-            weapon
+            weapon,
+            ammoTemplates
           )
         );
 
@@ -2600,20 +3199,47 @@ export default function ShootingRange() {
     function updateBullets(dt: number) {
       for (let i = bulletsRef.current.length - 1; i >= 0; i -= 1) {
         const bullet = bulletsRef.current[i];
-        bullet.t += dt * bullet.speed;
-        const p = THREE.MathUtils.smoothstep(Math.min(1, bullet.t), 0, 1);
-        bullet.mesh.position.lerpVectors(bullet.start, bullet.end, p);
-        bullet.trail.position
-          .copy(bullet.mesh.position)
-          .lerp(bullet.start, 0.15);
-        bullet.trail.lookAt(bullet.end);
+        bullet.age += dt;
 
-        if (bullet.t >= 1) {
-          scene.remove(bullet.mesh, bullet.trail);
-          bullet.mesh.geometry.dispose();
-          (bullet.mesh.material as THREE.Material).dispose();
-          bullet.trail.geometry.dispose();
-          (bullet.trail.material as THREE.Material).dispose();
+        if (bullet.cinematic && bullet.prelaunch > 0 && !bullet.launched) {
+          const p = THREE.MathUtils.smoothstep(
+            Math.min(1, bullet.age / bullet.prelaunch),
+            0,
+            1
+          );
+          bullet.pos.copy(bullet.inside).lerp(bullet.muzzle, p);
+          if (bullet.age >= bullet.prelaunch) {
+            bullet.launched = true;
+            bullet.pos.copy(bullet.muzzle);
+            bullet.t = 0;
+          }
+        } else {
+          bullet.t += dt * bullet.speed;
+          const p = THREE.MathUtils.smoothstep(Math.min(1, bullet.t), 0, 1);
+          bullet.pos.lerpVectors(bullet.muzzle, bullet.end, p);
+        }
+
+        bullet.root.position.copy(bullet.pos);
+        bullet.root.quaternion.copy(bullet.flightQuat);
+        bullet.spin += BULLET_SPIN * dt;
+        bullet.spinGroup.rotation.set(0, 0, bullet.spin);
+
+        bullet.trail.position.copy(bullet.pos).lerp(bullet.muzzle, 0.15);
+        bullet.trail.lookAt(bullet.end);
+        bullet.trail.visible = bullet.launched;
+
+        if (bullet.wake) {
+          bullet.wake.visible = bullet.launched;
+          bullet.wake.position.copy(bullet.pos);
+          bullet.wake.quaternion.copy(bullet.flightQuat);
+        }
+
+        if (bullet.t >= 1 || bullet.age >= bullet.life) {
+          scene.remove(bullet.root, bullet.trail);
+          if (bullet.wake) scene.remove(bullet.wake);
+          disposeObject(bullet.root);
+          disposeObject(bullet.trail);
+          if (bullet.wake) disposeObject(bullet.wake);
           bulletsRef.current.splice(i, 1);
         }
       }
@@ -2622,17 +3248,37 @@ export default function ShootingRange() {
     function updateShells(dt: number) {
       for (let i = shellsRef.current.length - 1; i >= 0; i -= 1) {
         const shell = shellsRef.current[i];
+        shell.age += dt;
         shell.life -= dt;
-        shell.vel.y -= dt * 1.8;
-        shell.mesh.position.addScaledVector(shell.vel, dt);
-        shell.mesh.rotation.x += shell.spin.x * dt;
-        shell.mesh.rotation.y += shell.spin.y * dt;
-        shell.mesh.rotation.z += shell.spin.z * dt;
+
+        if (!shell.launched) {
+          shell.pos.copy(shell.start).lerp(
+            shell.end,
+            THREE.MathUtils.smoothstep(Math.min(1, shell.age / shell.pre), 0, 1)
+          );
+          if (shell.age >= shell.pre) shell.launched = true;
+        } else if (!shell.grounded) {
+          shell.vel.y -= dt * 2.8;
+          shell.pos.addScaledVector(shell.vel, dt);
+          if (shell.pos.y < 0.08) {
+            shell.pos.y = 0.08;
+            shell.vel.y *= -0.18;
+            shell.vel.x *= 0.82;
+            shell.vel.z *= 0.82;
+            if (Math.abs(shell.vel.y) < 0.08) shell.grounded = true;
+          }
+        } else {
+          shell.vel.multiplyScalar(Math.exp(-1.2 * dt));
+        }
+
+        shell.root.position.copy(shell.pos);
+        shell.root.rotation.x += shell.spin.x * dt;
+        shell.root.rotation.y += shell.spin.y * dt;
+        shell.root.rotation.z += shell.spin.z * dt;
 
         if (shell.life <= 0) {
-          scene.remove(shell.mesh);
-          shell.mesh.geometry.dispose();
-          (shell.mesh.material as THREE.Material).dispose();
+          scene.remove(shell.root);
+          disposeObject(shell.root);
           shellsRef.current.splice(i, 1);
         }
       }
@@ -2646,37 +3292,41 @@ export default function ShootingRange() {
         const isUser = lane.controller === 'USER';
         const aim = isUser ? aimRef.current : lane.aiAim;
         const recoil = isUser ? recoilRef.current : 0;
+        const weapon = WEAPONS[lane.activeWeaponIndex];
+        const nineMm = isNineMmWeapon(weapon);
+        const kick = Math.sin(Math.max(0, Math.min(1, recoil)) * Math.PI) * (nineMm ? 0.09 : recoil);
+        const baseMount = nineMm ? SERVICE_PISTOL_AIM.mount : new THREE.Vector3(0.34, 1.27, -0.12);
 
         lane.weaponMount.position.x = THREE.MathUtils.lerp(
           lane.weaponMount.position.x,
-          0.34 + aim.x * 0.1,
-          0.16
+          baseMount.x + aim.x * (nineMm ? 0.04 : 0.1),
+          nineMm ? 0.22 : 0.16
         );
         lane.weaponMount.position.y = THREE.MathUtils.lerp(
           lane.weaponMount.position.y,
-          1.27 + lane.pickupLift * 0.18 + aim.y * 0.06 - recoil * 0.05,
-          0.16
+          baseMount.y + lane.pickupLift * 0.18 + aim.y * (nineMm ? 0.03 : 0.06) - kick * (nineMm ? 0.09 : 0.05),
+          nineMm ? 0.22 : 0.16
         );
         lane.weaponMount.position.z = THREE.MathUtils.lerp(
           lane.weaponMount.position.z,
-          -0.12 + recoil * 0.18,
-          0.16
+          baseMount.z + kick * (nineMm ? 0.045 : 0.18),
+          nineMm ? 0.22 : 0.16
         );
 
         lane.weaponMount.rotation.x = THREE.MathUtils.lerp(
           lane.weaponMount.rotation.x,
-          0.02 - recoil * 0.2 + aim.y * 0.05,
-          0.16
+          (nineMm ? -0.02 : 0.02) - kick * (nineMm ? 0.44 : 0.2) + aim.y * 0.05,
+          nineMm ? 0.22 : 0.16
         );
         lane.weaponMount.rotation.y = THREE.MathUtils.lerp(
           lane.weaponMount.rotation.y,
-          -0.03 - aim.x * 0.08,
-          0.16
+          (nineMm ? 0.01 : -0.03) - aim.x * 0.08 + kick * (nineMm ? 0.08 : 0),
+          nineMm ? 0.22 : 0.16
         );
         lane.weaponMount.rotation.z = THREE.MathUtils.lerp(
           lane.weaponMount.rotation.z,
-          0.1 + aim.x * 0.05,
-          0.16
+          (nineMm ? 0.005 : 0.1) + aim.x * 0.05 + kick * (nineMm ? 0.12 : 0),
+          nineMm ? 0.22 : 0.16
         );
       });
 
@@ -2793,11 +3443,23 @@ export default function ShootingRange() {
           .clone()
           .sub(cinematicBullet.start)
           .normalize();
-        tempPos
-          .copy(cinematicBullet.mesh.position)
-          .addScaledVector(dir, -0.7)
-          .add(new THREE.Vector3(0.18, 0.14, 0.28));
-        tempLook.copy(cinematicBullet.mesh.position).addScaledVector(dir, 0.9);
+        if (!cinematicBullet.launched && cinematicBullet.prelaunch > 0) {
+          tempPos
+            .copy(cinematicBullet.muzzle)
+            .addScaledVector(dir, -1.3)
+            .addScaledVector(cinematicBullet.right, 0.52)
+            .add(new THREE.Vector3(0, 0.52, 0));
+          tempLook
+            .copy(cinematicBullet.muzzle)
+            .addScaledVector(dir, 0.46)
+            .addScaledVector(cinematicBullet.right, 0.15);
+        } else {
+          tempPos
+            .copy(cinematicBullet.root.position)
+            .addScaledVector(dir, -0.7)
+            .add(new THREE.Vector3(0.18, 0.14, 0.28));
+          tempLook.copy(cinematicBullet.root.position).addScaledVector(dir, 0.9);
+        }
         camera.position.lerp(tempPos, 0.22);
         camera.lookAt(tempLook);
         return;
@@ -2827,6 +3489,7 @@ export default function ShootingRange() {
     const clock = new THREE.Clock();
 
     function resize() {
+      if (!mount) return;
       const w = Math.max(1, mount.clientWidth);
       const h = Math.max(1, mount.clientHeight);
       camera.aspect = w / h;


### PR DESCRIPTION
### Motivation
- Improve realism for 9mm/classic pistols by extracting or synthesizing bullet and shell models from weapon GLTFs and by loading high-quality pistol texture maps.
- Add cinematic muzzle-to-target launch sequences, spinning projectile visuals, and wake effects for selected weapons to enhance firing presentation. 
- Provide robust fallbacks so weapons without explicit ammo parts still spawn plausible bullets and shells.

### Description
- Introduce new runtime types and templates: `AmmoTemplates`, `ServicePistolTextureMaps`, extended `BulletRuntime` and `ShellRuntime` fields, and constants for prelaunch and spin behavior. 
- Add texture helpers `loadTextureAny` and `loadServicePistolTextureMaps` plus functions `applyServicePistolMaps`, `applyServicePistolMapsToObject`, and `servicePistolTexture` URL helpers to fetch and apply multiple resolution maps for the service pistol. 
- Implement ammo extraction and creation utilities: `extractServicePistolAmmo`, `createFallbackAmmoTemplates`, `makeBulletHead`, `makeFallbackBulletHead`, `makeShell`, `splitMesh`, `findAmmoCarrier`, and related mesh/material helpers to find or synthesize bullet and shell visuals. 
- Update `createBullet` and `createShell` to accept `ammoTemplates`, build hierarchical `root`/`spinGroup`/`wake` objects for bullets, support cinematic prelaunch, lifetime, spin, wake visuals, and improved trail materials for 9mm; shells now support staged launch, physics, grounding and longer lifetime for 9mm. 
- Persist `ammoTemplatesRef` and, when loading the service pistol GLTF, extract ammo templates and apply custom maps to the model; fall back to synthesized templates when unavailable. 
- Adjust held-weapon layout for 9mm weapons (`normalizeToLength`, `orientWeaponForward`, positioning) and tweak character mount offsets, recoil/kick calculations, and camera follow behavior to accommodate cinematic bullets (prelaunch and follow framing). 
- Add utility functions `cloneRenderable`, `alignToDirection`, `makeWake`, `addRoundedRearCap`, `materialFrom`, and `bestMesh` to support the above features and ensure proper material propagation and UV handling.

### Testing
- Ran TypeScript type-check (`yarn tsc`) against the modified files with no type errors. 
- Performed a production build (`yarn build`) to ensure bundling succeeded with the new assets and code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b8a0a9808329923620a8e0e239c8)