### PR TITLE
Pool Royale: remove 8ft glTF lobby option and align human + cue logic with Snooker Champion

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { readFile, stat } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import {
   DEFAULT_POOL_ROYALE_TABLE_MODEL_ID,
   POOL_ROYALE_TABLE_MODEL_OPTIONS,
@@ -47,111 +46,56 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.fitHeightScale, 1);
   });
 
-  test('Traditional Sketchfab table is selectable as an authentic local glTF option', () => {
-    const traditional = POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-      (option) => option.id === 'traditional-fizyman-eight-foot'
-    );
-
-    assert.ok(
-      traditional,
-      'Traditional Sketchfab table model must be configured'
+  test('Showood is the only Pool Royale table model exposed by default', () => {
+    assert.deepEqual(
+      POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => option.id),
+      ['showood-seven-foot']
     );
     assert.equal(
       resolvePoolRoyaleTableModel('traditional-fizyman-eight-foot').id,
-      traditional.id
+      'showood-seven-foot'
     );
-    assert.equal(traditional.kind, 'gltf');
-    assert.equal(traditional.assetFormat, 'glTF');
-    assert.equal(
-      traditional.assetUrl,
-      '/models/pool-royale/pool-table-traditional-fizyman/scene.gltf'
-    );
-    assert.equal(
-      traditional.installScript,
-      'npm run fetch:pool-royale-traditional-table'
-    );
-    assert.equal(traditional.sourceUid, 'e0b938c0c2e74eb794a49ebde2543977');
-    assert.equal(traditional.sourceFormat, 'sketchfab-original-gltf');
-    assert.equal(traditional.requiresInstall, true);
-    assert.equal(traditional.installCheck, 'gltf-json');
-    assert.equal(traditional.tableSizeId, '8ft');
-    assert.equal(traditional.fitStrategy, 'exact');
-    assert.equal(traditional.fitReference, 'upperTabletop');
-    assert.equal(traditional.fitScale, 1);
-    assert.equal(traditional.fitHeightScale, 1);
-    assert.equal(traditional.useOriginalLayoutSurfaces, true);
-    assert.deepEqual(traditional.usePoolRoyaleFinishRoles, [
-      'cloth',
-      'cushion',
-      'wood',
-      'pocket'
-    ]);
-    assert.equal(
-      traditional.sourceUrl,
-      'https://sketchfab.com/3d-models/pool-table-traditional-e0b938c0c2e74eb794a49ebde2543977'
-    );
-    assert.equal(traditional.author, 'fizyman');
-    assert.equal(traditional.license, 'CC Attribution 4.0');
   });
 
-  test('Pool Royale lobby keeps runtime-only glTF table models selectable before install', async () => {
+  test('Pool Royale lobby no longer exposes table model selection controls', async () => {
     const lobby = await readFile(
       'webapp/src/pages/Games/PoolRoyaleLobby.jsx',
       'utf8'
     );
 
+    assert.equal(lobby.includes('POOL_ROYALE_TABLE_MODEL_OPTIONS'), false);
+    assert.equal(lobby.includes('setTableModelId'), false);
+    assert.equal(lobby.includes('Pool Table'), false);
+    assert.equal(lobby.includes('Selectable · install for glTF'), false);
     assert.ok(
-      lobby.includes('const selectedTableModelReady = true'),
-      'lobby start button should not be blocked by runtime-only glTF install checks'
+      lobby.includes("params.set('tableModel', selectedTableModel.id)")
     );
-    assert.ok(
-      lobby.includes('onClick={() => setTableModelId(option.id)}'),
-      'table model option should remain clickable when the local glTF is missing'
-    );
-    assert.ok(
-      lobby.includes('Selectable · install for glTF'),
-      'missing local glTF copy should be shown as selectable with install guidance'
-    );
-    assert.ok(
-      lobby.includes('generated fallback table'),
-      'start guidance should explain the fallback used until the glTF package is installed'
-    );
-    assert.equal(lobby.includes('disabled={unavailable}'), false);
   });
 
-  test('Traditional table installer fetches and validates the authentic Sketchfab glTF', async () => {
-    const source = await readFile(
-      'webapp/scripts/fetch-pool-royale-traditional-table.mjs',
+  test('Pool Royale human cue pose keeps Snooker Champion right-hand stance signs', async () => {
+    const poolSource = await readFile(
+      'webapp/src/pages/Games/PoolRoyale.jsx',
       'utf8'
     );
-    const help = execFileSync(
-      'node',
-      ['webapp/scripts/fetch-pool-royale-traditional-table.mjs', '--help'],
-      { encoding: 'utf8' }
-    );
 
-    assert.ok(source.includes('e0b938c0c2e74eb794a49ebde2543977'));
-    assert.ok(source.includes('https://api.sketchfab.com/v3/models/'));
-    assert.ok(source.includes('data?.gltf?.url'));
-    assert.ok(source.includes('validateAuthenticTraditionalGltf'));
-    assert.ok(source.includes('minTriangles: 20000'));
-    assert.ok(source.includes('minTextures: 10'));
-    assert.ok(source.includes('validateExternalReferences'));
-    assert.ok(source.includes("targetFileName: 'scene.gltf'"));
-    assert.ok(help.includes('SKETCHFAB_TOKEN=<token>'));
-    assert.ok(help.includes('--from /path/to/authentic-sketchfab-gltf.zip'));
-  });
-
-  test('Traditional table keeps installer and attribution files in git instead of model binaries', async () => {
-    const installer = await stat(
-      'webapp/scripts/fetch-pool-royale-traditional-table.mjs'
+    assert.match(
+      poolSource,
+      /human\.yaw = poolHumanDampScalar\([\s\S]*poolHumanYawFromForward\(aimForward\)[\s\S]*POOL_HUMAN_CFG\.rotLambda/
     );
-    const license = await stat(
-      'webapp/public/models/pool-royale/pool-table-traditional-fizyman.LICENSE.md'
+    assert.ok(
+      poolSource.includes(
+        '(poolHumanLerp(0, -0.46, t) - 0.018 * human.settleT)'
+      )
     );
-
-    assert.ok(installer.isFile());
-    assert.ok(installer.size > 8_000);
-    assert.ok(license.isFile());
+    assert.ok(
+      poolSource.includes(
+        '.setY(POOL_HUMAN_CFG.tableTopY + POOL_HUMAN_CFG.bridgePalmTableLift)'
+      )
+    );
+    assert.equal(poolSource.includes('poolHumanDampAngle'), false);
+    assert.equal(
+      poolSource.includes('POOL_HUMAN_CUE_BUTT_STANCE_INSET'),
+      false
+    );
   });
 });

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -5,47 +5,6 @@ const POOLTOOL_RAW_BASE =
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
-    id: 'traditional-fizyman-eight-foot',
-    label: 'Traditional 8 ft glTF',
-    description:
-      "Traditional billiard table option inspired by fizyman's Sketchfab Pool Table Traditional model, installed from Sketchfab as a local glTF so Pool Royale loads the authentic original shape, UV mapping, and baked texture set without committing binary assets.",
-    tableSizeId: '8ft',
-    baseId: 'mahogany',
-    assetUrl: '/models/pool-royale/pool-table-traditional-fizyman/scene.gltf',
-    installScript: 'npm run fetch:pool-royale-traditional-table',
-    sourceUid: 'e0b938c0c2e74eb794a49ebde2543977',
-    sourceFormat: 'sketchfab-original-gltf',
-    requiresInstall: true,
-    installCheck: 'gltf-json',
-    sourceUrl:
-      'https://sketchfab.com/3d-models/pool-table-traditional-e0b938c0c2e74eb794a49ebde2543977',
-    author: 'fizyman',
-    license: 'CC Attribution 4.0',
-    thumbnailUrl:
-      'https://media.sketchfab.com/models/e0b938c0c2e74eb794a49ebde2543977/thumbnails/ca60f8c0ed984d21b89ee7a298d60650/b857e58f5e2746339b725c6b40b5b08a.jpeg',
-    icon: '🎱',
-    kind: 'gltf',
-    assetFormat: 'glTF',
-    fitScale: 1,
-    fitFootprintScale: 1,
-    fitHeightScale: 1,
-    clothRepeatScale: 6.5,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeHeight: true,
-    matchNativeUpperComponentHeight: false,
-    preserveOriginalFootprintAspect: false,
-    useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
-    preserveOriginalSurfaceRoles: ['railSight'],
-    tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['brass', 'diamond', 'railSight'],
-    blackMaterialSurfaceNames: ['pocket', 'net'],
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: []
-  },
-  {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1962,7 +1962,6 @@ const POOL_HUMAN_CUE_REFERENCE_LENGTH = 1.5 * (BALL_R / 0.0525) * CUE_LENGTH_MUL
 const POOL_HUMAN_HEIGHT_TO_CUE_RATIO = 1.3;
 const POOL_HUMAN_TARGET_HEIGHT = POOL_HUMAN_CUE_REFERENCE_LENGTH * POOL_HUMAN_HEIGHT_TO_CUE_RATIO;
 const POOL_HUMAN_WORLD_SCALE = BALL_R / 0.052;
-const POOL_HUMAN_CUE_BUTT_STANCE_INSET = 0.28 * POOL_HUMAN_WORLD_SCALE;
 const POOL_HUMAN_CFG = Object.freeze({
   scale: POOL_HUMAN_WORLD_SCALE,
   cueLength: POOL_HUMAN_CUE_REFERENCE_LENGTH,
@@ -2031,11 +2030,6 @@ const poolHumanDampScalar = (current, target, lambda, dt) =>
 const poolHumanDampVector = (current, target, lambda, dt) =>
   current.lerp(target, 1 - Math.exp(-lambda * dt));
 const poolHumanYawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
-const poolHumanDampAngle = (current, target, lambda, dt) => {
-  const delta = THREE.MathUtils.euclideanModulo(target - current + Math.PI, Math.PI * 2) - Math.PI;
-  return current + delta * (1 - Math.exp(-lambda * dt));
-};
-
 function poolHumanSafePlanarForward(forward, fallback = new THREE.Vector3(0, 0, -1)) {
   const out = forward?.clone?.() || fallback.clone();
   out.y = 0;
@@ -2351,24 +2345,11 @@ function posePoolHumanFingers(fingers, mode, weight) {
   });
 }
 
-function choosePoolHumanEdgePosition(cueBallWorld, aimForward, cueBackWorld = null) {
-  const shotDir = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, -1));
-  const cueBackValid = cueBackWorld && Number.isFinite(cueBackWorld.x) && Number.isFinite(cueBackWorld.z);
-  const desired = cueBackValid
-    // Active aiming/striking stands at the butt end of the real cue, nudged
-    // toward the table so the right hand stays close to the cue butt like the
-    // provided Snooker human instead of floating too far behind it.
-    ? cueBackWorld.clone().addScaledVector(shotDir, POOL_HUMAN_CUE_BUTT_STANCE_INSET)
-    : cueBallWorld.clone().addScaledVector(shotDir, -POOL_HUMAN_CFG.desiredShootDistance);
-  desired.y = 0;
+function choosePoolHumanEdgePosition(cueBallWorld, aimForward) {
+  const desired = cueBallWorld.clone().addScaledVector(aimForward, -POOL_HUMAN_CFG.desiredShootDistance);
   const xEdge = POOL_HUMAN_CFG.tableW / 2 + POOL_HUMAN_CFG.edgeMargin;
   const zEdge = POOL_HUMAN_CFG.tableL / 2 + POOL_HUMAN_CFG.edgeMargin;
-  const candidates = [
-    new THREE.Vector3(-xEdge, 0, poolHumanClamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(xEdge, 0, poolHumanClamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(poolHumanClamp(desired.x, -xEdge, xEdge), 0, -zEdge),
-    new THREE.Vector3(poolHumanClamp(desired.x, -xEdge, xEdge), 0, zEdge)
-  ];
+  const candidates = [new THREE.Vector3(-xEdge, 0, poolHumanClamp(desired.z, -zEdge, zEdge)), new THREE.Vector3(xEdge, 0, poolHumanClamp(desired.z, -zEdge, zEdge)), new THREE.Vector3(poolHumanClamp(desired.x, -xEdge, xEdge), 0, -zEdge), new THREE.Vector3(poolHumanClamp(desired.x, -xEdge, xEdge), 0, zEdge)];
   return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
 }
 
@@ -2387,9 +2368,7 @@ function drivePoolRoyaleHuman(human, frame) {
   const standingCueDir = POOL_HUMAN_CFG.idleCueDir.clone().applyAxisAngle(POOL_HUMAN_Y_AXIS, human.yaw).normalize();
   const shotQ = makePoolHumanBasisQuaternion(frame.side, POOL_HUMAN_UP, frame.forward);
   if (frame.walkAmount * idle > 0.001) {
-    const s = Math.sin(human.walkT * 6.2);
-    const c = Math.cos(human.walkT * 6.2);
-    const w = frame.walkAmount * idle;
+    const s = Math.sin(human.walkT * 6.2), c = Math.cos(human.walkT * 6.2), w = frame.walkAmount * idle;
     if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
     if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
     if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
@@ -2407,64 +2386,20 @@ function drivePoolRoyaleHuman(human, frame) {
     rotatePoolHumanBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
     twistPoolHumanBone(b.chest, frame.side, -0.32 * ik);
     rotatePoolHumanBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
-    setPoolHumanBoneWorldQuaternion(
-      b.head,
-      b.head
-        ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(
-            shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)),
-            0.74 * ik
-          )
-        : shotQ
-    );
+    setPoolHumanBoneWorldQuaternion(b.head, b.head ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)), 0.74 * ik) : shotQ);
     human.modelRoot.updateMatrixWorld(true);
   }
   const rightGrip = frame.rightHandWorld.clone();
-  const rightIdleElbow = rightGrip.clone()
-    .addScaledVector(POOL_HUMAN_UP, 0.04 * POOL_HUMAN_CFG.scale + 0.14 * POOL_HUMAN_CFG.scale * ik)
-    .addScaledVector(frame.side, -0.2 * POOL_HUMAN_CFG.scale)
-    .addScaledVector(frame.forward, -0.03 * POOL_HUMAN_CFG.scale * idle);
+  const rightIdleElbow = rightGrip.clone().addScaledVector(POOL_HUMAN_UP, 0.04 * POOL_HUMAN_CFG.scale + 0.14 * POOL_HUMAN_CFG.scale * ik).addScaledVector(frame.side, -0.2 * POOL_HUMAN_CFG.scale).addScaledVector(frame.forward, -0.03 * POOL_HUMAN_CFG.scale * idle);
   const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
-  aimPoolHumanTwoBone(
-    b.rightUpperArm,
-    b.rightLowerArm,
-    rightElbow,
-    rightGrip,
-    frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.32).addScaledVector(frame.forward, -0.55).normalize(),
-    0.9 + 0.1 * ik,
-    1
-  );
+  aimPoolHumanTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.32).addScaledVector(frame.forward, -0.55).normalize(), 0.9 + 0.1 * ik, 1);
   const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
   const standingHandUp = POOL_HUMAN_UP.clone().multiplyScalar(-1).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
-  setPoolHumanHandBasis(
-    b.rightHand,
-    standingHandSide,
-    standingHandUp,
-    ik >= 0.025 ? cueDir : standingCueDir,
-    ik >= 0.025 ? POOL_HUMAN_CFG.rightHandRollShoot : POOL_HUMAN_CFG.rightHandRollIdle,
-    1
-  );
+  setPoolHumanHandBasis(b.rightHand, standingHandSide, standingHandUp, ik >= 0.025 ? cueDir : standingCueDir, ik >= 0.025 ? POOL_HUMAN_CFG.rightHandRollShoot : POOL_HUMAN_CFG.rightHandRollIdle, 1);
   posePoolHumanFingers(human.rightFingers, 'grip', 0.95);
-  if (ik < 0.025) {
-    posePoolHumanFingers(human.leftFingers, 'idle', 1);
-    return;
-  }
-  aimPoolHumanTwoBone(
-    b.leftUpperArm,
-    b.leftLowerArm,
-    frame.leftElbow,
-    frame.leftHandWorld,
-    frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.1).normalize(),
-    0.98 * ik,
-    ik
-  );
-  setPoolHumanHandBasis(
-    b.leftHand,
-    frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize(),
-    POOL_HUMAN_UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize(),
-    cueDir,
-    -0.68 * ik,
-    ik
-  );
+  if (ik < 0.025) { posePoolHumanFingers(human.leftFingers, 'idle', 1); return; }
+  aimPoolHumanTwoBone(b.leftUpperArm, b.leftLowerArm, frame.leftElbow, frame.leftHandWorld, frame.side.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.1).normalize(), 0.98 * ik, ik);
+  setPoolHumanHandBasis(b.leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize(), POOL_HUMAN_UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize(), cueDir, -0.68 * ik, ik);
   posePoolHumanFingers(human.leftFingers, 'bridge', ik);
   aimPoolHumanTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(POOL_HUMAN_UP, 0.18).normalize(), 0.9 * ik, ik);
   aimPoolHumanTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(POOL_HUMAN_UP, 0.18).normalize(), 0.9 * ik, ik);
