### PR TITLE
Refactor pool-human pose/stance logic and tweak cue/IK parameters

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1959,7 +1959,8 @@ const POOL_HUMAN_URLS = Object.freeze([
   'https://threejs.org/examples/models/gltf/readyplayer.me.glb'
 ]);
 const POOL_HUMAN_CUE_REFERENCE_LENGTH = 1.5 * (BALL_R / 0.0525) * CUE_LENGTH_MULTIPLIER;
-const POOL_HUMAN_TARGET_HEIGHT = POOL_HUMAN_CUE_REFERENCE_LENGTH * 1.3;
+const POOL_HUMAN_HEIGHT_TO_CUE_RATIO = 1.3;
+const POOL_HUMAN_TARGET_HEIGHT = POOL_HUMAN_CUE_REFERENCE_LENGTH * POOL_HUMAN_HEIGHT_TO_CUE_RATIO;
 const POOL_HUMAN_WORLD_SCALE = BALL_R / 0.052;
 const POOL_HUMAN_CFG = Object.freeze({
   scale: POOL_HUMAN_WORLD_SCALE,
@@ -2003,7 +2004,7 @@ const POOL_HUMAN_CFG = Object.freeze({
   rightForearmDown: 0.48 * POOL_HUMAN_WORLD_SCALE,
   rightForearmLength: 0.34 * POOL_HUMAN_WORLD_SCALE,
   rightStrokePull: 0.30 * POOL_HUMAN_WORLD_SCALE,
-  rightStrokePush: 0.26 * POOL_HUMAN_WORLD_SCALE,
+  rightStrokePush: 0.24 * POOL_HUMAN_WORLD_SCALE,
   rightHandShotLift: -0.30 * POOL_HUMAN_WORLD_SCALE,
   shootCueGripFromBack: 0.58 * POOL_HUMAN_WORLD_SCALE,
   idleRightHandY: 0.8 * POOL_HUMAN_WORLD_SCALE,
@@ -2353,6 +2354,8 @@ function choosePoolHumanEdgePosition(cueBallWorld, aimForward, cueBackWorld = nu
   const shotDir = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, -1));
   const behindDir = shotDir.clone().multiplyScalar(-1);
   const cueBackValid = cueBackWorld && Number.isFinite(cueBackWorld.x) && Number.isFinite(cueBackWorld.z);
+  // During aim/strike, bias the stance toward the cue butt so the avatar stands
+  // close to the bottom end of the cue stick while still staying on the table edge.
   const desired = cueBackValid
     ? cueBackWorld.clone()
     : cueBallWorld.clone().addScaledVector(behindDir, POOL_HUMAN_CFG.desiredShootDistance);
@@ -2422,22 +2425,16 @@ function drivePoolRoyaleHuman(human, frame) {
   if (ik >= 0.025) {
     rotatePoolHumanBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
     twistPoolHumanBone(b.hips, frame.side, -0.045 * ik);
-    twistPoolHumanBone(b.hips, frame.forward, -0.025 * ik);
-    rotatePoolHumanBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
     twistPoolHumanBone(b.spine, frame.side, -0.2 * ik);
-    twistPoolHumanBone(b.spine, frame.forward, -0.04 * ik);
+    rotatePoolHumanBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
     rotatePoolHumanBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
     twistPoolHumanBone(b.chest, frame.side, -0.32 * ik);
-    twistPoolHumanBone(b.chest, frame.forward, -0.025 * ik);
     rotatePoolHumanBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
-    twistPoolHumanBone(b.neck, frame.side, -0.12 * ik);
     setPoolHumanBoneWorldQuaternion(
       b.head,
       b.head
         ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(
-            shotQ.clone()
-              .multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik))
-              .multiply(new THREE.Quaternion().setFromAxisAngle(frame.forward, -0.025 * ik)),
+            shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)),
             0.74 * ik
           )
         : shotQ
@@ -2450,38 +2447,50 @@ function drivePoolRoyaleHuman(human, frame) {
     .addScaledVector(frame.side, -0.2 * POOL_HUMAN_CFG.scale)
     .addScaledVector(frame.forward, -0.03 * POOL_HUMAN_CFG.scale * idle);
   const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
-  const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.32).addScaledVector(frame.forward, -0.55).normalize();
-  aimPoolHumanTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, pole, 0.9 + 0.1 * ik, 1.0);
+  aimPoolHumanTwoBone(
+    b.rightUpperArm,
+    b.rightLowerArm,
+    rightElbow,
+    rightGrip,
+    frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.32).addScaledVector(frame.forward, -0.55).normalize(),
+    0.9 + 0.1 * ik,
+    1
+  );
   const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
