### PR TITLE
Use ReadyPlayer demo human for cue poses; add shared demo human loader and refactor human rigs

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8,6 +8,7 @@ import React, {
   useState
 } from 'react';
 import * as THREE from 'three';
+import { DEMO_HUMAN_URL } from './shared/demoCueHumanSource.js';
 import polygonClipping from 'polygon-clipping';
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -36,7 +37,6 @@ import {
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
 import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
-import { MURLAN_CHARACTER_THEMES } from '../../config/murlanCharacterThemes.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { chatBeep } from '../../assets/coreSoundData.js';
 import {
@@ -1948,16 +1948,13 @@ const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 9.6; // let full-power hops peak 
 const CUE_BUTT_LIFT = BALL_R * 0.18; // flatter table-level cue orientation so the stick stays visible on the cloth
 const CUE_BUTT_CUSHION_CLEARANCE = BALL_R * 0.38; // keep extra vertical headroom so cue helpers clear cushion lips more reliably
 const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.35; // raise cue helper path a bit more to avoid cushion/ball clipping on tight angles
-const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
+const CUE_LENGTH_MULTIPLIER = 1.78 / 1.5; // demo cue length: CFG.cueLength (1.78 * scale) mapped onto the full-game cue mesh
 
-const POOL_HUMAN_CHARACTER_THEME =
-  MURLAN_CHARACTER_THEMES.find((theme) => theme.id === 'rpm-current') ||
-  MURLAN_CHARACTER_THEMES[0];
+const POOL_HUMAN_URL = DEMO_HUMAN_URL;
 const POOL_HUMAN_UP = new THREE.Vector3(0, 1, 0);
 const POOL_HUMAN_Y_AXIS = POOL_HUMAN_UP;
-const POOL_HUMAN_SIZE_MULTIPLIER = 1.08; // same Snooker Royal avatar, scaled only slightly larger for Pool Royale
-const POOL_HUMAN_WORLD_SCALE = (BALL_R / 0.0525) * POOL_HUMAN_SIZE_MULTIPLIER;
-const POOL_HUMAN_CUE_REFERENCE_LENGTH = 1.5 * CUE_LENGTH_MULTIPLIER * POOL_HUMAN_WORLD_SCALE;
+const POOL_HUMAN_WORLD_SCALE = BALL_R / 0.0525;
+const POOL_HUMAN_CUE_REFERENCE_LENGTH = 1.78 * POOL_HUMAN_WORLD_SCALE;
 const POOL_HUMAN_TARGET_HEIGHT = POOL_HUMAN_CUE_REFERENCE_LENGTH * 1.2;
 const POOL_HUMAN_CFG = Object.freeze({
   scale: POOL_HUMAN_WORLD_SCALE,
@@ -1978,9 +1975,9 @@ const POOL_HUMAN_CFG = Object.freeze({
   poseLambda: 9,
   moveLambda: 5.6,
   rotLambda: 8.5,
-  humanScale: 1.26 * POOL_HUMAN_WORLD_SCALE,
+  humanScale: POOL_HUMAN_TARGET_HEIGHT,
   shotPoseAmount: 1.0,
-  humanVisualYawFix: 0,
+  humanVisualYawFix: Math.PI,
   stanceWidth: 0.52 * POOL_HUMAN_WORLD_SCALE,
   bridgePalmTableLift: BALL_R * 0.12,
   bridgeCueLift: BALL_R * 0.34,
@@ -2097,19 +2094,18 @@ function collectPoolHumanFingerBones(hand) {
 }
 
 function normalizePoolHumanModel(model, targetHeight = POOL_HUMAN_CFG.targetHeight) {
+  model.rotation.set(0, POOL_HUMAN_CFG.humanVisualYawFix, 0);
+  model.position.set(0, 0, 0);
   model.updateMatrixWorld(true);
   const box = new THREE.Box3().setFromObject(model);
-  const size = box.getSize(new THREE.Vector3());
-  const height = Math.max(size.y, 1e-4);
-  const scale = targetHeight / height;
-  model.scale.multiplyScalar(scale);
+  const height = Math.max(box.max.y - box.min.y, 0.0001);
+  model.scale.multiplyScalar(targetHeight / height);
   model.updateMatrixWorld(true);
   const scaledBox = new THREE.Box3().setFromObject(model);
   const center = scaledBox.getCenter(new THREE.Vector3());
-  model.position.sub(center);
-  model.position.y -= scaledBox.min.y - center.y;
-  model.rotation.y += POOL_HUMAN_CFG.humanVisualYawFix;
+  model.position.set(-center.x, -scaledBox.min.y, -center.z);
 }
+
 
 function createPoolHumanGLTFLoader(renderer = null) {
   const loader = new GLTFLoader();
@@ -2158,20 +2154,10 @@ function loadPoolHumanModel(loader, url) {
   });
 }
 
-function buildPoolHumanModelUrls(theme = POOL_HUMAN_CHARACTER_THEME) {
-  const urls = [
-    ...(theme?.modelUrls || []),
-    theme?.url,
-    ...MURLAN_CHARACTER_THEMES.flatMap((entry) => [
-      ...(entry?.modelUrls || []),
-      entry?.url
-    ]),
-    'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
-    'https://threejs.org/examples/models/gltf/Xbot.glb',
-    'https://threejs.org/examples/models/gltf/Soldier.glb'
-  ].filter(Boolean);
-  return [...new Set(urls)];
+function buildPoolHumanModelUrls() {
+  return [POOL_HUMAN_URL];
 }
+
 
 async function loadPoolHumanModelFromCatalog(loader, urls = buildPoolHumanModelUrls()) {
   let lastError = null;
@@ -2207,8 +2193,7 @@ function createPoolRoyaleHumanRig(parent, renderer) {
     strikeRoot: new THREE.Vector3(),
     strikeYaw: 0,
     strikeClock: 0,
-    idleCuePose: null,
-    theme: POOL_HUMAN_CHARACTER_THEME
+    idleCuePose: null
   };
   human.root.name = 'PoolRoyalHumanPlayerRoot';
   human.modelRoot.name = 'PoolRoyalSnookerSharedCharacterRoot';
@@ -2216,10 +2201,9 @@ function createPoolRoyaleHumanRig(parent, renderer) {
   human.modelRoot.visible = false;
   parent.add(human.root, human.modelRoot);
   const loader = createPoolHumanGLTFLoader(renderer);
-  const urls = buildPoolHumanModelUrls(human.theme);
-  loadPoolHumanModelFromCatalog(loader, urls)
-    .then(({ model, url }) => {
-      human.modelUrl = url;
+  loadPoolHumanModel(loader, POOL_HUMAN_URL)
+    .then((model) => {
+      if (!model) throw new Error('ReadyPlayer demo human GLTF did not contain a scene');
       normalizePoolHumanModel(model);
       model.traverse((obj) => {
         if (!obj?.isMesh) return;
@@ -2229,7 +2213,7 @@ function createPoolRoyaleHumanRig(parent, renderer) {
         const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
         mats.forEach((mat) => {
           if (mat?.map) {
-            applySRGBColorSpace(mat.map);
+            mat.map.colorSpace = THREE.SRGBColorSpace;
             mat.map.flipY = false;
             mat.map.needsUpdate = true;
           }
@@ -2248,15 +2232,13 @@ function createPoolRoyaleHumanRig(parent, renderer) {
       });
       human.activeGlb = Boolean(
         human.bones.hips && human.bones.spine && human.bones.head &&
-        human.bones.rightUpperArm && human.bones.rightLowerArm && human.bones.rightHand &&
-        human.bones.leftUpperLeg && human.bones.leftLowerLeg && human.bones.leftFoot &&
-        human.bones.rightUpperLeg && human.bones.rightLowerLeg && human.bones.rightFoot
+        human.bones.rightUpperArm && human.bones.rightLowerArm && human.bones.rightHand
       );
       human.model = model;
       human.modelRoot.add(model);
       human.modelRoot.visible = human.activeGlb;
     })
-    .catch((error) => console.warn('Pool Royale shared Snooker human rig failed', error))
+    .catch((error) => console.warn('Pool Royale demo human GLTF failed', error))
     .finally(() => disposePoolHumanGLTFLoader(loader));
   return human;
 }
@@ -2613,15 +2595,18 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   drivePoolRoyaleHuman(human, { t, stroke: forearmStroke / POOL_HUMAN_CFG.scale, follow: strikeFollow, walkAmount, forward, side, up: POOL_HUMAN_UP, rootWorld, torsoCenterWorld: torso, chestCenterWorld: chest, neckWorld: neck, headCenterWorld: head, leftElbow, rightElbow: lockedRightElbow, leftHandWorld: leftHand, rightHandWorld: rightHand, leftKnee, rightKnee, leftFootWorld: leftFoot, rightFootWorld: rightFoot, cueBackWorld: cueBack, cueTipWorld: cueTip });
 }
 
-function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForward, cueStick, cueLen, power) {
+function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForward, cueStick, cueLen, power, table = null) {
   if (!human || !cueBallWorld) return null;
   const dir = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, 1));
+  const toHumanWorld = (point) => (table?.localToWorld ? table.localToWorld(point.clone()) : point.clone());
+  const cueBallLocal = cueBallWorld.clone();
+  const cueBallWorldPos = toHumanWorld(cueBallLocal);
   const tableCue = getPoolHumanCueEndpoints(cueStick, cueLen);
   const cueEndpoints = tableCue
-    ? { butt: tableCue.back, tip: tableCue.tip }
+    ? { butt: toHumanWorld(tableCue.back), tip: toHumanWorld(tableCue.tip) }
     : {
-        tip: cueBallWorld.clone().addScaledVector(dir, -CUE_TIP_GAP),
-        butt: cueBallWorld.clone().addScaledVector(dir, -(cueLen + CUE_TIP_GAP))
+        tip: cueBallWorldPos.clone().addScaledVector(dir, -CUE_TIP_GAP),
+        butt: cueBallWorldPos.clone().addScaledVector(dir, -(cueLen + CUE_TIP_GAP))
       };
   const cueShotDir = cueEndpoints.tip.clone().sub(cueEndpoints.butt);
   if (cueShotDir.lengthSq() > 1e-8) dir.copy(cueShotDir.normalize());
@@ -2634,7 +2619,7 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
   human.settleT = poolHumanDampScalar(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
   if (state === 'striking') {
     if (human.strikeClock === 0) {
-      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : choosePoolHumanEdgePosition(cueBallWorld, dir));
+      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : toHumanWorld(choosePoolHumanEdgePosition(cueBallLocal, dir)));
       human.strikeYaw = human.yaw;
     }
     human.strikeClock += dt;
@@ -2642,10 +2627,9 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
     human.strikeClock = 0;
   }
 
-  const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, dir)
+  const rootTarget = toHumanWorld(choosePoolHumanEdgePosition(cueBallLocal, dir))
     .addScaledVector(dir, state === 'dragging' ? -activePower * BALL_R * 1.8 : 0)
     .addScaledVector(side, -POOL_HUMAN_CFG.stanceWidth * 0.16);
-  rootTarget.y = POOL_HUMAN_CFG.floorLocalY;
   const rootGoal = state === 'striking' ? human.strikeRoot : rootTarget;
   poolHumanDampVector(human.root.position, rootGoal, state === 'striking' ? 12 : POOL_HUMAN_CFG.moveLambda, dt);
   const travel = human.root.position.distanceTo(rootGoal);
@@ -2682,7 +2666,7 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
   const rightHip = local(new THREE.Vector3(0.13 * POOL_HUMAN_CFG.scale, 0.92 * POOL_HUMAN_CFG.scale, 0.02 * POOL_HUMAN_CFG.scale));
   const leftFoot = local(new THREE.Vector3(-0.13 * POOL_HUMAN_CFG.scale, POOL_HUMAN_CFG.footGroundY, 0.03 * POOL_HUMAN_CFG.scale + walk * 0.018 * POOL_HUMAN_CFG.scale).lerp(new THREE.Vector3(-POOL_HUMAN_CFG.stanceWidth * 0.42, POOL_HUMAN_CFG.footGroundY, -0.34 * POOL_HUMAN_CFG.scale), t));
   const rightFoot = local(new THREE.Vector3(0.13 * POOL_HUMAN_CFG.scale, POOL_HUMAN_CFG.footGroundY, -0.03 * POOL_HUMAN_CFG.scale - walk * 0.018 * POOL_HUMAN_CFG.scale).lerp(new THREE.Vector3(POOL_HUMAN_CFG.stanceWidth * 0.5, POOL_HUMAN_CFG.footGroundY, 0.34 * POOL_HUMAN_CFG.scale), t));
-  const bridgePalmTarget = cueBallWorld.clone()
+  const bridgePalmTarget = cueBallWorldPos.clone()
     .addScaledVector(dir, -POOL_HUMAN_CFG.bridgeHandBackFromBall)
     .addScaledVector(side, POOL_HUMAN_CFG.bridgeHandSide)
     .setY(POOL_HUMAN_CFG.tableTopY + POOL_HUMAN_CFG.bridgePalmTableLift)
@@ -27275,7 +27259,7 @@ const shotPowerRef = useRef(0);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      const humanRig = createPoolRoyaleHumanRig(table, rendererRef.current);
+      const humanRig = createPoolRoyaleHumanRig(scene, rendererRef.current);
       const cueShadow = ENABLE_CUE_CLOTH_SHADOW
         ? (() => {
             const shadowWidth = Math.max(BALL_R * CUE_SHADOW_WIDTH_RATIO, BALL_R * 0.4);
@@ -33398,7 +33382,8 @@ const shotPowerRef = useRef(0);
           aimForwardForHuman,
           cueStick,
           cueLen,
-          THREE.MathUtils.clamp(powerRef.current ?? 0, 0, 1)
+          THREE.MathUtils.clamp(powerRef.current ?? 0, 0, 1),
+          table
         );
         if (humanShotState === 'idle' || humanShotState === 'rolling') {
           movePoolRoyaleCueToHumanHand(humanRig, cueStick);

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -6,8 +6,8 @@ import React, {
   useRef,
   useState
 } from 'react';
-import SnookerRoyalProvided from './SnookerRoyalProvided.jsx';
 import * as THREE from 'three';
+import { DEMO_HUMAN_URL } from './shared/demoCueHumanSource.js';
 import polygonClipping from 'polygon-clipping';
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -70,7 +70,6 @@ import {
   SNOOKER_ROYALE_OPTION_LABELS
 } from '../../config/snookerRoyalInventoryConfig.js';
 import { SNOOKER_ROYALE_CLOTH_VARIANTS } from '../../config/snookerRoyalClothPresets.js';
-import { MURLAN_CHARACTER_THEMES } from '../../config/murlanCharacterThemes.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 import {
   getCachedSnookerRoyalInventory,
@@ -1656,17 +1655,15 @@ const MAX_POWER_LIFT_HEIGHT = CUE_TIP_RADIUS * 9.6; // let full-power hops peak 
 const CUE_BUTT_LIFT = BALL_R * 0.52; // keep the butt elevated for clearance while keeping the tip level with the cue-ball centre
 const CUE_BUTT_CUSHION_CLEARANCE = BALL_R * 0.11; // keep the cue butt from dipping below the cushion top surface
 const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.06; // lift the cue slightly more as cushions rise so it never touches
-const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
+const CUE_LENGTH_MULTIPLIER = 1.78 / 1.5; // demo cue length: CFG.cueLength (1.78 * scale) mapped onto the full-game cue mesh
 
 
-const SNOOKER_HUMAN_CHARACTER_THEME =
-  MURLAN_CHARACTER_THEMES.find((theme) => theme.id === 'rpm-current') ||
-  MURLAN_CHARACTER_THEMES[0];
+const SNOOKER_HUMAN_URL = DEMO_HUMAN_URL;
 const SNOOKER_HUMAN_UP = new THREE.Vector3(0, 1, 0);
 const SNOOKER_HUMAN_FORWARD_LOCAL = new THREE.Vector3(0, 0, 1);
 const SNOOKER_HUMAN_BASIS_MAT = new THREE.Matrix4();
 const SNOOKER_HUMAN_WORLD_SCALE = BALL_R / 0.0525;
-const SNOOKER_HUMAN_CUE_BASE_LENGTH = 1.5 * CUE_LENGTH_MULTIPLIER * SNOOKER_HUMAN_WORLD_SCALE;
+const SNOOKER_HUMAN_CUE_BASE_LENGTH = 1.78 * SNOOKER_HUMAN_WORLD_SCALE;
 const SNOOKER_HUMAN_HEIGHT_TO_CUE_RATIO = 1.2;
 const SNOOKER_HUMAN_CFG = Object.freeze({
   targetHeight: SNOOKER_HUMAN_CUE_BASE_LENGTH * SNOOKER_HUMAN_HEIGHT_TO_CUE_RATIO,
@@ -1711,7 +1708,7 @@ const SNOOKER_HUMAN_CFG = Object.freeze({
   rightHandDownPose: 0.42,
   rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(SNOOKER_HUMAN_WORLD_SCALE),
   shootCueGripFromBack: 0.58 * SNOOKER_HUMAN_WORLD_SCALE,
-  yawFix: 0
+  yawFix: Math.PI
 });
 const cleanSnookerHumanBoneName = (name = '') => name.toLowerCase().replace(/[^a-z0-9]/g, '');
 const snookerHumanClamp01 = (value) => Math.max(0, Math.min(1, value));
@@ -1735,121 +1732,19 @@ function makeSnookerHumanSegment(radius, color, metalness = 0.02) {
   );
 }
 
-function createSnookerHumanFallbackRig() {
-  const rig = new THREE.Group();
-  rig.name = 'SnookerRoyalFallbackHumanPoseRig';
-  const skin = new THREE.MeshStandardMaterial({ color: 0xd9a27d, roughness: 0.68 });
-  const vest = new THREE.MeshStandardMaterial({ color: 0x111827, roughness: 0.64 });
-  const shirt = new THREE.MeshStandardMaterial({ color: 0xf8fafc, roughness: 0.7 });
-  const trouser = new THREE.MeshStandardMaterial({ color: 0x1f2937, roughness: 0.75 });
-  const shoe = new THREE.MeshStandardMaterial({ color: 0x050505, roughness: 0.6 });
-  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.135, 0.34, 5, 12), vest);
-  const chest = new THREE.Mesh(new THREE.CapsuleGeometry(0.105, 0.22, 5, 12), shirt);
-  const head = new THREE.Mesh(new THREE.SphereGeometry(0.078, 18, 14), skin);
-  const neck = makeSnookerHumanSegment(0.032, 0xd9a27d);
-  const leftHand = new THREE.Mesh(new THREE.SphereGeometry(0.036, 14, 10), skin);
-  const rightHand = new THREE.Mesh(new THREE.SphereGeometry(0.034, 14, 10), skin);
-  const leftFoot = new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.045, 0.25), shoe);
-  const rightFoot = leftFoot.clone();
-  const segments = {
-    leftUpperArm: makeSnookerHumanSegment(0.032, 0xf8fafc),
-    leftForearm: makeSnookerHumanSegment(0.027, 0xd9a27d),
-    rightUpperArm: makeSnookerHumanSegment(0.033, 0xf8fafc),
-    rightForearm: makeSnookerHumanSegment(0.027, 0xd9a27d),
-    leftThigh: makeSnookerHumanSegment(0.043, 0x1f2937),
-    leftShin: makeSnookerHumanSegment(0.036, 0x1f2937),
-    rightThigh: makeSnookerHumanSegment(0.043, 0x1f2937),
-    rightShin: makeSnookerHumanSegment(0.036, 0x1f2937)
-  };
-  rig.add(torso, chest, head, neck, leftHand, rightHand, leftFoot, rightFoot, ...Object.values(segments));
-  rig.userData.parts = { torso, chest, head, neck, leftHand, rightHand, leftFoot, rightFoot, ...segments };
-  rig.traverse((obj) => {
-    if (obj?.isMesh) {
-      obj.castShadow = true;
-      obj.receiveShadow = true;
-    }
-  });
-  return rig;
-}
-
-function collectSnookerHumanFingerBones(hand) {
-  const fingers = [];
-  hand?.traverse?.((obj) => {
-    if (!obj?.isBone || obj === hand) return;
-    const name = cleanSnookerHumanBoneName(obj.name);
-    if (['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((part) => name.includes(part))) {
-      fingers.push(obj);
-    }
-  });
-  return fingers;
-}
-
-function makeSnookerHumanBasisQuaternion(side, up, forward) {
-  SNOOKER_HUMAN_BASIS_MAT.makeBasis(
-    side.clone().normalize(),
-    up.clone().normalize(),
-    forward.clone().normalize()
-  );
-  return new THREE.Quaternion().setFromRotationMatrix(SNOOKER_HUMAN_BASIS_MAT);
-}
-
-function placeSnookerHumanSegment(segment, a, b) {
-  if (!segment || !a || !b) return;
-  const mid = a.clone().add(b).multiplyScalar(0.5);
-  const delta = b.clone().sub(a);
-  const len = delta.length();
-  segment.position.copy(mid);
-  segment.scale.set(1, Math.max(len, 1e-4), 1);
-  if (len > 1e-5) {
-    segment.quaternion.setFromUnitVectors(SNOOKER_HUMAN_UP, delta.normalize());
-  }
-}
-
-function poseSnookerHumanFallback(human, points) {
-  const parts = human?.fallback?.userData?.parts;
-  if (!parts) return;
-  const {
-    root, torso, chest, head, neck, leftShoulder, rightShoulder,
-    leftElbow, rightElbow, leftHand, rightHand, leftHip, rightHip,
-    leftKnee, rightKnee, leftFoot, rightFoot
-  } = points;
-  parts.torso.position.copy(torso);
-  parts.torso.rotation.set(THREE.MathUtils.degToRad(71), 0, 0);
-  parts.chest.position.copy(chest);
-  parts.chest.rotation.copy(parts.torso.rotation);
-  parts.head.position.copy(head);
-  parts.neck.position.copy(neck);
-  parts.leftHand.position.copy(leftHand);
-  parts.rightHand.position.copy(rightHand);
-  parts.leftFoot.position.copy(leftFoot);
-  parts.rightFoot.position.copy(rightFoot);
-  parts.leftFoot.rotation.y = 0.15;
-  parts.rightFoot.rotation.y = -0.12;
-  placeSnookerHumanSegment(parts.leftUpperArm, leftShoulder, leftElbow);
-  placeSnookerHumanSegment(parts.leftForearm, leftElbow, leftHand);
-  placeSnookerHumanSegment(parts.rightUpperArm, rightShoulder, rightElbow);
-  placeSnookerHumanSegment(parts.rightForearm, rightElbow, rightHand);
-  placeSnookerHumanSegment(parts.leftThigh, leftHip, leftKnee);
-  placeSnookerHumanSegment(parts.leftShin, leftKnee, leftFoot);
-  placeSnookerHumanSegment(parts.rightThigh, rightHip, rightKnee);
-  placeSnookerHumanSegment(parts.rightShin, rightKnee, rightFoot);
-  root.updateMatrixWorld(true);
-}
-
 function normalizeSnookerHumanModel(model, targetHeight = SNOOKER_HUMAN_CFG.targetHeight) {
+  model.rotation.set(0, SNOOKER_HUMAN_CFG.yawFix, 0);
+  model.position.set(0, 0, 0);
   model.updateMatrixWorld(true);
   const box = new THREE.Box3().setFromObject(model);
-  const size = box.getSize(new THREE.Vector3());
-  const height = Math.max(size.y, 1e-4);
-  const scale = targetHeight / height;
-  model.scale.multiplyScalar(scale);
+  const height = Math.max(box.max.y - box.min.y, 0.0001);
+  model.scale.multiplyScalar(targetHeight / height);
   model.updateMatrixWorld(true);
   const scaledBox = new THREE.Box3().setFromObject(model);
   const center = scaledBox.getCenter(new THREE.Vector3());
-  model.position.sub(center);
-  model.position.y -= scaledBox.min.y - center.y;
-  model.rotation.y += SNOOKER_HUMAN_CFG.yawFix;
+  model.position.set(-center.x, -scaledBox.min.y, -center.z);
 }
+
 
 function findSnookerHumanBone(root, ...names) {
   const wanted = names.map(cleanSnookerHumanBoneName);
@@ -1933,43 +1828,6 @@ function loadSnookerHumanModel(loader, url) {
         }
       }
     );
-  });
-}
-
-function buildSnookerHumanModelUrls(theme = SNOOKER_HUMAN_CHARACTER_THEME) {
-  const urls = [
-    ...(theme?.modelUrls || []),
-    theme?.url,
-    ...MURLAN_CHARACTER_THEMES.flatMap((entry) => [
-      ...(entry?.modelUrls || []),
-      entry?.url
-    ]),
-    'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
-    'https://threejs.org/examples/models/gltf/Xbot.glb',
-    'https://threejs.org/examples/models/gltf/Soldier.glb'
-  ].filter(Boolean);
-  return [...new Set(urls)];
-}
-
-async function loadSnookerHumanModelFromCatalog(loader, urls = buildSnookerHumanModelUrls()) {
-  let lastError = null;
-  for (const url of urls) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      const model = await loadSnookerHumanModel(loader, url);
-      if (model) return { model, url };
-    } catch (error) {
-      lastError = error;
-      console.warn('Snooker Royal human model failed, trying fallback', url, error);
-    }
-  }
-  throw lastError || new Error('No Snooker Royal human models configured');
-}
-
-function resetSnookerHumanRestPose(human) {
-  if (!human?.restQuats) return;
-  human.restQuats.forEach((quat, bone) => {
-    if (bone?.quaternion) bone.quaternion.copy(quat);
   });
 }
 
@@ -2081,22 +1939,22 @@ function poseSnookerHumanFingers(fingers, mode, weight) {
 }
 
 function poseSnookerHumanGlb(human, frame) {
-  if (!human?.activeGlb || !human.model || !human.modelRoot?.parent) return;
+  if (!human.activeGlb || !human.model) return;
   human.modelRoot.visible = true;
   human.modelRoot.position.copy(frame.rootWorld);
   human.modelRoot.rotation.y = human.yaw;
   human.modelRoot.updateMatrixWorld(true);
   resetSnookerHumanRestPose(human);
   human.modelRoot.updateMatrixWorld(true);
-  const b = human.bones || {};
+  const b = human.bones;
   const ik = snookerHumanEaseInOut(snookerHumanClamp01(frame.t));
   const idle = 1 - ik;
   const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
   const standingCueDir = SNOOKER_HUMAN_CFG.idleCueDir.clone().applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw).normalize();
   const shotQ = makeSnookerHumanBasisQuaternion(frame.side, SNOOKER_HUMAN_UP, frame.forward);
   if (frame.walkAmount * idle > 0.001) {
-    const s = Math.sin(human.walkPhase * 6.2);
-    const c = Math.cos(human.walkPhase * 6.2);
+    const s = Math.sin(human.walkT * 6.2);
+    const c = Math.cos(human.walkT * 6.2);
     const w = frame.walkAmount * idle;
     if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
     if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
@@ -2110,105 +1968,67 @@ function poseSnookerHumanGlb(human, frame) {
   if (ik >= 0.025) {
     rotateSnookerHumanBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
     twistSnookerHumanBone(b.hips, frame.side, -0.045 * ik);
-    twistSnookerHumanBone(b.hips, frame.forward, -0.025 * ik);
-    rotateSnookerHumanBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
     twistSnookerHumanBone(b.spine, frame.side, -0.2 * ik);
-    twistSnookerHumanBone(b.spine, frame.forward, -0.04 * ik);
+    rotateSnookerHumanBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
     rotateSnookerHumanBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
     twistSnookerHumanBone(b.chest, frame.side, -0.32 * ik);
-    twistSnookerHumanBone(b.chest, frame.forward, -0.025 * ik);
     rotateSnookerHumanBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
-    twistSnookerHumanBone(b.neck, frame.side, -0.12 * ik);
-    if (b.head) {
-      setSnookerHumanBoneWorldQuaternion(
-        b.head,
-        b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(
-          shotQ.clone()
-            .multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik))
-            .multiply(new THREE.Quaternion().setFromAxisAngle(frame.forward, -0.025 * ik)),
-          0.74 * ik
-        )
-      );
-    }
+    setSnookerHumanBoneWorldQuaternion(
+      b.head,
+      b.head ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)), 0.74 * ik) : shotQ
+    );
     human.modelRoot.updateMatrixWorld(true);
   }
   const rightGrip = frame.rightHandWorld.clone();
