### PR TITLE
Align Pool avatar with cue and fix yaw facing during shots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1959,7 +1959,7 @@ const POOL_HUMAN_URLS = Object.freeze([
   'https://threejs.org/examples/models/gltf/readyplayer.me.glb'
 ]);
 const POOL_HUMAN_CUE_REFERENCE_LENGTH = 1.5 * (BALL_R / 0.0525) * CUE_LENGTH_MULTIPLIER;
-const POOL_HUMAN_HEIGHT_TO_CUE_RATIO = 1.3;
+const POOL_HUMAN_HEIGHT_TO_CUE_RATIO = 1.42;
 const POOL_HUMAN_TARGET_HEIGHT = POOL_HUMAN_CUE_REFERENCE_LENGTH * POOL_HUMAN_HEIGHT_TO_CUE_RATIO;
 const POOL_HUMAN_WORLD_SCALE = BALL_R / 0.052;
 const POOL_HUMAN_CFG = Object.freeze({
@@ -2500,7 +2500,18 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   poolHumanDampVector(human.root.position, rootGoal, state === 'striking' ? 12 : POOL_HUMAN_CFG.moveLambda, dt);
   const moveAmountRaw = human.root.position.distanceTo(rootGoal);
   human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / POOL_HUMAN_CFG.scale));
-  human.yaw = poolHumanDampScalar(human.yaw, state === 'striking' ? human.strikeYaw : poolHumanYawFromForward(aimForward), POOL_HUMAN_CFG.rotLambda, dt);
+  const tableFacingAimForward = poolHumanSafePlanarForward(aimForward);
+  const rootToTable = bridgeTarget.clone().sub(human.root.position);
+  rootToTable.y = 0;
+  if (rootToTable.lengthSq() > 1e-8 && tableFacingAimForward.dot(rootToTable.normalize()) < 0) {
+    tableFacingAimForward.multiplyScalar(-1);
+  }
+  human.yaw = poolHumanDampScalar(
+    human.yaw,
+    state === 'striking' ? human.strikeYaw : poolHumanYawFromForward(tableFacingAimForward),
+    POOL_HUMAN_CFG.rotLambda,
+    dt
+  );
   const t = poolHumanEaseInOut(human.poseT);
   const idle = 1 - t;
   const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * POOL_HUMAN_CFG.scale);

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -1100,6 +1100,7 @@ function updateOriginalSkeletonHumanPose(human, dt, frameData) {
     : dampAngle(human.yaw, targetYaw, cfg.rotLambda, dt);
 
   const t = easeInOut(human.poseT);
+  const handPoseT = t;
   const idle = 1 - t;
   const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * cfg.unit);
   const walk = Math.sin(human.walkT * 6.2) * Math.min(1, (moveAmountRaw * 12) / cfg.unit);


### PR DESCRIPTION
### Motivation

- Ensure the Pool Royale avatar visually matches the cue stick length by adjusting the height-to-cue ratio. 
- Prevent the avatar from turning away from the table during shots by making yaw selection aware of the bridge/root relative direction. 
- Prepare for more explicit hand/arm pose blending in the shared rig code.

### Description

- Bumped `POOL_HUMAN_HEIGHT_TO_CUE_RATIO` from `1.3` to `1.42` which raises `POOL_HUMAN_TARGET_HEIGHT` to better match cue reference length. 
- In `updatePoolRoyaleHumanPose`, compute a planar `tableFacingAimForward` via `poolHumanSafePlanarForward`, compare it to the planar vector from `human.root` to `bridgeTarget`, and invert the aim forward when it points away from the table so yaw is damped toward a table-facing orientation. 
- Replaced the previous direct yaw damping call with the new conditional logic to use the corrected forward vector when not striking. 
- Added a `handPoseT` alias for `t` in `updateOriginalSkeletonHumanPose` in `humanRigCore.js` to make hand/pose timing explicit for later use.

### Testing

- Ran the project's unit test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a8b736e8832999b700dc7eb4dac3)