### PR TITLE
Snooker: use original GLB physical mapping, align shot physics with Pool Royale, and auto-play replays on pot/foul

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -6,7 +6,10 @@ import {
   usesProceduralSnookerTableRailDecor,
   TABLE_MODEL_CLASSIC,
   TABLE_MODEL_OPENSOURCE,
-  TABLE_MODEL_OPENSOURCE_GLB_URL
+  TABLE_MODEL_OPENSOURCE_GLB_URL,
+  SNOOKER_GLB_PHYSICAL_TABLE_MAP,
+  resolveSnookerPhysicalPocketMap,
+  resolveSnookerPhysicalTableMap
 } from '../webapp/src/pages/Games/snookerTableModel.js';
 
 describe('snooker table model selection', () => {
@@ -44,6 +47,35 @@ describe('snooker table model selection', () => {
       { x: 12, y: 1, z: 20 }
     );
     assert.deepEqual(transform.scale, { x: 6, y: 1, z: 4 });
+  });
+
+  test('resolves the original GLB physical snooker playfield map exactly', () => {
+    const map = resolveSnookerPhysicalTableMap(10);
+    assert.equal(map.tableW, SNOOKER_GLB_PHYSICAL_TABLE_MAP.playfieldWidthM * 10);
+    assert.equal(map.tableL, SNOOKER_GLB_PHYSICAL_TABLE_MAP.playfieldLengthM * 10);
+    assert.equal(map.ballR, (SNOOKER_GLB_PHYSICAL_TABLE_MAP.ballDiameterM * 10) / 2);
+    assert.equal(map.visualPlayfieldFitMultiplier, 1);
+  });
+
+  test('resolves all six pockets from the physical GLB cushion-nose map', () => {
+    const map = resolveSnookerPhysicalTableMap(10);
+    const pockets = resolveSnookerPhysicalPocketMap(
+      map.tableW,
+      map.tableL,
+      map.cornerJawSetback,
+      map.middleJawSetback,
+      map.cornerPocketRadius,
+      map.middlePocketRadius
+    );
+    assert.equal(pockets.length, 6);
+    assert.deepEqual(
+      pockets.map((pocket) => pocket.kind),
+      ['corner', 'corner', 'corner', 'corner', 'middle', 'middle']
+    );
+    assert.equal(pockets[0].x, -map.tableW / 2 + map.cornerJawSetback);
+    assert.equal(pockets[0].z, -map.tableL / 2 + map.cornerJawSetback);
+    assert.equal(pockets[5].x, map.tableW / 2 - map.middleJawSetback);
+    assert.equal(pockets[5].z, 0);
   });
 
   test('uses procedural rail decor only for the classic table model', () => {

--- a/webapp/src/pages/Games/SnookerRoyalProvided.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalProvided.jsx
@@ -23,7 +23,9 @@ import { getBallMaterial as getBilliardBallMaterial } from '../../utils/ballMate
 import { mapSpinForPhysics, normalizeSpinInput } from './poolRoyaleSpinUtils.js';
 import {
   TABLE_MODEL_OPENSOURCE_GLB_URL,
-  resolveSnookerGlbFitTransform
+  resolveSnookerGlbFitTransform,
+  resolveSnookerPhysicalPocketMap,
+  resolveSnookerPhysicalTableMap
 } from './snookerTableModel.js';
 
 const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
@@ -96,28 +98,27 @@ const SNOOKER_BALL_MATERIAL_VARIANT = 'pool';
 const BALL_VISUAL_LIFT = 0.015;
 const SNOOKER_TABLE_MARKING_LIFT = 0.012 * WORLD_SCALE;
 const SNOOKER_TABLE_MARKING_RADIUS = 0.0065 * WORLD_SCALE;
-const OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M = 1.778;
-const OFFICIAL_SNOOKER_PLAYFIELD_LENGTH_M = 3.569;
-const OFFICIAL_SNOOKER_BALL_DIAMETER_M = 0.0525;
-const OFFICIAL_SNOOKER_BAULK_LINE_FROM_CUSHION_M = 0.737;
-const OFFICIAL_SNOOKER_D_RADIUS_M = 0.292;
-const OFFICIAL_SNOOKER_BLACK_FROM_TOP_CUSHION_M = 0.324;
-const OFFICIAL_SNOOKER_POCKET_CORNER_MOUTH_M = 0.086;
-const OFFICIAL_SNOOKER_POCKET_MIDDLE_MOUTH_M = 0.095;
-const SNOOKER_TABLE_VISUAL_LENGTH_TRIM = 0.94; // shorter GLB cabinet framing so official baulk/D markings and balls stay visible
-const SNOOKER_PLAYFIELD_SCALE = (2.55 * WORLD_SCALE) / OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M;
-const SNOOKER_OFFICIAL_PLAYFIELD_W = OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M * SNOOKER_PLAYFIELD_SCALE;
-const SNOOKER_OFFICIAL_PLAYFIELD_L = OFFICIAL_SNOOKER_PLAYFIELD_LENGTH_M * SNOOKER_PLAYFIELD_SCALE;
-const SNOOKER_OFFICIAL_BALL_R = (OFFICIAL_SNOOKER_BALL_DIAMETER_M * SNOOKER_PLAYFIELD_SCALE) / 2;
+const SNOOKER_PLAYFIELD_SCALE = (2.55 * WORLD_SCALE) / 1.778;
+const SNOOKER_PHYSICAL_MAP = resolveSnookerPhysicalTableMap(SNOOKER_PLAYFIELD_SCALE);
+const SNOOKER_TABLE_VISUAL_LENGTH_TRIM = SNOOKER_PHYSICAL_MAP.visualPlayfieldFitMultiplier;
+const SNOOKER_OFFICIAL_PLAYFIELD_W = SNOOKER_PHYSICAL_MAP.tableW;
+const SNOOKER_OFFICIAL_PLAYFIELD_L = SNOOKER_PHYSICAL_MAP.tableL;
+const SNOOKER_OFFICIAL_BALL_R = SNOOKER_PHYSICAL_MAP.ballR;
 const SNOOKER_BALL_CENTER_Y = SNOOKER_OFFICIAL_BALL_R * 1.03;
-const SNOOKER_OFFICIAL_BAULK_FROM_CUSHION = OFFICIAL_SNOOKER_BAULK_LINE_FROM_CUSHION_M * SNOOKER_PLAYFIELD_SCALE;
-const SNOOKER_OFFICIAL_D_RADIUS = OFFICIAL_SNOOKER_D_RADIUS_M * SNOOKER_PLAYFIELD_SCALE;
-const SNOOKER_OFFICIAL_BLACK_FROM_TOP_CUSHION = OFFICIAL_SNOOKER_BLACK_FROM_TOP_CUSHION_M * SNOOKER_PLAYFIELD_SCALE;
-const SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS = (OFFICIAL_SNOOKER_POCKET_CORNER_MOUTH_M * SNOOKER_PLAYFIELD_SCALE) / 2;
-const SNOOKER_OFFICIAL_MIDDLE_POCKET_RADIUS = (OFFICIAL_SNOOKER_POCKET_MIDDLE_MOUTH_M * SNOOKER_PLAYFIELD_SCALE) / 2;
-const SNOOKER_CORNER_JAW_SETBACK = SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS * 0.72;
-const SNOOKER_MIDDLE_JAW_SETBACK = SNOOKER_OFFICIAL_MIDDLE_POCKET_RADIUS * 0.68;
-const SNOOKER_SHOT_POWER_BOOST = 1.3; // Pool Royale-matched strike with ~30% extra headroom for snooker
+const SNOOKER_OFFICIAL_BAULK_FROM_CUSHION = SNOOKER_PHYSICAL_MAP.baulkLineFromCushion;
+const SNOOKER_OFFICIAL_D_RADIUS = SNOOKER_PHYSICAL_MAP.dRadius;
+const SNOOKER_OFFICIAL_BLACK_FROM_TOP_CUSHION = SNOOKER_PHYSICAL_MAP.blackFromTopCushion;
+const SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS = SNOOKER_PHYSICAL_MAP.cornerPocketRadius;
+const SNOOKER_OFFICIAL_MIDDLE_POCKET_RADIUS = SNOOKER_PHYSICAL_MAP.middlePocketRadius;
+const SNOOKER_CORNER_JAW_SETBACK = SNOOKER_PHYSICAL_MAP.cornerJawSetback;
+const SNOOKER_MIDDLE_JAW_SETBACK = SNOOKER_PHYSICAL_MAP.middleJawSetback;
+const POOL_ROYALE_SHOT_POWER_REDUCTION = 0.425;
+const POOL_ROYALE_SHOT_POWER_MULTIPLIER = 2.109375;
+const POOL_ROYALE_SHOT_POWER_INCREASE = 1.5;
+const POOL_ROYALE_SHOT_POWER_ADJUSTMENT = 0.72;
+const POOL_ROYALE_SHOT_POWER_BOOST = 1.32;
+const POOL_ROYALE_SHOT_GLOBAL_POWER_SCALE = 1.06;
+const SNOOKER_POOL_ROYALE_SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * 1.5 * 0.75 * 0.85 * 0.8 * 1.3 * 0.85 * POOL_ROYALE_SHOT_POWER_REDUCTION * POOL_ROYALE_SHOT_POWER_MULTIPLIER * POOL_ROYALE_SHOT_POWER_INCREASE * POOL_ROYALE_SHOT_POWER_ADJUSTMENT * POOL_ROYALE_SHOT_POWER_BOOST * POOL_ROYALE_SHOT_GLOBAL_POWER_SCALE;
 const SNOOKER_BALL_MASS = 0.17;
 const SNOOKER_BALL_INERTIA = (2 / 5) * SNOOKER_BALL_MASS * SNOOKER_OFFICIAL_BALL_R * SNOOKER_OFFICIAL_BALL_R;
 const SNOOKER_SPIN_FIXED_DT = 1 / 120;
@@ -197,7 +198,7 @@ const CFG = {
   tableTopY: 0.84 * WORLD_SCALE,
   tableW: SNOOKER_OFFICIAL_PLAYFIELD_W,
   tableL: SNOOKER_OFFICIAL_PLAYFIELD_L,
-  tableVisualMultiplier: 1.08 * SNOOKER_TABLE_VISUAL_LENGTH_TRIM,
+  tableVisualMultiplier: SNOOKER_TABLE_VISUAL_LENGTH_TRIM,
   topThickness: 0.09 * WORLD_SCALE,
   railW: 0.15 * WORLD_SCALE,
   railH: 0.08 * WORLD_SCALE,
@@ -750,16 +751,16 @@ function addTable(scene, renderer, options = {}) {
     proceduralTableMeshes.push(addBox(tableGroup, size, pos, mat));
   });
   const pocketY = CFG.ballR + 0.006 * CFG.scale;
-  const pocketPositions = [
-    [-CFG.tableW / 2 + SNOOKER_CORNER_JAW_SETBACK, pocketY, -CFG.tableL / 2 + SNOOKER_CORNER_JAW_SETBACK, SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS],
-    [CFG.tableW / 2 - SNOOKER_CORNER_JAW_SETBACK, pocketY, -CFG.tableL / 2 + SNOOKER_CORNER_JAW_SETBACK, SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS],
-    [-CFG.tableW / 2 + SNOOKER_CORNER_JAW_SETBACK, pocketY, CFG.tableL / 2 - SNOOKER_CORNER_JAW_SETBACK, SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS],
-    [CFG.tableW / 2 - SNOOKER_CORNER_JAW_SETBACK, pocketY, CFG.tableL / 2 - SNOOKER_CORNER_JAW_SETBACK, SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS],
-    [-CFG.tableW / 2 + SNOOKER_MIDDLE_JAW_SETBACK, pocketY, 0, SNOOKER_OFFICIAL_MIDDLE_POCKET_RADIUS],
-    [CFG.tableW / 2 - SNOOKER_MIDDLE_JAW_SETBACK, pocketY, 0, SNOOKER_OFFICIAL_MIDDLE_POCKET_RADIUS]
-  ].map(([x, y, z, radius]) => {
-    const pocket = new THREE.Vector3(x, y, z);
-    pocket.userData = { radius };
+  const pocketPositions = resolveSnookerPhysicalPocketMap(
+    CFG.tableW,
+    CFG.tableL,
+    SNOOKER_CORNER_JAW_SETBACK,
+    SNOOKER_MIDDLE_JAW_SETBACK,
+    SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS,
+    SNOOKER_OFFICIAL_MIDDLE_POCKET_RADIUS
+  ).map(({ x, z, radius, kind }) => {
+    const pocket = new THREE.Vector3(x, pocketY, z);
+    pocket.userData = { radius, kind, physicalGlbMap: true };
     return pocket;
   });
   addOfficialSnookerMarkings(tableGroup);
@@ -1152,17 +1153,21 @@ function applyCueShot(cueBall, power, yaw, out, spinInput = { x: 0, y: 0 }) {
   const dir = out.set(0, 0, -1).applyAxisAngle(Y_AXIS, yaw).normalize();
   const side = new THREE.Vector3(dir.z, 0, -dir.x).normalize();
   const spin = mapSpinForPhysics(normalizeSpinInput(spinInput));
-  const speed = (2.8 + p * 9.2) * CFG.scale * SNOOKER_SHOT_POWER_BOOST;
+  const speed = SNOOKER_POOL_ROYALE_SHOT_BASE_SPEED * p;
   cueBall.vel.copy(dir.multiplyScalar(speed));
-  cueBall.vel.addScaledVector(side, (spin.x ?? 0) * p * 1.05 * CFG.scale * SNOOKER_SHOT_POWER_BOOST);
+  cueBall.vel.addScaledVector(side, (spin.x ?? 0) * p * CFG.ballR * 0.65);
   cueBall.spin.set(spin.x ?? 0, spin.y ?? 0);
   cueBall.omega?.set(0, 0, 0);
   const launchSpeed = cueBall.vel.length();
   if (launchSpeed > 1e-6 && cueBall.omega) {
     const rollingAxis = new THREE.Vector3(cueBall.vel.z, 0, -cueBall.vel.x).normalize();
     cueBall.omega.addScaledVector(rollingAxis, launchSpeed / CFG.ballR);
-    cueBall.omega.x += -(spin.y ?? 0) * p * 18;
-    cueBall.omega.z += -(spin.x ?? 0) * p * 18;
+    const shotDir = cueBall.vel.clone().normalize();
+    const sideAxis = new THREE.Vector3(-shotDir.z, 0, shotDir.x).normalize();
+    const rOffset = sideAxis.multiplyScalar((spin.x ?? 0) * CFG.ballR).addScaledVector(UP, (spin.y ?? 0) * CFG.ballR);
+    const impulse = shotDir.multiplyScalar(SNOOKER_BALL_MASS * launchSpeed);
+    const torqueImpulse = rOffset.cross(impulse);
+    cueBall.omega.addScaledVector(torqueImpulse, 1 / SNOOKER_BALL_INERTIA);
   }
   cueBall.launchDir = cueBall.vel.lengthSq() > 1e-8 ? cueBall.vel.clone().normalize() : null;
   cueBall.impacted = false;
@@ -1209,21 +1214,62 @@ function updateSnookerRulesAfterPot(ball, balls, rulesState) {
 function findSnookerPocketCapture(ball, pocketPositions = []) {
   return pocketPositions.find((pocket) => {
     const radius = pocket.userData?.radius ?? SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS;
-    const captureRadius = Math.max(radius + CFG.ballR * 0.56, CFG.ballR * 1.35);
+    const captureRadius = Math.max(
+      radius + CFG.ballR * SNOOKER_PHYSICAL_MAP.pocketMouthCaptureBallRatio,
+      CFG.ballR * 1.35
+    );
     return ball.pos.distanceToSquared(pocket) < captureRadius * captureRadius;
   });
+}
+
+function findNearestSnookerPocket(ball, pocketPositions = []) {
+  let nearest = null;
+  let nearestDistance = Infinity;
+  pocketPositions.forEach((pocket) => {
+    const distance = ball.pos.distanceToSquared(pocket);
+    if (distance < nearestDistance) {
+      nearest = pocket;
+      nearestDistance = distance;
+    }
+  });
+  return nearest;
 }
 
 function isInSnookerPocketMouth(ball, axis, sign, pocketPositions = []) {
   const nearPocket = pocketPositions.some((pocket) => {
     const radius = pocket.userData?.radius ?? SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS;
-    const mouth = Math.max(radius + CFG.ballR * 0.92, CFG.ballR * 1.65);
+    const mouth = Math.max(
+      radius + CFG.ballR * SNOOKER_PHYSICAL_MAP.pocketMouthRailClearanceBallRatio,
+      CFG.ballR * 1.65
+    );
     if (axis === 'x') {
       return Math.sign(pocket.x || sign) === sign && Math.abs(ball.pos.z - pocket.z) <= mouth;
     }
     return Math.sign(pocket.z || sign) === sign && Math.abs(ball.pos.x - pocket.x) <= mouth;
   });
   return nearPocket;
+}
+
+function enforceSnookerGlbPhysicalBounds(ball, pocketPositions = []) {
+  const halfW = CFG.tableW / 2;
+  const halfL = CFG.tableL / 2;
+  const safety = CFG.ballR * SNOOKER_PHYSICAL_MAP.outerSafetyBallRatio;
+  const outside =
+    ball.pos.x < -halfW - safety ||
+    ball.pos.x > halfW + safety ||
+    ball.pos.z < -halfL - safety ||
+    ball.pos.z > halfL + safety;
+  if (!outside) return null;
+  const nearestPocket = findNearestSnookerPocket(ball, pocketPositions);
+  if (nearestPocket) {
+    const radius = nearestPocket.userData?.radius ?? SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS;
+    const rescueRadius = Math.max(radius + CFG.ballR * 2.6, CFG.ballR * 3.1);
+    if (ball.pos.distanceToSquared(nearestPocket) <= rescueRadius * rescueRadius) return nearestPocket;
+  }
+  ball.pos.x = clamp(ball.pos.x, -halfW + CFG.ballR, halfW - CFG.ballR);
+  ball.pos.z = clamp(ball.pos.z, -halfL + CFG.ballR, halfL - CFG.ballR);
+  ball.vel.multiplyScalar(0.35);
+  return null;
 }
 
 function decaySnookerSpin(ball, stepScale) {
@@ -1321,7 +1367,7 @@ function updateBalls(balls, dt, tmpA, tmpB, pocketPositions = [], rulesState = n
     updateSnookerRollingBall(ball, stepScale);
     ball.pos.addScaledVector(ball.vel, dt);
     let railNormal = null;
-    const pocket = findSnookerPocketCapture(ball, pocketPositions);
+    const pocket = findSnookerPocketCapture(ball, pocketPositions) ?? enforceSnookerGlbPhysicalBounds(ball, pocketPositions);
     if (!pocket) {
       if (ball.pos.x < -halfW + CFG.ballR && !isInSnookerPocketMouth(ball, 'x', -1, pocketPositions)) {
         ball.pos.x = -halfW + CFG.ballR;
@@ -1356,7 +1402,7 @@ function updateBalls(balls, dt, tmpA, tmpB, pocketPositions = [], rulesState = n
       if (!hasSpinAfter) ball.spin?.set(0, 0);
       ball.launchDir = null;
     }
-    const capture = pocket ?? findSnookerPocketCapture(ball, pocketPositions);
+    const capture = pocket ?? findSnookerPocketCapture(ball, pocketPositions) ?? enforceSnookerGlbPhysicalBounds(ball, pocketPositions);
     if (capture && ball.vel.lengthSq() < (8.5 * CFG.scale) ** 2) {
       if (ball.isCue) {
         ball.pos.copy(getOfficialSnookerSpots(SNOOKER_BALL_CENTER_Y).cue);
@@ -1908,6 +1954,9 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
     const tmpA = new THREE.Vector3(), tmpB = new THREE.Vector3(), tmpC = new THREE.Vector3();
     let strikeT = 0, didHit = false, frameId = 0, last = performance.now(), isAiming = false, lastAimX = 0, lastAimY = 0;
     let recordingReplay = false, replayStartedAt = 0, lastReplaySampleAt = 0;
+    let replayShotStartScore = 0;
+    let replayShotStartFoul = '';
+    let replayShotStartPottedCount = 0;
     let lastScore = rulesRef.current.score;
     let lastTarget = rulesRef.current.target;
     let lastFoul = rulesRef.current.foul;
@@ -1990,6 +2039,9 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
             replayStartedAt = now;
             lastReplaySampleAt = 0;
             replayFramesRef.current = [{ t: 0, balls: createReplaySnapshot(balls), cameraMode: 'cue-follow' }];
+            replayShotStartScore = rulesRef.current.score;
+            replayShotStartFoul = rulesRef.current.foul || '';
+            replayShotStartPottedCount = balls.filter((ball) => ball.potted).length;
             setHasReplay(false);
           }
         }
@@ -2020,7 +2072,14 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
         replayFramesRef.current.push({ t: now - replayStartedAt, balls: createReplaySnapshot(balls), cameraMode: cameraModeRef.current });
         if (!ballsMoving || now - replayStartedAt >= SNOOKER_REPLAY_MAX_MS) {
           recordingReplay = false;
-          setHasReplay(replayFramesRef.current.length > 2);
+          const replayReady = replayFramesRef.current.length > 2;
+          const hadSuccessfulPot = balls.filter((ball) => ball.potted).length > replayShotStartPottedCount || rulesRef.current.score > replayShotStartScore;
+          const hadFoul = Boolean(rulesRef.current.foul && rulesRef.current.foul !== replayShotStartFoul);
+          setHasReplay(replayReady);
+          if (replayReady && !replaySkipAllRef.current && (hadSuccessfulPot || hadFoul)) {
+            replayStartedAtRef.current = performance.now() + 180;
+            setReplayActive(true);
+          }
         }
       }
       if (rulesRef.current.score !== lastScore) { lastScore = rulesRef.current.score; setScore(lastScore); }

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -3,6 +3,64 @@ export const TABLE_MODEL_OPENSOURCE = 'opensource';
 export const TABLE_MODEL_OPENSOURCE_GLB_URL =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
 
+export const SNOOKER_GLB_PHYSICAL_TABLE_MAP = Object.freeze({
+  playfieldWidthM: 1.778,
+  playfieldLengthM: 3.569,
+  ballDiameterM: 0.0525,
+  baulkLineFromCushionM: 0.737,
+  dRadiusM: 0.292,
+  blackFromTopCushionM: 0.324,
+  cornerPocketMouthM: 0.086,
+  middlePocketMouthM: 0.095,
+  // The Pooltool snooker GLBs are authored around the cushion-nose playfield.
+  // Keep physics, pockets, spots, and the GLB fit on that same physical bed rather
+  // than expanding the collision map to the decorative wooden cabinet.
+  visualPlayfieldFitMultiplier: 1,
+  cornerJawSetbackRatio: 0.72,
+  middleJawSetbackRatio: 0.68,
+  pocketMouthCaptureBallRatio: 0.56,
+  pocketMouthRailClearanceBallRatio: 0.92,
+  outerSafetyBallRatio: 0.18
+});
+
+export function resolveSnookerPhysicalTableMap(scale = 1) {
+  const safeScale = safePositiveDimension(scale, 1);
+  const map = SNOOKER_GLB_PHYSICAL_TABLE_MAP;
+  const tableW = map.playfieldWidthM * safeScale;
+  const tableL = map.playfieldLengthM * safeScale;
+  const ballR = (map.ballDiameterM * safeScale) / 2;
+  const cornerPocketRadius = (map.cornerPocketMouthM * safeScale) / 2;
+  const middlePocketRadius = (map.middlePocketMouthM * safeScale) / 2;
+  return Object.freeze({
+    tableW,
+    tableL,
+    ballR,
+    baulkLineFromCushion: map.baulkLineFromCushionM * safeScale,
+    dRadius: map.dRadiusM * safeScale,
+    blackFromTopCushion: map.blackFromTopCushionM * safeScale,
+    cornerPocketRadius,
+    middlePocketRadius,
+    cornerJawSetback: cornerPocketRadius * map.cornerJawSetbackRatio,
+    middleJawSetback: middlePocketRadius * map.middleJawSetbackRatio,
+    visualPlayfieldFitMultiplier: map.visualPlayfieldFitMultiplier,
+    pocketMouthCaptureBallRatio: map.pocketMouthCaptureBallRatio,
+    pocketMouthRailClearanceBallRatio: map.pocketMouthRailClearanceBallRatio,
+    outerSafetyBallRatio: map.outerSafetyBallRatio
+  });
+}
+
+export function resolveSnookerPhysicalPocketMap(tableW, tableL, cornerJawSetback, middleJawSetback, cornerPocketRadius, middlePocketRadius) {
+  const halfW = safePositiveDimension(tableW) / 2;
+  const halfL = safePositiveDimension(tableL) / 2;
+  return Object.freeze([
+    Object.freeze({ x: -halfW + cornerJawSetback, z: -halfL + cornerJawSetback, radius: cornerPocketRadius, kind: 'corner' }),
+    Object.freeze({ x: halfW - cornerJawSetback, z: -halfL + cornerJawSetback, radius: cornerPocketRadius, kind: 'corner' }),
+    Object.freeze({ x: -halfW + cornerJawSetback, z: halfL - cornerJawSetback, radius: cornerPocketRadius, kind: 'corner' }),
+    Object.freeze({ x: halfW - cornerJawSetback, z: halfL - cornerJawSetback, radius: cornerPocketRadius, kind: 'corner' }),
+    Object.freeze({ x: -halfW + middleJawSetback, z: 0, radius: middlePocketRadius, kind: 'middle' }),
+    Object.freeze({ x: halfW - middleJawSetback, z: 0, radius: middlePocketRadius, kind: 'middle' })
+  ]);
+}
 
 const MIN_GLB_FIT_SIZE = 0.0001;
 


### PR DESCRIPTION
### Motivation
- Use the original Pooltool GLB cushion-nose playfield and pocket map as the authoritative physical mapping so balls no longer appear off-table and markings/positions are precise. 
- Make Snooker Champion ball power and spin behavior match the Pool Royale reference so shot feel, travel and spin transfer are identical between modes. 
- Reuse Pool Royale broadcast/replay logic so replays auto-play on meaningful events (successful pot or foul) unless the player disables auto-replay. 

### Description
- Added a canonical GLB physical table map and helpers in `webapp/src/pages/Games/snookerTableModel.js` (`SNOOKER_GLB_PHYSICAL_TABLE_MAP`, `resolveSnookerPhysicalTableMap`, `resolveSnookerPhysicalPocketMap`).
- Switched Snooker Champion to derive table width/length, ball radius, pocket radii, baulk/D offsets and visual fit from the physical map and used `resolveSnookerPhysicalPocketMap` for the six-pocket layout (changes in `webapp/src/pages/Games/SnookerRoyalProvided.jsx`).
- Aligned shot force and spin to Pool Royale tuning: introduced a Snooker Pool-Royale shot base speed, moved lateral spin offset to use ball radius scaling, and changed spin→omega application to a torque-style impulse for more accurate spin transfer on `applyCueShot`.
- Added GLB-bound safety: `enforceSnookerGlbPhysicalBounds` clamps/recues balls that drift outside the physical bed and allows nearest-pocket rescue when appropriate to prevent balls leaving the mapped playfield.
- Updated pocket mouth/capture thresholds to use ratios from the physical map and adjusted pocket-mouth detection functions accordingly.
- Replay recording: capture shot-start score/foul/potted count and auto-start replay when the recording finishes if a pot or foul occurred, unless the user has enabled the replay-skip toggle; added small lead delay before automatic playback.
- Tests and small utilities: extended `test/snookerTableModel.test.js` with unit tests that validate the physical map resolver and pocket mapping.

### Testing
- Ran unit tests: `npm test -- --runInBand test/snookerTableModel.test.js` — all tests passed (added physical-map and pocket mapping assertions). 
- Built the web app production bundle: `npm --prefix webapp run build` — build succeeded; `SnookerRoyalProvided` bundle included and artifacts emitted. 
- Attempted an automated Playwright screenshot to sanity-check the page, but the run failed due to a missing system library in the environment (`libatk-1.0.so.0`); this is an environment dependency and not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08abb074e083298998bcff92a2d74e)