### PR TITLE
Tune Snooker Champion cushion mapping and cue-spin physics

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyalProvided.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalProvided.jsx
@@ -151,6 +151,19 @@ const SNOOKER_SHOT_POWER_RANGE = 0.75;
 const SNOOKER_SHOT_FULL_SPEED = 12 * WORLD_SCALE * SNOOKER_SHOT_POWER_BOOST;
 const SNOOKER_BALL_MASS = 0.17;
 const SNOOKER_SHOT_SPIN_SCALE = 0.25;
+const SNOOKER_SPIN_GLOBAL_SCALE = 0.82;
+const SNOOKER_STRAIGHT_TOPSPIN_BONUS_SCALE = 1;
+const SNOOKER_STRAIGHT_TOPSPIN_SIDE_THRESHOLD = 0.08;
+const SNOOKER_TOPSPIN_POWER_SOFT_CAP = 0.985;
+const SNOOKER_SPIN_ROLL_ACCELERATION = 1.2 * Math.max(
+  SNOOKER_OFFICIAL_PLAYFIELD_W / 2.627,
+  SNOOKER_OFFICIAL_PLAYFIELD_L / 1.07707
+);
+const SNOOKER_BACKSPIN_ROLL_BOOST = 1.35;
+const SNOOKER_CUE_BACKSPIN_ROLL_BOOST = 3.4;
+const SNOOKER_TOPSPIN_FOLLOW_TRANSFER_RATE = 0.62;
+const SNOOKER_TOPSPIN_FOLLOW_DECAY_ASSIST = 0.84;
+const SNOOKER_TOPSPIN_ROLL_SPEED_FACTOR = 0.84;
 const SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER = 1.2;
 const SNOOKER_SIDE_SPIN_MULTIPLIER = 1.5 * SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER;
 const SNOOKER_BACKSPIN_MULTIPLIER = 2.6 * SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER;
@@ -1182,31 +1195,53 @@ function updateHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget,
   const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * CFG.scale, CFG.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * CFG.scale * t).addScaledVector(side, 0.014 * CFG.scale * t);
   driveHuman(human, { t, stroke: forearmStroke / CFG.scale, follow: strikeFollow, walkAmount, forward, side, up: UP, rootWorld, torsoCenterWorld: torso, chestCenterWorld: chest, neckWorld: neck, headCenterWorld: head, leftElbow, rightElbow: lockedRightElbow, leftHandWorld: leftHand, rightHandWorld: rightHand, leftKnee, rightKnee, leftFootWorld: leftFoot, rightFootWorld: rightFoot, cueBackWorld: cueBack, cueTipWorld: cueTip });
 }