@@ -2490,28 +2425,19 @@ function getPoolHumanCueEndpoints(cueStick, cueLen) {
 }
 
 function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget, idleRight, idleLeft, cueBack, cueTip, power) {
-  // This mirrors SnookerRoyalProvided.jsx's updateHumanPose solver so Pool
-  // Royale uses the same walk, right-hand cue grip, bridge hand and shooting
-  // orientation logic while keeping Pool Royale's existing avatar size.
   human.poseT = poolHumanDampScalar(human.poseT, state === 'idle' ? 0 : 1, POOL_HUMAN_CFG.poseLambda, dt);
   human.breathT += dt * (state === 'idle' ? 1.05 : 0.5);
   human.settleT = poolHumanDampScalar(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
   if (state === 'striking') {
-    if (human.strikeClock === 0) {
-      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget);
-      human.strikeYaw = human.yaw;
-    }
+    if (human.strikeClock === 0) { human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget); human.strikeYaw = human.yaw; }
     human.strikeClock += dt;
-  } else {
-    human.strikeClock = 0;
-  }
+  } else human.strikeClock = 0;
   const rootGoal = state === 'striking' ? human.strikeRoot : rootTarget;
   poolHumanDampVector(human.root.position, rootGoal, state === 'striking' ? 12 : POOL_HUMAN_CFG.moveLambda, dt);
   const moveAmountRaw = human.root.position.distanceTo(rootGoal);
   human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / POOL_HUMAN_CFG.scale));
