### PR TITLE
Align Pool Royale human stance with Snooker human solver

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1962,7 +1962,6 @@ const POOL_HUMAN_CUE_REFERENCE_LENGTH = 1.5 * (BALL_R / 0.0525) * CUE_LENGTH_MUL
 const POOL_HUMAN_HEIGHT_TO_CUE_RATIO = 1.3;
 const POOL_HUMAN_TARGET_HEIGHT = POOL_HUMAN_CUE_REFERENCE_LENGTH * POOL_HUMAN_HEIGHT_TO_CUE_RATIO;
 const POOL_HUMAN_WORLD_SCALE = BALL_R / 0.052;
-const POOL_HUMAN_CUE_BUTT_STANCE_INSET = 0.28 * POOL_HUMAN_WORLD_SCALE;
 const POOL_HUMAN_CFG = Object.freeze({
   scale: POOL_HUMAN_WORLD_SCALE,
   cueLength: POOL_HUMAN_CUE_REFERENCE_LENGTH,
@@ -1994,7 +1993,7 @@ const POOL_HUMAN_CFG = Object.freeze({
   upperBodyCueBallLean: 0.18 * POOL_HUMAN_WORLD_SCALE,
   chestCueBallLean: 0.24 * POOL_HUMAN_WORLD_SCALE,
   headCueBallLean: 0.28 * POOL_HUMAN_WORLD_SCALE,
-  footGroundY: 0,
+  footGroundY: 0.035 * POOL_HUMAN_WORLD_SCALE,
   footLockStrength: 1.0,
   kneeBendShot: 0.16 * POOL_HUMAN_WORLD_SCALE,
   rightElbowShotRise: 0.18 * POOL_HUMAN_WORLD_SCALE,
@@ -2031,11 +2030,6 @@ const poolHumanDampScalar = (current, target, lambda, dt) =>
 const poolHumanDampVector = (current, target, lambda, dt) =>
   current.lerp(target, 1 - Math.exp(-lambda * dt));
 const poolHumanYawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
-const poolHumanDampAngle = (current, target, lambda, dt) => {
-  const delta = THREE.MathUtils.euclideanModulo(target - current + Math.PI, Math.PI * 2) - Math.PI;
-  return current + delta * (1 - Math.exp(-lambda * dt));
-};
-
 function poolHumanSafePlanarForward(forward, fallback = new THREE.Vector3(0, 0, -1)) {
   const out = forward?.clone?.() || fallback.clone();
   out.y = 0;
@@ -2351,15 +2345,12 @@ function posePoolHumanFingers(fingers, mode, weight) {
   });
 }
 
-function choosePoolHumanEdgePosition(cueBallWorld, aimForward, cueBackWorld = null) {
+function choosePoolHumanEdgePosition(cueBallWorld, aimForward) {
+  // Keep Pool Royale on the same Snooker Champion stance solver: the body is
+  // positioned behind the cue ball from the shot direction and clamped to the
+  // nearest table edge. Pool-specific height/grounding is applied later.
   const shotDir = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, -1));
-  const cueBackValid = cueBackWorld && Number.isFinite(cueBackWorld.x) && Number.isFinite(cueBackWorld.z);
-  const desired = cueBackValid
-    // Active aiming/striking stands at the butt end of the real cue, nudged
-    // toward the table so the right hand stays close to the cue butt like the
-    // provided Snooker human instead of floating too far behind it.
-    ? cueBackWorld.clone().addScaledVector(shotDir, POOL_HUMAN_CUE_BUTT_STANCE_INSET)
-    : cueBallWorld.clone().addScaledVector(shotDir, -POOL_HUMAN_CFG.desiredShootDistance);
+  const desired = cueBallWorld.clone().addScaledVector(shotDir, -POOL_HUMAN_CFG.desiredShootDistance);
   desired.y = 0;
   const xEdge = POOL_HUMAN_CFG.tableW / 2 + POOL_HUMAN_CFG.edgeMargin;
   const zEdge = POOL_HUMAN_CFG.tableL / 2 + POOL_HUMAN_CFG.edgeMargin;
@@ -2509,7 +2500,7 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   poolHumanDampVector(human.root.position, rootGoal, state === 'striking' ? 12 : POOL_HUMAN_CFG.moveLambda, dt);
   const moveAmountRaw = human.root.position.distanceTo(rootGoal);
   human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / POOL_HUMAN_CFG.scale));
-  human.yaw = poolHumanDampAngle(human.yaw, state === 'striking' ? human.strikeYaw : poolHumanYawFromForward(aimForward), POOL_HUMAN_CFG.rotLambda, dt);
+  human.yaw = poolHumanDampScalar(human.yaw, state === 'striking' ? human.strikeYaw : poolHumanYawFromForward(aimForward), POOL_HUMAN_CFG.rotLambda, dt);
   const t = poolHumanEaseInOut(human.poseT);
   const idle = 1 - t;
   const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * POOL_HUMAN_CFG.scale);