-  const rightIdleElbow = rightGrip.clone()
-    .addScaledVector(SNOOKER_HUMAN_UP, 0.04 * SNOOKER_HUMAN_WORLD_SCALE + 0.14 * SNOOKER_HUMAN_WORLD_SCALE * ik)
-    .addScaledVector(frame.side, -0.2 * SNOOKER_HUMAN_WORLD_SCALE)
-    .addScaledVector(frame.forward, -0.03 * SNOOKER_HUMAN_WORLD_SCALE * idle);
+  const rightIdleElbow = rightGrip.clone().addScaledVector(SNOOKER_HUMAN_UP, 0.04 * SNOOKER_HUMAN_WORLD_SCALE + 0.14 * SNOOKER_HUMAN_WORLD_SCALE * ik).addScaledVector(frame.side, -0.2 * SNOOKER_HUMAN_WORLD_SCALE).addScaledVector(frame.forward, -0.03 * SNOOKER_HUMAN_WORLD_SCALE * idle);
   const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
-  const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, 0.32).addScaledVector(frame.forward, -0.55).normalize();
-  aimSnookerHumanTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, pole, 0.9 + 0.1 * ik, 1.0);
+  aimSnookerHumanTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, 0.32).addScaledVector(frame.forward, -0.55).normalize(), 0.9 + 0.1 * ik, 1);
   const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
