### PR TITLE
Snooker: richer human rig and posing, improved GLTF loading and bone handling

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1660,35 +1660,68 @@ const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.06; // lift the cue slightly more as cu
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 
 
+
 const SNOOKER_HUMAN_CHARACTER_THEME =
   MURLAN_CHARACTER_THEMES.find((theme) => theme.id === 'rpm-current') ||
   MURLAN_CHARACTER_THEMES[0];
 const SNOOKER_HUMAN_UP = new THREE.Vector3(0, 1, 0);
-const SNOOKER_HUMAN_FORWARD_LOCAL = new THREE.Vector3(0, 0, 1);
+const SNOOKER_HUMAN_BASIS_MAT = new THREE.Matrix4();
 const SNOOKER_HUMAN_WORLD_SCALE = BALL_R / 0.0525;
+const SNOOKER_HUMAN_CUE_LENGTH = 1.78 * SNOOKER_HUMAN_WORLD_SCALE;
 const SNOOKER_HUMAN_CFG = Object.freeze({
-  targetHeight: 1.72 * SNOOKER_HUMAN_WORLD_SCALE,
+  targetHeight: SNOOKER_HUMAN_CUE_LENGTH * 1.2,
   floorY: FLOOR_Y - TABLE_Y,
-  idleDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
-  bridgeBackFromBall: 0.27 * SNOOKER_HUMAN_WORLD_SCALE,
-  bridgeSide: -0.025 * SNOOKER_HUMAN_WORLD_SCALE,
-  stanceSide: 0.25 * SNOOKER_HUMAN_WORLD_SCALE,
-  rightFootBack: 0.38 * SNOOKER_HUMAN_WORLD_SCALE,
-  leftFootForward: 0.30 * SNOOKER_HUMAN_WORLD_SCALE,
-  chinCueOffsetY: 0.12 * SNOOKER_HUMAN_WORLD_SCALE,
-  chestCueOffsetY: 0.22 * SNOOKER_HUMAN_WORLD_SCALE,
-  rootLambda: 7.5,
-  poseLambda: 10,
-  yawFix: 0
+  desiredShootDistance: 1.25 * SNOOKER_HUMAN_WORLD_SCALE,
+  edgeMargin: 0.68 * SNOOKER_HUMAN_WORLD_SCALE,
+  poseLambda: 9,
+  moveLambda: 5.6,
+  rotLambda: 8.5,
+  stanceWidth: 0.52 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgePalmTableLift: 0.006 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeCueLift: 0.018 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeHandBackFromBall: 0.235 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeHandSide: -0.012 * SNOOKER_HUMAN_WORLD_SCALE,
+  chinToCueHeight: 0.11 * SNOOKER_HUMAN_WORLD_SCALE,
+  footGroundY: 0.035 * SNOOKER_HUMAN_WORLD_SCALE,
+  footLockStrength: 1,
+  kneeBendShot: 0.16 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightElbowShotRise: 0.18 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightElbowShotSide: -0.46 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightElbowShotBack: -0.78 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightForearmOutward: 0.36 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightForearmBack: 0.44 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightForearmDown: 0.48 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightForearmLength: 0.34 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightStrokePull: 0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightStrokePush: 0.24 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightHandShotLift: -0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+  idleRightHandY: 0.8 * SNOOKER_HUMAN_WORLD_SCALE,
+  idleRightHandX: 0.31 * SNOOKER_HUMAN_WORLD_SCALE,
+  idleRightHandZ: -0.015 * SNOOKER_HUMAN_WORLD_SCALE,
+  idleCueGripFromBack: 0.24 * SNOOKER_HUMAN_WORLD_SCALE,
+  idleCueDir: new THREE.Vector3(0.055, 0.965, -0.13),
+  rightHandRollIdle: -2.2,
+  rightHandRollShoot: -2.05,
+  rightHandDownPose: 0.42,
+  rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(SNOOKER_HUMAN_WORLD_SCALE),
+  strikeTime: 0.12,
+  holdTime: 0.05,
+  yawFix: Math.PI
 });
 const cleanSnookerHumanBoneName = (name = '') => name.toLowerCase().replace(/[^a-z0-9]/g, '');
 const snookerHumanClamp01 = (value) => Math.max(0, Math.min(1, value));
+const snookerHumanLerp = (a, b, t) => a + (b - a) * t;
+const snookerHumanEaseOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+const snookerHumanEaseInOut = (t) => t * t * (3 - 2 * t);
 const snookerHumanDamp = (current, target, lambda, dt) =>
   THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+const snookerHumanDampVector = (current, target, lambda, dt) =>
+  current.lerp(target, 1 - Math.exp(-lambda * dt));
 const snookerHumanDampAngle = (current, target, lambda, dt) => {
   const delta = THREE.MathUtils.euclideanModulo(target - current + Math.PI, Math.PI * 2) - Math.PI;
   return current + delta * (1 - Math.exp(-lambda * dt));
 };