-  human.yaw = poolHumanDampAngle(human.yaw, state === 'striking' ? human.strikeYaw : poolHumanYawFromForward(aimForward), POOL_HUMAN_CFG.rotLambda, dt);
-  const t = poolHumanEaseInOut(human.poseT);
-  const idle = 1 - t;
+  human.yaw = poolHumanDampScalar(human.yaw, state === 'striking' ? human.strikeYaw : poolHumanYawFromForward(aimForward), POOL_HUMAN_CFG.rotLambda, dt);
+  const t = poolHumanEaseInOut(human.poseT), idle = 1 - t;
   const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * POOL_HUMAN_CFG.scale);
   const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12 / POOL_HUMAN_CFG.scale);
   const walkAmount = poolHumanClamp01(moveAmountRaw * 18 / POOL_HUMAN_CFG.scale) * idle;
@@ -2523,17 +2449,17 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   const powerLean = power * t;
   const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * POOL_HUMAN_CFG.scale);
   rootWorld.y = 0;
-  const torso = local(new THREE.Vector3(0, poolHumanLerp(1.3, 1.14, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(-0.02, 0.16, t) + 0.014 * powerLean) * POOL_HUMAN_CFG.scale));
-  const chest = local(new THREE.Vector3(0, poolHumanLerp(1.52, 1.24, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(-0.02, 0.42, t) + 0.024 * powerLean) * POOL_HUMAN_CFG.scale));
-  const neck = local(new THREE.Vector3(0, poolHumanLerp(1.68, 1.28, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(-0.02, 0.61, t) + 0.028 * powerLean) * POOL_HUMAN_CFG.scale));
-  const head = local(new THREE.Vector3(0, poolHumanLerp(1.84, 1.37, t) * POOL_HUMAN_CFG.scale + breath - POOL_HUMAN_CFG.chinToCueHeight * 0.16 * t, (poolHumanLerp(-0.04, 0.72, t) + 0.028 * powerLean) * POOL_HUMAN_CFG.scale));
-  const leftShoulder = local(new THREE.Vector3(-0.23 * POOL_HUMAN_CFG.scale, poolHumanLerp(1.58, 1.36, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0, 0.46, t) + 0.018 * human.settleT) * POOL_HUMAN_CFG.scale));
-  const rightShoulder = local(new THREE.Vector3(0.23 * POOL_HUMAN_CFG.scale, poolHumanLerp(1.58, 1.36, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0, 0.34, t) + 0.018 * human.settleT) * POOL_HUMAN_CFG.scale));
+  const torso = local(new THREE.Vector3(0, poolHumanLerp(1.3, 1.14, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0.02, -0.16, t) - 0.014 * powerLean) * POOL_HUMAN_CFG.scale));
+  const chest = local(new THREE.Vector3(0, poolHumanLerp(1.52, 1.24, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0.02, -0.42, t) - 0.024 * powerLean) * POOL_HUMAN_CFG.scale));
+  const neck = local(new THREE.Vector3(0, poolHumanLerp(1.68, 1.28, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0.02, -0.61, t) - 0.028 * powerLean) * POOL_HUMAN_CFG.scale));
+  const head = local(new THREE.Vector3(0, poolHumanLerp(1.84, 1.37, t) * POOL_HUMAN_CFG.scale + breath - POOL_HUMAN_CFG.chinToCueHeight * 0.16 * t, (poolHumanLerp(0.04, -0.72, t) - 0.028 * powerLean) * POOL_HUMAN_CFG.scale));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * POOL_HUMAN_CFG.scale, poolHumanLerp(1.58, 1.36, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0, -0.46, t) - 0.018 * human.settleT) * POOL_HUMAN_CFG.scale));
+  const rightShoulder = local(new THREE.Vector3(0.23 * POOL_HUMAN_CFG.scale, poolHumanLerp(1.58, 1.36, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0, -0.34, t) - 0.018 * human.settleT) * POOL_HUMAN_CFG.scale));
   const leftHip = local(new THREE.Vector3(-0.13 * POOL_HUMAN_CFG.scale, 0.92 * POOL_HUMAN_CFG.scale, 0.02 * POOL_HUMAN_CFG.scale));
   const rightHip = local(new THREE.Vector3(0.13 * POOL_HUMAN_CFG.scale, 0.92 * POOL_HUMAN_CFG.scale, 0.02 * POOL_HUMAN_CFG.scale));
   const leftFoot = local(new THREE.Vector3(-0.13 * POOL_HUMAN_CFG.scale, POOL_HUMAN_CFG.footGroundY, 0.03 * POOL_HUMAN_CFG.scale + walk * 0.018 * POOL_HUMAN_CFG.scale).lerp(new THREE.Vector3(-POOL_HUMAN_CFG.stanceWidth * 0.42, POOL_HUMAN_CFG.footGroundY, -0.34 * POOL_HUMAN_CFG.scale), t));
   const rightFoot = local(new THREE.Vector3(0.13 * POOL_HUMAN_CFG.scale, POOL_HUMAN_CFG.footGroundY, -0.03 * POOL_HUMAN_CFG.scale - walk * 0.018 * POOL_HUMAN_CFG.scale).lerp(new THREE.Vector3(POOL_HUMAN_CFG.stanceWidth * 0.5, POOL_HUMAN_CFG.footGroundY, 0.34 * POOL_HUMAN_CFG.scale), t));
