### PR TITLE
Tune Murlan Royale card layout

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3305,7 +3305,7 @@ async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
 }
 
 const STOOL_SCALE = 1.5 * 1.3 * 1.3 * CHAIR_SIZE_SCALE;
-const CARD_SCALE = 1.08 * CARD_VISUAL_TRIM;
+const CARD_SCALE = 1.04 * CARD_VISUAL_TRIM;
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const CARD_H = 0.56 * MODEL_SCALE * CARD_SCALE;
 const CARD_D = 0.01 * MODEL_SCALE * CARD_SCALE; // Extra-trimmed thickness to avoid dark edge wedges.
@@ -3368,7 +3368,7 @@ const HUMAN_HAND_BOTTOM_SHIFT_Y = 0;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
 const HUMAN_HAND_LEFT_SHIFT = 0;
 const AI_HAND_LEFT_SHIFT = 0;
-const HUMAN_HAND_UP_SHIFT_Y = 0.168 * MODEL_SCALE;
+const HUMAN_HAND_UP_SHIFT_Y = 0.128 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = THREE.MathUtils.degToRad(4);
 const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;


### PR DESCRIPTION
### Motivation
- Adjust the Murlan Royale hand/card presentation so cards read better by slightly reducing global card size and lowering the player-held cards a bit.

### Description
- Reduce the shared card scale and lower the human hand vertical offset by changing `CARD_SCALE` from `1.08 * CARD_VISUAL_TRIM` to `1.04 * CARD_VISUAL_TRIM` and `HUMAN_HAND_UP_SHIFT_Y` from `0.168 * MODEL_SCALE` to `0.128 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Built the webapp with `npm --prefix webapp run build` (succeeded), installed Playwright browsers with `npx playwright install chromium` and system deps with `npx playwright install-deps chromium` (succeeded), and attempted an automated Playwright screenshot of `/games/murlanroyale` which timed out / failed in the headless environment due to runtime resource/load errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09292d5ee88329a8251d363de33c60)