### PR TITLE
Adjust Snooker Royal human shooting pose

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -131,7 +131,7 @@ const CFG = {
   poseLambda: 9,
   moveLambda: 5.6,
   rotLambda: 8.5,
-  humanScale: 1.2 * 1.78 * WORLD_SCALE,
+  humanScale: 1.3 * 1.78 * WORLD_SCALE,
   humanVisualYawFix: Math.PI,
   stanceWidth: 0.52 * WORLD_SCALE,
   bridgePalmTableLift: 0.006 * WORLD_SCALE,
@@ -153,6 +153,7 @@ const CFG = {
   rightStrokePush: 0.24 * WORLD_SCALE,
   rightHandShotLift: -0.30 * WORLD_SCALE,
   shootCueGripFromBack: 0.58 * WORLD_SCALE,
+  upperBodyShotSideLean: 0.16 * WORLD_SCALE,
   idleRightHandY: 0.8 * WORLD_SCALE,
   idleRightHandX: 0.31 * WORLD_SCALE,
   idleRightHandZ: -0.015 * WORLD_SCALE,
@@ -503,11 +504,11 @@ function driveHuman(human, frame) {
   }
   if (ik >= 0.025) {
     rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
-    twistBone(b.hips, frame.side, -0.045 * ik);
-    twistBone(b.spine, frame.side, -0.2 * ik);
+    twistBone(b.hips, frame.side, 0.045 * ik);
+    twistBone(b.spine, frame.side, 0.2 * ik);
     rotateBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
     rotateBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
-    twistBone(b.chest, frame.side, -0.32 * ik);
+    twistBone(b.chest, frame.side, 0.32 * ik);
     rotateBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
     setBoneWorldQuaternion(b.head, b.head ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)), 0.74 * ik) : shotQ);
     human.modelRoot.updateMatrixWorld(true);
@@ -559,12 +560,13 @@ function updateHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget,
   const powerLean = power * t;
   const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * CFG.scale);
   rootWorld.y = human.root.position.y;
-  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.12, t) * CFG.scale + breath, (lerp(0.02, -0.28, t) - 0.018 * powerLean) * CFG.scale));
-  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.21, t) * CFG.scale + breath, (lerp(0.02, -0.62, t) - 0.03 * powerLean) * CFG.scale));
-  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.25, t) * CFG.scale + breath, (lerp(0.02, -0.8, t) - 0.034 * powerLean) * CFG.scale));
-  const head = local(new THREE.Vector3(0, lerp(1.84, 1.34, t) * CFG.scale + breath - CFG.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.94, t) - 0.034 * powerLean) * CFG.scale));
-  const leftShoulder = local(new THREE.Vector3(-0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * CFG.scale));
-  const rightShoulder = local(new THREE.Vector3(0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * CFG.scale));
+  const shotSideLean = CFG.upperBodyShotSideLean * t;
+  const torso = local(new THREE.Vector3(shotSideLean * 0.38, lerp(1.3, 1.12, t) * CFG.scale + breath, (lerp(0.02, -0.28, t) - 0.018 * powerLean) * CFG.scale));
+  const chest = local(new THREE.Vector3(shotSideLean * 0.72, lerp(1.52, 1.21, t) * CFG.scale + breath, (lerp(0.02, -0.62, t) - 0.03 * powerLean) * CFG.scale));
+  const neck = local(new THREE.Vector3(shotSideLean * 0.88, lerp(1.68, 1.25, t) * CFG.scale + breath, (lerp(0.02, -0.8, t) - 0.034 * powerLean) * CFG.scale));
+  const head = local(new THREE.Vector3(shotSideLean, lerp(1.84, 1.34, t) * CFG.scale + breath - CFG.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.94, t) - 0.034 * powerLean) * CFG.scale));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * CFG.scale + shotSideLean * 0.7, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * CFG.scale));
+  const rightShoulder = local(new THREE.Vector3(0.23 * CFG.scale + shotSideLean * 0.7, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * CFG.scale));
   const leftHip = local(new THREE.Vector3(-0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
   const rightHip = local(new THREE.Vector3(0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
   const leftFoot = local(new THREE.Vector3(-0.13 * CFG.scale, CFG.footGroundY, 0.03 * CFG.scale + walk * 0.018 * CFG.scale).lerp(new THREE.Vector3(-CFG.stanceWidth * 0.42, CFG.footGroundY, -0.34 * CFG.scale), t));
@@ -580,7 +582,9 @@ function updateHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget,
   const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04 * CFG.scale, CFG.rightElbowShotRise, t)).addScaledVector(side, lerp(-0.18 * CFG.scale, CFG.rightElbowShotSide, t)).addScaledVector(forward, lerp(-0.04 * CFG.scale, CFG.rightElbowShotBack, t));
   const forearmStroke = (state === 'dragging' ? -CFG.rightStrokePull * easeOutCubic(power) : 0) + (state === 'striking' ? CFG.rightStrokePush * strikeFollow : 0) + (state === 'dragging' ? dragStroke * 0.035 * CFG.scale : 0);
   const forearmBase = lockedRightElbow.clone().addScaledVector(side, CFG.rightForearmOutward * t).addScaledVector(UP, -CFG.rightForearmDown * t).addScaledVector(UP, CFG.rightHandShotLift * t).addScaledVector(forward, -CFG.rightForearmBack * t).addScaledVector(cueDirForHand, CFG.rightForearmLength);
-  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
+  const cueLengthForGrip = Math.max(CFG.cueLength, cueBack.distanceTo(cueTip), CFG.shootCueGripFromBack + 0.001 * CFG.scale);
+  const rightCueGripFromBack = clamp(CFG.shootCueGripFromBack, 0.08 * CFG.scale, cueLengthForGrip - 0.08 * CFG.scale);
+  const liveCueGripPoint = cueBack.clone().addScaledVector(cueDirForHand, rightCueGripFromBack + forearmStroke * 0.08).lerp(forearmBase, 0.08 * idle);
   const idleWristTarget = idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, CFG.rightHandRollIdle));
   const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(CFG.rightHandRollIdle, CFG.rightHandRollShoot - CFG.rightHandDownPose, handIk)));
   const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
