### PR TITLE
Fix Ludo battle royale weapon textures and FPS framing

### DIFF
--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -11,6 +11,7 @@ namespace Aiming.Gameplay.Rendering
         [SerializeField] private Renderer[] targetRenderers;
         [SerializeField] private bool runOnAwake = true;
         [SerializeField] private bool forceUrpLitShader = true;
+        [SerializeField] private bool upgradeGltfImportShaders = true;
         [SerializeField] private Shader urpLitShader;
         [SerializeField] private Shader standardShader;
 
@@ -24,6 +25,13 @@ namespace Aiming.Gameplay.Rendering
         private static readonly int EmissionMapId = Shader.PropertyToID("_EmissionMap");
         private static readonly int BaseMapStId = Shader.PropertyToID("_BaseMap_ST");
         private static readonly int MainTexStId = Shader.PropertyToID("_MainTex_ST");
+        private static readonly int GltfBaseColorTextureId = Shader.PropertyToID("_BaseColorTexture");
+        private static readonly int GltfBaseColorMapId = Shader.PropertyToID("baseColorTexture");
+        private static readonly int GltfNormalTextureId = Shader.PropertyToID("_NormalTexture");
+        private static readonly int GltfMetallicRoughnessTextureId = Shader.PropertyToID("_MetallicRoughnessTexture");
+        private static readonly int GltfOcclusionTextureId = Shader.PropertyToID("_OcclusionTexture");
+        private static readonly int GltfEmissiveTextureId = Shader.PropertyToID("_EmissiveTexture");
+        private static readonly int GltfBaseColorFactorId = Shader.PropertyToID("_BaseColorFactor");
 
         void Awake()
         {
@@ -54,8 +62,9 @@ namespace Aiming.Gameplay.Rendering
                         continue;
                     }
 
-                    EnsureSupportedShader(mat);
-                    CopyPbrMaps(mat);
+                    MaterialTextureSnapshot textureSnapshot = MaterialTextureSnapshot.Capture(mat);
+                    EnsureSupportedShader(mat, textureSnapshot);
+                    CopyPbrMaps(mat, textureSnapshot);
                 }
             }
         }
@@ -70,9 +79,11 @@ namespace Aiming.Gameplay.Rendering
             return GetComponentsInChildren<Renderer>(true);
         }
 
-        private void EnsureSupportedShader(Material material)
+        private void EnsureSupportedShader(Material material, MaterialTextureSnapshot textureSnapshot)
         {
-            if (material.shader != null && material.shader.isSupported)
+            bool needsFallbackShader = material.shader == null || !material.shader.isSupported;
+            bool shouldUpgradeGltfShader = upgradeGltfImportShaders && textureSnapshot.HasGltfOnlyBaseTexture && ResolveFallbackShader() != null;
+            if (!needsFallbackShader && !shouldUpgradeGltfShader)
             {
                 return;
             }
@@ -107,10 +118,15 @@ namespace Aiming.Gameplay.Rendering
             return standardShader;
         }
 
