### PR TITLE
Align Pool Royale human with Snooker Champion rig

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -84,6 +84,11 @@ import {
   POOL_ROYALE_OPTION_LABELS
 } from '../../config/poolRoyaleInventoryConfig.js';
 import { BILARDO_MIN_RELEASE_POWER } from './shared/bilardoShotModel';
+import {
+  createHumanPoolPlayer as createSnookerChampionHumanPlayer,
+  chooseHumanEdgePosition as chooseSnookerChampionHumanEdgePosition,
+  updateHumanPose as updateSnookerChampionHumanPose
+} from './shared/HumanPoolPlayer.js';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothPresets.js';
 import {
   getCachedPoolRoyalInventory,
@@ -2177,70 +2182,69 @@ async function loadPoolHumanModelFromCatalog(loader, urls = POOL_HUMAN_URLS) {
 }
 
 function createPoolRoyaleHumanRig(parent, renderer) {
-  const human = {
-    root: new THREE.Group(),
-    modelRoot: new THREE.Group(),
-    model: null,
-    bones: {},
-    leftFingers: [],
-    rightFingers: [],
-    restQuats: new Map(),
-    activeGlb: false,
-    poseT: 0,
-    walkT: 0,
-    yaw: 0,
-    breathT: 0,
-    settleT: 0,
-    strikeRoot: new THREE.Vector3(),
-    strikeYaw: 0,
-    strikeClock: 0,
-    idleCuePose: null
-  };
-  human.root.visible = false;
-  human.modelRoot.visible = false;
-  parent.add(human.root, human.modelRoot);
   const loader = createPoolHumanGLTFLoader(renderer);
-  loadPoolHumanModelFromCatalog(loader)
-    .then(({ model, url }) => {
-      human.modelUrl = url;
-      normalizePoolHumanModel(model);
-      model.traverse((obj) => {
-        if (!obj?.isMesh) return;
-        obj.castShadow = true;
-        obj.receiveShadow = true;
-        obj.frustumCulled = false;
-        const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
-        mats.forEach((mat) => {
-          if (mat?.map) {
-            applySRGBColorSpace(mat.map);
-            mat.map.flipY = false;
-            mat.map.needsUpdate = true;
-          }
-          if (mat) {
-            mat.depthWrite = true;
-            mat.depthTest = true;
-            mat.needsUpdate = true;
-          }
-        });
-      });
-      human.bones = buildPoolHumanBones(model);
-      human.leftFingers = collectPoolHumanFingerBones(human.bones.leftHand);
-      human.rightFingers = collectPoolHumanFingerBones(human.bones.rightHand);
-      [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((bone) => {
-        if (bone) human.restQuats.set(bone, bone.quaternion.clone());
-      });
-      human.activeGlb = Boolean(
-        human.bones.hips && human.bones.spine && human.bones.head &&
-        human.bones.rightUpperArm && human.bones.rightLowerArm && human.bones.rightHand &&
-        human.bones.leftUpperLeg && human.bones.leftLowerLeg && human.bones.leftFoot &&
-        human.bones.rightUpperLeg && human.bones.rightLowerLeg && human.bones.rightFoot
-      );
-      human.model = model;
-      human.modelRoot.add(model);
-      human.modelRoot.visible = human.activeGlb;
-    })
-    .catch((error) => console.warn('Pool Royale human rig failed', error))
-    .finally(() => disposePoolHumanGLTFLoader(loader));
+  const human = createSnookerChampionHumanPlayer(parent, {
+    loader,
+    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'],
+    onStatus: (status) => {
+      if (status && !String(status).includes('Loading')) {
+        disposePoolHumanGLTFLoader(loader);
+      }
+    },
+    // Pool Royale keeps only the existing avatar height/scale. Every movement,
+    // stance, right-hand cue grip, grounded feet, bridge hand, and shot pose is
+    // delegated to the Snooker Champion human solver for identical behavior.
+    originalSkeletonLogic: true,
+    scale: POOL_HUMAN_WORLD_SCALE,
+    unit: POOL_HUMAN_WORLD_SCALE,
+    humanScale: POOL_HUMAN_TARGET_HEIGHT,
+    humanVisualYawFix: Math.PI,
+    tableTopY: POOL_HUMAN_CFG.tableTopY,
+    groundY: POOL_HUMAN_CFG.floorLocalY,
+    floorLocalY: POOL_HUMAN_CFG.floorLocalY,
+    tableW: POOL_HUMAN_CFG.tableW,
+    tableL: POOL_HUMAN_CFG.tableL,
+    edgeMargin: POOL_HUMAN_CFG.edgeMargin,
+    desiredShootDistance: POOL_HUMAN_CFG.desiredShootDistance,
+    strikeTime: POOL_HUMAN_CFG.strikeTime,
+    holdTime: POOL_HUMAN_CFG.holdTime,
+    poseLambda: POOL_HUMAN_CFG.poseLambda,
+    moveLambda: POOL_HUMAN_CFG.moveLambda,
+    rotLambda: POOL_HUMAN_CFG.rotLambda,
+    stanceWidth: POOL_HUMAN_CFG.stanceWidth,
+    bridgePalmTableLift: POOL_HUMAN_CFG.bridgePalmTableLift,
+    bridgeCueLift: POOL_HUMAN_CFG.bridgeCueLift,
+    bridgeHandBackFromBall: POOL_HUMAN_CFG.bridgeHandBackFromBall,
+    bridgeHandSide: POOL_HUMAN_CFG.bridgeHandSide,
+    chinToCueHeight: POOL_HUMAN_CFG.chinToCueHeight,
+    footGroundY: POOL_HUMAN_CFG.footGroundY,
+    footLockStrength: POOL_HUMAN_CFG.footLockStrength,
+    kneeBendShot: POOL_HUMAN_CFG.kneeBendShot,
+    rightElbowShotRise: POOL_HUMAN_CFG.rightElbowShotRise,
+    rightElbowShotSide: POOL_HUMAN_CFG.rightElbowShotSide,
+    rightElbowShotBack: POOL_HUMAN_CFG.rightElbowShotBack,
+    rightForearmOutward: POOL_HUMAN_CFG.rightForearmOutward,
+    rightForearmBack: POOL_HUMAN_CFG.rightForearmBack,
+    rightForearmDown: POOL_HUMAN_CFG.rightForearmDown,
+    rightForearmLength: POOL_HUMAN_CFG.rightForearmLength,
+    rightStrokePull: POOL_HUMAN_CFG.rightStrokePull,
+    rightStrokePush: POOL_HUMAN_CFG.rightStrokePush,
+    rightHandShotLift: POOL_HUMAN_CFG.rightHandShotLift,
+    shootCueGripFromBack: POOL_HUMAN_CFG.shootCueGripFromBack,
+    idleRightHandY: POOL_HUMAN_CFG.idleRightHandY,
+    idleRightHandX: POOL_HUMAN_CFG.idleRightHandX,
+    idleRightHandZ: POOL_HUMAN_CFG.idleRightHandZ,
+    idleCueGripFromBack: POOL_HUMAN_CFG.idleCueGripFromBack,
+    idleCueDir: POOL_HUMAN_CFG.idleCueDir,
+    rightHandRollIdle: POOL_HUMAN_CFG.rightHandRollIdle,
+    rightHandRollShoot: POOL_HUMAN_CFG.rightHandRollShoot,
+    rightHandDownPose: POOL_HUMAN_CFG.rightHandDownPose,
+    rightHandCueSocketLocal: POOL_HUMAN_CFG.rightHandCueSocketLocal,
+    forceTableFacingAim: true,
+    plantFeetDuringShot: true,
+    showDebugArrows: false
+  });
+  human.idleCuePose = null;
   return human;
 }
 
@@ -2559,8 +2563,14 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
   const poseForward = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, 1));
   const activeHumanState = shotState === 'rolling' ? 'idle' : shotState;
   const tableCue = getPoolHumanCueEndpoints(cueStick, cueLen);
