### PR TITLE
Align Pool Royale human with Snooker Champion human rig and pose solver

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -122,6 +122,11 @@ import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
+import {
+  createHumanRig as createSnookerChampionHumanRig,
+  chooseHumanEdgePosition as chooseSnookerChampionHumanEdgePosition,
+  updateHumanPose as updateSnookerChampionHumanPose
+} from './shared/humanRigCore.js';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
@@ -2171,72 +2176,85 @@ async function loadPoolHumanModelFromCatalog(loader, urls = POOL_HUMAN_URLS) {
 }
 
 function createPoolRoyaleHumanRig(parent, renderer) {
-  const human = {
-    root: new THREE.Group(),
-    modelRoot: new THREE.Group(),
-    model: null,
-    bones: {},
-    leftFingers: [],
-    rightFingers: [],
-    restQuats: new Map(),
-    activeGlb: false,
-    poseT: 0,
-    walkT: 0,
-    yaw: 0,
-    breathT: 0,
-    settleT: 0,
-    strikeRoot: new THREE.Vector3(),
-    strikeYaw: 0,
-    strikeClock: 0,
-    idleCuePose: null
-  };
-  human.root.visible = false;
-  human.modelRoot.visible = false;
-  parent.add(human.root, human.modelRoot);
   const loader = createPoolHumanGLTFLoader(renderer);
-  loadPoolHumanModelFromCatalog(loader)
-    .then(({ model, url }) => {
-      human.modelUrl = url;
-      normalizePoolHumanModel(model);
-      model.traverse((obj) => {
-        if (!obj?.isMesh) return;
-        obj.castShadow = true;
-        obj.receiveShadow = true;
-        obj.frustumCulled = false;
-        const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
-        mats.forEach((mat) => {
-          if (mat?.map) {
-            applySRGBColorSpace(mat.map);
-            mat.map.flipY = false;
-            mat.map.needsUpdate = true;
-          }
-          if (mat) {
-            mat.depthWrite = true;
-            mat.depthTest = true;
-            mat.needsUpdate = true;
-          }
-        });
-      });
-      human.bones = buildPoolHumanBones(model);
-      human.leftFingers = collectPoolHumanFingerBones(human.bones.leftHand);
-      human.rightFingers = collectPoolHumanFingerBones(human.bones.rightHand);
-      [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((bone) => {
-        if (bone) human.restQuats.set(bone, bone.quaternion.clone());
-      });
-      human.activeGlb = Boolean(
-        human.bones.hips && human.bones.spine && human.bones.head &&
-        human.bones.rightUpperArm && human.bones.rightLowerArm && human.bones.rightHand &&
-        human.bones.leftUpperLeg && human.bones.leftLowerLeg && human.bones.leftFoot &&
-        human.bones.rightUpperLeg && human.bones.rightLowerLeg && human.bones.rightFoot
-      );
-      human.model = model;
-      human.modelRoot.add(model);
-      human.modelRoot.visible = human.activeGlb;
-    })
-    .catch((error) => console.warn('Pool Royale human rig failed', error))
-    .finally(() => disposePoolHumanGLTFLoader(loader));
+  let loaderDisposed = false;
+  const disposeLoader = () => {
+    if (loaderDisposed) return;
+    loaderDisposed = true;
+    disposePoolHumanGLTFLoader(loader);
+  };
+  const human = createSnookerChampionHumanRig(parent, {
+    loader,
+    modelUrls: POOL_HUMAN_URLS,
+    unit: POOL_HUMAN_CFG.scale,
+    targetHeight: POOL_HUMAN_CFG.targetHeight,
+    humanScale: POOL_HUMAN_CFG.targetHeight,
+    humanVisualYawFix: POOL_HUMAN_CFG.humanVisualYawFix,
+    tableTopY: POOL_HUMAN_CFG.tableTopY,
+    groundY: POOL_HUMAN_CFG.floorLocalY,
+    tableW: POOL_HUMAN_CFG.tableW,
+    tableL: POOL_HUMAN_CFG.tableL,
+    edgeMargin: POOL_HUMAN_CFG.edgeMargin,
+    desiredShootDistance: POOL_HUMAN_CFG.desiredShootDistance,
+    poseLambda: POOL_HUMAN_CFG.poseLambda,
+    moveLambda: POOL_HUMAN_CFG.moveLambda,
+    rotLambda: POOL_HUMAN_CFG.rotLambda,
+    stanceWidth: POOL_HUMAN_CFG.stanceWidth,
+    bridgePalmTableLift: POOL_HUMAN_CFG.bridgePalmTableLift,
+    bridgeCueLift: POOL_HUMAN_CFG.bridgeCueLift,
+    bridgeHandBackFromBall: POOL_HUMAN_CFG.bridgeHandBackFromBall,
+    bridgeHandSide: POOL_HUMAN_CFG.bridgeHandSide,
+    chinToCueHeight: POOL_HUMAN_CFG.chinToCueHeight,
+    footGroundY: POOL_HUMAN_CFG.footGroundY,
+    footLockStrength: POOL_HUMAN_CFG.footLockStrength,
+    kneeBendShot: POOL_HUMAN_CFG.kneeBendShot,
+    rightElbowShotRise: POOL_HUMAN_CFG.rightElbowShotRise,
+    rightElbowShotSide: POOL_HUMAN_CFG.rightElbowShotSide,
+    rightElbowShotBack: POOL_HUMAN_CFG.rightElbowShotBack,
+    rightForearmOutward: POOL_HUMAN_CFG.rightForearmOutward,
+    rightForearmBack: POOL_HUMAN_CFG.rightForearmBack,
+    rightForearmDown: POOL_HUMAN_CFG.rightForearmDown,
+    rightForearmLength: POOL_HUMAN_CFG.rightForearmLength,
+    rightStrokePull: POOL_HUMAN_CFG.rightStrokePull,
+    rightStrokePush: POOL_HUMAN_CFG.rightStrokePush,
+    rightHandShotLift: POOL_HUMAN_CFG.rightHandShotLift,
+    shootCueGripFromBack: POOL_HUMAN_CFG.shootCueGripFromBack,
+    idleRightHandY: POOL_HUMAN_CFG.idleRightHandY,
+    idleRightHandX: POOL_HUMAN_CFG.idleRightHandX,
+    idleRightHandZ: POOL_HUMAN_CFG.idleRightHandZ,
+    idleCueGripFromBack: POOL_HUMAN_CFG.idleCueGripFromBack,
+    idleCueDir: POOL_HUMAN_CFG.idleCueDir,
+    rightHandRollIdle: POOL_HUMAN_CFG.rightHandRollIdle,
+    rightHandRollShoot: POOL_HUMAN_CFG.rightHandRollShoot,
+    rightHandDownPose: POOL_HUMAN_CFG.rightHandDownPose,
+    rightHandCueSocketLocal: POOL_HUMAN_CFG.rightHandCueSocketLocal,
+    strikeTime: POOL_HUMAN_CFG.strikeTime,
+    holdTime: POOL_HUMAN_CFG.holdTime,
+    originalSkeletonLogic: true,
+    forceTableFacingAim: true,
+    showDebugArrows: false,
+    addFaceDetails: false,
+    onStatus: (message) => {
+      if (message?.includes?.('failed')) {
+        console.warn('Pool Royale human rig status:', message);
+        disposeLoader();
+      }
+    }
+  });
+  human.idleCuePose = null;
+  const disposeDeadline = Date.now() + 20000;
+  const disposeWhenLoaded = () => {
+    if (loaderDisposed) return;
+    if (human.model || human.activeGlb || Date.now() > disposeDeadline) {
+      disposeLoader();
+      return;
+    }
+    window.setTimeout(disposeWhenLoaded, 250);
+  };
+  if (typeof window !== 'undefined') window.setTimeout(disposeWhenLoaded, 250);
   return human;
 }
+
 
 function setPoolHumanBoneWorldQuaternion(bone, q) {
   if (!bone || !q) return;
@@ -2550,7 +2568,14 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
   const poseForward = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, 1));
   const activeHumanState = shotState === 'rolling' ? 'idle' : shotState;
   const tableCue = getPoolHumanCueEndpoints(cueStick, cueLen);