-  const standingHandUp = POOL_HUMAN_UP.clone().multiplyScalar(-1.0).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
-  const handForwardForOrientation = ik >= 0.025 ? cueDir : standingCueDir;
-  setPoolHumanHandBasis(b.rightHand, standingHandSide, standingHandUp, handForwardForOrientation, POOL_HUMAN_CFG.rightHandRollIdle, 1.0);
+  const standingHandUp = POOL_HUMAN_UP.clone().multiplyScalar(-1).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
+  setPoolHumanHandBasis(
+    b.rightHand,
+    standingHandSide,
+    standingHandUp,
+    ik >= 0.025 ? cueDir : standingCueDir,
+    ik >= 0.025 ? POOL_HUMAN_CFG.rightHandRollShoot : POOL_HUMAN_CFG.rightHandRollIdle,
+    1
+  );
   posePoolHumanFingers(human.rightFingers, 'grip', 0.95);
   if (ik < 0.025) {
     posePoolHumanFingers(human.leftFingers, 'idle', 1);
     return;
   }
-  const leftHand = frame.leftHandWorld.clone()
-    .addScaledVector(frame.forward, 0.032 * POOL_HUMAN_CFG.scale * ik)
-    .addScaledVector(frame.side, -0.018 * POOL_HUMAN_CFG.scale * ik)
-    .addScaledVector(POOL_HUMAN_UP, -0.018 * POOL_HUMAN_CFG.scale * ik);
-  const leftElbow = frame.leftElbow.clone()
-    .addScaledVector(frame.forward, 0.045 * POOL_HUMAN_CFG.scale * ik)
-    .addScaledVector(frame.side, -0.05 * POOL_HUMAN_CFG.scale * ik)
-    .addScaledVector(POOL_HUMAN_UP, -0.01 * POOL_HUMAN_CFG.scale * ik);
-  aimPoolHumanTwoBone(b.leftUpperArm, b.leftLowerArm, leftElbow, leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.1).normalize(), 0.98 * ik, 1.0 * ik);
-  twistPoolHumanBone(b.leftUpperArm, frame.forward, -0.2 * ik);
-  twistPoolHumanBone(b.leftLowerArm, frame.forward, 0.025 * ik);
-  const bridgeSide = frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize();
-  const bridgeUp = POOL_HUMAN_UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize();
-  setPoolHumanHandBasis(b.leftHand, bridgeSide, bridgeUp, cueDir, -0.68 * ik, 1.0 * ik);
+  aimPoolHumanTwoBone(
+    b.leftUpperArm,
+    b.leftLowerArm,
+    frame.leftElbow,
+    frame.leftHandWorld,
+    frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.1).normalize(),
+    0.98 * ik,
+    ik
+  );
+  setPoolHumanHandBasis(
+    b.leftHand,
+    frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize(),
+    POOL_HUMAN_UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize(),
+    cueDir,
+    -0.68 * ik,
+    ik
+  );
   posePoolHumanFingers(human.leftFingers, 'bridge', ik);
-  aimPoolHumanTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(POOL_HUMAN_UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
-  twistPoolHumanBone(b.leftUpperLeg, frame.forward, -0.035 * ik);
-  setPoolHumanHandBasis(b.leftFoot, frame.side, frame.up, frame.forward, -0.02 * ik, POOL_HUMAN_CFG.footLockStrength * ik);
-  aimPoolHumanTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
-  twistPoolHumanBone(b.rightUpperLeg, frame.forward, 0.03 * ik);
-  setPoolHumanHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, POOL_HUMAN_CFG.footLockStrength * ik);
+  aimPoolHumanTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(POOL_HUMAN_UP, 0.18).normalize(), 0.9 * ik, ik);
+  aimPoolHumanTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.18).normalize(), 0.9 * ik, ik);
 }
 
 function cuePoseFromPoolHumanGrip(grip, dir, gripFromBack, length = POOL_HUMAN_CFG.cueLength) {
@@ -2504,11 +2513,12 @@ function getPoolHumanCueEndpoints(cueStick, cueLen) {
 }
 
 function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget, idleRight, idleLeft, cueBack, cueTip, power) {
-  const activeState = state === 'rolling' ? 'idle' : state;
-  human.poseT = poolHumanDampScalar(human.poseT, activeState === 'idle' ? 0 : 1, POOL_HUMAN_CFG.poseLambda, dt);
-  human.breathT += dt * (activeState === 'idle' ? 1.05 : 0.5);
-  human.settleT = poolHumanDampScalar(human.settleT, activeState === 'dragging' ? 1 : 0, 5.5, dt);
-  if (activeState === 'striking') {
+  // This keeps Pool Royale's right-hand cue grip synced with the Snooker flow,
+  // but flips the upper-body bend to the table/cue-ball side requested for Pool.
+  human.poseT = poolHumanDampScalar(human.poseT, state === 'idle' ? 0 : 1, POOL_HUMAN_CFG.poseLambda, dt);
+  human.breathT += dt * (state === 'idle' ? 1.05 : 0.5);
+  human.settleT = poolHumanDampScalar(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
+  if (state === 'striking') {
     if (human.strikeClock === 0) {
       human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget);
       human.strikeYaw = human.yaw;
@@ -2517,8 +2527,8 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   } else {
     human.strikeClock = 0;
   }
-  const rootGoal = activeState === 'striking' ? human.strikeRoot : rootTarget;
-  poolHumanDampVector(human.root.position, rootGoal, activeState === 'striking' ? 12 : POOL_HUMAN_CFG.moveLambda, dt);
+  const rootGoal = state === 'striking' ? human.strikeRoot : rootTarget;
+  poolHumanDampVector(human.root.position, rootGoal, state === 'striking' ? 12 : POOL_HUMAN_CFG.moveLambda, dt);
   const moveAmountRaw = human.root.position.distanceTo(rootGoal);
   human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / POOL_HUMAN_CFG.scale));
   const rootToCueBall = bridgeTarget.clone().sub(human.root.position);
@@ -2527,11 +2537,7 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
     ? rootToCueBall.normalize()
     : poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, -1));
   const targetYaw = poolHumanYawFromForward(tableFacingForward);
