### PR TITLE
Tune table tennis ball physics

### DIFF
--- a/webapp/src/pages/Games/TableTennis.tsx
+++ b/webapp/src/pages/Games/TableTennis.tsx
@@ -137,7 +137,7 @@ const CFG = {
   gravity: 9.81,
   airDrag: 0.18,
   magnus: 0.00138,
-  tableRestitution: 1.02,
+  tableRestitution: 1.16,
   tableFriction: 0.988,
   spinDecay: 0.66,
   playerHeight: 3.5,
@@ -158,12 +158,14 @@ const CFG = {
   netThickness: 0.032,
   netTopBandRadius: 0.018,
   bodyPowerRetention: 0.2,
-  floorRestitution: 0.56,
+  floorRestitution: 0.68,
   floorFriction: 0.88,
   railRestitution: 0.5,
-  minShotSpeed: 7.2,
-  maxShotSpeed: 34.0,
-  netClearance: 0.26,
+  minShotSpeed: 8.9,
+  maxShotSpeed: 38.0,
+  netClearance: 0.34,
+  rallyFlightMin: 0.16,
+  rallyFlightMax: 0.68,
   playerVisualYawFix: Math.PI,
   paddlePalmOffset: 0.038,
 };
@@ -1086,7 +1088,7 @@ function makeUserHitFromSwipe(startX: number, startY: number, endX: number, endY
   const upwardIntent = clamp(-dy / (shortSide * 0.52), -0.16, 1.2);
   const depth = clamp(upwardIntent * 0.96 + Math.max(0, Math.abs(dx) / (shortSide * 0.92)) * 0.04, 0, 1);
   const rawPower = Math.hypot(dx, dy) / (shortSide * (isServe ? 0.36 : 0.28));
-  const power = clamp(Math.pow(clamp01(rawPower), 0.62), isServe ? 0.68 : 0.5, 1);
+  const power = clamp(Math.pow(clamp01(rawPower), 0.56), isServe ? 0.76 : 0.62, 1);
   const safetyMargin = isServe ? 0.18 : 0.1;
   const targetX = clamp(lateral * (TABLE_HALF_W - safetyMargin), -TABLE_HALF_W + safetyMargin, TABLE_HALF_W - safetyMargin);
   const targetZ = isServe ? -lerp(0.38, TABLE_HALF_L - 0.32, depth) : -lerp(0.3, TABLE_HALF_L - 0.1, depth);
@@ -1106,7 +1108,7 @@ function makeAiServeTarget(): DesiredHit {
   const z = shortServe ? lerp(0.32, 0.52, Math.random()) : lerp(TABLE_HALF_L - 0.35, TABLE_HALF_L - 0.16, Math.random());
   return {
     target: new THREE.Vector3(x, BALL_SURFACE_Y, z),
-    power: shortServe ? 0.48 + Math.random() * 0.12 : 0.62 + Math.random() * 0.18,
+    power: shortServe ? 0.58 + Math.random() * 0.14 : 0.72 + Math.random() * 0.18,
     topSpin: shortServe ? 0.24 + Math.random() * 0.28 : 0.62 + Math.random() * 0.35,
     sideSpin,
     tactic: "serve",
@@ -1207,8 +1209,8 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
     ball.pos.y = clamp(ball.pos.y, CFG.tableY + 0.08, CFG.tableY + 0.48);
     const dist = Math.hypot(target.x - ball.pos.x, target.z - ball.pos.z);
     const speedScale = Math.max(1, TABLE_SCALE_FACTOR * 0.85);
-    const baseFlight = dist / ((7.4 + hit.power * 9.8) * speedScale);
-    const flight = flightWithNetClearance(ball.pos, target, baseFlight, 0.1, 0.38);
+    const baseFlight = dist / ((9.2 + hit.power * 12.4) * speedScale);
+    const flight = flightWithNetClearance(ball.pos, target, baseFlight, CFG.rallyFlightMin, CFG.rallyFlightMax);
     ball.vel.copy(ballisticVelocity(ball.pos, target, flight));
     ball.spin.set(-dirZ * (68 + hit.topSpin * 102), hit.sideSpin * 118, hit.sideSpin * 14);
     ball.phase = { kind: "rally" };
@@ -1340,7 +1342,7 @@ function predictAiStrikeRead(ball: BallState, ai: HumanRig) {
       }
       landing = p.clone();
       if (sideOfZ(p.z) === "far") hasFarBounce = true;
-      v.y = Math.abs(v.y) * CFG.tableRestitution;
+      v.y = Math.max(Math.abs(v.y) * CFG.tableRestitution, 1.32);
       v.x *= CFG.tableFriction;
       v.z *= CFG.tableFriction;
       v.z += spin.x * 0.0016;
@@ -1781,7 +1783,7 @@ export default function MobileRealisticTableTennisGame() {
       if (descendingThroughSurface && isOverTable(tableImpactX, tableImpactZ, 0)) {
         ball.pos.set(tableImpactX, BALL_SURFACE_Y, tableImpactZ);
         const side = sideOfZ(tableImpactZ);
-        ball.vel.y = Math.max(-ball.vel.y * CFG.tableRestitution, 1.05);
+        ball.vel.y = Math.max(-ball.vel.y * CFG.tableRestitution, 1.32);
         ball.vel.x *= CFG.tableFriction;
         ball.vel.z *= CFG.tableFriction;
         ball.vel.z += ball.spin.x * 0.0016;


### PR DESCRIPTION
### Motivation
- Make table tennis shots feel more powerful and produce higher bounces so the ball reliably clears the net and rallies look livelier.
- Adjust both user/AI shot strength and the physics parameters that control energy retention and flight so on-screen behavior matches stronger swipes/serves.

### Description
- Updated physics constants in `webapp/src/pages/Games/TableTennis.tsx` to increase retained energy and shot speeds, including `tableRestitution` (1.02 → 1.16) and `floorRestitution` (0.56 → 0.68). 
- Raised shot speed bounds and net clearance by changing `minShotSpeed` (7.2 → 8.9), `maxShotSpeed` (34.0 → 38.0), and `netClearance` (0.26 → 0.34), and added `rallyFlightMin` / `rallyFlightMax` (0.16 / 0.68) to expand rally arc limits. 
- Increased perceived user/AI power by adjusting swipe-to-power mapping (power exponent and minimums) and AI serve power ranges so serves/returns are stronger (`makeUserHitFromSwipe` and `makeAiServeTarget`). 
- Changed rally trajectory calculation constants to bias faster/longer shots and made post-bounce vertical velocity clamps more aggressive so table bounces lift higher (`performHit`, `predictAiStrikeRead`, and table-impact handling). 

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully. 
- Launched the dev server with `npm --prefix webapp run dev` (Vite) to exercise the page during tuning. 
- Installed Playwright browsers with `npx playwright install chromium`; installation succeeded but automated screenshot verification failed because Playwright Chromium cannot launch in this container due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0928b8a98883299d1ed8b9c4435526)