### PR TITLE
Allow selecting traditional Pool Royale table

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -94,6 +94,31 @@ describe('Pool Royale table models', () => {
     assert.equal(traditional.license, 'CC Attribution 4.0');
   });
 
+  test('Pool Royale lobby keeps runtime-only glTF table models selectable before install', async () => {
+    const lobby = await readFile(
+      'webapp/src/pages/Games/PoolRoyaleLobby.jsx',
+      'utf8'
+    );
+
+    assert.ok(
+      lobby.includes('const selectedTableModelReady = true'),
+      'lobby start button should not be blocked by runtime-only glTF install checks'
+    );
+    assert.ok(
+      lobby.includes('onClick={() => setTableModelId(option.id)}'),
+      'table model option should remain clickable when the local glTF is missing'
+    );
+    assert.ok(
+      lobby.includes('Selectable · install for glTF'),
+      'missing local glTF copy should be shown as selectable with install guidance'
+    );
+    assert.ok(
+      lobby.includes('generated fallback table'),
+      'start guidance should explain the fallback used until the glTF package is installed'
+    );
+    assert.equal(lobby.includes('disabled={unavailable}'), false);
+  });
+
   test('Traditional table installer fetches and validates the authentic Sketchfab glTF', async () => {
     const source = await readFile(
       'webapp/scripts/fetch-pool-royale-traditional-table.mjs',

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -154,7 +154,10 @@ export default function PoolRoyaleLobby() {
   const selectedTableModelAvailability = selectedTableModel?.requiresInstall
     ? tableModelAvailability[selectedTableModel.id]
     : true;
-  const selectedTableModelReady = selectedTableModelAvailability === true;
+  // Runtime-only glTF assets must remain selectable from the lobby even before
+  // their local Sketchfab package is installed. The game renderer already keeps
+  // the generated/native table visible if an external model cannot load.
+  const selectedTableModelReady = true;
   const selectedTableModelPending =
     selectedTableModel?.requiresInstall &&
     typeof selectedTableModelAvailability === 'undefined';
@@ -299,12 +302,12 @@ export default function PoolRoyaleLobby() {
       const installCommand =
         selectedTableModel.installScript ||
         'npm run fetch:pool-royale-traditional-table';
-      const message = `${selectedTableModel.label} is not installed yet. Run ${installCommand} so the authentic glTF table loads instead of the generated fallback.`;
+      const message = [
+        `${selectedTableModel.label} is selectable now.`,
+        `Run ${installCommand} to install the authentic glTF package;`,
+        'until then Pool Royale will open with the generated fallback table if the model is unavailable.'
+      ].join(' ');
       setTableModelInstallError(message);
-      try {
-        window?.Telegram?.WebApp?.showAlert?.(message);
-      } catch {}
-      return;
     }
 
     try {
@@ -960,13 +963,12 @@ export default function PoolRoyaleLobby() {
                   <button
                     key={option.id}
                     type="button"
-                    onClick={() => !unavailable && setTableModelId(option.id)}
-                    disabled={unavailable}
+                    onClick={() => setTableModelId(option.id)}
                     className={`lobby-option-card ${
                       active
                         ? 'lobby-option-card-active'
                         : 'lobby-option-card-inactive'
-                    } ${unavailable ? 'lobby-option-card-disabled' : ''}`}
+                    } ${unavailable ? 'border-amber-300/45' : ''}`}
                   >
                     <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/25 via-amber-500/10 to-transparent">
                       <div className="lobby-option-thumb-inner">
@@ -1001,10 +1003,10 @@ export default function PoolRoyaleLobby() {
                           }`}
                         >
                           {availability === true
-                            ? 'Installed'
+                            ? 'Installed glTF'
                             : availability === false
-                              ? 'Run installer first'
-                              : 'Checking install…'}
+                              ? 'Selectable · install for glTF'
+                              : 'Selectable · checking glTF…'}
                         </p>
                       )}
                     </div>
@@ -1021,8 +1023,8 @@ export default function PoolRoyaleLobby() {
             {(selectedTableModelUnavailable || selectedTableModelPending) && (
               <div className="rounded-xl border border-amber-300/40 bg-amber-500/10 p-3 text-xs text-amber-100">
                 {selectedTableModelPending
-                  ? 'Checking the local glTF table install before start…'
-                  : `${selectedTableModel.label} is not installed. Run ${selectedTableModel.installScript || 'npm run fetch:pool-royale-traditional-table'} so the authentic glTF table is available.`}
+                  ? 'This table can be selected now while we check the local glTF install.'
+                  : `${selectedTableModel.label} can be selected now. Run ${selectedTableModel.installScript || 'npm run fetch:pool-royale-traditional-table'} to install the authentic glTF package; the generated fallback remains available if it is missing.`}
               </div>
             )}
             {tableModelInstallError && (


### PR DESCRIPTION
### Motivation
- Players should be able to pick the authentic 8 ft Sketchfab glTF table from the Pool Royale lobby even if the local Sketchfab package is not yet installed. 
- The renderer already has a generated/native fallback, so the lobby should not block starting a match while local runtime-only glTF assets are pending. 

### Description
- Make runtime-only glTF table models selectable by forcing `selectedTableModelReady = true` and by changing start logic to show guidance instead of aborting when `selectedTableModelPending`/`selectedTableModelUnavailable` is detected. 
- Keep lobby table option buttons clickable (remove the `disabled` behavior) and update the option labels and warning text to indicate `Selectable · install for glTF` and provide install guidance while explaining the generated fallback will be used if the glTF is missing. 
- Add a regression test `Pool Royale lobby keeps runtime-only glTF table models selectable before install` in `test/poolRoyaleTableModels.test.js` asserting the lobby no longer disables missing runtime-only glTF table options. 

### Testing
- Ran the targeted unit tests with `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and the suite passed. 
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully (Vite chunk-size warnings unchanged). 
- Installed Playwright browsers and dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium` and performed a headless smoke check to capture a lobby screenshot which completed and produced `/tmp/pool-royale-lobby-table-select.png`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087db6a9488329a216a5602fcef876)