### PR TITLE
Improve tennis court scale and contact physics

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/README.md
+++ b/Assets/Scripts/Gameplay/Tennis/README.md
@@ -2,10 +2,12 @@
 
 This folder adds modular tennis systems:
 
-- `TennisShotTuning`: keeps shots at a calmer match-power pace and supports flat/power/topspin/curve variants.
-- `TennisCourtScaler`: scales the court/net larger than the players and moves the camera back to keep the bigger court framed.
+- `TennisShotTuning`: keeps shots at match-power pace, adds contact-quality power/spin, and supports flat/power/topspin/curve variants.
+- `TennisCourtScaler`: expands the court independently across width, length, and height, raises the net, and moves the camera back to keep the bigger court framed.
+- `TennisBallContactPhysics`: softens collisions against humans, nets, and soft obstacles so the ball loses power but keeps bouncing with gradual drag loss.
+- `TennisRacketHitDetector`: only fires a shot when the ball physically touches the racket face/sweet spot; missed swings leave the ball on its existing path.
 - `TennisAudioController`: trigger shot and bounce SFX.
-- `TennisAIOpponent`: faster AI reaction, mixed shot variants, and capped match-power shot selection.
+- `TennisAIOpponent`: faster AI reaction, mixed shot variants, capped match-power shot selection, and precise racket-range contact checks.
 - `CharacterWalk8Dir`: 8-direction walk movement (forward/backward/sideways).
 
 ## Free/open-source sound effect sources
