### PR TITLE
Tune tennis court physics and movement

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -48,6 +48,10 @@ type BonePack = {
   leftUpperArm?: THREE.Bone;
   leftForeArm?: THREE.Bone;
   leftHand?: THREE.Bone;
+  leftThigh?: THREE.Bone;
+  leftCalf?: THREE.Bone;
+  rightThigh?: THREE.Bone;
+  rightCalf?: THREE.Bone;
 };
 
 type BoneRest = { bone: THREE.Bone; q: THREE.Quaternion };
@@ -107,6 +111,9 @@ type HumanRig = {
   desiredHit: DesiredHit | null;
   hitThisSwing: boolean;
   speed: number;
+  walkCycle: number;
+  yawVelocity: number;
+  locomotion: { amount: number; forward: number; side: number; backward: number };
 };
 
 type HudState = { nearScore: number; farScore: number; nearLabel?: string; farLabel?: string; nearGames?: number; farGames?: number; status: string; power: number; server?: PlayerSide; serveSide?: "deuce" | "ad"; firstServe?: boolean; debug?: string };
@@ -1016,6 +1023,10 @@ function findHumanBones(model: THREE.Object3D): BonePack {
     leftUpperArm: findFirstBone(model, ["leftarm", "leftupperarm", "larm", "lupperarm"]),
     leftForeArm: findFirstBone(model, ["leftforearm", "leftlowerarm", "lforearm", "llowerarm"]),
     leftHand: findFirstBone(model, ["lefthand", "lhand"]),
+    leftThigh: findFirstBone(model, ["leftupleg", "leftthigh", "lthigh", "legl", "legjointl1"]),
+    leftCalf: findFirstBone(model, ["leftleg", "leftcalf", "lcalf", "shinl", "legjointl2"]),
+    rightThigh: findFirstBone(model, ["rightupleg", "rightthigh", "rthigh", "legr", "legjointr1"]),
+    rightCalf: findFirstBone(model, ["rightleg", "rightcalf", "rcalf", "shinr", "legjointr2"]),
   };
 }
 
@@ -1112,6 +1123,53 @@ function addLocalRotation(bone: THREE.Bone | undefined, x: number, y: number, z:
   bone.quaternion.multiply(new THREE.Quaternion().setFromEuler(new THREE.Euler(x, y, z, "XYZ")));
 }
 
+function addBoneEulerOffset(bone: THREE.Bone | undefined, x = 0, y = 0, z = 0) {
+  if (!bone) return;
+  bone.rotation.x += x;
+  bone.rotation.y += y;
+  bone.rotation.z += z;
+}
+
+function applyTennisBowlingWalkMotion(player: HumanRig) {
+  if (!player.model) return;
+  // Tennis uses the same planted human walk recipe as Bowling Realistic, then
+  // layers tennis-specific shuffle/backpedal direction on top. Real tennis
+  // recovery favors short lateral shuffles and backward steps while the torso
+  // stays square to the court/net.
+  const { amount, forward, side, backward } = player.locomotion;
+  if (amount <= 0.001) {
+    player.model.position.set(0, 0, 0);
+    player.model.rotation.set(0, 0, 0);
+    return;
+  }
+
+  const phase = player.walkCycle;
+  const step = Math.sin(phase);
+  const counter = Math.sin(phase + Math.PI);
+  const footfall = Math.abs(step);
+  const stride = lerp(0.24, 0.42, amount) * (1 + Math.abs(side) * 0.18 + backward * 0.1);
+  const turnLean = clamp(player.yawVelocity * 0.003, -0.1, 0.1);
+  const shuffle = Math.abs(side);
+  const deg = THREE.MathUtils.degToRad;
+
+  player.model.position.y = footfall * stride * 0.115;
+  player.model.position.x = Math.sin(phase * 0.5) * stride * 0.035 + side * shuffle * 0.018;
+  player.model.rotation.x = 0.012 + counter * stride * 0.045 - backward * 0.035 + Math.max(0, forward) * 0.025;
+  player.model.rotation.y = step * stride * 0.18 * (1 - shuffle * 0.45);
+  player.model.rotation.z = step * stride * 0.105 - turnLean - side * 0.075;
+
+  addBoneEulerOffset(player.bones.leftThigh, step * stride * (1.05 - shuffle * 0.34) + side * 0.18 * shuffle, 0, deg(1.5) - side * deg(4.5) * shuffle);
+  addBoneEulerOffset(player.bones.rightThigh, counter * stride * (1.05 - shuffle * 0.34) - side * 0.18 * shuffle, 0, deg(-1.5) - side * deg(4.5) * shuffle);
+  addBoneEulerOffset(player.bones.leftCalf, Math.max(0, -step) * stride * 0.74 + backward * 0.08, 0, side * deg(2.5) * shuffle);
+  addBoneEulerOffset(player.bones.rightCalf, Math.max(0, -counter) * stride * 0.74 + backward * 0.08, 0, side * deg(2.5) * shuffle);
+
+  addBoneEulerOffset(player.bones.spine, deg(2.5) - backward * 0.035, -step * stride * 0.035, step * stride * 0.045 - side * 0.04 * shuffle);
+  addBoneEulerOffset(player.bones.leftUpperArm, -counter * stride * 1.08 + side * 0.12, 0, deg(-5));
+  addBoneEulerOffset(player.bones.rightUpperArm, -step * stride * 1.08 - side * 0.12, 0, deg(5));
+  addBoneEulerOffset(player.bones.leftForeArm, Math.max(0, step) * stride * 0.34, 0, 0);
+  addBoneEulerOffset(player.bones.rightForeArm, Math.max(0, counter) * stride * 0.34, 0, 0);
+}
+
 function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, accent: number, theme?: CharacterTheme): HumanRig {
   const root = new THREE.Group();
   const modelRoot = new THREE.Group();
@@ -1143,6 +1201,9 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
     desiredHit: null,
     hitThisSwing: false,
     speed: side === "near" ? CFG.playerSpeed : CFG.aiSpeed,
+    walkCycle: 0,
+    yawVelocity: 0,
+    locomotion: { amount: 0, forward: 0, side: 0, backward: 0 },
   };
 
   modelRoot.rotation.y = rig.yaw;