+const snookerHumanYawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
 
 function makeSnookerHumanSegment(radius, color, metalness = 0.02) {
   return new THREE.Mesh(
@@ -1699,11 +1732,10 @@ function makeSnookerHumanSegment(radius, color, metalness = 0.02) {
 
 function createSnookerHumanFallbackRig() {
   const rig = new THREE.Group();
-  rig.name = 'SnookerRoyalFallbackHumanPoseRig';
+  rig.name = 'SnookerRoyalProvidedHumanFallbackRig';
   const skin = new THREE.MeshStandardMaterial({ color: 0xd9a27d, roughness: 0.68 });
   const vest = new THREE.MeshStandardMaterial({ color: 0x111827, roughness: 0.64 });
   const shirt = new THREE.MeshStandardMaterial({ color: 0xf8fafc, roughness: 0.7 });
-  const trouser = new THREE.MeshStandardMaterial({ color: 0x1f2937, roughness: 0.75 });
   const shoe = new THREE.MeshStandardMaterial({ color: 0x050505, roughness: 0.6 });
   const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.135, 0.34, 5, 12), vest);
   const chest = new THREE.Mesh(new THREE.CapsuleGeometry(0.105, 0.22, 5, 12), shirt);
@@ -1741,9 +1773,7 @@ function placeSnookerHumanSegment(segment, a, b) {
   const len = delta.length();
   segment.position.copy(mid);
   segment.scale.set(1, Math.max(len, 1e-4), 1);
-  if (len > 1e-5) {
-    segment.quaternion.setFromUnitVectors(SNOOKER_HUMAN_UP, delta.normalize());
-  }
+  if (len > 1e-5) segment.quaternion.setFromUnitVectors(SNOOKER_HUMAN_UP, delta.normalize());
 }
 
 function poseSnookerHumanFallback(human, points) {
@@ -1777,13 +1807,28 @@ function poseSnookerHumanFallback(human, points) {
   root.updateMatrixWorld(true);
 }
 
+function collectSnookerHumanFingerBones(hand) {
+  const fingers = [];
+  hand?.traverse?.((obj) => {
+    if (!obj?.isBone || obj === hand) return;
+    const name = cleanSnookerHumanBoneName(obj.name);
+    if (['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((part) => name.includes(part))) {
+      fingers.push(obj);
+    }
+  });
+  return fingers;
+}
+
+function makeSnookerHumanBasisQuaternion(side, up, forward) {
+  SNOOKER_HUMAN_BASIS_MAT.makeBasis(side.clone().normalize(), up.clone().normalize(), forward.clone().normalize());
+  return new THREE.Quaternion().setFromRotationMatrix(SNOOKER_HUMAN_BASIS_MAT);
+}
+
 function normalizeSnookerHumanModel(model, targetHeight = SNOOKER_HUMAN_CFG.targetHeight) {
   model.updateMatrixWorld(true);
   const box = new THREE.Box3().setFromObject(model);
-  const size = box.getSize(new THREE.Vector3());
-  const height = Math.max(size.y, 1e-4);
-  const scale = targetHeight / height;
-  model.scale.multiplyScalar(scale);
+  const height = Math.max(box.max.y - box.min.y, 1e-4);
+  model.scale.multiplyScalar(targetHeight / height);
   model.updateMatrixWorld(true);
   const scaledBox = new THREE.Box3().setFromObject(model);
   const center = scaledBox.getCenter(new THREE.Vector3());
@@ -1798,31 +1843,32 @@ function findSnookerHumanBone(root, ...names) {
   root.traverse((obj) => {
     if (found || !obj?.isBone) return;
     const n = cleanSnookerHumanBoneName(obj.name);
-    if (wanted.some((needle) => n === needle || n.includes(needle))) found = obj;
+    if (wanted.some((needle) => n === needle || n.endsWith(needle) || n.includes(needle))) found = obj;
   });
   return found;
 }
 
 function buildSnookerHumanBones(model) {
   return {
-    hips: findSnookerHumanBone(model, 'hips', 'pelvis'),
-    spine: findSnookerHumanBone(model, 'spine'),
-    chest: findSnookerHumanBone(model, 'spine2', 'chest', 'upperchest'),
-    neck: findSnookerHumanBone(model, 'neck'),
-    head: findSnookerHumanBone(model, 'head'),
-    leftUpperArm: findSnookerHumanBone(model, 'leftarm', 'leftupperarm', 'mixamorigleftarm'),
-    leftLowerArm: findSnookerHumanBone(model, 'leftforearm', 'leftlowerarm'),
-    leftHand: findSnookerHumanBone(model, 'lefthand'),
-    rightUpperArm: findSnookerHumanBone(model, 'rightarm', 'rightupperarm', 'mixamorigrightarm'),
-    rightLowerArm: findSnookerHumanBone(model, 'rightforearm', 'rightlowerarm'),
-    rightHand: findSnookerHumanBone(model, 'righthand'),
-    leftUpperLeg: findSnookerHumanBone(model, 'leftupleg', 'leftupperleg'),
-    leftLowerLeg: findSnookerHumanBone(model, 'leftleg', 'leftlowerleg'),
-    rightUpperLeg: findSnookerHumanBone(model, 'rightupleg', 'rightupperleg'),
-    rightLowerLeg: findSnookerHumanBone(model, 'rightleg', 'rightlowerleg')
+    hips: findSnookerHumanBone(model, 'hips', 'pelvis', 'mixamorigHips'),
+    spine: findSnookerHumanBone(model, 'spine', 'spine01', 'mixamorigSpine'),
+    chest: findSnookerHumanBone(model, 'spine2', 'chest', 'upperchest', 'mixamorigSpine2', 'mixamorigSpine1'),
+    neck: findSnookerHumanBone(model, 'neck', 'mixamorigNeck'),
+    head: findSnookerHumanBone(model, 'head', 'mixamorigHead'),
+    leftUpperArm: findSnookerHumanBone(model, 'leftupperarm', 'leftarm', 'upperarml', 'mixamorigLeftArm'),
+    leftLowerArm: findSnookerHumanBone(model, 'leftforearm', 'leftlowerarm', 'forearml', 'mixamorigLeftForeArm'),
+    leftHand: findSnookerHumanBone(model, 'lefthand', 'handl', 'mixamorigLeftHand'),
+    rightUpperArm: findSnookerHumanBone(model, 'rightupperarm', 'rightarm', 'upperarmr', 'mixamorigRightArm'),
+    rightLowerArm: findSnookerHumanBone(model, 'rightforearm', 'rightlowerarm', 'forearmr', 'mixamorigRightForeArm'),
+    rightHand: findSnookerHumanBone(model, 'righthand', 'handr', 'mixamorigRightHand'),
+    leftUpperLeg: findSnookerHumanBone(model, 'leftupleg', 'leftupperleg', 'leftthigh', 'mixamorigLeftUpLeg'),
+    leftLowerLeg: findSnookerHumanBone(model, 'leftleg', 'leftlowerleg', 'leftcalf', 'mixamorigLeftLeg'),
+    leftFoot: findSnookerHumanBone(model, 'leftfoot', 'footl', 'mixamorigLeftFoot'),
+    rightUpperLeg: findSnookerHumanBone(model, 'rightupleg', 'rightupperleg', 'rightthigh', 'mixamorigRightUpLeg'),
+    rightLowerLeg: findSnookerHumanBone(model, 'rightleg', 'rightlowerleg', 'rightcalf', 'mixamorigRightLeg'),
+    rightFoot: findSnookerHumanBone(model, 'rightfoot', 'footr', 'mixamorigRightFoot')
   };
 }
-
 
 function disposeSnookerHumanGLTFLoader(loader) {
   loader?.userData?.draco?.dispose?.();
@@ -1862,12 +1908,7 @@ function loadSnookerHumanModel(loader, url) {
           if (!response.ok) throw new Error(`HTTP ${response.status}`);
           const buffer = await response.arrayBuffer();
           const basePath = url.slice(0, url.lastIndexOf('/') + 1);
-          loader.parse(
-            buffer,
-            basePath,
-            (gltf) => resolve(gltf?.scene || gltf?.scenes?.[0] || null),
-            reject
-          );
+          loader.parse(buffer, basePath, (gltf) => resolve(gltf?.scene || gltf?.scenes?.[0] || null), reject);
         } catch (fetchError) {
           reject(fetchError || loaderError);
         }
@@ -1884,6 +1925,7 @@ function buildSnookerHumanModelUrls(theme = SNOOKER_HUMAN_CHARACTER_THEME) {
       ...(entry?.modelUrls || []),
       entry?.url
     ]),
+    'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
     'https://threejs.org/examples/models/gltf/Xbot.glb',
     'https://threejs.org/examples/models/gltf/Soldier.glb'
   ].filter(Boolean);
@@ -1906,8 +1948,7 @@ async function loadSnookerHumanModelFromCatalog(loader, urls = buildSnookerHuman
 }
 
 function resetSnookerHumanRestPose(human) {
-  if (!human?.restQuats) return;
-  human.restQuats.forEach((quat, bone) => {
+  human?.restQuats?.forEach((quat, bone) => {
     if (bone?.quaternion) bone.quaternion.copy(quat);
   });
 }
@@ -1928,7 +1969,7 @@ function rotateSnookerHumanBoneToward(bone, targetWorld, strength = 0.72, fallba
   if (!bone || !targetWorld || strength <= 0) return;
   const bonePos = bone.getWorldPosition(new THREE.Vector3());
   const child = firstSnookerHumanBoneChild(bone);
-  const childPos = child?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir, 0.2);
+  const childPos = child?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25 * SNOOKER_HUMAN_WORLD_SCALE);
   const current = childPos.sub(bonePos).normalize();
   const desired = targetWorld.clone().sub(bonePos);
   if (current.lengthSq() < 1e-8 || desired.lengthSq() < 1e-8) return;
@@ -1937,30 +1978,193 @@ function rotateSnookerHumanBoneToward(bone, targetWorld, strength = 0.72, fallba
   setSnookerHumanBoneWorldQuaternion(bone, blended.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
 }
 
-function poseSnookerHumanGlb(human, targetsLocal) {
-  if (!human?.activeGlb || !human.modelRoot?.parent) return;
-  const tableGroup = human.modelRoot.parent;
-  if (!tableGroup) return;
-  resetSnookerHumanRestPose(human);
-  const toWorld = (local) => tableGroup.localToWorld(local.clone());
-  const bones = human.bones || {};
-  human.modelRoot.updateMatrixWorld(true);
-  const leftHand = toWorld(targetsLocal.leftHandWorld);
-  const rightHand = toWorld(targetsLocal.rightHandWorld);
-  const leftElbow = toWorld(targetsLocal.leftElbowWorld);
-  const rightElbow = toWorld(targetsLocal.rightElbowWorld);
-  const head = toWorld(targetsLocal.headWorld);
-  const chest = toWorld(targetsLocal.chestWorld);
-  rotateSnookerHumanBoneToward(bones.spine, chest, 0.4, SNOOKER_HUMAN_UP);
-  rotateSnookerHumanBoneToward(bones.chest, head, 0.45, SNOOKER_HUMAN_UP);
-  rotateSnookerHumanBoneToward(bones.neck, head, 0.55, SNOOKER_HUMAN_UP);
-  rotateSnookerHumanBoneToward(bones.head, toWorld(targetsLocal.cueTipWorld), 0.32, SNOOKER_HUMAN_FORWARD_LOCAL);
-  for (let i = 0; i < 3; i += 1) {
-    rotateSnookerHumanBoneToward(bones.leftUpperArm, leftElbow, 0.75, SNOOKER_HUMAN_UP);
-    rotateSnookerHumanBoneToward(bones.leftLowerArm, leftHand, 0.78, SNOOKER_HUMAN_UP);
-    rotateSnookerHumanBoneToward(bones.rightUpperArm, rightElbow, 0.76, SNOOKER_HUMAN_UP);
-    rotateSnookerHumanBoneToward(bones.rightLowerArm, rightHand, 0.8, SNOOKER_HUMAN_UP);
+function twistSnookerHumanBone(bone, axis, amount) {
+  if (!bone || Math.abs(amount) < 1e-5) return;
+  setSnookerHumanBoneWorldQuaternion(
+    bone,
+    new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount)
+      .multiply(bone.getWorldQuaternion(new THREE.Quaternion()))
+  );
+}
+
+function aimSnookerHumanTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) {
+  for (let i = 0; i < 4; i += 1) {
+    rotateSnookerHumanBoneToward(upper, elbow, upperStrength, pole);
+    rotateSnookerHumanBoneToward(lower, hand, lowerStrength, pole);
   }
+}
+
+function setSnookerHumanHandBasis(bone, side, up, forward, roll = 0, strength = 1) {
+  if (!bone || strength <= 0) return;
+  const q = makeSnookerHumanBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  setSnookerHumanBoneWorldQuaternion(
+    bone,
+    bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, snookerHumanClamp01(strength))
+  );
+}
+
+function snookerHumanCueSocketOffsetWorld(side, up, forward, roll, socketLocal = SNOOKER_HUMAN_CFG.rightHandCueSocketLocal) {
+  const q = makeSnookerHumanBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  return socketLocal.clone().applyQuaternion(q);
+}
+
+function poseSnookerHumanFingers(fingers, mode, weight) {
+  const w = snookerHumanClamp01(weight);
+  fingers?.forEach((finger, i) => {
+    const n = cleanSnookerHumanBoneName(finger.name);
+    const thumb = n.includes('thumb');
+    const index = n.includes('index');
+    const middle = n.includes('middle');
+    const ring = n.includes('ring');
+    const pinky = n.includes('pinky') || n.includes('little');
+    const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal'));
+    const mid = n.includes('2') || n.includes('intermediate');
+    const tip = n.includes('3') || n.includes('distal');
+    if (mode === 'idle') {
+      finger.rotation.x += 0.018 * w;
+      finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1);
+      return;
+    }
+    if (mode === 'grip') {
+      if (thumb) {
+        finger.rotation.x += 0.48 * w;
+        finger.rotation.y += -0.82 * w;
+        finger.rotation.z += 0.54 * w;
+        return;
+      }
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0;
+      finger.rotation.x += curl * w;
+      finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w;
+      finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w;
+      return;
+    }
+    if (thumb) {
+      finger.rotation.x += -0.18 * w;
+      finger.rotation.y += 0.95 * w;
+      finger.rotation.z += -0.95 * w;
+    } else if (index) {
+      finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w;
+      finger.rotation.y += -0.46 * w;
+      finger.rotation.z += -0.42 * w;
+    } else if (middle) {
+      finger.rotation.x += (base ? 0.18 : mid ? 0.32 : 0.22) * w;
+      finger.rotation.y += -0.12 * w;
+      finger.rotation.z += -0.14 * w;
+    } else if (ring || pinky) {
+      finger.rotation.x += (base ? (ring ? 0.08 : 0.05) : mid ? (ring ? 0.18 : 0.16) : tip ? (ring ? 0.12 : 0.1) : 0.1) * w;
+      finger.rotation.y += (ring ? 0.18 : 0.34) * w;
+      finger.rotation.z += (ring ? 0.28 : 0.46) * w;
+    }
+  });
+}
+
+function getSnookerCueEndpoints(cueStick, cueLen) {
+  if (!cueStick) return null;
+  cueStick.updateMatrixWorld(true);
+  const tip = new THREE.Vector3(0, 0, -cueLen / 2).applyMatrix4(cueStick.matrixWorld);
+  const butt = new THREE.Vector3(0, 0, cueLen / 2).applyMatrix4(cueStick.matrixWorld);
+  const parent = cueStick.parent;
+  if (parent) {
+    parent.worldToLocal(tip);
+    parent.worldToLocal(butt);
+  }
+  return { tip, butt };
+}
+
+function chooseSnookerHumanEdgePosition(cueBallWorld, aimForward) {
+  const desired = cueBallWorld.clone().addScaledVector(aimForward, -SNOOKER_HUMAN_CFG.desiredShootDistance);
+  const xEdge = PLAY_W / 2 + SNOOKER_HUMAN_CFG.edgeMargin;
+  const zEdge = PLAY_H / 2 + SNOOKER_HUMAN_CFG.edgeMargin;
+  const candidates = [
+    new THREE.Vector3(-xEdge, SNOOKER_HUMAN_CFG.floorY, clamp(desired.z, -zEdge, zEdge)),
+    new THREE.Vector3(xEdge, SNOOKER_HUMAN_CFG.floorY, clamp(desired.z, -zEdge, zEdge)),
+    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), SNOOKER_HUMAN_CFG.floorY, -zEdge),
+    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), SNOOKER_HUMAN_CFG.floorY, zEdge)
+  ];
+  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+}
+
+function poseSnookerHumanGlb(human, frame) {
+  if (!human?.activeGlb || !human.model || !human.modelRoot?.parent) return;
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(frame.rootWorld);
+  human.modelRoot.rotation.y = human.yaw;
+  human.modelRoot.updateMatrixWorld(true);
+  resetSnookerHumanRestPose(human);
+  human.modelRoot.updateMatrixWorld(true);
+  const b = human.bones || {};
+  const ik = snookerHumanEaseInOut(snookerHumanClamp01(frame.t));
+  const idle = 1 - ik;
+  const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
+  const standingCueDir = SNOOKER_HUMAN_CFG.idleCueDir.clone().applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw).normalize();
+  const shotQ = makeSnookerHumanBasisQuaternion(frame.side, SNOOKER_HUMAN_UP, frame.forward);
+  if (frame.walkAmount * idle > 0.001) {
+    const s = Math.sin(human.walkPhase * 6.2);
+    const c = Math.cos(human.walkPhase * 6.2);
+    const w = frame.walkAmount * idle;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+  }
+  if (ik >= 0.025) {
+    rotateSnookerHumanBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
+    twistSnookerHumanBone(b.hips, frame.side, -0.045 * ik);
+    twistSnookerHumanBone(b.hips, frame.forward, -0.025 * ik);
+    rotateSnookerHumanBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
+    twistSnookerHumanBone(b.spine, frame.side, -0.2 * ik);
+    twistSnookerHumanBone(b.spine, frame.forward, -0.04 * ik);
+    rotateSnookerHumanBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
+    twistSnookerHumanBone(b.chest, frame.side, -0.32 * ik);
+    twistSnookerHumanBone(b.chest, frame.forward, -0.025 * ik);
+    rotateSnookerHumanBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
+    twistSnookerHumanBone(b.neck, frame.side, -0.12 * ik);
+    if (b.head) {
+      setSnookerHumanBoneWorldQuaternion(
+        b.head,
+        b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(
+          shotQ.clone()
+            .multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik))
+            .multiply(new THREE.Quaternion().setFromAxisAngle(frame.forward, -0.025 * ik)),
+          0.74 * ik
+        )
+      );
+    }
+    human.modelRoot.updateMatrixWorld(true);
+  }
+  const rightGrip = frame.rightHandWorld.clone();
+  const rightIdleElbow = rightGrip.clone()
+    .addScaledVector(SNOOKER_HUMAN_UP, 0.04 * SNOOKER_HUMAN_WORLD_SCALE + 0.14 * SNOOKER_HUMAN_WORLD_SCALE * ik)
+    .addScaledVector(frame.side, -0.2 * SNOOKER_HUMAN_WORLD_SCALE)
+    .addScaledVector(frame.forward, -0.03 * SNOOKER_HUMAN_WORLD_SCALE * idle);
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
+  const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, 0.32).addScaledVector(frame.forward, -0.55).normalize();
+  aimSnookerHumanTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, pole, 0.9 + 0.1 * ik, 1.0);
+  const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
+  const standingHandUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(-1.0).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
+  const handForwardForOrientation = ik >= 0.025 ? cueDir : standingCueDir;
+  const rollForOrientation = ik >= 0.025 ? SNOOKER_HUMAN_CFG.rightHandRollShoot : SNOOKER_HUMAN_CFG.rightHandRollIdle + 0.02 * frame.stroke;
+  setSnookerHumanHandBasis(b.rightHand, standingHandSide, standingHandUp, handForwardForOrientation, rollForOrientation, 1.0);
+  poseSnookerHumanFingers(human.rightFingers, 'grip', 0.95);
+  if (ik < 0.025) {
+    poseSnookerHumanFingers(human.leftFingers, 'idle', 1);
+    return;
+  }
+  aimSnookerHumanTwoBone(b.leftUpperArm, b.leftLowerArm, frame.leftElbow, frame.leftHandWorld, frame.side.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, 0.1).normalize(), 0.98 * ik, 1.0 * ik);
+  const bridgeSide = frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize();
+  const bridgeUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize();
+  setSnookerHumanHandBasis(b.leftHand, bridgeSide, bridgeUp, cueDir, -0.68 * ik, 1.0 * ik);
+  poseSnookerHumanFingers(human.leftFingers, 'bridge', ik);
+  aimSnookerHumanTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(SNOOKER_HUMAN_UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
+  setSnookerHumanHandBasis(b.leftFoot, frame.side, frame.up, frame.forward, -0.02 * ik, SNOOKER_HUMAN_CFG.footLockStrength * ik);
+  aimSnookerHumanTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
+  setSnookerHumanHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, SNOOKER_HUMAN_CFG.footLockStrength * ik);
 }
 
 function createSnookerRoyalHumanPlayer(parent, renderer) {
@@ -1968,21 +2172,29 @@ function createSnookerRoyalHumanPlayer(parent, renderer) {
     root: new THREE.Group(),
     modelRoot: new THREE.Group(),
     fallback: createSnookerHumanFallbackRig(),
+    model: null,
     bones: {},
     activeGlb: false,
     yaw: 0,
     poseT: 0,
+    breathT: 0,
+    settleT: 0,
     loaded: false,
     disabled: false,
     loadFailed: false,
+    strikeRoot: new THREE.Vector3(),
+    strikeYaw: 0,
+    strikeClock: 0,
     lastRootPosition: new THREE.Vector3(),
     walkPhase: 0,
     walkAmount: 0,
     restQuats: new Map(),
+    leftFingers: [],
+    rightFingers: [],
     theme: SNOOKER_HUMAN_CHARACTER_THEME
   };
-  human.root.name = 'SnookerRoyalHumanPlayerRoot';
-  human.modelRoot.name = 'SnookerRoyalDominoCharacterRoot';
+  human.root.name = 'SnookerRoyalProvidedHumanPlayerRoot';
+  human.modelRoot.name = 'SnookerRoyalProvidedHumanCharacterRoot';
   human.root.visible = false;
   human.modelRoot.visible = false;
   human.root.add(human.fallback);
@@ -2008,14 +2220,24 @@ function createSnookerRoyalHumanPlayer(parent, renderer) {
         });
       });
       human.bones = buildSnookerHumanBones(model);