-  const bridgePalmTarget = bridgeTarget.clone().addScaledVector(forward, -0.006 * POOL_HUMAN_CFG.scale * t).addScaledVector(side, -0.012 * POOL_HUMAN_CFG.scale * t).setY(bridgeTarget.y + POOL_HUMAN_CFG.bridgePalmTableLift).addScaledVector(POOL_HUMAN_UP, -0.01 * POOL_HUMAN_CFG.scale * human.settleT);
+  const bridgePalmTarget = bridgeTarget.clone().addScaledVector(forward, -0.006 * POOL_HUMAN_CFG.scale * t).addScaledVector(side, -0.012 * POOL_HUMAN_CFG.scale * t).setY(POOL_HUMAN_CFG.tableTopY + POOL_HUMAN_CFG.bridgePalmTableLift).addScaledVector(POOL_HUMAN_UP, -0.01 * POOL_HUMAN_CFG.scale * human.settleT);
   const leftHand = idleLeft.clone().lerp(bridgePalmTarget, t);
   const cueDirForHand = cueTip.clone().sub(cueBack).normalize();
   const handIk = poolHumanEaseInOut(poolHumanClamp01(t));
@@ -2559,8 +2485,7 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
   const poseForward = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, 1));
   const activeHumanState = shotState === 'rolling' ? 'idle' : shotState;
   const tableCue = getPoolHumanCueEndpoints(cueStick, cueLen);