@@ -2522,7 +2513,7 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   const local = (v) => v.clone().applyAxisAngle(POOL_HUMAN_Y_AXIS, human.yaw).add(human.root.position);
   const powerLean = power * t;
   const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * POOL_HUMAN_CFG.scale);
-  rootWorld.y = 0;
+  rootWorld.y = POOL_HUMAN_CFG.floorLocalY;
   const torso = local(new THREE.Vector3(0, poolHumanLerp(1.3, 1.14, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0.02, -0.16, t) - 0.014 * powerLean) * POOL_HUMAN_CFG.scale));
   const chest = local(new THREE.Vector3(0, poolHumanLerp(1.52, 1.24, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0.02, -0.42, t) - 0.024 * powerLean) * POOL_HUMAN_CFG.scale));
   const neck = local(new THREE.Vector3(0, poolHumanLerp(1.68, 1.28, t) * POOL_HUMAN_CFG.scale + breath, (poolHumanLerp(0.02, -0.61, t) - 0.028 * powerLean) * POOL_HUMAN_CFG.scale));
@@ -2559,8 +2550,7 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
   const poseForward = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, 1));
   const activeHumanState = shotState === 'rolling' ? 'idle' : shotState;
   const tableCue = getPoolHumanCueEndpoints(cueStick, cueLen);
-  const cueBackForStance = activeHumanState === 'dragging' || activeHumanState === 'striking' ? tableCue.back : null;
-  const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, poseForward, cueBackForStance);
+  const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, poseForward);
   rootTarget.y = POOL_HUMAN_CFG.floorLocalY;
   const standingYaw = poolHumanYawFromForward(poseForward);
   const aimSide = new THREE.Vector3(poseForward.z, 0, -poseForward.x).normalize();


### PR DESCRIPTION
### Motivation
- Make the Pool Royale human character use the same robust stance/aiming solver and visual pose behavior as the Snooker implementation while preserving Pool Royale's avatar scale and height.
- Ensure the human is grounded and facing the table consistently during aiming/striking so the cue grip/bridge and shooting orientation match the Snooker behavior.
- Remove a Pool-specific cue-butt stance override that caused inconsistent placement behind the cue and simplify the stance selection to the shared edge-clamped solver.

### Description
- Reworked the Pool human edge placement by replacing the cue-back-based stance with the Snooker-style behind-cue-ball, edge-clamped solver via `choosePoolHumanEdgePosition` and moved Pool-specific height grounding into `POOL_HUMAN_CFG` (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Grounding and yaw behavior now mirror Snooker: `rootWorld.y` is set to `POOL_HUMAN_CFG.floorLocalY` and yaw damping uses the existing `poolHumanDampScalar` pathway instead of the removed `poolHumanDampAngle` helper to match Snooker visual stability.
- Removed `POOL_HUMAN_CUE_BUTT_STANCE_INSET` usage and adjusted human config values such as `footGroundY` so Pool Royale retains its size/scale while adopting Snooker pose math; updated human frame/update flow to call the shared solver without passing `cueBack` overrides.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production build artifacts.
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed but reported the file is ignored by the repo's ESLint ignore settings (warning only).
- Attempted an automated Playwright screenshot test of `/games/poolroyale` after installing Playwright browsers and system deps, but the headless WebGL page screenshot timed out/failed in the CI/headless environment despite browser and dependencies being installed (investigation/logs included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0899767c5c8329afcfea6917bb86b0)