-        private static void CopyPbrMaps(Material material)
+        private static void CopyPbrMaps(Material material, MaterialTextureSnapshot textureSnapshot)
         {
             int sourceUvPropertyId;
-            Texture baseTexture = FirstTexture(material, out sourceUvPropertyId, BaseMapId, MainTexId);
+            Texture baseTexture = FirstTexture(material, out sourceUvPropertyId, BaseMapId, MainTexId, GltfBaseColorTextureId, GltfBaseColorMapId);
+            if (baseTexture == null)
+            {
+                baseTexture = textureSnapshot.BaseTexture;
+                sourceUvPropertyId = textureSnapshot.BaseTexturePropertyId;
+            }
             if (baseTexture != null)
             {
                 TrySetTexture(material, BaseMapId, baseTexture);
@@ -118,41 +134,108 @@ namespace Aiming.Gameplay.Rendering
                 SyncTextureTransform(material, sourceUvPropertyId);
             }
 
-            if (material.HasProperty(BaseColorId) && material.HasProperty(ColorId))
+            Color resolvedBaseColor = textureSnapshot.HasBaseColor ? textureSnapshot.BaseColor : Color.white;
+            if (!textureSnapshot.HasBaseColor && material.HasProperty(BaseColorId))
             {
-                Color baseColor = material.GetColor(BaseColorId);
-                material.SetColor(ColorId, baseColor);
+                resolvedBaseColor = material.GetColor(BaseColorId);
             }
-            else if (material.HasProperty(ColorId) && material.HasProperty(BaseColorId))
+            else if (!textureSnapshot.HasBaseColor && material.HasProperty(ColorId))
             {
-                Color mainColor = material.GetColor(ColorId);
-                material.SetColor(BaseColorId, mainColor);
+                resolvedBaseColor = material.GetColor(ColorId);
             }
 
-            Texture normal = FirstTexture(material, BumpMapId);
+            if (material.HasProperty(BaseColorId))
+            {
+                material.SetColor(BaseColorId, resolvedBaseColor);
+            }
+
+            if (material.HasProperty(ColorId))
+            {
+                material.SetColor(ColorId, resolvedBaseColor);
+            }
+
+            Texture normal = FirstTexture(material, BumpMapId, GltfNormalTextureId);
+            if (normal == null)
+            {
+                normal = textureSnapshot.NormalTexture;
+            }
             if (normal != null)
             {
                 TrySetTexture(material, BumpMapId, normal);
                 material.EnableKeyword("_NORMALMAP");
             }
 
-            Texture metallic = FirstTexture(material, MetallicGlossMapId);
+            Texture metallic = FirstTexture(material, MetallicGlossMapId, GltfMetallicRoughnessTextureId);
+            if (metallic == null)
+            {
+                metallic = textureSnapshot.MetallicTexture;
+            }
             if (metallic != null)
             {
                 TrySetTexture(material, MetallicGlossMapId, metallic);
             }
 
-            Texture occlusion = FirstTexture(material, OcclusionMapId);
+            Texture occlusion = FirstTexture(material, OcclusionMapId, GltfOcclusionTextureId);
+            if (occlusion == null)
+            {
+                occlusion = textureSnapshot.OcclusionTexture;
+            }
             if (occlusion != null)
             {
                 TrySetTexture(material, OcclusionMapId, occlusion);
             }
 
-            Texture emission = FirstTexture(material, EmissionMapId);
+            Texture emission = FirstTexture(material, EmissionMapId, GltfEmissiveTextureId);
+            if (emission == null)
+            {
+                emission = textureSnapshot.EmissionTexture;
+            }
             if (emission != null)
             {
                 TrySetTexture(material, EmissionMapId, emission);
                 material.EnableKeyword("_EMISSION");
+            }
+        }
+
+        private sealed class MaterialTextureSnapshot
+        {
+            public Texture BaseTexture;
+            public int BaseTexturePropertyId = -1;
+            public Texture NormalTexture;
+            public Texture MetallicTexture;
+            public Texture OcclusionTexture;
+            public Texture EmissionTexture;
+            public Color BaseColor = Color.white;
+            public bool HasBaseColor;
+            public bool HasGltfOnlyBaseTexture;
+
+            public static MaterialTextureSnapshot Capture(Material material)
+            {
+                MaterialTextureSnapshot snapshot = new MaterialTextureSnapshot();
+                snapshot.BaseTexture = FirstTexture(material, out snapshot.BaseTexturePropertyId, BaseMapId, MainTexId, GltfBaseColorTextureId, GltfBaseColorMapId);
+                snapshot.HasGltfOnlyBaseTexture = snapshot.BaseTexture != null && snapshot.BaseTexturePropertyId != BaseMapId && snapshot.BaseTexturePropertyId != MainTexId;
+                snapshot.NormalTexture = FirstTexture(material, BumpMapId, GltfNormalTextureId);
+                snapshot.MetallicTexture = FirstTexture(material, MetallicGlossMapId, GltfMetallicRoughnessTextureId);
+                snapshot.OcclusionTexture = FirstTexture(material, OcclusionMapId, GltfOcclusionTextureId);
+                snapshot.EmissionTexture = FirstTexture(material, EmissionMapId, GltfEmissiveTextureId);
+
+                if (material.HasProperty(BaseColorId))
+                {
+                    snapshot.BaseColor = material.GetColor(BaseColorId);
+                    snapshot.HasBaseColor = true;
+                }
+                else if (material.HasProperty(ColorId))
+                {
+                    snapshot.BaseColor = material.GetColor(ColorId);
+                    snapshot.HasBaseColor = true;
+                }
+                else if (material.HasProperty(GltfBaseColorFactorId))
+                {
+                    snapshot.BaseColor = material.GetColor(GltfBaseColorFactorId);
+                    snapshot.HasBaseColor = true;
+                }
+
+                return snapshot;
             }
         }
 

