### PR TITLE
Adjust Snooker human shooting pose: cue‑relative height, opposite upper‑body bend, right‑hand grip

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -106,6 +106,9 @@ import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 const PROVIDED_SNOOKER_HUMAN = (() => {
 const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const WORLD_SCALE = 3.5;
+const HUMAN_HEIGHT_TO_CUE_LENGTH_RATIO = 1.3;
+const SHOOTING_UPPER_BODY_BEND_SIDE = 1;
+const RIGHT_HAND_CUE_GRIP_BLEND = 0.88;
 const CFG = {
   scale: WORLD_SCALE,
   tableTopY: 0.84 * WORLD_SCALE,
@@ -131,7 +134,7 @@ const CFG = {
   poseLambda: 9,
   moveLambda: 5.6,
   rotLambda: 8.5,
-  humanScale: 1.2 * 1.78 * WORLD_SCALE,
+  humanScale: 1.78 * WORLD_SCALE * HUMAN_HEIGHT_TO_CUE_LENGTH_RATIO,
   humanVisualYawFix: Math.PI,
   stanceWidth: 0.52 * WORLD_SCALE,
   bridgePalmTableLift: 0.006 * WORLD_SCALE,
@@ -559,12 +562,13 @@ function updateHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget,
   const powerLean = power * t;
   const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * CFG.scale);
   rootWorld.y = human.root.position.y;
-  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.12, t) * CFG.scale + breath, (lerp(0.02, -0.28, t) - 0.018 * powerLean) * CFG.scale));
-  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.21, t) * CFG.scale + breath, (lerp(0.02, -0.62, t) - 0.03 * powerLean) * CFG.scale));
-  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.25, t) * CFG.scale + breath, (lerp(0.02, -0.8, t) - 0.034 * powerLean) * CFG.scale));
-  const head = local(new THREE.Vector3(0, lerp(1.84, 1.34, t) * CFG.scale + breath - CFG.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.94, t) - 0.034 * powerLean) * CFG.scale));
-  const leftShoulder = local(new THREE.Vector3(-0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * CFG.scale));
-  const rightShoulder = local(new THREE.Vector3(0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * CFG.scale));
+  const upperBodyBendSide = SHOOTING_UPPER_BODY_BEND_SIDE;
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.12, t) * CFG.scale + breath, (lerp(0.02, 0.28 * upperBodyBendSide, t) + 0.018 * upperBodyBendSide * powerLean) * CFG.scale));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.21, t) * CFG.scale + breath, (lerp(0.02, 0.62 * upperBodyBendSide, t) + 0.03 * upperBodyBendSide * powerLean) * CFG.scale));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.25, t) * CFG.scale + breath, (lerp(0.02, 0.8 * upperBodyBendSide, t) + 0.034 * upperBodyBendSide * powerLean) * CFG.scale));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.34, t) * CFG.scale + breath - CFG.chinToCueHeight * 0.16 * t, (lerp(0.04, 0.94 * upperBodyBendSide, t) + 0.034 * upperBodyBendSide * powerLean) * CFG.scale));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, 0.46 * upperBodyBendSide, t) + 0.018 * upperBodyBendSide * human.settleT) * CFG.scale));
+  const rightShoulder = local(new THREE.Vector3(0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, 0.34 * upperBodyBendSide, t) + 0.018 * upperBodyBendSide * human.settleT) * CFG.scale));
   const leftHip = local(new THREE.Vector3(-0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
   const rightHip = local(new THREE.Vector3(0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
   const leftFoot = local(new THREE.Vector3(-0.13 * CFG.scale, CFG.footGroundY, 0.03 * CFG.scale + walk * 0.018 * CFG.scale).lerp(new THREE.Vector3(-CFG.stanceWidth * 0.42, CFG.footGroundY, -0.34 * CFG.scale), t));
@@ -580,7 +584,10 @@ function updateHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget,
   const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04 * CFG.scale, CFG.rightElbowShotRise, t)).addScaledVector(side, lerp(-0.18 * CFG.scale, CFG.rightElbowShotSide, t)).addScaledVector(forward, lerp(-0.04 * CFG.scale, CFG.rightElbowShotBack, t));
   const forearmStroke = (state === 'dragging' ? -CFG.rightStrokePull * easeOutCubic(power) : 0) + (state === 'striking' ? CFG.rightStrokePush * strikeFollow : 0) + (state === 'dragging' ? dragStroke * 0.035 * CFG.scale : 0);
   const forearmBase = lockedRightElbow.clone().addScaledVector(side, CFG.rightForearmOutward * t).addScaledVector(UP, -CFG.rightForearmDown * t).addScaledVector(UP, CFG.rightHandShotLift * t).addScaledVector(forward, -CFG.rightForearmBack * t).addScaledVector(cueDirForHand, CFG.rightForearmLength);
-  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
+  const cueLineRightHandGrip = cueTip.clone().addScaledVector(cueDirForHand, -CFG.shootCueGripFromBack + forearmStroke);
+  const liveCueGripPoint = forearmBase.clone()
+    .addScaledVector(cueDirForHand, forearmStroke)
+    .lerp(cueLineRightHandGrip, RIGHT_HAND_CUE_GRIP_BLEND * handIk);
   const idleWristTarget = idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, CFG.rightHandRollIdle));
   const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(CFG.rightHandRollIdle, CFG.rightHandRollShoot - CFG.rightHandDownPose, handIk)));
   const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