-  const standingHandUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(-1.0).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
-  const handForwardForOrientation = ik >= 0.025 ? cueDir : standingCueDir;
-  const rollForOrientation = ik >= 0.025 ? SNOOKER_HUMAN_CFG.rightHandRollShoot : SNOOKER_HUMAN_CFG.rightHandRollIdle + 0.02 * frame.stroke;
-  setSnookerHumanHandBasis(b.rightHand, standingHandSide, standingHandUp, handForwardForOrientation, rollForOrientation, 1.0);
+  const standingHandUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(-1).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
+  setSnookerHumanHandBasis(b.rightHand, standingHandSide, standingHandUp, ik >= 0.025 ? cueDir : standingCueDir, ik >= 0.025 ? SNOOKER_HUMAN_CFG.rightHandRollShoot : SNOOKER_HUMAN_CFG.rightHandRollIdle, 1);
   poseSnookerHumanFingers(human.rightFingers, 'grip', 0.95);
   if (ik < 0.025) {
     poseSnookerHumanFingers(human.leftFingers, 'idle', 1);
     return;
   }
-  const leftHand = frame.leftHandWorld.clone()
-    .addScaledVector(frame.forward, 0.032 * SNOOKER_HUMAN_WORLD_SCALE * ik)
-    .addScaledVector(frame.side, -0.018 * SNOOKER_HUMAN_WORLD_SCALE * ik)
-    .addScaledVector(SNOOKER_HUMAN_UP, -0.018 * SNOOKER_HUMAN_WORLD_SCALE * ik);
-  const leftElbow = frame.leftElbow.clone()
-    .addScaledVector(frame.forward, 0.045 * SNOOKER_HUMAN_WORLD_SCALE * ik)
-    .addScaledVector(frame.side, -0.05 * SNOOKER_HUMAN_WORLD_SCALE * ik)
-    .addScaledVector(SNOOKER_HUMAN_UP, -0.01 * SNOOKER_HUMAN_WORLD_SCALE * ik);
-  aimSnookerHumanTwoBone(b.leftUpperArm, b.leftLowerArm, leftElbow, leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, 0.1).normalize(), 0.98 * ik, 1.0 * ik);
-  twistSnookerHumanBone(b.leftUpperArm, frame.forward, -0.2 * ik);
-  twistSnookerHumanBone(b.leftLowerArm, frame.forward, 0.025 * ik);
-  const bridgeSide = frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize();
-  const bridgeUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize();
-  setSnookerHumanHandBasis(b.leftHand, bridgeSide, bridgeUp, cueDir, -0.68 * ik, 1.0 * ik);
+  aimSnookerHumanTwoBone(b.leftUpperArm, b.leftLowerArm, frame.leftElbow, frame.leftHandWorld, frame.side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, 0.1).normalize(), 0.98 * ik, ik);
+  setSnookerHumanHandBasis(b.leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize(), SNOOKER_HUMAN_UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize(), cueDir, -0.68 * ik, ik);
   poseSnookerHumanFingers(human.leftFingers, 'bridge', ik);