+      human.leftFingers = collectSnookerHumanFingerBones(human.bones.leftHand);
+      human.rightFingers = collectSnookerHumanFingerBones(human.bones.rightHand);
+      [...human.leftFingers, ...human.rightFingers].forEach((bone) => human.restQuats.set(bone, bone.quaternion.clone()));
       human.activeGlb = Boolean(
-        human.bones.head &&
+        human.bones.hips &&
         human.bones.spine &&
-        human.bones.leftUpperArm &&
-        human.bones.leftLowerArm &&
+        human.bones.head &&
         human.bones.rightUpperArm &&
-        human.bones.rightLowerArm
+        human.bones.rightLowerArm &&
+        human.bones.rightHand &&
+        human.bones.leftUpperLeg &&
+        human.bones.leftLowerLeg &&
+        human.bones.leftFoot &&
+        human.bones.rightUpperLeg &&
+        human.bones.rightLowerLeg &&
+        human.bones.rightFoot
       );
+      human.model = model;
       human.modelUrl = url;
       human.modelRoot.add(model);
       human.modelRoot.visible = human.root.visible && human.activeGlb;
@@ -2032,19 +2254,6 @@ function createSnookerRoyalHumanPlayer(parent, renderer) {
   return human;
 }
 
-function getSnookerCueEndpoints(cueStick, cueLen) {
-  if (!cueStick) return null;
-  cueStick.updateMatrixWorld(true);
-  const tip = new THREE.Vector3(0, 0, -cueLen / 2).applyMatrix4(cueStick.matrixWorld);
-  const butt = new THREE.Vector3(0, 0, cueLen / 2).applyMatrix4(cueStick.matrixWorld);
-  const parent = cueStick.parent;
-  if (parent) {
-    parent.worldToLocal(tip);
-    parent.worldToLocal(butt);
-  }
-  return { tip, butt };
-}
-
 function updateSnookerRoyalHumanPlayer(human, dt, options) {
   if (!human?.root || human.disabled) return;
   const { cue, cueStick, cueLen, aimDir, visible, power = 0, shooting = false, cueAnimating = false } = options || {};
@@ -2057,94 +2266,150 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
   const dir = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
   if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
   dir.normalize();
-  const side = new THREE.Vector3(-dir.z, 0, dir.x).normalize();
   const cueBall = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
   const cueEndpoints = getSnookerCueEndpoints(cueStick, cueLen) || {
     tip: cueBall.clone().addScaledVector(dir, -CUE_TIP_GAP),
     butt: cueBall.clone().addScaledVector(dir, -(cueLen + CUE_TIP_GAP))
   };
-  const pullPose = THREE.MathUtils.clamp((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0), 0, 1);
-  // Orientation is driven from the actual shot line: the root stands behind
-  // the cue ball on -dir, then faces +dir back through cue ball/object ball.
-  // Keeping local +Z on the shot line prevents mirrored cue/hand placement.
-  const rootTarget = cueBall.clone()
-    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.idleDistance - pullPose * BALL_R * 1.8)
-    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceSide * 0.32);
+  const cueShotDir = cueEndpoints.tip.clone().sub(cueEndpoints.butt);
+  if (cueShotDir.lengthSq() > 1e-8) dir.copy(cueShotDir.normalize());
+  const side = new THREE.Vector3(dir.z, 0, -dir.x).normalize();
+  const state = shooting ? 'striking' : sliderInstanceRef.current?.dragging || cueAnimating ? 'dragging' : 'idle';
+  human.poseT = snookerHumanDamp(human.poseT, state === 'idle' ? 0 : 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
+  human.breathT += dt * (state === 'idle' ? 1.05 : 0.5);
+  human.settleT = snookerHumanDamp(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
+  const activePower = snookerHumanClamp01(power ?? 0);
+  const baseRootTarget = chooseSnookerHumanEdgePosition(cueBall, dir);
+  if (state === 'striking') {
+    if (human.strikeClock === 0) {
+      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : baseRootTarget);
+      human.strikeYaw = human.yaw;
+    }
+    human.strikeClock += dt;
+  } else {
+    human.strikeClock = 0;
+  }
+  const rootTarget = baseRootTarget.clone()
+    .addScaledVector(dir, state === 'dragging' ? -activePower * BALL_R * 1.8 : 0)
+    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceWidth * 0.16);
   rootTarget.y = SNOOKER_HUMAN_CFG.floorY;
