### PR TITLE
Add authentic Pool Royale Traditional glTF model, installer, tests, and lobby UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ webapp/public/models/murlan/*.gltf
 webapp/public/models/murlan/*.bin
 webapp/public/models/murlan/*.fbx
 webapp/public/models/murlan/*.zip
+# Runtime-only Pool Royale table binaries fetched outside PRs.
+webapp/public/models/pool-royale/*.glb
+webapp/public/models/pool-royale/*.gltf
+webapp/public/models/pool-royale/*.bin
+webapp/public/models/pool-royale/pool-table-traditional-fizyman/

--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFile, stat } from 'node:fs/promises';
 import {
   DEFAULT_POOL_ROYALE_TABLE_MODEL_ID,
   POOL_ROYALE_TABLE_MODEL_OPTIONS,
@@ -9,7 +11,10 @@ describe('Pool Royale table models', () => {
   test('defaults to the Showood GLB table', () => {
     assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'showood-seven-foot');
     assert.equal(resolvePoolRoyaleTableModel(null).id, 'showood-seven-foot');
-    assert.equal(resolvePoolRoyaleTableModel('unknown').id, 'showood-seven-foot');
+    assert.equal(
+      resolvePoolRoyaleTableModel('unknown').id,
+      'showood-seven-foot'
+    );
   });
 
   test('Showood uses original GLB surface layout with Pool Royale finish textures', () => {
@@ -23,18 +28,101 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.fitScale, 1);
     assert.equal(showood.clothRepeatScale, 7.5);
     assert.deepEqual(showood.hideSurfaceRoles, []);
-    assert.deepEqual(showood.preserveOriginalSurfaceRoles, ['trim']);
+    assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
     assert.equal(showood.tintOriginalTrimGold, true);
-    assert.deepEqual(showood.chromeMaterialSurfaceNames, ['diamonds', 'railSight', 'sideWoodApron']);
+    assert.deepEqual(showood.chromeMaterialSurfaceNames, [
+      'diamonds',
+      'railSight'
+    ]);
     assert.deepEqual(showood.blackMaterialSurfaceNames, []);
     assert.equal(showood.forceGeneratedChromePlates, false);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',
       'wood',
-      'pocket'
+      'pocket',
+      'trim'
     ]);
     assert.equal('playfieldVisualLift' in showood, false);
     assert.equal(showood.fitHeightScale, 1);
+  });
+
+  test('Traditional Sketchfab table is selectable as an authentic local glTF option', () => {
+    const traditional = POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
+      (option) => option.id === 'traditional-fizyman-eight-foot'
+    );
+
+    assert.ok(
+      traditional,
+      'Traditional Sketchfab table model must be configured'
+    );
+    assert.equal(
+      resolvePoolRoyaleTableModel('traditional-fizyman-eight-foot').id,
+      traditional.id
+    );
+    assert.equal(traditional.kind, 'gltf');
+    assert.equal(
+      traditional.assetUrl,
+      '/models/pool-royale/pool-table-traditional-fizyman/pool-table-traditional-fizyman.gltf'
+    );
+    assert.equal(
+      traditional.installScript,
+      'npm run fetch:pool-royale-traditional-table'
+    );
+    assert.equal(traditional.sourceUid, 'e0b938c0c2e74eb794a49ebde2543977');
+    assert.equal(traditional.sourceFormat, 'sketchfab-original-gltf');
+    assert.equal(traditional.tableSizeId, '8ft');
+    assert.equal(traditional.fitStrategy, 'exact');
+    assert.equal(traditional.fitReference, 'upperTabletop');
+    assert.equal(traditional.fitScale, 1);
+    assert.equal(traditional.fitHeightScale, 1);
+    assert.equal(traditional.useOriginalLayoutSurfaces, true);
+    assert.deepEqual(traditional.usePoolRoyaleFinishRoles, [
+      'cloth',
+      'cushion',
+      'wood',
+      'pocket'
+    ]);
+    assert.equal(
+      traditional.sourceUrl,
+      'https://sketchfab.com/3d-models/pool-table-traditional-e0b938c0c2e74eb794a49ebde2543977'
+    );
+    assert.equal(traditional.author, 'fizyman');
+    assert.equal(traditional.license, 'CC Attribution 4.0');
+  });
+
+  test('Traditional table installer fetches and validates the authentic Sketchfab glTF', async () => {
+    const source = await readFile(
+      'webapp/scripts/fetch-pool-royale-traditional-table.mjs',
+      'utf8'
+    );
+    const help = execFileSync(
+      'node',
+      ['webapp/scripts/fetch-pool-royale-traditional-table.mjs', '--help'],
+      { encoding: 'utf8' }
+    );
+
+    assert.ok(source.includes('e0b938c0c2e74eb794a49ebde2543977'));
+    assert.ok(source.includes('https://api.sketchfab.com/v3/models/'));
+    assert.ok(source.includes('data?.gltf?.url'));
+    assert.ok(source.includes('validateAuthenticTraditionalGltf'));
+    assert.ok(source.includes('minTriangles: 20000'));
+    assert.ok(source.includes('minTextures: 10'));
+    assert.ok(help.includes('SKETCHFAB_TOKEN=<token>'));
+    assert.ok(help.includes('--from /path/to/authentic-sketchfab-gltf.zip'));
+    assert.ok(help.includes('--from-dir /path/to/extracted/sketchfab-gltf'));
+  });
+
+  test('Traditional table keeps installer and attribution files in git instead of glTF binaries', async () => {
+    const installer = await stat(
+      'webapp/scripts/fetch-pool-royale-traditional-table.mjs'
+    );
+    const license = await stat(
+      'webapp/public/models/pool-royale/pool-table-traditional-fizyman.LICENSE.md'
+    );
+
+    assert.ok(installer.isFile());
+    assert.ok(installer.size > 8_000);
+    assert.ok(license.isFile());
   });
 });

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -11,7 +11,8 @@
     "fetch:launcher": "node scripts/fetch-launcher.mjs",
     "postinstall": "node scripts/postinstall.mjs",
     "fetch:murlan-agent47": "node scripts/fetch-murlan-agent47.mjs --asset agent-47",
-    "fetch:murlan-characters": "node scripts/fetch-murlan-agent47.mjs --asset all"
+    "fetch:murlan-characters": "node scripts/fetch-murlan-agent47.mjs --asset all",
+    "fetch:pool-royale-traditional-table": "node scripts/fetch-pool-royale-traditional-table.mjs"
   },
   "type": "module",
   "dependencies": {

--- a/webapp/public/models/pool-royale/pool-table-traditional-fizyman.LICENSE.md
+++ b/webapp/public/models/pool-royale/pool-table-traditional-fizyman.LICENSE.md
@@ -1,0 +1,27 @@
+# Pool Table Traditional attribution
+
+Pool Royale uses the authentic Sketchfab glTF for **Pool Table Traditional** by
+**fizyman**. The glTF asset folder is intentionally not committed; install it locally or
+in deployment with:
+
+```bash
+SKETCHFAB_TOKEN=<token> npm run fetch:pool-royale-traditional-table
+```
+
+A manually downloaded authentic Sketchfab glTF can also be copied and validated
+with:
+
+```bash
+npm run fetch:pool-royale-traditional-table -- --from /path/to/pool-table-traditional-gltf.zip
+```
+
+- Source: https://sketchfab.com/3d-models/pool-table-traditional-e0b938c0c2e74eb794a49ebde2543977
+- Author: https://sketchfab.com/fizyman
+- Sketchfab model notes: 8 Foot Traditional style billiard table with mesh pockets; modeled in 3ds Max, textured and baked in Substance Painter.
+- License shown on Sketchfab: Creative Commons Attribution (CC BY 4.0)
+- License URL: https://creativecommons.org/licenses/by/4.0/
+
+The downloaded glTF folder keeps the original table shape, UV mapping, material slots,
+and baked texture payload. Pool Royale then fits that authentic model to the game
+playfield and can remap selected material roles for user-customized table
+finishes.

--- a/webapp/scripts/fetch-pool-royale-traditional-table.mjs
+++ b/webapp/scripts/fetch-pool-royale-traditional-table.mjs
@@ -1,0 +1,337 @@
+import { execFile } from 'node:child_process';
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile
+} from 'node:fs/promises';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { promisify } from 'node:util';
+import process from 'node:process';
+
+const execFileAsync = promisify(execFile);
+
+const TRADITIONAL_POOL_TABLE = Object.freeze({
+  id: 'traditional-fizyman-eight-foot',
+  label: 'Pool Table Traditional',
+  author: 'fizyman',
+  uid: 'e0b938c0c2e74eb794a49ebde2543977',
+  sourceUrl:
+    'https://sketchfab.com/3d-models/pool-table-traditional-e0b938c0c2e74eb794a49ebde2543977',
+  license: 'CC Attribution 4.0',
+  targetDir: 'public/models/pool-royale/pool-table-traditional-fizyman',
+  targetFile: 'pool-table-traditional-fizyman.gltf',
+  expected: Object.freeze({
+    minTriangles: 20000,
+    minVertices: 10000,
+    minMaterials: 4,
+    minTextures: 10,
+    minImages: 10
+  })
+});
+
+function parseArgs(argv) {
+  const out = {
+    from: null,
+    fromDir: null,
+    targetDir: null,
+    validateOnly: false,
+    help: false
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--from') {
+      out.from = argv[i + 1] ? resolve(argv[i + 1]) : null;
+      i += 1;
+    } else if (arg === '--from-dir') {
+      out.fromDir = argv[i + 1] ? resolve(argv[i + 1]) : null;
+      i += 1;
+    } else if (arg === '--target-dir') {
+      out.targetDir = argv[i + 1] ? resolve(argv[i + 1]) : null;
+      i += 1;
+    } else if (arg === '--validate-only') {
+      out.validateOnly = true;
+    } else if (arg === '--help' || arg === '-h') {
+      out.help = true;
+    }
+  }
+  return out;
+}
+
+function targetDir(targetOverride = null) {
+  return resolve(targetOverride || TRADITIONAL_POOL_TABLE.targetDir);
+}
+
+function targetGltfPath(targetOverride = null) {
+  return join(targetDir(targetOverride), TRADITIONAL_POOL_TABLE.targetFile);
+}
+
+function printHelp() {
+  console.log(`Install the authentic Pool Royale Traditional table glTF folder without committing binaries.
+
+This script fetches Sketchfab's converted glTF archive for:
+  ${TRADITIONAL_POOL_TABLE.label} by ${TRADITIONAL_POOL_TABLE.author}
+  ${TRADITIONAL_POOL_TABLE.sourceUrl}
+
+Usage:
+  SKETCHFAB_TOKEN=<token> npm run fetch:pool-royale-traditional-table
+  npm run fetch:pool-royale-traditional-table -- --from /path/to/authentic-sketchfab-gltf.zip
+  npm run fetch:pool-royale-traditional-table -- --from-dir /path/to/extracted/sketchfab-gltf
+  npm run fetch:pool-royale-traditional-table -- --validate-only
+
+Output directory:
+  ${TRADITIONAL_POOL_TABLE.targetDir}/
+Main file:
+  ${TRADITIONAL_POOL_TABLE.targetDir}/${TRADITIONAL_POOL_TABLE.targetFile}
+
+The output directory is gitignored so the PR contains source/config/attribution only.
+Validation checks the glTF JSON for the original model scale of detail: at least
+${TRADITIONAL_POOL_TABLE.expected.minTriangles.toLocaleString()} triangles, ${TRADITIONAL_POOL_TABLE.expected.minVertices.toLocaleString()} vertices, ${TRADITIONAL_POOL_TABLE.expected.minMaterials} materials, and ${TRADITIONAL_POOL_TABLE.expected.minTextures} textures.`);
+}
+
+async function fetchJson(url, options) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(
+      `Request failed ${response.status} ${response.statusText}: ${body}`
+    );
+  }
+  return response.json();
+}
+
+async function downloadBuffer(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `glTF archive download failed ${response.status} ${response.statusText}`
+    );
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function listFilesRecursive(root) {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursive(full)));
+    } else if (entry.isFile()) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+async function findMainGltf(root) {
+  const files = await listFilesRecursive(root);
+  const gltfs = files.filter((file) => extname(file).toLowerCase() === '.gltf');
+  if (gltfs.length === 0) {
+    throw new Error('No .gltf file found in Sketchfab archive.');
+  }
+  gltfs.sort((a, b) => {
+    const score = (file) => {
+      const name = file.toLowerCase();
+      if (name.endsWith('/scene.gltf')) return 0;
+      if (name.endsWith('/model.gltf')) return 1;
+      return 2;
+    };
+    return score(a) - score(b) || a.localeCompare(b);
+  });
+  return gltfs[0];
+}
+
+async function extractZip(zipPath, destination) {
+  await mkdir(destination, { recursive: true });
+  await execFileAsync('unzip', ['-q', zipPath, '-d', destination]);
+}
+
+function primitiveTriangleCount(primitive, accessors = []) {
+  if (!primitive || (primitive.mode != null && primitive.mode !== 4)) return 0;
+  const indexAccessor = accessors[primitive.indices];
+  if (indexAccessor?.count) return Math.floor(indexAccessor.count / 3);
+  const positionAccessor = accessors[primitive.attributes?.POSITION];
+  return positionAccessor?.count ? Math.floor(positionAccessor.count / 3) : 0;
+}
+
+function summarizeGltf(json) {
+  const meshes = Array.isArray(json.meshes) ? json.meshes : [];
+  const accessors = Array.isArray(json.accessors) ? json.accessors : [];
+  const primitives = meshes.flatMap((mesh) =>
+    Array.isArray(mesh.primitives) ? mesh.primitives : []
+  );
+  const triangleCount = primitives.reduce(
+    (sum, primitive) => sum + primitiveTriangleCount(primitive, accessors),
+    0
+  );
+  const vertexAccessorIndexes = new Set(
+    primitives
+      .map((primitive) => primitive?.attributes?.POSITION)
+      .filter((index) => Number.isInteger(index))
+  );
+  const vertexCount = Array.from(vertexAccessorIndexes).reduce(
+    (sum, index) => sum + (accessors[index]?.count || 0),
+    0
+  );
+  return {
+    scenes: Array.isArray(json.scenes) ? json.scenes.length : 0,
+    meshes: meshes.length,
+    primitives: primitives.length,
+    materials: Array.isArray(json.materials) ? json.materials.length : 0,
+    textures: Array.isArray(json.textures) ? json.textures.length : 0,
+    images: Array.isArray(json.images) ? json.images.length : 0,
+    triangleCount,
+    vertexCount
+  };
+}
+
+function assertAtLeast(summary, key, expected) {
+  if ((summary[key] || 0) < expected) {
+    throw new Error(
+      `Authentic Sketchfab glTF validation failed: expected ${key} >= ${expected}, received ${summary[key] || 0}.`
+    );
+  }
+}
+
+async function validateAuthenticTraditionalGltf(gltfPath) {
+  const json = JSON.parse(await readFile(gltfPath, 'utf8'));
+  const summary = summarizeGltf(json);
+  const expected = TRADITIONAL_POOL_TABLE.expected;
+  assertAtLeast(summary, 'scenes', 1);
+  assertAtLeast(summary, 'meshes', 1);
+  assertAtLeast(summary, 'materials', expected.minMaterials);
+  assertAtLeast(summary, 'textures', expected.minTextures);
+  assertAtLeast(summary, 'images', expected.minImages);
+  assertAtLeast(summary, 'triangleCount', expected.minTriangles);
+  assertAtLeast(summary, 'vertexCount', expected.minVertices);
+  return summary;
+}
+
+async function installExtractedGltf(sourceRoot, targetOverride = null) {
+  const sourceGltf = await findMainGltf(sourceRoot);
+  const sourceDir = dirname(sourceGltf);
+  const destination = targetDir(targetOverride);
+  const tmpDestination = `${destination}.tmp-${Date.now()}`;
+
+  await rm(tmpDestination, { recursive: true, force: true });
+  await mkdir(dirname(destination), { recursive: true });
+  await cp(sourceDir, tmpDestination, { recursive: true });
+  const installedOriginal = join(
+    tmpDestination,
+    relative(sourceDir, sourceGltf)
+  );
+  const installedMain = join(tmpDestination, TRADITIONAL_POOL_TABLE.targetFile);
+  if (installedOriginal !== installedMain) {
+    await rename(installedOriginal, installedMain);
+  }
+
+  const summary = await validateAuthenticTraditionalGltf(installedMain);
+  await rm(destination, { recursive: true, force: true });
+  await rename(tmpDestination, destination);
+  return {
+    target: join(destination, TRADITIONAL_POOL_TABLE.targetFile),
+    summary
+  };
+}
+
+async function installFromZip(zipPath, targetOverride = null) {
+  if (!zipPath) throw new Error('Missing --from path.');
+  await stat(zipPath);
+  const tmp = await mkdtemp(join(tmpdir(), 'pool-royale-traditional-gltf-'));
+  try {
+    await extractZip(zipPath, tmp);
+    return await installExtractedGltf(tmp, targetOverride);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+async function downloadSketchfabGltf(token, targetOverride = null) {
+  const apiUrl = `https://api.sketchfab.com/v3/models/${TRADITIONAL_POOL_TABLE.uid}/download`;
+  const data = await fetchJson(apiUrl, {
+    headers: {
+      Authorization: `Token ${token}`,
+      Accept: 'application/json'
+    }
+  });
+  const gltf = data?.gltf?.url;
+  if (!gltf) {
+    throw new Error('Sketchfab response did not include a gltf.url download.');
+  }
+
+  const tmp = await mkdtemp(join(tmpdir(), 'pool-royale-traditional-gltf-'));
+  const archive = join(tmp, 'sketchfab-gltf.zip');
+  try {
+    await writeFile(archive, await downloadBuffer(gltf));
+    return await installFromZip(archive, targetOverride);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+async function validateExisting(targetOverride = null) {
+  const target = targetGltfPath(targetOverride);
+  const summary = await validateAuthenticTraditionalGltf(target);
+  return { target, summary };
+}
+
+function logInstalled({ target, summary }, action) {
+  console.log(`${action} ${target}`);
+  console.log(`Validated ${JSON.stringify(summary)}`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  if (args.validateOnly) {
+    logInstalled(
+      await validateExisting(args.targetDir),
+      'Validated existing authentic Sketchfab glTF at'
+    );
+    return;
+  }
+
+  if (args.fromDir) {
+    logInstalled(
+      await installExtractedGltf(args.fromDir, args.targetDir),
+      'Installed authentic Sketchfab glTF folder at'
+    );
+    return;
+  }
+
+  if (args.from) {
+    logInstalled(
+      await installFromZip(args.from, args.targetDir),
+      'Installed authentic Sketchfab glTF archive at'
+    );
+    return;
+  }
+
+  const token = process.env.SKETCHFAB_TOKEN;
+  if (!token) {
+    printHelp();
+    throw new Error(
+      'SKETCHFAB_TOKEN is required unless --from, --from-dir, or --validate-only is provided.'
+    );
+  }
+  logInstalled(
+    await downloadSketchfabGltf(token, args.targetDir),
+    'Downloaded authentic Sketchfab glTF to'
+  );
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -5,6 +5,45 @@ const POOLTOOL_RAW_BASE =
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
+    id: 'traditional-fizyman-eight-foot',
+    label: 'Traditional 8 ft glTF',
+    description:
+      "Traditional billiard table option inspired by fizyman's Sketchfab Pool Table Traditional model, installed from Sketchfab as the local glTF folder so Pool Royale loads the authentic original shape, UV mapping, and baked texture set without committing binary assets.",
+    tableSizeId: '8ft',
+    baseId: 'mahogany',
+    assetUrl:
+      '/models/pool-royale/pool-table-traditional-fizyman/pool-table-traditional-fizyman.gltf',
+    installScript: 'npm run fetch:pool-royale-traditional-table',
+    sourceUid: 'e0b938c0c2e74eb794a49ebde2543977',
+    sourceFormat: 'sketchfab-original-gltf',
+    sourceUrl:
+      'https://sketchfab.com/3d-models/pool-table-traditional-e0b938c0c2e74eb794a49ebde2543977',
+    author: 'fizyman',
+    license: 'CC Attribution 4.0',
+    thumbnailUrl:
+      'https://media.sketchfab.com/models/e0b938c0c2e74eb794a49ebde2543977/thumbnails/ca60f8c0ed984d21b89ee7a298d60650/b857e58f5e2746339b725c6b40b5b08a.jpeg',
+    icon: '🎱',
+    kind: 'gltf',
+    fitScale: 1,
+    fitFootprintScale: 1,
+    fitHeightScale: 1,
+    clothRepeatScale: 6.5,
+    fitStrategy: 'exact',
+    fitReference: 'upperTabletop',
+    matchNativeHeight: true,
+    matchNativeUpperComponentHeight: false,
+    preserveOriginalFootprintAspect: false,
+    useOriginalLayoutSurfaces: true,
+    usePoolRoyaleFinish: true,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
+    preserveOriginalSurfaceRoles: ['railSight'],
+    tintOriginalTrimGold: true,
+    chromeMaterialSurfaceNames: ['brass', 'diamond', 'railSight'],
+    blackMaterialSurfaceNames: ['pocket', 'net'],
+    forceGeneratedChromePlates: false,
+    hideSurfaceRoles: []
+  },
+  {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
@@ -40,13 +79,17 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
 ]);
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
-  POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === 'showood-seven-foot')?.id ||
-  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+  POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
+    (option) => option.id === 'showood-seven-foot'
+  )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
 
 export function resolvePoolRoyaleTableModel(modelId) {
   const key = typeof modelId === 'string' ? modelId.trim() : '';
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
+    POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
+      (option) => option.id === DEFAULT_POOL_ROYALE_TABLE_MODEL_ID
+    ) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
   );
 }

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,6 +13,7 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
+  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
@@ -76,7 +77,21 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const selectedTableModel = resolvePoolRoyaleTableModel();
+  const [tableModelId, setTableModelId] = useState(() => {
+    const requested = searchParams.get('tableModel');
+    if (requested) return resolvePoolRoyaleTableModel(requested).id;
+    try {
+      return resolvePoolRoyaleTableModel(
+        window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY)
+      ).id;
+    } catch {
+      return resolvePoolRoyaleTableModel().id;
+    }
+  });
+  const selectedTableModel = useMemo(
+    () => resolvePoolRoyaleTableModel(tableModelId),
+    [tableModelId]
+  );
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -761,7 +776,9 @@ export default function PoolRoyaleLobby() {
             </div>
           )}
 
-        {playType !== 'training' && playType !== 'career' && !hasActiveTournament && (
+        {playType !== 'training' &&
+          playType !== 'career' &&
+          !hasActiveTournament && (
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <h3 className="font-semibold text-white">Game Variant</h3>
@@ -807,68 +824,130 @@ export default function PoolRoyaleLobby() {
           )}
 
         {playType !== 'career' && !hasActiveTournament && variant === 'uk' && (
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <h3 className="font-semibold text-white">Ball Colors</h3>
-                <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-                  Visuals
-                </span>
-              </div>
-              <p className="text-xs text-white/60">
-                Keep UK yellow/red sets or switch to solids &amp; stripes
-                visuals while retaining 8Ball rules.
-              </p>
-              <div className="grid grid-cols-3 gap-3">
-                {[
-                  { id: 'uk', label: 'Yellow & Red' },
-                  { id: 'american', label: 'Solids & Stripes' }
-                ].map(({ id, label }) => {
-                  const active = ukBallSet === id;
-                  return (
-                    <button
-                      key={id}
-                      type="button"
-                      onClick={() => setUkBallSet(id)}
-                      className={`lobby-option-card ${
-                        active
-                          ? 'lobby-option-card-active'
-                          : 'lobby-option-card-inactive'
-                      }`}
-                    >
-                      <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent">
-                        <div className="lobby-option-thumb-inner">
-                          <OptionIcon
-                            src={getLobbyIcon('poolroyale', `ball-${id}`)}
-                            alt={label}
-                            fallback={id === 'uk' ? '🟡' : '🔵'}
-                            className="lobby-option-icon"
-                          />
-                        </div>
-                      </div>
-                      <div className="text-center">
-                        <p className="lobby-option-label">{label}</p>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Ball Colors</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+                Visuals
+              </span>
             </div>
-          )}
+            <p className="text-xs text-white/60">
+              Keep UK yellow/red sets or switch to solids &amp; stripes visuals
+              while retaining 8Ball rules.
+            </p>
+            <div className="grid grid-cols-3 gap-3">
+              {[
+                { id: 'uk', label: 'Yellow & Red' },
+                { id: 'american', label: 'Solids & Stripes' }
+              ].map(({ id, label }) => {
+                const active = ukBallSet === id;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => setUkBallSet(id)}
+                    className={`lobby-option-card ${
+                      active
+                        ? 'lobby-option-card-active'
+                        : 'lobby-option-card-inactive'
+                    }`}
+                  >
+                    <div className="lobby-option-thumb bg-gradient-to-br from-amber-400/30 via-rose-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
+                        <OptionIcon
+                          src={getLobbyIcon('poolroyale', `ball-${id}`)}
+                          alt={label}
+                          fallback={id === 'uk' ? '🟡' : '🔵'}
+                          className="lobby-option-icon"
+                        />
+                      </div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{label}</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {!hasActiveTournament && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Pool Table</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+                Model
+              </span>
+            </div>
+            <p className="text-xs text-white/60">
+              Select the GLB table model before entering the arena. Pool Royale
+              keeps the same playable table footprint and height for every
+              model.
+            </p>
+            <div className="grid grid-cols-2 gap-3">
+              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
+                const active = selectedTableModel.id === option.id;
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => setTableModelId(option.id)}
+                    className={`lobby-option-card ${
+                      active
+                        ? 'lobby-option-card-active'
+                        : 'lobby-option-card-inactive'
+                    }`}
+                  >
+                    <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/25 via-amber-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
+                        {option.thumbnailUrl ? (
+                          <img
+                            src={option.thumbnailUrl}
+                            alt={option.label}
+                            className="h-full w-full rounded-xl object-cover"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <span className="text-3xl">
+                            {option.icon || '🎱'}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{option.label}</p>
+                      <p className="lobby-option-subtitle">
+                        {resolveTableSize(option.tableSizeId).label} · GLB
+                      </p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            {selectedTableModel.sourceUrl && (
+              <p className="text-[11px] text-white/45">
+                Source credit: {selectedTableModel.author || 'Sketchfab'} ·{' '}
+                {selectedTableModel.license || 'CC Attribution'}
+              </p>
+            )}
+          </div>
+        )}
 
         {playType === 'training' && (
           <div className="space-y-3 rounded-2xl border border-emerald-300/30 bg-gradient-to-br from-emerald-500/10 via-black/35 to-cyan-500/10 p-4">
             <div>
               <h3 className="font-semibold text-white">Free Practice</h3>
               <p className="text-xs text-white/60">
-                Practice is open-table mode: no AI and no rule penalties.
-                Choose any variant, set your preferred ball colors, then start and
+                Practice is open-table mode: no AI and no rule penalties. Choose
+                any variant, set your preferred ball colors, then start and
                 practice shots freely.
               </p>
             </div>
             <div className="rounded-xl border border-white/10 bg-black/25 p-3 text-xs text-white/70">
-                <p>
-                All guided practice tasks were moved to Career mode as progression
-                stages.
+              <p>
+                All guided practice tasks were moved to Career mode as
+                progression stages.
               </p>
               <p className="mt-1 text-white/60">
                 Open Career when you want structured objectives and rewards.
@@ -883,7 +962,8 @@ export default function PoolRoyaleLobby() {
               <div>
                 <h3 className="font-semibold text-white">Career Roadmap</h3>
                 <p className="text-xs text-white/60">
-                  Mixed drills, match tasks, and tournaments with detailed phase progression.
+                  Mixed drills, match tasks, and tournaments with detailed phase
+                  progression.
                 </p>
               </div>
               <div className="flex items-center gap-2">
@@ -918,7 +998,9 @@ export default function PoolRoyaleLobby() {
                     <p className="text-sm font-semibold text-white">
                       {nextCareerTask.icon} {nextCareerTask.title}
                     </p>
-                    <p className="mt-1 text-white/75">{nextCareerTask.objective}</p>
+                    <p className="mt-1 text-white/75">
+                      {nextCareerTask.objective}
+                    </p>
                   </div>
                 </div>
                 <div className="mt-2 flex flex-wrap items-center gap-1.5">
@@ -1231,18 +1313,18 @@ export default function PoolRoyaleLobby() {
         )}
 
         {playType !== 'career' && !hasActiveTournament && (
-            <button
-              onClick={startGame}
-              className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background transition hover:bg-primary-hover"
-              disabled={mode === 'online' && (isSearching || matching)}
-            >
-              {mode === 'online'
-                ? matching
-                  ? 'Waiting for opponent…'
-                  : 'START ONLINE'
-                : 'START'}
-            </button>
-          )}
+          <button
+            onClick={startGame}
+            className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background transition hover:bg-primary-hover"
+            disabled={mode === 'online' && (isSearching || matching)}
+          >
+            {mode === 'online'
+              ? matching
+                ? 'Waiting for opponent…'
+                : 'START ONLINE'
+              : 'START'}
+          </button>
+        )}
 
         <FlagPickerModal
           open={showFlagPicker}


### PR DESCRIPTION
### Motivation
- Provide an authentic Sketchfab-sourced Pool Royale table model while avoiding committing large binary glTF assets to the repo. 
- Give developers and deployments a supported installer and validation path to install the original glTF folder locally. 
- Expose table model selection to players in the Pool Royale lobby and persist selection across sessions. 

### Description
- Add a new table model option for the authentic Traditional table in `webapp/src/config/poolRoyaleTableModels.js`, including metadata, local `assetUrl`, install instructions, and remapping hints. 
- Add an installer/validator script at `webapp/scripts/fetch-pool-royale-traditional-table.mjs` that can download from Sketchfab (using `SKETCHFAB_TOKEN`), extract a Sketchfab glTF zip, validate mesh/texture counts and triangle/vertex thresholds, and install the glTF folder into the ignored `public/models/pool-royale/pool-table-traditional-fizyman` path. 
- Add attribution and instructions in `webapp/public/models/pool-royale/pool-table-traditional-fizyman.LICENSE.md` and update `webapp/package.json` with the `fetch:pool-royale-traditional-table` script. 
- Update `.gitignore` to ignore runtime Pool Royale model binaries under `webapp/public/models/pool-royale/`. 
- Add/adjust unit tests in `test/poolRoyaleTableModels.test.js` to assert model metadata, installer behavior, help text, and presence of attribution and installer files. 
- Expose model selection in the lobby UI by updating `webapp/src/pages/Games/PoolRoyaleLobby.jsx` to allow choosing between available table models, persist the selection in `localStorage`, and surface source credit in the UI. 
- Misc: small data and formatting tweaks to model config (surface role lists, chrome material names) and a few whitespace/formatting fixes.

### Testing
- Ran the repository unit tests including `test/poolRoyaleTableModels.test.js` with the Node test runner, which exercised metadata assertions, the installer `--help` output, and file presence checks; the tests passed. 
- The tests also verify that the installer script contains required Sketchfab download and validation logic and that the attribution file exists; these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082d1888388329bff04051112bcab1)