-  aimSnookerHumanTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(SNOOKER_HUMAN_UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
-  twistSnookerHumanBone(b.leftUpperLeg, frame.forward, -0.035 * ik);
-  setSnookerHumanHandBasis(b.leftFoot, frame.side, frame.up, frame.forward, -0.02 * ik, SNOOKER_HUMAN_CFG.footLockStrength * ik);
-  aimSnookerHumanTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
-  twistSnookerHumanBone(b.rightUpperLeg, frame.forward, 0.03 * ik);
-  setSnookerHumanHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, SNOOKER_HUMAN_CFG.footLockStrength * ik);
+  aimSnookerHumanTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(SNOOKER_HUMAN_UP, 0.18).normalize(), 0.9 * ik, ik);
+  aimSnookerHumanTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, 0.18).normalize(), 0.9 * ik, ik);
 }
+
 
 function createSnookerRoyalHumanPlayer(parent, renderer) {
   const human = {
     root: new THREE.Group(),
     modelRoot: new THREE.Group(),
-    fallback: createSnookerHumanFallbackRig(),
     model: null,
     bones: {},
+    leftFingers: [],
+    rightFingers: [],
+    restQuats: new Map(),
     activeGlb: false,
-    yaw: 0,
     poseT: 0,
+    walkT: 0,
+    yaw: 0,
     breathT: 0,
     settleT: 0,
-    loaded: false,
-    disabled: false,
-    loadFailed: false,
     strikeRoot: new THREE.Vector3(),
     strikeYaw: 0,
     strikeClock: 0,
-    lastRootPosition: new THREE.Vector3(),
-    walkPhase: 0,
-    walkAmount: 0,
-    restQuats: new Map(),
-    leftFingers: [],
-    rightFingers: [],
-    theme: SNOOKER_HUMAN_CHARACTER_THEME
+    disabled: false
   };
-  human.root.name = 'SnookerRoyalHumanPlayerRoot';
-  human.modelRoot.name = 'SnookerRoyalDominoCharacterRoot';
+  human.root.name = 'SnookerRoyalDemoHumanRoot';
+  human.modelRoot.name = 'SnookerRoyalDemoHumanModelRoot';
   human.root.visible = false;
   human.modelRoot.visible = false;
-  human.root.add(human.fallback);
   parent.add(human.root, human.modelRoot);
-  const urls = buildSnookerHumanModelUrls(human.theme);
+
   const loader = createSnookerHumanGLTFLoader(renderer);
-  loadSnookerHumanModelFromCatalog(loader, urls)
-    .then(({ model, url }) => {
+  loadSnookerHumanModel(loader, SNOOKER_HUMAN_URL)
+    .then((model) => {
+      if (!model) throw new Error('ReadyPlayer demo human GLTF did not contain a scene');
       normalizeSnookerHumanModel(model);
       model.traverse((obj) => {
         if (obj?.isBone) human.restQuats.set(obj, obj.quaternion.clone());
@@ -2219,7 +2039,8 @@ function createSnookerRoyalHumanPlayer(parent, renderer) {
         const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
         mats.forEach((mat) => {
           if (mat?.map) {
-            applySRGBColorSpace(mat.map);
+            mat.map.colorSpace = THREE.SRGBColorSpace;
+            mat.map.flipY = false;
             mat.map.needsUpdate = true;
           }
           if (mat) mat.needsUpdate = true;
@@ -2228,37 +2049,28 @@ function createSnookerRoyalHumanPlayer(parent, renderer) {
       human.bones = buildSnookerHumanBones(model);
       human.leftFingers = collectSnookerHumanFingerBones(human.bones.leftHand);
       human.rightFingers = collectSnookerHumanFingerBones(human.bones.rightHand);
-      [...human.leftFingers, ...human.rightFingers].forEach((bone) => human.restQuats.set(bone, bone.quaternion.clone()));
+      [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers]
+        .forEach((bone) => bone && human.restQuats.set(bone, bone.quaternion.clone()));
       human.activeGlb = Boolean(
         human.bones.hips &&
         human.bones.spine &&
         human.bones.head &&
         human.bones.rightUpperArm &&
         human.bones.rightLowerArm &&
-        human.bones.rightHand &&
-        human.bones.leftUpperLeg &&
-        human.bones.leftLowerLeg &&
-        human.bones.leftFoot &&
-        human.bones.rightUpperLeg &&
-        human.bones.rightLowerLeg &&
-        human.bones.rightFoot
+        human.bones.rightHand
       );
       human.model = model;
-      human.modelUrl = url;
       human.modelRoot.add(model);
-      human.modelRoot.visible = human.root.visible && human.activeGlb;
-      human.fallback.visible = !human.activeGlb;
-      human.loaded = true;
+      human.modelRoot.visible = human.activeGlb;
     })
     .catch((error) => {
-      human.loadFailed = true;
       human.activeGlb = false;
-      human.fallback.visible = true;
-      console.warn('Snooker Royal human GLB catalog failed; using fallback pose rig.', error);
+      console.warn('Snooker Royal demo human GLTF failed', error);
     })
     .finally(() => disposeSnookerHumanGLTFLoader(loader));
   return human;
 }
+
 
 function chooseSnookerHumanEdgePosition(cueBallWorld, aimForward) {
   const desired = cueBallWorld.clone().addScaledVector(aimForward, -SNOOKER_HUMAN_CFG.idleDistance);
@@ -2286,142 +2098,202 @@ function getSnookerCueEndpoints(cueStick, cueLen) {
   return { tip, butt };
 }
 
+function snookerDemoCuePoseFromGrip(grip, dir, gripFromBack, length) {
+  const n = dir.clone().normalize();
+  return {
+    back: grip.clone().addScaledVector(n, -gripFromBack),
+    tip: grip.clone().addScaledVector(n, length - gripFromBack)
+  };
+}
+
+function resolveSnookerDemoCuePose({ cueBallWorld, aimForward, humanRootTarget, humanYaw, cueLen, state, power, strikeNorm }) {
+  const demoScale = SNOOKER_HUMAN_WORLD_SCALE;
+  const aimDir = aimForward.clone().normalize();
+  const aimSide = new THREE.Vector3(aimDir.z, 0, -aimDir.x).normalize();
+  const bridgeHandTarget = cueBallWorld.clone()
+    .addScaledVector(aimDir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
+    .addScaledVector(aimSide, SNOOKER_HUMAN_CFG.bridgeSide)
+    .setY(CUE_Y + SNOOKER_HUMAN_CFG.bridgePalmTableLift);
+  const bridgeCuePoint = bridgeHandTarget.clone()
+    .addScaledVector(aimDir, 0.014 * demoScale)
+    .add(new THREE.Vector3(0, SNOOKER_HUMAN_CFG.bridgeCueLift, 0));
+  const activePower = snookerHumanClamp01(power ?? 0);
+  const pull = SNOOKER_HUMAN_CFG.pullRange * snookerHumanEaseOutCubic(activePower);
+  const practiceStroke = state === 'dragging'
+    ? Math.sin(performance.now() * 0.012) * 0.035 * demoScale * (0.25 + activePower * 0.75)
+    : 0;
+  let gap = SNOOKER_HUMAN_CFG.idleGap;
+  if (state === 'dragging') gap += pull + practiceStroke;
+  if (state === 'striking') {
+    gap = snookerHumanLerp(
+      SNOOKER_HUMAN_CFG.idleGap + pull,
+      BALL_R * 0.022857142857142857,
+      snookerHumanEaseOutCubic(snookerHumanClamp01(strikeNorm ?? 0))
+    );
+  }
+  const shootTip = cueBallWorld.clone().addScaledVector(aimDir, -(BALL_R + gap));
+  const shootBack = bridgeCuePoint.clone()
+    .addScaledVector(aimDir, -(cueLen - 0.28 * demoScale - BALL_R - gap))
+    .add(new THREE.Vector3(0, 0.024 * demoScale, 0));
+  const idleRightHandTarget = humanRootTarget.clone().add(
+    new THREE.Vector3(
+      SNOOKER_HUMAN_CFG.idleRightHandX,
+      SNOOKER_HUMAN_CFG.idleRightHandY,
+      SNOOKER_HUMAN_CFG.idleRightHandZ
+    ).applyAxisAngle(SNOOKER_HUMAN_UP, humanYaw)
+  );
+  const idleDir = SNOOKER_HUMAN_CFG.idleCueDir.clone().applyAxisAngle(SNOOKER_HUMAN_UP, humanYaw).normalize();
+  const idleCue = snookerDemoCuePoseFromGrip(
+    idleRightHandTarget,
+    idleDir,
+    SNOOKER_HUMAN_CFG.idleCueGripFromBack,
+    cueLen
+  );
+  return state === 'idle' ? idleCue : { back: shootBack, tip: shootTip };
+}
+
+function applySnookerDemoCuePoseToStick(cueStick, pose) {
+  if (!cueStick || !pose?.back || !pose?.tip) return;
+  const dir = pose.tip.clone().sub(pose.back);
+  const len = dir.length();
+  if (len < 1e-6) return;
+  cueStick.position.copy(pose.back).addScaledVector(dir, 0.5);
+  cueStick.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, -1), dir.normalize());
+  TMP_VEC3_BUTT.copy(pose.back);
+  cueStick.visible = true;
+}
+
 function updateSnookerRoyalHumanPlayer(human, dt, options) {
   if (!human?.root || human.disabled) return;
-  const { cue, cueStick, cueLen, aimDir, visible, power = 0, shooting = false, cueAnimating = false, cueDragging = false } = options || {};
+  const { cue, cueStick, cueLen, aimDir, visible, power = 0, shooting = false, cueDragging = false, table = null } = options || {};
   const cuePos = cue?.pos;
-  if (!cuePos || !cue?.active || !visible) {
+  if (!cuePos || !cue?.active || !visible || !human.activeGlb || !human.model) {
     human.root.visible = false;
     human.modelRoot.visible = false;
     return;
   }
-  const dir = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
-  if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
-  dir.normalize();
-  const cueBall = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
-  const cueEndpoints = getSnookerCueEndpoints(cueStick, cueLen) || {
-    tip: cueBall.clone().addScaledVector(dir, -CUE_TIP_GAP),
-    butt: cueBall.clone().addScaledVector(dir, -(cueLen + CUE_TIP_GAP))
-  };
+
+  const aimForward = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
+  if (aimForward.lengthSq() < 1e-8) aimForward.set(0, 0, 1);
+  aimForward.normalize();
+  const toHumanWorld = (point) => (table?.localToWorld ? table.localToWorld(point.clone()) : point.clone());
+  const cueBallLocal = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
+  const cueBallWorld = toHumanWorld(cueBallLocal);
+  const localCueEndpoints = getSnookerCueEndpoints(cueStick, cueLen);
+  const cueEndpoints = localCueEndpoints
+    ? { tip: toHumanWorld(localCueEndpoints.tip), butt: toHumanWorld(localCueEndpoints.butt) }
+    : {
+        tip: cueBallWorld.clone().addScaledVector(aimForward, -CUE_TIP_GAP),
+        butt: cueBallWorld.clone().addScaledVector(aimForward, -(cueLen + CUE_TIP_GAP))
+      };
   const cueShotDir = cueEndpoints.tip.clone().sub(cueEndpoints.butt);
-  if (cueShotDir.lengthSq() > 1e-8) dir.copy(cueShotDir.normalize());
-  const side = new THREE.Vector3(dir.z, 0, -dir.x).normalize();
-  const state = shooting ? 'striking' : cueDragging || cueAnimating ? 'dragging' : 'idle';
+  if (cueShotDir.lengthSq() > 1e-8) aimForward.copy(cueShotDir.normalize());
+
+  const state = shooting ? 'striking' : cueDragging ? 'dragging' : 'idle';
+  const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+  const humanRootTarget = toHumanWorld(chooseSnookerHumanEdgePosition(cueBallLocal, aimForward));
+  const standingYaw = snookerHumanYawFromForward(aimForward);
+  const bridgeHandTarget = cueBallWorld.clone()
+    .addScaledVector(aimForward, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
+    .addScaledVector(aimSide, SNOOKER_HUMAN_CFG.bridgeSide)
+    .setY(CUE_Y + SNOOKER_HUMAN_CFG.bridgePalmTableLift);
+  const idleRightHandTarget = humanRootTarget.clone().add(
+    new THREE.Vector3(
+      SNOOKER_HUMAN_CFG.idleRightHandX,
+      SNOOKER_HUMAN_CFG.idleRightHandY,
+      SNOOKER_HUMAN_CFG.idleRightHandZ
+    ).applyAxisAngle(SNOOKER_HUMAN_UP, standingYaw)
+  );
+  const idleLeftHandTarget = humanRootTarget.clone().add(
+    new THREE.Vector3(
+      -0.18 * SNOOKER_HUMAN_WORLD_SCALE,
+      1.08 * SNOOKER_HUMAN_WORLD_SCALE,
+      0.03 * SNOOKER_HUMAN_WORLD_SCALE
+    ).applyAxisAngle(SNOOKER_HUMAN_UP, standingYaw)
+  );
+
   human.poseT = snookerHumanDamp(human.poseT, state === 'idle' ? 0 : 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
   human.breathT += dt * (state === 'idle' ? 1.05 : 0.5);
   human.settleT = snookerHumanDamp(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
-  const activePower = snookerHumanClamp01(power ?? 0);
   if (state === 'striking') {
     if (human.strikeClock === 0) {
-      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : chooseSnookerHumanEdgePosition(cueBall, dir));
+      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : humanRootTarget);
       human.strikeYaw = human.yaw;
     }
     human.strikeClock += dt;
   } else {
     human.strikeClock = 0;
   }
-  const rootTarget = chooseSnookerHumanEdgePosition(cueBall, dir)
-    .addScaledVector(dir, state === 'dragging' ? -activePower * BALL_R * 1.8 : 0)
-    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceWidth * 0.16);
-  rootTarget.y = SNOOKER_HUMAN_CFG.floorY;
-  const rootGoal = state === 'striking' ? human.strikeRoot : rootTarget;
+  const rootGoal = state === 'striking' ? human.strikeRoot : humanRootTarget;
   snookerHumanDampVector(human.root.position, rootGoal, state === 'striking' ? 12 : SNOOKER_HUMAN_CFG.moveLambda, dt);
-  const travel = human.root.position.distanceTo(rootGoal);
-  human.walkAmount = snookerHumanDamp(human.walkAmount, snookerHumanClamp01(travel / Math.max(BALL_R * 4, 1e-4)), 8, dt);
-  human.walkPhase += dt * (2 + Math.min(7, travel * 10 / SNOOKER_HUMAN_WORLD_SCALE));
-  human.yaw = snookerHumanDampAngle(human.yaw, state === 'striking' ? human.strikeYaw : snookerHumanYawFromForward(dir), SNOOKER_HUMAN_CFG.rotLambda, dt);
-  human.root.rotation.set(0, human.yaw, 0);
-  human.root.visible = true;
-  human.modelRoot.visible = human.loaded && human.activeGlb;
-  human.fallback.visible = !human.activeGlb;
+  const moveAmountRaw = human.root.position.distanceTo(rootGoal);
+  human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / SNOOKER_HUMAN_WORLD_SCALE));
+  human.yaw = snookerHumanDamp(human.yaw, state === 'striking' ? human.strikeYaw : snookerHumanYawFromForward(aimForward), SNOOKER_HUMAN_CFG.rotLambda, dt);
 
   const t = snookerHumanEaseInOut(human.poseT);
   const idle = 1 - t;
+  const activePower = snookerHumanClamp01(power ?? 0);
   const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * SNOOKER_HUMAN_WORLD_SCALE);
-  const walk = Math.sin(human.walkPhase * 6.2) * Math.min(1, travel * 12 / SNOOKER_HUMAN_WORLD_SCALE);
-  const walkAmount = snookerHumanClamp01(travel * 18 / SNOOKER_HUMAN_WORLD_SCALE) * idle;
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12 / SNOOKER_HUMAN_WORLD_SCALE);
+  const walkAmount = snookerHumanClamp01(moveAmountRaw * 18 / SNOOKER_HUMAN_WORLD_SCALE) * idle;
   const dragStroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + activePower * 0.75) : 0;
   const strikeFollow = state === 'striking'
     ? Math.sin(snookerHumanClamp01(human.strikeClock / (SNOOKER_HUMAN_CFG.strikeTime + SNOOKER_HUMAN_CFG.holdTime)) * Math.PI)
     : 0;
   const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw).normalize();
-  const shotSide = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
   const local = (v) => v.clone().applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw).add(human.root.position);
-  const powerLean = activePower * t;
-  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * SNOOKER_HUMAN_WORLD_SCALE);
-  rootWorld.y = SNOOKER_HUMAN_CFG.floorY;
-  const torso = local(new THREE.Vector3(0, snookerHumanLerp(1.3, 1.14, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0.02, -0.16, t) - 0.014 * powerLean) * SNOOKER_HUMAN_WORLD_SCALE));
-  const chest = local(new THREE.Vector3(0, snookerHumanLerp(1.52, 1.24, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0.02, -0.42, t) - 0.024 * powerLean) * SNOOKER_HUMAN_WORLD_SCALE));
-  const neck = local(new THREE.Vector3(0, snookerHumanLerp(1.68, 1.28, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0.02, -0.61, t) - 0.028 * powerLean) * SNOOKER_HUMAN_WORLD_SCALE));
-  const head = local(new THREE.Vector3(0, snookerHumanLerp(1.84, 1.37, t) * SNOOKER_HUMAN_WORLD_SCALE + breath - SNOOKER_HUMAN_CFG.chinCueOffsetY * 0.16 * t, (snookerHumanLerp(0.04, -0.72, t) - 0.028 * powerLean) * SNOOKER_HUMAN_WORLD_SCALE));
+  const rootWorld = human.root.position.clone();
+  const torso = local(new THREE.Vector3(0, snookerHumanLerp(1.3, 1.14, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, snookerHumanLerp(0.02, -0.16, t) * SNOOKER_HUMAN_WORLD_SCALE));
+  const chest = local(new THREE.Vector3(0, snookerHumanLerp(1.52, 1.24, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, snookerHumanLerp(0.02, -0.42, t) * SNOOKER_HUMAN_WORLD_SCALE));
+  const neck = local(new THREE.Vector3(0, snookerHumanLerp(1.68, 1.28, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, snookerHumanLerp(0.02, -0.61, t) * SNOOKER_HUMAN_WORLD_SCALE));
+  const head = local(new THREE.Vector3(0, snookerHumanLerp(1.84, 1.37, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, snookerHumanLerp(0.04, -0.72, t) * SNOOKER_HUMAN_WORLD_SCALE));
   const leftShoulder = local(new THREE.Vector3(-0.23 * SNOOKER_HUMAN_WORLD_SCALE, snookerHumanLerp(1.58, 1.36, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0, -0.46, t) - 0.018 * human.settleT) * SNOOKER_HUMAN_WORLD_SCALE));
   const rightShoulder = local(new THREE.Vector3(0.23 * SNOOKER_HUMAN_WORLD_SCALE, snookerHumanLerp(1.58, 1.36, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0, -0.34, t) - 0.018 * human.settleT) * SNOOKER_HUMAN_WORLD_SCALE));
   const leftHip = local(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.92 * SNOOKER_HUMAN_WORLD_SCALE, 0.02 * SNOOKER_HUMAN_WORLD_SCALE));
   const rightHip = local(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.92 * SNOOKER_HUMAN_WORLD_SCALE, 0.02 * SNOOKER_HUMAN_WORLD_SCALE));
   const leftFoot = local(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.footGroundY, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + walk * 0.018 * SNOOKER_HUMAN_WORLD_SCALE).lerp(new THREE.Vector3(-SNOOKER_HUMAN_CFG.stanceWidth * 0.42, SNOOKER_HUMAN_CFG.footGroundY, -0.34 * SNOOKER_HUMAN_WORLD_SCALE), t));
   const rightFoot = local(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.footGroundY, -0.03 * SNOOKER_HUMAN_WORLD_SCALE - walk * 0.018 * SNOOKER_HUMAN_WORLD_SCALE).lerp(new THREE.Vector3(SNOOKER_HUMAN_CFG.stanceWidth * 0.5, SNOOKER_HUMAN_CFG.footGroundY, 0.34 * SNOOKER_HUMAN_WORLD_SCALE), t));
