### PR TITLE
Restore Snooker Royal game card

### DIFF
--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -44,6 +44,13 @@ const gamesCatalog = [
     description: 'Rack up and run the table in stylish arenas.'
   },
   {
+    name: 'Snooker Royal',
+    route: '/games/snookerroyale/lobby',
+    slug: 'snookerroyale',
+    image: '/assets/icons/file_00000000123071f4a91766ac58320bce.png',
+    description: 'Precision snooker battles with competitive stakes.'
+  },
+  {
     name: 'Snooker Champion',
     route: '/games/snookerchampion/lobby',
     slug: 'snookerchampion',


### PR DESCRIPTION
### Motivation
- Restore the Snooker Royal card to the Games lobby so the game is visible again and navigates to the existing Snooker Royal route.

### Description
- Add a `Snooker Royal` entry to `webapp/src/config/gamesCatalog.js` with `name`, `route: '/games/snookerroyale/lobby'`, `slug`, `image`, and `description` so the card appears between Pool Royale and Snooker Champion.

### Testing
- Successfully ran a production build with `npm run build` to ensure bundling completed without errors.
- Started the dev server and after running `npx playwright install chromium` and `npx playwright install-deps chromium`, a Playwright visual check against `/games` confirmed the `Snooker Royal` card is visible (`Snooker Royal visible: true`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a094b4e63408329adfa7c3e4c7590e7)