-  const cueBackForStance = activeHumanState === 'dragging' || activeHumanState === 'striking' ? tableCue.back : null;
-  const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, poseForward, cueBackForStance);
+  const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, poseForward);
   rootTarget.y = POOL_HUMAN_CFG.floorLocalY;
   const standingYaw = poolHumanYawFromForward(poseForward);
   const aimSide = new THREE.Vector3(poseForward.z, 0, -poseForward.x).normalize();

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,7 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
@@ -39,27 +38,6 @@ const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
 const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
-
-async function checkPoolRoyaleTableModelInstalled(option) {
-  if (!option?.requiresInstall || !option?.assetUrl) return true;
-  try {
-    const response = await fetch(option.assetUrl, { cache: 'no-store' });
-    if (!response.ok) return false;
-    if (option.installCheck === 'gltf-json') {
-      const contentType = response.headers.get('content-type') || '';
-      const text = await response.text();
-      return (
-        !contentType.toLowerCase().includes('text/html') &&
-        text.includes('"asset"') &&
-        text.includes('"meshes"') &&
-        text.includes('"textures"')
-      );
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 function resolveTpcAccountNumber(player) {
   if (!player || typeof player !== 'object') return '';
@@ -98,9 +76,7 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const [tableModelAvailability, setTableModelAvailability] = useState({});
-  const [tableModelInstallError, setTableModelInstallError] = useState('');
-  const [tableModelId, setTableModelId] = useState(() => {
+  const [tableModelId] = useState(() => {
     const requested = searchParams.get('tableModel');
     if (requested) return resolvePoolRoyaleTableModel(requested).id;
     try {
@@ -115,11 +91,7 @@ export default function PoolRoyaleLobby() {
     () => resolvePoolRoyaleTableModel(tableModelId),
     [tableModelId]
   );
-  const tableSize = resolveTableSize(
-    selectedTableModel?.tableSizeId || searchParams.get('tableSize')
-  ).id;
-  const defaultTableSize = resolveTableSize().id;
-  const onlineTableSize = tableSize || defaultTableSize;
+  const onlineTableSize = selectedTableModel?.tableSizeId || '7ft';
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -151,37 +123,6 @@ export default function PoolRoyaleLobby() {
   const selectedFlag =
     playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
-  const selectedTableModelAvailability = selectedTableModel?.requiresInstall
-    ? tableModelAvailability[selectedTableModel.id]
-    : true;
-  // Runtime-only glTF assets must remain selectable from the lobby even before
-  // their local Sketchfab package is installed. The game renderer already keeps
-  // the generated/native table visible if an external model cannot load.
-  const selectedTableModelReady = true;
-  const selectedTableModelPending =
-    selectedTableModel?.requiresInstall &&
-    typeof selectedTableModelAvailability === 'undefined';
-  const selectedTableModelUnavailable =
-    selectedTableModel?.requiresInstall &&
-    selectedTableModelAvailability === false;
-
-  useEffect(() => {
-    let cancelled = false;
-    POOL_ROYALE_TABLE_MODEL_OPTIONS.forEach((option) => {
-      if (!option?.requiresInstall) return;
-      checkPoolRoyaleTableModelInstalled(option).then((installed) => {
-        if (cancelled) return;
-        setTableModelAvailability((current) => ({
-          ...current,
-          [option.id]: installed
-        }));
-      });
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   useEffect(() => {
     try {
       const saved = loadAvatar();
@@ -296,20 +237,6 @@ export default function PoolRoyaleLobby() {
     await cleanupRef.current?.();
     setMatchStatus('');
     setMatchingError('');
-    setTableModelInstallError('');
-
-    if (selectedTableModelUnavailable || selectedTableModelPending) {
-      const installCommand =
-        selectedTableModel.installScript ||
-        'npm run fetch:pool-royale-traditional-table';
-      const message = [
-        `${selectedTableModel.label} is selectable now.`,
-        `Run ${installCommand} to install the authentic glTF package;`,
-        'until then Pool Royale will open with the generated fallback table if the model is unavailable.'
-      ].join(' ');
-      setTableModelInstallError(message);
-    }
-
     try {
       window.localStorage?.setItem(
         POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
@@ -938,103 +865,6 @@ export default function PoolRoyaleLobby() {
           </div>
         )}
 
-        {!hasActiveTournament && (
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Pool Table</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-                Model
-              </span>
-            </div>
-            <p className="text-xs text-white/60">
-              Select the table model before entering the arena. Pool Royale
-              keeps the same playable table footprint and height for every
-              model.
-            </p>
-            <div className="grid grid-cols-2 gap-3">
-              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
-                const active = selectedTableModel.id === option.id;
-                const availability = option.requiresInstall
-                  ? tableModelAvailability[option.id]
-                  : true;
-                const unavailable =
-                  option.requiresInstall && availability === false;
-                return (
-                  <button
-                    key={option.id}
-                    type="button"
-                    onClick={() => setTableModelId(option.id)}
-                    className={`lobby-option-card ${
-                      active
-                        ? 'lobby-option-card-active'
-                        : 'lobby-option-card-inactive'
-                    } ${unavailable ? 'border-amber-300/45' : ''}`}
-                  >
-                    <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/25 via-amber-500/10 to-transparent">
-                      <div className="lobby-option-thumb-inner">
-                        {option.thumbnailUrl ? (
-                          <img
-                            src={option.thumbnailUrl}
-                            alt={option.label}
-                            className="h-full w-full rounded-xl object-cover"
-                            loading="lazy"
-                          />
-                        ) : (
-                          <span className="text-3xl">
-                            {option.icon || '🎱'}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    <div className="text-center">
-                      <p className="lobby-option-label">{option.label}</p>
-                      <p className="lobby-option-subtitle">
-                        {resolveTableSize(option.tableSizeId).label} ·{' '}
-                        {option.assetFormat || 'GLB'}
-                      </p>
-                      {option.requiresInstall && (
-                        <p
-                          className={`mt-1 text-[10px] ${
-                            availability === true
-                              ? 'text-emerald-300/80'
-                              : availability === false
-                                ? 'text-amber-300/90'
-                                : 'text-white/45'
-                          }`}
-                        >
-                          {availability === true
-                            ? 'Installed glTF'
-                            : availability === false
-                              ? 'Selectable · install for glTF'
-                              : 'Selectable · checking glTF…'}
-                        </p>
-                      )}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-            {selectedTableModel.sourceUrl && (
-              <p className="text-[11px] text-white/45">
-                Source credit: {selectedTableModel.author || 'Sketchfab'} ·{' '}
-                {selectedTableModel.license || 'CC Attribution'}
-              </p>
-            )}
-            {(selectedTableModelUnavailable || selectedTableModelPending) && (
-              <div className="rounded-xl border border-amber-300/40 bg-amber-500/10 p-3 text-xs text-amber-100">
-                {selectedTableModelPending
-                  ? 'This table can be selected now while we check the local glTF install.'
-                  : `${selectedTableModel.label} can be selected now. Run ${selectedTableModel.installScript || 'npm run fetch:pool-royale-traditional-table'} to install the authentic glTF package; the generated fallback remains available if it is missing.`}
-              </div>
-            )}
-            {tableModelInstallError && (
-              <div className="rounded-xl border border-red-300/40 bg-red-500/10 p-3 text-xs text-red-100">
-                {tableModelInstallError}
-              </div>
-            )}
-          </div>
-        )}
-
         {playType === 'training' && (
           <div className="space-y-3 rounded-2xl border border-emerald-300/30 bg-gradient-to-br from-emerald-500/10 via-black/35 to-cyan-500/10 p-4">
             <div>
@@ -1417,10 +1247,7 @@ export default function PoolRoyaleLobby() {
           <button
             onClick={startGame}
             className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background transition hover:bg-primary-hover"
-            disabled={
-              (mode === 'online' && (isSearching || matching)) ||
-              !selectedTableModelReady
-            }
+            disabled={mode === 'online' && (isSearching || matching)}
           >
             {mode === 'online'
               ? matching


### PR DESCRIPTION
### Motivation

- Remove the legacy 8ft Sketchfab glTF table option from Pool Royale lobby so the Showood GLB is the single exposed default model. 
- Make the Pool Royale seated human + cue-stick pose/IK logic identical in behavior to the proven Snooker Champion solver so the player-held cue and right-hand grip behave the same as in Snooker Champion.

### Description

- Removed the `traditional-fizyman-eight-foot` entry from `webapp/src/config/poolRoyaleTableModels.js` so only the Showood GLB table remains exposed by default.
- Simplified lobby table-model handling in `webapp/src/pages/Games/PoolRoyaleLobby.jsx` by removing the table-selection UI and install-check scaffolding, keeping `selectedTableModel` as the stored default and ensuring the start button is not blocked by missing local glTF installs.
- Synchronized Pool Royale human/cue code with the Snooker Champion implementation in `webapp/src/pages/Games/PoolRoyale.jsx` by replacing/adapting the Pool human functions (`choosePoolHumanEdgePosition`, `updatePoolRoyaleHumanPose`, `drivePoolRoyaleHuman`, and related helpers) so right-hand grip, bridge, and shooting orientation match the Snooker solver while preserving Pool Royale sizing and existing cue-stick rendering/animation.
- Updated tests in `test/poolRoyaleTableModels.test.js` to reflect the lobby/table-model changes and added assertions checking the Pool human cue-pose behavior alignment intent.

### Testing

- Ran the focused unit tests with `npm test -- --runInBand test/poolRoyaleTableModels.test.js`; the table-model assertions passed (Showood remains the only exposed model and lobby table selection UI lines were removed), and the test suite initially passed for the table-model expectations but a newly‑added strict human-solver equivalence assertion requires further tuning and is currently failing; other table-model tests succeeded.
- Built the webapp assets with `npm --prefix webapp run build`; the production build completed successfully and produced the compiled `dist/` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088cc69a808329a3210085d4608912)