@@ -638,7 +645,7 @@ function configureProvidedHumanForArena() {
   CFG.bridgeDist = 0.28 * scale;
   CFG.edgeMargin = 0.68 * scale;
   CFG.desiredShootDistance = 1.25 * scale;
-  CFG.humanScale = 1.5 * scale;
+  CFG.humanScale = CFG.cueLength * HUMAN_HEIGHT_TO_CUE_LENGTH_RATIO;
   CFG.stanceWidth = 0.52 * scale;
   CFG.bridgePalmTableLift = 0.006 * scale;
   CFG.bridgeCueLift = 0.018 * scale;


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal avatar visually align with the cue stick by scaling the avatar height relative to the cue length (approx 130% of cue length). 
- Force the avatar to lean the upper body toward the cue line on the opposite side of the previous lowering so the head/torso fold reads correctly while taking the shooting position. 
- Ensure the avatar grips the cue with the right hand by blending the right-hand grip toward the cue line.

### Description
- Added new tuning constants `HUMAN_HEIGHT_TO_CUE_LENGTH_RATIO`, `SHOOTING_UPPER_BODY_BEND_SIDE`, and `RIGHT_HAND_CUE_GRIP_BLEND` at the top of `webapp/src/pages/Games/SnookerRoyal.jsx` and used them in the human pose solver. 
- Replaced the fixed `humanScale` with a cue-relative expression so `humanScale` is computed as `CFG.cueLength * HUMAN_HEIGHT_TO_CUE_LENGTH_RATIO` when configuring the arena (in `configureProvidedHumanForArena`). 
- Flipped/adjusted the upper-body target math in `updateHumanPose` by introducing `upperBodyBendSide` and using it to bias `torso`, `chest`, `neck`, `head`, and shoulder targets so the avatar lowers toward the cue on the intended (opposite) side. 
- Blended the right-hand grip toward a cue-line grip by computing a cue-line grip position and lerping the live grip (`liveCueGripPoint`) toward that line with `RIGHT_HAND_CUE_GRIP_BLEND`, so the right hand holds the cue stick as intended.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully. 
- Installed Playwright and its Chromium dependency with `npx --yes playwright install chromium` and `npx --yes playwright install-deps chromium` which both completed. 
- Attempted an automated Playwright screenshot of `http://127.0.0.1:5173/games/snookerroyale` to visually validate the pose, but `page.screenshot` timed out in the headless CI environment so the screenshot step failed; the build and dependency installation steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0817991b988329afe959029bf3a562)