### PR TITLE
Add Snooker Champion tournament: lobby, bracket page, routes and provided SnookerRoyal view

### DIFF
--- a/webapp/public/snooker-champion-bracket.html
+++ b/webapp/public/snooker-champion-bracket.html
@@ -1,0 +1,580 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Snooker Champion Bracket</title>
+<style>
+  :root{
+    --bg:#0b1020;
+    --panel:#11172a;
+    --ink:#dbe7ff;
+    --accent:#2563eb;
+    --accent-2:#f97316;
+    --accent-3:#a855f7;
+    --muted:#8aa0d1;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%}
+  body{
+    margin:0;
+    font-family:system-ui,Segoe UI,Roboto,Arial,Helvetica,sans-serif;
+    background: radial-gradient(80% 60% at 50% 0%, #0f1735 0%, var(--bg) 60%);
+    color:var(--ink);
+    display:flex; flex-direction:column; gap:10px;
+  }
+  /* Original demo toolbar and notes are hidden */
+  header, .setup, .footer-note{display:none}
+  .canvas-wrap{
+    position:relative;
+    overflow:auto; /* allow horizontal scroll on phones */
+    border-top:1px solid rgba(255,255,255,.06);
+    border-bottom:1px solid rgba(255,255,255,.06);
+    background:
+      radial-gradient(1000px 300px at 50% -50px, rgba(37,99,235,.25), transparent 70%),
+      radial-gradient(800px 300px at 50% 100%, rgba(249,115,22,.15), transparent 70%);
+  }
+  canvas{ display:block; margin:0 auto; }
+  .footer-note{padding:8px 12px; text-align:center; color:var(--muted); font-size:.85rem}
+  details{margin-left:auto}
+  summary{cursor:pointer}
+  .pill {
+    display:inline-flex; align-items:center; gap:8px; padding:4px 8px; border-radius:999px;
+    background:rgba(37,99,235,.15); border:1px solid rgba(37,99,235,.35); color:#cfe0ff;
+    font-size:.8rem;
+  }
+  .coin-confetti{position:fixed;top:-40px;width:32px;height:32px;pointer-events:none;animation:coin-fall var(--duration,3s) linear forwards}
+  @keyframes coin-fall{from{transform:translateY(-10vh) rotate(0deg);opacity:1}to{transform:translateY(100vh) rotate(360deg);opacity:0}}
+</style>
+</head>
+<body>
+<div class="canvas-wrap">
+  <canvas id="board" width="1200" height="800" aria-label="Tournament bracket canvas"></canvas>
+</div>
+
+<button id="continueBtn" style="position:fixed;bottom:20px;left:50%;transform:translateX(-50%);padding:8px 16px;border:none;border-radius:6px;background:var(--accent);color:var(--ink);">Continue</button>
+
+<script src="/flag-emojis.js"></script>
+<script>
+(function(){
+  const DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+  const canvas = document.getElementById('board');
+  const ctx = canvas.getContext('2d');
+  const params = new URLSearchParams(window.location.search);
+  const tgKey = params.get("tgId") || "anon";
+  const STATE_KEY = `snookerChampionTournamentState_${tgKey}`;
+  const OPP_KEY = `snookerChampionTournamentOpponent_${tgKey}`;
+  const stake = Number(params.get('amount')) || 0;
+  const theme = {
+    bg:'#0b1020',
+    panel:'#11172a',
+    ink:'#dbe7ff',
+    muted:'#8aa0d1',
+    neonA:'#2563eb',
+    neonB:'#f97316',
+    neonC:'#a855f7',
+    line:'#233155'
+  };
+  const tpcImg = new Image();
+  tpcImg.src = '/assets/icons/ezgif-54c96d8a9b9236.webp';
+
+  let hitRegions = []; // {round, match, slot, x,y,w,h}
+
+  let state = {
+    players: [],
+    N: 0,
+    bracketN: 0,
+    rounds: [],
+    seedToPlayer: {},
+    pot: 0,
+    userSeed: 1,
+    currentRound: 0,
+    championSeed: 0,
+    complete: false
+  };
+
+  function nextPow2(n){ let p=1; while(p<n) p<<=1; return p; }
+
+  function seedOrder(N){
+    if(N===2) return [1,2];
+    const prev = seedOrder(N/2);
+    const mirror = prev.map(x => N + 1 - x);
+    return prev.concat(mirror);
+  }
+
+  function round0PairsFromSeeds(N){
+    const order = seedOrder(N);
+    const pairs = [];
+    for(let i=0;i<N;i+=2){
+      pairs.push([order[i], order[i+1]]);
+    }
+    return pairs;
+  }
+
+  function createBracket(players){
+    const Nrequested = players.length;
+    const pow2 = nextPow2(Nrequested);
+    state.N = Nrequested;
+    state.bracketN = pow2;
+    const seedToPlayer = {};
+    for(let s=1; s<=pow2; s++){
+      if(s<=Nrequested) seedToPlayer[s]=players[s-1];
+      else seedToPlayer[s]={name:'BYE'};
+    }
+    state.seedToPlayer = seedToPlayer;
+
+    const r0 = round0PairsFromSeeds(pow2);
+    state.rounds = [r0];
+    let matches = r0.length;
+    while(matches>1){
+      matches = Math.ceil(matches/2);
+      state.rounds.push(Array.from({length:matches}, _=>[0,0]));
+    }
+    layoutAndDraw();
+  }
+
+  function layoutAndDraw(){
+    const rounds = state.rounds.length;
+    const colW = 220;
+    const colGap = 64;
+    const padX = 24;
+    const padY = 24;
+    const widthCSS = padX*2 + rounds*colW + (rounds-1)*colGap;
+
+    const matches0 = state.rounds[0].length;
+
+    const boxH = 56;
+    const slotH = boxH/2;
+    const baseGap = 28;
+
+    const centers = [];
+    centers[0] = Array.from({length:matches0}, (_,i)=> padY + (boxH/2) + i*(boxH + baseGap));
+    for(let r=1; r<rounds; r++){
+      const prev = centers[r-1];
+      const arr=[];
+      for(let i=0;i<Math.ceil(prev.length/2);i++){
+        const c = (prev[2*i] + prev[2*i+1]) / 2;
+        arr.push(c);
+      }
+      centers[r]=arr;
+    }
+
+    const lastCenter = centers[rounds-1][0] || padY + boxH/2;
+    const heightCSS = Math.max(600, lastCenter + padY + boxH/2);
+
+    canvas.style.width = widthCSS + 'px';
+    canvas.style.height = heightCSS + 'px';
+    canvas.width = Math.floor(widthCSS * DPR);
+    canvas.height = Math.floor(heightCSS * DPR);
+    ctx.setTransform(DPR,0,0,DPR,0,0);
+
+    ctx.clearRect(0,0,widthCSS,heightCSS);
+    drawBackground(widthCSS, heightCSS);
+
+    hitRegions = [];
+    for(let r=0;r<rounds;r++){
+      const x = padX + r*(colW + colGap);
+      drawRoundTitle(r, x, 6 + (r==0? 10:0));
+
+      const matchesR = state.rounds[r].length;
+      for(let m=0;m<matchesR;m++){
+        const yCenter = centers[r][m];
+        drawMatchBox(r, m, x, yCenter - boxH/2, colW, boxH, slotH);
+      }
+
+      if(r>0){
+        const xPrev = padX + (r-1)*(colW + colGap) + colW;
+        const xConn = xPrev + 18;
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = theme.line;
+        ctx.beginPath();
+        for(let m=0;m<state.rounds[r].length;m++){
+          const cy = centers[r][m];
+          const top = centers[r-1][2*m];
+          const bot = centers[r-1][2*m+1];
+          ctx.moveTo(xPrev, top);
+          ctx.lineTo(xConn, top);
+          ctx.moveTo(xPrev, bot);
+          ctx.lineTo(xConn, bot);
+          ctx.moveTo(xConn, top);
+          ctx.lineTo(xConn, bot);
+          ctx.moveTo(xConn, cy);
+          ctx.lineTo(x, cy);
+        }
+        ctx.stroke();
+      }
+    }
+
+    drawCenterLabels(widthCSS);
+  }
+
+  function drawBackground(w,h){
+    const g = ctx.createLinearGradient(0,0,w,0);
+    g.addColorStop(0,'rgba(168,85,247,.08)');
+    g.addColorStop(.5,'rgba(37,99,235,.10)');
+    g.addColorStop(1,'rgba(249,115,22,.08)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0,0,w,h);
+  }
+
+  function drawRoundTitle(r, x, topPad){
+    ctx.save();
+    ctx.fillStyle = '#bcd0ff';
+    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
+    ctx.textAlign = 'left';
+    let label = '';
+    const rounds = state.rounds.length;
+    if(r === 0) label = 'ROUND OF ' + state.N;
+    else if(r === rounds-1){
+      label = 'FINAL 🏆 ';
+      ctx.fillText(label, x, topPad + 10);
+      let imgX = x + ctx.measureText(label).width + 2;
+      if (tpcImg.complete) {
+        ctx.drawImage(tpcImg, imgX, topPad, 12, 12);
+        imgX += 16;
+      }
+      ctx.fillText(String(state.pot), imgX, topPad + 10);
+      ctx.restore();
+      return;
+    }
+    else if(r === rounds-2) label = 'SEMIFINAL';
+    else label = 'QUARTER / R' + (r+1);
+    ctx.fillText(label, x, topPad + 10);
+    ctx.restore();
+  }
+
+  function slotColor(r, slot){
+    const palettes = [theme.neonC, theme.neonA, theme.neonB];
+    const base = palettes[r % palettes.length];
+    const alpha = .22;
+    return hexToRgba(base, alpha);
+  }
+
+  function drawMatchBox(r, m, x, y, w, h, slotH){
+    const radius = 12;
+    roundRect(ctx, x, y, w, h, radius);
+    const grad = ctx.createLinearGradient(x, y, x, y+h);
+    grad.addColorStop(0, 'rgba(255,255,255,.04)');
+    grad.addColorStop(1, 'rgba(0,0,0,.25)');
+    ctx.fillStyle = grad;
+    ctx.fill();
+
+    ctx.fillStyle = slotColor(r,0);
+    roundRect(ctx, x+4, y+4, w-8, slotH-6, 8);
+    ctx.fill();
+    ctx.fillStyle = slotColor(r,1);
+    roundRect(ctx, x+4, y+slotH+2, w-8, slotH-6, 8);
+    ctx.fill();
+
+    ctx.strokeStyle = 'rgba(255,255,255,.06)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(x+8, y+slotH);
+    ctx.lineTo(x+w-8, y+slotH);
+    ctx.stroke();
+
+    ctx.fillStyle = '#e7efff';
+    ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
+    ctx.textAlign = 'left';
+
+    const players = matchPlayers(r,m);
+    renderPlayer(players[0], x+12, y+slotH/2+4, slotH);
+    renderPlayer(players[1], x+12, y+slotH + slotH/2+4, slotH);
+
+    hitRegions.push({round:r, match:m, slot:0, x:x+4, y:y+4, w:w-8, h:slotH-6});
+    hitRegions.push({round:r, match:m, slot:1, x:x+4, y:y+slotH+2, w:w-8, h:slotH-6});
+  }
+
+  function coinConfetti(count=20){
+    const container=document.createElement('div');
+    container.style.position='fixed';container.style.top='0';container.style.left='0';
+    container.style.width='100%';container.style.height='0';container.style.pointerEvents='none';
+    container.style.zIndex='100';container.style.overflow='visible';
+    document.body.appendChild(container);
+    for(let i=0;i<count;i++){
+      const img=document.createElement('img');
+      img.src='/assets/icons/ezgif-54c96d8a9b9236.webp';
+      img.className='coin-confetti';
+      const left=Math.random()*100; const delay=Math.random()*3; const duration=2+Math.random()*2;
+      img.style.left=left+'vw'; img.style.animationDelay=delay+'s'; img.style.setProperty('--duration',duration+'s');
+      container.appendChild(img);
+    }
+    setTimeout(()=>container.remove(),5000);
+  }
+
+  function matchPlayers(r,m){
+    const [sA, sB] = state.rounds[r][m] || [];
+    const playerA = state.seedToPlayer[sA] || { name: 'TBD' };
+    const playerB = state.seedToPlayer[sB] || { name: 'TBD' };
+    return [playerA, playerB];
+  }
+
+  function renderPlayer(player, x, y, slotH){
+    if(player.name === 'BYE') return;
+    const avatarSize = 20;
+    if(player.flag){
+      ctx.fillText(player.flag, x, y+1);
+      ctx.fillText(player.name, x+18, y);
+    }else{
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(x+avatarSize/2, y-8, avatarSize/2, 0, Math.PI*2);
+      ctx.fillStyle = '#233155';
+      ctx.fill();
+      ctx.fillStyle = '#e7efff';
+      ctx.font = '600 11px system-ui,Segoe UI,Roboto,Arial';
+      ctx.textAlign = 'center';
+      ctx.fillText((player.name||'')[0]||'', x+avatarSize/2, y-4);
+      ctx.restore();
+      ctx.textAlign = 'left';
+      ctx.font = '600 13px system-ui,Segoe UI,Roboto,Arial';
+      ctx.fillText(player.name, x+avatarSize+6, y);
+    }
+  }
+
+  function labelForSource(r,m){
+    if(r===0){
+      const [sA,sB]=state.rounds[0][m];
+      return `(${seedShort(sA)} vs ${seedShort(sB)})`;
+    }else{
+      return `R${r+1}-M${m+1}`;
+    }
+  }
+
+  function seedShort(s){
+    const n = state.seedToPlayer[s].name;
+    if(n==='BYE') return 'BYE';
+    if(/^Team \d+$/i.test(n)) return n.replace('Team ', '#');
+    return n.length>10? n.slice(0,10)+'…': n;
+  }
+
+  function drawCenterLabels(w){
+    ctx.save();
+    ctx.textAlign = 'center';
+    ctx.font = '700 20px system-ui,Segoe UI,Roboto,Arial';
+    ctx.fillStyle = '#e8f0ff';
+    ctx.fillText('THE PLAYOFFS', w/2, 34);
+    ctx.font = '600 12px system-ui,Segoe UI,Roboto,Arial';
+    ctx.fillStyle = '#9fb3de';
+    ctx.fillText('WORLD CHAMPIONSHIP', w/2, 54);
+    ctx.restore();
+  }
+
+  function hexToRgba(hex, a){
+    let c = hex.replace('#','');
+    if(c.length===3){ c = c.split('').map(x=>x+x).join(''); }
+    const num = parseInt(c,16);
+    const r = (num>>16)&255, g=(num>>8)&255, b=num&255;
+    return `rgba(${r},${g},${b},${a})`;
+  }
+
+  function roundRect(ctx, x, y, w, h, r){
+    const rr = Math.min(r, w/2, h/2);
+    ctx.beginPath();
+    ctx.moveTo(x+rr, y);
+    ctx.lineTo(x+w-rr, y);
+    ctx.quadraticCurveTo(x+w, y, x+w, y+rr);
+    ctx.lineTo(x+w, y+h-rr);
+    ctx.quadraticCurveTo(x+w, y+h, x+w-rr, y+h);
+    ctx.lineTo(x+rr, y+h);
+    ctx.quadraticCurveTo(x, y+h, x, y+h-rr);
+    ctx.lineTo(x, y+rr);
+    ctx.quadraticCurveTo(x, y, x+rr, y);
+    ctx.closePath();
+  }
+
+  canvas.addEventListener('click', ()=>{
+    // Name editing disabled in tournament view
+  });
+
+  function getNameAt(r,m,slot){
+    const [a,b] = matchPlayers(r,m);
+    return slot===0? a.name : b.name;
+  }
+
+  function setNameAt(r,m,slot,newName){
+    if(r===0){
+      const seed = state.rounds[0][m][slot];
+      state.seedToPlayer[seed].name = newName;
+    }else{
+      alert('Names in this round are auto-filled from previous matches.');
+    }
+  }
+
+  function simulateRoundAI(st, round){
+    const next = st.rounds[round+1];
+    const userSeed = st.userSeed;
+    st.rounds[round].forEach((pair, idx) => {
+      if(pair.includes(userSeed)) return;
+      if(next && next[Math.floor(idx/2)][idx%2]) return;
+      const s1 = pair[0];
+      const s2 = pair[1];
+      const p1 = st.seedToPlayer[s1];
+      const p2 = st.seedToPlayer[s2];
+      let w;
+      if(p1 && p1.name==='BYE') w = s2;
+      else if(p2 && p2.name==='BYE') w = s1;
+      else w = Math.random() < 0.5 ? s1 : s2;
+      if(next) next[Math.floor(idx/2)][idx%2] = w;
+      else { st.championSeed = w; st.complete = true; }
+    });
+  }
+
+  function getUserMatch(st){
+    const r = st.currentRound || 0;
+    const userSeed = st.userSeed;
+    const roundMatches = st.rounds[r] || [];
+    for(let i=0;i<roundMatches.length;i++){
+      const pair = roundMatches[i];
+      const next = st.rounds[r+1] && st.rounds[r+1][Math.floor(i/2)][i%2];
+      if(next) continue;
+      if(pair[0]===userSeed || pair[1]===userSeed){
+        const oppSeed = pair[0]===userSeed? pair[1]:pair[0];
+        const opp = st.seedToPlayer[oppSeed];
+        if(opp && opp.name==='BYE'){
+          if(st.rounds[r+1]) st.rounds[r+1][Math.floor(i/2)][i%2]=userSeed;
+          simulateRoundAI(st, r);
+          if(st.rounds[r].every((p,idx)=> st.rounds[r+1][Math.floor(idx/2)][idx%2])){
+            st.currentRound++;
+          }
+          localStorage.setItem(STATE_KEY, JSON.stringify(st));
+          layoutAndDraw();
+          return null;
+        }
+        return {round:r, match:i, pair};
+      }
+    }
+    return null;
+  }
+
+  function startNextMatch(){
+    const st = state;
+    const info = getUserMatch(st);
+    if(!info) return;
+    st.pendingMatch = info;
+    const opponentSeed = info.pair[0] === st.userSeed ? info.pair[1] : info.pair[0];
+    localStorage.setItem(OPP_KEY, JSON.stringify(st.seedToPlayer[opponentSeed]));
+    localStorage.setItem(STATE_KEY, JSON.stringify(st));
+    window.location.href = '/games/snookerchampion' + window.location.search;
+  }
+
+  (function init(){
+    const totalPlayers = parseInt(params.get('players') || '8', 10);
+    const saved = localStorage.getItem(STATE_KEY);
+    if(saved){
+      try{
+        const parsed = JSON.parse(saved);
+        const savedComplete = Boolean(parsed?.complete && parsed?.championSeed);
+        const savedCount = parsed?.N || (parsed?.players || []).length;
+        if (!savedComplete && savedCount === totalPlayers) {
+          state = parsed;
+          if (!state.pot && stake > 0) {
+            state.pot = Math.round(stake * totalPlayers);
+          }
+        } else {
+          localStorage.removeItem(STATE_KEY);
+          localStorage.removeItem(OPP_KEY);
+        }
+      }catch{
+        localStorage.removeItem(STATE_KEY);
+        localStorage.removeItem(OPP_KEY);
+      }
+    }
+    if(!state?.players?.length){
+      const userName = params.get('name') || 'You';
+      const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
+      function flagToName(flag){
+        const codes = Array.from(flag).map(c => c.codePointAt(0) - 0x1F1E6 + 65);
+        return regionNames.of(String.fromCharCode(...codes)) || 'CPU';
+      }
+      function shuffle(arr){ for(let i=arr.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [arr[i],arr[j]]=[arr[j],arr[i]]; } }
+      const flags = [...(window.FLAG_EMOJIS || [])];
+      shuffle(flags);
+      const players = [{ name: userName, flag: params.get('flag') || '🏳️' }];
+      for(let i=0;i<totalPlayers-1;i++){
+        const f=flags[i];
+        players.push({ name: flagToName(f), flag: f });
+      }
+      state.players = players;
+      createBracket(players);
+      state.userSeed = 1;
+      state.currentRound = 0;
+      state.championSeed = 0;
+      state.complete = false;
+      state.pot = stake > 0 ? Math.round(stake * totalPlayers) : 0;
+      localStorage.setItem(STATE_KEY, JSON.stringify(state));
+    }
+    layoutAndDraw();
+    window.addEventListener('resize', ()=> layoutAndDraw());
+
+    function showExitPopup(){
+      if(document.getElementById('tournExit')) return;
+      const tg = window.Telegram?.WebApp;
+      const overlay=document.createElement('div');
+      overlay.id='tournExit';
+      overlay.style.position='fixed';overlay.style.inset='0';
+      overlay.style.background='rgba(0,0,0,0.6)';
+      overlay.style.display='flex';overlay.style.flexDirection='column';
+      overlay.style.alignItems='center';overlay.style.justifyContent='center';
+      const box=document.createElement('div');
+      box.style.background='#11172a';box.style.padding='20px';box.style.borderRadius='8px';box.style.textAlign='center';box.style.maxWidth='90%';box.style.color='#dbe7ff';
+      box.innerHTML='<p style="margin-bottom:12px;">If you quit the tournament, your funds will be lost and you will be placed last.</p>';
+      const quit=document.createElement('button');
+      quit.textContent='Quit Tournament';
+      quit.style.margin='4px';quit.style.padding='8px 12px';
+      quit.style.background='#f97316';quit.style.border='none';
+      quit.style.borderRadius='4px';quit.style.color='#fff';
+      const ret=document.createElement('button');
+      ret.textContent='Return to Lobby';
+      ret.style.margin='4px';ret.style.padding='8px 12px';
+      ret.style.background='#2563eb';ret.style.border='none';
+      ret.style.borderRadius='4px';ret.style.color='#fff';
+      box.appendChild(quit);box.appendChild(ret);overlay.appendChild(box);document.body.appendChild(overlay);
+      quit.onclick=()=>{localStorage.removeItem(STATE_KEY);localStorage.removeItem(OPP_KEY);if(tg) tg.BackButton.hide();window.location.href='/games/snookerchampion/lobby';};
+      ret.onclick=()=>{document.body.removeChild(overlay);if(tg) tg.BackButton.show();};
+    }
+    const tg = window.Telegram?.WebApp;
+    if(tg){ tg.BackButton.show(); tg.onEvent('backButtonClicked', showExitPopup); tg.onEvent('close', showExitPopup); }
+    history.pushState(null,'',location.href);
+    window.addEventListener('popstate', (e)=>{ e.preventDefault(); showExitPopup(); history.pushState(null,'',location.href); });
+
+    const btn = document.getElementById('continueBtn');
+    if(state.complete){
+      const champ = state.seedToPlayer[state.championSeed] || {};
+      coinConfetti(30);
+      const overlay=document.createElement('div');
+      overlay.style.position='fixed';overlay.style.inset='0';overlay.style.display='flex';overlay.style.flexDirection='column';
+      overlay.style.alignItems='center';overlay.style.justifyContent='center';overlay.style.background='rgba(0,0,0,0.6)';
+      const av=document.createElement('div');
+      av.style.width='120px';av.style.height='120px';av.style.borderRadius='50%';av.style.background='#fff';av.style.display='flex';
+      av.style.alignItems='center';av.style.justifyContent='center';av.style.fontSize='64px';
+      av.textContent=champ.flag||'';overlay.appendChild(av);
+      const last=JSON.parse(localStorage.getItem(`snookerChampionLastResult_${tgKey}`)||'{}');
+      if(last.p1!=null && last.p2!=null){
+        const res=document.createElement('div');res.style.color='#fff';res.style.marginTop='8px';res.textContent=`${last.p1}-${last.p2}`;
+        overlay.appendChild(res);
+      }
+      const prize=document.createElement('div');
+      prize.style.display='flex';prize.style.alignItems='center';prize.style.gap='4px';prize.style.marginTop='8px';
+      const icon=document.createElement('img');icon.src='/assets/icons/ezgif-54c96d8a9b9236.webp';icon.style.width='24px';icon.style.height='24px';
+      prize.appendChild(icon);
+      const amt=document.createElement('span');amt.textContent=String(state.pot);prize.appendChild(amt);
+      overlay.appendChild(prize);
+      btn.textContent='Return to Lobby';
+      btn.style.marginTop='12px';
+      btn.addEventListener('click', ()=>{
+        localStorage.removeItem(STATE_KEY);
+        localStorage.removeItem(OPP_KEY);
+        localStorage.removeItem(`snookerChampionLastResult_${tgKey}`);
+        window.location.href='/games/snookerchampion/lobby';
+      });
+      overlay.appendChild(btn);
+      document.body.appendChild(overlay);
+    } else {
+      btn.addEventListener('click', startNextMatch);
+    }
+  })();
+})();
+</script>
+</body>
+</html>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -101,8 +101,12 @@ const PoolRoyaleCareer = React.lazy(
   () => import('./pages/Games/PoolRoyaleCareer.jsx')
 );
 const SnookerRoyal = React.lazy(() => import('./pages/Games/SnookerRoyal.jsx'));
+const SnookerChampion = React.lazy(() => import('./pages/Games/SnookerChampion.jsx'));
 const SnookerRoyalLobby = React.lazy(
   () => import('./pages/Games/SnookerRoyalLobby.jsx')
+);
+const SnookerChampionLobby = React.lazy(
+  () => import('./pages/Games/SnookerChampionLobby.jsx')
 );
 const Tennis = React.lazy(() => import('./pages/Games/Tennis.tsx'));
 const TableTennis = React.lazy(() => import('./pages/Games/TableTennis.tsx'));
@@ -470,6 +474,18 @@ export default function App() {
                 element={
                   <GameLiveAvatarOverlay gameSlug="snookerroyale">
                     <SnookerRoyal />
+                  </GameLiveAvatarOverlay>
+                }
+              />
+              <Route
+                path="/games/snookerchampion/lobby"
+                element={<SnookerChampionLobby />}
+              />
+              <Route
+                path="/games/snookerchampion"
+                element={
+                  <GameLiveAvatarOverlay gameSlug="snookerchampion">
+                    <SnookerChampion />
                   </GameLiveAvatarOverlay>
                 }
               />

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -15,6 +15,7 @@ export const gameThumbnails = {
   'domino-royal': '/assets/icons/Domino%20battle%20Royal%20logo.png',
   poolroyale: '/assets/icons/Pool%20Royal%20game%20logo.png',
   snookerroyale: '/assets/icons/file_00000000123071f4a91766ac58320bce.png',
+  snookerchampion: '/assets/icons/file_00000000123071f4a91766ac58320bce.png',
   goalrush: '/assets/icons/Goal%20rush%20logo.png',
   airhockey: '/assets/icons/Air%20hockey%20game%20logo.png',
   snake: '/assets/icons/Snake%20and%20ladder%20game%20logo.png',
@@ -68,6 +69,15 @@ export const lobbyOptionIcons = {
     'ball-american': '/assets/icons/American%20Billiards%20.png'
   },
   snookerroyale: {
+    'type-regular': '/assets/icons/snooker-regular.svg',
+    'type-tournament': '/assets/icons/snooker-tournament.svg',
+    'mode-ai': '/assets/icons/snooker-royale.svg',
+    'mode-online': '/assets/icons/snooker-royale.svg',
+    'table-championship': '/assets/icons/snooker-royale.svg',
+    'table-club': '/assets/icons/snooker-royale.svg',
+    'table-practice': '/assets/icons/snooker-royale.svg'
+  },
+  snookerchampion: {
     'type-regular': '/assets/icons/snooker-regular.svg',
     'type-tournament': '/assets/icons/snooker-tournament.svg',
     'mode-ai': '/assets/icons/snooker-royale.svg',

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -51,6 +51,13 @@ const gamesCatalog = [
     description: 'Precision snooker battles with competitive stakes.'
   },
   {
+    name: 'Snooker Champion',
+    route: '/games/snookerchampion/lobby',
+    slug: 'snookerchampion',
+    image: '/assets/icons/file_00000000123071f4a91766ac58320bce.png',
+    description: 'Champion snooker battles with the Snooker Royal arena system.'
+  },
+  {
     name: 'Goal Rush',
     route: '/games/goalrush/lobby',
     slug: 'goalrush',

--- a/webapp/src/pages/Games/SnookerChampion.jsx
+++ b/webapp/src/pages/Games/SnookerChampion.jsx
@@ -1,0 +1,5 @@
+import SnookerRoyalProvided from './SnookerRoyalProvided.jsx';
+
+export default function SnookerChampion() {
+  return <SnookerRoyalProvided gameTitle="Snooker Champion" />;
+}

--- a/webapp/src/pages/Games/SnookerChampionLobby.jsx
+++ b/webapp/src/pages/Games/SnookerChampionLobby.jsx
@@ -1,0 +1,682 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramFirstName, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { resolveTableSize } from '../../config/snookerClubTables.js';
+import { socket } from '../../utils/socket.js';
+import { getOnlineUsers } from '../../utils/api.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { runSnookerRoyalOnlineFlow } from './snookerRoyalOnlineFlow.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
+import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import {
+  applySnookerTableModelParam,
+  TABLE_MODEL_OPENSOURCE
+} from './snookerTableModel.js';
+
+const PLAYER_FLAG_STORAGE_KEY = 'snookerChampionPlayerFlag';
+const AI_FLAG_STORAGE_KEY = 'snookerChampionAiFlag';
+
+export default function SnookerChampionLobby() {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  useTelegramBackButton();
+
+  const searchParams = new URLSearchParams(search);
+  const initialPlayType = (() => {
+    const requestedType = searchParams.get('type');
+    return requestedType === 'tournament' ? 'tournament' : 'regular';
+  })();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('ai');
+  const [avatar, setAvatar] = useState('');
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
+  const [aiFlagIndex, setAiFlagIndex] = useState(null);
+  const [playType, setPlayType] = useState(initialPlayType);
+  const [players, setPlayers] = useState(8);
+  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const tableModel = TABLE_MODEL_OPENSOURCE;
+  const [onlinePlayers, setOnlinePlayers] = useState([]);
+  const [matching, setMatching] = useState(false);
+  const [spinningPlayer, setSpinningPlayer] = useState('');
+  const [matchPlayers, setMatchPlayers] = useState([]);
+  const matchPlayersRef = useRef([]);
+  const [readyList, setReadyList] = useState([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [matchingError, setMatchingError] = useState('');
+  const [matchStatus, setMatchStatus] = useState('');
+  const spinIntervalRef = useRef(null);
+  const accountIdRef = useRef(null);
+  const pendingTableRef = useRef('');
+  const cleanupRef = useRef(() => {});
+  const stakeDebitRef = useRef(null);
+  const matchTimeoutRef = useRef(null);
+  const seatTimeoutRef = useRef(null);
+  const forcedVariant = 'snooker';
+
+  const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+  const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    import('./SnookerChampion.jsx').catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(PLAYER_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setPlayerFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setAiFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    matchPlayersRef.current = matchPlayers;
+  }, [matchPlayers]);
+
+
+  const navigateToSnookerChampion = ({ tableId: startedId, roster = [], accountId, currentTurn }) => {
+    const selfId = accountId || accountIdRef.current;
+    const selfEntry = roster.find((p) => String(p.id) === String(selfId));
+    const opponentEntry = roster.find((p) => String(p.id) !== String(selfId));
+    const starterId = currentTurn || roster?.[0]?.id || null;
+    const selfIndex = roster.findIndex((p) => String(p.id) === String(selfId));
+    const seat = selfIndex === 1 ? 'B' : 'A';
+    const starterSeat = starterId && String(starterId) === String(selfId) ? seat : seat === 'A' ? 'B' : 'A';
+    const friendlyName =
+      selfEntry?.name ||
+      getTelegramFirstName() ||
+      getTelegramId() ||
+      (selfId ? `TPC ${selfId}` : 'Player');
+    const friendlyAvatar = selfEntry?.avatar || avatar;
+    const opponentName =
+      opponentEntry?.name ||
+      opponentEntry?.username ||
+      opponentEntry?.telegramName ||
+      (opponentEntry?.id ? `TPC ${opponentEntry.id}` : '');
+    const opponentAvatar = opponentEntry?.avatar || '';
+    cleanupRef.current?.({ account: accountId, skipRefReset: true });
+    const params = new URLSearchParams();
+    params.set('variant', forcedVariant);
+    params.set('type', playType);
+    params.set('mode', 'online');
+    params.set('tableId', startedId);
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    if (friendlyAvatar) params.set('avatar', friendlyAvatar);
+    const tgId = getTelegramId();
+    if (tgId) params.set('tgId', tgId);
+    const resolvedAccountId = accountIdRef.current;
+    if (resolvedAccountId) params.set('accountId', resolvedAccountId);
+    if (tableSize) params.set('tableSize', tableSize);
+    applySnookerTableModelParam(params, tableModel);
+    params.set('seat', seat);
+    params.set('starter', starterSeat);
+    const name = (friendlyName || '').trim();
+    if (name) params.set('name', name);
+    if (opponentName) params.set('opponent', opponentName);
+    if (opponentAvatar) params.set('opponentAvatar', opponentAvatar);
+    navigate(`/games/snookerchampion?${params.toString()}`);
+  };
+
+  const startGame = async () => {
+    const isOnlineMatch = mode === 'online' && playType === 'regular';
+    if (matching) return;
+    await cleanupRef.current?.();
+    setMatchStatus('');
+    setMatchingError('');
+
+    if (isOnlineMatch) {
+      await runSnookerRoyalOnlineFlow({
+        stake,
+        variant: forcedVariant,
+        ballSet: null,
+        playType,
+        mode,
+        tableSize,
+        avatar,
+        gameType: 'snookerchampion',
+        transactionGame: 'snookerchampion-online',
+        deps: { ensureAccountId, getAccountBalance, addTransaction, getTelegramId, getTelegramFirstName, socket },
+        state: {
+          setMatchingError,
+          setMatchStatus,
+          setMatching,
+          setIsSearching,
+          setMatchPlayers,
+          setReadyList,
+          setSpinningPlayer
+        },
+        refs: {
+          accountIdRef,
+          matchPlayersRef,
+          pendingTableRef,
+          cleanupRef,
+          spinIntervalRef,
+          stakeDebitRef,
+          matchTimeoutRef,
+          seatTimeoutRef
+        },
+        onGameStart: navigateToSnookerChampion
+      });
+      return;
+    }
+
+    let tgId;
+    let accountId;
+    try {
+      tgId = getTelegramId();
+      accountId = await ensureAccountId();
+    } catch (error) {
+      const message = 'Unable to verify your TPC account. Please retry.';
+      setMatchingError(message);
+      try {
+        window?.Telegram?.WebApp?.showAlert?.(message);
+      } catch {}
+      console.error('[SnookerChampionLobby] ensureAccountId failed (offline)', error);
+      return;
+    }
+
+    accountIdRef.current = accountId;
+
+    const params = new URLSearchParams();
+    params.set('variant', forcedVariant);
+    params.set('tableSize', tableSize);
+    applySnookerTableModelParam(params, tableModel);
+    params.set('type', playType);
+    params.set('mode', mode);
+    if (isOnlineMatch) {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
+    }
+    if (playType === 'tournament') params.set('players', players);
+    const initData = window.Telegram?.WebApp?.initData;
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+    const devAcc = import.meta.env.VITE_DEV_ACCOUNT_ID;
+    const devAcc1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+    const devAcc2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+    if (devAcc) params.set('dev', devAcc);
+    if (devAcc1) params.set('dev1', devAcc1);
+    if (devAcc2) params.set('dev2', devAcc2);
+    if (initData) params.set('init', encodeURIComponent(initData));
+
+    if (playType === 'tournament') {
+      window.location.href = `/snooker-champion-bracket.html?${params.toString()}`;
+      return;
+    }
+
+    navigate(`/games/snookerchampion?${params.toString()}`);
+  };
+
+  useEffect(() => {
+    let active = true;
+    const loadOnline = () => {
+      getOnlineUsers()
+        .then((data) => {
+          if (!active) return;
+          const list = Array.isArray(data?.users)
+            ? data.users
+            : Array.isArray(data)
+            ? data
+            : [];
+          setOnlinePlayers(list);
+        })
+        .catch(() => {});
+    };
+    loadOnline();
+    const id = setInterval(loadOnline, 15000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  const matchingCandidates = useMemo(() => {
+    const base = (onlinePlayers || []).map((p) => ({
+      id: p.accountId || p.playerId || p.id,
+      name: p.username || p.name || p.telegramName || p.telegramId || p.accountId
+    }));
+    const lobbyEntries = (matchPlayers || []).map((p) => ({ id: p.id, name: p.name || p.id }));
+    const merged = [...base, ...lobbyEntries].filter((p) => p.id);
+    const seen = new Set();
+    return merged.filter((p) => {
+      const key = String(p.id);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [matchPlayers, onlinePlayers]);
+
+  useEffect(() => {
+    if (spinIntervalRef.current) {
+      clearInterval(spinIntervalRef.current);
+      spinIntervalRef.current = null;
+    }
+    if (!matching || matchingCandidates.length === 0) return undefined;
+    setSpinningPlayer(matchingCandidates[0].name || 'Searching…');
+    spinIntervalRef.current = setInterval(() => {
+      const pick = matchingCandidates[Math.floor(Math.random() * matchingCandidates.length)];
+      setSpinningPlayer(pick?.name || 'Searching…');
+    }, 500);
+    return () => {
+      if (spinIntervalRef.current) clearInterval(spinIntervalRef.current);
+    };
+  }, [matching, matchingCandidates]);
+
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  useEffect(() => {
+    if (playType === 'tournament') {
+      setMode('ai');
+    }
+  }, [playType]);
+
+  useEffect(() => {
+    if (mode !== 'online' || playType !== 'regular') {
+      cleanupRef.current?.();
+      setMatching(false);
+      setMatchStatus('');
+      setMatchPlayers([]);
+      setReadyList([]);
+      setIsSearching(false);
+    }
+  }, [mode, playType]);
+
+  useEffect(() => {
+    if (!matching) return;
+    const readyIds = new Set((readyList || []).map((id) => String(id)));
+    const selfId = accountIdRef.current;
+    if (selfId && readyIds.has(String(selfId)) && readyIds.size >= 2) {
+      setMatchStatus('All players ready. Launching match…');
+    }
+  }, [matching, readyList]);
+
+  const readyIds = useMemo(
+    () => new Set((readyList || []).map((id) => String(id))),
+    [readyList]
+  );
+
+  const winnerParam = searchParams.get('winner');
+
+  return (
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-6 p-4 pb-8">
+        {winnerParam && (
+          <div className="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-center text-sm font-semibold text-emerald-200">
+            {winnerParam === '1' ? 'You won!' : 'CPU won!'}
+          </div>
+        )}
+        <GameLobbyHeader
+          slug="snookerchampion"
+          title="Snooker Champion Lobby"
+          badge={`${onlinePlayers.length} online`}
+        />
+
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+          <div className="mt-3 flex items-center gap-3">
+            <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+              {avatar ? (
+                <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+              )}
+            </div>
+            <div className="text-sm text-white/80">
+              <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
+              <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2">
+            <button
+              type="button"
+              onClick={() => setShowFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedFlag || '🌐'}</span>
+                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAiFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flag</div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick opponent'}</span>
+              </div>
+            </button>
+          </div>
+          <p className="mt-3 text-xs text-white/60">Your lobby choices persist into the match intro.</p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Match Type</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              {
+                id: 'regular',
+                label: 'Regular',
+                desc: 'Quick single match',
+                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
+                icon: '🔴'
+              },
+              {
+                id: 'tournament',
+                label: 'Tournament',
+                desc: 'Bracket challenge',
+                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
+                icon: '🏆'
+              }
+            ].map(({ id, label, desc, accent, icon }) => {
+              const active = playType === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setPlayType(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('snookerchampion', `type-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60 text-center">
+            Tournament mode locks online matchmaking and uses the bracket flow.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Table</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">GLB</span>
+          </div>
+          <div className="lobby-option-card lobby-option-card-active cursor-default">
+            <div className="text-center">
+              <p className="lobby-option-label">GLB Snooker Table</p>
+              <p className="lobby-option-subtitle">Default table with original GLB cushions and procedural bases.</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              {
+                id: 'ai',
+                label: 'Vs AI',
+                desc: 'Instant practice',
+                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
+                icon: '🤖',
+                disabled: false
+              },
+              {
+                id: 'online',
+                label: '1v1 Online',
+                desc: 'Stake & match',
+                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
+                icon: '⚔️',
+                disabled: playType === 'tournament'
+              }
+            ].map(({ id, label, desc, accent, icon, disabled }) => {
+              const active = mode === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => !disabled && setMode(id)}
+                  disabled={disabled}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  } ${disabled ? 'lobby-option-card-disabled' : ''}`}
+                >
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('poolroyale', `mode-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">
+                      {disabled ? 'Tournament bracket only' : desc}
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60 text-center">
+            AI matches stay offline. Online mode uses your TPC stake and pairs you with another player.
+          </p>
+        </div>
+
+        {playType === 'tournament' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  🧩
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Tournament Seats</h3>
+                <p className="text-xs text-white/60">Choose the bracket size before launching.</p>
+              </div>
+            </div>
+            <div className="mt-3 grid grid-cols-3 gap-3">
+              {[8, 16, 24].map((p) => {
+                const active = players === p;
+                return (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => setPlayers(p)}
+                    className={`lobby-option-card ${
+                      active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                    }`}
+                  >
+                    <div className="lobby-option-thumb bg-gradient-to-br from-purple-400/30 via-indigo-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
+                        <span className="text-2xl font-semibold">{p}</span>
+                      </div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{p} Players</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-white/60">
+              Winner takes the pot minus a 10% developer fee.
+            </p>
+          </div>
+        )}
+
+        {mode === 'online' && playType === 'regular' && (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-yellow-400/40 to-orange-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  💰
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Select Stake</h3>
+                <p className="text-xs text-white/60">Stake your TPC to lock a table.</p>
+              </div>
+            </div>
+            <div className="mt-3">
+              <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            </div>
+            <p className="text-center text-white/60 text-xs">
+              Online games use your TPC stake as escrow, while AI matches stay free.
+            </p>
+          </div>
+        )}
+
+        {mode === 'online' && playType === 'regular' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-white">Online Arena</h3>
+                <p className="text-sm text-white/60">
+                  We match players by TPC account number, stake ({stake.amount} {stake.token}),
+                  and Snooker Champion game type.
+                </p>
+              </div>
+              <div className="text-xs text-white/60">{onlinePlayers.length} online</div>
+            </div>
+            {matchingError && <div className="text-sm text-red-400">{matchingError}</div>}
+            {matching && (
+              <div className="space-y-2">
+                {matchStatus && <div className="text-xs text-white/60">{matchStatus}</div>}
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-white">Spinning wheel</span>
+                  <span className="text-xs text-white/60">Searching for stake match…</span>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white/80">
+                  <div className="flex items-center justify-between">
+                    <span>🎯 {spinningPlayer || 'Searching…'}</span>
+                    <span className="text-xs text-white/60">
+                      Stake {stake.amount} {stake.token}
+                    </span>
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  {matchPlayers.map((p) => (
+                    <div
+                      key={p.id}
+                      className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white/80"
+                    >
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="text-sm font-semibold">{p.name || `TPC ${p.id}`}</p>
+                          <p className="text-xs text-white/60">Account #{p.id}</p>
+                        </div>
+                        <span
+                          className={`text-xs font-semibold ${
+                            readyIds.has(String(p.id)) ? 'text-emerald-400' : 'text-white/50'
+                          }`}
+                        >
+                          {readyIds.has(String(p.id)) ? 'Ready' : 'Waiting'}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                  {matchPlayers.length === 0 && (
+                    <div className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white/60">
+                      Waiting for another player in this snooker arena…
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+            {!matching && (
+              <div className="text-sm text-white/60">
+                Start to join a 1v1 snooker arena. We keep you at the same table until the match begins.
+              </div>
+            )}
+          </div>
+        )}
+
+        <button
+          onClick={startGame}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={mode === 'online' && (isSearching || matching)}
+        >
+          {mode === 'online' ? (matching ? 'Waiting for opponent…' : 'Start Online') : 'Start'}
+        </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setPlayerFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
+
+        <FlagPickerModal
+          open={showAiFlagPicker}
+          count={1}
+          selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setAiFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SnookerRoyalProvided.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalProvided.jsx
@@ -1,0 +1,687 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+
+const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const WORLD_SCALE = 3.5;
+const CFG = {
+  scale: WORLD_SCALE,
+  tableTopY: 0.84 * WORLD_SCALE,
+  tableW: 2.55 * WORLD_SCALE,
+  tableL: 4.85 * WORLD_SCALE,
+  tableVisualMultiplier: 1.18,
+  topThickness: 0.09 * WORLD_SCALE,
+  railW: 0.15 * WORLD_SCALE,
+  railH: 0.08 * WORLD_SCALE,
+  ballR: 0.045 * WORLD_SCALE,
+  friction: 1.18,
+  restitution: 0.92,
+  minSpeed2: 0.00045 * WORLD_SCALE * WORLD_SCALE,
+  idleGap: 0.012 * WORLD_SCALE,
+  contactGap: 0.0012 * WORLD_SCALE,
+  pullRange: 0.42 * WORLD_SCALE,
+  strikeTime: 0.12,
+  holdTime: 0.05,
+  cueLength: 1.78 * WORLD_SCALE,
+  bridgeDist: 0.28 * WORLD_SCALE,
+  edgeMargin: 0.68 * WORLD_SCALE,
+  desiredShootDistance: 1.25 * WORLD_SCALE,
+  poseLambda: 9,
+  moveLambda: 5.6,
+  rotLambda: 8.5,
+  humanScale: 1.2 * 1.78 * WORLD_SCALE,
+  humanVisualYawFix: Math.PI,
+  stanceWidth: 0.52 * WORLD_SCALE,
+  bridgePalmTableLift: 0.006 * WORLD_SCALE,
+  bridgeCueLift: 0.018 * WORLD_SCALE,
+  bridgeHandBackFromBall: 0.235 * WORLD_SCALE,
+  bridgeHandSide: -0.012 * WORLD_SCALE,
+  chinToCueHeight: 0.11 * WORLD_SCALE,
+  footGroundY: 0.035 * WORLD_SCALE,
+  footLockStrength: 1,
+  kneeBendShot: 0.16 * WORLD_SCALE,
+  rightElbowShotRise: 0.18 * WORLD_SCALE,
+  rightElbowShotSide: -0.46 * WORLD_SCALE,
+  rightElbowShotBack: -0.78 * WORLD_SCALE,
+  rightForearmOutward: 0.36 * WORLD_SCALE,
+  rightForearmBack: 0.44 * WORLD_SCALE,
+  rightForearmDown: 0.48 * WORLD_SCALE,
+  rightForearmLength: 0.34 * WORLD_SCALE,
+  rightStrokePull: 0.30 * WORLD_SCALE,
+  rightStrokePush: 0.24 * WORLD_SCALE,
+  rightHandShotLift: -0.30 * WORLD_SCALE,
+  shootCueGripFromBack: 0.58 * WORLD_SCALE,
+  idleRightHandY: 0.8 * WORLD_SCALE,
+  idleRightHandX: 0.31 * WORLD_SCALE,
+  idleRightHandZ: -0.015 * WORLD_SCALE,
+  idleCueGripFromBack: 0.24 * WORLD_SCALE,
+  idleCueDir: new THREE.Vector3(0.055, 0.965, -0.13),
+  rightHandRollIdle: -2.2,
+  rightHandRollShoot: -2.05,
+  rightHandDownPose: 0.42,
+  rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(WORLD_SCALE)
+};
+const UP = new THREE.Vector3(0, 1, 0);
+const Y_AXIS = UP;
+const BASIS_MAT = new THREE.Matrix4();
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+const clamp01 = (v) => clamp(v, 0, 1);
+const lerp = (a, b, t) => a + (b - a) * t;
+const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+const easeInOut = (t) => t * t * (3 - 2 * t);
+const dampScalar = (current, target, lambda, dt) => THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+const dampVector = (current, target, lambda, dt) => current.lerp(target, 1 - Math.exp(-lambda * dt));
+const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
+const cleanName = (name) => name.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+function makeBasisQuaternion(side, up, forward) {
+  BASIS_MAT.makeBasis(side.clone().normalize(), up.clone().normalize(), forward.clone().normalize());
+  return new THREE.Quaternion().setFromRotationMatrix(BASIS_MAT);
+}
+function createMaterial(color, roughness = 0.72, metalness = 0.03) {
+  return new THREE.MeshStandardMaterial({ color, roughness, metalness });
+}
+function enableShadow(obj) {
+  obj.traverse((child) => {
+    if (child.isMesh) {
+      child.castShadow = true;
+      child.receiveShadow = true;
+      child.frustumCulled = false;
+    }
+  });
+  return obj;
+}
+function addBox(group, size, pos, mat) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), mat);
+  mesh.position.set(...pos);
+  enableShadow(mesh);
+  group.add(mesh);
+  return mesh;
+}
+function createUnitCylinder(color) {
+  return new THREE.Mesh(new THREE.CylinderGeometry(1, 1, 1, 18), createMaterial(color, 0.7, 0.03));
+}
+function setSegment(mesh, a, b, radius) {
+  const dir = b.clone().sub(a);
+  const len = Math.max(0.0001, dir.length());
+  mesh.position.copy(a).addScaledVector(dir, 0.5);
+  mesh.quaternion.setFromUnitVectors(UP, dir.normalize());
+  mesh.scale.set(radius, len, radius);
+}
+function createLine(color, opacity = 0.9) {
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(6), 3));
+  return new THREE.Line(geo, new THREE.LineBasicMaterial({ color, transparent: true, opacity }));
+}
+function setLinePoints(line, a, b) {
+  const pos = line.geometry.getAttribute('position');
+  pos.setXYZ(0, a.x, a.y, a.z);
+  pos.setXYZ(1, b.x, b.y, b.z);
+  pos.needsUpdate = true;
+  line.geometry.computeBoundingSphere();
+}
+function createCue() {
+  const group = new THREE.Group();
+  const shaft = createUnitCylinder(0xd9b88d);
+  const ferrule = createUnitCylinder(0xf8fafc);
+  const tip = createUnitCylinder(0x2563eb);
+  group.add(enableShadow(shaft), enableShadow(ferrule), enableShadow(tip));
+  return { group, shaft, ferrule, tip };
+}
+function setCuePose(cue, back, tip) {
+  const dir = tip.clone().sub(back).normalize();
+  const tipBack = tip.clone().addScaledVector(dir, -0.02 * CFG.scale);
+  const ferruleBack = tipBack.clone().addScaledVector(dir, -0.03 * CFG.scale);
+  setSegment(cue.shaft, back, ferruleBack, 0.012 * CFG.scale);
+  setSegment(cue.ferrule, ferruleBack, tipBack, 0.0105 * CFG.scale);
+  setSegment(cue.tip, tipBack, tip, 0.009 * CFG.scale);
+}
+function cuePoseFromGrip(grip, dir, gripFromBack, length = CFG.cueLength) {
+  const n = dir.clone().normalize();
+  return { back: grip.clone().addScaledVector(n, -gripFromBack), tip: grip.clone().addScaledVector(n, length - gripFromBack) };
+}
+function createBall(number, color, isCue = false) {
+  const mesh = new THREE.Mesh(new THREE.SphereGeometry(CFG.ballR, 40, 40), createMaterial(color, isCue ? 0.18 : 0.28, 0.018));
+  const shine = new THREE.Mesh(new THREE.SphereGeometry(CFG.ballR * 0.18, 16, 16), new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.22 }));
+  shine.position.set(-CFG.ballR * 0.28, CFG.ballR * 0.34, CFG.ballR * 0.32);
+  mesh.add(shine);
+  enableShadow(mesh);
+  return { mesh, pos: new THREE.Vector3(), vel: new THREE.Vector3(), isCue, number, radius: CFG.ballR };
+}
+function snookerRackPositions() {
+  const out = [{ n: 0, c: 0xf8fafc, p: new THREE.Vector3(0, CFG.ballR, CFG.tableL * 0.31), cue: true }];
+  const redOrigin = new THREE.Vector3(0, CFG.ballR, -CFG.tableL * 0.18);
+  let idx = 1;
+  for (let row = 0; row < 3; row += 1) {
+    for (let i = 0; i <= row; i += 1) {
+      out.push({ n: idx++, c: 0xdc2626, p: new THREE.Vector3(redOrigin.x + (i - row / 2) * CFG.ballR * 2.05, CFG.ballR, redOrigin.z - row * CFG.ballR * 1.88) });
+    }
+  }
+  out.push(
+    { n: 7, c: 0xfacc15, p: new THREE.Vector3(-CFG.tableW * 0.22, CFG.ballR, CFG.tableL * 0.2) },
+    { n: 8, c: 0x16a34a, p: new THREE.Vector3(CFG.tableW * 0.22, CFG.ballR, CFG.tableL * 0.2) },
+    { n: 9, c: 0x7c2d12, p: new THREE.Vector3(0, CFG.ballR, CFG.tableL * 0.2) },
+    { n: 10, c: 0x2563eb, p: new THREE.Vector3(0, CFG.ballR, 0) },
+    { n: 11, c: 0xf472b6, p: new THREE.Vector3(0, CFG.ballR, -CFG.tableL * 0.12) },
+    { n: 12, c: 0x111827, p: new THREE.Vector3(0, CFG.ballR, -CFG.tableL * 0.35) }
+  );
+  return out;
+}
+function addBalls(tableGroup) {
+  const balls = snookerRackPositions().map((item) => {
+    const ball = createBall(item.n, item.c, Boolean(item.cue));
+    ball.pos.copy(item.p);
+    ball.mesh.position.copy(ball.pos);
+    tableGroup.add(ball.mesh);
+    return ball;
+  });
+  return { balls, cueBall: balls.find((b) => b.isCue) || balls[0] };
+}
+function createBaizeTexture() {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 512;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#0f6f45';
+  ctx.fillRect(0, 0, 512, 512);
+  for (let i = 0; i < 18000; i += 1) {
+    const a = 0.025 + Math.random() * 0.06;
+    ctx.fillStyle = Math.random() > 0.5 ? `rgba(255,255,255,${a})` : `rgba(0,0,0,${a})`;
+    ctx.fillRect(Math.random() * 512, Math.random() * 512, 1 + Math.random() * 2, 1);
+  }
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(7, 13);
+  return tex;
+}
+function addTable(scene) {
+  const tableGroup = new THREE.Group();
+  tableGroup.position.y = CFG.tableTopY;
+  scene.add(tableGroup);
+  addBox(tableGroup, [CFG.tableW * CFG.tableVisualMultiplier + 0.1 * CFG.scale, CFG.topThickness, CFG.tableL * CFG.tableVisualMultiplier + 0.1 * CFG.scale], [0, -CFG.topThickness / 2 + CFG.ballR, 0], new THREE.MeshStandardMaterial({ color: 0x0f6f45, map: createBaizeTexture(), roughness: 0.96 }));
+  const wood = createMaterial(0x4d2f1f, 0.64);
+  const cushion = createMaterial(0x1b5b39, 0.9, 0);
+  const railY = CFG.railH / 2 - CFG.topThickness + CFG.ballR;
+  const cushionY = 0.11 * CFG.scale + CFG.ballR;
+  const w = CFG.tableW * CFG.tableVisualMultiplier;
+  const l = CFG.tableL * CFG.tableVisualMultiplier;
+  [
+    [[CFG.railW, CFG.railH, l + 0.34 * CFG.scale], [-(w / 2 + CFG.railW / 2 - 0.03 * CFG.scale), railY, 0], wood],
+    [[CFG.railW, CFG.railH, l + 0.34 * CFG.scale], [w / 2 + CFG.railW / 2 - 0.03 * CFG.scale, railY, 0], wood],
+    [[w + 0.34 * CFG.scale, CFG.railH, CFG.railW], [0, railY, -(l / 2 + CFG.railW / 2 - 0.03 * CFG.scale)], wood],
+    [[w + 0.34 * CFG.scale, CFG.railH, CFG.railW], [0, railY, l / 2 + CFG.railW / 2 - 0.03 * CFG.scale], wood],
+    [[0.18 * CFG.scale, 0.1 * CFG.scale, l + 0.38 * CFG.scale], [-(w / 2 + 0.09 * CFG.scale), cushionY, 0], cushion],
+    [[0.18 * CFG.scale, 0.1 * CFG.scale, l + 0.38 * CFG.scale], [w / 2 + 0.09 * CFG.scale, cushionY, 0], cushion],
+    [[w + 0.18 * CFG.scale, 0.1 * CFG.scale, 0.18 * CFG.scale], [0, cushionY, -(l / 2 + 0.09 * CFG.scale)], cushion],
+    [[w + 0.18 * CFG.scale, 0.1 * CFG.scale, 0.18 * CFG.scale], [0, cushionY, l / 2 + 0.09 * CFG.scale], cushion]
+  ].forEach(([size, pos, mat]) => addBox(tableGroup, size, pos, mat));
+  const floor = new THREE.Mesh(new THREE.PlaneGeometry(48 * CFG.scale, 48 * CFG.scale), createMaterial(0x1d232a, 0.96, 0));
+  floor.rotation.x = -Math.PI / 2;
+  floor.receiveShadow = true;
+  scene.add(floor);
+  return { tableGroup, disposeTableLoader: () => {} };
+}
+function createUniversalGLTFLoader(renderer) {
+  const manager = new THREE.LoadingManager();
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin('anonymous');
+  const draco = new DRACOLoader(manager);
+  draco.setDecoderPath('https://www.gstatic.com/draco/versioned/decoders/1.5.7/');
+  loader.setDRACOLoader(draco);
+  const ktx2 = new KTX2Loader(manager);
+  ktx2.setTranscoderPath('https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/');
+  ktx2.detectSupport(renderer);
+  loader.setKTX2Loader(ktx2);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+  return { loader, dispose: () => { draco.dispose(); ktx2.dispose(); } };
+}
+function findBone(all, aliases) {
+  const list = all.map((bone) => ({ bone, name: cleanName(bone.name) }));
+  const names = aliases.map(cleanName);
+  for (const alias of names) {
+    const exact = list.find((x) => x.name === alias || x.name.endsWith(alias));
+    if (exact) return exact.bone;
+  }
+  for (const alias of names) {
+    const loose = list.find((x) => x.name.includes(alias));
+    if (loose) return loose.bone;
+  }
+  return undefined;
+}
+function buildAvatarBones(model) {
+  const all = [];
+  model.traverse((obj) => { if (obj.isBone) all.push(obj); });
+  const f = (...names) => findBone(all, names);
+  return {
+    hips: f('hips', 'pelvis', 'mixamorigHips'), spine: f('spine', 'spine01', 'mixamorigSpine'), chest: f('spine2', 'chest', 'upperchest', 'mixamorigSpine2', 'mixamorigSpine1'), neck: f('neck', 'mixamorigNeck'), head: f('head', 'mixamorigHead'),
+    leftUpperArm: f('leftupperarm', 'leftarm', 'upperarml', 'mixamorigLeftArm'), leftLowerArm: f('leftforearm', 'leftlowerarm', 'forearml', 'mixamorigLeftForeArm'), leftHand: f('lefthand', 'handl', 'mixamorigLeftHand'),
+    rightUpperArm: f('rightupperarm', 'rightarm', 'upperarmr', 'mixamorigRightArm'), rightLowerArm: f('rightforearm', 'rightlowerarm', 'forearmr', 'mixamorigRightForeArm'), rightHand: f('righthand', 'handr', 'mixamorigRightHand'),
+    leftUpperLeg: f('leftupleg', 'leftupperleg', 'leftthigh', 'mixamorigLeftUpLeg'), leftLowerLeg: f('leftleg', 'leftlowerleg', 'leftcalf', 'mixamorigLeftLeg'), leftFoot: f('leftfoot', 'footl', 'mixamorigLeftFoot'),
+    rightUpperLeg: f('rightupleg', 'rightupperleg', 'rightthigh', 'mixamorigRightUpLeg'), rightLowerLeg: f('rightleg', 'rightlowerleg', 'rightcalf', 'mixamorigRightLeg'), rightFoot: f('rightfoot', 'footr', 'mixamorigRightFoot')
+  };
+}
+function collectFingerBones(hand) {
+  const out = [];
+  hand?.traverse((obj) => {
+    if (!obj.isBone || obj === hand) return;
+    const n = cleanName(obj.name);
+    if (['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((s) => n.includes(s))) out.push(obj);
+  });
+  return out;
+}
+function normalizeHuman(model) {
+  model.rotation.set(0, CFG.humanVisualYawFix, 0);
+  model.position.set(0, 0, 0);
+  model.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const height = Math.max(box.max.y - box.min.y, 0.0001);
+  model.scale.multiplyScalar(CFG.humanScale / height);
+  model.updateMatrixWorld(true);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.set(-center.x, -scaledBox.min.y, -center.z);
+}
+function addHuman(scene, renderer, setStatus) {
+  const human = { root: new THREE.Group(), modelRoot: new THREE.Group(), model: null, bones: {}, leftFingers: [], rightFingers: [], restQuats: new Map(), activeGlb: false, poseT: 0, walkT: 0, yaw: 0, breathT: 0, settleT: 0, strikeRoot: new THREE.Vector3(), strikeYaw: 0, strikeClock: 0 };
+  human.root.visible = false;
+  human.modelRoot.visible = false;
+  scene.add(human.root, human.modelRoot);
+  const { loader } = createUniversalGLTFLoader(renderer);
+  setStatus('Loading ReadyPlayer GLTF human…');
+  loader.load(HUMAN_URL, (gltf) => {
+    const model = gltf.scene;
+    normalizeHuman(model);
+    model.traverse((obj) => {
+      if (!obj.isMesh) return;
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+      obj.frustumCulled = false;
+      const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+      mats.forEach((m) => { if (m.map) { m.map.colorSpace = THREE.SRGBColorSpace; m.map.flipY = false; m.map.needsUpdate = true; } m.needsUpdate = true; });
+    });
+    human.bones = buildAvatarBones(model);
+    human.leftFingers = collectFingerBones(human.bones.leftHand);
+    human.rightFingers = collectFingerBones(human.bones.rightHand);
+    [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((bone) => bone && human.restQuats.set(bone, bone.quaternion.clone()));
+    human.activeGlb = Boolean(human.bones.hips && human.bones.spine && human.bones.head && human.bones.rightUpperArm && human.bones.rightLowerArm && human.bones.rightHand);
+    human.model = model;
+    human.modelRoot.add(model);
+    human.modelRoot.visible = human.activeGlb;
+    setStatus(human.activeGlb ? 'ReadyPlayer GLTF human active' : 'ReadyPlayer loaded but skeleton aliases incomplete');
+  }, undefined, () => setStatus('ReadyPlayer GLTF human failed'));
+  return human;
+}
+function setBoneWorldQuaternion(bone, q) {
+  if (!bone || !q) return;
+  const parentQ = new THREE.Quaternion();
+  bone.parent?.getWorldQuaternion(parentQ);
+  bone.quaternion.copy(parentQ.invert().multiply(q));
+  bone.updateMatrixWorld(true);
+}
+function firstBoneChild(bone) { return bone?.children.find((child) => child.isBone); }
+function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) {
+  if (!bone || strength <= 0) return;
+  const bonePos = bone.getWorldPosition(new THREE.Vector3());
+  const childPos = firstBoneChild(bone)?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25 * CFG.scale);
+  const current = childPos.sub(bonePos).normalize();
+  const desired = target.clone().sub(bonePos);
+  if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return;
+  const delta = new THREE.Quaternion().slerpQuaternions(new THREE.Quaternion(), new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()), clamp01(strength));
+  setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+function twistBone(bone, axis, amount) {
+  if (!bone || Math.abs(amount) < 1e-5) return;
+  setBoneWorldQuaternion(bone, new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount).multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) {
+  for (let i = 0; i < 4; i += 1) {
+    rotateBoneToward(upper, elbow, upperStrength, pole);
+    rotateBoneToward(lower, hand, lowerStrength, pole);
+  }
+}
+function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) {
+  if (!bone || strength <= 0) return;
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength)));
+}
+function cueSocketOffsetWorld(side, up, forward, roll, socketLocal = CFG.rightHandCueSocketLocal) {
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  return socketLocal.clone().applyQuaternion(q);
+}
+function poseFingers(fingers, mode, weight) {
+  const w = clamp01(weight);
+  fingers.forEach((finger, i) => {
+    const n = cleanName(finger.name);
+    const thumb = n.includes('thumb'), index = n.includes('index'), middle = n.includes('middle'), ring = n.includes('ring'), pinky = n.includes('pinky') || n.includes('little');
+    const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal'));
+    const mid = n.includes('2') || n.includes('intermediate');
+    const tip = n.includes('3') || n.includes('distal');
+    if (mode === 'idle') { finger.rotation.x += 0.018 * w; finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1); return; }
+    if (mode === 'grip') {
+      if (thumb) { finger.rotation.x += 0.48 * w; finger.rotation.y += -0.82 * w; finger.rotation.z += 0.54 * w; return; }
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0;
+      finger.rotation.x += curl * w;
+      finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w;
+      finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w;
+      return;
+    }
+    if (thumb) { finger.rotation.x += -0.18 * w; finger.rotation.y += 0.95 * w; finger.rotation.z += -0.95 * w; }
+    else if (index) { finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w; finger.rotation.y += -0.46 * w; finger.rotation.z += -0.42 * w; }
+    else if (middle) { finger.rotation.x += (base ? 0.18 : mid ? 0.32 : 0.22) * w; finger.rotation.y += -0.12 * w; finger.rotation.z += -0.14 * w; }
+    else if (ring || pinky) { finger.rotation.x += (base ? (ring ? 0.08 : 0.05) : mid ? (ring ? 0.18 : 0.16) : tip ? (ring ? 0.12 : 0.1) : 0.1) * w; finger.rotation.y += (ring ? 0.18 : 0.34) * w; finger.rotation.z += (ring ? 0.28 : 0.46) * w; }
+  });
+}
+function driveHuman(human, frame) {
+  if (!human.activeGlb || !human.model) return;
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(frame.rootWorld);
+  human.modelRoot.rotation.y = human.yaw;
+  human.modelRoot.updateMatrixWorld(true);
+  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
+  human.modelRoot.updateMatrixWorld(true);
+  const b = human.bones;
+  const ik = easeInOut(clamp01(frame.t));
+  const idle = 1 - ik;
+  const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
+  const standingCueDir = CFG.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
+  if (frame.walkAmount * idle > 0.001) {
+    const s = Math.sin(human.walkT * 6.2), c = Math.cos(human.walkT * 6.2), w = frame.walkAmount * idle;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+  }
+  if (ik >= 0.025) {
+    rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
+    twistBone(b.hips, frame.side, -0.045 * ik);
+    twistBone(b.spine, frame.side, -0.2 * ik);
+    rotateBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
+    rotateBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
+    twistBone(b.chest, frame.side, -0.32 * ik);
+    rotateBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
+    setBoneWorldQuaternion(b.head, b.head ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)), 0.74 * ik) : shotQ);
+    human.modelRoot.updateMatrixWorld(true);
+  }
+  const rightGrip = frame.rightHandWorld.clone();
+  const rightIdleElbow = rightGrip.clone().addScaledVector(UP, 0.04 * CFG.scale + 0.14 * CFG.scale * ik).addScaledVector(frame.side, -0.2 * CFG.scale).addScaledVector(frame.forward, -0.03 * CFG.scale * idle);
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.32).addScaledVector(frame.forward, -0.55).normalize(), 0.9 + 0.1 * ik, 1);
+  const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
+  const standingHandUp = UP.clone().multiplyScalar(-1).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
+  setHandBasis(b.rightHand, standingHandSide, standingHandUp, ik >= 0.025 ? cueDir : standingCueDir, ik >= 0.025 ? CFG.rightHandRollShoot : CFG.rightHandRollIdle, 1);
+  poseFingers(human.rightFingers, 'grip', 0.95);
+  if (ik < 0.025) { poseFingers(human.leftFingers, 'idle', 1); return; }
+  aimTwoBone(b.leftUpperArm, b.leftLowerArm, frame.leftElbow, frame.leftHandWorld, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(), 0.98 * ik, ik);
+  setHandBasis(b.leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize(), UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize(), cueDir, -0.68 * ik, ik);
+  poseFingers(human.leftFingers, 'bridge', ik);
+  aimTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(UP, 0.18).normalize(), 0.9 * ik, ik);
+  aimTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), 0.9 * ik, ik);
+}
+function chooseHumanEdgePosition(cueBallWorld, aimForward) {
+  const desired = cueBallWorld.clone().addScaledVector(aimForward, -CFG.desiredShootDistance);
+  const xEdge = CFG.tableW / 2 + CFG.edgeMargin;
+  const zEdge = CFG.tableL / 2 + CFG.edgeMargin;
+  const candidates = [new THREE.Vector3(-xEdge, 0, clamp(desired.z, -zEdge, zEdge)), new THREE.Vector3(xEdge, 0, clamp(desired.z, -zEdge, zEdge)), new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, -zEdge), new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, zEdge)];
+  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+}
+function updateHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget, idleRight, idleLeft, cueBack, cueTip, power) {
+  human.poseT = dampScalar(human.poseT, state === 'idle' ? 0 : 1, CFG.poseLambda, dt);
+  human.breathT += dt * (state === 'idle' ? 1.05 : 0.5);
+  human.settleT = dampScalar(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
+  if (state === 'striking') {
+    if (human.strikeClock === 0) { human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget); human.strikeYaw = human.yaw; }
+    human.strikeClock += dt;
+  } else human.strikeClock = 0;
+  const rootGoal = state === 'striking' ? human.strikeRoot : rootTarget;
+  dampVector(human.root.position, rootGoal, state === 'striking' ? 12 : CFG.moveLambda, dt);
+  const moveAmountRaw = human.root.position.distanceTo(rootGoal);
+  human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / CFG.scale));
+  human.yaw = dampScalar(human.yaw, state === 'striking' ? human.strikeYaw : yawFromForward(aimForward), CFG.rotLambda, dt);
+  const t = easeInOut(human.poseT), idle = 1 - t;
+  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * CFG.scale);
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12 / CFG.scale);
+  const walkAmount = clamp01(moveAmountRaw * 18 / CFG.scale) * idle;
+  const dragStroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75) : 0;
+  const strikeFollow = state === 'striking' ? Math.sin(clamp01(human.strikeClock / (CFG.strikeTime + CFG.holdTime)) * Math.PI) : 0;
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
+  const powerLean = power * t;
+  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * CFG.scale);
+  rootWorld.y = 0;
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) * CFG.scale + breath, (lerp(0.02, -0.16, t) - 0.014 * powerLean) * CFG.scale));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) * CFG.scale + breath, (lerp(0.02, -0.42, t) - 0.024 * powerLean) * CFG.scale));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) * CFG.scale + breath, (lerp(0.02, -0.61, t) - 0.028 * powerLean) * CFG.scale));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) * CFG.scale + breath - CFG.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.72, t) - 0.028 * powerLean) * CFG.scale));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * CFG.scale));
+  const rightShoulder = local(new THREE.Vector3(0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * CFG.scale));
+  const leftHip = local(new THREE.Vector3(-0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
+  const rightHip = local(new THREE.Vector3(0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
+  const leftFoot = local(new THREE.Vector3(-0.13 * CFG.scale, CFG.footGroundY, 0.03 * CFG.scale + walk * 0.018 * CFG.scale).lerp(new THREE.Vector3(-CFG.stanceWidth * 0.42, CFG.footGroundY, -0.34 * CFG.scale), t));
+  const rightFoot = local(new THREE.Vector3(0.13 * CFG.scale, CFG.footGroundY, -0.03 * CFG.scale - walk * 0.018 * CFG.scale).lerp(new THREE.Vector3(CFG.stanceWidth * 0.5, CFG.footGroundY, 0.34 * CFG.scale), t));
+  const bridgePalmTarget = bridgeTarget.clone().addScaledVector(forward, -0.006 * CFG.scale * t).addScaledVector(side, -0.012 * CFG.scale * t).setY(CFG.tableTopY + CFG.bridgePalmTableLift).addScaledVector(UP, -0.01 * CFG.scale * human.settleT);
+  const leftHand = idleLeft.clone().lerp(bridgePalmTarget, t);
+  const cueDirForHand = cueTip.clone().sub(cueBack).normalize();
+  const handIk = easeInOut(clamp01(t));
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = UP.clone().multiplyScalar(-1).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
+  const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04 * CFG.scale, CFG.rightElbowShotRise, t)).addScaledVector(side, lerp(-0.18 * CFG.scale, CFG.rightElbowShotSide, t)).addScaledVector(forward, lerp(-0.04 * CFG.scale, CFG.rightElbowShotBack, t));
+  const forearmStroke = (state === 'dragging' ? -CFG.rightStrokePull * easeOutCubic(power) : 0) + (state === 'striking' ? CFG.rightStrokePush * strikeFollow : 0) + (state === 'dragging' ? dragStroke * 0.035 * CFG.scale : 0);
+  const forearmBase = lockedRightElbow.clone().addScaledVector(side, CFG.rightForearmOutward * t).addScaledVector(UP, -CFG.rightForearmDown * t).addScaledVector(UP, CFG.rightHandShotLift * t).addScaledVector(forward, -CFG.rightForearmBack * t).addScaledVector(cueDirForHand, CFG.rightForearmLength);
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
+  const idleWristTarget = idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, CFG.rightHandRollIdle));
+  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(CFG.rightHandRollIdle, CFG.rightHandRollShoot - CFG.rightHandDownPose, handIk)));
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * CFG.scale * t).addScaledVector(side, -0.044 * CFG.scale * t).addScaledVector(forward, 0.065 * CFG.scale * t);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * CFG.scale, CFG.kneeBendShot, t)).addScaledVector(forward, 0.04 * CFG.scale * t).addScaledVector(side, -0.012 * CFG.scale * t);
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * CFG.scale, CFG.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * CFG.scale * t).addScaledVector(side, 0.014 * CFG.scale * t);
+  driveHuman(human, { t, stroke: forearmStroke / CFG.scale, follow: strikeFollow, walkAmount, forward, side, up: UP, rootWorld, torsoCenterWorld: torso, chestCenterWorld: chest, neckWorld: neck, headCenterWorld: head, leftElbow, rightElbow: lockedRightElbow, leftHandWorld: leftHand, rightHandWorld: rightHand, leftKnee, rightKnee, leftFootWorld: leftFoot, rightFootWorld: rightFoot, cueBackWorld: cueBack, cueTipWorld: cueTip });
+}
+function applyCueShot(cueBall, power, yaw, tmp) {
+  cueBall.vel.copy(tmp.set(0, 0, -1).applyAxisAngle(Y_AXIS, yaw).normalize()).multiplyScalar((1.9 + 8.2 * Math.pow(power, 1.08)) * CFG.scale);
+}
+function updateBalls(balls, dt, tmpA, tmpB) {
+  const halfW = CFG.tableW / 2, halfL = CFG.tableL / 2;
+  for (const ball of balls) {
+    ball.pos.addScaledVector(ball.vel, dt);
+    ball.vel.multiplyScalar(Math.exp(-CFG.friction * dt));
+    if (ball.vel.lengthSq() < CFG.minSpeed2) ball.vel.set(0, 0, 0);
+    if (ball.pos.x < -halfW + CFG.ballR) { ball.pos.x = -halfW + CFG.ballR; ball.vel.x = Math.abs(ball.vel.x) * CFG.restitution; }
+    else if (ball.pos.x > halfW - CFG.ballR) { ball.pos.x = halfW - CFG.ballR; ball.vel.x = -Math.abs(ball.vel.x) * CFG.restitution; }
+    if (ball.pos.z < -halfL + CFG.ballR) { ball.pos.z = -halfL + CFG.ballR; ball.vel.z = Math.abs(ball.vel.z) * CFG.restitution; }
+    else if (ball.pos.z > halfL - CFG.ballR) { ball.pos.z = halfL - CFG.ballR; ball.vel.z = -Math.abs(ball.vel.z) * CFG.restitution; }
+  }
+  for (let i = 0; i < balls.length; i += 1) for (let j = i + 1; j < balls.length; j += 1) {
+    const a = balls[i], b = balls[j];
+    const delta = tmpA.copy(a.pos).sub(b.pos);
+    const dist = delta.length();
+    const minDist = CFG.ballR * 2;
+    if (dist <= 0 || dist >= minDist) continue;
+    const n = delta.normalize();
+    const rel = tmpB.copy(a.vel).sub(b.vel);
+    const sep = rel.dot(n);
+    const overlap = minDist - dist;
+    a.pos.addScaledVector(n, overlap * 0.5 + 0.0005 * CFG.scale);
+    b.pos.addScaledVector(n, -overlap * 0.5 - 0.0005 * CFG.scale);
+    if (sep <= 0) {
+      const impulse = -(1 + CFG.restitution) * sep * 0.5;
+      a.vel.addScaledVector(n, impulse);
+      b.vel.addScaledVector(n, -impulse);
+    }
+  }
+  for (const ball of balls) ball.mesh.position.copy(ball.pos);
+}
+
+export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provided' } = {}) {
+  const hostRef = useRef(null);
+  const canvasRef = useRef(null);
+  const [power, setPower] = useState(0);
+  const [shotState, setShotState] = useState('idle');
+  const [tableStatus] = useState('Using provided Snooker Royal table/cue/player code');
+  const [humanStatus, setHumanStatus] = useState('Preparing ReadyPlayer human…');
+  const powerRef = useRef(0);
+  const shotPowerRef = useRef(0);
+  const shotStateRef = useRef('idle');
+  const draggingSliderRef = useRef(false);
+  const aimYawRef = useRef(0);
+  useEffect(() => { powerRef.current = power; }, [power]);
+  useEffect(() => { shotStateRef.current = shotState; }, [shotState]);
+  const animatePowerToZero = (from, ms = 220) => {
+    const start = performance.now();
+    const tick = () => {
+      const t = clamp01((performance.now() - start) / ms);
+      setPower(lerp(from, 0, easeOutCubic(t)));
+      if (t < 1) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  };
+  const setSliderPower = (e) => {
+    const r = e.currentTarget.getBoundingClientRect();
+    const p = clamp01((e.clientY - r.top) / r.height);
+    setPower(p);
+    shotPowerRef.current = p;
+  };
+  const onSliderDown = (e) => { e.currentTarget.setPointerCapture(e.pointerId); draggingSliderRef.current = true; setShotState('dragging'); setSliderPower(e); };
+  const onSliderMove = (e) => { if (draggingSliderRef.current) setSliderPower(e); };
+  const onSliderUp = (e) => { try { e.currentTarget.releasePointerCapture(e.pointerId); } catch {} draggingSliderRef.current = false; setShotState(shotPowerRef.current > 0.02 ? 'striking' : 'idle'); animatePowerToZero(powerRef.current, 180); };
+
+  useEffect(() => {
+    const host = hostRef.current;
+    const canvas = canvasRef.current;
+    if (!host || !canvas) return undefined;
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: false, powerPreference: 'high-performance' });
+    renderer.setClearColor(0x0b0b0b, 1);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.05;
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(40, 1, 0.05 * CFG.scale, 80 * CFG.scale);
+    camera.position.set(1.85 * CFG.scale, 2.45 * CFG.scale, 7.85 * CFG.scale);
+    camera.lookAt(0, 1.05 * CFG.scale, 0);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.86));
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x334155, 0.55));
+    const sun = new THREE.DirectionalLight(0xffffff, 1.35);
+    sun.position.set(3.5 * CFG.scale, 7 * CFG.scale, 5 * CFG.scale);
+    sun.castShadow = true;
+    scene.add(sun);
+    const { tableGroup, disposeTableLoader } = addTable(scene);
+    const { balls, cueBall } = addBalls(tableGroup);
+    const cue = createCue();
+    scene.add(cue.group);
+    const human = addHuman(scene, renderer, setHumanStatus);
+    const cueLine = createLine(0xffd166, 0.95);
+    const aimLine = createLine(0xff6b4a, 0.85);
+    scene.add(cueLine, aimLine);
+    const tmpA = new THREE.Vector3(), tmpB = new THREE.Vector3(), tmpC = new THREE.Vector3();
+    let strikeT = 0, didHit = false, frameId = 0, last = performance.now(), isAiming = false, lastAimX = 0;
+    const resize = () => {
+      const w = Math.max(1, host.clientWidth), h = Math.max(1, host.clientHeight);
+      renderer.setSize(w, h, false);
+      renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    };
+    const onCanvasDown = (e) => { if (!draggingSliderRef.current) { isAiming = true; lastAimX = e.clientX; } };
+    const onCanvasMove = (e) => { if (!isAiming || draggingSliderRef.current) return; aimYawRef.current -= (e.clientX - lastAimX) * 0.006; lastAimX = e.clientX; };
+    const onCanvasUp = () => { isAiming = false; };
+    canvas.addEventListener('pointerdown', onCanvasDown);
+    canvas.addEventListener('pointermove', onCanvasMove);
+    canvas.addEventListener('pointerup', onCanvasUp);
+    canvas.addEventListener('pointercancel', onCanvasUp);
+    window.addEventListener('resize', resize);
+    resize();
+    function animate() {
+      frameId = requestAnimationFrame(animate);
+      const now = performance.now();
+      const dt = Math.min(0.033, (now - last) / 1000);
+      last = now;
+      const state = shotStateRef.current;
+      const activePower = state === 'dragging' ? powerRef.current : shotPowerRef.current;
+      const cueBallWorld = cueBall.mesh.getWorldPosition(new THREE.Vector3());
+      const aimForward = tmpA.set(0, 0, -1).applyAxisAngle(Y_AXIS, aimYawRef.current).normalize().clone();
+      const aimSide = tmpB.set(aimForward.z, 0, -aimForward.x).normalize().clone();
+      const humanRootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward);
+      const bridgeHandTarget = cueBallWorld.clone().addScaledVector(aimForward, -CFG.bridgeHandBackFromBall).addScaledVector(aimSide, CFG.bridgeHandSide).setY(CFG.tableTopY + CFG.bridgePalmTableLift);
+      const bridgeCuePoint = bridgeHandTarget.clone().addScaledVector(aimForward, 0.014 * CFG.scale).add(new THREE.Vector3(0, CFG.bridgeCueLift, 0));
+      const pull = CFG.pullRange * easeOutCubic(activePower);
+      const practiceStroke = state === 'dragging' ? Math.sin(now * 0.012) * 0.035 * CFG.scale * (0.25 + activePower * 0.75) : 0;
+      const strikeNorm = clamp01(strikeT / CFG.strikeTime);
+      let gap = CFG.idleGap;
+      if (state === 'dragging') gap += pull + practiceStroke;
+      if (state === 'striking') gap = lerp(CFG.idleGap + pull, CFG.contactGap, easeOutCubic(strikeNorm));
+      const cueTipShoot = cueBallWorld.clone().addScaledVector(aimForward, -(CFG.ballR + gap));
+      const cueBackShoot = bridgeCuePoint.clone().addScaledVector(aimForward, -(CFG.cueLength - CFG.bridgeDist - CFG.ballR - gap)).add(new THREE.Vector3(0, 0.024 * CFG.scale, 0));
+      const standingYaw = yawFromForward(aimForward);
+      const idleRightHandTarget = humanRootTarget.clone().add(new THREE.Vector3(CFG.idleRightHandX, CFG.idleRightHandY, CFG.idleRightHandZ).applyAxisAngle(Y_AXIS, standingYaw));
+      const idleLeftHandTarget = humanRootTarget.clone().add(new THREE.Vector3(-0.18 * CFG.scale, 1.08 * CFG.scale, 0.03 * CFG.scale).applyAxisAngle(Y_AXIS, standingYaw));
+      const idleDir = CFG.idleCueDir.clone().applyAxisAngle(Y_AXIS, standingYaw).normalize();
+      const idleCue = cuePoseFromGrip(idleRightHandTarget, idleDir, CFG.idleCueGripFromBack, CFG.cueLength);
+      if (state === 'idle') { strikeT = 0; didHit = false; }
+      else if (state === 'dragging') { strikeT = 0; didHit = false; }
+      else {
+        strikeT += dt;
+        if (!didHit && strikeNorm > 0.88) { didHit = true; applyCueShot(cueBall, shotPowerRef.current, aimYawRef.current, tmpC); }
+        if (strikeT >= CFG.strikeTime + CFG.holdTime) { strikeT = 0; didHit = false; setShotState('idle'); }
+      }
+      const activeCueBack = state === 'idle' ? idleCue.back : cueBackShoot;
+      const activeCueTip = state === 'idle' ? idleCue.tip : cueTipShoot;
+      setCuePose(cue, activeCueBack, activeCueTip);
+      updateBalls(balls, dt, tmpB, tmpC);
+      updateHumanPose(human, dt, state, humanRootTarget, aimForward, bridgeHandTarget, idleRightHandTarget, idleLeftHandTarget, activeCueBack, activeCueTip, activePower);
+      setLinePoints(cueLine, activeCueBack, cueBallWorld);
+      setLinePoints(aimLine, cueBallWorld, cueBallWorld.clone().add(aimForward.clone().multiplyScalar(2.1 * CFG.scale)));
+      renderer.render(scene, camera);
+    }
+    animate();
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', resize);
+      canvas.removeEventListener('pointerdown', onCanvasDown);
+      canvas.removeEventListener('pointermove', onCanvasMove);
+      canvas.removeEventListener('pointerup', onCanvasUp);
+      canvas.removeEventListener('pointercancel', onCanvasUp);
+      disposeTableLoader();
+      renderer.dispose();
+    };
+  }, []);
+
+  const sliderH = 320;
+  const sliderW = 58;
+  const knob = 30;
+  const knobTop = clamp(power * sliderH - knob / 2, -2, sliderH - knob + 2);
+  return (
+    <div style={{ position: 'fixed', inset: 0, background: '#0b0b0b' }}>
+      <div ref={hostRef} style={{ position: 'absolute', inset: 0 }}>
+        <canvas ref={canvasRef} style={{ width: '100%', height: '100%', display: 'block', touchAction: 'none' }} />
+      </div>
+      <div style={{ position: 'fixed', inset: 0, pointerEvents: 'none', fontFamily: 'system-ui, sans-serif' }}>
+        <div style={{ position: 'absolute', left: 10, top: 10, color: 'white', background: 'rgba(0,0,0,0.62)', padding: '8px 10px', borderRadius: 10, fontSize: 12, lineHeight: 1.35, maxWidth: '76vw' }}>
+          <strong>{gameTitle}</strong><br />ReadyPlayer human active<br />Textured snooker table materials<br />{tableStatus}<br />{humanStatus}
+        </div>
+        <div style={{ position: 'absolute', right: 14, top: '50%', transform: 'translateY(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 14, pointerEvents: 'auto', touchAction: 'none', userSelect: 'none' }}>
+          <div onPointerDown={onSliderDown} onPointerMove={onSliderMove} onPointerUp={onSliderUp} style={{ position: 'relative', height: sliderH, width: sliderW, borderRadius: 18, background: 'rgba(255,255,255,0.92)', boxShadow: '0 12px 28px rgba(0,0,0,0.2)', padding: 9 }}>
+            <div style={{ position: 'absolute', left: 14, right: 14, top: 14, bottom: 14, borderRadius: 999, background: 'rgba(0,0,0,0.12)', overflow: 'hidden' }}>
+              <div style={{ position: 'absolute', left: 0, right: 0, top: 0, height: `${power * 100}%`, background: 'rgba(17,17,17,0.58)' }} />
+            </div>
+            <div style={{ position: 'absolute', left: (sliderW - knob) / 2, top: 14 + knobTop, width: knob, height: knob, borderRadius: 999, background: 'rgba(255,255,255,0.98)', border: '1px solid rgba(0,0,0,0.18)', boxShadow: '0 10px 18px rgba(0,0,0,0.18)' }} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/snookerRoyalOnlineFlow.js
+++ b/webapp/src/pages/Games/snookerRoyalOnlineFlow.js
@@ -25,6 +25,8 @@ export async function runSnookerRoyalOnlineFlow({
   mode,
   tableSize,
   avatar,
+  gameType = 'snookerroyale',
+  transactionGame = 'snookerroyale-online',
   deps = {},
   state,
   refs,
@@ -74,7 +76,7 @@ export async function runSnookerRoyalOnlineFlow({
     const { telegramId: debitedTelegram, accountId: debitedAccount, amount } = stakeDebitRef.current;
     try {
       await addTransactionFn(debitedTelegram, amount, 'stake_refund', {
-        game: 'snookerroyale-online',
+        game: transactionGame,
         players: 2,
         accountId: debitedAccount,
         reason,
@@ -128,7 +130,7 @@ export async function runSnookerRoyalOnlineFlow({
 
   try {
     await addTransactionFn(telegramId, -stake.amount, 'stake', {
-      game: 'snookerroyale-online',
+      game: transactionGame,
       players: 2,
       accountId
     });
@@ -238,7 +240,7 @@ export async function runSnookerRoyalOnlineFlow({
       accountId,
       stake: stake.amount,
       token: stake.token,
-      gameType: 'snookerroyale',
+      gameType,
       maxPlayers: 2,
       mode,
       variant,


### PR DESCRIPTION
### Motivation
- Introduce a new "Snooker Champion" game flow that supports tournament brackets and reuses the existing Snooker Royal gameplay and online matchmaking plumbing.
- Provide a standalone bracket UI for tournament mode and a dedicated lobby so players can pick tournament size, flags and stakes.

### Description
- Added a static bracket page at `public/snooker-champion-bracket.html` implementing a full client-side tournament bracket renderer and localStorage-based tournament state (`snookerChampionTournamentState_*`).
- Added lazy-loaded routes and pages: `SnookerChampion.jsx` (wrapper), `SnookerChampionLobby.jsx` (full lobby UI with tournament/regular modes and stake handling) and `SnookerRoyalProvided.jsx` (provided Snooker Royal renderer reused by the new wrapper).
- Updated `App.jsx` to register new routes for `/games/snookerchampion` and `/games/snookerchampion/lobby` and updated `gamesCatalog.js` and `gameAssets.js` to include `snookerchampion` catalog entry and assets/icons.
- Extended online matchmaking helper `snookerRoyalOnlineFlow.js` to accept `gameType` and `transactionGame` parameters so the same flow correctly debits/refunds and seats for `snookerchampion` matches.
- Lobby now launches the tournament bracket page for `playType === 'tournament'` via `window.location.href` to the new bracket HTML and navigates to the in-app game for regular matches, passing parameters such as `tgId`, `accountId`, `stake`, `flag` and `tableSize`.

### Testing
- Ran a production build with `npm run build` and verified the build completed successfully.
- Executed the project's test suite with `npm test` and the existing tests passed.
- Ran `npm run lint` to ensure new files meet lint rules and fixed any reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081c4b39708329bbdd1bd8b29c0e97)