### PR TITLE
Replace legacy snooker human rig with ReadyPlayer.me GLTF rig and implement inline power slider UI

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -24,8 +24,6 @@ import {
   TABLE_MODEL_OPENSOURCE,
   TABLE_MODEL_OPENSOURCE_GLB_URL
 } from './snookerTableModel.js';
-import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
-import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   isTelegramWebView,
@@ -103,6 +101,438 @@ import {
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+
+
+const SnookerRoyalProvidedHumanRig = (() => {
+const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const WORLD_SCALE = 3.5;
+const CFG = {
+  scale: WORLD_SCALE,
+  tableTopY: 0.84 * WORLD_SCALE,
+  tableW: 2.55 * WORLD_SCALE,
+  tableL: 4.85 * WORLD_SCALE,
+  tableVisualMultiplier: 1.18,
+  topThickness: 0.09 * WORLD_SCALE,
+  railW: 0.15 * WORLD_SCALE,
+  railH: 0.08 * WORLD_SCALE,
+  ballR: 0.045 * WORLD_SCALE,
+  friction: 1.18,
+  restitution: 0.92,
+  minSpeed2: 0.00045 * WORLD_SCALE * WORLD_SCALE,
+  idleGap: 0.012 * WORLD_SCALE,
+  contactGap: 0.0012 * WORLD_SCALE,
+  pullRange: 0.42 * WORLD_SCALE,
+  strikeTime: 0.12,
+  holdTime: 0.05,
+  cueLength: 1.78 * WORLD_SCALE,
+  bridgeDist: 0.28 * WORLD_SCALE,
+  edgeMargin: 0.68 * WORLD_SCALE,
+  desiredShootDistance: 1.25 * WORLD_SCALE,
+  poseLambda: 9,
+  moveLambda: 5.6,
+  rotLambda: 8.5,
+  humanScale: 1.2 * 1.78 * WORLD_SCALE,
+  humanVisualYawFix: Math.PI,
+  stanceWidth: 0.52 * WORLD_SCALE,
+  bridgePalmTableLift: 0.006 * WORLD_SCALE,
+  bridgeCueLift: 0.018 * WORLD_SCALE,
+  bridgeHandBackFromBall: 0.235 * WORLD_SCALE,
+  bridgeHandSide: -0.012 * WORLD_SCALE,
+  chinToCueHeight: 0.11 * WORLD_SCALE,
+  footGroundY: 0.035 * WORLD_SCALE,
+  footLockStrength: 1,
+  kneeBendShot: 0.16 * WORLD_SCALE,
+  rightElbowShotRise: 0.18 * WORLD_SCALE,
+  rightElbowShotSide: -0.46 * WORLD_SCALE,
+  rightElbowShotBack: -0.78 * WORLD_SCALE,
+  rightForearmOutward: 0.36 * WORLD_SCALE,
+  rightForearmBack: 0.44 * WORLD_SCALE,
+  rightForearmDown: 0.48 * WORLD_SCALE,
+  rightForearmLength: 0.34 * WORLD_SCALE,
+  rightStrokePull: 0.30 * WORLD_SCALE,
+  rightStrokePush: 0.24 * WORLD_SCALE,
+  rightHandShotLift: -0.30 * WORLD_SCALE,
+  shootCueGripFromBack: 0.58 * WORLD_SCALE,
+  idleRightHandY: 0.8 * WORLD_SCALE,
+  idleRightHandX: 0.31 * WORLD_SCALE,
+  idleRightHandZ: -0.015 * WORLD_SCALE,
+  idleCueGripFromBack: 0.24 * WORLD_SCALE,
+  idleCueDir: new THREE.Vector3(0.055, 0.965, -0.13),
+  rightHandRollIdle: -2.2,
+  rightHandRollShoot: -2.05,
+  rightHandDownPose: 0.42,
+  rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(WORLD_SCALE)
+};
+const UP = new THREE.Vector3(0, 1, 0);
+const Y_AXIS = UP;
+const BASIS_MAT = new THREE.Matrix4();
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+const clamp01 = (v) => clamp(v, 0, 1);
+const lerp = (a, b, t) => a + (b - a) * t;
+const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+const easeInOut = (t) => t * t * (3 - 2 * t);
+const dampScalar = (current, target, lambda, dt) => THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+const dampVector = (current, target, lambda, dt) => current.lerp(target, 1 - Math.exp(-lambda * dt));
+const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
+const cleanName = (name) => name.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+function makeBasisQuaternion(side, up, forward) {
+  BASIS_MAT.makeBasis(side.clone().normalize(), up.clone().normalize(), forward.clone().normalize());
+  return new THREE.Quaternion().setFromRotationMatrix(BASIS_MAT);
+}
+function createUniversalGLTFLoader(renderer) {
+  const manager = new THREE.LoadingManager();
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin('anonymous');
+  const draco = new DRACOLoader(manager);
+  draco.setDecoderPath('https://www.gstatic.com/draco/versioned/decoders/1.5.7/');
+  loader.setDRACOLoader(draco);
+  const ktx2 = new KTX2Loader(manager);
+  ktx2.setTranscoderPath('https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/');
+  ktx2.detectSupport(renderer);
+  loader.setKTX2Loader(ktx2);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+  return { loader, dispose: () => { draco.dispose(); ktx2.dispose(); } };
+}
+function findBone(all, aliases) {
+  const list = all.map((bone) => ({ bone, name: cleanName(bone.name) }));
+  const names = aliases.map(cleanName);
+  for (const alias of names) {
+    const exact = list.find((x) => x.name === alias || x.name.endsWith(alias));
+    if (exact) return exact.bone;
+  }
+  for (const alias of names) {
+    const loose = list.find((x) => x.name.includes(alias));
+    if (loose) return loose.bone;
+  }
+  return undefined;
+}
+function buildAvatarBones(model) {
+  const all = [];
+  model.traverse((obj) => { if (obj.isBone) all.push(obj); });
+  const f = (...names) => findBone(all, names);
+  return {
+    hips: f('hips', 'pelvis', 'mixamorigHips'), spine: f('spine', 'spine01', 'mixamorigSpine'), chest: f('spine2', 'chest', 'upperchest', 'mixamorigSpine2', 'mixamorigSpine1'), neck: f('neck', 'mixamorigNeck'), head: f('head', 'mixamorigHead'),
+    leftUpperArm: f('leftupperarm', 'leftarm', 'upperarml', 'mixamorigLeftArm'), leftLowerArm: f('leftforearm', 'leftlowerarm', 'forearml', 'mixamorigLeftForeArm'), leftHand: f('lefthand', 'handl', 'mixamorigLeftHand'),
+    rightUpperArm: f('rightupperarm', 'rightarm', 'upperarmr', 'mixamorigRightArm'), rightLowerArm: f('rightforearm', 'rightlowerarm', 'forearmr', 'mixamorigRightForeArm'), rightHand: f('righthand', 'handr', 'mixamorigRightHand'),
+    leftUpperLeg: f('leftupleg', 'leftupperleg', 'leftthigh', 'mixamorigLeftUpLeg'), leftLowerLeg: f('leftleg', 'leftlowerleg', 'leftcalf', 'mixamorigLeftLeg'), leftFoot: f('leftfoot', 'footl', 'mixamorigLeftFoot'),
+    rightUpperLeg: f('rightupleg', 'rightupperleg', 'rightthigh', 'mixamorigRightUpLeg'), rightLowerLeg: f('rightleg', 'rightlowerleg', 'rightcalf', 'mixamorigRightLeg'), rightFoot: f('rightfoot', 'footr', 'mixamorigRightFoot')
+  };
+}
+function collectFingerBones(hand) {
+  const out = [];
+  hand?.traverse((obj) => {
+    if (!obj.isBone || obj === hand) return;
+    const n = cleanName(obj.name);
+    if (['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((s) => n.includes(s))) out.push(obj);
+  });
+  return out;
+}
+function normalizeHuman(model) {
+  model.rotation.set(0, CFG.humanVisualYawFix, 0);
+  model.position.set(0, 0, 0);
+  model.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const height = Math.max(box.max.y - box.min.y, 0.0001);
+  model.scale.multiplyScalar(CFG.humanScale / height);
+  model.updateMatrixWorld(true);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.set(-center.x, -scaledBox.min.y, -center.z);
+}
+function addHuman(scene, renderer, setStatus) {
+  const human = { root: new THREE.Group(), modelRoot: new THREE.Group(), model: null, bones: {}, leftFingers: [], rightFingers: [], restQuats: new Map(), activeGlb: false, poseT: 0, walkT: 0, yaw: 0, breathT: 0, settleT: 0, strikeRoot: new THREE.Vector3(), strikeYaw: 0, strikeClock: 0 };
+  human.root.visible = false;
+  human.modelRoot.visible = false;
+  scene.add(human.root, human.modelRoot);
+  const { loader } = createUniversalGLTFLoader(renderer);
+  setStatus('Loading ReadyPlayer GLTF human…');
+  loader.load(HUMAN_URL, (gltf) => {
+    const model = gltf.scene;
+    normalizeHuman(model);
+    model.traverse((obj) => {
+      if (!obj.isMesh) return;
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+      obj.frustumCulled = false;
+      const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+      mats.forEach((m) => { if (m.map) { m.map.colorSpace = THREE.SRGBColorSpace; m.map.flipY = false; m.map.needsUpdate = true; } m.needsUpdate = true; });
+    });
+    human.bones = buildAvatarBones(model);
+    human.leftFingers = collectFingerBones(human.bones.leftHand);
+    human.rightFingers = collectFingerBones(human.bones.rightHand);
+    [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((bone) => bone && human.restQuats.set(bone, bone.quaternion.clone()));
+    human.activeGlb = Boolean(human.bones.hips && human.bones.spine && human.bones.head && human.bones.rightUpperArm && human.bones.rightLowerArm && human.bones.rightHand);
+    human.model = model;
+    human.modelRoot.add(model);
+    human.modelRoot.visible = human.activeGlb;
+    setStatus(human.activeGlb ? 'ReadyPlayer GLTF human active' : 'ReadyPlayer loaded but skeleton aliases incomplete');
+  }, undefined, () => setStatus('ReadyPlayer GLTF human failed'));
+  return human;
+}
+function setBoneWorldQuaternion(bone, q) {
+  if (!bone || !q) return;
+  const parentQ = new THREE.Quaternion();
+  bone.parent?.getWorldQuaternion(parentQ);
+  bone.quaternion.copy(parentQ.invert().multiply(q));
+  bone.updateMatrixWorld(true);
+}
+function firstBoneChild(bone) { return bone?.children.find((child) => child.isBone); }
+function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) {
+  if (!bone || strength <= 0) return;
+  const bonePos = bone.getWorldPosition(new THREE.Vector3());
+  const childPos = firstBoneChild(bone)?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25 * CFG.scale);
+  const current = childPos.sub(bonePos).normalize();
+  const desired = target.clone().sub(bonePos);
+  if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return;
+  const delta = new THREE.Quaternion().slerpQuaternions(new THREE.Quaternion(), new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()), clamp01(strength));
+  setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+function twistBone(bone, axis, amount) {
+  if (!bone || Math.abs(amount) < 1e-5) return;
+  setBoneWorldQuaternion(bone, new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount).multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) {
+  for (let i = 0; i < 4; i += 1) {
+    rotateBoneToward(upper, elbow, upperStrength, pole);
+    rotateBoneToward(lower, hand, lowerStrength, pole);
+  }
+}
+function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) {
+  if (!bone || strength <= 0) return;
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength)));
+}
+function cueSocketOffsetWorld(side, up, forward, roll, socketLocal = CFG.rightHandCueSocketLocal) {
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  return socketLocal.clone().applyQuaternion(q);
+}
+function poseFingers(fingers, mode, weight) {
+  const w = clamp01(weight);
+  fingers.forEach((finger, i) => {
+    const n = cleanName(finger.name);
+    const thumb = n.includes('thumb'), index = n.includes('index'), middle = n.includes('middle'), ring = n.includes('ring'), pinky = n.includes('pinky') || n.includes('little');
+    const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal'));
+    const mid = n.includes('2') || n.includes('intermediate');
+    const tip = n.includes('3') || n.includes('distal');
+    if (mode === 'idle') { finger.rotation.x += 0.018 * w; finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1); return; }
+    if (mode === 'grip') {
+      if (thumb) { finger.rotation.x += 0.48 * w; finger.rotation.y += -0.82 * w; finger.rotation.z += 0.54 * w; return; }
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0;
+      finger.rotation.x += curl * w;
+      finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w;
+      finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w;
+      return;
+    }
+    if (thumb) { finger.rotation.x += -0.18 * w; finger.rotation.y += 0.95 * w; finger.rotation.z += -0.95 * w; }
+    else if (index) { finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w; finger.rotation.y += -0.46 * w; finger.rotation.z += -0.42 * w; }
+    else if (middle) { finger.rotation.x += (base ? 0.18 : mid ? 0.32 : 0.22) * w; finger.rotation.y += -0.12 * w; finger.rotation.z += -0.14 * w; }
+    else if (ring || pinky) { finger.rotation.x += (base ? (ring ? 0.08 : 0.05) : mid ? (ring ? 0.18 : 0.16) : tip ? (ring ? 0.12 : 0.1) : 0.1) * w; finger.rotation.y += (ring ? 0.18 : 0.34) * w; finger.rotation.z += (ring ? 0.28 : 0.46) * w; }
+  });
+}
+function driveHuman(human, frame) {
+  if (!human.activeGlb || !human.model) return;
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(frame.rootWorld);
+  human.modelRoot.rotation.y = human.yaw;
+  human.modelRoot.updateMatrixWorld(true);
+  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
+  human.modelRoot.updateMatrixWorld(true);
+  const b = human.bones;
+  const ik = easeInOut(clamp01(frame.t));
+  const idle = 1 - ik;
+  const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
+  const standingCueDir = CFG.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
+  if (frame.walkAmount * idle > 0.001) {
+    const s = Math.sin(human.walkT * 6.2), c = Math.cos(human.walkT * 6.2), w = frame.walkAmount * idle;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+  }
+  if (ik >= 0.025) {
+    rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
+    twistBone(b.hips, frame.side, -0.045 * ik);
+    twistBone(b.spine, frame.side, -0.2 * ik);
+    rotateBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
+    rotateBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
+    twistBone(b.chest, frame.side, -0.32 * ik);
+    rotateBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
+    setBoneWorldQuaternion(b.head, b.head ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)), 0.74 * ik) : shotQ);
+    human.modelRoot.updateMatrixWorld(true);
+  }
+  const rightGrip = frame.rightHandWorld.clone();
+  const rightIdleElbow = rightGrip.clone().addScaledVector(UP, 0.04 * CFG.scale + 0.14 * CFG.scale * ik).addScaledVector(frame.side, -0.2 * CFG.scale).addScaledVector(frame.forward, -0.03 * CFG.scale * idle);
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.32).addScaledVector(frame.forward, -0.55).normalize(), 0.9 + 0.1 * ik, 1);
+  const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
+  const standingHandUp = UP.clone().multiplyScalar(-1).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
+  setHandBasis(b.rightHand, standingHandSide, standingHandUp, ik >= 0.025 ? cueDir : standingCueDir, ik >= 0.025 ? CFG.rightHandRollShoot : CFG.rightHandRollIdle, 1);
+  poseFingers(human.rightFingers, 'grip', 0.95);
+  if (ik < 0.025) { poseFingers(human.leftFingers, 'idle', 1); return; }
+  aimTwoBone(b.leftUpperArm, b.leftLowerArm, frame.leftElbow, frame.leftHandWorld, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(), 0.98 * ik, ik);
+  setHandBasis(b.leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize(), UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize(), cueDir, -0.68 * ik, ik);
+  poseFingers(human.leftFingers, 'bridge', ik);
+  aimTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(UP, 0.18).normalize(), 0.9 * ik, ik);
+  aimTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), 0.9 * ik, ik);
+}
+function chooseHumanEdgePosition(cueBallWorld, aimForward) {
+  const desired = cueBallWorld.clone().addScaledVector(aimForward, -CFG.desiredShootDistance);
+  const xEdge = CFG.tableW / 2 + CFG.edgeMargin;
+  const zEdge = CFG.tableL / 2 + CFG.edgeMargin;
+  const candidates = [new THREE.Vector3(-xEdge, 0, clamp(desired.z, -zEdge, zEdge)), new THREE.Vector3(xEdge, 0, clamp(desired.z, -zEdge, zEdge)), new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, -zEdge), new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, zEdge)];
+  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+}
+function updateHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget, idleRight, idleLeft, cueBack, cueTip, power) {
+  human.poseT = dampScalar(human.poseT, state === 'idle' ? 0 : 1, CFG.poseLambda, dt);
+  human.breathT += dt * (state === 'idle' ? 1.05 : 0.5);
+  human.settleT = dampScalar(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
+  if (state === 'striking') {
+    if (human.strikeClock === 0) { human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget); human.strikeYaw = human.yaw; }
+    human.strikeClock += dt;
+  } else human.strikeClock = 0;
+  const rootGoal = state === 'striking' ? human.strikeRoot : rootTarget;
+  dampVector(human.root.position, rootGoal, state === 'striking' ? 12 : CFG.moveLambda, dt);
+  const moveAmountRaw = human.root.position.distanceTo(rootGoal);
+  human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / CFG.scale));
+  human.yaw = dampScalar(human.yaw, state === 'striking' ? human.strikeYaw : yawFromForward(aimForward), CFG.rotLambda, dt);
+  const t = easeInOut(human.poseT), idle = 1 - t;
+  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * CFG.scale);
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12 / CFG.scale);
+  const walkAmount = clamp01(moveAmountRaw * 18 / CFG.scale) * idle;
+  const dragStroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75) : 0;
+  const strikeFollow = state === 'striking' ? Math.sin(clamp01(human.strikeClock / (CFG.strikeTime + CFG.holdTime)) * Math.PI) : 0;
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
+  const powerLean = power * t;
+  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * CFG.scale);
+  rootWorld.y = 0;
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) * CFG.scale + breath, (lerp(0.02, -0.16, t) - 0.014 * powerLean) * CFG.scale));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) * CFG.scale + breath, (lerp(0.02, -0.42, t) - 0.024 * powerLean) * CFG.scale));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) * CFG.scale + breath, (lerp(0.02, -0.61, t) - 0.028 * powerLean) * CFG.scale));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) * CFG.scale + breath - CFG.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.72, t) - 0.028 * powerLean) * CFG.scale));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * CFG.scale));
+  const rightShoulder = local(new THREE.Vector3(0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * CFG.scale));
+  const leftHip = local(new THREE.Vector3(-0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
+  const rightHip = local(new THREE.Vector3(0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
+  const leftFoot = local(new THREE.Vector3(-0.13 * CFG.scale, CFG.footGroundY, 0.03 * CFG.scale + walk * 0.018 * CFG.scale).lerp(new THREE.Vector3(-CFG.stanceWidth * 0.42, CFG.footGroundY, -0.34 * CFG.scale), t));
+  const rightFoot = local(new THREE.Vector3(0.13 * CFG.scale, CFG.footGroundY, -0.03 * CFG.scale - walk * 0.018 * CFG.scale).lerp(new THREE.Vector3(CFG.stanceWidth * 0.5, CFG.footGroundY, 0.34 * CFG.scale), t));
+  const bridgePalmTarget = bridgeTarget.clone().addScaledVector(forward, -0.006 * CFG.scale * t).addScaledVector(side, -0.012 * CFG.scale * t).setY(CFG.tableTopY + CFG.bridgePalmTableLift).addScaledVector(UP, -0.01 * CFG.scale * human.settleT);
+  const leftHand = idleLeft.clone().lerp(bridgePalmTarget, t);
+  const cueDirForHand = cueTip.clone().sub(cueBack).normalize();
+  const handIk = easeInOut(clamp01(t));
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = UP.clone().multiplyScalar(-1).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
+  const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04 * CFG.scale, CFG.rightElbowShotRise, t)).addScaledVector(side, lerp(-0.18 * CFG.scale, CFG.rightElbowShotSide, t)).addScaledVector(forward, lerp(-0.04 * CFG.scale, CFG.rightElbowShotBack, t));
+  const forearmStroke = (state === 'dragging' ? -CFG.rightStrokePull * easeOutCubic(power) : 0) + (state === 'striking' ? CFG.rightStrokePush * strikeFollow : 0) + (state === 'dragging' ? dragStroke * 0.035 * CFG.scale : 0);
+  const forearmBase = lockedRightElbow.clone().addScaledVector(side, CFG.rightForearmOutward * t).addScaledVector(UP, -CFG.rightForearmDown * t).addScaledVector(UP, CFG.rightHandShotLift * t).addScaledVector(forward, -CFG.rightForearmBack * t).addScaledVector(cueDirForHand, CFG.rightForearmLength);
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
+  const idleWristTarget = idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, CFG.rightHandRollIdle));
+  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(CFG.rightHandRollIdle, CFG.rightHandRollShoot - CFG.rightHandDownPose, handIk)));
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * CFG.scale * t).addScaledVector(side, -0.044 * CFG.scale * t).addScaledVector(forward, 0.065 * CFG.scale * t);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * CFG.scale, CFG.kneeBendShot, t)).addScaledVector(forward, 0.04 * CFG.scale * t).addScaledVector(side, -0.012 * CFG.scale * t);
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * CFG.scale, CFG.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * CFG.scale * t).addScaledVector(side, 0.014 * CFG.scale * t);
+  driveHuman(human, { t, stroke: forearmStroke / CFG.scale, follow: strikeFollow, walkAmount, forward, side, up: UP, rootWorld, torsoCenterWorld: torso, chestCenterWorld: chest, neckWorld: neck, headCenterWorld: head, leftElbow, rightElbow: lockedRightElbow, leftHandWorld: leftHand, rightHandWorld: rightHand, leftKnee, rightKnee, leftFootWorld: leftFoot, rightFootWorld: rightFoot, cueBackWorld: cueBack, cueTipWorld: cueTip });
+}
+function getProvidedCueEndpoints(cueStick, cueLen) {
+  if (!cueStick) return null;
+  cueStick.updateMatrixWorld(true);
+  const tip = new THREE.Vector3(0, 0, -cueLen / 2).applyMatrix4(cueStick.matrixWorld);
+  const butt = new THREE.Vector3(0, 0, cueLen / 2).applyMatrix4(cueStick.matrixWorld);
+  const parent = cueStick.parent;
+  if (parent) {
+    parent.worldToLocal(tip);
+    parent.worldToLocal(butt);
+  }
+  return { tip, butt };
+}
+
+function createSnookerRoyalHumanPlayer(parent, renderer) {
+  const human = addHuman(parent, renderer, () => {});
+  human.root.name = 'SnookerRoyalProvidedHumanRoot';
+  human.modelRoot.name = 'SnookerRoyalProvidedHumanModelRoot';
+  human.root.visible = false;
+  human.modelRoot.visible = false;
+  human.lastRootPosition = new THREE.Vector3();
+  human.walkAmount = 0;
+  return human;
+}
+
+function updateSnookerRoyalHumanPlayer(human, dt, options) {
+  if (!human?.root || human.disabled) return;
+  const { cue, cueStick, cueLen = CFG.cueLength, aimDir, visible, power = 0, shooting = false, cueAnimating = false, cueDragging = false } = options || {};
+  const cuePos = cue?.pos;
+  if (!cuePos || !cue?.active || !visible) {
+    human.root.visible = false;
+    human.modelRoot.visible = false;
+    return;
+  }
+  const fallbackDir = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
+  if (fallbackDir.lengthSq() < 1e-8) fallbackDir.set(0, 0, 1);
+  fallbackDir.normalize();
+  const cueEndpoints = getProvidedCueEndpoints(cueStick, cueLen) || {
+    tip: new THREE.Vector3(cuePos.x, 0, cuePos.y).addScaledVector(fallbackDir, -CFG.idleGap),
+    butt: new THREE.Vector3(cuePos.x, 0, cuePos.y).addScaledVector(fallbackDir, -(cueLen + CFG.idleGap))
+  };
+  const aimForward = cueEndpoints.tip.clone().sub(cueEndpoints.butt);
+  if (aimForward.lengthSq() < 1e-8) aimForward.copy(fallbackDir);
+  aimForward.normalize();
+  const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+  const cueBallWorld = new THREE.Vector3(cuePos.x, cueEndpoints.tip.y, cuePos.y);
+  const state = shooting ? 'striking' : cueDragging || cueAnimating ? 'dragging' : 'idle';
+  const activePower = clamp01(power ?? 0);
+  const humanRootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward);
+  const bridgeHandTarget = cueBallWorld.clone()
+    .addScaledVector(aimForward, -CFG.bridgeHandBackFromBall)
+    .addScaledVector(aimSide, CFG.bridgeHandSide)
+    .setY(cueEndpoints.tip.y + CFG.bridgePalmTableLift);
+  const standingYaw = yawFromForward(aimForward);
+  const idleRightHandTarget = humanRootTarget.clone().add(new THREE.Vector3(
+    CFG.idleRightHandX,
+    CFG.idleRightHandY,
+    CFG.idleRightHandZ
+  ).applyAxisAngle(Y_AXIS, standingYaw));
+  const idleLeftHandTarget = humanRootTarget.clone().add(new THREE.Vector3(
+    -0.18 * CFG.scale,
+    1.08 * CFG.scale,
+    0.03 * CFG.scale
+  ).applyAxisAngle(Y_AXIS, standingYaw));
+  updateHumanPose(
+    human,
+    dt,
+    state,
+    humanRootTarget,
+    aimForward,
+    bridgeHandTarget,
+    idleRightHandTarget,
+    idleLeftHandTarget,
+    cueEndpoints.butt,
+    cueEndpoints.tip,
+    activePower
+  );
+  human.root.visible = true;
+  human.modelRoot.visible = Boolean(human.activeGlb);
+}
+
+  return { createSnookerRoyalHumanPlayer, updateSnookerRoyalHumanPlayer };
+})();
+
+const {
+  createSnookerRoyalHumanPlayer,
+  updateSnookerRoyalHumanPlayer
+} = SnookerRoyalProvidedHumanRig;
+
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -1660,491 +2090,6 @@ const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.06; // lift the cue slightly more as cu
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 
 
