### PR TITLE
Tune table tennis shot power and bounce

### DIFF
--- a/webapp/src/pages/Games/TableTennis.tsx
+++ b/webapp/src/pages/Games/TableTennis.tsx
@@ -137,8 +137,8 @@ const CFG = {
   gravity: 9.81,
   airDrag: 0.22,
   magnus: 0.00125,
-  tableRestitution: 0.9,
-  tableFriction: 0.965,
+  tableRestitution: 1.04,
+  tableFriction: 0.982,
   spinDecay: 0.72,
   playerHeight: 3.5,
   playerSpeed: 4.15,
@@ -154,11 +154,11 @@ const CFG = {
   netFaceRestitution: 0.18,
   netPowerRetention: 0.2,
   bodyPowerRetention: 0.2,
-  floorRestitution: 0.56,
+  floorRestitution: 0.68,
   floorFriction: 0.88,
   railRestitution: 0.5,
-  minShotSpeed: 4.6,
-  maxShotSpeed: 12.2,
+  minShotSpeed: 5.4,
+  maxShotSpeed: 15.4,
   playerVisualYawFix: Math.PI,
   paddlePalmOffset: 0.038,
 };
@@ -1054,7 +1054,7 @@ function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, flight: n
 function makeUserHitFromSwipe(startX: number, startY: number, endX: number, endY: number, isServe: boolean): DesiredHit {
   const dx = endX - startX;
   const dy = endY - startY;
-  const power = clamp(Math.hypot(dx, dy) / 180, isServe ? 0.56 : 0.36, 1);
+  const power = clamp(Math.hypot(dx, dy) / 150, isServe ? 0.64 : 0.44, 1);
   const lateral = clamp(dx / 170, -1, 1);
   const depth = clamp((-dy + 42) / 255, 0, 1);
   const targetX = clamp(lateral * (TABLE_HALF_W - scaleTableX(0.13)), -TABLE_HALF_W + scaleTableX(0.12), TABLE_HALF_W - scaleTableX(0.12));
@@ -1149,7 +1149,7 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
   if (serve) {
     ball.pos.copy(serveContactPosition(player));
     const ownBounce = new THREE.Vector3(clamp(target.x * 0.45, -TABLE_HALF_W + scaleTableX(0.12), TABLE_HALF_W - scaleTableX(0.12)), BALL_SURFACE_Y, dirZ * -scaleTableZ(0.56));
-    const flight = clamp(0.18 + (1 - hit.power) * 0.075, 0.17, 0.28);
+    const flight = clamp(0.16 + (1 - hit.power) * 0.06, 0.145, 0.245);
     ball.vel.copy(ballisticVelocity(ball.pos, ownBounce, flight));
     ball.spin.set(-dirZ * (52 + hit.topSpin * 50), hit.sideSpin * 86, hit.sideSpin * 9);
     ball.phase = { kind: "serve", server: player.side, stage: "own" };
@@ -1157,7 +1157,7 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
     ball.pos.y = clamp(ball.pos.y, CFG.tableY + 0.08, CFG.tableY + 0.48);
     const dist = Math.hypot(target.x - ball.pos.x, target.z - ball.pos.z);
     const speedScale = Math.max(1, TABLE_SCALE_FACTOR * 0.85);
-    const flight = clamp(dist / ((4.2 + hit.power * 4.1) * speedScale), 0.14, 0.4);
+    const flight = clamp(dist / ((4.8 + hit.power * 5.4) * speedScale), 0.115, 0.34);
     ball.vel.copy(ballisticVelocity(ball.pos, target, flight));
     ball.spin.set(-dirZ * (68 + hit.topSpin * 102), hit.sideSpin * 118, hit.sideSpin * 14);
     ball.phase = { kind: "rally" };


### PR DESCRIPTION
### Motivation
- Make table tennis shots feel stronger and make the ball carry more energy after contact so rallies feel punchier and more responsive.
- Reduce swipe distance required for full power and shorten flight times so serves and rallies arrive faster to the target.

### Description
- Increased physics restitution/friction values in `webapp/src/pages/Games/TableTennis.tsx` by raising `tableRestitution` and `tableFriction` and increasing `floorRestitution` for livelier bounces.
- Raised shot speed clamps `minShotSpeed`/`maxShotSpeed` to allow faster shots and adjusted swipe-to-power scaling by changing the user swipe power divisor and serve/rally minima.
- Shortened serve and rally `flight` calculations to reduce travel time, and adjusted the flight divisor constants used to compute ballistic velocity for hits.
- Changes are localized to `webapp/src/pages/Games/TableTennis.tsx` (tuning values and `makeUserHitFromSwipe`/`performHit` logic). 

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Ran `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully to enable headless browser testing.
- Started the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1` and it became reachable at the local dev URL.
- Captured a Playwright screenshot of `/games/table-tennis` which produced an output file (`/workspace/TonPlaygramWebApp/table-tennis-power-bounce.png`) indicating the scene rendered; automated steps completed with success notes in the build and browser runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b65b37d8832992deb6e872c37905)