+
+function resolveSnookerTopspinPowerScale(power) {
+  if (!Number.isFinite(power)) return 0.55 + SNOOKER_TOPSPIN_POWER_SOFT_CAP * 0.45;
+  const cappedPower = THREE.MathUtils.clamp(power, 0, SNOOKER_TOPSPIN_POWER_SOFT_CAP);
+  return 0.55 + cappedPower * 0.45;
+}
+
 function applyCueShot(cueBall, power, yaw, out, spinInput = { x: 0, y: 0 }) {
   const p = clamp01(power);
   const dir = out.set(0, 0, -1).applyAxisAngle(Y_AXIS, yaw).normalize();
   const side = new THREE.Vector3(dir.z, 0, -dir.x).normalize();
   const spinMapped = mapSpinForPhysics(normalizeSpinInput(spinInput));
   const powerSpinScale = 0.55 + p * 0.45;
-  const rawTopSpin = (spinMapped.y ?? 0) * SNOOKER_SHOT_SPIN_SCALE * powerSpinScale;
-  const spin = {
-    x: (spinMapped.x ?? 0) * SNOOKER_SHOT_SPIN_SCALE * SNOOKER_SIDE_SPIN_MULTIPLIER * powerSpinScale,
-    y: rawTopSpin < 0
-      ? rawTopSpin * SNOOKER_BACKSPIN_MULTIPLIER
-      : rawTopSpin * SNOOKER_TOPSPIN_MULTIPLIER
+  const topspinPowerScale = resolveSnookerTopspinPowerScale(p);
+  const scaledSpin = {
+    x: (spinMapped.x ?? 0) * SNOOKER_SPIN_GLOBAL_SCALE,
+    y: (spinMapped.y ?? 0) * SNOOKER_SPIN_GLOBAL_SCALE
   };
+  const baseSide = scaledSpin.x * SNOOKER_SHOT_SPIN_SCALE;
+  let spinSide = baseSide * SNOOKER_SIDE_SPIN_MULTIPLIER * powerSpinScale;
+  let spinTop = scaledSpin.y * SNOOKER_SHOT_SPIN_SCALE * powerSpinScale;
+  if (scaledSpin.y < 0) {
+    spinTop *= SNOOKER_BACKSPIN_MULTIPLIER;
+  } else if (scaledSpin.y > 0) {
+    spinTop = scaledSpin.y * SNOOKER_SHOT_SPIN_SCALE * topspinPowerScale;
+    spinTop *= SNOOKER_TOPSPIN_MULTIPLIER;
+    if (Math.abs(baseSide) <= SNOOKER_STRAIGHT_TOPSPIN_SIDE_THRESHOLD) {
+      spinTop *= SNOOKER_STRAIGHT_TOPSPIN_BONUS_SCALE;
+    }
+    if (Math.abs(baseSide) > 1e-6) {
+      spinSide = baseSide * SNOOKER_SIDE_SPIN_MULTIPLIER * topspinPowerScale;
+    }
+  }
+  const spin = { x: spinSide, y: spinTop };
   const powerScale = SNOOKER_SHOT_MIN_FACTOR + SNOOKER_SHOT_POWER_RANGE * p;
   const speed = SNOOKER_SHOT_FULL_SPEED * powerScale;
   cueBall.vel.copy(dir.multiplyScalar(speed));
-  cueBall.vel.addScaledVector(side, (spin.x ?? 0) * p * 1.05 * CFG.scale * SNOOKER_SHOT_POWER_BOOST);
   cueBall.spin.set(spin.x ?? 0, spin.y ?? 0);
   cueBall.omega?.set(0, 0, 0);
-  const launchSpeed = cueBall.vel.length();
-  if (launchSpeed > 1e-6 && cueBall.omega) {
-    const rollingAxis = new THREE.Vector3(cueBall.vel.z, 0, -cueBall.vel.x).normalize();
-    cueBall.omega.addScaledVector(rollingAxis, launchSpeed / CFG.ballR);
-    cueBall.omega.x += -(spin.y ?? 0) * p * 18;
-    cueBall.omega.z += -(spin.x ?? 0) * p * 18;
+  if (cueBall.omega) {
+    const contactOffset = side
+      .clone()
+      .multiplyScalar((spin.x ?? 0) * CFG.ballR)
+      .addScaledVector(UP, (spin.y ?? 0) * CFG.ballR);
+    const impulse = cueBall.vel.clone().multiplyScalar(SNOOKER_BALL_MASS);
+    const torqueImpulse = contactOffset.cross(impulse);
+    cueBall.omega.addScaledVector(torqueImpulse, 1 / SNOOKER_BALL_INERTIA);
   }
   cueBall.launchDir = cueBall.vel.lengthSq() > 1e-8 ? cueBall.vel.clone().normalize() : null;
   cueBall.impacted = false;
@@ -1389,6 +1424,36 @@ function isInsideSnookerPocketThroat(ball, axis, sign, pocketPositions = []) {
   return Boolean(findSnookerPocketCapture(ball, pocketPositions));
 }
 
+
+function resolveSnookerCushionContact(ball, previousPos, halfW, halfL, pocketPositions = []) {
+  if (!ball || !previousPos) return null;
+  const minX = -halfW + CFG.ballR;
+  const maxX = halfW - CFG.ballR;
+  const minZ = -halfL + CFG.ballR;
+  const maxZ = halfL - CFG.ballR;
+  let railNormal = null;
+  const crossedLeft = ball.pos.x < minX || (previousPos.x >= minX && ball.pos.x <= minX && ball.vel.x < 0);
+  const crossedRight = ball.pos.x > maxX || (previousPos.x <= maxX && ball.pos.x >= maxX && ball.vel.x > 0);
+  const crossedTop = ball.pos.z < minZ || (previousPos.z >= minZ && ball.pos.z <= minZ && ball.vel.z < 0);
+  const crossedBottom = ball.pos.z > maxZ || (previousPos.z <= maxZ && ball.pos.z >= maxZ && ball.vel.z > 0);
+
+  if (crossedLeft && !isInsideSnookerPocketThroat(ball, 'x', -1, pocketPositions)) {
+    ball.pos.x = minX;
+    if (ball.vel.x < 0) railNormal = new THREE.Vector3(1, 0, 0);
+  } else if (crossedRight && !isInsideSnookerPocketThroat(ball, 'x', 1, pocketPositions)) {
+    ball.pos.x = maxX;
+    if (ball.vel.x > 0) railNormal = new THREE.Vector3(-1, 0, 0);
+  }
+  if (crossedTop && !isInsideSnookerPocketThroat(ball, 'z', -1, pocketPositions)) {
+    ball.pos.z = minZ;
+    if (ball.vel.z < 0) railNormal = new THREE.Vector3(0, 0, 1);
+  } else if (crossedBottom && !isInsideSnookerPocketThroat(ball, 'z', 1, pocketPositions)) {
+    ball.pos.z = maxZ;
+    if (ball.vel.z > 0) railNormal = new THREE.Vector3(0, 0, -1);
+  }
+  return railNormal;
+}
+
 function clampSnookerAimImpactToPerimeter(point) {
   return new THREE.Vector2(
     clamp(point.x, -CFG.tableW / 2 + CFG.ballR, CFG.tableW / 2 - CFG.ballR),
@@ -1413,20 +1478,35 @@ function decaySnookerSpin(ball, stepScale) {
 
 function applySnookerSpinController(ball, stepScale) {
   if (!ball?.spin || ball.spin.lengthSq() < 1e-6) return false;
+  if (ball.isCue && !ball.impacted) return decaySnookerSpin(ball, stepScale);
   const speed = Math.max(ball.vel.length(), 0);
   if (speed > 1e-6) {
     const forward = SNOOKER_TMP_VEC3_A.copy(ball.vel).setY(0).normalize();
-    const lateral = SNOOKER_TMP_VEC3_B.set(forward.z, 0, -forward.x).normalize();
-    const sideSpin = ball.spin.x || 0;
-    const forwardSpin = ball.spin.y || 0;
-    const speedScale = clamp(speed / Math.max(CFG.scale * 8, 1e-6), 0.35, 1.4);
-    if (Math.abs(sideSpin) > 1e-8) {
-      ball.vel.addScaledVector(lateral, sideSpin * 0.22 * CFG.scale * speedScale * stepScale);
+    let forwardSpin = ball.spin.y || 0;
+    const powerScale = clamp(speed / Math.max(CFG.scale * 8, 1e-6), 0.35, 1.4);
+    let rollAccel = SNOOKER_SPIN_ROLL_ACCELERATION * powerScale * stepScale;
+    if (forwardSpin < 0) {
+      rollAccel *= ball.isCue && ball.impacted
+        ? SNOOKER_CUE_BACKSPIN_ROLL_BOOST
+        : SNOOKER_BACKSPIN_ROLL_BOOST;
     }
     if (Math.abs(forwardSpin) > 1e-8) {
-      ball.vel.addScaledVector(forward, forwardSpin * 0.11 * CFG.scale * speedScale * stepScale);
+      ball.vel.addScaledVector(forward, forwardSpin * rollAccel);
       if (forwardSpin > 0) {
-        ball.spin.y = Math.max(0, forwardSpin - 0.028 * stepScale * speedScale);
+        const naturalRollSpeed = Math.max(CFG.ballR * 2.2, speed * SNOOKER_TOPSPIN_ROLL_SPEED_FACTOR);
+        const settling = THREE.MathUtils.clamp(speed / Math.max(naturalRollSpeed, 1e-6), 0, 1);
+        const transfer = Math.min(
+          forwardSpin,
+          rollAccel * SNOOKER_TOPSPIN_FOLLOW_TRANSFER_RATE * (0.28 + settling * 0.72)
+        );
+        let remainingSpin = Math.max(0, forwardSpin - transfer);
+        if (speed >= naturalRollSpeed * 0.98) {
+          remainingSpin *= Math.exp(-SNOOKER_TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * 1.25);
+        }
+        const assistedDecay = Math.exp(
+          -SNOOKER_TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * (0.35 + 0.65 * settling)
+        );
+        ball.spin.y = remainingSpin * assistedDecay;
       }
     }
   }
@@ -1500,24 +1580,12 @@ function updateBalls(balls, dt, tmpA, tmpB, pocketPositions = [], rulesState = n
     for (const ball of balls) {
     if (ball.potted) continue;
     updateSnookerRollingBall(ball, stepScale);
+    const previousPos = SNOOKER_TMP_VEC3_E.copy(ball.pos);
     ball.pos.addScaledVector(ball.vel, subDt);
     let railNormal = null;
     const pocket = findSnookerPocketCapture(ball, pocketPositions);
     if (!pocket) {
-      if (ball.pos.x < -halfW + CFG.ballR && !isInsideSnookerPocketThroat(ball, 'x', -1, pocketPositions)) {
-        ball.pos.x = -halfW + CFG.ballR;
-        if (ball.vel.x < 0) railNormal = new THREE.Vector3(1, 0, 0);
-      } else if (ball.pos.x > halfW - CFG.ballR && !isInsideSnookerPocketThroat(ball, 'x', 1, pocketPositions)) {
-        ball.pos.x = halfW - CFG.ballR;
-        if (ball.vel.x > 0) railNormal = new THREE.Vector3(-1, 0, 0);
-      }
-      if (ball.pos.z < -halfL + CFG.ballR && !isInsideSnookerPocketThroat(ball, 'z', -1, pocketPositions)) {
-        ball.pos.z = -halfL + CFG.ballR;
-        if (ball.vel.z < 0) railNormal = new THREE.Vector3(0, 0, 1);
-      } else if (ball.pos.z > halfL - CFG.ballR && !isInsideSnookerPocketThroat(ball, 'z', 1, pocketPositions)) {
-        ball.pos.z = halfL - CFG.ballR;
-        if (ball.vel.z > 0) railNormal = new THREE.Vector3(0, 0, -1);
-      }
+      railNormal = resolveSnookerCushionContact(ball, previousPos, halfW, halfL, pocketPositions);
     }
     if (railNormal) {
       if (rulesState?.shotActive && rulesState.firstContactKind) rulesState.railAfterContact = true;

--- a/webapp/src/pages/Games/snookerRoyalSpinUtils.js
+++ b/webapp/src/pages/Games/snookerRoyalSpinUtils.js
@@ -1,16 +1,17 @@
-const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value))
 
-export const MAX_SPIN_OFFSET = 0.75;
-export const SPIN_STUN_RADIUS = 0.12;
-export const SPIN_RING1_RADIUS = 0.33;
-export const SPIN_RING2_RADIUS = 0.66;
-export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
-export const SPIN_LEVEL0_MAG = 0;
-export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
-export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
-export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
-export const STRAIGHT_SPIN_DEADZONE = 0.02;
-export const SPIN_RESPONSE_EXPONENT = 1.45;
+export const MAX_SPIN_OFFSET = 0.75
+export const SPIN_STUN_RADIUS = 0.12
+export const SPIN_RING1_RADIUS = 0.33
+export const SPIN_RING2_RADIUS = 0.66
+export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET
+export const SPIN_LEVEL0_MAG = 0
+export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS
+export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS
+export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS
+export const STRAIGHT_SPIN_DEADZONE = 0.02
+export const SPIN_RESPONSE_EXPONENT = 1.32
+export const SPIN_CENTER_TOPSPIN_BIAS = 0.13
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',
@@ -75,93 +76,93 @@ export const SPIN_DIRECTIONS = [
     effect:
       'Offset diagonal poshtë-djathtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
   }
-];
+]
 
 export const clampToUnitCircle = (x, y) => {
-  const length = Math.hypot(x, y);
+  const length = Math.hypot(x, y)
   if (!Number.isFinite(length) || length <= 1) {
-    return { x, y };
+    return { x, y }
   }
-  const scale = length > 1e-6 ? 1 / length : 0;
-  return { x: x * scale, y: y * scale };
-};
+  const scale = length > 1e-6 ? 1 / length : 0
+  return { x: x * scale, y: y * scale }
+}
 
 export const clampToMaxOffset = (x, y, maxOffset = MAX_SPIN_OFFSET) => {
-  const length = Math.hypot(x, y);
+  const length = Math.hypot(x, y)
   if (!Number.isFinite(length) || length <= maxOffset) {
-    return { x, y };
+    return { x, y }
   }
-  const scale = length > 1e-6 ? maxOffset / length : 0;
-  return { x: x * scale, y: y * scale };
-};
+  const scale = length > 1e-6 ? maxOffset / length : 0
+  return { x: x * scale, y: y * scale }
+}
 
 export const computeQuantizedOffsetScaled = (
   rawX,
   rawY,
   options = {}
 ) => {
-  const maxOffset = options.maxOffset ?? MAX_SPIN_OFFSET;
-  const stunRadius = options.stunRadius ?? SPIN_STUN_RADIUS;
-  const ring1Radius = options.ring1Radius ?? SPIN_RING1_RADIUS;
-  const ring2Radius = options.ring2Radius ?? SPIN_RING2_RADIUS;
-  const ring3Radius = options.ring3Radius ?? SPIN_RING3_RADIUS;
-  const level0Mag = options.level0Mag ?? SPIN_LEVEL0_MAG;
-  const level1Mag = options.level1Mag ?? SPIN_LEVEL1_MAG;
-  const level2Mag = options.level2Mag ?? SPIN_LEVEL2_MAG;
-  const level3Mag = options.level3Mag ?? SPIN_LEVEL3_MAG;
-  const angleStep = options.angleStepRad ?? Math.PI / 4;
+  const maxOffset = options.maxOffset ?? MAX_SPIN_OFFSET
+  const stunRadius = options.stunRadius ?? SPIN_STUN_RADIUS
+  const ring1Radius = options.ring1Radius ?? SPIN_RING1_RADIUS
+  const ring2Radius = options.ring2Radius ?? SPIN_RING2_RADIUS
+  const ring3Radius = options.ring3Radius ?? SPIN_RING3_RADIUS
+  const level0Mag = options.level0Mag ?? SPIN_LEVEL0_MAG
+  const level1Mag = options.level1Mag ?? SPIN_LEVEL1_MAG
+  const level2Mag = options.level2Mag ?? SPIN_LEVEL2_MAG
+  const level3Mag = options.level3Mag ?? SPIN_LEVEL3_MAG
+  const angleStep = options.angleStepRad ?? Math.PI / 4
 
-  const raw = clampToMaxOffset(rawX, rawY, maxOffset);
-  const distance = Math.hypot(raw.x, raw.y);
-  let mag = level3Mag;
+  const raw = clampToMaxOffset(rawX, rawY, maxOffset)
+  const distance = Math.hypot(raw.x, raw.y)
+  let mag = level3Mag
   if (distance <= stunRadius) {
-    mag = level0Mag;
+    mag = level0Mag
   } else if (distance <= ring1Radius) {
-    mag = level1Mag;
+    mag = level1Mag
   } else if (distance <= ring2Radius) {
-    mag = level2Mag;
+    mag = level2Mag
   } else if (distance <= ring3Radius) {
-    mag = level3Mag;
+    mag = level3Mag
   }
   if (mag === 0 || distance <= 1e-6) {
-    return { x: 0, y: 0 };
+    return { x: 0, y: 0 }
   }
-  const angle = Math.atan2(raw.y, raw.x);
+  const angle = Math.atan2(raw.y, raw.x)
   const snappedAngle = angleStep > 0
     ? Math.round(angle / angleStep) * angleStep
-    : angle;
+    : angle
   return {
     x: Math.cos(snappedAngle) * mag,
     y: Math.sin(snappedAngle) * mag
-  };
-};
+  }
+}
 
 export const normalizeSpinInput = (spin) => {
-  let x = clamp(spin?.x ?? 0, -1, 1);
-  let y = clamp(spin?.y ?? 0, -1, 1);
+  let x = clamp(spin?.x ?? 0, -1, 1)
+  let y = clamp(spin?.y ?? 0, -1, 1)
 
   // Keep straight high/low and left/right shots easier to select by gently
   // snapping near-axis drag noise to the principal axis.
-  if (Math.abs(x) <= STRAIGHT_SPIN_DEADZONE) x = 0;
-  if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) y = 0;
+  if (Math.abs(x) <= STRAIGHT_SPIN_DEADZONE) x = 0
+  if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) y = 0
 
-  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
-  const distance = Math.hypot(clamped.x, clamped.y);
-  const deadzone = Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE);
+  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET)
+  const distance = Math.hypot(clamped.x, clamped.y)
+  const deadzone = Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE)
   if (distance <= deadzone) {
-    return { x: 0, y: 0 };
+    return { x: 0, y: 0 }
   }
 