@@ -1267,9 +1328,9 @@ function strokePose(player: HumanRig, ball: BallState): StrokePose {
     }
     wristPronation = 1.2 * contact - 0.55 * follow;
   } else {
-    const prep = clamp01(tRaw / 0.28);
-    const slot = clamp01((tRaw - 0.18) / 0.26);
-    const contact = clamp01((tRaw - 0.42) / 0.18);
+    const prep = clamp01(tRaw / 0.34);
+    const slot = clamp01((tRaw - 0.2) / 0.28);
+    const contact = clamp01((tRaw - 0.44) / 0.16);
     const follow = clamp01((tRaw - 0.58) / 0.42);
     const ballSide = clamp((ball.pos.x - player.pos.x) * 0.9, -0.4 * poseScale, 0.4 * poseScale);
 
@@ -1277,17 +1338,17 @@ function strokePose(player: HumanRig, ball: BallState): StrokePose {
     torsoLean = -0.1 * prep + 0.08 * contact;
     shoulderLift = 0.12 * contact;
 
-    const prepHand = rightShoulder.clone().addScaledVector(right, 0.62 * poseScale + ballSide).addScaledVector(forward, -0.35 * poseScale).setY(1.05 * poseScale);
-    const slotHand = rightShoulder.clone().addScaledVector(right, 0.54 * poseScale + ballSide).addScaledVector(forward, -0.05 * poseScale).setY(0.82 * poseScale);
-    const contactHand = player.pos.clone().addScaledVector(right, 0.38 * poseScale + ballSide * 0.45).addScaledVector(forward, 0.72 * poseScale).setY(clamp(ball.pos.y, 0.72 * poseScale, 1.24 * poseScale));
-    const followHand = player.pos.clone().addScaledVector(right, -0.42 * poseScale).addScaledVector(forward, 0.34 * poseScale).setY(1.38 * poseScale);
+    const prepHand = rightShoulder.clone().addScaledVector(right, 0.76 * poseScale + ballSide).addScaledVector(forward, -0.68 * poseScale).setY(1.08 * poseScale);
+    const slotHand = rightShoulder.clone().addScaledVector(right, 0.6 * poseScale + ballSide).addScaledVector(forward, -0.16 * poseScale).setY(0.84 * poseScale);
+    const contactHand = player.pos.clone().addScaledVector(right, 0.4 * poseScale + ballSide * 0.45).addScaledVector(forward, 0.84 * poseScale).setY(clamp(ball.pos.y, 0.72 * poseScale, 1.28 * poseScale));
+    const followHand = player.pos.clone().addScaledVector(right, -0.48 * poseScale).addScaledVector(forward, 0.48 * poseScale).setY(1.44 * poseScale);
 
     rightHand.copy(prepHand).lerp(slotHand, slot).lerp(contactHand, contact).lerp(followHand, follow);
     rightElbow = rightShoulder.clone().lerp(rightHand, 0.52).addScaledVector(right, 0.1 * poseScale * (1 - follow)).setY((rightShoulder.y + rightHand.y) * 0.5 + 0.12 * poseScale);
 
-    const lagHead = rightHand.clone().addScaledVector(right, 0.35 * poseScale).addScaledVector(forward, -0.26 * poseScale).setY(1.25 * poseScale);
-    const contactHead = ball.pos.clone().addScaledVector(forward, 0.02 * poseScale).setY(clamp(ball.pos.y, 0.74 * poseScale, 1.3 * poseScale));
-    const followHead = player.pos.clone().addScaledVector(right, -0.68 * poseScale).addScaledVector(forward, 0.22 * poseScale).setY(1.56 * poseScale);
+    const lagHead = rightHand.clone().addScaledVector(right, 0.42 * poseScale).addScaledVector(forward, -0.48 * poseScale).setY(1.3 * poseScale);
+    const contactHead = ball.pos.clone().addScaledVector(forward, 0.04 * poseScale).setY(clamp(ball.pos.y, 0.74 * poseScale, 1.34 * poseScale));
+    const followHead = player.pos.clone().addScaledVector(right, -0.78 * poseScale).addScaledVector(forward, 0.34 * poseScale).setY(1.62 * poseScale);
     racketHead.copy(lagHead).lerp(contactHead, contact).lerp(followHead, follow);
 
     leftElbow = leftShoulder.clone().addScaledVector(right, -0.23 * poseScale).addScaledVector(forward, 0.08 * poseScale).setY((1.08 + 0.12 * follow) * poseScale);
@@ -1352,6 +1413,7 @@ function updateSkeletonTorso(player: HumanRig, pose: StrokePose) {
 function updateModelRigWithCharacterHands(player: HumanRig, pose: StrokePose) {
   if (!player.model) return false;
   restoreRestPose(player);
+  applyTennisBowlingWalkMotion(player);
   updateSkeletonTorso(player, pose);
 
   const rightSolved = solveTwoBoneArm(player.rightArmChain, pose.rightShoulder, pose.rightElbow, pose.rightHand);
@@ -1548,43 +1610,42 @@ function startSwing(player: HumanRig, desiredHit: DesiredHit, action: StrokeActi
 }
 
 function updatePlayerMotion(player: HumanRig, ball: BallState, dt: number) {
-  const to = player.target.clone().sub(player.pos);
-  const dist = to.length();
+  const toTarget = player.target.clone().sub(player.pos);
+  const dist = toTarget.length();
+  const moveDir = dist > 0.0001 ? toTarget.clone().normalize() : new THREE.Vector3();
   const maxStep = player.speed * dt;
-  if (dist > 0.0001) player.pos.addScaledVector(to.normalize(), Math.min(maxStep, dist));
+  if (dist > 0.0001) player.pos.addScaledVector(moveDir, Math.min(maxStep, dist));
 
   PlayerController.clampMovement(player.pos, player.side);
 
-  let face: THREE.Vector3;
-  if (ball.lastHitBy === null && player.side === "near") face = new THREE.Vector3(0.22, 0, -1).normalize();
-  else face = ball.pos.clone().sub(player.pos).setY(0);
-  if (face.lengthSq() < 0.02) face.set(0, 0, player.side === "near" ? -1 : 1);
+  const courtForward = new THREE.Vector3(0, 0, player.side === "near" ? -1 : 1);
+  const ballFace = ball.pos.clone().sub(player.pos).setY(0);
+  let face = courtForward.clone();
+  if (ballFace.lengthSq() > 0.02) face.lerp(ballFace.normalize(), ball.lastHitBy === null ? 0.18 : 0.36);
   face.normalize();
 
   const targetYaw = yawFromForward(face);
   let delta = targetYaw - player.yaw;
   while (delta > Math.PI) delta -= Math.PI * 2;
   while (delta < -Math.PI) delta += Math.PI * 2;
-  player.yaw += delta * (1 - Math.exp(-8 * dt));
+  const yawStep = delta * (1 - Math.exp(-9.5 * dt));
+  player.yaw += yawStep;
+  player.yawVelocity = yawStep / Math.max(0.0001, dt);
+
+  const localForward = forwardFromYaw(player.yaw);
+  const localRight = rightFromForward(localForward);
+  const forwardDot = moveDir.dot(localForward);
+  const sideDot = moveDir.dot(localRight);
+  const runAmount = clamp01(dist / (0.42 * CFG.worldScale));
+  player.locomotion.amount = runAmount;
+  player.locomotion.forward = forwardDot * runAmount;
+  player.locomotion.side = sideDot * runAmount;
+  player.locomotion.backward = Math.max(0, -forwardDot) * runAmount;
+  player.walkCycle += dt * (7.8 + runAmount * 12.6 + Math.abs(sideDot) * 5.4);
 
   player.root.position.copy(player.pos);
   player.modelRoot.position.copy(player.pos);
   player.modelRoot.rotation.y = player.yaw;
-
-  if (player.model) {
-    const runAmount = clamp01(dist / 0.42);
-    const moveDir = dist > 0.0001 ? to.clone().normalize() : new THREE.Vector3();
-    const localForward = forwardFromYaw(player.yaw);
-    const localRight = rightFromForward(localForward);
-    const forwardDot = moveDir.dot(localForward);
-    const sideDot = moveDir.dot(localRight);
-    const walkT = performance.now() * 0.015 + (player.side === "near" ? 0 : Math.PI);
-    const bob = Math.sin(walkT) * 0.03 * runAmount;
-    const strafeLean = sideDot * 0.1 * runAmount;
-    player.model.position.y = bob;
-    player.model.rotation.x = 0.05 * runAmount * Math.max(0, forwardDot) - 0.03 * runAmount * Math.max(0, -forwardDot);
-    player.model.rotation.z = strafeLean;
-  }
 
   player.cooldown = Math.max(0, player.cooldown - dt);
   if (player.swingT > 0) {
@@ -1742,8 +1803,8 @@ export default function MobileThreeTennisPrototype() {
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
       camera.aspect = w / h;
       camera.fov = camera.aspect < 0.72 ? 52 : 46;
-      if (camera.aspect < 0.72) cameraOffset.set(0, 7.95 * CFG.cameraViewScale, 12.95 * CFG.cameraViewScale);
-      else cameraOffset.set(0, 7.35 * CFG.cameraViewScale, 11.85 * CFG.cameraViewScale);
+      if (camera.aspect < 0.72) cameraOffset.set(0, 9.85 * CFG.cameraViewScale, 16.2 * CFG.cameraViewScale);
+      else cameraOffset.set(0, 9.15 * CFG.cameraViewScale, 14.75 * CFG.cameraViewScale);
       cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
       camera.position.copy(cameraPosTarget);
       camera.lookAt(cameraTarget);
@@ -1775,13 +1836,13 @@ export default function MobileThreeTennisPrototype() {
       control.lastTs = performance.now();
       const dx = e.clientX - control.startX;
       const dy = e.clientY - control.startY;
-      nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.012, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
-      const minZ = ball.lastHitBy === null ? CFG.serveNearBaselineZ : 0.76;
+      nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.016 * CFG.worldScale, -CFG.courtW / 2 + 0.35 * CFG.worldScale, CFG.courtW / 2 - 0.35 * CFG.worldScale);
+      const minZ = ball.lastHitBy === null ? CFG.serveNearBaselineZ : 0.76 * CFG.worldScale;
       if (ball.lastHitBy === null) {
         const lane = serveLaneBoundsX(currentServeSide, "near");
-        nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.012, Math.min(lane.min, lane.max), Math.max(lane.min, lane.max));
+        nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.016 * CFG.worldScale, Math.min(lane.min, lane.max), Math.max(lane.min, lane.max));
       }
-      nearPlayer.target.z = clamp(control.startPlayer.z + dy * 0.012, minZ, CFG.courtL / 2 - 0.42);
+      nearPlayer.target.z = clamp(control.startPlayer.z + dy * 0.016 * CFG.worldScale, minZ, CFG.courtL / 2 - 0.42 * CFG.worldScale);
       setHudSafe({ power: clamp01(Math.hypot(dx, dy) / 185) });
     };
 
@@ -2020,8 +2081,8 @@ export default function MobileThreeTennisPrototype() {
           pointLock = false;
           nearPlayer.action = "ready";
           farPlayer.action = "ready";
-          nearPlayer.target.set(0, 0, CFG.courtL / 2 - 1.04);
-          farPlayer.target.set(0, 0, -CFG.courtL / 2 + 1.04);
+          nearPlayer.target.set(0, 0, CFG.courtL / 2 - 1.04 * CFG.worldScale);
+          farPlayer.target.set(0, 0, -CFG.courtL / 2 + 1.04 * CFG.worldScale);
           currentServeSide = scoreManager.snapshot().serveSide;
           const serverPlayer = scoreManager.snapshot().server === "near" ? nearPlayer : farPlayer;
           resetBallForServe(ball, serverPlayer, currentServeSide);

--- a/webapp/src/pages/Games/tennis/BallController.ts
+++ b/webapp/src/pages/Games/tennis/BallController.ts
@@ -19,8 +19,8 @@ export class BallController {
 
   stepFixed(ball: BallLike, dt: number, opts: { awaitingServe: boolean; serveSide: "deuce" | "ad"; onRuleEvent?: (event: CourtRuleEvent) => void; onBounce?: () => void; onNet?: () => void }) {
     const prevZ = ball.pos.z;
-    const spinDip = Math.max(0, ball.spin) * 0.16;
-    const spinLift = Math.max(0, -ball.spin) * 0.05;
+    const spinDip = Math.max(0, ball.spin) * 0.12;
+    const spinLift = Math.max(0, -ball.spin) * 0.04;
     ball.vel.y -= gameConfig.gravity * (1 + spinDip - spinLift) * dt;
     if (ball.lastHitBy && Math.abs(ball.vel.z) > 0.001) {
       const forwardSign = ball.lastHitBy === "near" ? -1 : 1;
@@ -33,7 +33,7 @@ export class BallController {
 
     if (ball.lastHitBy && this.rules.isNetCollision(ball.pos, prevZ)) {
       ball.state = TennisBallState.NetHit;
-      ball.vel.multiplyScalar(0.2);
+      ball.vel.multiplyScalar(0.16);
       ball.vel.z = Math.sign(ball.vel.z || (ball.lastHitBy === "near" ? -1 : 1)) * Math.max(0.4, Math.abs(ball.vel.z));
       ball.vel.y = Math.max(0.45, Math.abs(ball.vel.y) + 0.2);
       ball.pos.z = ball.lastHitBy === "near" ? -0.12 : 0.12;
@@ -48,14 +48,16 @@ export class BallController {
         ball.state = TennisBallState.CourtBounce;
         const incomingZ = ball.vel.z;
         const forwardSign = ball.lastHitBy === "near" ? -1 : ball.lastHitBy === "far" ? 1 : Math.sign(ball.vel.z || 1);
-        ball.vel.y = -ball.vel.y * gameConfig.bounceRestitution;
+        const verticalImpact = Math.abs(ball.vel.y);
+        const bounceEnergy = clamp(gameConfig.bounceRestitution + (verticalImpact / (24 * gameConfig.worldScale)) * 0.1, 0.54, 0.68);
+        ball.vel.y = verticalImpact * bounceEnergy;
         ball.vel.x *= gameConfig.groundFriction;
         ball.vel.z *= gameConfig.groundFriction;
-        ball.vel.z += forwardSign * ball.spin * 0.33 * gameConfig.worldScale;
-        ball.vel.x += Math.sign(ball.vel.x || Math.sin(ball.spin)) * Math.abs(ball.spin) * 0.045 * gameConfig.worldScale;
-        ball.vel.y *= clamp(1 - Math.max(0, ball.spin) * 0.055, 0.78, 1.08);
+        ball.vel.z += forwardSign * ball.spin * 0.29 * gameConfig.worldScale;
+        ball.vel.x += Math.sign(ball.vel.x || Math.sin(ball.spin)) * Math.abs(ball.spin) * 0.038 * gameConfig.worldScale;
+        ball.vel.y *= clamp(1 - Math.max(0, ball.spin) * 0.05, 0.76, 1.05);
         if (Math.sign(incomingZ) !== Math.sign(ball.vel.z) && Math.abs(incomingZ) > 0.01) ball.vel.z *= 0.65;
-        ball.spin *= -0.38;
+        ball.spin *= -0.34;
         const bounceSide = sideOfZ(ball.pos.z);
         ball.bounceCount = ball.bounceSide === bounceSide ? ball.bounceCount + 1 : 1;
         ball.bounceSide = bounceSide;

--- a/webapp/src/pages/Games/tennis/CameraController.ts
+++ b/webapp/src/pages/Games/tennis/CameraController.ts
@@ -31,12 +31,12 @@ export class CameraController {
     const lateral = Math.max(-0.45, Math.min(0.45, ballPos.x * 0.08));
 
     if (preServe) {
-      cameraPosTarget.copy(playerTarget).add(tempOffset.set(playerTarget.x * 0.08 + lateral, 8.85 * gameConfig.cameraViewScale, 14.65 * gameConfig.cameraViewScale));
-      tempLookTarget.set(playerTarget.x * 0.2 + lateral, 1.55 * gameConfig.cameraViewScale, -gameConfig.courtL * 0.31);
+      cameraPosTarget.copy(playerTarget).add(tempOffset.set(playerTarget.x * 0.08 + lateral, 10.4 * gameConfig.cameraViewScale, 17.9 * gameConfig.cameraViewScale));
+      tempLookTarget.set(playerTarget.x * 0.2 + lateral, 1.95 * gameConfig.cameraViewScale, -gameConfig.courtL * 0.34);
       cameraTarget.lerp(tempLookTarget, targetDamping);
     } else {
       tempFollowAnchor.copy(playerTarget);
-      tempBaseTarget.set(playerTarget.x + lateral, 1.52 * gameConfig.cameraViewScale, playerTarget.z - 9.35 * gameConfig.cameraViewScale);
+      tempBaseTarget.set(playerTarget.x + lateral, 1.95 * gameConfig.cameraViewScale, playerTarget.z - 11.25 * gameConfig.cameraViewScale);
 
       if (incomingToPlayer) {
         tempIncomingTarget.copy(options.predictedLanding || ballPos);
@@ -45,7 +45,7 @@ export class CameraController {
         tempFollowAnchor.lerp(tempIncomingTarget, gameConfig.cameraPlayerFollowBlend);
 
         tempBallBias.copy(ballPos).lerp(tempIncomingTarget, 0.45);
-        tempBallBias.y = Math.max(1.45 * gameConfig.cameraViewScale, ballPos.y * 0.3 + 1.35 * gameConfig.cameraViewScale);
+        tempBallBias.y = Math.max(1.82 * gameConfig.cameraViewScale, ballPos.y * 0.3 + 1.62 * gameConfig.cameraViewScale);
         tempBaseTarget.lerp(tempBallBias, gameConfig.cameraBallLookAhead);
       }
 

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -29,11 +29,11 @@ export enum TennisBallState {
 }
 
 const BASE_WORLD_SCALE = 1.72;
-const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 2.72;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 3.15;
 const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
 // Keep camera scaling independent from world scale so camera framing can be
 // tuned precisely while the enlarged court keeps its regulation proportions.
-const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE * 1.18;
+const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE * 1.34;
 // Extra character scale keeps human avatars visibly bigger than the court uplift.
 const PLAYER_CHARACTER_SCALE = 1.35;
 const PLAYER_SCALE = WORLD_SCALE * PLAYER_CHARACTER_SCALE;
@@ -52,17 +52,18 @@ export const gameConfig = {
   serviceLineZ: 6.4 * WORLD_SCALE,
   netH: 0.914 * WORLD_SCALE,
   ballR: 0.085 * WORLD_SCALE,
-  gravity: 24.5,
-  airDrag: 0.105,
-  bounceRestitution: 0.66,
-  groundFriction: 0.78,
+  // Gravity scales with the enlarged court so arcs land naturally instead of floating.
+  gravity: 8.65 * WORLD_SCALE,
+  airDrag: 0.086,
+  bounceRestitution: 0.58,
+  groundFriction: 0.74,
   minBallSpeed: 0.12 * WORLD_SCALE,
   courtFriction: 0.78,
   playerHeight: 1.88 * PLAYER_SCALE,
-  playerSpeed: 8.4 * PLAYER_SCALE,
+  playerSpeed: 8.9 * PLAYER_SCALE,
   playerAcceleration: 28 * PLAYER_SCALE,
   playerDeceleration: 34 * PLAYER_SCALE,
-  aiSpeed: 11.2 * PLAYER_SCALE,
+  aiSpeed: 11.8 * PLAYER_SCALE,
   reach: 1.62 * PLAYER_SCALE,
   racketHitRadius: 0.56 * PLAYER_SCALE,
   contactAngleTolerance: 0.18,
@@ -75,9 +76,9 @@ export const gameConfig = {
   serveContactT: 0.72,
   serveTossMinHeight: 1.85 * PLAYER_SCALE,
   // Scales the full match shot force so player and AI strokes share a softer, lower power ceiling.
-  matchPowerMultiplier: 0.55,
-  servePower: { min: 0.42, max: 0.62 },
-  shotPower: { min: 0.16, max: 0.56 },
+  matchPowerMultiplier: 0.72,
+  servePower: { min: 0.48, max: 0.74 },
+  shotPower: { min: 0.22, max: 0.72 },
   spinAmount: { flat: 0.8, topspin: 1.6, slice: -1.4, lob: 1.1, drop: -0.7, block: 0.25 },
   playerVisualYawFix: Math.PI,
   serveNearBaselineZ: (23.77 / 2 + 0.92) * WORLD_SCALE,
@@ -93,10 +94,10 @@ export const gameConfig = {
   scoring: { gamesPerSet: 6, winByTwoGames: true },
   aiDifficulty: {
     reactionTime: 0.07,
-    moveSpeed: 12.8 * PLAYER_SCALE,
+    moveSpeed: 13.6 * PLAYER_SCALE,
     reachRadius: 1.95 * PLAYER_SCALE,
     accuracy: 0.94,
-    power: 0.54,
+    power: 0.66,
     spin: 0.88,
     mistakeChance: 0.018,
     serveQuality: 0.84,


### PR DESCRIPTION
### Motivation
- Make the tennis experience feel larger and more powerful by scaling the play area, camera framing, and physical forces so ball arcs and player motion read naturally at the bigger court size.
- Improve ball flight, bounce and spin realism on the scaled court and make AI / player stroke power match the new dimensions.
- Replace the simple walking layer with a planted, bowling-style walk plus tennis-specific lateral shuffle/backpedal so characters move and face the court more realistically.

### Description
- World & camera: increased `COURT_AND_CHARACTER_SIZE_MULTIPLIER` and `CAMERA_VIEW_SCALE` in `gameConfig.ts`, raised camera offsets/damping in `CameraController.ts` and adjusted pre-serve / rally framing to sit farther back and higher.
- Physics & power: scaled gravity to the enlarged world, reduced `airDrag`, lowered `bounceRestitution` and tuned `groundFriction` in `gameConfig.ts`, increased `matchPowerMultiplier`, `servePower` and `shotPower`, and raised player/AI speeds and AI power/moveSpeed in `gameConfig.ts`.
- Ball dynamics: tweaked spin lift/dip factors, weakened net-velocity retention, replaced simple restitution with a vertical-impact based `bounceEnergy`, adjusted spin/roll/friction contributions and spin decay in `BallController.ts`.
- Character locomotion & animation: added leg bone detection, walk state (`walkCycle`, `yawVelocity`, `locomotion`) and a new `applyTennisBowlingWalkMotion` planted-walk + shuffle/backpedal routine in `Tennis.tsx`, applied the locomotion layer before arm IK, and lengthened groundstroke timing and hand/racket pullback → push-forward values to emphasize stronger swings.
- Controls & positioning: scaled pointer-to-target movement, serve/home player positions and camera offsets by `WORLD_SCALE` so input and placement match the enlarged court.

### Testing
- Built the web client with `npm --prefix webapp run build` and the build completed successfully (Vite production build).
- Ran a local dev server and a Playwright smoke check that navigated to `/games/tennis` and produced a screenshot (`tennis-court-update.png`) to verify camera/court/character visuals render; screenshot file was generated.
- Ran `git diff --check` to validate no whitespace/errors introduced by edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a768bd748329a1e1f17ffb2d208f)