-  // A billiards player walks behind the shot, then squares the eyes/bridge/cue
-  // directly toward the cue ball before practice strokes.  Use wrapped angle
-  // damping while walking, but lock aim/strike frames to the table-facing line so
-  // the avatar never shoots while visually rotated toward the wrong rail.
-  human.yaw = activeState === 'dragging' || activeState === 'striking'
+  human.yaw = state === 'dragging' || state === 'striking'
     ? targetYaw
     : poolHumanDampAngle(human.yaw, targetYaw, POOL_HUMAN_CFG.rotLambda, dt);
   const t = poolHumanEaseInOut(human.poseT) * POOL_HUMAN_CFG.shotPoseAmount;
@@ -2539,10 +2545,10 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * POOL_HUMAN_CFG.scale);
   const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12 / POOL_HUMAN_CFG.scale);
   const walkAmount = poolHumanClamp01(moveAmountRaw * 18 / POOL_HUMAN_CFG.scale) * idle;
-  const dragStroke = activeState === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75) : 0;
-  const strikeFollow = activeState === 'striking' ? Math.sin(poolHumanClamp01(human.strikeClock / (POOL_HUMAN_CFG.strikeTime + POOL_HUMAN_CFG.holdTime)) * Math.PI) : 0;
+  const dragStroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75) : 0;
+  const strikeFollow = state === 'striking' ? Math.sin(poolHumanClamp01(human.strikeClock / (POOL_HUMAN_CFG.strikeTime + POOL_HUMAN_CFG.holdTime)) * Math.PI) : 0;
   const visualForward = new THREE.Vector3(0, 0, -1).applyAxisAngle(POOL_HUMAN_Y_AXIS, human.yaw).normalize();
-  const forward = activeState === 'dragging' || activeState === 'striking'
+  const forward = state === 'dragging' || state === 'striking'
     ? tableFacingForward.clone().normalize()
     : visualForward;
   const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
@@ -2578,9 +2584,9 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, poolHumanLerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, poolHumanLerp(0.16, -0.08, handIk)).normalize();
   const liveGripUp = POOL_HUMAN_UP.clone().multiplyScalar(poolHumanLerp(-1.0, 0.12, handIk)).addScaledVector(side, poolHumanLerp(-0.64, -0.04, handIk)).addScaledVector(forward, poolHumanLerp(0.2, -0.48, handIk)).normalize();
   const lockedRightElbow = rightShoulder.clone().addScaledVector(POOL_HUMAN_UP, poolHumanLerp(0.04 * POOL_HUMAN_CFG.scale, POOL_HUMAN_CFG.rightElbowShotRise, t)).addScaledVector(side, poolHumanLerp(-0.18 * POOL_HUMAN_CFG.scale, POOL_HUMAN_CFG.rightElbowShotSide, t)).addScaledVector(forward, poolHumanLerp(-0.04 * POOL_HUMAN_CFG.scale, POOL_HUMAN_CFG.rightElbowShotBack, t));