-  const activeSpan = Math.max(MAX_SPIN_OFFSET - deadzone, 1e-6);
-  const normalized = clamp((distance - deadzone) / activeSpan, 0, 1);
-  const shaped = normalized ** SPIN_RESPONSE_EXPONENT;
-  const magnitude = deadzone + shaped * activeSpan;
-  const scale = magnitude / Math.max(distance, 1e-6);
+  const activeSpan = Math.max(MAX_SPIN_OFFSET - deadzone, 1e-6)
+  const normalized = clamp((distance - deadzone) / activeSpan, 0, 1)
+  const shaped = normalized ** SPIN_RESPONSE_EXPONENT
+  const magnitude = deadzone + shaped * activeSpan
+  const scale = magnitude / Math.max(distance, 1e-6)
   return {
     x: clamped.x * scale,
     y: clamped.y * scale
-  };
-};
+  }
+}
 
 export const mapUiOffsetToCueFrame = (
   uiX,
@@ -171,44 +172,47 @@ export const mapUiOffsetToCueFrame = (
   cueForward
 ) => {
   if (!cameraRight || !cameraUp || !cueForward) {
-    return { x: uiX, y: uiY };
+    return { x: uiX, y: uiY }
   }
-  const right = cameraRight;
-  const up = cameraUp;
-  const forward = cueForward;
+  const right = cameraRight
+  const up = cameraUp
+  const forward = cueForward
   const offsetWorld = {
     x: right.x * uiX + up.x * uiY,
     y: right.y * uiX + up.y * uiY,
     z: right.z * uiX + up.z * uiY
-  };
-  offsetWorld.y = 0;
-  const forwardPlanarLength = Math.hypot(forward.x, forward.z);
+  }
+  offsetWorld.y = 0
+  const forwardPlanarLength = Math.hypot(forward.x, forward.z)
   const forwardPlanar =
     forwardPlanarLength > 1e-6
       ? { x: forward.x / forwardPlanarLength, z: forward.z / forwardPlanarLength }
-      : { x: 0, z: 1 };
-  const side = { x: -forwardPlanar.z, z: forwardPlanar.x };
+      : { x: 0, z: 1 }
+  const side = { x: -forwardPlanar.z, z: forwardPlanar.x }
   return {
     x: -(offsetWorld.x * side.x + offsetWorld.z * side.z),
     y: offsetWorld.x * forwardPlanar.x + offsetWorld.z * forwardPlanar.z
-  };
-};
+  }
+}
 
 export const mapSpinForPhysics = (spin, options = {}) => {
   const adjusted = {
     x: clamp(spin?.x ?? 0, -1, 1),
     y: clamp(spin?.y ?? 0, -1, 1)
-  };
-  const quantized = normalizeSpinInput(adjusted);
-  const { cameraRight, cameraUp, cueForward } = options;
+  }
+  const quantized = normalizeSpinInput(adjusted)
+  if (Math.hypot(quantized.x, quantized.y) <= 1e-6) {
+    return { x: 0, y: SPIN_CENTER_TOPSPIN_BIAS }
+  }
+  const { cameraRight, cameraUp, cueForward } = options
   return mapUiOffsetToCueFrame(
-    -quantized.x,
+    quantized.x,
     quantized.y,
     cameraRight,
     cameraUp,
     cueForward
-  );
-};
+  )
+}
 
 // Smooth damp helper adapted from Unity's Mathf.SmoothDamp (MIT licensed).
 export const smoothDamp = (
@@ -219,23 +223,23 @@ export const smoothDamp = (
   maxSpeed,
   deltaTime
 ) => {
-  const clampedSmooth = Math.max(0.0001, smoothTime || 0);
-  const omega = 2 / clampedSmooth;
-  const x = omega * deltaTime;
-  const exp = 1 / (1 + x + 0.48 * x * x + 0.235 * x * x * x);
-  let change = current - target;
-  const originalTarget = target;
-  const maxChange = (maxSpeed ?? Number.POSITIVE_INFINITY) * clampedSmooth;
+  const clampedSmooth = Math.max(0.0001, smoothTime || 0)
+  const omega = 2 / clampedSmooth
+  const x = omega * deltaTime
+  const exp = 1 / (1 + x + 0.48 * x * x + 0.235 * x * x * x)
+  let change = current - target
+  const originalTarget = target
+  const maxChange = (maxSpeed ?? Number.POSITIVE_INFINITY) * clampedSmooth
   if (Number.isFinite(maxChange)) {
-    change = clamp(change, -maxChange, maxChange);
+    change = clamp(change, -maxChange, maxChange)
   }
-  target = current - change;
-  const temp = (currentVelocity + omega * change) * deltaTime;
-  let velocity = (currentVelocity - omega * temp) * exp;
-  let output = target + (change + temp) * exp;
+  target = current - change
+  const temp = (currentVelocity + omega * change) * deltaTime
+  let velocity = (currentVelocity - omega * temp) * exp
+  let output = target + (change + temp) * exp
   if ((originalTarget - current > 0) === (output > originalTarget)) {
-    output = originalTarget;
-    velocity = (output - originalTarget) / Math.max(deltaTime, 1e-4);
+    output = originalTarget
+    velocity = (output - originalTarget) / Math.max(deltaTime, 1e-4)
   }
-  return { value: output, velocity };
-};
+  return { value: output, velocity }
+}