-  const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, poseForward);
+  const rootTarget = chooseSnookerChampionHumanEdgePosition(cueBallWorld, poseForward, {
+    unit: POOL_HUMAN_CFG.scale,
+    groundY: POOL_HUMAN_CFG.floorLocalY,
+    tableW: POOL_HUMAN_CFG.tableW,
+    tableL: POOL_HUMAN_CFG.tableL,
+    edgeMargin: POOL_HUMAN_CFG.edgeMargin,
+    desiredShootDistance: POOL_HUMAN_CFG.desiredShootDistance
+  });
   rootTarget.y = POOL_HUMAN_CFG.floorLocalY;
   const standingYaw = poolHumanYawFromForward(poseForward);
   const aimSide = new THREE.Vector3(poseForward.z, 0, -poseForward.x).normalize();
@@ -2573,21 +2598,21 @@ function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForwa
   const activeCueBack = activeHumanState === 'idle' ? idleCue.back : tableCue.back;
   const activeCueTip = activeHumanState === 'idle' ? idleCue.tip : tableCue.tip;
   human.idleCuePose = idleCue;
-  updatePoolRoyaleHumanPose(
-    human,
-    dt,
-    activeHumanState,
+  updateSnookerChampionHumanPose(human, dt, {
+    state: activeHumanState,
     rootTarget,
-    poseForward,
-    bridgeHandTarget,
-    idleRightHandTarget,
-    idleLeftHandTarget,
-    activeCueBack,
-    activeCueTip,
-    power
-  );
+    aimForward: poseForward,
+    bridgeTarget: bridgeHandTarget,
+    idleRight: idleRightHandTarget,
+    idleLeft: idleLeftHandTarget,
+    cueBack: activeCueBack,
+    cueTip: activeCueTip,
+    power,
+    tableCenter: new THREE.Vector3(0, POOL_HUMAN_CFG.tableTopY, 0)
+  });
   return { idleCue, rootTarget, bridgeHandTarget };
 }
