### PR TITLE
Tune table tennis AI and swipe shooting

### DIFF
--- a/frontend/src/table-tennis/AIController.ts
+++ b/frontend/src/table-tennis/AIController.ts
@@ -10,7 +10,7 @@ export class AIController {
   currentShot: ShotType = 'forehand drive';
   private reactionTimer = 0;
   private committedLanding: THREE.Vector3 | null = null;
-  private readonly shotCommand: ShotCommand = { aimX: 0, power: 0.58, lift: 0.45, curve: 0, spin: 0.25 };
+  private readonly shotCommand: ShotCommand = { aimX: 0, power: 0.76, lift: 0.42, curve: 0, spin: 0.34 };
 
   constructor(private root: THREE.Group, private hand: THREE.Object3D, private paddle: THREE.Object3D) {}
 
@@ -20,10 +20,12 @@ export class AIController {
     if (this.reactionTimer <= 0) {
       this.committedLanding = ball.predictLandingPoint('ai');
       if (this.committedLanding) {
-        const noise = (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(0.55);
+        const noise = (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(0.38);
         this.targetX.value = THREE.MathUtils.clamp(this.committedLanding.x + noise, GAME_CONFIG.ai.minX, GAME_CONFIG.ai.maxX);
+        this.prepareShotCommand(ball);
       }
-      this.reactionTimer = cfg.reactionTime;
+      const speedRead = THREE.MathUtils.clamp(ball.velocity.length() / 7, 0, 0.055);
+      this.reactionTimer = Math.max(0.075, cfg.reactionTime - speedRead);
     }
 
     this.root.position.x = THREE.MathUtils.damp(this.root.position.x, this.targetX.value, cfg.moveSpeed, dt);
@@ -34,6 +36,16 @@ export class AIController {
     this.hand.position.set(this.currentShot === 'forehand drive' ? -0.16 : 0.16, 0.92, -0.28);
     this.paddle.position.set(0, -0.02, -0.12);
     this.paddle.rotation.set(-0.25, 0, this.currentShot === 'forehand drive' ? -0.16 : 0.16);
+  }
+
+  private prepareShotCommand(ball: BallPhysics) {
+    const pressure = THREE.MathUtils.clamp(ball.velocity.length() / 6, 0, 1);
+    const openCourtAim = THREE.MathUtils.clamp(-this.root.position.x / (GAME_CONFIG.table.width * 0.5), -0.82, 0.82);
+    this.shotCommand.aimX = THREE.MathUtils.clamp(openCourtAim + THREE.MathUtils.randFloatSpread(0.34), -1, 1);
+    this.shotCommand.power = THREE.MathUtils.clamp(0.68 + pressure * 0.24 + THREE.MathUtils.randFloatSpread(0.08), 0.62, 0.95);
+    this.shotCommand.lift = THREE.MathUtils.clamp(0.34 + pressure * 0.18 + THREE.MathUtils.randFloatSpread(0.1), 0.26, 0.66);
+    this.shotCommand.curve = THREE.MathUtils.clamp(THREE.MathUtils.randFloatSpread(0.34), -0.5, 0.5);
+    this.shotCommand.spin = THREE.MathUtils.clamp(0.28 + pressure * 0.28, 0.22, 0.72);
   }
 
   canReach(ballPosition: THREE.Vector3) {

--- a/frontend/src/table-tennis/GameManager.ts
+++ b/frontend/src/table-tennis/GameManager.ts
@@ -191,12 +191,16 @@ export class GameManager {
     const dx = end.x - start.x;
     const dy = start.y - end.y;
     const distance = Math.hypot(dx, dy);
-    const fastSwipeBonus = THREE.MathUtils.clamp(320 / Math.max(durationMs, 80), 0, 1);
-    const aimX = THREE.MathUtils.clamp(end.x * 1.08, -1, 1);
-    const power = THREE.MathUtils.clamp(distance * 0.64 + fastSwipeBonus * 0.42, 0.16, 1);
-    const lift = THREE.MathUtils.clamp(0.28 + dy * 0.58, 0, 1);
-    const curve = THREE.MathUtils.clamp(dx * 0.92, -1, 1);
-    const spin = THREE.MathUtils.clamp(dy * 0.92 + power * 0.22 - Math.abs(curve) * 0.1, -1, 1);
+    const horizontalIntent = THREE.MathUtils.clamp(dx / Math.max(distance, 0.001), -1, 1);
+    const verticalIntent = THREE.MathUtils.clamp(dy / Math.max(distance, 0.001), -1, 1);
+    const swipeSpeed = distance / Math.max(durationMs / 1000, 0.08);
+    const speedPower = THREE.MathUtils.clamp(swipeSpeed / 4.4, 0, 1);
+    const distancePower = THREE.MathUtils.clamp(distance / 1.35, 0, 1);
+    const aimX = THREE.MathUtils.clamp(end.x * 0.62 + horizontalIntent * 0.38 + dx * 0.18, -1, 1);
+    const power = THREE.MathUtils.clamp(distancePower * 0.58 + speedPower * 0.42, 0.14, 1);
+    const lift = THREE.MathUtils.clamp(0.22 + Math.max(verticalIntent, -0.25) * 0.44 + dy * 0.18, 0, 1);
+    const curve = THREE.MathUtils.clamp(dx * 0.62 + horizontalIntent * 0.22, -1, 1);
+    const spin = THREE.MathUtils.clamp(verticalIntent * 0.52 + dy * 0.28 + power * 0.24 - Math.abs(curve) * 0.08, -1, 1);
     return { aimX, power, lift, curve, spin };
   }
 

--- a/frontend/src/table-tennis/PaddleHitDetector.ts
+++ b/frontend/src/table-tennis/PaddleHitDetector.ts
@@ -47,17 +47,25 @@ export class PaddleHitDetector {
 
     const command = input.shotCommand ?? DEFAULT_COMMAND;
     const profile = shotProfiles[input.requestedShot];
-    const targetZ = input.side === 'player'
-      ? THREE.MathUtils.randFloat(TABLE_BOUNDS.minZ * 0.78, TABLE_BOUNDS.minZ * 0.28)
-      : THREE.MathUtils.randFloat(TABLE_BOUNDS.maxZ * 0.28, TABLE_BOUNDS.maxZ * 0.78);
     const screenAim = input.side === 'player' ? command.aimX : -command.aimX;
-    const edgeInset = GAME_CONFIG.table.width * 0.065;
+    const edgeInset = GAME_CONFIG.table.width * 0.055;
     const targetXBase = THREE.MathUtils.lerp(TABLE_BOUNDS.minX + edgeInset, TABLE_BOUNDS.maxX - edgeInset, (screenAim + 1) / 2);
-    const error = (1 - (input.accuracy ?? GAME_CONFIG.paddle.accuracy)) * THREE.MathUtils.lerp(0.48, 0.22, command.power);
+    const accuracy = input.accuracy ?? GAME_CONFIG.paddle.accuracy;
+    const error = (1 - accuracy) * GAME_CONFIG.table.width * THREE.MathUtils.lerp(0.16, 0.07, command.power);
+    const targetX = THREE.MathUtils.clamp(
+      targetXBase + THREE.MathUtils.randFloatSpread(error),
+      TABLE_BOUNDS.minX + edgeInset,
+      TABLE_BOUNDS.maxX - edgeInset,
+    );
+    const nearZ = input.side === 'player' ? TABLE_BOUNDS.minZ * 0.28 : TABLE_BOUNDS.maxZ * 0.28;
+    const deepZ = input.side === 'player' ? TABLE_BOUNDS.minZ * 0.84 : TABLE_BOUNDS.maxZ * 0.84;
+    const depthPower = THREE.MathUtils.clamp(command.power * 0.82 + (1 - command.lift) * 0.18, 0, 1);
+    const targetZBase = THREE.MathUtils.lerp(nearZ, deepZ, depthPower);
+    const targetZ = targetZBase + THREE.MathUtils.randFloatSpread((1 - accuracy) * GAME_CONFIG.table.length * 0.06);
     const target = new THREE.Vector3(
-      THREE.MathUtils.clamp(targetXBase + THREE.MathUtils.randFloatSpread(error), TABLE_BOUNDS.minX + edgeInset, TABLE_BOUNDS.maxX - edgeInset),
+      targetX,
       GAME_CONFIG.table.topY + profile.arc + command.lift * 0.32,
-      targetZ,
+      THREE.MathUtils.clamp(targetZ, Math.min(nearZ, deepZ), Math.max(nearZ, deepZ)),
     );
     const direction = target.sub(input.ballPosition).normalize();
     const commandPower = THREE.MathUtils.lerp(0.72, 1.28, command.power);

--- a/frontend/src/table-tennis/gameConfig.ts
+++ b/frontend/src/table-tennis/gameConfig.ts
@@ -74,11 +74,11 @@ export const GAME_CONFIG = {
     maxReach: 0.58 * TABLE_WIDTH_SCALE,
     avatarScale: 1.62,
     difficulty: {
-      reactionTime: 0.24,
-      moveSpeed: 2.05 * TABLE_WIDTH_SCALE,
-      accuracy: 0.78,
-      shotPower: 1.0,
-      mistakeChance: 0.14,
+      reactionTime: 0.14,
+      moveSpeed: 3.05 * TABLE_WIDTH_SCALE,
+      accuracy: 0.84,
+      shotPower: 1.18,
+      mistakeChance: 0.1,
     } satisfies DifficultyConfig,
   },
   paddle: {
@@ -91,7 +91,7 @@ export const GAME_CONFIG = {
     powerShotMultiplier: 1.18,
     spin: 3.6,
     sideSpin: 4.2,
-    accuracy: 0.9,
+    accuracy: 0.96,
   },
   camera: {
     position: new THREE.Vector3(0, 2.7, 6.1),


### PR DESCRIPTION
### Motivation
- Make the AI respond and shoot faster and more aggressively so rallies feel more competitive. 
- Improve mapping from screen swipe to in-game shot so power and direction more closely reflect the player's swipe intent. 
- Reduce random drift on paddle hits so requested aim/depth is preserved more reliably.

### Description
- Increased AI difficulty and paddle accuracy by updating `GAME_CONFIG.ai.difficulty` and `GAME_CONFIG.paddle.accuracy` in `frontend/src/table-tennis/gameConfig.ts` to lower reaction time, raise movement speed and shot power, and reduce mistake chance. 
- Added adaptive AI shot planning in `frontend/src/table-tennis/AIController.ts` by reducing aim noise, shortening reaction delay based on ball speed, and adding `prepareShotCommand` to set `aimX`, `power`, `lift`, `curve`, and `spin` from ball pressure and open-court position. 
- Reworked swipe-to-shot mapping in `frontend/src/table-tennis/GameManager.ts` to compute `aimX`, `power`, `lift`, `curve`, and `spin` from swipe distance, speed, and directional intent for more precise and predictable player shots. 
- Made paddle-hit target selection in `frontend/src/table-tennis/PaddleHitDetector.ts` more deterministic and power-aware by computing a clamped `targetX` and depth (`targetZ`) using command power and an accuracy-scaled spread instead of the previous looser random ranges. 

### Testing
- Built the frontend with `npm --prefix frontend run build` (succeeded). 
- Launched the dev server with `npm --prefix frontend run dev -- --host 127.0.0.1` (server started). 
- Captured a visual smoke test via Playwright with `cd frontend && npx --yes playwright@1.56.1 screenshot --wait-for-timeout=1500 http://127.0.0.1:5173/ /tmp/table-tennis-swipe-ai.png` (screenshot captured; Playwright browser artifacts were downloaded and system deps installed during the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0851fb03d083298f4315329ee9654b)