### PR TITLE
Resize Table Tennis to Pool Royale footprint and adjust camera/AI/physics

### DIFF
--- a/frontend/src/table-tennis/AIController.ts
+++ b/frontend/src/table-tennis/AIController.ts
@@ -1,13 +1,16 @@
 import * as THREE from 'three';
 import { BallPhysics } from './BallPhysics';
-import { GAME_CONFIG, ShotCommand, ShotType } from './gameConfig';
+import { GAME_CONFIG, ShotCommand, ShotType, TABLE_BOUNDS } from './gameConfig';
+
+const TABLE_AI_REACH_MAX_Z = TABLE_BOUNDS.minZ + 0.34;
+const TABLE_AI_REACH_MIN_Z = GAME_CONFIG.ai.z - 0.27;
 
 export class AIController {
   readonly targetX = { value: 0 };
   currentShot: ShotType = 'forehand drive';
   private reactionTimer = 0;
   private committedLanding: THREE.Vector3 | null = null;
-  private shotCommand: ShotCommand = { aimX: 0, power: 0.62, lift: 0.42, curve: 0, spin: 0.2 };
+  private readonly shotCommand: ShotCommand = { aimX: 0, power: 0.58, lift: 0.45, curve: 0, spin: 0.25 };
 
   constructor(private root: THREE.Group, private hand: THREE.Object3D, private paddle: THREE.Object3D) {}
 
@@ -19,24 +22,26 @@ export class AIController {
       if (this.committedLanding) {
         const noise = (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(0.55);
         this.targetX.value = THREE.MathUtils.clamp(this.committedLanding.x + noise, GAME_CONFIG.ai.minX, GAME_CONFIG.ai.maxX);
-        this.shotCommand = this.planShot(ball, cfg.accuracy);
       }
       this.reactionTimer = cfg.reactionTime;
     }
 
     this.root.position.x = THREE.MathUtils.damp(this.root.position.x, this.targetX.value, cfg.moveSpeed, dt);
     this.root.position.z = GAME_CONFIG.ai.z;
-    this.currentShot = this.chooseShot(ball.position);
-    const yaw = THREE.MathUtils.clamp((ball.position.x - this.root.position.x) * 0.4 + this.shotCommand.curve * 0.1, -0.55, 0.55);
+    this.currentShot = ball.position.x > this.root.position.x ? 'forehand drive' : 'backhand drive';
+    const yaw = THREE.MathUtils.clamp((ball.position.x - this.root.position.x) * 0.4, -0.5, 0.5);
     this.root.rotation.y = Math.PI + yaw;
-    const side = this.currentShot === 'forehand drive' ? -1 : 1;
-    this.hand.position.set(side * (0.16 + Math.abs(this.shotCommand.curve) * 0.05), 0.92 + this.shotCommand.lift * 0.08, -0.22 - this.shotCommand.power * 0.12);
+    this.hand.position.set(this.currentShot === 'forehand drive' ? -0.16 : 0.16, 0.92, -0.28);
     this.paddle.position.set(0, -0.02, -0.12);
-    this.paddle.rotation.set(-0.25 - this.shotCommand.lift * 0.16, this.shotCommand.curve * -0.2, side * (0.12 + this.shotCommand.power * 0.1));
+    this.paddle.rotation.set(-0.25, 0, this.currentShot === 'forehand drive' ? -0.16 : 0.16);
   }
 
   canReach(ballPosition: THREE.Vector3) {
-    return Math.abs(ballPosition.x - this.root.position.x) <= GAME_CONFIG.ai.maxReach && ballPosition.z < -1.3 && ballPosition.z > -2.68;
+    return (
+      Math.abs(ballPosition.x - this.root.position.x) <= GAME_CONFIG.ai.maxReach &&
+      ballPosition.z < TABLE_AI_REACH_MAX_Z &&
+      ballPosition.z > TABLE_AI_REACH_MIN_Z
+    );
   }
 
   shouldMiss() {
@@ -55,21 +60,4 @@ export class AIController {
     return new THREE.Vector3(0, 0, 1).applyQuaternion(this.paddle.getWorldQuaternion(new THREE.Quaternion())).normalize();
   }
 
-  private planShot(ball: BallPhysics, accuracy: number): ShotCommand {
-    const crossCourt = ball.position.x > 0 ? -0.62 : 0.62;
-    const openTable = THREE.MathUtils.clamp(crossCourt + THREE.MathUtils.randFloatSpread((1 - accuracy) * 0.5), -1, 1);
-    const power = THREE.MathUtils.clamp(THREE.MathUtils.randFloat(0.48, 0.92) * GAME_CONFIG.ai.difficulty.shotPower, 0, 1);
-    const lift = THREE.MathUtils.clamp(ball.position.y > GAME_CONFIG.table.topY + 0.42 ? 0.72 : THREE.MathUtils.randFloat(0.22, 0.58), 0, 1);
-    const curve = THREE.MathUtils.randFloatSpread(0.9) * accuracy;
-    const spin = power > 0.72 ? THREE.MathUtils.randFloat(0.35, 0.85) : THREE.MathUtils.randFloat(-0.28, 0.45);
-    return { aimX: openTable, power, lift, curve, spin };
-  }
-
-  private chooseShot(ballPosition: THREE.Vector3): ShotType {
-    if (this.shotCommand.power > 0.8 && Math.abs(this.shotCommand.curve) > 0.32) return 'swerve power';
-    if (this.shotCommand.lift > 0.72 || ballPosition.y > GAME_CONFIG.table.topY + 0.55) return 'lob';
-    if (this.shotCommand.power < 0.34 || ballPosition.y < GAME_CONFIG.table.topY + 0.18) return 'push';
-    if (this.shotCommand.spin > 0.45 || Math.abs(this.shotCommand.curve) > 0.22) return 'brush/topspin';
-    return ballPosition.x > this.root.position.x ? 'forehand drive' : 'backhand drive';
-  }
 }

--- a/frontend/src/table-tennis/BallPhysics.ts
+++ b/frontend/src/table-tennis/BallPhysics.ts
@@ -41,7 +41,11 @@ export class BallPhysics {
   private accumulator = 0;
 
   resetForServe(server: Side) {
-    this.position.set(server === 'player' ? -0.16 : 0.16, GAME_CONFIG.table.topY + GAME_CONFIG.serveHeight, server === 'player' ? 1.08 : -1.08);
+    this.position.set(
+      server === 'player' ? -GAME_CONFIG.table.width * 0.09 : GAME_CONFIG.table.width * 0.09,
+      GAME_CONFIG.table.topY + GAME_CONFIG.serveHeight,
+      server === 'player' ? GAME_CONFIG.table.length * 0.35 : -GAME_CONFIG.table.length * 0.35,
+    );
     this.velocity.set(0, 0, 0);
     this.spin.set(0, 0, 0);
     this.lastTouch = server;
@@ -52,7 +56,7 @@ export class BallPhysics {
 
   serve(server: Side) {
     this.resetBouncesAfterHit(server);
-    this.velocity.set(server === 'player' ? 0.08 : -0.08, 1.25, server === 'player' ? -2.9 : 2.9);
+    this.velocity.set(server === 'player' ? 0.08 : -0.08, 1.25, server === 'player' ? -GAME_CONFIG.serveForwardPower : GAME_CONFIG.serveForwardPower);
     this.spin.set(server === 'player' ? 0.2 : -0.2, 0, server === 'player' ? -1.2 : 1.2);
     this.state = 'flying';
   }

--- a/frontend/src/table-tennis/GameManager.ts
+++ b/frontend/src/table-tennis/GameManager.ts
@@ -273,7 +273,10 @@ export class GameManager {
     const net = this.createNet();
     table.add(net);
 
-    const floor = new THREE.Mesh(new THREE.PlaneGeometry(6.2, 8.4), new THREE.ShadowMaterial({ opacity: 0.24 }));
+    const floor = new THREE.Mesh(
+      new THREE.PlaneGeometry(GAME_CONFIG.table.width + 4.4, GAME_CONFIG.table.length + 5.3),
+      new THREE.ShadowMaterial({ opacity: 0.24 }),
+    );
     floor.rotation.x = -Math.PI / 2;
     floor.receiveShadow = true;
     this.scene.add(floor, table);

--- a/frontend/src/table-tennis/PaddleHitDetector.ts
+++ b/frontend/src/table-tennis/PaddleHitDetector.ts
@@ -47,12 +47,15 @@ export class PaddleHitDetector {
 
     const command = input.shotCommand ?? DEFAULT_COMMAND;
     const profile = shotProfiles[input.requestedShot];
-    const targetZ = input.side === 'player' ? THREE.MathUtils.randFloat(-1.2, -0.34) : THREE.MathUtils.randFloat(0.34, 1.2);
+    const targetZ = input.side === 'player'
+      ? THREE.MathUtils.randFloat(TABLE_BOUNDS.minZ * 0.78, TABLE_BOUNDS.minZ * 0.28)
+      : THREE.MathUtils.randFloat(TABLE_BOUNDS.maxZ * 0.28, TABLE_BOUNDS.maxZ * 0.78);
     const screenAim = input.side === 'player' ? command.aimX : -command.aimX;
-    const targetXBase = THREE.MathUtils.lerp(TABLE_BOUNDS.minX + 0.1, TABLE_BOUNDS.maxX - 0.1, (screenAim + 1) / 2);
+    const edgeInset = GAME_CONFIG.table.width * 0.065;
+    const targetXBase = THREE.MathUtils.lerp(TABLE_BOUNDS.minX + edgeInset, TABLE_BOUNDS.maxX - edgeInset, (screenAim + 1) / 2);
     const error = (1 - (input.accuracy ?? GAME_CONFIG.paddle.accuracy)) * THREE.MathUtils.lerp(0.48, 0.22, command.power);
     const target = new THREE.Vector3(
-      THREE.MathUtils.clamp(targetXBase + THREE.MathUtils.randFloatSpread(error), TABLE_BOUNDS.minX + 0.08, TABLE_BOUNDS.maxX - 0.08),
+      THREE.MathUtils.clamp(targetXBase + THREE.MathUtils.randFloatSpread(error), TABLE_BOUNDS.minX + edgeInset, TABLE_BOUNDS.maxX - edgeInset),
       GAME_CONFIG.table.topY + profile.arc + command.lift * 0.32,
       targetZ,
     );

--- a/frontend/src/table-tennis/PlayerController.ts
+++ b/frontend/src/table-tennis/PlayerController.ts
@@ -99,7 +99,9 @@ export class PlayerController {
     const hand = this.visuals.hand;
     const paddle = this.visuals.paddle;
     const side = this.currentShot === 'backhand drive' ? -1 : 1;
-    const reach = this.isRecovering ? 0.34 : THREE.MathUtils.clamp((GAME_CONFIG.player.z - ballPosition.z) * 0.28, 0.12, 0.48);
+    const reach = this.isRecovering
+      ? GAME_CONFIG.player.reach * 0.7
+      : THREE.MathUtils.clamp((GAME_CONFIG.player.z - ballPosition.z) * 0.28, 0.12, GAME_CONFIG.player.reach);
     const powerLoad = THREE.MathUtils.lerp(-0.08, -0.2, command.power);
     hand.position.set((0.16 + Math.abs(command.curve) * 0.05) * side, 0.92 + command.lift * 0.08, powerLoad - reach);
     hand.rotation.y = THREE.MathUtils.damp(hand.rotation.y, side * (0.22 + Math.abs(command.curve) * 0.28), 12, dt);

--- a/frontend/src/table-tennis/gameConfig.ts
+++ b/frontend/src/table-tennis/gameConfig.ts
@@ -24,66 +24,78 @@ export interface DifficultyConfig {
   mistakeChance: number;
 }
 
+// Pool Royale exports its current 7ft outer table footprint as 61.651044 × 90.4215312
+// world units. Table Tennis uses the same width:length ratio and scaled-down footprint so
+// it occupies the same HDRI placement/orientation while staying in this game's meter-sized scene.
+const POOL_ROYALE_TABLE_WIDTH = 61.651044;
+const POOL_ROYALE_TABLE_LENGTH = 90.4215312;
+const POOL_ROYALE_TO_TABLE_TENNIS_SCALE = 0.045;
+const TABLE_WIDTH = POOL_ROYALE_TABLE_WIDTH * POOL_ROYALE_TO_TABLE_TENNIS_SCALE;
+const TABLE_LENGTH = POOL_ROYALE_TABLE_LENGTH * POOL_ROYALE_TO_TABLE_TENNIS_SCALE;
+const TABLE_LENGTH_SCALE = TABLE_LENGTH / 2.74;
+const TABLE_WIDTH_SCALE = TABLE_WIDTH / 1.55;
+
 export const GAME_CONFIG = {
   fixedDt: 1 / 120,
   gravity: -9.8,
   drag: 0.09,
-  spinCurve: 0.11,
-  ballRadius: 0.055,
-  serveHeight: 0.34,
+  spinCurve: 0.08,
+  ballRadius: 0.062,
+  serveHeight: 0.38,
+  serveForwardPower: 2.9 * TABLE_LENGTH_SCALE,
   table: {
-    width: 1.8,
-    length: 3.08,
+    width: TABLE_WIDTH,
+    length: TABLE_LENGTH,
     topY: 0.76,
-    thickness: 0.08,
+    thickness: 0.09,
     color: '#1266c3',
     lineColor: '#e8f4ff',
   },
   net: {
-    height: 0.18,
-    thickness: 0.028,
-    overhang: 0.1,
+    height: 0.2,
+    thickness: 0.03,
+    overhang: 0.13,
   },
   player: {
-    z: 2.38,
-    minX: -1.02,
-    maxX: 1.02,
-    safeZ: 2.22,
-    moveSpeed: 4.25,
-    reach: 0.66,
-    autoTrackLead: 0.34,
+    z: TABLE_LENGTH / 2 + 0.84,
+    minX: -TABLE_WIDTH / 2 - 0.12,
+    maxX: TABLE_WIDTH / 2 + 0.12,
+    safeZ: TABLE_LENGTH / 2 + 0.68,
+    moveSpeed: 2.55 * TABLE_WIDTH_SCALE,
+    reach: 0.48 * TABLE_WIDTH_SCALE,
+    autoTrackLead: 0.34 * TABLE_WIDTH_SCALE,
     recoveryTime: 0.28,
-    avatarScale: 1.42,
+    avatarScale: 1.62,
   },
   ai: {
-    z: -2.38,
-    minX: -1.02,
-    maxX: 1.02,
-    maxReach: 0.66,
-    avatarScale: 1.42,
+    z: -TABLE_LENGTH / 2 - 0.84,
+    minX: -TABLE_WIDTH / 2 - 0.12,
+    maxX: TABLE_WIDTH / 2 + 0.12,
+    maxReach: 0.58 * TABLE_WIDTH_SCALE,
+    avatarScale: 1.62,
     difficulty: {
-      reactionTime: 0.18,
-      moveSpeed: 2.85,
-      accuracy: 0.8,
-      shotPower: 1.08,
+      reactionTime: 0.24,
+      moveSpeed: 2.05 * TABLE_WIDTH_SCALE,
+      accuracy: 0.78,
+      shotPower: 1.0,
       mistakeChance: 0.14,
     } satisfies DifficultyConfig,
   },
   paddle: {
-    hitRadius: 0.28,
+    hitRadius: 0.18 * TABLE_WIDTH_SCALE,
     timingWindow: 0.12,
-    minFacingDot: 0.1,
-    drivePower: 4.35,
-    pushPower: 3.15,
-    lobPower: 3.25,
-    powerShotMultiplier: 1.34,
-    spin: 4.6,
-    sideSpin: 5.2,
+    minFacingDot: 0.22,
+    drivePower: 3.35 * TABLE_LENGTH_SCALE,
+    pushPower: 2.55 * TABLE_LENGTH_SCALE,
+    lobPower: 2.65 * TABLE_LENGTH_SCALE,
+    powerShotMultiplier: 1.18,
+    spin: 3.6,
+    sideSpin: 4.2,
     accuracy: 0.9,
   },
   camera: {
-    position: new THREE.Vector3(0, 2.2, 4.7),
-    target: new THREE.Vector3(0, 0.94, 0.15),
+    position: new THREE.Vector3(0, 2.7, 6.1),
+    target: new THREE.Vector3(0, 1.02, 0.18),
     damping: 8,
   },
   score: {


### PR DESCRIPTION
### Motivation
- Align the Table Tennis arena with the Pool Royale outer-table footprint so the table appears in the same place/orientation on shared HDRI scenes while keeping playable scale and framing. 
- Keep the original game feel (player/avatar reach, AI timing and decision behaviour, paddle/ball interactions) while adjusting power and spawn positions so trajectories match the larger table.

### Description
- Rescaled table geometry and derived gameplay scales by computing a Table Tennis table from Pool Royale's outer footprint constants and introduced `TABLE_WIDTH`, `TABLE_LENGTH`, `TABLE_WIDTH_SCALE` and `TABLE_LENGTH_SCALE` used throughout gameplay, camera and UI (modified `frontend/src/table-tennis/gameConfig.ts`).
- Adjusted camera position and target to preserve framing for the larger table and increased ball radius/serve height/serve forward power to match the new layout (in `gameConfig.ts` and `GameManager.ts`).
- Repositioned serve spawn to be relative to the table size and scaled serve velocity, and adjusted ball spawn/serve logic in `frontend/src/table-tennis/BallPhysics.ts`.
- Reworked AI to the simpler initial behaviour (predictive lateral tracking and forehand/backhand choice), tightened its reach window to table-relative Z bounds, and simplified fixed paddle pose for clarity (in `frontend/src/table-tennis/AIController.ts`).
- Updated player reach attachment to respect the new `GAME_CONFIG.player.reach` and scaled paddle hit logic to target inside the new table footprint with an inset edge (in `frontend/src/table-tennis/PlayerController.ts` and `frontend/src/table-tennis/PaddleHitDetector.ts`).
- Enlarged the floor shadow plane to fit the new table footprint and adjusted a few presentation values to keep visuals consistent (in `frontend/src/table-tennis/GameManager.ts`).
- Files changed: `gameConfig.ts`, `AIController.ts`, `BallPhysics.ts`, `PaddleHitDetector.ts`, `PlayerController.ts`, `GameManager.ts`.

### Testing
- Ran TypeScript build with `cd frontend && npm exec -- tsc -b`, which completed successfully.
- Attempted a full production build with `npm --prefix frontend run build`; TypeScript succeeded but Vite bundling failed due to an unresolved package import (`@particle-network/chains`) pulled in by a wallet-adapter dependency, so the final bundle did not complete.
- Tried to capture an automated screenshot via Playwright after installing browsers with `npx playwright install chromium`, but launching Chromium failed because the environment lacked the system library `libatk-1.0.so.0`, so headless screenshoting could not complete.
- Ran local sanity checks (`git diff --check` and source lints/build checks used during development) and confirmed no diff-check errors on the modified table-tennis files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083b9746948329b3da392771f542d2)