+
 
 function movePoolRoyaleCueToHumanHand(human, cueStick) {
   const pose = human?.idleCuePose;

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -611,11 +611,20 @@ function collectFingerBones(hand) {
 }
 
 function normalizeHuman(model, cfg) {
-  model.scale.setScalar(cfg.humanScale);
+  model.scale.setScalar(1);
   model.rotation.set(0, cfg.humanVisualYawFix, 0);
   model.position.set(0, 0, 0);
   model.updateMatrixWorld(true);
-  const box = new THREE.Box3().setFromObject(model);
+  let box = new THREE.Box3().setFromObject(model);
+  const targetHeight = Number(cfg.targetHeight);
+  if (Number.isFinite(targetHeight) && targetHeight > 0) {
+    const unscaledHeight = Math.max(box.getSize(new THREE.Vector3()).y, 1e-4);
+    model.scale.setScalar(targetHeight / unscaledHeight);
+  } else {
+    model.scale.setScalar(cfg.humanScale);
+  }
+  model.updateMatrixWorld(true);
+  box = new THREE.Box3().setFromObject(model);
   const center = box.getCenter(new THREE.Vector3());
   model.position.set(-center.x, -box.min.y, -center.z);
 }


### PR DESCRIPTION
### Motivation
- Unify the Pool Royale human-avatar behaviour with the proven Snooker Champion human rig so the Pool human uses the same stance, cue grip, bridge and shooting pose logic. 
- Preserve Pool Royale’s current visual height/scale and table grounding while delegating pose math to the shared solver to ensure identical shooting/standing orientation and animation fidelity.

### Description
- Replaced Pool Royale’s bespoke human rig creation with the shared entrypoint by importing `createHumanRig`, `chooseHumanEdgePosition`, and `updateHumanPose` from `shared/humanRigCore.js` and wiring them into Pool Royale (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Updated `createPoolRoyaleHumanRig` to call the shared rig creator with Pool-specific configuration (scales, table dims, cue/socket params, timing) and added safe loader-dispose/deadline logic to free GLTF loaders once a model is loaded or after timeout. 
- Routed Pool Royale frame updates to the shared solver by calling the shared `updateHumanPose` (aliased for clarity) from `updatePoolRoyaleHumanFrame` so the avatar faces the table, stays grounded, holds the cue in the right hand and reproduces Snooker Champion shooting/standing poses.
- Extended `normalizeHuman` in `webapp/src/pages/Games/shared/humanRigCore.js` to accept a `targetHeight` override (falling back to `humanScale`) so Pool Royale can retain its previous avatar height while using the shared skeleton logic.

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully (Vite production build). 
- Ran unit tests `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js`, and the test suite passed (4 tests, all green).
- Attempted an automated Playwright screenshot run to visually verify the human pose, but Chromium failed to launch in the container due to a missing system library (`libatk-1.0.so.0`); this prevented the screenshot step (library issue, not runtime code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a8b736e8832999b700dc7eb4dac3)