@@ -22,3 +24,10 @@ Import chosen WAV/OGG files into Unity and assign them to `shotClip` and `ballBo
 - Call `OnDecisivePoint(...)` for match-point / winner moments and `OnFoul(...)` for fouls.
 - Wire `menuSkipReplayButton` (menu-level skip) and `replaySkipIconButton` (overlay skip icon).
 - Optional: assign `replayOverlay` CanvasGroup to show replay UI while active.
+
+
+## Tennis realism setup
+
+- Add `TennisBallContactPhysics` to the tennis ball Rigidbody. Tag the net as `Net`; tag player/opponent body colliders as `Player` / `Opponent` or name them with `human` / `player` for automatic soft-contact damping.
+- Add `TennisRacketHitDetector` to player racket face colliders. Assign `shotTuning`, `ballBody`, `racketFaceCollider`, and an optional `aimTarget`. Set the racket collider as trigger or keep it as a normal collision collider; both paths require physical contact before a shot is applied.
+- Assign `racketContactPoint` on `TennisAIOpponent` to the AI racket sweet spot so AI shots happen only when the ball reaches the racket radius.

--- a/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
@@ -7,13 +7,30 @@ namespace TonPlaygram.Gameplay.Tennis
         [SerializeField] private TennisShotTuning shotTuning;
         [SerializeField] private Rigidbody ballBody;
         [SerializeField] private Transform hitTarget;
+        [SerializeField] private Transform racketContactPoint;
         [SerializeField, Min(0.01f)] private float reactionTime = 0.1f;
         [SerializeField, Min(0f)] private float anticipationTime = 0.14f;
         [SerializeField, Min(0.01f)] private float minReactionTime = 0.05f;
         [SerializeField, Min(0.1f)] private float minShotPower01 = 0.45f;
         [SerializeField, Min(0.1f)] private float maxShotPower01 = 0.82f;
+        [SerializeField, Min(0.01f)] private float preciseContactRadius = 0.42f;
+        [SerializeField, Range(0f, 1f)] private float edgeContactPenalty = 0.35f;
 
         private float _nextHitTime;
+        private Vector3 _lastRacketPosition;
+        private Vector3 _racketVelocity;
+
+        private void Start()
+        {
+            _lastRacketPosition = ContactPoint.position;
+        }
+
+        private void FixedUpdate()
+        {
+            Vector3 currentRacketPosition = ContactPoint.position;
+            _racketVelocity = (currentRacketPosition - _lastRacketPosition) / Time.fixedDeltaTime;
+            _lastRacketPosition = currentRacketPosition;
+        }
 
         private void Update()
         {
@@ -22,21 +39,30 @@ namespace TonPlaygram.Gameplay.Tennis
 
             bool ballComingToAi = ballBody.velocity.z > 0f;
             float predictedBallZ = ballBody.position.z + (ballBody.velocity.z * anticipationTime);
-            if (ballComingToAi && predictedBallZ > transform.position.z)
+            if (ballComingToAi && predictedBallZ > transform.position.z && IsBallAtRacket(out float sweetSpot01))
             {
                 float speed = ballBody.velocity.magnitude;
                 float adaptiveReaction = Mathf.Max(minReactionTime, reactionTime - (speed * 0.003f));
                 _nextHitTime = Time.time + adaptiveReaction;
-                ShootAdaptive();
+                ShootAdaptive(sweetSpot01);
             }
         }
 
-        private void ShootAdaptive()
+        private void ShootAdaptive(float sweetSpot01)
         {
             Vector3 aim = (hitTarget.position - ballBody.position).normalized;
-            float power = Random.Range(minShotPower01, maxShotPower01);
+            float power = Random.Range(minShotPower01, maxShotPower01) * Mathf.Lerp(edgeContactPenalty, 1f, sweetSpot01);
             ShotVariant variant = (ShotVariant)Random.Range(0, 5);
-            shotTuning.ApplyShot(ballBody, aim, power, variant);
+            shotTuning.ApplyContactShot(ballBody, aim, power, variant, sweetSpot01, _racketVelocity);
         }
+
+        private bool IsBallAtRacket(out float sweetSpot01)
+        {
+            float distance = Vector3.Distance(ballBody.position, ContactPoint.position);
+            sweetSpot01 = 1f - Mathf.Clamp01(distance / preciseContactRadius);
+            return distance <= preciseContactRadius;
+        }
+
+        private Transform ContactPoint => racketContactPoint != null ? racketContactPoint : transform;
     }
 }

--- a/Assets/Scripts/Gameplay/Tennis/TennisBallContactPhysics.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisBallContactPhysics.cs
@@ -1,0 +1,113 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Rigidbody))]
+    public class TennisBallContactPhysics : MonoBehaviour
+    {
+        [Header("Contact damping")]
+        [Range(0.05f, 1f)] public float humanVelocityRetain = 0.42f;
+        [Range(0.05f, 1f)] public float netVelocityRetain = 0.32f;
+        [Range(0.05f, 1f)] public float genericSoftVelocityRetain = 0.62f;
+        [Range(0f, 1f)] public float spinRetainOnSoftHit = 0.55f;
+        [Min(0f)] public float softBounceLift = 0.9f;
+        [Min(0f)] public float netDropBias = 0.35f;
+
+        [Header("Rolling loss after contact")]
+        [Range(0f, 2f)] public float postContactDrag = 0.2f;
+        [Range(0f, 2f)] public float postContactAngularDrag = 0.35f;
+        [Min(0f)] public float minimumReadableBounceSpeed = 0.25f;
+
+        [Header("Detection")]
+        [SerializeField] private string humanTag = "Player";
+        [SerializeField] private string opponentTag = "Opponent";
+        [SerializeField] private string netTag = "Net";
+        [SerializeField] private string softObstacleTag = "SoftObstacle";
+
+        private Rigidbody _body;
+        private float _baseDrag;
+        private float _baseAngularDrag;
+
+        private void Awake()
+        {
+            _body = GetComponent<Rigidbody>();
+            _baseDrag = _body.drag;
+            _baseAngularDrag = _body.angularDrag;
+        }
+
+        private void OnCollisionEnter(Collision collision)
+        {
+            Vector3 normal = collision.contactCount > 0 ? collision.GetContact(0).normal : Vector3.up;
+            ApplyNaturalContactLoss(collision.collider, normal);
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            ApplyNaturalContactLoss(other, Vector3.up);
+        }
+
+        private void FixedUpdate()
+        {
+            if (_body.velocity.sqrMagnitude < minimumReadableBounceSpeed * minimumReadableBounceSpeed)
+            {
+                _body.drag = Mathf.Lerp(_body.drag, _baseDrag, Time.fixedDeltaTime * 2f);
+                _body.angularDrag = Mathf.Lerp(_body.angularDrag, _baseAngularDrag, Time.fixedDeltaTime * 2f);
+            }
+        }
+
+        private void ApplyNaturalContactLoss(Collider collider, Vector3 contactNormal)
+        {
+            if (collider == null || _body == null) return;
+
+            ContactKind kind = ResolveContactKind(collider);
+            if (kind == ContactKind.HardCourt) return;
+
+            float retain = kind == ContactKind.Net
+                ? netVelocityRetain
+                : kind == ContactKind.Human
+                    ? humanVelocityRetain
+                    : genericSoftVelocityRetain;
+
+            Vector3 velocity = _body.velocity;
+            Vector3 normal = contactNormal.sqrMagnitude > 0.001f ? contactNormal.normalized : Vector3.up;
+            Vector3 tangentVelocity = Vector3.ProjectOnPlane(velocity, normal) * retain;
+            Vector3 normalVelocity = Vector3.Project(velocity, normal) * Mathf.Min(retain, 0.45f);
+            Vector3 softened = tangentVelocity + normalVelocity;
+
+            float lift = kind == ContactKind.Net ? -netDropBias : softBounceLift;
+            softened += Vector3.up * lift;
+
+            _body.velocity = softened;
+            _body.angularVelocity *= spinRetainOnSoftHit;
+            _body.drag = Mathf.Max(_body.drag, postContactDrag);
+            _body.angularDrag = Mathf.Max(_body.angularDrag, postContactAngularDrag);
+        }
+
+        private ContactKind ResolveContactKind(Collider collider)
+        {
+            if (MatchesTag(collider, netTag) || NameContains(collider, "net")) return ContactKind.Net;
+            if (MatchesTag(collider, humanTag) || MatchesTag(collider, opponentTag) || NameContains(collider, "human") || NameContains(collider, "player")) return ContactKind.Human;
+            if (MatchesTag(collider, softObstacleTag)) return ContactKind.SoftObstacle;
+            return ContactKind.HardCourt;
+        }
+
+        private static bool MatchesTag(Component component, string tagName)
+        {
+            return !string.IsNullOrWhiteSpace(tagName) && component.tag == tagName;
+        }
+
+        private static bool NameContains(Component component, string token)
+        {
+            return component.name.ToLowerInvariant().Contains(token);
+        }
+
+        private enum ContactKind
+        {
+            HardCourt,
+            Human,
+            Net,
+            SoftObstacle
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
@@ -12,8 +12,13 @@ namespace TonPlaygram.Gameplay.Tennis
         [SerializeField] private Camera targetCamera;
         [SerializeField] private Transform framingPivot;
         [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 2.45f;
-        [SerializeField, Min(0.1f)] private float courtScaleMultiplier = 3.2f;
-        [SerializeField, Min(1f)] private float framingDistanceScale = 2.65f;
+        [SerializeField, Min(0.1f)] private float courtWidthMultiplier = 4.25f;
+        [SerializeField, Min(0.1f)] private float courtLengthMultiplier = 4.65f;
+        [SerializeField, Min(0.1f)] private float courtHeightMultiplier = 1.18f;
+        [SerializeField, Min(0.1f)] private float netWidthMultiplier = 4.25f;
+        [SerializeField, Min(0.1f)] private float netHeightMultiplier = 1.55f;
+        [SerializeField, Min(0.1f)] private float netDepthMultiplier = 1.2f;
+        [SerializeField, Min(1f)] private float framingDistanceScale = 3.25f;
 
         private bool _initialized;
         private Vector3 _initialCourtScale;
@@ -33,9 +38,9 @@ namespace TonPlaygram.Gameplay.Tennis
         {
             EnsureInitialized();
 
-            SetScaled(courtRoot, _initialCourtScale, courtScaleMultiplier);
-            SetScaled(ballRoot, _initialBallScale, worldScaleMultiplier);
-            SetScaled(netRoot, _initialNetScale, courtScaleMultiplier);
+            SetScaled(courtRoot, _initialCourtScale, CourtScale);
+            SetScaled(ballRoot, _initialBallScale, Vector3.one * worldScaleMultiplier);
+            SetScaled(netRoot, _initialNetScale, NetScale);
             SetScaledArray(characterRoots, _initialCharacterScales);
             SetScaledArray(racketRoots, _initialRacketScales);
 
@@ -92,14 +97,18 @@ namespace TonPlaygram.Gameplay.Tennis
             if (roots == null || baseScales == null) return;
             for (int i = 0; i < roots.Length && i < baseScales.Length; i++)
             {
-                SetScaled(roots[i], baseScales[i], worldScaleMultiplier);
+                SetScaled(roots[i], baseScales[i], Vector3.one * worldScaleMultiplier);
             }
         }
 
-        private void SetScaled(Transform target, Vector3 baseScale, float scaleMultiplier)
+        private Vector3 CourtScale => new Vector3(courtWidthMultiplier, courtHeightMultiplier, courtLengthMultiplier);
+
+        private Vector3 NetScale => new Vector3(netWidthMultiplier, netHeightMultiplier, netDepthMultiplier);
+
+        private void SetScaled(Transform target, Vector3 baseScale, Vector3 scaleMultiplier)
         {
             if (target == null) return;
-            target.localScale = baseScale * scaleMultiplier;
+            target.localScale = Vector3.Scale(baseScale, scaleMultiplier);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/Tennis/TennisRacketHitDetector.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisRacketHitDetector.cs
@@ -1,0 +1,107 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [DisallowMultipleComponent]
+    public class TennisRacketHitDetector : MonoBehaviour
+    {
+        [SerializeField] private TennisShotTuning shotTuning;
+        [SerializeField] private Rigidbody ballBody;
+        [SerializeField] private Collider racketFaceCollider;
+        [SerializeField] private Transform racketFaceCenter;
+        [SerializeField] private Transform aimTarget;
+        [SerializeField] private ShotVariant defaultVariant = ShotVariant.Flat;
+
+        [Header("Precision")]
+        [Min(0.005f)] public float ballRadius = 0.12f;
+        [Min(0.005f)] public float contactTolerance = 0.025f;
+        [Range(0f, 1f)] public float minSweetSpot01 = 0.18f;
+        [Min(0f)] public float hitCooldown = 0.08f;
+        [Range(0f, 1f)] public float minimumRacketForwardDot = 0.12f;
+
+        private Vector3 _lastRacketPosition;
+        private Vector3 _racketVelocity;
+        private float _nextHitTime;
+
+        private void Awake()
+        {
+            Transform velocityRoot = racketFaceCenter != null ? racketFaceCenter : transform;
+            _lastRacketPosition = velocityRoot.position;
+        }
+
+        private void FixedUpdate()
+        {
+            Transform velocityRoot = racketFaceCenter != null ? racketFaceCenter : transform;
+            _racketVelocity = (velocityRoot.position - _lastRacketPosition) / Time.fixedDeltaTime;
+            _lastRacketPosition = velocityRoot.position;
+        }
+
+        private void OnTriggerStay(Collider other)
+        {
+            if (ballBody != null && other.attachedRigidbody == ballBody)
+            {
+                TryHitBall();
+            }
+        }
+
+        private void OnCollisionStay(Collision collision)
+        {
+            if (ballBody != null && collision.rigidbody == ballBody)
+            {
+                TryHitBall();
+            }
+        }
+
+        public bool TryHitBall()
+        {
+            if (Time.time < _nextHitTime || shotTuning == null || ballBody == null) return false;
+            if (!IsActuallyTouchingBall(out float sweetSpot01)) return false;
+
+            Vector3 aim = ResolveAimDirection();
+            float racketSpeed = _racketVelocity.magnitude;
+            float incomingSpeed = ballBody.velocity.magnitude;
+            float dynamicPower = Mathf.InverseLerp(1.5f, 14f, racketSpeed + (incomingSpeed * 0.35f));
+            dynamicPower = Mathf.Lerp(dynamicPower, dynamicPower * sweetSpot01, 0.55f);
+
+            if (!HasForwardContactIntent(aim, racketSpeed)) return false;
+
+            shotTuning.ApplyContactShot(ballBody, aim, dynamicPower, defaultVariant, sweetSpot01, _racketVelocity);
+            _nextHitTime = Time.time + hitCooldown;
+            return true;
+        }
+
+        private bool IsActuallyTouchingBall(out float sweetSpot01)
+        {
+            sweetSpot01 = 0f;
+            Collider face = racketFaceCollider != null ? racketFaceCollider : GetComponent<Collider>();
+            if (face == null) return false;
+
+            Vector3 closest = face.ClosestPoint(ballBody.position);
+            float distance = Vector3.Distance(closest, ballBody.position);
+            if (distance > ballRadius + contactTolerance) return false;
+
+            Vector3 center = racketFaceCenter != null ? racketFaceCenter.position : face.bounds.center;
+            float maxSweetSpotDistance = Mathf.Max(Mathf.Max(face.bounds.extents.x, face.bounds.extents.y), Mathf.Max(face.bounds.extents.z, ballRadius));
+            sweetSpot01 = 1f - Mathf.Clamp01(Vector3.Distance(closest, center) / maxSweetSpotDistance);
+            return sweetSpot01 >= minSweetSpot01;
+        }
+
+        private bool HasForwardContactIntent(Vector3 aim, float racketSpeed)
+        {
+            if (racketSpeed <= 0.05f) return true;
+            return Vector3.Dot(_racketVelocity.normalized, aim.normalized) >= minimumRacketForwardDot;
+        }
+
+        private Vector3 ResolveAimDirection()
+        {
+            if (aimTarget != null)
+            {
+                Vector3 targetAim = aimTarget.position - ballBody.position;
+                if (targetAim.sqrMagnitude > 0.001f) return targetAim.normalized;
+            }
+
+            if (_racketVelocity.sqrMagnitude > 0.01f) return _racketVelocity.normalized;
+            return transform.forward;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
@@ -12,27 +12,52 @@ namespace TonPlaygram.Gameplay.Tennis
         [Range(0f, 2f)] public float sidespin = 0.2f;
         [Range(0f, 2f)] public float curvePower = 0.5f;
 
+        [Header("Dynamic contact")]
+        [Range(0f, 1f)] public float incomingVelocityCarry = 0.22f;
+        [Range(0f, 1f)] public float offCenterPowerLoss = 0.38f;
+        [Range(0f, 1f)] public float racketVelocityInfluence = 0.3f;
+        [Min(0f)] public float minimumLift = 0.18f;
+        [Min(0f)] public float precisionSpinBonus = 0.45f;
+
         public void ApplyShot(Rigidbody ballBody, Vector3 aimDirection, float normalizedPower, ShotVariant variant)
+        {
+            ApplyContactShot(ballBody, aimDirection, normalizedPower, variant, 1f, Vector3.zero);
+        }
+
+        public void ApplyContactShot(Rigidbody ballBody, Vector3 aimDirection, float normalizedPower, ShotVariant variant, float sweetSpot01, Vector3 racketVelocity)
         {
             if (ballBody == null) return;
 
             var dir = aimDirection.sqrMagnitude > 0.0001f ? aimDirection.normalized : transform.forward;
+            if (dir.y < minimumLift)
+            {
+                dir = new Vector3(dir.x, minimumLift, dir.z).normalized;
+            }
+
+            float contactQuality = Mathf.Clamp01(sweetSpot01);
             float matchPower = Mathf.Clamp(normalizedPower, 0f, maxMatchPower01);
-            float power = baseShotPower * matchPower;
+            float centeredPower = Mathf.Lerp(matchPower * (1f - offCenterPowerLoss), matchPower, contactQuality);
+            float power = baseShotPower * centeredPower;
 
-            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.02f : 1f;
-            float finalPower = power * variantPowerMultiplier;
+            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.08f : 1f;
+            float racketBoost = racketVelocity.magnitude * racketVelocityInfluence * Mathf.Lerp(0.35f, 1f, contactQuality);
+            float finalPower = (power * variantPowerMultiplier) + racketBoost;
 
+            Vector3 retainedIncoming = Vector3.Project(ballBody.velocity, dir) * incomingVelocityCarry;
+            ballBody.velocity = retainedIncoming;
             ballBody.AddForce(dir * finalPower, ForceMode.Impulse);
 
             Vector3 right = Vector3.Cross(Vector3.up, dir).normalized;
-            float side = variant == ShotVariant.CurveLeft ? -1f : variant == ShotVariant.CurveRight ? 1f : 0f;
-            float spinY = (variant == ShotVariant.Topspin ? topspin : 0.15f) * finalPower;
+            if (right.sqrMagnitude < 0.001f) right = transform.right;
 
-            ballBody.AddTorque((Vector3.right * spinY) + (right * side * sidespin * finalPower), ForceMode.Impulse);
+            float side = variant == ShotVariant.CurveLeft ? -1f : variant == ShotVariant.CurveRight ? 1f : 0f;
+            float spinMultiplier = Mathf.Lerp(0.5f, 1f + precisionSpinBonus, contactQuality);
+            float spinY = (variant == ShotVariant.Topspin ? topspin : 0.15f) * finalPower * spinMultiplier;
+
+            ballBody.AddTorque((Vector3.right * spinY) + (right * side * sidespin * finalPower * spinMultiplier), ForceMode.Impulse);
             if (Mathf.Abs(side) > 0f)
             {
-                ballBody.AddForce(right * side * curvePower * matchPower, ForceMode.Impulse);
+                ballBody.AddForce(right * side * curvePower * centeredPower * contactQuality, ForceMode.Impulse);
             }
         }
     }


### PR DESCRIPTION
### Motivation

- Provide a more realistic tennis experience by enlarging the play field and net, making ball contacts with humans/nets feel natural and lose power gradually, and ensuring racket hits are precise and only applied when the ball is actually contacted.

### Description

- Add `TennisBallContactPhysics` to soften collisions against humans, nets and soft obstacles so the ball loses velocity and spin but continues bouncing and recovers drag gradually. 
- Add `TennisRacketHitDetector` to require physical contact/sweet-spot checks before applying a shot and compute racket velocity/sweet-spot quality for more precise hits. 
- Replace single-scale court scaling with `TennisCourtScaler` multipliers for width, length, height and separate net scale plus camera framing adjustments so the court and net can be expanded independently. 
- Extend `TennisShotTuning` with `ApplyContactShot` to incorporate contact quality, racket velocity influence, incoming-ball carry, lift, spin bonuses and off-center power loss, and update `TennisAIOpponent` to use precise racket contact checks and contact-quality-scaled power. 
- Update `Assets/Scripts/Gameplay/Tennis/README.md` with wiring/setup notes for the new systems.

### Testing

- Ran `git diff --check` to statically validate diffs and it returned no problems. 
- Attempted to run `dotnet test billiards.Tests/Billiards.Tests.csproj` but the command failed because `dotnet` was not available in the environment, so unit test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ada116288329956829ff9520131c)