### PR TITLE
Reduce tennis shot power

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -1694,7 +1694,7 @@ function makeAiTarget(near: HumanRig, ball: BallState): DesiredHit {
     CFG.courtW / 2 - 0.45 * CFG.worldScale
   );
   const z = lerp(1.35 * CFG.worldScale, CFG.courtL / 2 - 1.0 * CFG.worldScale, 0.35 + pressure * 0.55);
-  const power = clamp(0.48 + pressure * 0.38 + Math.random() * 0.12, CFG.shotPower.min, CFG.shotPower.max);
+  const power = clamp(0.42 + pressure * 0.3 + Math.random() * 0.08, CFG.shotPower.min, CFG.shotPower.max);
   return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique: "flat" };
 }
 

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -76,10 +76,11 @@ export const gameConfig = {
   serveDuration: 0.86,
   serveContactT: 0.72,
   serveTossMinHeight: 1.85 * PLAYER_SCALE,
-  // Scales the full match shot force so player and AI strokes share a softer, lower power ceiling.
-  matchPowerMultiplier: 0.68,
-  servePower: { min: 0.48, max: 0.74 },
-  shotPower: { min: 0.2, max: 0.68 },
+  // Scales full-match shot force so player and AI strokes share a softer, lower power ceiling.
+  // Keep this conservative: the enlarged court already magnifies perceived ball speed.
+  matchPowerMultiplier: 0.58,
+  servePower: { min: 0.42, max: 0.68 },
+  shotPower: { min: 0.18, max: 0.6 },
   spinAmount: { flat: 0.8, topspin: 1.6, slice: -1.4, lob: 1.1, drop: -0.7, block: 0.25 },
   playerVisualYawFix: Math.PI,
   serveNearBaselineZ: (23.77 / 2 + 0.92) * WORLD_SCALE,
@@ -98,7 +99,7 @@ export const gameConfig = {
     moveSpeed: 13.5 * PLAYER_SCALE,
     reachRadius: 1.95 * PLAYER_SCALE,
     accuracy: 0.94,
-    power: 0.62,
+    power: 0.54,
     spin: 0.88,
     mistakeChance: 0.018,
     serveQuality: 0.84,


### PR DESCRIPTION
### Motivation
- Players reported that tennis strokes felt too powerful, so the match shot ceiling and AI returns were reduced to produce a softer, more realistic pace.

### Description
- Lowered the global `matchPowerMultiplier` from `0.68` to `0.58` to reduce full-match shot force in `gameConfig.ts`.
- Reduced serve and rally ranges by changing `servePower` to `{ min: 0.42, max: 0.68 }` and `shotPower` to `{ min: 0.18, max: 0.6 }` in `gameConfig.ts`.
- Tuned AI difficulty power (`aiDifficulty.power`) from `0.62` to `0.54` so opponent stroke strength matches the new ceiling in `gameConfig.ts`.
- Adjusted the AI return power calculation in `Tennis.tsx` to lower generated rally pace by reducing base and pressure contributions and jitter.

### Testing
- Built the webapp with `npm --prefix webapp run build` which completed successfully (Vite build completed and artifacts produced). 
- Launched the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1` which started successfully and served the tennis page. 
- Installed Playwright and platform deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully. 
- Performed a Playwright smoke screenshot of `/games/tennis` which saved to `/tmp/tennis-power-tuning.png` indicating the page rendered under the tuned settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b63176d883298afd477efabda97c)