### PR TITLE
Tennis: enlarge court/net separately and adjust camera framing

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/README.md
+++ b/Assets/Scripts/Gameplay/Tennis/README.md
@@ -3,7 +3,7 @@
 This folder adds modular tennis systems:
 
 - `TennisShotTuning`: keeps shots at a calmer match-power pace and supports flat/power/topspin/curve variants.
-- `TennisCourtScaler`: scales court + characters and moves camera back to keep similar framing.
+- `TennisCourtScaler`: scales the court/net larger than the players and moves the camera back to keep the bigger court framed.
 - `TennisAudioController`: trigger shot and bounce SFX.
 - `TennisAIOpponent`: faster AI reaction, mixed shot variants, and capped match-power shot selection.
 - `CharacterWalk8Dir`: 8-direction walk movement (forward/backward/sideways).

--- a/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
@@ -12,7 +12,8 @@ namespace TonPlaygram.Gameplay.Tennis
         [SerializeField] private Camera targetCamera;
         [SerializeField] private Transform framingPivot;
         [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 2.45f;
-        [SerializeField, Min(1f)] private float framingDistanceScale = 2.15f;
+        [SerializeField, Min(0.1f)] private float courtScaleMultiplier = 3.2f;
+        [SerializeField, Min(1f)] private float framingDistanceScale = 2.65f;
 
         private bool _initialized;
         private Vector3 _initialCourtScale;
@@ -32,9 +33,9 @@ namespace TonPlaygram.Gameplay.Tennis
         {
             EnsureInitialized();
 
-            SetScaled(courtRoot, _initialCourtScale);
-            SetScaled(ballRoot, _initialBallScale);
-            SetScaled(netRoot, _initialNetScale);
+            SetScaled(courtRoot, _initialCourtScale, courtScaleMultiplier);
+            SetScaled(ballRoot, _initialBallScale, worldScaleMultiplier);
+            SetScaled(netRoot, _initialNetScale, courtScaleMultiplier);
             SetScaledArray(characterRoots, _initialCharacterScales);
             SetScaledArray(racketRoots, _initialRacketScales);
 
@@ -91,14 +92,14 @@ namespace TonPlaygram.Gameplay.Tennis
             if (roots == null || baseScales == null) return;
             for (int i = 0; i < roots.Length && i < baseScales.Length; i++)
             {
-                SetScaled(roots[i], baseScales[i]);
+                SetScaled(roots[i], baseScales[i], worldScaleMultiplier);
             }
         }
 
-        private void SetScaled(Transform target, Vector3 baseScale)
+        private void SetScaled(Transform target, Vector3 baseScale, float scaleMultiplier)
         {
             if (target == null) return;
-            target.localScale = baseScale * worldScaleMultiplier;
+            target.localScale = baseScale * scaleMultiplier;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make the tennis court and net appear larger relative to players so gameplay visuals better match the desired scale and camera framing.

### Description
- Add a new `courtScaleMultiplier` field (default `3.2f`) and increase `framingDistanceScale` to `2.65f` to keep a larger court in view.
- Apply `courtScaleMultiplier` to `courtRoot` and `netRoot`, while keeping `worldScaleMultiplier` for the ball, characters, and rackets.
- Change the `SetScaled` method to accept a `scaleMultiplier` parameter and update `SetScaledArray` to use `worldScaleMultiplier` for character/racket scaling.
- Update `Assets/Scripts/Gameplay/Tennis/README.md` to document the new court/net scaling behavior.

### Testing
- Ran `git diff --check -- Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs Assets/Scripts/Gameplay/Tennis/README.md`, which completed with no issues.
- Attempted `dotnet build billiards/Billiards.csproj --no-restore`, which failed because `dotnet` is not installed in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0925d445608329969dd7d6a09e12c1)