@@ -638,7 +642,7 @@ function configureProvidedHumanForArena() {
   CFG.bridgeDist = 0.28 * scale;
   CFG.edgeMargin = 0.68 * scale;
   CFG.desiredShootDistance = 1.25 * scale;
-  CFG.humanScale = 1.5 * scale;
+  CFG.humanScale = CFG.cueLength * 1.3;
   CFG.stanceWidth = 0.52 * scale;
   CFG.bridgePalmTableLift = 0.006 * scale;
   CFG.bridgeCueLift = 0.018 * scale;
@@ -658,6 +662,7 @@ function configureProvidedHumanForArena() {
   CFG.rightStrokePush = 0.24 * scale;
   CFG.rightHandShotLift = -0.30 * scale;
   CFG.shootCueGripFromBack = 0.58 * scale;
+  CFG.upperBodyShotSideLean = 0.16 * scale;
   CFG.idleRightHandY = 0.8 * scale;
   CFG.idleRightHandX = 0.31 * scale;
   CFG.idleRightHandZ = -0.015 * scale;


### PR DESCRIPTION
### Motivation
- Make the provided Snooker human look more realistic when taking the shot by increasing the avatar height relative to the cue, ensuring the right hand grips the cue stick, and reversing the upper-body twist/lean to the intended side for the shooting pose.

### Description
- Increase baseline human scale by changing `CFG.humanScale` and derive the arena runtime scale from the active cue by setting `CFG.humanScale = CFG.cueLength * 1.3` in `configureProvidedHumanForArena()` so the human is ~30% taller than the cue length.
- Flip shooting-side twist by reversing the sign on `twistBone` calls for `hips`, `spine`, and `chest` in `driveHuman` so the upper-body rotation leans the opposite direction during shots.
- Add `CFG.upperBodyShotSideLean` and apply it to `torso`, `chest`, `neck`, `head`, and shoulder X offsets in `updateHumanPose` to visually lower/shift the upper body toward the corrected side while shooting.
- Anchor the visible right-hand grip to the cue line by computing a safe `rightCueGripFromBack` (clamped against the cue length) and deriving `liveCueGripPoint` from `cueBack` + this offset with a small blend toward the forearm base so the right hand holds the cue during pull/release.
- All edits are contained in `webapp/src/pages/Games/SnookerRoyal.jsx` (pose/twist/scale/grip logic changes). 

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production bundle completed successfully (Vite build completed). (succeeded)
- Ran `git diff --check` / repo checks for whitespace and lint-level diff issues and no problems were reported. (succeeded)
- Attempted an automated visual smoke check using Playwright to capture a WebGL screenshot of the running dev server; Playwright and system browser dependencies were installed but the headless run timed out/failed to capture the WebGL screenshot in this environment due to headless/browser environment constraints (browser closed / page screenshot timeout). (attempted, failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0817991b988329afe959029bf3a562)