### PR TITLE
Tune table tennis swipe shot physics

### DIFF
--- a/webapp/src/pages/Games/TableTennis.tsx
+++ b/webapp/src/pages/Games/TableTennis.tsx
@@ -135,11 +135,11 @@ const CFG = {
   netPostOutside: 0.21,
   ballR: 0.052,
   gravity: 9.81,
-  airDrag: 0.22,
-  magnus: 0.00125,
-  tableRestitution: 0.96,
-  tableFriction: 0.982,
-  spinDecay: 0.72,
+  airDrag: 0.18,
+  magnus: 0.00138,
+  tableRestitution: 1.02,
+  tableFriction: 0.988,
+  spinDecay: 0.66,
   playerHeight: 3.5,
   playerSpeed: 3.9,
   aiSpeed: 4.95,
@@ -161,9 +161,9 @@ const CFG = {
   floorRestitution: 0.56,
   floorFriction: 0.88,
   railRestitution: 0.5,
-  minShotSpeed: 4.6,
-  maxShotSpeed: 14.2,
-  netClearance: 0.16,
+  minShotSpeed: 5.35,
+  maxShotSpeed: 16.8,
+  netClearance: 0.19,
   playerVisualYawFix: Math.PI,
   paddlePalmOffset: 0.038,
 };
@@ -1081,20 +1081,20 @@ function makeUserHitFromSwipe(startX: number, startY: number, endX: number, endY
   const screenH = Math.max(480, typeof window !== "undefined" ? window.innerHeight : 844);
   const shortSide = Math.max(320, Math.min(screenW, screenH));
   const releaseLane = clamp((endX / screenW - 0.5) * 2, -1, 1);
-  const swipeLane = clamp(dx / (shortSide * 0.36), -1, 1);
-  const lateral = clamp(releaseLane * 0.64 + swipeLane * 0.36, -1, 1);
-  const upwardIntent = clamp(-dy / (shortSide * 0.62), -0.12, 1.15);
-  const depth = clamp(upwardIntent * 0.92 + Math.max(0, Math.abs(dx) / (shortSide * 1.05)) * 0.08, 0, 1);
-  const rawPower = Math.hypot(dx, dy) / (shortSide * (isServe ? 0.42 : 0.34));
-  const power = clamp(Math.pow(clamp01(rawPower), 0.72), isServe ? 0.62 : 0.42, 1);
+  const swipeLane = clamp(dx / (shortSide * 0.27), -1, 1);
+  const lateral = clamp(swipeLane * 0.68 + releaseLane * 0.32, -1, 1);
+  const upwardIntent = clamp(-dy / (shortSide * 0.52), -0.16, 1.2);
+  const depth = clamp(upwardIntent * 0.96 + Math.max(0, Math.abs(dx) / (shortSide * 0.92)) * 0.04, 0, 1);
+  const rawPower = Math.hypot(dx, dy) / (shortSide * (isServe ? 0.36 : 0.28));
+  const power = clamp(Math.pow(clamp01(rawPower), 0.62), isServe ? 0.68 : 0.5, 1);
   const safetyMargin = isServe ? 0.18 : 0.1;
   const targetX = clamp(lateral * (TABLE_HALF_W - safetyMargin), -TABLE_HALF_W + safetyMargin, TABLE_HALF_W - safetyMargin);
   const targetZ = isServe ? -lerp(0.38, TABLE_HALF_L - 0.32, depth) : -lerp(0.3, TABLE_HALF_L - 0.1, depth);
   return {
     target: new THREE.Vector3(targetX, BALL_SURFACE_Y, targetZ),
     power,
-    topSpin: clamp(0.42 + depth * 0.78 + power * 0.32, 0.26, 1.34),
-    sideSpin: clamp(swipeLane * 0.82 + releaseLane * 0.18, -1, 1),
+    topSpin: clamp(0.5 + depth * 0.92 + power * 0.36, 0.32, 1.58),
+    sideSpin: clamp(swipeLane * 0.9 + releaseLane * 0.1, -1, 1),
   };
 }
 
@@ -1197,7 +1197,7 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
   if (serve) {
     ball.pos.copy(serveContactPosition(player));
     const ownBounce = new THREE.Vector3(clamp(target.x * 0.45, -TABLE_HALF_W + 0.12, TABLE_HALF_W - 0.12), BALL_SURFACE_Y, dirZ * -0.62);
-    const flight = clamp(0.16 + (1 - hit.power) * 0.07, 0.145, 0.26);
+    const flight = clamp(0.145 + (1 - hit.power) * 0.055, 0.13, 0.23);
     ball.vel.copy(ballisticVelocity(ball.pos, ownBounce, flight));
     ball.spin.set(-dirZ * (52 + hit.topSpin * 50), hit.sideSpin * 86, hit.sideSpin * 9);
     ball.phase = { kind: "serve", server: player.side, stage: "own" };
@@ -1205,8 +1205,8 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
     ball.pos.y = clamp(ball.pos.y, CFG.tableY + 0.08, CFG.tableY + 0.48);
     const dist = Math.hypot(target.x - ball.pos.x, target.z - ball.pos.z);
     const speedScale = Math.max(1, TABLE_SCALE_FACTOR * 0.85);
-    const baseFlight = dist / ((4.9 + hit.power * 6.1) * speedScale);
-    const flight = flightWithNetClearance(ball.pos, target, baseFlight, 0.115, 0.38);
+    const baseFlight = dist / ((5.6 + hit.power * 7.2) * speedScale);
+    const flight = flightWithNetClearance(ball.pos, target, baseFlight, 0.1, 0.34);
     ball.vel.copy(ballisticVelocity(ball.pos, target, flight));
     ball.spin.set(-dirZ * (68 + hit.topSpin * 102), hit.sideSpin * 118, hit.sideSpin * 14);
     ball.phase = { kind: "rally" };
@@ -1779,7 +1779,7 @@ export default function MobileRealisticTableTennisGame() {
       if (descendingThroughSurface && isOverTable(tableImpactX, tableImpactZ, 0)) {
         ball.pos.set(tableImpactX, BALL_SURFACE_Y, tableImpactZ);
         const side = sideOfZ(tableImpactZ);
-        ball.vel.y = -ball.vel.y * CFG.tableRestitution;
+        ball.vel.y = Math.max(-ball.vel.y * CFG.tableRestitution, 1.05);
         ball.vel.x *= CFG.tableFriction;
         ball.vel.z *= CFG.tableFriction;
         ball.vel.z += ball.spin.x * 0.0016;


### PR DESCRIPTION
### Motivation
- Improve table tennis feel by giving players more perceived power and livelier bounces while making swipe inputs map more precisely to shot outcomes.
- Reduce sluggish flight/drag and make table impacts return more vertical energy so rallies feel punchier and shot variety (topspin/slice) is more responsive.

### Description
- Adjusted shot/physics tuning in `webapp/src/pages/Games/TableTennis.tsx` by changing CFG parameters: lowered `airDrag`, increased `magnus`, raised `tableRestitution` and `tableFriction`, decreased `spinDecay`, and increased `minShotSpeed`/`maxShotSpeed` and `netClearance` to allow stronger, bouncier shots.
- Reworked swipe → hit mapping in `makeUserHitFromSwipe` to increase horizontal influence and sensitivity (`swipeLane`, `lateral`, `upwardIntent`, `rawPower`, `power`) so swipes better match player intent on screen.
- Increased spin/power scaling for user hits (`topSpin`, `sideSpin`) and adjusted flight timing calculations in `performHit` (changed `baseFlight` and `flight` ranges) so shots travel faster and clear the net more naturally.
- Enforced a minimum vertical rebound on table contact by clamping impact vertical velocity (`ball.vel.y = Math.max(-ball.vel.y * CFG.tableRestitution, 1.05)`) to make bounces feel livelier.

### Testing
- Ran the production build: `npm --prefix webapp run build`, which completed successfully (Vite build finished and emitted bundles).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0851a626e08329979d68c7b847b70b)