### PR TITLE
Adjust Real Bowling camera framing

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -194,6 +194,8 @@ const CHROME_ITEMS = POOL_ROYALE_STORE_ITEMS.filter(
 );
 const PORTRAIT_CAMERA_SIDE_OFFSET = 0.42;
 const PORTRAIT_CAMERA_HEIGHT_OFFSET = 0.18;
+const BOWLING_CAMERA_PULLBACK = 0.5;
+const BOWLING_CAMERA_WIDER_FOV_BOOST = 1.5;
 const BOWLING_HDRI_WALL_ALIGNMENT_Y = Math.PI / 2;
 const BOWLING_GRAPHICS_PROFILES: Record<
   GraphicsQuality,
@@ -4160,6 +4162,10 @@ function updateCamera(
     look.x = lerp(look.x, BOWLING_LOUNGE_CENTER.x * 0.38, 0.16);
     look.z += 0.82;
   }
+  const pullback = desired.clone().sub(look);
+  if (pullback.lengthSq() > 0.0001) {
+    desired.addScaledVector(pullback.normalize(), BOWLING_CAMERA_PULLBACK);
+  }
   if (lookState) {
     lookState.yaw = lerp(
       lookState.yaw,
@@ -4172,7 +4178,7 @@ function updateCamera(
       1 - Math.exp(-7.5 * dt)
     );
   }
-  const baseFov = isPortraitCamera ? 52 : 46;
+  const baseFov = (isPortraitCamera ? 52 : 46) + BOWLING_CAMERA_WIDER_FOV_BOOST;
   const speedFov = ball.rolling
     ? clamp01(Math.hypot(ball.vel.x, ball.vel.z) / 16) * 3.5
     : 0;


### PR DESCRIPTION
### Motivation
- The in-game bowling camera felt too tight and required a small pullback and wider framing so players can see more of the lane during play.

### Description
- Added two new constants `BOWLING_CAMERA_PULLBACK` and `BOWLING_CAMERA_WIDER_FOV_BOOST` in `webapp/src/pages/Games/BowlingRealistic.tsx` to tune framing and FOV.
- In `updateCamera` the camera `desired` position is nudged away from the `look` point by the normalized pullback vector so the camera sits slightly further back for a wider view.
- Increased the base field-of-view by the configured FOV boost so portrait and landscape modes both feel less tight.
- Only `webapp/src/pages/Games/BowlingRealistic.tsx` was committed for this change; unrelated local edits to `webapp/ios/App/.../Contents.json` were present but not included in the commit.

### Testing
- Ran `npm run build` successfully and produced the production `dist` bundle.
- Ran `npx playwright install chromium` and `npx playwright install-deps chromium` successfully to provision browsers and system deps.
- Started the dev server and used Playwright to open `http://127.0.0.1:5173/games/bowling?mode=practice` and capture a screenshot; screenshot capture completed but the run logged expected network/asset warnings for external resources.
- All automated steps above completed (build and browser provisioning succeeded); the runtime dev session showed non-blocking warnings related to external assets and local API/socket resources but did not prevent the camera framing verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09286d09788329b93c0111442ad344)