--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Aiming.Gameplay.Rendering;
 using UnityEngine;
 
 namespace TonPlaygram.Gameplay.Weapons
@@ -130,7 +131,7 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private int minorPiecesPerNonFinalShot = 3;
 
         [Header("Camera anchors")]
-        [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, -0.04f, 0.18f);
+        [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, 0.08f, 0.28f);
         [SerializeField] private float aimPositionLerp = 20f;
         [SerializeField] private bool followAllBullets = true;
         [SerializeField] private bool forceAttackerAimAnchor = true;
@@ -141,6 +142,9 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Vector3 swapIconWorldOffset = new Vector3(0f, 0.11f, 0f);
         [SerializeField] private bool allowDynamicCameraOnlyDuringAnimation = true;
         [SerializeField] private float turnFocusDuration = 0.22f;
+        [SerializeField] private float aimPitchDownDegrees = 8f;
+        [SerializeField] private float maxLookUpDegrees = 8f;
+        [SerializeField] private float maxLookDownDegrees = 26f;
 
 
         private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();
@@ -189,6 +193,7 @@ namespace TonPlaygram.Gameplay.Weapons
             BuildProfileMap();
             CacheTokenPieces();
             CacheStaticAnchors();
+            ApplyWeaponMaterialCompatibility();
             _eventListeners = GetComponentsInParent<ILudoWeaponEvents>(true);
             _projectileListeners = GetComponentsInParent<ILudoProjectileBroadcastEvents>(true);
             Equip(startingWeapon);
@@ -581,7 +586,7 @@ namespace TonPlaygram.Gameplay.Weapons
 
                 playerCamera.fieldOfView = Mathf.Lerp(startFov, weapon.aimFov, t);
                 playerCamera.transform.localPosition = Vector3.Lerp(startPos, targetLocalPos, Mathf.Clamp01(Time.deltaTime * aimPositionLerp));
-                Quaternion toTarget = Quaternion.LookRotation((targetWorld - playerCamera.transform.position).normalized, Vector3.up);
+                Quaternion toTarget = ResolveLimitedLookRotation(targetWorld - playerCamera.transform.position);
                 playerCamera.transform.rotation = Quaternion.Slerp(playerCamera.transform.rotation, toTarget, Mathf.Clamp01(Time.deltaTime * cameraLookLerp));
                 yield return null;
             }
@@ -613,7 +618,7 @@ namespace TonPlaygram.Gameplay.Weapons
                 t += Time.deltaTime;
                 Vector3 targetPos = bulletTransform.position - (bulletTransform.forward * bulletFollowDistance) + (Vector3.up * bulletFollowHeight);
                 playerCamera.transform.position = Vector3.Lerp(playerCamera.transform.position, targetPos, Mathf.Clamp01(Time.deltaTime * cameraTrackLerp));
-                Quaternion toBullet = Quaternion.LookRotation((bulletTransform.position - playerCamera.transform.position).normalized, Vector3.up);
+                Quaternion toBullet = ResolveLimitedLookRotation(bulletTransform.position - playerCamera.transform.position, 0f);
                 playerCamera.transform.rotation = Quaternion.Slerp(playerCamera.transform.rotation, toBullet, Mathf.Clamp01(Time.deltaTime * cameraLookLerp));
                 yield return null;
             }
@@ -642,7 +647,7 @@ namespace TonPlaygram.Gameplay.Weapons
             {
                 t += Time.deltaTime;
                 Vector3 towardImpact = (impactPoint - playerCamera.transform.position).normalized;
-                Quaternion impactRot = Quaternion.LookRotation(towardImpact, Vector3.up);
+                Quaternion impactRot = ResolveLimitedLookRotation(towardImpact, 0f);
                 playerCamera.transform.rotation = Quaternion.Slerp(startRot, impactRot, Mathf.Clamp01(t / seconds));
                 yield return null;
             }
@@ -699,9 +704,69 @@ namespace TonPlaygram.Gameplay.Weapons
                 elapsed += Time.deltaTime;
                 Vector3 toTarget = (turnAnchor.position - playerCamera.transform.position).normalized;
                 Vector3 lerped = Vector3.Slerp(fromForward, toTarget, Mathf.Clamp01(elapsed / duration));
