### PR TITLE
Activate full Snooker Royal game (render SnookerRoyalGame)

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -6,7 +6,6 @@ import React, {
   useRef,
   useState
 } from 'react';
-import SnookerRoyalProvided from './SnookerRoyalProvided.jsx';
 import * as THREE from 'three';
 import polygonClipping from 'polygon-clipping';
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
@@ -29961,5 +29960,22 @@ export default function SnookerRoyal() {
     const params = new URLSearchParams(location.search);
     return params.get('opponentAvatar') || '';
   }, [location.search]);
-  return <SnookerRoyalProvided />;
+  return (
+    <SnookerRoyalGame
+      variantKey={variantKey}
+      ballSetKey={ballSetKey}
+      tableSizeKey={tableSizeKey}
+      tableModel={tableModel}
+      playType={playType}
+      mode={mode}
+      trainingMode={trainingMode}
+      trainingRulesEnabled={trainingRulesEnabled}
+      accountId={accountId}
+      tgId={tgId}
+      playerName={playerName}
+      playerAvatar={playerAvatar}
+      opponentName={opponentName}
+      opponentAvatar={opponentAvatar}
+    />
+  );
 }


### PR DESCRIPTION
### Motivation
- Replace the demo/provided wrapper so the app uses the full Snooker Royal implementation as the main game experience. 
- Ensure the full game's GLB table support, ball set, rules, menus and match flow are active while keeping the existing human cue/cuestick behavior intact. 

### Description
- Removed the `SnookerRoyalProvided` wrapper import and now return the main `SnookerRoyalGame` component from `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Forward route- and UI-derived parameters into the game by passing `variantKey`, `ballSetKey`, `tableSizeKey`, `tableModel`, `playType`, `mode`, `trainingMode`, `trainingRulesEnabled`, `accountId`, `tgId`, `playerName`, `playerAvatar`, `opponentName`, and `opponentAvatar` to `SnookerRoyalGame`.
- Keep existing `tableModel` resolution and GLB open-source table loading logic intact so the GLB snooker table, textures, and procedural fallbacks continue to work.
- No changes to the core physics, ball creation, or human rig/cue logic were made in this PR; the change switches which component is rendered.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build output, chunk list produced).
- Ran `git diff --check` and there were no whitespace or diff-check issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071a580b6083298526445f22969144)