-const SNOOKER_HUMAN_CHARACTER_THEME =
-  MURLAN_CHARACTER_THEMES.find((theme) => theme.id === 'rpm-current') ||
-  MURLAN_CHARACTER_THEMES[0];
-const SNOOKER_HUMAN_UP = new THREE.Vector3(0, 1, 0);
-const SNOOKER_HUMAN_FORWARD_LOCAL = new THREE.Vector3(0, 0, 1);
-const SNOOKER_HUMAN_WORLD_SCALE = BALL_R / 0.0525;
-const SNOOKER_HUMAN_CFG = Object.freeze({
-  targetHeight: 1.72 * SNOOKER_HUMAN_WORLD_SCALE,
-  floorY: FLOOR_Y - TABLE_Y,
-  idleDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
-  bridgeBackFromBall: 0.27 * SNOOKER_HUMAN_WORLD_SCALE,
-  bridgeSide: -0.025 * SNOOKER_HUMAN_WORLD_SCALE,
-  stanceSide: 0.25 * SNOOKER_HUMAN_WORLD_SCALE,
-  rightFootBack: 0.38 * SNOOKER_HUMAN_WORLD_SCALE,
-  leftFootForward: 0.30 * SNOOKER_HUMAN_WORLD_SCALE,
-  chinCueOffsetY: 0.12 * SNOOKER_HUMAN_WORLD_SCALE,
-  chestCueOffsetY: 0.22 * SNOOKER_HUMAN_WORLD_SCALE,
-  rootLambda: 7.5,
-  poseLambda: 10,
-  yawFix: 0
-});
-const cleanSnookerHumanBoneName = (name = '') => name.toLowerCase().replace(/[^a-z0-9]/g, '');
-const snookerHumanClamp01 = (value) => Math.max(0, Math.min(1, value));
-const snookerHumanDamp = (current, target, lambda, dt) =>
-  THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
-const snookerHumanDampAngle = (current, target, lambda, dt) => {
-  const delta = THREE.MathUtils.euclideanModulo(target - current + Math.PI, Math.PI * 2) - Math.PI;
-  return current + delta * (1 - Math.exp(-lambda * dt));
-};
-
-function makeSnookerHumanSegment(radius, color, metalness = 0.02) {
-  return new THREE.Mesh(
-    new THREE.CylinderGeometry(radius, radius, 1, 14),
-    new THREE.MeshStandardMaterial({ color, roughness: 0.72, metalness })
-  );
-}
-
-function createSnookerHumanFallbackRig() {
-  const rig = new THREE.Group();
-  rig.name = 'SnookerRoyalFallbackHumanPoseRig';
-  const skin = new THREE.MeshStandardMaterial({ color: 0xd9a27d, roughness: 0.68 });
-  const vest = new THREE.MeshStandardMaterial({ color: 0x111827, roughness: 0.64 });
-  const shirt = new THREE.MeshStandardMaterial({ color: 0xf8fafc, roughness: 0.7 });
-  const trouser = new THREE.MeshStandardMaterial({ color: 0x1f2937, roughness: 0.75 });
-  const shoe = new THREE.MeshStandardMaterial({ color: 0x050505, roughness: 0.6 });
-  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.135, 0.34, 5, 12), vest);
-  const chest = new THREE.Mesh(new THREE.CapsuleGeometry(0.105, 0.22, 5, 12), shirt);
-  const head = new THREE.Mesh(new THREE.SphereGeometry(0.078, 18, 14), skin);
-  const neck = makeSnookerHumanSegment(0.032, 0xd9a27d);
-  const leftHand = new THREE.Mesh(new THREE.SphereGeometry(0.036, 14, 10), skin);
-  const rightHand = new THREE.Mesh(new THREE.SphereGeometry(0.034, 14, 10), skin);
-  const leftFoot = new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.045, 0.25), shoe);
-  const rightFoot = leftFoot.clone();
-  const segments = {
-    leftUpperArm: makeSnookerHumanSegment(0.032, 0xf8fafc),
-    leftForearm: makeSnookerHumanSegment(0.027, 0xd9a27d),
-    rightUpperArm: makeSnookerHumanSegment(0.033, 0xf8fafc),
-    rightForearm: makeSnookerHumanSegment(0.027, 0xd9a27d),
-    leftThigh: makeSnookerHumanSegment(0.043, 0x1f2937),
-    leftShin: makeSnookerHumanSegment(0.036, 0x1f2937),
-    rightThigh: makeSnookerHumanSegment(0.043, 0x1f2937),
-    rightShin: makeSnookerHumanSegment(0.036, 0x1f2937)
-  };
-  rig.add(torso, chest, head, neck, leftHand, rightHand, leftFoot, rightFoot, ...Object.values(segments));
-  rig.userData.parts = { torso, chest, head, neck, leftHand, rightHand, leftFoot, rightFoot, ...segments };
-  rig.traverse((obj) => {
-    if (obj?.isMesh) {
-      obj.castShadow = true;
-      obj.receiveShadow = true;
-    }
-  });
-  return rig;
-}
-
-function placeSnookerHumanSegment(segment, a, b) {
-  if (!segment || !a || !b) return;
-  const mid = a.clone().add(b).multiplyScalar(0.5);
-  const delta = b.clone().sub(a);
-  const len = delta.length();
-  segment.position.copy(mid);
-  segment.scale.set(1, Math.max(len, 1e-4), 1);
-  if (len > 1e-5) {
-    segment.quaternion.setFromUnitVectors(SNOOKER_HUMAN_UP, delta.normalize());
-  }
-}
-
-function poseSnookerHumanFallback(human, points) {
-  const parts = human?.fallback?.userData?.parts;
-  if (!parts) return;
-  const {
-    root, torso, chest, head, neck, leftShoulder, rightShoulder,
-    leftElbow, rightElbow, leftHand, rightHand, leftHip, rightHip,
-    leftKnee, rightKnee, leftFoot, rightFoot
-  } = points;
-  parts.torso.position.copy(torso);
-  parts.torso.rotation.set(THREE.MathUtils.degToRad(71), 0, 0);
-  parts.chest.position.copy(chest);
-  parts.chest.rotation.copy(parts.torso.rotation);
-  parts.head.position.copy(head);
-  parts.neck.position.copy(neck);
-  parts.leftHand.position.copy(leftHand);
-  parts.rightHand.position.copy(rightHand);
-  parts.leftFoot.position.copy(leftFoot);
-  parts.rightFoot.position.copy(rightFoot);
-  parts.leftFoot.rotation.y = 0.15;
-  parts.rightFoot.rotation.y = -0.12;
-  placeSnookerHumanSegment(parts.leftUpperArm, leftShoulder, leftElbow);
-  placeSnookerHumanSegment(parts.leftForearm, leftElbow, leftHand);
-  placeSnookerHumanSegment(parts.rightUpperArm, rightShoulder, rightElbow);
-  placeSnookerHumanSegment(parts.rightForearm, rightElbow, rightHand);
-  placeSnookerHumanSegment(parts.leftThigh, leftHip, leftKnee);
-  placeSnookerHumanSegment(parts.leftShin, leftKnee, leftFoot);
-  placeSnookerHumanSegment(parts.rightThigh, rightHip, rightKnee);
-  placeSnookerHumanSegment(parts.rightShin, rightKnee, rightFoot);
-  root.updateMatrixWorld(true);
-}
-
-function normalizeSnookerHumanModel(model, targetHeight = SNOOKER_HUMAN_CFG.targetHeight) {
-  model.updateMatrixWorld(true);
-  const box = new THREE.Box3().setFromObject(model);
-  const size = box.getSize(new THREE.Vector3());
-  const height = Math.max(size.y, 1e-4);
-  const scale = targetHeight / height;
-  model.scale.multiplyScalar(scale);
-  model.updateMatrixWorld(true);
-  const scaledBox = new THREE.Box3().setFromObject(model);
-  const center = scaledBox.getCenter(new THREE.Vector3());
-  model.position.sub(center);
-  model.position.y -= scaledBox.min.y - center.y;
-  model.rotation.y += SNOOKER_HUMAN_CFG.yawFix;
-}
-
-function findSnookerHumanBone(root, ...names) {
-  const wanted = names.map(cleanSnookerHumanBoneName);
-  let found = null;
-  root.traverse((obj) => {
-    if (found || !obj?.isBone) return;
-    const n = cleanSnookerHumanBoneName(obj.name);
-    if (wanted.some((needle) => n === needle || n.includes(needle))) found = obj;
-  });
-  return found;
-}
-
-function buildSnookerHumanBones(model) {
-  return {
-    hips: findSnookerHumanBone(model, 'hips', 'pelvis'),
-    spine: findSnookerHumanBone(model, 'spine'),
-    chest: findSnookerHumanBone(model, 'spine2', 'chest', 'upperchest'),
-    neck: findSnookerHumanBone(model, 'neck'),
-    head: findSnookerHumanBone(model, 'head'),
-    leftUpperArm: findSnookerHumanBone(model, 'leftarm', 'leftupperarm', 'mixamorigleftarm'),
-    leftLowerArm: findSnookerHumanBone(model, 'leftforearm', 'leftlowerarm'),
-    leftHand: findSnookerHumanBone(model, 'lefthand'),
-    rightUpperArm: findSnookerHumanBone(model, 'rightarm', 'rightupperarm', 'mixamorigrightarm'),
-    rightLowerArm: findSnookerHumanBone(model, 'rightforearm', 'rightlowerarm'),
-    rightHand: findSnookerHumanBone(model, 'righthand'),
-    leftUpperLeg: findSnookerHumanBone(model, 'leftupleg', 'leftupperleg'),
-    leftLowerLeg: findSnookerHumanBone(model, 'leftleg', 'leftlowerleg'),
-    rightUpperLeg: findSnookerHumanBone(model, 'rightupleg', 'rightupperleg'),
-    rightLowerLeg: findSnookerHumanBone(model, 'rightleg', 'rightlowerleg')
-  };
-}
-
-
-function disposeSnookerHumanGLTFLoader(loader) {
-  loader?.userData?.draco?.dispose?.();
-  loader?.userData?.ktx2?.dispose?.();
-}
-
-function createSnookerHumanGLTFLoader(renderer = null) {
-  const loader = new GLTFLoader();
-  loader.setCrossOrigin('anonymous');
-  const draco = new DRACOLoader();
-  draco.setDecoderPath(DRACO_DECODER_PATH);
-  loader.setDRACOLoader(draco);
-  const ktx2 = new KTX2Loader();
-  ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
-  if (renderer) {
-    try {
-      ktx2.detectSupport(renderer);
-    } catch (error) {
-      console.warn('Snooker Royal human KTX2 support detection failed', error);
-    }
-  }
-  loader.setKTX2Loader(ktx2);
-  loader.setMeshoptDecoder?.(MeshoptDecoder);
-  loader.userData = { draco, ktx2 };
-  return loader;
-}
-
-function loadSnookerHumanModel(loader, url) {
-  return new Promise((resolve, reject) => {
-    loader.load(
-      url,
-      (gltf) => resolve(gltf?.scene || gltf?.scenes?.[0] || null),
-      undefined,
-      async (loaderError) => {
-        try {
-          const response = await fetch(url, { mode: 'cors', cache: 'reload' });
-          if (!response.ok) throw new Error(`HTTP ${response.status}`);
-          const buffer = await response.arrayBuffer();
-          const basePath = url.slice(0, url.lastIndexOf('/') + 1);
-          loader.parse(
-            buffer,
-            basePath,
-            (gltf) => resolve(gltf?.scene || gltf?.scenes?.[0] || null),
-            reject
-          );
-        } catch (fetchError) {
-          reject(fetchError || loaderError);
-        }
-      }
-    );
-  });
-}
-
-function buildSnookerHumanModelUrls(theme = SNOOKER_HUMAN_CHARACTER_THEME) {
-  const urls = [
-    ...(theme?.modelUrls || []),
-    theme?.url,
-    ...MURLAN_CHARACTER_THEMES.flatMap((entry) => [
-      ...(entry?.modelUrls || []),
-      entry?.url
-    ]),
-    'https://threejs.org/examples/models/gltf/Xbot.glb',
-    'https://threejs.org/examples/models/gltf/Soldier.glb'
-  ].filter(Boolean);
-  return [...new Set(urls)];
-}
-
-async function loadSnookerHumanModelFromCatalog(loader, urls = buildSnookerHumanModelUrls()) {
-  let lastError = null;
-  for (const url of urls) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      const model = await loadSnookerHumanModel(loader, url);
-      if (model) return { model, url };
-    } catch (error) {
-      lastError = error;
-      console.warn('Snooker Royal human model failed, trying fallback', url, error);
-    }
-  }
-  throw lastError || new Error('No Snooker Royal human models configured');
-}
-
-function resetSnookerHumanRestPose(human) {
-  if (!human?.restQuats) return;
-  human.restQuats.forEach((quat, bone) => {
-    if (bone?.quaternion) bone.quaternion.copy(quat);
-  });
-}
-
-function setSnookerHumanBoneWorldQuaternion(bone, q) {
-  if (!bone || !q) return;
-  const parentQ = new THREE.Quaternion();
-  bone.parent?.getWorldQuaternion(parentQ);
-  bone.quaternion.copy(parentQ.invert().multiply(q));
-  bone.updateMatrixWorld(true);
-}
-
-function firstSnookerHumanBoneChild(bone) {
-  return bone?.children.find((child) => child?.isBone);
-}
-
-function rotateSnookerHumanBoneToward(bone, targetWorld, strength = 0.72, fallbackDir = SNOOKER_HUMAN_UP) {
-  if (!bone || !targetWorld || strength <= 0) return;
-  const bonePos = bone.getWorldPosition(new THREE.Vector3());
-  const child = firstSnookerHumanBoneChild(bone);
-  const childPos = child?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir, 0.2);
-  const current = childPos.sub(bonePos).normalize();
-  const desired = targetWorld.clone().sub(bonePos);
-  if (current.lengthSq() < 1e-8 || desired.lengthSq() < 1e-8) return;
-  const delta = new THREE.Quaternion().setFromUnitVectors(current, desired.normalize());
-  const blended = new THREE.Quaternion().slerpQuaternions(new THREE.Quaternion(), delta, snookerHumanClamp01(strength));
-  setSnookerHumanBoneWorldQuaternion(bone, blended.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
-}
-
-function poseSnookerHumanGlb(human, targetsLocal) {
-  if (!human?.activeGlb || !human.modelRoot?.parent) return;
-  const tableGroup = human.modelRoot.parent;
-  if (!tableGroup) return;
-  resetSnookerHumanRestPose(human);
-  const toWorld = (local) => tableGroup.localToWorld(local.clone());
-  const bones = human.bones || {};
-  human.modelRoot.updateMatrixWorld(true);
-  const leftHand = toWorld(targetsLocal.leftHandWorld);
-  const rightHand = toWorld(targetsLocal.rightHandWorld);
-  const leftElbow = toWorld(targetsLocal.leftElbowWorld);
-  const rightElbow = toWorld(targetsLocal.rightElbowWorld);
-  const head = toWorld(targetsLocal.headWorld);
-  const chest = toWorld(targetsLocal.chestWorld);
-  rotateSnookerHumanBoneToward(bones.spine, chest, 0.4, SNOOKER_HUMAN_UP);
-  rotateSnookerHumanBoneToward(bones.chest, head, 0.45, SNOOKER_HUMAN_UP);
-  rotateSnookerHumanBoneToward(bones.neck, head, 0.55, SNOOKER_HUMAN_UP);
-  rotateSnookerHumanBoneToward(bones.head, toWorld(targetsLocal.cueTipWorld), 0.32, SNOOKER_HUMAN_FORWARD_LOCAL);
-  for (let i = 0; i < 3; i += 1) {
-    rotateSnookerHumanBoneToward(bones.leftUpperArm, leftElbow, 0.75, SNOOKER_HUMAN_UP);
-    rotateSnookerHumanBoneToward(bones.leftLowerArm, leftHand, 0.78, SNOOKER_HUMAN_UP);
-    rotateSnookerHumanBoneToward(bones.rightUpperArm, rightElbow, 0.76, SNOOKER_HUMAN_UP);
-    rotateSnookerHumanBoneToward(bones.rightLowerArm, rightHand, 0.8, SNOOKER_HUMAN_UP);
-  }
-}
-
-function createSnookerRoyalHumanPlayer(parent, renderer) {
-  const human = {
-    root: new THREE.Group(),
-    modelRoot: new THREE.Group(),
-    fallback: createSnookerHumanFallbackRig(),
-    bones: {},
-    activeGlb: false,
-    yaw: 0,
-    poseT: 0,
-    loaded: false,
-    disabled: false,
-    loadFailed: false,
-    lastRootPosition: new THREE.Vector3(),
-    walkPhase: 0,
-    walkAmount: 0,
-    restQuats: new Map(),
-    theme: SNOOKER_HUMAN_CHARACTER_THEME
-  };
-  human.root.name = 'SnookerRoyalHumanPlayerRoot';
-  human.modelRoot.name = 'SnookerRoyalDominoCharacterRoot';
-  human.root.visible = false;
-  human.modelRoot.visible = false;
-  human.root.add(human.fallback);
-  parent.add(human.root, human.modelRoot);
-  const urls = buildSnookerHumanModelUrls(human.theme);
-  const loader = createSnookerHumanGLTFLoader(renderer);
-  loadSnookerHumanModelFromCatalog(loader, urls)
-    .then(({ model, url }) => {
-      normalizeSnookerHumanModel(model);
-      model.traverse((obj) => {
-        if (obj?.isBone) human.restQuats.set(obj, obj.quaternion.clone());
-        if (!obj?.isMesh) return;
-        obj.castShadow = true;
-        obj.receiveShadow = true;
-        obj.frustumCulled = false;
-        const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
-        mats.forEach((mat) => {
-          if (mat?.map) {
-            applySRGBColorSpace(mat.map);
-            mat.map.needsUpdate = true;
-          }
-          if (mat) mat.needsUpdate = true;
-        });
-      });
-      human.bones = buildSnookerHumanBones(model);
-      human.activeGlb = Boolean(
-        human.bones.head &&
-        human.bones.spine &&
-        human.bones.leftUpperArm &&
-        human.bones.leftLowerArm &&
-        human.bones.rightUpperArm &&
-        human.bones.rightLowerArm
-      );
-      human.modelUrl = url;
-      human.modelRoot.add(model);
-      human.modelRoot.visible = human.root.visible && human.activeGlb;
-      human.fallback.visible = !human.activeGlb;
-      human.loaded = true;
-    })
-    .catch((error) => {
-      human.loadFailed = true;
-      human.activeGlb = false;
-      human.fallback.visible = true;
-      console.warn('Snooker Royal human GLB catalog failed; using fallback pose rig.', error);
-    })
-    .finally(() => disposeSnookerHumanGLTFLoader(loader));
-  return human;
-}
-
-function getSnookerCueEndpoints(cueStick, cueLen) {
-  if (!cueStick) return null;
-  cueStick.updateMatrixWorld(true);
-  const tip = new THREE.Vector3(0, 0, -cueLen / 2).applyMatrix4(cueStick.matrixWorld);
-  const butt = new THREE.Vector3(0, 0, cueLen / 2).applyMatrix4(cueStick.matrixWorld);
-  const parent = cueStick.parent;
-  if (parent) {
-    parent.worldToLocal(tip);
-    parent.worldToLocal(butt);
-  }
-  return { tip, butt };
-}
-
-function updateSnookerRoyalHumanPlayer(human, dt, options) {
-  if (!human?.root || human.disabled) return;
-  const { cue, cueStick, cueLen, aimDir, visible, power = 0, shooting = false, cueAnimating = false } = options || {};
-  const cuePos = cue?.pos;
-  if (!cuePos || !cue?.active || !visible) {
-    human.root.visible = false;
-    human.modelRoot.visible = false;
-    return;
-  }
-  const dir = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
-  if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
-  dir.normalize();
-  const side = new THREE.Vector3(-dir.z, 0, dir.x).normalize();
-  const cueBall = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
-  const cueEndpoints = getSnookerCueEndpoints(cueStick, cueLen) || {
-    tip: cueBall.clone().addScaledVector(dir, -CUE_TIP_GAP),
-    butt: cueBall.clone().addScaledVector(dir, -(cueLen + CUE_TIP_GAP))
-  };
-  const pullPose = THREE.MathUtils.clamp((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0), 0, 1);
-  // Orientation is driven from the actual shot line: the root stands behind
-  // the cue ball on -dir, then faces +dir back through cue ball/object ball.
-  // Keeping local +Z on the shot line prevents mirrored cue/hand placement.
-  const rootTarget = cueBall.clone()
-    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.idleDistance - pullPose * BALL_R * 1.8)
-    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceSide * 0.32);
-  rootTarget.y = SNOOKER_HUMAN_CFG.floorY;
-  const yawTarget = Math.atan2(dir.x, dir.z);
-  human.root.visible = true;
-  human.modelRoot.visible = human.loaded && human.activeGlb;
-  const travel = human.lastRootPosition.distanceTo(rootTarget);
-  human.walkAmount = snookerHumanDamp(human.walkAmount, snookerHumanClamp01(travel / Math.max(BALL_R * 4, 1e-4)), 8, dt);
-  human.walkPhase += dt * (4.5 + human.walkAmount * 5.5);
-  human.root.position.lerp(rootTarget, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
-  human.lastRootPosition.copy(human.root.position);
-  human.yaw = snookerHumanDampAngle(human.yaw, yawTarget, SNOOKER_HUMAN_CFG.rootLambda, dt);
-  human.root.rotation.set(0, human.yaw, 0);
-  human.modelRoot.position.copy(human.root.position);
-  human.modelRoot.rotation.copy(human.root.rotation);
-  human.poseT = snookerHumanDamp(human.poseT, 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
-  const invRoot = new THREE.Matrix4().copy(human.root.matrixWorld).invert();
-  const toRootLocal = (v) => v.clone().applyMatrix4(invRoot);
-  const bridge = cueBall.clone()
-    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
-    .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
-    .setY(CUE_Y + BALL_R * 0.08);
-  const grip = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
-  const chestWorld = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
-  const headWorld = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const torso = toRootLocal(chestWorld).add(new THREE.Vector3(0, 0.16 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
-  const chest = toRootLocal(chestWorld);
-  const head = toRootLocal(headWorld);
-  const neck = chest.clone().lerp(head, 0.68);
-  const leftShoulder = chest.clone().add(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, -0.025 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightShoulder = chest.clone().add(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.055 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
-  const leftHand = toRootLocal(bridge);
-  const rightHand = toRootLocal(grip);
-  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.58).add(new THREE.Vector3(-0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.03 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightElbow = rightShoulder.clone().lerp(rightHand, 0.42).add(new THREE.Vector3(0.22 * SNOOKER_HUMAN_WORLD_SCALE, 0.20 * SNOOKER_HUMAN_WORLD_SCALE, -0.20 * SNOOKER_HUMAN_WORLD_SCALE));
-  const leftHip = new THREE.Vector3(-0.07 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const rightHip = new THREE.Vector3(0.08 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.12 * SNOOKER_HUMAN_WORLD_SCALE);
-  const walkLift = Math.sin(human.walkPhase) * 0.028 * SNOOKER_HUMAN_WORLD_SCALE * human.walkAmount;
-  const leftFoot = new THREE.Vector3(-SNOOKER_HUMAN_CFG.stanceSide, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, walkLift), SNOOKER_HUMAN_CFG.leftFootForward);
-  const rightFoot = new THREE.Vector3(SNOOKER_HUMAN_CFG.stanceSide * 0.62, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, -walkLift), -SNOOKER_HUMAN_CFG.rightFootBack);
-  const leftKnee = leftHip.clone().lerp(leftFoot, 0.55).add(new THREE.Vector3(-0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.12 * SNOOKER_HUMAN_WORLD_SCALE, 0.04 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).add(new THREE.Vector3(0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.14 * SNOOKER_HUMAN_WORLD_SCALE, -0.03 * SNOOKER_HUMAN_WORLD_SCALE));
-  poseSnookerHumanFallback(human, {
-    root: human.root,
-    torso,
-    chest,
-    head,
-    neck,
-    leftShoulder,
-    rightShoulder,
-    leftElbow,
-    rightElbow,
-    leftHand,
-    rightHand,
-    leftHip,
-    rightHip,
-    leftKnee,
-    rightKnee,
-    leftFoot,
-    rightFoot
-  });
-  const leftElbowTable = human.root.parent
-    ? human.root.parent.worldToLocal(human.root.localToWorld(leftElbow.clone()))
-    : leftElbow.clone();
-  const rightElbowTable = human.root.parent
-    ? human.root.parent.worldToLocal(human.root.localToWorld(rightElbow.clone()))
-    : rightElbow.clone();
-  poseSnookerHumanGlb(human, {
-    leftHandWorld: bridge,
-    rightHandWorld: grip,
-    leftElbowWorld: leftElbowTable,
-    rightElbowWorld: rightElbowTable,
-    headWorld: headWorld,
-    chestWorld: chestWorld,
-    cueTipWorld: cueEndpoints.tip
-  });
-}
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_LIFT_DRAG_SCALE = 0.0048;
 const CUE_LIFT_MAX_TILT = THREE.MathUtils.degToRad(12.5);
@@ -26363,7 +26308,8 @@ const powerRef = useRef(hud.power);
             visible: cueStick.visible || cueAnimating || shooting,
             power: powerRef.current ?? activeAiPlan?.power ?? 0,
             shooting,
-            cueAnimating
+            cueAnimating,
+            cueDragging: Boolean(sliderInstanceRef.current?.dragging)
           });
         } catch (error) {
           snookerHumanPlayer.disabled = true;
@@ -27460,51 +27406,106 @@ const powerRef = useRef(hud.power);
   }, [isPortrait, uiScale]);
 
   // --------------------------------------------------
-  // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
+  // Snooker Royal pull slider: direct port of the provided drag-down power UI.
   // --------------------------------------------------
   const sliderRef = useRef(null);
+  const draggingSliderRef = useRef(false);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
-  useEffect(() => {
-    if (!showPowerSlider) {
-      return undefined;
-    }
-    const mount = sliderRef.current;
-    if (!mount) return undefined;
-    const slider = new PoolRoyalePowerSlider({
-      mount,
-      value: powerRef.current * 100,
-      cueSrc: '/assets/snooker/cue.webp',
-      labels: true,
-      onChange: (v) => applyPower(v / 100),
-      onStart: () => {
-        captureCueStickAnchor();
-      },
-      onCommit: () => {
+  const animateSliderPowerToZero = useCallback(
+    (from, ms = 220) => {
+      const start = performance.now();
+      const tick = () => {
+        const t = snookerHumanClamp01((performance.now() - start) / ms);
+        applyPower(snookerHumanLerp(from, 0, snookerHumanEaseOutCubic(t)));
+        if (t < 1) requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+    },
+    [applyPower]
+  );
+  const setSliderPowerFromPointer = useCallback(
+    (event) => {
+      const rect = event.currentTarget.getBoundingClientRect();
+      const nextPower = snookerHumanClamp01((event.clientY - rect.top) / rect.height);
+      applyPower(nextPower);
+    },
+    [applyPower]
+  );
+  const onPowerSliderDown = useCallback(
+    (event) => {
+      const slider = sliderInstanceRef.current;
+      if (slider?.locked) return;
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      draggingSliderRef.current = true;
+      if (slider) slider.dragging = true;
+      captureCueStickAnchor();
+      setSliderPowerFromPointer(event);
+    },
+    [captureCueStickAnchor, setSliderPowerFromPointer]
+  );
+  const onPowerSliderMove = useCallback(
+    (event) => {
+      if (!draggingSliderRef.current || sliderInstanceRef.current?.locked) return;
+      setSliderPowerFromPointer(event);
+    },
+    [setSliderPowerFromPointer]
+  );
+  const onPowerSliderUp = useCallback(
+    (event) => {
+      try {
+        event.currentTarget.releasePointerCapture?.(event.pointerId);
+      } catch {}
+      const slider = sliderInstanceRef.current;
+      if (slider) slider.dragging = false;
+      draggingSliderRef.current = false;
+      if (!slider?.locked && powerRef.current > 0.02) {
         fireRef.current?.();
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
       }
-    });
+      animateSliderPowerToZero(powerRef.current, 180);
+    },
+    [animateSliderPowerToZero]
+  );
+  useEffect(() => {
+    if (!showPowerSlider) return undefined;
+    const slider = {
+      dragging: false,
+      locked: false,
+      min: 0,
+      set: (value = 0) => applyPower(snookerHumanClamp01(value / 100)),
+      lock() {
+        this.locked = true;
+        this.dragging = false;
+        draggingSliderRef.current = false;
+      },
+      unlock() {
+        this.locked = false;
+      },
+      destroy() {
+        this.dragging = false;
+      }
+    };
     sliderInstanceRef.current = slider;
     applySliderLock();
     return () => {
-      sliderInstanceRef.current = null;
       slider.destroy();
+      if (sliderInstanceRef.current === slider) sliderInstanceRef.current = null;
     };
-  }, [applySliderLock, captureCueStickAnchor, showPowerSlider]);
+  }, [applyPower, applySliderLock, showPowerSlider]);
   useEffect(() => {
     if (shotActive || hud.over || hud.turn !== 0) return;
     const slider = sliderInstanceRef.current;
     if (slider) {
-      slider.set(slider.min, { animate: true });
+      slider.set(slider.min);
     }
     applyPower(0);
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;
   }, [applyPower, hud.over, hud.turn, shotActive]);
 
+  const sliderH = 320;
+  const sliderW = 58;
+  const sliderKnob = 30;
+  const sliderKnobTop = THREE.MathUtils.clamp((powerRef.current ?? hud.power ?? 0) * sliderH - sliderKnob / 2, -2, sliderH - sliderKnob + 2);
   const isPlayerTurn = hud.turn === 0;
   const isOpponentTurn = hud.turn === 1;
   const showPlayerControls = isPlayerTurn && !hud.over && !replayActive;
@@ -29288,17 +29289,68 @@ const powerRef = useRef(hud.power);
       {/* Power Slider */}
       {showPowerSlider && !replayActive && (
         <div
-          className="absolute right-3 top-[56%] -translate-y-1/2"
+          className="absolute right-3 top-1/2 z-40 -translate-y-1/2"
           data-ai-taking-shot={aiTakingShot ? 'true' : 'false'}
           data-player-turn={isPlayerTurn ? 'true' : 'false'}
+          style={{ transform: `translateY(-50%) scale(${uiScale})`, transformOrigin: 'center right' }}
         >
           <div
             ref={sliderRef}
+            onPointerDown={onPowerSliderDown}
+            onPointerMove={onPowerSliderMove}
+            onPointerUp={onPowerSliderUp}
+            onPointerCancel={onPowerSliderUp}
             style={{
-              transform: `scale(${uiScale})`,
-              transformOrigin: 'top right'
+              position: 'relative',
+              height: sliderH,
+              width: sliderW,
+              borderRadius: 18,
+              background: 'rgba(255,255,255,0.92)',
+              boxShadow: '0 12px 28px rgba(0,0,0,0.2)',
+              padding: 9,
+              touchAction: 'none',
+              userSelect: 'none',
+              cursor: sliderInstanceRef.current?.locked ? 'not-allowed' : 'grab',
+              opacity: sliderInstanceRef.current?.locked ? 0.55 : 1
             }}
-          />
+          >
+            <div
+              style={{
+                position: 'absolute',
+                left: 14,
+                right: 14,
+                top: 14,
+                bottom: 14,
+                borderRadius: 999,
+                background: 'rgba(0,0,0,0.12)',
+                overflow: 'hidden'
+              }}
+            >
+              <div
+                style={{
+                  position: 'absolute',
+                  left: 0,
+                  right: 0,
+                  top: 0,
+                  height: `${(hud.power ?? 0) * 100}%`,
+                  background: 'rgba(17,17,17,0.58)'
+                }}
+              />
+            </div>
+            <div
+              style={{
+                position: 'absolute',
+                left: (sliderW - sliderKnob) / 2,
+                top: 14 + sliderKnobTop,
+                width: sliderKnob,
+                height: sliderKnob,
+                borderRadius: 999,
+                background: 'rgba(255,255,255,0.98)',
+                border: '1px solid rgba(0,0,0,0.18)',
+                boxShadow: '0 10px 18px rgba(0,0,0,0.18)'
+              }}
+            />
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
### Motivation
- Replace the old, large, brittle snooker human rig and fallback poser with a single reusable GLTF-based human rig to improve pose fidelity and simplify loading.
- Remove dependency on the external `PoolRoyalePowerSlider` widget and implement a compact inline pointer-driven power slider to reduce complexity and enable tighter control over drag behavior.

### Description
- Added a new `SnookerRoyalProvidedHumanRig` (ReadyPlayer.me GLTF) that exposes `createSnookerRoyalHumanPlayer` and `updateSnookerRoyalHumanPlayer` and contains loaders, bone discovery, IK helpers, finger posing and pose driving logic, and a simple model normalizer/loader pipeline.
- Replaced the previous long snooker human model/pose code paths and loader utilities with the new rig and wired the game to use `createSnookerRoyalHumanPlayer` / `updateSnookerRoyalHumanPlayer` instead of the legacy implementation.
- Removed import of the external `PoolRoyalePowerSlider` and its CSS and implemented an inline DOM slider with pointer handlers (`onPowerSliderDown`, `onPowerSliderMove`, `onPowerSliderUp`), animation helpers (`animateSliderPowerToZero`) and a small `sliderInstanceRef` shim that supports `lock`/`unlock`/`destroy` and `set` semantics used by existing code.
- Updated the call site to `updateSnookerRoyalHumanPlayer` to pass `cueDragging: Boolean(sliderInstanceRef.current?.dragging)` so the human rig responds to slider drag state, and added UI scale/position/style adjustments for the new inline slider knob and track.

### Testing
- Ran the app build with `yarn build` which completed successfully.
- Ran the test suite with `yarn test` and unit tests passed.
- Ran linter via `yarn lint` with no new errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069ac1c88883299c51391fc47502a9)