-                playerCamera.transform.rotation = Quaternion.LookRotation(lerped, Vector3.up);
+                playerCamera.transform.rotation = ResolveLimitedLookRotation(lerped, 0f);
                 yield return null;
             }
+        }
+
+        private Quaternion ResolveLimitedLookRotation(Vector3 worldDirection)
+        {
+            return ResolveLimitedLookRotation(worldDirection, aimPitchDownDegrees);
+        }
+
+        private Quaternion ResolveLimitedLookRotation(Vector3 worldDirection, float extraPitchDownDegrees)
+        {
+            if (worldDirection.sqrMagnitude <= 0.000001f)
+            {
+                return playerCamera != null ? playerCamera.transform.rotation : Quaternion.identity;
+            }
+
+            Vector3 direction = worldDirection.normalized;
+            Vector3 flatDirection = Vector3.ProjectOnPlane(direction, Vector3.up);
+            if (flatDirection.sqrMagnitude <= 0.000001f)
+            {
+                flatDirection = playerCamera != null ? Vector3.ProjectOnPlane(playerCamera.transform.forward, Vector3.up) : Vector3.forward;
+                if (flatDirection.sqrMagnitude <= 0.000001f)
+                {
+                    flatDirection = Vector3.forward;
+                }
+            }
+
+            flatDirection.Normalize();
+            float signedPitch = Mathf.Atan2(direction.y, flatDirection.magnitude) * Mathf.Rad2Deg - extraPitchDownDegrees;
+            signedPitch = Mathf.Clamp(signedPitch, -Mathf.Abs(maxLookDownDegrees), Mathf.Abs(maxLookUpDegrees));
+
+            Quaternion yaw = Quaternion.LookRotation(flatDirection, Vector3.up);
+            return yaw * Quaternion.AngleAxis(-signedPitch, Vector3.right);
+        }
+
+        private void ApplyWeaponMaterialCompatibility()
+        {
+            ApplyMaterialCompatibility(weaponRoot);
+
+            for (int i = 0; i < weaponProfiles.Count; i++)
+            {
+                WeaponBallisticsProfile profile = weaponProfiles[i];
+                Animator animator = profile != null && profile.gripPose != null ? profile.gripPose.animator : null;
+                if (animator != null)
+                {
+                    ApplyMaterialCompatibility(animator.transform);
+                }
+            }
+        }
+
+        private static void ApplyMaterialCompatibility(Transform root)
+        {
+            if (root == null)
+                return;
+
+            GltfMaterialCompatibilityAdapter adapter = root.GetComponent<GltfMaterialCompatibilityAdapter>();
+            if (adapter == null)
+            {
+                adapter = root.gameObject.AddComponent<GltfMaterialCompatibilityAdapter>();
+            }
+
+            adapter.ApplyCompatibilityPass();
         }
 
         private Vector3 ResolveLiveTargetPosition()

--- a/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
+++ b/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
@@ -87,8 +87,18 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Vector3 weaponGripPositionOffset;
         [SerializeField] private Vector3 weaponGripEulerOffset;
 
+        [Header("FPS screen presentation")]
+        [SerializeField] private Camera presentationCamera;
+        [SerializeField] private Transform fpsPresentationRoot;
+        [SerializeField] private bool keepWeaponVisibleInFpsView = true;
+        [SerializeField] private Vector3 cameraSpaceWeaponOffset = new Vector3(0.18f, -0.2f, 0.55f);
+        [SerializeField] private Vector3 cameraSpaceWeaponEuler = new Vector3(-4f, 2f, 0f);
+        [SerializeField] private Vector2 minWeaponViewport = new Vector2(0.12f, 0.06f);
+        [SerializeField] private Vector2 maxWeaponViewport = new Vector2(0.88f, 0.42f);
+
         private readonly List<Renderer> _hiddenOriginalHandRenderers = new List<Renderer>();
         private Quaternion _weaponGripRotationOffset;
+        private Quaternion _cameraSpaceWeaponRotationOffset;
         private Quaternion _originalGripToWeaponRotation = Quaternion.identity;
         private Vector3 _originalGripToWeaponPosition;
         private bool _hasOriginalGripToWeapon;