-  const bridgePalmTarget = cueBall.clone()
-    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
-    .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
+  const bridgePalmTarget = bridgeHandTarget.clone()
+    .addScaledVector(forward, -0.006 * SNOOKER_HUMAN_WORLD_SCALE * t)
+    .addScaledVector(side, -0.012 * SNOOKER_HUMAN_WORLD_SCALE * t)
     .setY(CUE_Y + SNOOKER_HUMAN_CFG.bridgePalmTableLift)
     .addScaledVector(SNOOKER_HUMAN_UP, -0.01 * SNOOKER_HUMAN_WORLD_SCALE * human.settleT);
-  const idleRight = rootTarget.clone().add(new THREE.Vector3(SNOOKER_HUMAN_CFG.idleRightHandX, SNOOKER_HUMAN_CFG.idleRightHandY, SNOOKER_HUMAN_CFG.idleRightHandZ).applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw));
-  const idleLeft = rootTarget.clone().add(new THREE.Vector3(-0.18 * SNOOKER_HUMAN_WORLD_SCALE, 1.08 * SNOOKER_HUMAN_WORLD_SCALE, 0.03 * SNOOKER_HUMAN_WORLD_SCALE).applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw));
-  const leftHand = idleLeft.clone().lerp(bridgePalmTarget, t);
+  const leftHand = idleLeftHandTarget.clone().lerp(bridgePalmTarget, t);
   const cueDirForHand = cueEndpoints.tip.clone().sub(cueEndpoints.butt).normalize();
   const handIk = snookerHumanEaseInOut(snookerHumanClamp01(t));