-  const pullBack = activeState === 'dragging' ? -POOL_HUMAN_CFG.rightStrokePull * poolHumanEaseOutCubic(power) : 0;
-  const pushForward = activeState === 'striking' ? POOL_HUMAN_CFG.rightStrokePush * strikeFollow : 0;
-  const smallPractice = activeState === 'dragging' ? dragStroke * 0.035 * POOL_HUMAN_CFG.scale : 0;
+  const pullBack = state === 'dragging' ? -POOL_HUMAN_CFG.rightStrokePull * poolHumanEaseOutCubic(power) : 0;
+  const pushForward = state === 'striking' ? POOL_HUMAN_CFG.rightStrokePush * strikeFollow : 0;
+  const smallPractice = state === 'dragging' ? dragStroke * 0.035 * POOL_HUMAN_CFG.scale : 0;
   const forearmStroke = pullBack + pushForward + smallPractice;
   const forearmBase = lockedRightElbow.clone().addScaledVector(side, POOL_HUMAN_CFG.rightForearmOutward * t).addScaledVector(POOL_HUMAN_UP, -POOL_HUMAN_CFG.rightForearmDown * t).addScaledVector(POOL_HUMAN_UP, POOL_HUMAN_CFG.rightHandShotLift * t).addScaledVector(forward, -POOL_HUMAN_CFG.rightForearmBack * t).addScaledVector(cueDirForHand, POOL_HUMAN_CFG.rightForearmLength);
   const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
@@ -2596,8 +2602,9 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
 function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForward, cueStick, cueLen, power) {
   if (!human) return null;
   const poseForward = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, 1));
+  const activeHumanState = shotState === 'rolling' ? 'idle' : shotState;
   const tableCue = getPoolHumanCueEndpoints(cueStick, cueLen);
-  const cueBackForStance = shotState === 'dragging' || shotState === 'striking' ? tableCue.back : null;
+  const cueBackForStance = activeHumanState === 'dragging' || activeHumanState === 'striking' ? tableCue.back : null;
   const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, poseForward, cueBackForStance);
   rootTarget.y = POOL_HUMAN_CFG.floorLocalY;
   const standingYaw = poolHumanYawFromForward(poseForward);
@@ -2618,13 +2625,13 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
   ).applyAxisAngle(POOL_HUMAN_Y_AXIS, standingYaw));
   const idleDir = POOL_HUMAN_CFG.idleCueDir.clone().applyAxisAngle(POOL_HUMAN_Y_AXIS, standingYaw).normalize();
   const idleCue = cuePoseFromPoolHumanGrip(idleRightHandTarget, idleDir, POOL_HUMAN_CFG.idleCueGripFromBack, cueLen);
-  const activeCueBack = shotState === 'idle' || shotState === 'rolling' ? idleCue.back : tableCue.back;
-  const activeCueTip = shotState === 'idle' || shotState === 'rolling' ? idleCue.tip : tableCue.tip;
+  const activeCueBack = activeHumanState === 'idle' ? idleCue.back : tableCue.back;
+  const activeCueTip = activeHumanState === 'idle' ? idleCue.tip : tableCue.tip;
   human.idleCuePose = idleCue;
   updatePoolRoyaleHumanPose(
     human,
     dt,
-    shotState,
+    activeHumanState,
     rootTarget,
     poseForward,
     bridgeHandTarget,


### PR DESCRIPTION
### Motivation
- Clarify and centralize sizing constants for pool human models and make stance/pose behavior more consistent between Pool Royale and Snooker flows.
- Reduce overly-large right-hand push and refine hand/leg IK blending to produce more stable, table-facing poses during aim and strike.
- Improve ordering and readability of upper-body rotations and hand basis setup to avoid visual jitter and make intent explicit.

### Description
- Introduced `POOL_HUMAN_HEIGHT_TO_CUE_RATIO` and compute `POOL_HUMAN_TARGET_HEIGHT` from it, making height relationship explicit. 
- Tuned `POOL_HUMAN_CFG.rightStrokePush` from `0.26` to `0.24` and adjusted several IK/weight arguments to use `ik` or `1` consistently for arms and legs. 
- Reworked pose/rotation ordering in `drivePoolRoyaleHuman` to change how hips, spine, chest, neck and head are rotated and twisted, and updated hand basis calls to select different roll values when aiming/striking. 
- Changed stance selection and state handling: bias stance toward cue butt during aim/strike, replace some `activeState` aliasing with explicit `state`/`activeHumanState` handling in `updatePoolRoyaleHumanPose` and `updatePoolRoyaleHumanFrame`, and simplify stroke/pull/push calculations accordingly.

### Testing
- Ran unit and integration tests with `yarn test` and all tests completed successfully. 
- Ran a production build with `yarn build` and the build succeeded. 
- Ran linter with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0802e335f08329a5fb6468dde3f0a8)