### PR TITLE
Tennis: add locomotion/footwork and retune physics, camera, and scale

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -107,6 +107,8 @@ type HumanRig = {
   desiredHit: DesiredHit | null;
   hitThisSwing: boolean;
   speed: number;
+  walkCycle: number;
+  yawVelocity: number;
 };
 
 type HudState = { nearScore: number; farScore: number; nearLabel?: string; farLabel?: string; nearGames?: number; farGames?: number; status: string; power: number; server?: PlayerSide; serveSide?: "deuce" | "ad"; firstServe?: boolean; debug?: string };
@@ -1112,6 +1114,117 @@ function addLocalRotation(bone: THREE.Bone | undefined, x: number, y: number, z:
   bone.quaternion.multiply(new THREE.Quaternion().setFromEuler(new THREE.Euler(x, y, z, "XYZ")));
 }
 
+
+type TennisLocomotionMode = "idle" | "forward" | "backpedal" | "shuffle";
+
+function tennisPoseBone(model: THREE.Object3D, key: string) {
+  const hints: Record<string, string[]> = {
+    hips: ["hips", "pelvis", "pelvisjoint", "hipjoint"],
+    spine: ["spine", "chest", "torso"],
+    leftUpperArm: ["leftarm", "leftupperarm", "lupperarm", "shoulderl"],
+    leftForeArm: ["leftforearm", "leftlowerarm", "lforearm", "elbowl"],
+    rightUpperArm: ["rightarm", "rightupperarm", "rupperarm", "shoulderr"],
+    rightForeArm: ["rightforearm", "rightlowerarm", "rforearm", "elbowr"],
+    leftThigh: ["leftupleg", "leftthigh", "lthigh", "legjointl1"],
+    leftCalf: ["leftleg", "leftcalf", "lcalf", "legjointl2"],
+    rightThigh: ["rightupleg", "rightthigh", "rthigh", "legjointr1"],
+    rightCalf: ["rightleg", "rightcalf", "rcalf", "legjointr2"],
+  };
+  return findFirstBone(model, hints[key] || []);
+}
+
+function captureTennisLocomotionDefaultPose(model: THREE.Object3D) {
+  if (model.userData.tennisLocomotionDefaultPose) return;
+  const bones = [
+    "hips",
+    "spine",
+    "leftUpperArm",
+    "leftForeArm",
+    "rightUpperArm",
+    "rightForeArm",
+    "leftThigh",
+    "leftCalf",
+    "rightThigh",
+    "rightCalf",
+  ] as const;
+  const pose: Record<string, THREE.Euler> = {};
+  for (const key of bones) {
+    const bone = tennisPoseBone(model, key);
+    if (bone) pose[key] = bone.rotation.clone();
+  }
+  model.userData.tennisLocomotionDefaultPose = pose;
+}
+
+function resetTennisLocomotionPose(model: THREE.Object3D | null) {
+  const pose = model?.userData?.tennisLocomotionDefaultPose as Record<string, THREE.Euler> | undefined;
+  if (!model || !pose) return;
+  Object.entries(pose).forEach(([key, rotation]) => {
+    const bone = tennisPoseBone(model, key);
+    if (bone) bone.rotation.copy(rotation);
+  });
+}
+
+function applyTennisRotationOffset(bone: THREE.Object3D | undefined, x = 0, y = 0, z = 0) {
+  if (!bone) return;
+  bone.rotation.x += x;
+  bone.rotation.y += y;
+  bone.rotation.z += z;
+}
+
+function applyBowlingStyleTennisWalk(player: HumanRig, mode: TennisLocomotionMode, dt: number, runAmount: number, sideDot: number, forwardDot: number) {
+  if (!player.model) return;
+  captureTennisLocomotionDefaultPose(player.model);
+  resetTennisLocomotionPose(player.model);
+
+  if (mode === "idle" || runAmount <= 0.02) {
+    player.model.position.set(0, 0, 0);
+    player.model.rotation.set(0, CFG.playerVisualYawFix, 0);
+    return;
+  }
+
+  const cadence = mode === "shuffle" ? 10.6 : mode === "backpedal" ? 9.1 : 8.8;
+  player.walkCycle += dt * cadence * lerp(0.52, 1.18, runAmount);
+  const phase = player.walkCycle;
+  const step = Math.sin(phase);
+  const counter = Math.sin(phase + Math.PI);
+  const footfall = Math.abs(step);
+  const deg = THREE.MathUtils.degToRad;
+  const stride = (mode === "shuffle" ? 0.82 : mode === "backpedal" ? 0.74 : 0.9) * runAmount;
+  const sideSign = Math.sign(sideDot || 1);
+  const turnLean = clamp(player.yawVelocity * 0.003, -0.1, 0.1);
+
+  player.model.position.y = footfall * stride * 0.115;
+  player.model.position.x = Math.sin(phase * 0.5) * stride * (mode === "shuffle" ? 0.08 : 0.035) * sideSign;
+  player.model.rotation.x = 0.012 + counter * stride * (mode === "backpedal" ? -0.035 : 0.045);
+  player.model.rotation.y = CFG.playerVisualYawFix + step * stride * (mode === "shuffle" ? 0.08 : 0.18);
+  player.model.rotation.z = (mode === "shuffle" ? -sideSign * 0.08 : step * 0.105) * stride - turnLean;
+
+  applyTennisRotationOffset(tennisPoseBone(player.model, "hips"), 0, step * stride * 0.08, -step * stride * 0.09);
+  applyTennisRotationOffset(tennisPoseBone(player.model, "spine"), deg(2.5), -step * stride * 0.035, step * stride * 0.045);
+  applyTennisRotationOffset(tennisPoseBone(player.model, "leftUpperArm"), -counter * stride * 1.35, 0, deg(-5));
+  applyTennisRotationOffset(tennisPoseBone(player.model, "rightUpperArm"), -step * stride * 1.35, 0, deg(5));
+  applyTennisRotationOffset(tennisPoseBone(player.model, "leftForeArm"), Math.max(0, step) * stride * 0.42, 0, 0);
+  applyTennisRotationOffset(tennisPoseBone(player.model, "rightForeArm"), Math.max(0, counter) * stride * 0.42, 0, 0);
+
+  const shuffleOpen = mode === "shuffle" ? sideSign * 0.28 : 0;
+  const reverse = mode === "backpedal" ? -1 : 1;
+  applyTennisRotationOffset(tennisPoseBone(player.model, "leftThigh"), step * stride * 1.05 * reverse, shuffleOpen, deg(1.5));
+  applyTennisRotationOffset(tennisPoseBone(player.model, "rightThigh"), counter * stride * 1.05 * reverse, shuffleOpen, deg(-1.5));
+  applyTennisRotationOffset(tennisPoseBone(player.model, "leftCalf"), Math.max(0, -step) * stride * 0.74, 0, 0);
+  applyTennisRotationOffset(tennisPoseBone(player.model, "rightCalf"), Math.max(0, -counter) * stride * 0.74, 0, 0);
+
+  if (mode === "shuffle") {
+    // Tennis recovery uses pas-chassé/side-shuffle footwork: stay square to the net/court,
+    // keep the center of gravity low, and push-pull sideways instead of turning into a run.
+    applyTennisRotationOffset(tennisPoseBone(player.model, "hips"), 0, sideSign * deg(4) * stride, -sideSign * deg(4.5) * stride);
+    applyTennisRotationOffset(tennisPoseBone(player.model, "leftThigh"), 0, sideSign * deg(7) * stride, 0);
+    applyTennisRotationOffset(tennisPoseBone(player.model, "rightThigh"), 0, sideSign * deg(7) * stride, 0);
+  } else if (mode === "backpedal") {
+    applyTennisRotationOffset(tennisPoseBone(player.model, "hips"), deg(-2.5) * stride, 0, 0);
+    player.model.rotation.x -= 0.045 * runAmount * Math.abs(forwardDot);
+  }
+}
+
 function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, accent: number, theme?: CharacterTheme): HumanRig {
   const root = new THREE.Group();
   const modelRoot = new THREE.Group();
@@ -1143,6 +1256,8 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
     desiredHit: null,
     hitThisSwing: false,
     speed: side === "near" ? CFG.playerSpeed : CFG.aiSpeed,
+    walkCycle: 0,
+    yawVelocity: 0,
   };
 
   modelRoot.rotation.y = rig.yaw;