-  const idleGripSide = shotSide.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, -0.55).addScaledVector(forward, 0.16).normalize();
-  const idleGripUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(-1.0).addScaledVector(shotSide, -0.64).addScaledVector(forward, 0.2).normalize();
-  const liveGripSide = shotSide.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(-0.55, -0.62, handIk)).addScaledVector(shotSide, 0.5 * handIk).addScaledVector(forward, snookerHumanLerp(0.16, -0.08, handIk)).normalize();
-  const liveGripUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(snookerHumanLerp(-1.0, 0.12, handIk)).addScaledVector(shotSide, snookerHumanLerp(-0.64, -0.04, handIk)).addScaledVector(forward, snookerHumanLerp(0.2, -0.48, handIk)).normalize();
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(-1).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, snookerHumanLerp(0.16, -0.08, handIk)).normalize();
+  const liveGripUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(snookerHumanLerp(-1, 0.12, handIk)).addScaledVector(side, snookerHumanLerp(-0.64, -0.04, handIk)).addScaledVector(forward, snookerHumanLerp(0.2, -0.48, handIk)).normalize();
   const lockedRightElbow = rightShoulder.clone()
     .addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(0.04 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.rightElbowShotRise, t))
-    .addScaledVector(shotSide, snookerHumanLerp(-0.18 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.rightElbowShotSide, t))
+    .addScaledVector(side, snookerHumanLerp(-0.18 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.rightElbowShotSide, t))
     .addScaledVector(forward, snookerHumanLerp(-0.04 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.rightElbowShotBack, t));
-  const pullBack = state === 'dragging' ? -SNOOKER_HUMAN_CFG.rightStrokePull * snookerHumanEaseOutCubic(activePower) : 0;
-  const pushForward = state === 'striking' ? SNOOKER_HUMAN_CFG.rightStrokePush * strikeFollow : 0;
-  const smallPractice = state === 'dragging' ? dragStroke * 0.035 * SNOOKER_HUMAN_WORLD_SCALE : 0;
-  const forearmStroke = pullBack + pushForward + smallPractice;
+  const forearmStroke =
+    (state === 'dragging' ? -SNOOKER_HUMAN_CFG.rightStrokePull * snookerHumanEaseOutCubic(activePower) : 0) +
+    (state === 'striking' ? SNOOKER_HUMAN_CFG.rightStrokePush * strikeFollow : 0) +
+    (state === 'dragging' ? dragStroke * 0.035 * SNOOKER_HUMAN_WORLD_SCALE : 0);
   const forearmBase = lockedRightElbow.clone()
-    .addScaledVector(shotSide, SNOOKER_HUMAN_CFG.rightForearmOutward * t)
+    .addScaledVector(side, SNOOKER_HUMAN_CFG.rightForearmOutward * t)
     .addScaledVector(SNOOKER_HUMAN_UP, -SNOOKER_HUMAN_CFG.rightForearmDown * t)
     .addScaledVector(SNOOKER_HUMAN_UP, SNOOKER_HUMAN_CFG.rightHandShotLift * t)
     .addScaledVector(forward, -SNOOKER_HUMAN_CFG.rightForearmBack * t)
     .addScaledVector(cueDirForHand, SNOOKER_HUMAN_CFG.rightForearmLength);
   const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
-  const idleWristTarget = idleRight.clone().sub(snookerHumanCueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, SNOOKER_HUMAN_CFG.rightHandRollIdle));
+  const idleWristTarget = idleRightHandTarget.clone().sub(snookerHumanCueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, SNOOKER_HUMAN_CFG.rightHandRollIdle));
   const liveWristTarget = liveCueGripPoint.clone().sub(snookerHumanCueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, snookerHumanLerp(SNOOKER_HUMAN_CFG.rightHandRollIdle, SNOOKER_HUMAN_CFG.rightHandRollShoot - SNOOKER_HUMAN_CFG.rightHandDownPose, handIk)));
   const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
