### PR TITLE
Add Murlan Agent 47 character staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ cache/
 
 # Downloaded by webapp/scripts/fetch-gradle-wrapper.mjs; keep binary out of PRs.
 webapp/android/gradle/wrapper/gradle-wrapper.jar
+# Locally staged Sketchfab character source packages. Keep large/binary model files out of PRs.
+webapp/public/assets/models/murlan/agent-47-rigged-face-morphs/**
+!webapp/public/assets/models/murlan/agent-47-rigged-face-morphs/
+!webapp/public/assets/models/murlan/agent-47-rigged-face-morphs/README.md
+!webapp/public/assets/models/murlan/agent-47-rigged-face-morphs/asset-manifest.json

--- a/webapp/public/assets/models/murlan/agent-47-rigged-face-morphs/README.md
+++ b/webapp/public/assets/models/murlan/agent-47-rigged-face-morphs/README.md
@@ -1,0 +1,19 @@
+# Murlan Royale Agent 47 runtime asset staging
+
+The Murlan Royale character catalog references this folder so the Agent 47 character can be used in the game without committing Sketchfab binary assets to the pull request.
+
+## Source
+
+- Sketchfab page: <https://sketchfab.com/3d-models/agent-47-riggedface-morphs-1680cad927304bb687d6a9ad5b9dd98a>
+- Creator: Veterock (`@windofglass`)
+- License shown by Sketchfab: Creative Commons Attribution-NonCommercial 4.0
+- Notes from the source page: the model is described as a ripped Agent 47 model and credits IO Interactive ownership; verify legal/commercial approval before shipping.
+
+## Deployment-only files
+
+Download/export the Sketchfab model outside git and place one of these runtime entry files here:
+
+- `scene.gltf` plus its generated `scene.bin`, `textures/`, and any other exported sidecar files; or
+- `scene.glb` as a single binary GLB.
+
+The repository `.gitignore` intentionally ignores everything in this folder except this README and `asset-manifest.json`, so those large/binary files stay out of PRs while the app can still load them when present in the deployed static assets.

--- a/webapp/public/assets/models/murlan/agent-47-rigged-face-morphs/asset-manifest.json
+++ b/webapp/public/assets/models/murlan/agent-47-rigged-face-morphs/asset-manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "sketchfab-agent-47-rigged-face-morphs",
+  "name": "Agent 47 (rigged+face morphs)",
+  "sourcePage": "https://sketchfab.com/3d-models/agent-47-riggedface-morphs-1680cad927304bb687d6a9ad5b9dd98a",
+  "sketchfabUid": "1680cad927304bb687d6a9ad5b9dd98a",
+  "creator": "Veterock (@windofglass)",
+  "license": "Creative Commons Attribution-NonCommercial 4.0",
+  "licenseUrl": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "expectedRuntimeUrls": [
+    "/assets/models/murlan/agent-47-rigged-face-morphs/scene.gltf",
+    "/assets/models/murlan/agent-47-rigged-face-morphs/scene.glb"
+  ],
+  "gitPolicy": "Do not commit downloaded binary model, texture, buffer, archive, or image files for this package. Stage them in this directory during deployment only."
+}

--- a/webapp/src/config/murlanCharacterThemes.js
+++ b/webapp/src/config/murlanCharacterThemes.js
@@ -1,5 +1,8 @@
 import { khronosThumb } from './storeThumbnails.js';
 
+const AGENT_47_ASSET_ROOT = '/assets/models/murlan/agent-47-rigged-face-morphs';
+const AGENT_47_SKETCHFAB_URL = 'https://sketchfab.com/3d-models/agent-47-riggedface-morphs-1680cad927304bb687d6a9ad5b9dd98a';
+
 export const MURLAN_CHARACTER_THEMES = Object.freeze([
   {
     id: 'rpm-current',
@@ -192,6 +195,38 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     hairColor: 0x160f0a,
     eyeColor: 0x334d5f,
     skinTone: 0xd09a73
+  },
+
+  {
+    id: 'sketchfab-agent-47',
+    label: 'Agent 47',
+    source: 'Sketchfab / local runtime asset',
+    sourceUrl: AGENT_47_SKETCHFAB_URL,
+    assetRoot: AGENT_47_ASSET_ROOT,
+    assetManifestUrl: `${AGENT_47_ASSET_ROOT}/asset-manifest.json`,
+    sketchfabUid: '1680cad927304bb687d6a9ad5b9dd98a',
+    license: 'CC Attribution-NonCommercial 4.0; verify IO Interactive rights before production use',
+    price: 650,
+    description: 'Sketchfab Agent 47 rigged character staged from deployment-only local GLTF/GLB files so binary assets stay out of PRs.',
+    url: `${AGENT_47_ASSET_ROOT}/scene.gltf`,
+    modelUrls: [
+      `${AGENT_47_ASSET_ROOT}/scene.gltf`,
+      `${AGENT_47_ASSET_ROOT}/scene.glb`
+    ],
+    fallbackModelUrls: ['https://threejs.org/examples/models/gltf/Xbot.glb'],
+    thumbnail: 'https://media.sketchfab.com/models/1680cad927304bb687d6a9ad5b9dd98a/thumbnails/546b0676b5b24eaaa2732e1ee886a938/3ed8cfb016f441be89ee95908ba61de8.jpeg',
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04,
+    clothCombo: 'casinoCheck',
+    hairColor: 0x101010,
+    eyeColor: 0x38424d,
+    skinTone: 0xd0a080
   },
   {
     id: 'threejs-xbot-human',

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2090,11 +2090,13 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0, renderer = 
 const CHARACTER_MODEL_CACHE = new Map();
 
 async function loadCharacterModel(theme, renderer = null) {
-  const urls = Array.isArray(theme?.modelUrls) && theme.modelUrls.length
+  const primaryUrls = Array.isArray(theme?.modelUrls) && theme.modelUrls.length
     ? theme.modelUrls
     : theme?.url
       ? [theme.url]
       : [];
+  const fallbackUrls = Array.isArray(theme?.fallbackModelUrls) ? theme.fallbackModelUrls : [];
+  const urls = [...new Set([...primaryUrls, ...fallbackUrls].filter(Boolean))];
   if (!urls.length) throw new Error('Missing character model URL');
   const cacheKey = `${theme.id || urls[0]}::${urls.join('|')}`;
   if (CHARACTER_MODEL_CACHE.has(cacheKey)) {


### PR DESCRIPTION
### Motivation
- Add the Agent 47 character to the Murlan Royale catalog while keeping downloaded Sketchfab binary model files out of PRs and the repo history.
- Provide a clear deployment-only workflow so the runtime GLTF/GLB can be staged on servers without committing large assets.

### Description
- Added a tracked deployment staging folder with `asset-manifest.json` and `README.md` at `/webapp/public/assets/models/murlan/agent-47-rigged-face-morphs` documenting the Sketchfab source and expected runtime files.
- Updated `.gitignore` to ignore all binary files under the new asset folder while allowing the `README.md` and `asset-manifest.json` to remain in source control.
- Added a new `sketchfab-agent-47` entry to `MURLAN_CHARACTER_THEMES` in `webapp/src/config/murlanCharacterThemes.js` that references local runtime URLs (`/assets/models/murlan/agent-47-rigged-face-morphs/scene.gltf` and `scene.glb`), includes source/license metadata, and specifies a remote fallback model URL.
- Enhanced the character loader in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (`loadCharacterModel`) to attempt primary theme `modelUrls` first and then any configured `fallbackModelUrls`, so the catalog can point to an unstaged local runtime asset without breaking game load behavior.

### Testing
- Ran the frontend production build with `cd webapp && npm run build`, which completed successfully and produced the `dist/` artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07efa8a9ec8329aaeec37c6aee1da9)