### PR TITLE
Pool Royale: switch to ReadyPlayer human, adjust sizing, and fix facing/grounding

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1954,12 +1954,11 @@ const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear secti
 const POOL_HUMAN_UP = new THREE.Vector3(0, 1, 0);
 const POOL_HUMAN_Y_AXIS = POOL_HUMAN_UP;
 const POOL_HUMAN_URLS = Object.freeze([
-  'https://threejs.org/examples/models/gltf/Xbot.glb',
-  'https://threejs.org/examples/models/gltf/Soldier.glb',
+  // Match Snooker Champion's ReadyPlayer human; Pool Royale only changes the size.
   'https://threejs.org/examples/models/gltf/readyplayer.me.glb'
 ]);
 const POOL_HUMAN_CUE_REFERENCE_LENGTH = 1.5 * (BALL_R / 0.0525) * CUE_LENGTH_MULTIPLIER;
-const POOL_HUMAN_HEIGHT_TO_CUE_RATIO = 1.3;
+const POOL_HUMAN_HEIGHT_TO_CUE_RATIO = 1.42; // slightly larger than before while keeping Snooker Champion logic
 const POOL_HUMAN_TARGET_HEIGHT = POOL_HUMAN_CUE_REFERENCE_LENGTH * POOL_HUMAN_HEIGHT_TO_CUE_RATIO;
 const POOL_HUMAN_WORLD_SCALE = BALL_R / 0.052;
 const POOL_HUMAN_CFG = Object.freeze({
@@ -2036,6 +2035,18 @@ function poolHumanSafePlanarForward(forward, fallback = new THREE.Vector3(0, 0, 
   if (out.lengthSq() < 1e-8) out.copy(fallback).setY(0);
   if (out.lengthSq() < 1e-8) out.set(0, 0, -1);
   return out.normalize();
+}
+
+function poolHumanTableFacingForward(aimForward, rootTarget, cueBallWorld) {
+  const forward = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, 1));
+  const rootToTable = cueBallWorld?.clone?.().sub(rootTarget || new THREE.Vector3());
+  if (!rootToTable) return forward;
+  rootToTable.y = 0;
+  if (rootToTable.lengthSq() < 1e-8) return forward;
+  rootToTable.normalize();
+  // Keep the Snooker Champion pose math, but guarantee Pool Royale never feeds
+  // the mirrored shot axis that makes the body/cue point away from the table.
+  return forward.dot(rootToTable) < 0 ? forward.multiplyScalar(-1) : forward;
 }
 
 function makePoolHumanBasisQuaternion(side, up, forward) {
@@ -2498,6 +2509,7 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   }
   const rootGoal = state === 'striking' ? human.strikeRoot : rootTarget;
   poolHumanDampVector(human.root.position, rootGoal, state === 'striking' ? 12 : POOL_HUMAN_CFG.moveLambda, dt);
+  human.root.position.y = POOL_HUMAN_CFG.floorLocalY;
   const moveAmountRaw = human.root.position.distanceTo(rootGoal);
   human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / POOL_HUMAN_CFG.scale));
   human.yaw = poolHumanDampScalar(human.yaw, state === 'striking' ? human.strikeYaw : poolHumanYawFromForward(aimForward), POOL_HUMAN_CFG.rotLambda, dt);
@@ -2547,11 +2559,12 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
 
 function updatePoolRoyaleHumanFrame(human, dt, shotState, cueBallWorld, aimForward, cueStick, cueLen, power) {
   if (!human) return null;
-  const poseForward = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, 1));
+  const rawPoseForward = poolHumanSafePlanarForward(aimForward, new THREE.Vector3(0, 0, 1));
   const activeHumanState = shotState === 'rolling' ? 'idle' : shotState;
   const tableCue = getPoolHumanCueEndpoints(cueStick, cueLen);
-  const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, poseForward);
+  const rootTarget = choosePoolHumanEdgePosition(cueBallWorld, rawPoseForward);
   rootTarget.y = POOL_HUMAN_CFG.floorLocalY;
+  const poseForward = poolHumanTableFacingForward(rawPoseForward, rootTarget, cueBallWorld);
   const standingYaw = poolHumanYawFromForward(poseForward);
   const aimSide = new THREE.Vector3(poseForward.z, 0, -poseForward.x).normalize();
   const bridgeHandTarget = cueBallWorld.clone()


### PR DESCRIPTION
### Motivation

- Align Pool Royale's avatar with the ReadyPlayer human used by Snooker Champion while keeping Pool Royale-specific sizing. 
- Prevent mirrored pose orientations and vertical offset issues so the avatar consistently faces the table and stands at the table floor height.

### Description

- Replace `POOL_HUMAN_URLS` with the ReadyPlayer model and add a comment explaining the choice. 
- Increase `POOL_HUMAN_HEIGHT_TO_CUE_RATIO` from `1.3` to `1.42` to better match the cue-to-height scaling. 
- Add `poolHumanTableFacingForward` to ensure the computed forward vector is facing the table and to avoid feeding a mirrored shot axis. 
- Force `human.root.position.y` to `POOL_HUMAN_CFG.floorLocalY` and use the new facing helper in `updatePoolRoyaleHumanFrame` so the human is grounded and oriented correctly.

### Testing

- Ran frontend unit tests with `yarn test`, which completed successfully. 
- Ran linting with `yarn lint` and performed a local build with `yarn build`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a8b736e8832999b700dc7eb4dac3)