-  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(SNOOKER_HUMAN_UP, 0.006 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(shotSide, -0.044 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(forward, 0.065 * SNOOKER_HUMAN_WORLD_SCALE * t);
-  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(0.2 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.kneeBendShot, t)).addScaledVector(forward, 0.04 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(shotSide, -0.012 * SNOOKER_HUMAN_WORLD_SCALE * t);
-  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(0.2 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(shotSide, 0.014 * SNOOKER_HUMAN_WORLD_SCALE * t);
-  human.root.updateMatrixWorld(true);
-  poseSnookerHumanFallback(human, {
-    root: human.root,
-    torso: human.root.worldToLocal(torso.clone()),
-    chest: human.root.worldToLocal(chest.clone()),
-    head: human.root.worldToLocal(head.clone()),
-    neck: human.root.worldToLocal(neck.clone()),
-    leftShoulder: human.root.worldToLocal(leftShoulder.clone()),
-    rightShoulder: human.root.worldToLocal(rightShoulder.clone()),
-    leftElbow: human.root.worldToLocal(leftElbow.clone()),
-    rightElbow: human.root.worldToLocal(lockedRightElbow.clone()),
-    leftHand: human.root.worldToLocal(leftHand.clone()),
-    rightHand: human.root.worldToLocal(rightHand.clone()),
-    leftHip: human.root.worldToLocal(leftHip.clone()),
-    rightHip: human.root.worldToLocal(rightHip.clone()),
-    leftKnee: human.root.worldToLocal(leftKnee.clone()),
-    rightKnee: human.root.worldToLocal(rightKnee.clone()),
-    leftFoot: human.root.worldToLocal(leftFoot.clone()),
-    rightFoot: human.root.worldToLocal(rightFoot.clone())
-  });
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(SNOOKER_HUMAN_UP, 0.006 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(side, -0.044 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(forward, 0.065 * SNOOKER_HUMAN_WORLD_SCALE * t);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(0.2 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.kneeBendShot, t)).addScaledVector(forward, 0.04 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(side, -0.012 * SNOOKER_HUMAN_WORLD_SCALE * t);
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(0.2 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(side, 0.014 * SNOOKER_HUMAN_WORLD_SCALE * t);
   poseSnookerHumanGlb(human, {
     t,
     stroke: forearmStroke / SNOOKER_HUMAN_WORLD_SCALE,
     follow: strikeFollow,
     walkAmount,
     forward,
-    side: shotSide,
+    side,
     up: SNOOKER_HUMAN_UP,
     rootWorld,
     torsoCenterWorld: torso,
@@ -2440,6 +2312,7 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     cueTipWorld: cueEndpoints.tip
   });
 }
+
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_LIFT_DRAG_SCALE = 0.0048;
 const CUE_LIFT_MAX_TILT = THREE.MathUtils.degToRad(12.5);
@@ -22185,7 +22058,7 @@ const powerRef = useRef(hud.power);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      const snookerHumanPlayer = createSnookerRoyalHumanPlayer(table, renderer);
+      const snookerHumanPlayer = createSnookerRoyalHumanPlayer(scene, renderer);
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
       const closeCueGallery = () => {
@@ -26276,17 +26149,22 @@ const powerRef = useRef(hud.power);
           const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const liftTilt = resolveUserCueLift();
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount + liftTilt;
-          cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
-          applyCueButtTilt(
-            cueStick,
-            extraTilt + obstructionTilt + obstructionTiltFromLift
-          );
+          const humanRootTarget = chooseSnookerHumanEdgePosition(start, dir);
+          const demoCueState = sliderInstanceRef.current?.dragging ? 'dragging' : 'idle';
+          const demoCuePose = resolveSnookerDemoCuePose({
+            cueBallWorld: start,
+            aimForward: dir,
+            humanRootTarget,
+            humanYaw: snookerHumanYawFromForward(dir),
+            cueLen,
+            state: demoCueState,
+            power: powerStrength,
+            strikeNorm: 0
+          });
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          const tipTarget = resolveCueTipTarget(dir, visualPull, spinWorld);
-          applyCueStickTransform(tipTarget);
-          clampCueButtAboveCushion(tipTarget);
+          applySnookerDemoCuePoseToStick(cueStick, demoCuePose);
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
           if (chalkMeta) {
@@ -26659,7 +26537,8 @@ const powerRef = useRef(hud.power);
             power: powerRef.current ?? activeAiPlan?.power ?? 0,
             shooting,
             cueAnimating,
-            cueDragging: Boolean(sliderInstanceRef.current?.dragging)
+            cueDragging: Boolean(sliderInstanceRef.current?.dragging),
+            table
           });
         } catch (error) {
           snookerHumanPlayer.disabled = true;
@@ -29961,5 +29840,22 @@ export default function SnookerRoyal() {
     const params = new URLSearchParams(location.search);
     return params.get('opponentAvatar') || '';
   }, [location.search]);
-  return <SnookerRoyalProvided />;
+  return (
+    <SnookerRoyalGame
+      variantKey={variantKey}
+      ballSetKey={ballSetKey}
+      tableSizeKey={tableSizeKey}
+      tableModel={tableModel}
+      playType={playType}
+      mode={mode}
+      trainingMode={trainingMode}
+      trainingRulesEnabled={trainingRulesEnabled}
+      accountId={accountId}
+      tgId={tgId}
+      playerName={playerName}
+      playerAvatar={playerAvatar}
+      opponentName={opponentName}
+      opponentAvatar={opponentAvatar}
+    />
+  );
 }

--- a/webapp/src/pages/Games/shared/demoCueHumanSource.js
+++ b/webapp/src/pages/Games/shared/demoCueHumanSource.js
@@ -1,0 +1,347 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+
+export const DEMO_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+
+const UP = new THREE.Vector3(0, 1, 0);
+const Y_AXIS = UP;
+const BASIS_MAT = new THREE.Matrix4();
+const clamp01 = (v) => Math.max(0, Math.min(1, v));
+const lerp = (a, b, t) => a + (b - a) * t;
+const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+const easeInOut = (t) => t * t * (3 - 2 * t);
+const dampScalar = (current, target, lambda, dt) => THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+const dampVector = (current, target, lambda, dt) => current.lerp(target, 1 - Math.exp(-lambda * dt));
+const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
+const cleanName = (name) => name.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+function makeBasisQuaternion(side, up, forward) {
+  BASIS_MAT.makeBasis(side.clone().normalize(), up.clone().normalize(), forward.clone().normalize());
+  return new THREE.Quaternion().setFromRotationMatrix(BASIS_MAT);
+}
+
+function createUniversalGLTFLoader(renderer, { dracoPath = '/vendor/three/examples/jsm/libs/draco/', basisPath = '/vendor/three/examples/jsm/libs/basis/' } = {}) {
+  const loader = new GLTFLoader();
+  loader.setCrossOrigin('anonymous');
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(dracoPath);
+  loader.setDRACOLoader(draco);
+  const ktx2 = new KTX2Loader();
+  ktx2.setTranscoderPath(basisPath);
+  if (renderer) {
+    try { ktx2.detectSupport(renderer); } catch {}
+  }
+  loader.setKTX2Loader(ktx2);
+  loader.setMeshoptDecoder?.(MeshoptDecoder);
+  return { loader, dispose: () => { draco.dispose?.(); ktx2.dispose?.(); } };
+}
+
+function findBone(all, aliases) {
+  const list = all.map((bone) => ({ bone, name: cleanName(bone.name) }));
+  const names = aliases.map(cleanName);
+  for (const alias of names) {
+    const exact = list.find((x) => x.name === alias || x.name.endsWith(alias));
+    if (exact) return exact.bone;
+  }
+  for (const alias of names) {
+    const loose = list.find((x) => x.name.includes(alias));
+    if (loose) return loose.bone;
+  }
+  return undefined;
+}
+
+function buildAvatarBones(model) {
+  const all = [];
+  model.traverse((obj) => { if (obj.isBone) all.push(obj); });
+  const f = (...names) => findBone(all, names);
+  return {
+    hips: f('hips', 'pelvis', 'mixamorigHips'), spine: f('spine', 'spine01', 'mixamorigSpine'), chest: f('spine2', 'chest', 'upperchest', 'mixamorigSpine2', 'mixamorigSpine1'), neck: f('neck', 'mixamorigNeck'), head: f('head', 'mixamorigHead'),
+    leftUpperArm: f('leftupperarm', 'leftarm', 'upperarml', 'mixamorigLeftArm'), leftLowerArm: f('leftforearm', 'leftlowerarm', 'forearml', 'mixamorigLeftForeArm'), leftHand: f('lefthand', 'handl', 'mixamorigLeftHand'),
+    rightUpperArm: f('rightupperarm', 'rightarm', 'upperarmr', 'mixamorigRightArm'), rightLowerArm: f('rightforearm', 'rightlowerarm', 'forearmr', 'mixamorigRightForeArm'), rightHand: f('righthand', 'handr', 'mixamorigRightHand'),
+    leftUpperLeg: f('leftupleg', 'leftupperleg', 'leftthigh', 'mixamorigLeftUpLeg'), leftLowerLeg: f('leftleg', 'leftlowerleg', 'leftcalf', 'mixamorigLeftLeg'), leftFoot: f('leftfoot', 'footl', 'mixamorigLeftFoot'),
+    rightUpperLeg: f('rightupleg', 'rightupperleg', 'rightthigh', 'mixamorigRightUpLeg'), rightLowerLeg: f('rightleg', 'rightlowerleg', 'rightcalf', 'mixamorigRightLeg'), rightFoot: f('rightfoot', 'footr', 'mixamorigRightFoot')
+  };
+}
+
+function collectFingerBones(hand) {
+  const out = [];
+  hand?.traverse((obj) => {
+    if (!obj.isBone || obj === hand) return;
+    const n = cleanName(obj.name);
+    if (['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((s) => n.includes(s))) out.push(obj);
+  });
+  return out;
+}
+
+function normalizeHuman(model, cfg) {
+  model.rotation.set(0, cfg.humanVisualYawFix, 0);
+  model.position.set(0, 0, 0);
+  model.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const height = Math.max(box.max.y - box.min.y, 0.0001);
+  model.scale.multiplyScalar(cfg.humanScale / height);
+  model.updateMatrixWorld(true);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.set(-center.x, -scaledBox.min.y, -center.z);
+}
+
+export function createDemoHumanConfig(overrides = {}) {
+  return Object.freeze({
+    scale: 3.5,
+    tableTopY: 0.84 * 3.5,
+    tableW: 2.55 * 3.5,
+    tableL: 4.85 * 3.5,
+    ballR: 0.045 * 3.5,
+    idleGap: 0.012 * 3.5,
+    contactGap: 0.0012 * 3.5,
+    pullRange: 0.42 * 3.5,
+    strikeTime: 0.12,
+    holdTime: 0.05,
+    cueLength: 1.78 * 3.5,
+    bridgeDist: 0.28 * 3.5,
+    edgeMargin: 0.68 * 3.5,
+    desiredShootDistance: 1.25 * 3.5,
+    poseLambda: 9,
+    moveLambda: 5.6,
+    rotLambda: 8.5,
+    humanScale: 1.2 * 1.78 * 3.5,
+    humanVisualYawFix: Math.PI,
+    stanceWidth: 0.52 * 3.5,
+    bridgePalmTableLift: 0.006 * 3.5,
+    bridgeCueLift: 0.018 * 3.5,
+    bridgeHandBackFromBall: 0.235 * 3.5,
+    bridgeHandSide: -0.012 * 3.5,
+    chinToCueHeight: 0.11 * 3.5,
+    footGroundY: 0.035 * 3.5,
+    footLockStrength: 1,
+    kneeBendShot: 0.16 * 3.5,
+    rightElbowShotRise: 0.18 * 3.5,
+    rightElbowShotSide: -0.46 * 3.5,
+    rightElbowShotBack: -0.78 * 3.5,
+    rightForearmOutward: 0.36 * 3.5,
+    rightForearmBack: 0.44 * 3.5,
+    rightForearmDown: 0.48 * 3.5,
+    rightForearmLength: 0.34 * 3.5,
+    rightStrokePull: 0.30 * 3.5,
+    rightStrokePush: 0.24 * 3.5,
+    rightHandShotLift: -0.30 * 3.5,
+    shootCueGripFromBack: 0.58 * 3.5,
+    idleRightHandY: 0.8 * 3.5,
+    idleRightHandX: 0.31 * 3.5,
+    idleRightHandZ: -0.015 * 3.5,
+    idleCueGripFromBack: 0.24 * 3.5,
+    idleCueDir: new THREE.Vector3(0.055, 0.965, -0.13),
+    rightHandRollIdle: -2.2,
+    rightHandRollShoot: -2.05,
+    rightHandDownPose: 0.42,
+    rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(3.5),
+    ...overrides
+  });
+}
+
+export function createDemoHuman(parent, renderer, cfg = createDemoHumanConfig()) {
+  const human = { root: new THREE.Group(), modelRoot: new THREE.Group(), model: null, bones: {}, leftFingers: [], rightFingers: [], restQuats: new Map(), activeGlb: false, poseT: 0, walkT: 0, yaw: 0, breathT: 0, settleT: 0, strikeRoot: new THREE.Vector3(), strikeYaw: 0, strikeClock: 0, cfg };
+  human.root.visible = false;
+  human.modelRoot.visible = false;
+  parent.add(human.root, human.modelRoot);
+  const { loader, dispose } = createUniversalGLTFLoader(renderer);
+  loader.load(DEMO_HUMAN_URL, (gltf) => {
+    const model = gltf.scene || gltf.scenes?.[0];
+    if (!model) return;
+    normalizeHuman(model, cfg);
+    model.traverse((obj) => {
+      if (obj.isMesh) {
+        obj.castShadow = true;
+        obj.receiveShadow = true;
+        obj.frustumCulled = false;
+        const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+        mats.forEach((m) => { if (m.map) { m.map.colorSpace = THREE.SRGBColorSpace; m.map.flipY = false; m.map.needsUpdate = true; } m.needsUpdate = true; });
+      }
+    });
+    human.bones = buildAvatarBones(model);
+    human.leftFingers = collectFingerBones(human.bones.leftHand);
+    human.rightFingers = collectFingerBones(human.bones.rightHand);
+    [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((bone) => bone && human.restQuats.set(bone, bone.quaternion.clone()));
+    human.activeGlb = Boolean(human.bones.hips && human.bones.spine && human.bones.head && human.bones.rightUpperArm && human.bones.rightLowerArm && human.bones.rightHand);
+    human.model = model;
+    human.modelRoot.add(model);
+    human.modelRoot.visible = human.activeGlb;
+  }, undefined, (error) => console.warn('Demo ReadyPlayer human failed to load', error));
+  human.dispose = dispose;
+  return human;
+}
+
+function setBoneWorldQuaternion(bone, q) {
+  if (!bone || !q) return;
+  const parentQ = new THREE.Quaternion();
+  bone.parent?.getWorldQuaternion(parentQ);
+  bone.quaternion.copy(parentQ.invert().multiply(q));
+  bone.updateMatrixWorld(true);
+}
+function firstBoneChild(bone) { return bone?.children.find((child) => child.isBone); }
+function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP, cfg) {
+  if (!bone || strength <= 0) return;
+  const bonePos = bone.getWorldPosition(new THREE.Vector3());
+  const childPos = firstBoneChild(bone)?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25 * cfg.scale);
+  const current = childPos.sub(bonePos).normalize();
+  const desired = target.clone().sub(bonePos);
+  if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return;
+  const delta = new THREE.Quaternion().slerpQuaternions(new THREE.Quaternion(), new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()), clamp01(strength));
+  setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+function twistBone(bone, axis, amount) {
+  if (!bone || Math.abs(amount) < 1e-5) return;
+  setBoneWorldQuaternion(bone, new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount).multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98, cfg) {
+  for (let i = 0; i < 4; i += 1) {
+    rotateBoneToward(upper, elbow, upperStrength, pole, cfg);
+    rotateBoneToward(lower, hand, lowerStrength, pole, cfg);
+  }
+}
+function setHandBasis(hand, side, up, forward, roll = 0, strength = 1) {
+  if (!hand || strength <= 0) return;
+  const q = makeBasisQuaternion(side, up, forward).multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  setBoneWorldQuaternion(hand, hand.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength)));
+}
+function poseFingers(fingers, mode, amount) {
+  const w = clamp01(amount);
+  fingers.forEach((finger) => {
+    const n = cleanName(finger.name);
+    const thumb = n.includes('thumb'), index = n.includes('index'), middle = n.includes('middle'), ring = n.includes('ring'), pinky = n.includes('pinky') || n.includes('little');
+    const base = /1|proximal|metacarpal/.test(n), mid = /2|intermediate/.test(n), tip = /3|distal/.test(n);
+    if (mode === 'idle') { finger.rotation.x += (thumb ? 0.1 : base ? 0.08 : mid ? 0.12 : 0.08) * w; return; }
+    if (mode === 'grip') {
+      if (thumb) { finger.rotation.x += 0.48 * w; finger.rotation.y += -0.82 * w; finger.rotation.z += 0.54 * w; return; }
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0;
+      finger.rotation.x += curl * w;
+      return;
+    }
+    if (thumb) { finger.rotation.x += -0.18 * w; finger.rotation.y += 0.95 * w; finger.rotation.z += -0.95 * w; }
+    else if (index) { finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w; finger.rotation.y += -0.46 * w; finger.rotation.z += -0.42 * w; }
+    else if (middle) { finger.rotation.x += (base ? 0.18 : mid ? 0.32 : 0.22) * w; finger.rotation.y += -0.12 * w; finger.rotation.z += -0.14 * w; }
+    else if (ring || pinky) { finger.rotation.x += (base ? (ring ? 0.08 : 0.05) : mid ? (ring ? 0.18 : 0.16) : tip ? (ring ? 0.12 : 0.1) : 0.1) * w; finger.rotation.y += (ring ? 0.18 : 0.34) * w; finger.rotation.z += (ring ? 0.28 : 0.46) * w; }
+  });
+}
+function cueSocketOffsetWorld(side, up, forward, roll, cfg) {
+  const socket = cfg.rightHandCueSocketLocal;
+  const q = makeBasisQuaternion(side, up, forward).multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  return socket.clone().applyQuaternion(q);
+}
+function driveHuman(human, frame) {
+  const cfg = human.cfg;
+  if (!human.activeGlb || !human.model) return;
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(frame.rootWorld);
+  human.modelRoot.rotation.y = human.yaw;
+  human.modelRoot.updateMatrixWorld(true);
+  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
+  human.modelRoot.updateMatrixWorld(true);
+  const b = human.bones;
+  const ik = easeInOut(clamp01(frame.t));
+  const idle = 1 - ik;
+  const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
+  const standingCueDir = cfg.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
+  if (frame.walkAmount * idle > 0.001) {
+    const s = Math.sin(human.walkT * 6.2), c = Math.cos(human.walkT * 6.2), w = frame.walkAmount * idle;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+  }
+  if (ik >= 0.025) {
+    rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward, cfg);
+    twistBone(b.hips, frame.side, -0.045 * ik);
+    twistBone(b.spine, frame.side, -0.2 * ik);
+    rotateBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward, cfg);
+    rotateBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward, cfg);
+    twistBone(b.chest, frame.side, -0.32 * ik);
+    rotateBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward, cfg);
+    setBoneWorldQuaternion(b.head, b.head ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)), 0.74 * ik) : shotQ);
+    human.modelRoot.updateMatrixWorld(true);
+  }
+  const rightGrip = frame.rightHandWorld.clone();
+  const rightIdleElbow = rightGrip.clone().addScaledVector(UP, 0.04 * cfg.scale + 0.14 * cfg.scale * ik).addScaledVector(frame.side, -0.2 * cfg.scale).addScaledVector(frame.forward, -0.03 * cfg.scale * idle);
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.32).addScaledVector(frame.forward, -0.55).normalize(), 0.9 + 0.1 * ik, 1, cfg);
+  const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
+  const standingHandUp = UP.clone().multiplyScalar(-1).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
+  setHandBasis(b.rightHand, standingHandSide, standingHandUp, ik >= 0.025 ? cueDir : standingCueDir, ik >= 0.025 ? cfg.rightHandRollShoot : cfg.rightHandRollIdle, 1);
+  poseFingers(human.rightFingers, 'grip', 0.95);
+  if (ik < 0.025) { poseFingers(human.leftFingers, 'idle', 1); return; }
+  aimTwoBone(b.leftUpperArm, b.leftLowerArm, frame.leftElbow, frame.leftHandWorld, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(), 0.98 * ik, ik, cfg);
+  setHandBasis(b.leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize(), UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize(), cueDir, -0.68 * ik, ik);
+  poseFingers(human.leftFingers, 'bridge', ik);
+  aimTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(UP, 0.18).normalize(), 0.9 * ik, ik, cfg);
+  aimTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), 0.9 * ik, ik, cfg);
+}
+
+export function cuePoseFromDemoGrip(grip, dir, gripFromBack, length) {
+  const n = dir.clone().normalize();
+  return { back: grip.clone().addScaledVector(n, -gripFromBack), tip: grip.clone().addScaledVector(n, length - gripFromBack) };
+}
+
+export function updateDemoHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget, idleRight, idleLeft, cueBack, cueTip, power) {
+  const cfg = human.cfg;
+  human.poseT = dampScalar(human.poseT, state === 'idle' ? 0 : 1, cfg.poseLambda, dt);
+  human.breathT += dt * (state === 'idle' ? 1.05 : 0.5);
+  human.settleT = dampScalar(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
+  if (state === 'striking') {
+    if (human.strikeClock === 0) { human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget); human.strikeYaw = human.yaw; }
+    human.strikeClock += dt;
+  } else human.strikeClock = 0;
+  const rootGoal = state === 'striking' ? human.strikeRoot : rootTarget;
+  dampVector(human.root.position, rootGoal, state === 'striking' ? 12 : cfg.moveLambda, dt);
+  const moveAmountRaw = human.root.position.distanceTo(rootGoal);
+  human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / cfg.scale));
+  human.yaw = dampScalar(human.yaw, state === 'striking' ? human.strikeYaw : yawFromForward(aimForward), cfg.rotLambda, dt);
+  const t = easeInOut(human.poseT), idle = 1 - t;
+  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * cfg.scale);
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12 / cfg.scale);
+  const walkAmount = clamp01(moveAmountRaw * 18 / cfg.scale) * idle;
+  const dragStroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75) : 0;
+  const strikeFollow = state === 'striking' ? Math.sin(clamp01(human.strikeClock / (cfg.strikeTime + cfg.holdTime)) * Math.PI) : 0;
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
+  const rootWorld = human.root.position.clone();
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) * cfg.scale + breath, lerp(0.02, -0.16, t) * cfg.scale));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) * cfg.scale + breath, lerp(0.02, -0.42, t) * cfg.scale));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) * cfg.scale + breath, lerp(0.02, -0.61, t) * cfg.scale));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) * cfg.scale + breath, lerp(0.04, -0.72, t) * cfg.scale));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * cfg.scale, lerp(1.58, 1.36, t) * cfg.scale + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * cfg.scale));
+  const rightShoulder = local(new THREE.Vector3(0.23 * cfg.scale, lerp(1.58, 1.36, t) * cfg.scale + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.scale));
+  const leftHip = local(new THREE.Vector3(-0.13 * cfg.scale, 0.92 * cfg.scale, 0.02 * cfg.scale));
+  const rightHip = local(new THREE.Vector3(0.13 * cfg.scale, 0.92 * cfg.scale, 0.02 * cfg.scale));
+  const leftFoot = local(new THREE.Vector3(-0.13 * cfg.scale, cfg.footGroundY, 0.03 * cfg.scale + walk * 0.018 * cfg.scale).lerp(new THREE.Vector3(-cfg.stanceWidth * 0.42, cfg.footGroundY, -0.34 * cfg.scale), t));
+  const rightFoot = local(new THREE.Vector3(0.13 * cfg.scale, cfg.footGroundY, -0.03 * cfg.scale - walk * 0.018 * cfg.scale).lerp(new THREE.Vector3(cfg.stanceWidth * 0.5, cfg.footGroundY, 0.34 * cfg.scale), t));
+  const bridgePalmTarget = bridgeTarget.clone().addScaledVector(forward, -0.006 * cfg.scale * t).addScaledVector(side, -0.012 * cfg.scale * t).setY(cfg.tableTopY + cfg.bridgePalmTableLift).addScaledVector(UP, -0.01 * cfg.scale * human.settleT);
+  const leftHand = idleLeft.clone().lerp(bridgePalmTarget, t);
+  const cueDirForHand = cueTip.clone().sub(cueBack).normalize();
+  const handIk = easeInOut(clamp01(t));
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = UP.clone().multiplyScalar(-1).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
+  const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04 * cfg.scale, cfg.rightElbowShotRise, t)).addScaledVector(side, lerp(-0.18 * cfg.scale, cfg.rightElbowShotSide, t)).addScaledVector(forward, lerp(-0.04 * cfg.scale, cfg.rightElbowShotBack, t));
+  const forearmStroke = (state === 'dragging' ? -cfg.rightStrokePull * easeOutCubic(power) : 0) + (state === 'striking' ? cfg.rightStrokePush * strikeFollow : 0) + (state === 'dragging' ? dragStroke * 0.035 * cfg.scale : 0);
+  const forearmBase = lockedRightElbow.clone().addScaledVector(side, cfg.rightForearmOutward * t).addScaledVector(UP, -cfg.rightForearmDown * t).addScaledVector(UP, cfg.rightHandShotLift * t).addScaledVector(forward, -cfg.rightForearmBack * t).addScaledVector(cueDirForHand, cfg.rightForearmLength);
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
+  const idleWristTarget = idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg));
+  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - cfg.rightHandDownPose, handIk), cfg));
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * cfg.scale * t).addScaledVector(side, -0.044 * cfg.scale * t).addScaledVector(forward, 0.065 * cfg.scale * t);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.scale, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * cfg.scale * t).addScaledVector(side, -0.012 * cfg.scale * t);
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.scale, cfg.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * cfg.scale * t).addScaledVector(side, 0.014 * cfg.scale * t);
+  driveHuman(human, { t, stroke: forearmStroke / cfg.scale, follow: strikeFollow, walkAmount, forward, side, up: UP, rootWorld, torsoCenterWorld: torso, chestCenterWorld: chest, neckWorld: neck, headCenterWorld: head, leftElbow, rightElbow: lockedRightElbow, leftHandWorld: leftHand, rightHandWorld: rightHand, leftKnee, rightKnee, leftFootWorld: leftFoot, rightFootWorld: rightFoot, cueBackWorld: cueBack, cueTipWorld: cueTip });
+  return { idleCue: cuePoseFromDemoGrip(idleRight, cfg.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize(), cfg.idleCueGripFromBack, cfg.cueLength), rootTarget, bridgeHandTarget: bridgePalmTarget };
+}