### PR DESCRIPTION
### Motivation
- Fix visible ball overlap with cushions by clamping collisions to the TABLE playfield perimeter and respecting the GLB pocket throat so balls rebound precisely at the cushion line. 
- Reduce unintended cue-ball aerial/launch spin and align Snooker Champion spin behavior and UI mapping with the proven Pool Royale spin controller so spin magnitude/direction and follow/draw behavior match across games.

### Description
- Adjusted spin mapping and controller: updated `webapp/src/pages/Games/snookerRoyalSpinUtils.js` to match Pool Royale conventions (response exponent, center-topspin bias, cue-frame mapping) and return a consistent `mapSpinForPhysics` output for Snooker. 
- Reworked cue-shot spin application in `webapp/src/pages/Games/SnookerRoyalProvided.jsx` by adding `resolveSnookerTopspinPowerScale`, applying a global spin scale, topspin/backspin multipliers, a topspin soft-cap, and computing a torque impulse from the cue contact offset instead of injecting excessive launch angular velocity. 
- Added precise cushion/contact handling: introduced `resolveSnookerCushionContact` and replaced the simple axis boundary checks with a previous-position-aware clamp so balls collide with cushions at the official rail line while leaving GLB pocket throats open for capture. 
- Updated the snooker spin decay/roll transfer logic (`applySnookerSpinController`) to follow Pool Royale-style roll acceleration, backspin boosts, assisted topspin transfer/decay, and early decay for airborne cue balls so post-impact spin behaves realistically and consistently.
- Changes touch the main Snooker Champion files: `webapp/src/pages/Games/SnookerRoyalProvided.jsx` and `webapp/src/pages/Games/snookerRoyalSpinUtils.js`.

### Testing
- Ran unit tests with `npm test -- --runInBand test/poolRoyaleSpinController.test.js test/snookerTableModel.test.js`, and both suites passed. 
- Fixed lint issues and ran ESLint (`npx eslint --no-ignore --fix` then lint check) against modified spin util; lint fixes applied where necessary. 
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099810d8708329a9e42b03e1d23af5)