### PR TITLE
Use champion scene for Snooker Royal character and cue

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -26,7 +26,7 @@ import {
 } from './snookerTableModel.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   isTelegramWebView,
   getTelegramUsername,
@@ -103,6 +103,7 @@ import {
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import SnookerRoyalProvided from './SnookerRoyalProvided.jsx';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -29497,158 +29498,8 @@ const powerRef = useRef(hud.power);
 }
 
 export default function SnookerRoyal() {
-  const location = useLocation();
-  const tableModel = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return resolveSnookerTableModel(params.get('tableModel'));
-  }, [location.search]);
-
-  const navigate = useNavigate();
-  const variantKey = useMemo(() => {
-    return 'snooker';
-  }, [location.search]);
-  const ballSetKey = useMemo(() => {
-    return null;
-  }, [location.search]);
-  const tableSizeKey = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    const requested = params.get('tableSize');
-    return resolveTableSize(requested).id;
-  }, [location.search]);
-  const playType = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    const requested = params.get('type');
-    if (requested === 'training') return 'training';
-    if (requested === 'tournament') return 'tournament';
-    return 'regular';
-  }, [location.search]);
-  const mode = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    const requested = params.get('mode');
-    if (requested === 'online') return 'online';
-    if (requested === 'local') return 'local';
-    return 'ai';
-  }, [location.search]);
-  const trainingMode = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    const requested = params.get('mode');
-    return requested === 'solo' ? 'solo' : 'ai';
-  }, [location.search]);
-  const trainingRulesEnabled = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('rules') !== 'off';
-  }, [location.search]);
-  const accountId = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('accountId') || '';
-  }, [location.search]);
-  const tgId = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('tgId') || '';
-  }, [location.search]);
-  const playerName = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return (
-      params.get('name') ||
-      getTelegramUsername() ||
-      getTelegramId() ||
-      'Player'
-    );
-  }, [location.search]);
-  const playerAvatar = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('avatar') || '';
-  }, [location.search]);
-  const stakeAmount = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return Number(params.get('amount')) || 0;
-  }, [location.search]);
-  const stakeToken = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('token') || 'TPC';
-  }, [location.search]);
-  const exitMessage = useMemo(
-    () =>
-      stakeAmount > 0
-        ? `Are you sure you want to exit? Your ${stakeAmount} ${stakeToken} stake will be lost.`
-        : 'Are you sure you want to exit the match?',
-    [stakeAmount, stakeToken]
-  );
-  const confirmExit = useCallback(() => {
-    return new Promise((resolve) => {
-      const tg = window?.Telegram?.WebApp;
-      if (tg?.showPopup) {
-        tg.showPopup(
-          {
-            title: 'Exit game?',
-            message: exitMessage,
-            buttons: [
-              { id: 'yes', type: 'destructive', text: 'Yes' },
-              { id: 'no', type: 'default', text: 'No' }
-            ]
-          },
-          (buttonId) => resolve(buttonId === 'yes')
-        );
-        return;
-      }
-
-      resolve(window.confirm(exitMessage));
-    });
-  }, [exitMessage]);
-  useTelegramBackButton(() => {
-    confirmExit().then((confirmed) => {
-      if (confirmed) {
-        navigate('/games/snookerroyale/lobby');
-      }
-    });
-  });
-  useEffect(() => {
-    const handleBeforeUnload = (event) => {
-      event.preventDefault();
-      event.returnValue = exitMessage;
-      return exitMessage;
-    };
-    const handlePopState = () => {
-      confirmExit().then((confirmed) => {
-        if (!confirmed) {
-          window.history.pushState(null, '', window.location.href);
-        } else {
-          navigate('/games/snookerroyale/lobby');
-        }
-      });
-    };
-    window.history.pushState(null, '', window.location.href);
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    window.addEventListener('popstate', handlePopState);
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      window.removeEventListener('popstate', handlePopState);
-    };
-  }, [confirmExit, exitMessage, navigate]);
-  const opponentName = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('opponent') || '';
-  }, [location.search]);
-  const opponentAvatar = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('opponentAvatar') || '';
-  }, [location.search]);
-  return (
-    <SnookerRoyalGame
-      variantKey={variantKey}
-      ballSetKey={ballSetKey}
-      tableSizeKey={tableSizeKey}
-      tableModel={tableModel}
-      playType={playType}
-      mode={mode}
-      trainingMode={trainingMode}
-      trainingRulesEnabled={trainingRulesEnabled}
-      accountId={accountId}
-      tgId={tgId}
-      playerName={playerName}
-      playerAvatar={playerAvatar}
-      opponentName={opponentName}
-      opponentAvatar={opponentAvatar}
-    />
-  );
+  // Snooker Royal now mounts the same scene implementation used by Snooker
+  // Champion so the human character and cue stick are rendered by the shared,
+  // unmodified Champion code path.
+  return <SnookerRoyalProvided gameTitle="Snooker Royal" />;
 }


### PR DESCRIPTION
### Motivation
- Ensure Snooker Royal uses the exact same human character and cue-stick implementation as Snooker Champion so visuals and motion remain identical without modifying the shared champion code.

### Description
- Import `SnookerRoyalProvided` into `webapp/src/pages/Games/SnookerRoyal.jsx` and replace the previous Snooker Royal route wrapper with a component that returns `<SnookerRoyalProvided gameTitle="Snooker Royal" />`.
- Remove the duplicated query-param parsing and per-route scene construction in the Snooker Royal wrapper so the shared Champion scene drives human and cue rendering unchanged.
- Keep the shared implementation in `webapp/src/pages/Games/SnookerRoyalProvided.jsx` intact, which contains the ReadyPlayer human loader and cue construction/pose logic used by both games.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Installed Playwright browsers with `npx playwright install chromium` and system deps with `npx playwright install-deps chromium`, both completed successfully.
- Started the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1` and executed a Playwright smoke test that navigated to `/games/snookerroyale` and saved `snooker-royal-shared-champion-scene.png`, confirming the shared scene rendered; the run produced asset-fetch warnings but the smoke test completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a095cd61a308329a150ad3ceba33a13)