@@ -1162,6 +1277,7 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
       rig.model = model;
       rig.bones = findHumanBones(model);
       rig.rest = captureRestPose(rig.bones);
+      captureTennisLocomotionDefaultPose(model);
       rig.fallback.visible = false;
       rig.modelRoot.add(model);
       rig.modelRoot.updateMatrixWorld(true);
@@ -1385,11 +1501,11 @@ function updatePoseAndRacket(player: HumanRig, ball: BallState) {
 
 function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: number, serve = false) {
   const flatDist = Math.hypot(target.x - from.x, target.z - from.z);
-  const speedScale = CFG.worldScale * 1.48;
-  const shotPowerTrim = serve ? 0.8 : 0.76;
+  const speedScale = CFG.worldScale * 1.54;
+  const shotPowerTrim = serve ? 0.9 : 0.84;
   const matchPower = power * CFG.matchPowerMultiplier;
-  const baseSpeed = (serve ? 22.2 + power * 12.6 : 15.8 + power * 10.4) * speedScale * shotPowerTrim * CFG.matchPowerMultiplier;
-  const flight = clamp(flatDist / baseSpeed, serve ? 0.34 : 0.46, serve ? 0.78 : 1.04);
+  const baseSpeed = (serve ? 23.8 + power * 14.8 : 17.2 + power * 12.6) * speedScale * shotPowerTrim * CFG.matchPowerMultiplier;
+  const flight = clamp(flatDist / baseSpeed, serve ? 0.38 : 0.5, serve ? 0.88 : 1.16);
   const velocity = new THREE.Vector3(
     (target.x - from.x) / flight,
     (target.y - from.y + 0.5 * CFG.gravity * flight * flight) / flight,
@@ -1565,25 +1681,31 @@ function updatePlayerMotion(player: HumanRig, ball: BallState, dt: number) {
   let delta = targetYaw - player.yaw;
   while (delta > Math.PI) delta -= Math.PI * 2;
   while (delta < -Math.PI) delta += Math.PI * 2;
-  player.yaw += delta * (1 - Math.exp(-8 * dt));
+  const yawStep = delta * (1 - Math.exp(-8 * dt));
+  player.yaw += yawStep;
+  player.yawVelocity = yawStep / Math.max(0.0001, dt);
 
   player.root.position.copy(player.pos);
   player.modelRoot.position.copy(player.pos);
   player.modelRoot.rotation.y = player.yaw;
 
   if (player.model) {
-    const runAmount = clamp01(dist / 0.42);
-    const moveDir = dist > 0.0001 ? to.clone().normalize() : new THREE.Vector3();
+    const runAmount = clamp01(dist / (0.42 * CFG.worldScale));
+    const moveDir = dist > 0.0001 ? player.target.clone().sub(player.pos).normalize() : new THREE.Vector3();
     const localForward = forwardFromYaw(player.yaw);
     const localRight = rightFromForward(localForward);
     const forwardDot = moveDir.dot(localForward);
     const sideDot = moveDir.dot(localRight);
-    const walkT = performance.now() * 0.015 + (player.side === "near" ? 0 : Math.PI);
-    const bob = Math.sin(walkT) * 0.03 * runAmount;
-    const strafeLean = sideDot * 0.1 * runAmount;
-    player.model.position.y = bob;
-    player.model.rotation.x = 0.05 * runAmount * Math.max(0, forwardDot) - 0.03 * runAmount * Math.max(0, -forwardDot);
-    player.model.rotation.z = strafeLean;
+    const footwork = PlayerController.footworkFromDelta(player.target.x - player.pos.x, player.target.z - player.pos.z, player.side, player.action === "ready" ? null : player.action);
+    const canUseLocomotion = ball.lastHitBy !== null && player.action === "ready" && dist > 0.06 * CFG.worldScale;
+    const mode: TennisLocomotionMode = !canUseLocomotion
+      ? "idle"
+      : Math.abs(sideDot) > Math.abs(forwardDot) * 0.72 || footwork === "MoveLeft" || footwork === "MoveRight"
+        ? "shuffle"
+        : forwardDot < -0.2 || footwork === "MoveBack"
+          ? "backpedal"
+          : "forward";
+    applyBowlingStyleTennisWalk(player, mode, dt, canUseLocomotion ? runAmount : 0, sideDot, forwardDot);
   }
 
   player.cooldown = Math.max(0, player.cooldown - dt);
@@ -1647,8 +1769,8 @@ export default function MobileThreeTennisPrototype() {
     scene.fog = null;
 
     const camera = new THREE.PerspectiveCamera(44, 1, 0.05, Math.max(70, CFG.courtL * 1.8));
-    const cameraTarget = new THREE.Vector3(0, 1.12 * CFG.cameraViewScale, -1.7 * CFG.cameraViewScale);
-    const cameraOffset = new THREE.Vector3(0, 7.35 * CFG.cameraViewScale, 11.85 * CFG.cameraViewScale);
+    const cameraTarget = new THREE.Vector3(0, 1.48 * CFG.cameraViewScale, -2.2 * CFG.cameraViewScale);
+    const cameraOffset = new THREE.Vector3(0, 9.25 * CFG.cameraViewScale, 15.25 * CFG.cameraViewScale);
     const cameraPosTarget = new THREE.Vector3();
 
     addTrainingCourtLighting(scene);
@@ -1835,13 +1957,13 @@ export default function MobileThreeTennisPrototype() {
 
     function updateBall(dt: number) {
       const prevZ = ball.pos.z;
-      const spinDip = Math.max(0, ball.spin) * 0.16;
-      const spinLift = Math.max(0, -ball.spin) * 0.05;
+      const spinDip = Math.max(0, ball.spin) * 0.11;
+      const spinLift = Math.max(0, -ball.spin) * 0.035;
       ball.vel.y -= CFG.gravity * (1 + spinDip - spinLift) * dt;
       if (ball.lastHitBy && Math.abs(ball.vel.z) > 0.001) {
         const forwardSign = ball.lastHitBy === "near" ? -1 : 1;
-        ball.vel.z += forwardSign * ball.spin * 0.18 * CFG.worldScale * dt;
-        ball.vel.x += Math.sin(ball.spin * 0.65) * 0.018 * CFG.worldScale * dt;
+        ball.vel.z += forwardSign * ball.spin * 0.14 * CFG.worldScale * dt;
+        ball.vel.x += Math.sin(ball.spin * 0.65) * 0.022 * CFG.worldScale * dt;
       }
       ball.vel.multiplyScalar(Math.exp(-CFG.airDrag * dt));
       ball.pos.addScaledVector(ball.vel, dt);
@@ -1873,11 +1995,11 @@ export default function MobileThreeTennisPrototype() {
           ball.vel.y = -ball.vel.y * CFG.bounceRestitution;
           ball.vel.x *= CFG.groundFriction;
           ball.vel.z *= CFG.groundFriction;
-          ball.vel.z += forwardSign * ball.spin * 0.33 * CFG.worldScale;
-          ball.vel.x += Math.sign(ball.vel.x || Math.sin(ball.spin)) * Math.abs(ball.spin) * 0.045 * CFG.worldScale;
-          ball.vel.y *= clamp(1 - Math.max(0, ball.spin) * 0.055, 0.78, 1.08);
+          ball.vel.z += forwardSign * ball.spin * 0.25 * CFG.worldScale;
+          ball.vel.x += Math.sign(ball.vel.x || Math.sin(ball.spin)) * Math.abs(ball.spin) * 0.038 * CFG.worldScale;
+          ball.vel.y *= clamp(1 - Math.max(0, ball.spin) * 0.045, 0.8, 1.06);
           if (Math.sign(incomingZ) !== Math.sign(ball.vel.z) && Math.abs(incomingZ) > 0.01) ball.vel.z *= 0.65;
-          ball.spin *= -0.38;
+          ball.spin *= -0.32;
           const bounceSide = sideOfZ(ball.pos.z);
           audioVfx.play("bounce");
           if (ball.bounceSide === bounceSide) ball.bounceCount += 1;

--- a/webapp/src/pages/Games/tennis/BallController.ts
+++ b/webapp/src/pages/Games/tennis/BallController.ts
@@ -19,13 +19,13 @@ export class BallController {
 
   stepFixed(ball: BallLike, dt: number, opts: { awaitingServe: boolean; serveSide: "deuce" | "ad"; onRuleEvent?: (event: CourtRuleEvent) => void; onBounce?: () => void; onNet?: () => void }) {
     const prevZ = ball.pos.z;
-    const spinDip = Math.max(0, ball.spin) * 0.16;
-    const spinLift = Math.max(0, -ball.spin) * 0.05;
+    const spinDip = Math.max(0, ball.spin) * 0.11;
+    const spinLift = Math.max(0, -ball.spin) * 0.035;
     ball.vel.y -= gameConfig.gravity * (1 + spinDip - spinLift) * dt;
     if (ball.lastHitBy && Math.abs(ball.vel.z) > 0.001) {
       const forwardSign = ball.lastHitBy === "near" ? -1 : 1;
-      ball.vel.z += forwardSign * ball.spin * 0.18 * gameConfig.worldScale * dt;
-      ball.vel.x += Math.sin(ball.spin * 0.65) * 0.018 * gameConfig.worldScale * dt;
+      ball.vel.z += forwardSign * ball.spin * 0.14 * gameConfig.worldScale * dt;
+      ball.vel.x += Math.sin(ball.spin * 0.65) * 0.022 * gameConfig.worldScale * dt;
     }
     ball.vel.multiplyScalar(Math.exp(-gameConfig.airDrag * dt));
     ball.pos.addScaledVector(ball.vel, dt);
@@ -51,11 +51,11 @@ export class BallController {
         ball.vel.y = -ball.vel.y * gameConfig.bounceRestitution;
         ball.vel.x *= gameConfig.groundFriction;
         ball.vel.z *= gameConfig.groundFriction;
-        ball.vel.z += forwardSign * ball.spin * 0.33 * gameConfig.worldScale;
-        ball.vel.x += Math.sign(ball.vel.x || Math.sin(ball.spin)) * Math.abs(ball.spin) * 0.045 * gameConfig.worldScale;
-        ball.vel.y *= clamp(1 - Math.max(0, ball.spin) * 0.055, 0.78, 1.08);
+        ball.vel.z += forwardSign * ball.spin * 0.25 * gameConfig.worldScale;
+        ball.vel.x += Math.sign(ball.vel.x || Math.sin(ball.spin)) * Math.abs(ball.spin) * 0.038 * gameConfig.worldScale;
+        ball.vel.y *= clamp(1 - Math.max(0, ball.spin) * 0.045, 0.8, 1.06);
         if (Math.sign(incomingZ) !== Math.sign(ball.vel.z) && Math.abs(incomingZ) > 0.01) ball.vel.z *= 0.65;
-        ball.spin *= -0.38;
+        ball.spin *= -0.32;
         const bounceSide = sideOfZ(ball.pos.z);
         ball.bounceCount = ball.bounceSide === bounceSide ? ball.bounceCount + 1 : 1;
         ball.bounceSide = bounceSide;
@@ -65,7 +65,7 @@ export class BallController {
       }
     }
 
-    if ((Math.abs(ball.pos.x) > gameConfig.courtW / 2 + 3.2 || Math.abs(ball.pos.z) > gameConfig.courtL / 2 + 3.2 || ball.pos.y < -1.2) && ball.lastHitBy) {
+    if ((Math.abs(ball.pos.x) > gameConfig.courtW / 2 + 0.9 * gameConfig.worldScale || Math.abs(ball.pos.z) > gameConfig.courtL / 2 + 0.9 * gameConfig.worldScale || ball.pos.y < -1.2) && ball.lastHitBy) {
       ball.state = TennisBallState.Out;
       opts.onRuleEvent?.({ type: "out", side: sideOfZ(ball.pos.z), landing: ball.pos.clone() });
     }

--- a/webapp/src/pages/Games/tennis/CameraController.ts
+++ b/webapp/src/pages/Games/tennis/CameraController.ts
@@ -31,12 +31,12 @@ export class CameraController {
     const lateral = Math.max(-0.45, Math.min(0.45, ballPos.x * 0.08));
 
     if (preServe) {
-      cameraPosTarget.copy(playerTarget).add(tempOffset.set(playerTarget.x * 0.08 + lateral, 8.85 * gameConfig.cameraViewScale, 14.65 * gameConfig.cameraViewScale));
-      tempLookTarget.set(playerTarget.x * 0.2 + lateral, 1.55 * gameConfig.cameraViewScale, -gameConfig.courtL * 0.31);
+      cameraPosTarget.copy(playerTarget).add(tempOffset.set(playerTarget.x * 0.08 + lateral, 10.7 * gameConfig.cameraViewScale, 17.9 * gameConfig.cameraViewScale));
+      tempLookTarget.set(playerTarget.x * 0.2 + lateral, 1.95 * gameConfig.cameraViewScale, -gameConfig.courtL * 0.31);
       cameraTarget.lerp(tempLookTarget, targetDamping);
     } else {
       tempFollowAnchor.copy(playerTarget);
-      tempBaseTarget.set(playerTarget.x + lateral, 1.52 * gameConfig.cameraViewScale, playerTarget.z - 9.35 * gameConfig.cameraViewScale);
+      tempBaseTarget.set(playerTarget.x + lateral, 1.95 * gameConfig.cameraViewScale, playerTarget.z - 11.7 * gameConfig.cameraViewScale);
 
       if (incomingToPlayer) {
         tempIncomingTarget.copy(options.predictedLanding || ballPos);
@@ -45,7 +45,7 @@ export class CameraController {
         tempFollowAnchor.lerp(tempIncomingTarget, gameConfig.cameraPlayerFollowBlend);
 
         tempBallBias.copy(ballPos).lerp(tempIncomingTarget, 0.45);
-        tempBallBias.y = Math.max(1.45 * gameConfig.cameraViewScale, ballPos.y * 0.3 + 1.35 * gameConfig.cameraViewScale);
+        tempBallBias.y = Math.max(1.8 * gameConfig.cameraViewScale, ballPos.y * 0.34 + 1.72 * gameConfig.cameraViewScale);
         tempBaseTarget.lerp(tempBallBias, gameConfig.cameraBallLookAhead);
       }
 

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -29,11 +29,11 @@ export enum TennisBallState {
 }
 
 const BASE_WORLD_SCALE = 1.72;
-const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 2.72;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 3.05;
 const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
 // Keep camera scaling independent from world scale so camera framing can be
 // tuned precisely while the enlarged court keeps its regulation proportions.
-const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE * 1.18;
+const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE * 1.34;
 // Extra character scale keeps human avatars visibly bigger than the court uplift.
 const PLAYER_CHARACTER_SCALE = 1.35;
 const PLAYER_SCALE = WORLD_SCALE * PLAYER_CHARACTER_SCALE;
@@ -52,17 +52,17 @@ export const gameConfig = {
   serviceLineZ: 6.4 * WORLD_SCALE,
   netH: 0.914 * WORLD_SCALE,
   ballR: 0.085 * WORLD_SCALE,
-  gravity: 24.5,
-  airDrag: 0.105,
-  bounceRestitution: 0.66,
-  groundFriction: 0.78,
+  gravity: 9.81 * WORLD_SCALE * 1.04,
+  airDrag: 0.13,
+  bounceRestitution: 0.61,
+  groundFriction: 0.74,
   minBallSpeed: 0.12 * WORLD_SCALE,
-  courtFriction: 0.78,
+  courtFriction: 0.74,
   playerHeight: 1.88 * PLAYER_SCALE,
-  playerSpeed: 8.4 * PLAYER_SCALE,
+  playerSpeed: 8.9 * PLAYER_SCALE,
   playerAcceleration: 28 * PLAYER_SCALE,
   playerDeceleration: 34 * PLAYER_SCALE,
-  aiSpeed: 11.2 * PLAYER_SCALE,
+  aiSpeed: 11.7 * PLAYER_SCALE,
   reach: 1.62 * PLAYER_SCALE,
   racketHitRadius: 0.56 * PLAYER_SCALE,
   contactAngleTolerance: 0.18,
@@ -70,14 +70,14 @@ export const gameConfig = {
   minContactHeight: 0.25 * PLAYER_SCALE,
   maxContactHeight: 1.85 * PLAYER_SCALE,
   maxReachDistance: 1.62 * PLAYER_SCALE,
-  swingDuration: 0.38,
+  swingDuration: 0.42,
   serveDuration: 0.86,
   serveContactT: 0.72,
   serveTossMinHeight: 1.85 * PLAYER_SCALE,
   // Scales the full match shot force so player and AI strokes share a softer, lower power ceiling.
-  matchPowerMultiplier: 0.55,
-  servePower: { min: 0.42, max: 0.62 },
-  shotPower: { min: 0.16, max: 0.56 },
+  matchPowerMultiplier: 0.68,
+  servePower: { min: 0.48, max: 0.74 },
+  shotPower: { min: 0.2, max: 0.68 },
   spinAmount: { flat: 0.8, topspin: 1.6, slice: -1.4, lob: 1.1, drop: -0.7, block: 0.25 },
   playerVisualYawFix: Math.PI,
   serveNearBaselineZ: (23.77 / 2 + 0.92) * WORLD_SCALE,
@@ -93,10 +93,10 @@ export const gameConfig = {
   scoring: { gamesPerSet: 6, winByTwoGames: true },
   aiDifficulty: {
     reactionTime: 0.07,
-    moveSpeed: 12.8 * PLAYER_SCALE,
+    moveSpeed: 13.5 * PLAYER_SCALE,
     reachRadius: 1.95 * PLAYER_SCALE,
     accuracy: 0.94,
-    power: 0.54,
+    power: 0.62,
     spin: 0.88,
     mistakeChance: 0.018,
     serveQuality: 0.84,


### PR DESCRIPTION
### Motivation
- Improve player locomotion and on-court visuals with a dedicated tennis footwork system and more natural model poses. 
- Tune world scale, camera framing, and ball physics to make shot speeds, bounces, and camera behavior feel more realistic and consistent with enlarged court proportions.
- Reduce mismatch between visual character motion and gameplay by tracking yaw velocity and smoothing model animation.

### Description
- Add a tennis locomotion subsystem including `TennisLocomotionMode`, bone lookup helpers, `captureTennisLocomotionDefaultPose`, `resetTennisLocomotionPose`, and `applyBowlingStyleTennisWalk`, and wire it into `updatePlayerMotion`; add `walkCycle` and `yawVelocity` to `HumanRig` and capture default model poses on load.
- Replace the simple bobbing logic with directional footwork selection (`idle|forward|backpedal|shuffle`) and apply per-bone rotation/position offsets to produce shuffle/backpedal/forward animations via `applyBowlingStyleTennisWalk`.
- Retune ball flight and bounce math in `ballisticVelocity`, `updateBall`, and `BallController.stepFixed` by adjusting speed scaling, shot trim, spin influence, air drag, bounce restitution, and friction to align with the new world scale and expected flight times.
- Increase global world/court scale and camera view scaling in `gameConfig`, and update related gameplay constants such as gravity, `airDrag`, `bounceRestitution`, `groundFriction`, `playerSpeed`, `aiSpeed`, `matchPowerMultiplier`, and `swingDuration` to match the new scale and feel.
- Update camera framing offsets and target calculation in `CameraController.update` and adjust out-of-bounds detection in `BallController` to use the updated `worldScale`.

### Testing
- Performed a TypeScript build/type-check of the webapp and verified the project compiles successfully.
- Executed the existing automated test suite and linters where available; no new tests were added and the existing checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a768bd748329a1e1f17ffb2d208f)