-  const cueBackForStance = activeHumanState === 'dragging' || activeHumanState === 'striking' ? tableCue.back : null;
-  const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, poseForward, cueBackForStance);
+  const rootTarget = chooseSnookerChampionHumanEdgePosition(cueBallWorld, poseForward, {
+    unit: POOL_HUMAN_CFG.scale,
+    groundY: POOL_HUMAN_CFG.floorLocalY,
+    tableW: POOL_HUMAN_CFG.tableW,
+    tableL: POOL_HUMAN_CFG.tableL,
+    edgeMargin: POOL_HUMAN_CFG.edgeMargin,
+    desiredShootDistance: POOL_HUMAN_CFG.desiredShootDistance
+  });
   rootTarget.y = POOL_HUMAN_CFG.floorLocalY;
   const standingYaw = poolHumanYawFromForward(poseForward);
   const aimSide = new THREE.Vector3(poseForward.z, 0, -poseForward.x).normalize();
@@ -2583,19 +2593,19 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
   const activeCueBack = activeHumanState === 'idle' ? idleCue.back : tableCue.back;
   const activeCueTip = activeHumanState === 'idle' ? idleCue.tip : tableCue.tip;
   human.idleCuePose = idleCue;
-  updatePoolRoyaleHumanPose(
-    human,
-    dt,
-    activeHumanState,
+  updateSnookerChampionHumanPose(human, dt, {
+    state: activeHumanState,
     rootTarget,
-    poseForward,
-    bridgeHandTarget,
-    idleRightHandTarget,
-    idleLeftHandTarget,
-    activeCueBack,
-    activeCueTip,
-    power
-  );
+    aimForward: poseForward,
+    bridgeTarget: bridgeHandTarget,
+    idleRight: idleRightHandTarget,
+    idleLeft: idleLeftHandTarget,
+    cueBack: activeCueBack,
+    cueTip: activeCueTip,
+    power,
+    tableCenter: new THREE.Vector3(0, POOL_HUMAN_CFG.tableTopY, 0),
+    directRootTarget: true
+  });
   return { idleCue, rootTarget, bridgeHandTarget };
 }
 

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -611,13 +611,17 @@ function collectFingerBones(hand) {
 }
 
 function normalizeHuman(model, cfg) {
-  model.scale.setScalar(cfg.humanScale);
+  model.scale.setScalar(1);
   model.rotation.set(0, cfg.humanVisualYawFix, 0);
   model.position.set(0, 0, 0);
   model.updateMatrixWorld(true);
   const box = new THREE.Box3().setFromObject(model);
-  const center = box.getCenter(new THREE.Vector3());
-  model.position.set(-center.x, -box.min.y, -center.z);
+  const height = Math.max(box.max.y - box.min.y, 0.0001);
+  model.scale.multiplyScalar(cfg.humanScale / height);
+  model.updateMatrixWorld(true);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.set(-center.x, -scaledBox.min.y, -center.z);
 }
 
 export function createHumanRig(scene, opts = {}) {
@@ -1094,7 +1098,8 @@ function updateOriginalSkeletonHumanPose(human, dt, frameData) {
   const rootToTableForward = resolveRootToTableForward(human.root.position, frameData) ||
     frameData.aimForward.clone().setY(0).normalize();
   const shootingPoseActive = activeState === 'dragging' || activeState === 'striking';
-  const targetYaw = yawFromForward(shootingPoseActive ? rootToTableForward : frameData.aimForward);
+  const targetForward = cfg.forceTableFacingAim ? rootToTableForward : shootingPoseActive ? rootToTableForward : frameData.aimForward;
+  const targetYaw = yawFromForward(targetForward);
   human.yaw = shootingPoseActive
     ? targetYaw
     : dampAngle(human.yaw, targetYaw, cfg.rotLambda, dt);


### PR DESCRIPTION
### Motivation
- Make the Pool Royale player avatar use the exact same human/pose logic as the Snooker Champion implementation so stance, cue grip, bridge hand, shooting pose and body orientation are identical. 
- Preserve Pool Royale-specific runtime height/scale and table offsets while delegating all pose/IK/animation math to the proven shared solver.

### Description
- Replaced Pool Royale's custom rig creation with the shared Snooker human API by importing `createHumanPoolPlayer`, `chooseHumanEdgePosition` and `updateHumanPose` (aliased as `createSnookerChampionHumanPlayer`, `chooseSnookerChampionHumanEdgePosition`, `updateSnookerChampionHumanPose`) and instantiating the Snooker solver from `PoolRoyale.jsx` using Pool Royale sizing options and flags. 
- Routed Pool Royale frame updates to the shared solver by calling `updateSnookerChampionHumanPose(human, dt, {...})` and switched Pool Royale edge/stance selection to call the shared `chooseHumanEdgePosition` wrapper with Pool Royale table/scale parameters. 
- Adjusted the shared human rig loader (`humanRigCore.js`) `normalizeHuman` to scale loaded models to the requested `cfg.humanScale` (compute height then scale) so a different model can be reused while matching Pool Royale target height. 
- Tweaked original-skeleton yaw logic to prefer a table-facing forward when `cfg.forceTableFacingAim` is set so the avatar consistently faces the table during aiming/stance frames.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Ran `git diff --check` to ensure no whitespace/patch issues and it passed without reported errors. 
- Started the dev server (`npm --prefix webapp run dev`) and attempted an automated Playwright capture of `/games/poolroyale?mode=training&type=practice`; Playwright browser and OS deps were installed, but the headless WebGL screenshot timed out in the CI-like environment (Playwright launched but the page screenshot timed out), so visual confirmation in this headless run did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0899767c5c8329afcfea6917bb86b0)