### PR TITLE
Scale up table tennis scene by 30%

### DIFF
--- a/frontend/src/table-tennis/AIController.ts
+++ b/frontend/src/table-tennis/AIController.ts
@@ -2,8 +2,10 @@ import * as THREE from 'three';
 import { BallPhysics } from './BallPhysics';
 import { GAME_CONFIG, ShotCommand, ShotType, TABLE_BOUNDS } from './gameConfig';
 
-const TABLE_AI_REACH_MAX_Z = TABLE_BOUNDS.minZ + 0.34;
-const TABLE_AI_REACH_MIN_Z = GAME_CONFIG.ai.z - 0.27;
+const BASE_TABLE_WIDTH = 61.651044 * 0.045;
+const BASE_TABLE_LENGTH = 90.4215312 * 0.045;
+const TABLE_AI_REACH_MAX_Z = TABLE_BOUNDS.minZ + GAME_CONFIG.table.length * (0.34 / BASE_TABLE_LENGTH);
+const TABLE_AI_REACH_MIN_Z = GAME_CONFIG.ai.z - GAME_CONFIG.table.length * (0.27 / BASE_TABLE_LENGTH);
 
 export class AIController {
   readonly targetX = { value: 0 };
@@ -20,7 +22,7 @@ export class AIController {
     if (this.reactionTimer <= 0) {
       this.committedLanding = ball.predictLandingPoint('ai');
       if (this.committedLanding) {
-        const noise = (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(0.38);
+        const noise = (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(GAME_CONFIG.table.width * (0.38 / BASE_TABLE_WIDTH));
         this.targetX.value = THREE.MathUtils.clamp(this.committedLanding.x + noise, GAME_CONFIG.ai.minX, GAME_CONFIG.ai.maxX);
         this.prepareShotCommand(ball);
       }

--- a/frontend/src/table-tennis/BallPhysics.ts
+++ b/frontend/src/table-tennis/BallPhysics.ts
@@ -30,6 +30,10 @@ export interface BallEvent {
 }
 
 const tmp = new THREE.Vector3();
+const INITIAL_SERVE_X_RATIO = 0.16 / 1.55;
+const INITIAL_SERVE_Z_RATIO = 1.08 / 2.74;
+const INITIAL_OUT_X_MARGIN_RATIO = 0.44 / 1.55;
+const INITIAL_OUT_Z_MARGIN_RATIO = 1 / 2.74;
 
 export class BallPhysics {
   readonly position = new THREE.Vector3();
@@ -42,9 +46,9 @@ export class BallPhysics {
 
   resetForServe(server: Side) {
     this.position.set(
-      server === 'player' ? -GAME_CONFIG.table.width * 0.09 : GAME_CONFIG.table.width * 0.09,
+      server === 'player' ? -GAME_CONFIG.table.width * INITIAL_SERVE_X_RATIO : GAME_CONFIG.table.width * INITIAL_SERVE_X_RATIO,
       GAME_CONFIG.table.topY + GAME_CONFIG.serveHeight,
-      server === 'player' ? GAME_CONFIG.table.length * 0.35 : -GAME_CONFIG.table.length * 0.35,
+      server === 'player' ? GAME_CONFIG.table.length * INITIAL_SERVE_Z_RATIO : -GAME_CONFIG.table.length * INITIAL_SERVE_Z_RATIO,
     );
     this.velocity.set(0, 0, 0);
     this.spin.set(0, 0, 0);
@@ -145,8 +149,10 @@ export class BallPhysics {
   }
 
   private isClearlyOut() {
-    const margin = 0.44;
-    return this.position.y < GAME_CONFIG.table.topY - 0.42 || Math.abs(this.position.x) > TABLE_BOUNDS.maxX + margin || Math.abs(this.position.z) > TABLE_BOUNDS.maxZ + 1.0;
+    const xMargin = GAME_CONFIG.table.width * INITIAL_OUT_X_MARGIN_RATIO;
+    const zMargin = GAME_CONFIG.table.length * INITIAL_OUT_Z_MARGIN_RATIO;
+    const verticalMargin = GAME_CONFIG.table.topY * (0.42 / 0.76);
+    return this.position.y < GAME_CONFIG.table.topY - verticalMargin || Math.abs(this.position.x) > TABLE_BOUNDS.maxX + xMargin || Math.abs(this.position.z) > TABLE_BOUNDS.maxZ + zMargin;
   }
 
   private resetBouncesAfterHit(side: Side) {

--- a/frontend/src/table-tennis/CameraController.ts
+++ b/frontend/src/table-tennis/CameraController.ts
@@ -10,9 +10,10 @@ export class CameraController {
   }
 
   update(dt: number, ballPosition: THREE.Vector3, playerPosition: THREE.Vector3) {
-    const nearPlayer = ballPosition.z > 0.85;
-    const lateralOffset = nearPlayer ? THREE.MathUtils.clamp((ballPosition.x - playerPosition.x) * 0.55, -0.32, 0.32) : 0;
-    this.desired.set(lateralOffset, GAME_CONFIG.camera.position.y + (nearPlayer ? 0.18 : 0), GAME_CONFIG.camera.position.z);
+    const nearPlayer = ballPosition.z > GAME_CONFIG.table.length * 0.21;
+    const lateralClamp = GAME_CONFIG.table.width * 0.115;
+    const lateralOffset = nearPlayer ? THREE.MathUtils.clamp((ballPosition.x - playerPosition.x) * 0.55, -lateralClamp, lateralClamp) : 0;
+    this.desired.set(lateralOffset, GAME_CONFIG.camera.position.y + (nearPlayer ? GAME_CONFIG.table.topY * 0.237 : 0), GAME_CONFIG.camera.position.z);
     this.target.set(ballPosition.x * 0.14, GAME_CONFIG.camera.target.y + ballPosition.y * 0.08, GAME_CONFIG.camera.target.z);
     this.camera.position.lerp(this.desired, 1 - Math.exp(-GAME_CONFIG.camera.damping * dt));
     this.camera.lookAt(this.target);

--- a/frontend/src/table-tennis/GameManager.ts
+++ b/frontend/src/table-tennis/GameManager.ts
@@ -262,17 +262,20 @@ export class GameManager {
     table.add(top);
 
     const lineMat = new THREE.MeshBasicMaterial({ color: GAME_CONFIG.table.lineColor });
+    const centerLineThickness = GAME_CONFIG.table.width * (0.012 / (61.651044 * 0.045));
+    const edgeLineThickness = GAME_CONFIG.table.width * (0.016 / (61.651044 * 0.045));
+    const edgeInset = GAME_CONFIG.table.width * (0.01 / (61.651044 * 0.045));
     const addLine = (w: number, l: number, x: number, z: number) => {
       const line = new THREE.Mesh(new THREE.BoxGeometry(w, 0.006, l), lineMat);
       line.position.set(x, GAME_CONFIG.table.topY + 0.004, z);
       table.add(line);
     };
-    addLine(GAME_CONFIG.table.width, 0.012, 0, 0);
-    addLine(0.012, GAME_CONFIG.table.length, 0, 0);
-    addLine(GAME_CONFIG.table.width, 0.016, 0, GAME_CONFIG.table.length / 2 - 0.01);
-    addLine(GAME_CONFIG.table.width, 0.016, 0, -GAME_CONFIG.table.length / 2 + 0.01);
-    addLine(0.016, GAME_CONFIG.table.length, GAME_CONFIG.table.width / 2 - 0.01, 0);
-    addLine(0.016, GAME_CONFIG.table.length, -GAME_CONFIG.table.width / 2 + 0.01, 0);
+    addLine(GAME_CONFIG.table.width, centerLineThickness, 0, 0);
+    addLine(centerLineThickness, GAME_CONFIG.table.length, 0, 0);
+    addLine(GAME_CONFIG.table.width, edgeLineThickness, 0, GAME_CONFIG.table.length / 2 - edgeInset);
+    addLine(GAME_CONFIG.table.width, edgeLineThickness, 0, -GAME_CONFIG.table.length / 2 + edgeInset);
+    addLine(edgeLineThickness, GAME_CONFIG.table.length, GAME_CONFIG.table.width / 2 - edgeInset, 0);
+    addLine(edgeLineThickness, GAME_CONFIG.table.length, -GAME_CONFIG.table.width / 2 + edgeInset, 0);
 
     const net = this.createNet();
     table.add(net);
@@ -399,7 +402,7 @@ export class GameManager {
 
   private createPredictionMarker() {
     const marker = new THREE.Mesh(
-      new THREE.RingGeometry(0.09, 0.12, 32),
+      new THREE.RingGeometry(GAME_CONFIG.ballRadius * 1.45, GAME_CONFIG.ballRadius * 1.94, 32),
       new THREE.MeshBasicMaterial({ color: '#fef08a', transparent: true, opacity: 0.65, side: THREE.DoubleSide }),
     );
     marker.rotation.x = -Math.PI / 2;

--- a/frontend/src/table-tennis/gameConfig.ts
+++ b/frontend/src/table-tennis/gameConfig.ts
@@ -29,7 +29,9 @@ export interface DifficultyConfig {
 // it occupies the same HDRI placement/orientation while staying in this game's meter-sized scene.
 const POOL_ROYALE_TABLE_WIDTH = 61.651044;
 const POOL_ROYALE_TABLE_LENGTH = 90.4215312;
-const POOL_ROYALE_TO_TABLE_TENNIS_SCALE = 0.045;
+const POOL_ROYALE_TO_TABLE_TENNIS_BASE_SCALE = 0.045;
+const TABLE_TENNIS_SIZE_MULTIPLIER = 1.3;
+const POOL_ROYALE_TO_TABLE_TENNIS_SCALE = POOL_ROYALE_TO_TABLE_TENNIS_BASE_SCALE * TABLE_TENNIS_SIZE_MULTIPLIER;
 const TABLE_WIDTH = POOL_ROYALE_TABLE_WIDTH * POOL_ROYALE_TO_TABLE_TENNIS_SCALE;
 const TABLE_LENGTH = POOL_ROYALE_TABLE_LENGTH * POOL_ROYALE_TO_TABLE_TENNIS_SCALE;
 const TABLE_LENGTH_SCALE = TABLE_LENGTH / 2.74;
@@ -40,39 +42,39 @@ export const GAME_CONFIG = {
   gravity: -9.8,
   drag: 0.09,
   spinCurve: 0.08,
-  ballRadius: 0.062,
-  serveHeight: 0.38,
+  ballRadius: 0.062 * TABLE_TENNIS_SIZE_MULTIPLIER,
+  serveHeight: 0.38 * TABLE_TENNIS_SIZE_MULTIPLIER,
   serveForwardPower: 2.9 * TABLE_LENGTH_SCALE,
   table: {
     width: TABLE_WIDTH,
     length: TABLE_LENGTH,
-    topY: 0.76,
-    thickness: 0.09,
+    topY: 0.76 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    thickness: 0.09 * TABLE_TENNIS_SIZE_MULTIPLIER,
     color: '#1266c3',
     lineColor: '#e8f4ff',
   },
   net: {
-    height: 0.2,
-    thickness: 0.03,
-    overhang: 0.13,
+    height: 0.2 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    thickness: 0.03 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    overhang: 0.13 * TABLE_TENNIS_SIZE_MULTIPLIER,
   },
   player: {
-    z: TABLE_LENGTH / 2 + 0.84,
-    minX: -TABLE_WIDTH / 2 - 0.12,
-    maxX: TABLE_WIDTH / 2 + 0.12,
-    safeZ: TABLE_LENGTH / 2 + 0.68,
+    z: TABLE_LENGTH / 2 + 0.84 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    minX: -TABLE_WIDTH / 2 - 0.12 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    maxX: TABLE_WIDTH / 2 + 0.12 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    safeZ: TABLE_LENGTH / 2 + 0.68 * TABLE_TENNIS_SIZE_MULTIPLIER,
     moveSpeed: 2.55 * TABLE_WIDTH_SCALE,
     reach: 0.48 * TABLE_WIDTH_SCALE,
     autoTrackLead: 0.34 * TABLE_WIDTH_SCALE,
     recoveryTime: 0.28,
-    avatarScale: 1.62,
+    avatarScale: 1.62 * TABLE_TENNIS_SIZE_MULTIPLIER,
   },
   ai: {
-    z: -TABLE_LENGTH / 2 - 0.84,
-    minX: -TABLE_WIDTH / 2 - 0.12,
-    maxX: TABLE_WIDTH / 2 + 0.12,
+    z: -TABLE_LENGTH / 2 - 0.84 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    minX: -TABLE_WIDTH / 2 - 0.12 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    maxX: TABLE_WIDTH / 2 + 0.12 * TABLE_TENNIS_SIZE_MULTIPLIER,
     maxReach: 0.58 * TABLE_WIDTH_SCALE,
-    avatarScale: 1.62,
+    avatarScale: 1.62 * TABLE_TENNIS_SIZE_MULTIPLIER,
     difficulty: {
       reactionTime: 0.14,
       moveSpeed: 3.05 * TABLE_WIDTH_SCALE,
@@ -94,8 +96,8 @@ export const GAME_CONFIG = {
     accuracy: 0.96,
   },
   camera: {
-    position: new THREE.Vector3(0, 2.7, 6.1),
-    target: new THREE.Vector3(0, 1.02, 0.18),
+    position: new THREE.Vector3(0, 2.7 * TABLE_TENNIS_SIZE_MULTIPLIER, 6.1 * TABLE_TENNIS_SIZE_MULTIPLIER),
+    target: new THREE.Vector3(0, 1.02 * TABLE_TENNIS_SIZE_MULTIPLIER, 0.18 * TABLE_TENNIS_SIZE_MULTIPLIER),
     damping: 8,
   },
   score: {


### PR DESCRIPTION
### Motivation
- Increase the apparent size of the table-tennis scene (table, net, avatars, paddle, ball) while preserving the original gameplay feel and framing.
- Keep ball physics, serve behavior, out-of-bounds logic and AI decisioning proportional to the new dimensions so play behaves like before at a larger scale.

### Description
- Introduced a `TABLE_TENNIS_SIZE_MULTIPLIER` and applied it in `frontend/src/table-tennis/gameConfig.ts` to scale table footprint, `ballRadius`, `serveHeight`, net dimensions, avatar scales and camera position/target.
- Made ball serve placement and out-of-bounds margins ratio-driven by adding `INITIAL_SERVE_*` and `INITIAL_OUT_*` constants in `frontend/src/table-tennis/BallPhysics.ts` so serve and clear-out logic scale with the table.
- Updated AI reach/noise and timing to use table-relative measures in `frontend/src/table-tennis/AIController.ts` and adjusted camera follow thresholds/clamps to table-relative values in `frontend/src/table-tennis/CameraController.ts` so AI and camera framing remain consistent.
- Adjusted table line thickness/insets and the landing prediction marker sizing in `frontend/src/table-tennis/GameManager.ts` to match the scaled table and ball visuals.

### Testing
- Ran `npm --prefix frontend run build` and the front-end build completed successfully.
- Installed Playwright browsers with `npx playwright install chromium` and the installation completed successfully.
- Installed Playwright system dependencies with `npx playwright install-deps chromium` and the installation completed successfully.
- Launched the app and captured a headless Playwright screenshot which was written to `/tmp/table-tennis-scale.png` to verify visual framing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a093c8c0f0083298f4bedbc2a2e6094)