### PR DESCRIPTION
### Motivation

- Standardize and simplify the in-game demo cue human by using a single ReadyPlayer GLTF source instead of per-theme catalogs. 
- Make human model normalization, cue pose resolution and world-space transforms more robust so cue/human interactions are consistent across Pool Royale and Snooker Royal. 
- Remove dependency on the previous character theme catalog and eliminate duplicated fallback rig code by centralizing demo-human utilities.

### Description

- Added a new module `webapp/src/pages/Games/shared/demoCueHumanSource.js` exporting `DEMO_HUMAN_URL` and a loader/utility set for loading, normalizing and driving a demo ReadyPlayer human, collecting bones/fingers, pose driving, and cue-pose helpers. 
- Replaced catalog/theme-based human loading in `PoolRoyale.jsx` and `SnookerRoyal.jsx` with the demo GLTF URL (`DEMO_HUMAN_URL`) and simplified `loadPoolHumanModel`/`loadSnookerHumanModel` usage to load a single demo model. 
- Updated normalization and model setup: set model rotation/position before measuring bounds, compute height from `box.max.y - box.min.y`, set `model.position` to center on floor, and set texture color space directly with `mat.map.colorSpace = THREE.SRGBColorSpace` (and `flipY = false`). 
- Adjusted human configuration values and cue length mapping to match demo model scale, moved some yaw fixes into configs, and changed various human-update functions to account for table/world transforms (converting local cue endpoints to human/world space). 
- Refactored Snooker human code: removed large fallback rig duplication, added demo cue pose resolution functions (`resolveSnookerDemoCuePose`, `applySnookerDemoCuePoseToStick`) and integrated demo pose application for the snooker cue rendering path. Also changed human rig parent to scene root where appropriate. 

### Testing

- Ran production build via `npm run build` on the modified frontend; build completed successfully. 
- Ran frontend unit test suite via `npm test`; tests completed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d8dae3d88329ba391d0542198056)