@@ -161,6 +171,11 @@ namespace TonPlaygram.Gameplay.Weapons
         private void CacheRuntimeOffsets()
         {
             _weaponGripRotationOffset = Quaternion.Euler(weaponGripEulerOffset);
+            _cameraSpaceWeaponRotationOffset = Quaternion.Euler(cameraSpaceWeaponEuler);
+            if (presentationCamera == null)
+            {
+                presentationCamera = Camera.main;
+            }
             if (weaponRoot != null && originalFpsRightGrip != null)
             {
                 _originalGripToWeaponRotation = Quaternion.Inverse(originalFpsRightGrip.rotation) * weaponRoot.rotation;
@@ -187,11 +202,30 @@ namespace TonPlaygram.Gameplay.Weapons
             {
                 weaponRoot.rotation = humanRightGrip.rotation * _originalGripToWeaponRotation * _weaponGripRotationOffset;
                 weaponRoot.position = humanRightGrip.position + (humanRightGrip.rotation * (_originalGripToWeaponPosition + weaponGripPositionOffset));
+                KeepWeaponVisibleInFpsView();
                 return;
             }
 
             weaponRoot.position = humanRightGrip.TransformPoint(weaponGripPositionOffset);
             weaponRoot.rotation = humanRightGrip.rotation * _weaponGripRotationOffset;
+            KeepWeaponVisibleInFpsView();
+        }
+
+        private void KeepWeaponVisibleInFpsView()
+        {
+            Transform presentationRoot = fpsPresentationRoot != null ? fpsPresentationRoot : weaponRoot;
+            if (!keepWeaponVisibleInFpsView || presentationCamera == null || presentationRoot == null)
+                return;
+
+            Vector3 viewportPoint = presentationCamera.WorldToViewportPoint(presentationRoot.position);
+            bool behindCamera = viewportPoint.z <= presentationCamera.nearClipPlane;
+            bool outsideSafeBottomFrame = viewportPoint.x < minWeaponViewport.x || viewportPoint.x > maxWeaponViewport.x || viewportPoint.y < minWeaponViewport.y || viewportPoint.y > maxWeaponViewport.y;
+            if (!behindCamera && !outsideSafeBottomFrame)
+                return;
+
+            Transform cameraTransform = presentationCamera.transform;
+            presentationRoot.position = cameraTransform.TransformPoint(cameraSpaceWeaponOffset);
+            presentationRoot.rotation = cameraTransform.rotation * _cameraSpaceWeaponRotationOffset;
         }
 
         private void AddExtraOriginalHandRenderers()


### PR DESCRIPTION
### Motivation
- GLTF-imported weapons (AK-style) lost textures after shader fallbacks, causing invisible/missing weapon visuals.  
- The aim camera could rotate to match targets too aggressively and sit too low/far for an FPS-style presentation.  
- Weapon root / hand presentation during retargeting sometimes placed firearms off-screen or not framed like a conventional FPS view.

### Description
- Extended `GltfMaterialCompatibilityAdapter` to capture GLTF-only texture/property slots and a `MaterialTextureSnapshot`, and to prefer those textures when upgrading/falling back shaders so importer textures survive shader swaps (`Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs`).
- Hooked the compatibility pass into the battle-royale flow by calling `ApplyWeaponMaterialCompatibility()` at director startup and by applying the pass to the `weaponRoot` and any configured weapon animator rigs (`BattleRoyaleWeaponDirector.cs`).
- Tuned first-person presentation by moving `firstPersonAimOffset`, adding `aimPitchDownDegrees`, `maxLookUpDegrees`, and `maxLookDownDegrees`, and routing aiming/impact/bullet follow rotations through `ResolveLimitedLookRotation(...)` to clamp how far the camera can look up/down while still biasing the camera slightly downward (`BattleRoyaleWeaponDirector.cs`).
- Added FPS presentation safeguards to `FpsGunHumanHandRetargeter` including a configurable `presentationCamera`, `fpsPresentationRoot`, camera-space offsets/rotation, viewport safety rect (`minWeaponViewport`/`maxWeaponViewport`) and a `KeepWeaponVisibleInFpsView()` helper so the weapon stays visible at the lower portion of the screen during retargeting (`Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs`).

### Testing
- Ran `git diff --check` to validate workspace changes and staged/committed the modifications; this passed.  
- Attempted `dotnet test billiards.Tests/Billiards.Tests.csproj` but the test run could not execute in this environment because `dotnet` is not installed (no runtime tests executed).  
- No Unity editor/playmode tests were run in this container; recommend validating in-editor playtests to confirm GLTF texture fixes, camera framing, and weapon presentation on target hardware.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07eb99f73c8329b3ef4ef6bf4d987b)