-  const yawTarget = Math.atan2(dir.x, dir.z);
+  const rootGoal = state === 'striking' ? human.strikeRoot : rootTarget;
+  snookerHumanDampVector(human.root.position, rootGoal, state === 'striking' ? 12 : SNOOKER_HUMAN_CFG.moveLambda, dt);
+  const travel = human.root.position.distanceTo(rootGoal);
+  human.walkAmount = snookerHumanDamp(human.walkAmount, snookerHumanClamp01(travel / Math.max(BALL_R * 4, 1e-4)), 8, dt);
+  human.walkPhase += dt * (2 + Math.min(7, travel * 10 / SNOOKER_HUMAN_WORLD_SCALE));
+  human.yaw = snookerHumanDampAngle(human.yaw, state === 'striking' ? human.strikeYaw : snookerHumanYawFromForward(dir), SNOOKER_HUMAN_CFG.rotLambda, dt);
+  human.root.rotation.set(0, human.yaw, 0);
   human.root.visible = true;
   human.modelRoot.visible = human.loaded && human.activeGlb;
-  const travel = human.lastRootPosition.distanceTo(rootTarget);
-  human.walkAmount = snookerHumanDamp(human.walkAmount, snookerHumanClamp01(travel / Math.max(BALL_R * 4, 1e-4)), 8, dt);
-  human.walkPhase += dt * (4.5 + human.walkAmount * 5.5);
-  human.root.position.lerp(rootTarget, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
-  human.lastRootPosition.copy(human.root.position);
-  human.yaw = snookerHumanDampAngle(human.yaw, yawTarget, SNOOKER_HUMAN_CFG.rootLambda, dt);
-  human.root.rotation.set(0, human.yaw, 0);
-  human.modelRoot.position.copy(human.root.position);
-  human.modelRoot.rotation.copy(human.root.rotation);
-  human.poseT = snookerHumanDamp(human.poseT, 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
-  const invRoot = new THREE.Matrix4().copy(human.root.matrixWorld).invert();
-  const toRootLocal = (v) => v.clone().applyMatrix4(invRoot);
-  const bridge = cueBall.clone()
-    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
-    .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
-    .setY(CUE_Y + BALL_R * 0.08);
-  const grip = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
-  const chestWorld = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
-  const headWorld = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const torso = toRootLocal(chestWorld).add(new THREE.Vector3(0, 0.16 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
-  const chest = toRootLocal(chestWorld);
-  const head = toRootLocal(headWorld);
-  const neck = chest.clone().lerp(head, 0.68);
-  const leftShoulder = chest.clone().add(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, -0.025 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightShoulder = chest.clone().add(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.055 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
-  const leftHand = toRootLocal(bridge);
-  const rightHand = toRootLocal(grip);
-  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.58).add(new THREE.Vector3(-0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.03 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightElbow = rightShoulder.clone().lerp(rightHand, 0.42).add(new THREE.Vector3(0.22 * SNOOKER_HUMAN_WORLD_SCALE, 0.20 * SNOOKER_HUMAN_WORLD_SCALE, -0.20 * SNOOKER_HUMAN_WORLD_SCALE));
-  const leftHip = new THREE.Vector3(-0.07 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const rightHip = new THREE.Vector3(0.08 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.12 * SNOOKER_HUMAN_WORLD_SCALE);
-  const walkLift = Math.sin(human.walkPhase) * 0.028 * SNOOKER_HUMAN_WORLD_SCALE * human.walkAmount;
-  const leftFoot = new THREE.Vector3(-SNOOKER_HUMAN_CFG.stanceSide, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, walkLift), SNOOKER_HUMAN_CFG.leftFootForward);
-  const rightFoot = new THREE.Vector3(SNOOKER_HUMAN_CFG.stanceSide * 0.62, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, -walkLift), -SNOOKER_HUMAN_CFG.rightFootBack);
-  const leftKnee = leftHip.clone().lerp(leftFoot, 0.55).add(new THREE.Vector3(-0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.12 * SNOOKER_HUMAN_WORLD_SCALE, 0.04 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).add(new THREE.Vector3(0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.14 * SNOOKER_HUMAN_WORLD_SCALE, -0.03 * SNOOKER_HUMAN_WORLD_SCALE));
+  human.fallback.visible = !human.activeGlb;
+
+  const t = snookerHumanEaseInOut(human.poseT);
+  const idle = 1 - t;
+  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * SNOOKER_HUMAN_WORLD_SCALE);
+  const walk = Math.sin(human.walkPhase * 6.2) * Math.min(1, travel * 12 / SNOOKER_HUMAN_WORLD_SCALE);
+  const walkAmount = snookerHumanClamp01(travel * 18 / SNOOKER_HUMAN_WORLD_SCALE) * idle;
+  const dragStroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + activePower * 0.75) : 0;
+  const strikeFollow = state === 'striking'
+    ? Math.sin(snookerHumanClamp01(human.strikeClock / (SNOOKER_HUMAN_CFG.strikeTime + SNOOKER_HUMAN_CFG.holdTime)) * Math.PI)
+    : 0;
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw).normalize();
+  const shotSide = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+  const local = (v) => v.clone().applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw).add(human.root.position);
+  const powerLean = activePower * t;
+  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * SNOOKER_HUMAN_WORLD_SCALE);
+  rootWorld.y = SNOOKER_HUMAN_CFG.floorY;
+  const torso = local(new THREE.Vector3(0, snookerHumanLerp(1.3, 1.14, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0.02, -0.16, t) - 0.014 * powerLean) * SNOOKER_HUMAN_WORLD_SCALE));
+  const chest = local(new THREE.Vector3(0, snookerHumanLerp(1.52, 1.24, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0.02, -0.42, t) - 0.024 * powerLean) * SNOOKER_HUMAN_WORLD_SCALE));
+  const neck = local(new THREE.Vector3(0, snookerHumanLerp(1.68, 1.28, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0.02, -0.61, t) - 0.028 * powerLean) * SNOOKER_HUMAN_WORLD_SCALE));
+  const head = local(new THREE.Vector3(0, snookerHumanLerp(1.84, 1.37, t) * SNOOKER_HUMAN_WORLD_SCALE + breath - SNOOKER_HUMAN_CFG.chinToCueHeight * 0.16 * t, (snookerHumanLerp(0.04, -0.72, t) - 0.028 * powerLean) * SNOOKER_HUMAN_WORLD_SCALE));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * SNOOKER_HUMAN_WORLD_SCALE, snookerHumanLerp(1.58, 1.36, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0, -0.46, t) - 0.018 * human.settleT) * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightShoulder = local(new THREE.Vector3(0.23 * SNOOKER_HUMAN_WORLD_SCALE, snookerHumanLerp(1.58, 1.36, t) * SNOOKER_HUMAN_WORLD_SCALE + breath, (snookerHumanLerp(0, -0.34, t) - 0.018 * human.settleT) * SNOOKER_HUMAN_WORLD_SCALE));
+  const leftHip = local(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.92 * SNOOKER_HUMAN_WORLD_SCALE, 0.02 * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightHip = local(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.92 * SNOOKER_HUMAN_WORLD_SCALE, 0.02 * SNOOKER_HUMAN_WORLD_SCALE));
+  const leftFoot = local(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.footGroundY, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + walk * 0.018 * SNOOKER_HUMAN_WORLD_SCALE).lerp(new THREE.Vector3(-SNOOKER_HUMAN_CFG.stanceWidth * 0.42, SNOOKER_HUMAN_CFG.footGroundY, -0.34 * SNOOKER_HUMAN_WORLD_SCALE), t));
+  const rightFoot = local(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.footGroundY, -0.03 * SNOOKER_HUMAN_WORLD_SCALE - walk * 0.018 * SNOOKER_HUMAN_WORLD_SCALE).lerp(new THREE.Vector3(SNOOKER_HUMAN_CFG.stanceWidth * 0.5, SNOOKER_HUMAN_CFG.footGroundY, 0.34 * SNOOKER_HUMAN_WORLD_SCALE), t));
+  const bridgePalmTarget = cueBall.clone()
+    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeHandBackFromBall)
+    .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeHandSide)
+    .setY(CUE_Y + SNOOKER_HUMAN_CFG.bridgePalmTableLift)
+    .addScaledVector(SNOOKER_HUMAN_UP, -0.01 * SNOOKER_HUMAN_WORLD_SCALE * human.settleT);
+  const idleRight = rootTarget.clone().add(new THREE.Vector3(SNOOKER_HUMAN_CFG.idleRightHandX, SNOOKER_HUMAN_CFG.idleRightHandY, SNOOKER_HUMAN_CFG.idleRightHandZ).applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw));
+  const idleLeft = rootTarget.clone().add(new THREE.Vector3(-0.18 * SNOOKER_HUMAN_WORLD_SCALE, 1.08 * SNOOKER_HUMAN_WORLD_SCALE, 0.03 * SNOOKER_HUMAN_WORLD_SCALE).applyAxisAngle(SNOOKER_HUMAN_UP, human.yaw));
+  const leftHand = idleLeft.clone().lerp(bridgePalmTarget, t);
+  const cueDirForHand = cueEndpoints.tip.clone().sub(cueEndpoints.butt).normalize();
+  const handIk = snookerHumanEaseInOut(snookerHumanClamp01(t));
+  const idleGripSide = shotSide.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(-1.0).addScaledVector(shotSide, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = shotSide.clone().multiplyScalar(-1).addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(-0.55, -0.62, handIk)).addScaledVector(shotSide, 0.5 * handIk).addScaledVector(forward, snookerHumanLerp(0.16, -0.08, handIk)).normalize();
+  const liveGripUp = SNOOKER_HUMAN_UP.clone().multiplyScalar(snookerHumanLerp(-1.0, 0.12, handIk)).addScaledVector(shotSide, snookerHumanLerp(-0.64, -0.04, handIk)).addScaledVector(forward, snookerHumanLerp(0.2, -0.48, handIk)).normalize();
+  const lockedRightElbow = rightShoulder.clone()
+    .addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(0.04 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.rightElbowShotRise, t))
+    .addScaledVector(shotSide, snookerHumanLerp(-0.18 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.rightElbowShotSide, t))
+    .addScaledVector(forward, snookerHumanLerp(-0.04 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.rightElbowShotBack, t));
+  const pullBack = state === 'dragging' ? -SNOOKER_HUMAN_CFG.rightStrokePull * snookerHumanEaseOutCubic(activePower) : 0;
+  const pushForward = state === 'striking' ? SNOOKER_HUMAN_CFG.rightStrokePush * strikeFollow : 0;
+  const smallPractice = state === 'dragging' ? dragStroke * 0.035 * SNOOKER_HUMAN_WORLD_SCALE : 0;
+  const forearmStroke = pullBack + pushForward + smallPractice;
+  const forearmBase = lockedRightElbow.clone()
+    .addScaledVector(shotSide, SNOOKER_HUMAN_CFG.rightForearmOutward * t)
+    .addScaledVector(SNOOKER_HUMAN_UP, -SNOOKER_HUMAN_CFG.rightForearmDown * t)
+    .addScaledVector(SNOOKER_HUMAN_UP, SNOOKER_HUMAN_CFG.rightHandShotLift * t)
+    .addScaledVector(forward, -SNOOKER_HUMAN_CFG.rightForearmBack * t)
+    .addScaledVector(cueDirForHand, SNOOKER_HUMAN_CFG.rightForearmLength);
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
+  const idleWristTarget = idleRight.clone().sub(snookerHumanCueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, SNOOKER_HUMAN_CFG.rightHandRollIdle));
+  const liveWristTarget = liveCueGripPoint.clone().sub(snookerHumanCueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, snookerHumanLerp(SNOOKER_HUMAN_CFG.rightHandRollIdle, SNOOKER_HUMAN_CFG.rightHandRollShoot - SNOOKER_HUMAN_CFG.rightHandDownPose, handIk)));
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(SNOOKER_HUMAN_UP, 0.006 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(shotSide, -0.044 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(forward, 0.065 * SNOOKER_HUMAN_WORLD_SCALE * t);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(0.2 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.kneeBendShot, t)).addScaledVector(forward, 0.04 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(shotSide, -0.012 * SNOOKER_HUMAN_WORLD_SCALE * t);
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(SNOOKER_HUMAN_UP, snookerHumanLerp(0.2 * SNOOKER_HUMAN_WORLD_SCALE, SNOOKER_HUMAN_CFG.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * SNOOKER_HUMAN_WORLD_SCALE * t).addScaledVector(shotSide, 0.014 * SNOOKER_HUMAN_WORLD_SCALE * t);
+  human.root.updateMatrixWorld(true);
   poseSnookerHumanFallback(human, {
     root: human.root,
-    torso,
-    chest,
-    head,
-    neck,
-    leftShoulder,
-    rightShoulder,
+    torso: human.root.worldToLocal(torso.clone()),
+    chest: human.root.worldToLocal(chest.clone()),
+    head: human.root.worldToLocal(head.clone()),
+    neck: human.root.worldToLocal(neck.clone()),
+    leftShoulder: human.root.worldToLocal(leftShoulder.clone()),
+    rightShoulder: human.root.worldToLocal(rightShoulder.clone()),
+    leftElbow: human.root.worldToLocal(leftElbow.clone()),
+    rightElbow: human.root.worldToLocal(lockedRightElbow.clone()),
+    leftHand: human.root.worldToLocal(leftHand.clone()),
+    rightHand: human.root.worldToLocal(rightHand.clone()),
+    leftHip: human.root.worldToLocal(leftHip.clone()),
+    rightHip: human.root.worldToLocal(rightHip.clone()),
+    leftKnee: human.root.worldToLocal(leftKnee.clone()),
+    rightKnee: human.root.worldToLocal(rightKnee.clone()),
+    leftFoot: human.root.worldToLocal(leftFoot.clone()),
+    rightFoot: human.root.worldToLocal(rightFoot.clone())
+  });
+  poseSnookerHumanGlb(human, {
+    t,
+    stroke: forearmStroke / SNOOKER_HUMAN_WORLD_SCALE,
+    follow: strikeFollow,
+    walkAmount,
+    forward,
+    side: shotSide,
+    up: SNOOKER_HUMAN_UP,
+    rootWorld,
+    torsoCenterWorld: torso,
+    chestCenterWorld: chest,
+    neckWorld: neck,
+    headCenterWorld: head,
     leftElbow,
-    rightElbow,
-    leftHand,
-    rightHand,
-    leftHip,
-    rightHip,
+    rightElbow: lockedRightElbow,
+    leftHandWorld: leftHand,
+    rightHandWorld: rightHand,
     leftKnee,
     rightKnee,
-    leftFoot,
-    rightFoot
-  });
-  const leftElbowTable = human.root.parent
-    ? human.root.parent.worldToLocal(human.root.localToWorld(leftElbow.clone()))
-    : leftElbow.clone();
-  const rightElbowTable = human.root.parent
-    ? human.root.parent.worldToLocal(human.root.localToWorld(rightElbow.clone()))
-    : rightElbow.clone();
-  poseSnookerHumanGlb(human, {
-    leftHandWorld: bridge,
-    rightHandWorld: grip,
-    leftElbowWorld: leftElbowTable,
-    rightElbowWorld: rightElbowTable,
-    headWorld: headWorld,
-    chestWorld: chestWorld,
+    leftFootWorld: leftFoot,
+    rightFootWorld: rightFoot,
+    cueBackWorld: cueEndpoints.butt,
     cueTipWorld: cueEndpoints.tip
   });
 }
+
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_LIFT_DRAG_SCALE = 0.0048;
 const CUE_LIFT_MAX_TILT = THREE.MathUtils.degToRad(12.5);


### PR DESCRIPTION
### Motivation
- Improve the realism and robustness of the in-scene human player by adding better IK, finger posing, and blended pose states for idle/drag/strike. 
- Make GLTF model loading and normalization more forgiving and add additional fallback model sources. 
- Strengthen bone discovery and add utilities for stable per-frame damping and basis math to reduce visual jitter.

### Description
- Added numerous helper utilities and easing/damp functions (`snookerHumanDampVector`, `snookerHumanEaseInOut`, `snookerHumanEaseOutCubic`, `makeSnookerHumanBasisQuaternion`, `snookerHumanYawFromForward`, etc.), and implemented finger collection/posing via `collectSnookerHumanFingerBones` and `poseSnookerHumanFingers`.
- Reworked human configuration and world scaling (`SNOOKER_HUMAN_CFG`, `SNOOKER_HUMAN_CUE_LENGTH`, `SNOOKER_HUMAN_WORLD_SCALE`) and refactored fallback rig/model naming; expanded and hardened `findSnookerHumanBone` matching and `buildSnookerHumanBones` to cover more bone name variants.
- Improved GLTF loader usage and error handling (`loadSnookerHumanModel`, `loadSnookerHumanModelFromCatalog`, added an extra URL fallback) and minor safety changes to `normalizeSnookerHumanModel` and loader cleanup.
- Large pose/IK refactor: added `aimSnookerHumanTwoBone`, `setSnookerHumanHandBasis`, `twistSnookerHumanBone`, rewrote `poseSnookerHumanGlb` and `updateSnookerRoyalHumanPlayer` to support pose blending (idle/dragging/striking), breath/walk/strike state, hand/bridge IK, finger grips, and improved cue endpoint handling; saved/used rest quaternions for model bones and fingers.

### Testing
- Ran the project build with `yarn build` which completed successfully. 
- Ran the automated test suite with `yarn test` and it passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069ac1c88883299c51391fc47502a9)