### PR TITLE
Tune Snooker Champion table physics and spin

### DIFF
--- a/test/snookerRoyalSpinController.test.js
+++ b/test/snookerRoyalSpinController.test.js
@@ -1,0 +1,29 @@
+import {
+  SPIN_DIRECTIONS,
+  mapSpinForPhysics,
+  normalizeSpinInput
+} from '../webapp/src/pages/Games/snookerRoyalSpinUtils.js';
+
+describe('Snooker Royal/Champion natural spin controller', () => {
+  it('limits available presets to center and natural forward spin', () => {
+    expect(SPIN_DIRECTIONS.map((direction) => direction.id)).toEqual([
+      'stun',
+      'natural-follow'
+    ]);
+  });
+
+  it('suppresses side english and draw/backspin from user input', () => {
+    expect(normalizeSpinInput({ x: 1, y: 0 }).x).toBe(0);
+    expect(normalizeSpinInput({ x: -1, y: 0 }).x).toBe(0);
+    expect(normalizeSpinInput({ x: 0, y: -1 })).toEqual({ x: 0, y: 0 });
+  });
+
+  it('maps diagonal or backward UI drags to ahead-only natural spin', () => {
+    const diagonal = mapSpinForPhysics({ x: 1, y: 1 });
+    expect(diagonal.x).toBe(0);
+    expect(diagonal.y).toBeGreaterThan(0);
+
+    const backward = mapSpinForPhysics({ x: 1, y: -1 });
+    expect(backward).toEqual({ x: 0, y: 0 });
+  });
+});

--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -54,6 +54,15 @@ describe('snooker table model selection', () => {
     assert.match(source, /mapping = 'glb-bed-to-game-playfield'/);
   });
 
+
+  test('Snooker Champion scene enlarges the GLB table and tightens cushion mapping', async () => {
+    const source = await readFile('webapp/src/pages/Games/SnookerRoyalProvided.jsx', 'utf8');
+    assert.match(source, /SNOOKER_PLAYFIELD_SCALE = \(2\.75 \* WORLD_SCALE\)/);
+    assert.match(source, /SNOOKER_TABLE_VISUAL_LENGTH_TRIM = 1\.18/);
+    assert.match(source, /SNOOKER_CUSHION_COLLISION_SAFETY_INSET/);
+    assert.match(source, /SNOOKER_PHYSICS_MAX_STEP = 1 \/ 480/);
+  });
+
   test('uses procedural rail decor only for the classic table model', () => {
     assert.equal(usesProceduralSnookerTableRailDecor('classic'), true);
     assert.equal(usesProceduralSnookerTableRailDecor('opensource'), false);

--- a/webapp/src/pages/Games/SnookerRoyalProvided.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalProvided.jsx
@@ -137,8 +137,8 @@ const OFFICIAL_SNOOKER_D_RADIUS_M = 0.292;
 const OFFICIAL_SNOOKER_BLACK_FROM_TOP_CUSHION_M = 0.324;
 const OFFICIAL_SNOOKER_POCKET_CORNER_MOUTH_M = 0.086;
 const OFFICIAL_SNOOKER_POCKET_MIDDLE_MOUTH_M = 0.095;
-const SNOOKER_TABLE_VISUAL_LENGTH_TRIM = 1.08; // larger GLB cabinet framing so the imported snooker table wraps the official mapped cushion rectangle
-const SNOOKER_PLAYFIELD_SCALE = (2.55 * WORLD_SCALE) / OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M;
+const SNOOKER_TABLE_VISUAL_LENGTH_TRIM = 1.18; // larger GLB cabinet framing so the imported snooker table wraps the official mapped cushion rectangle
+const SNOOKER_PLAYFIELD_SCALE = (2.75 * WORLD_SCALE) / OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M;
 const SNOOKER_OFFICIAL_PLAYFIELD_W = OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M * SNOOKER_PLAYFIELD_SCALE;
 const SNOOKER_OFFICIAL_PLAYFIELD_L = OFFICIAL_SNOOKER_PLAYFIELD_LENGTH_M * SNOOKER_PLAYFIELD_SCALE;
 const SNOOKER_OFFICIAL_BALL_R = (OFFICIAL_SNOOKER_BALL_DIAMETER_M * SNOOKER_PLAYFIELD_SCALE) / 2;
@@ -155,11 +155,9 @@ const SNOOKER_SHOT_MIN_FACTOR = 0.25;
 const SNOOKER_SHOT_POWER_RANGE = 0.75;
 const SNOOKER_SHOT_FULL_SPEED = 12 * WORLD_SCALE * SNOOKER_SHOT_POWER_BOOST;
 const SNOOKER_BALL_MASS = 0.17;
-const SNOOKER_SHOT_SPIN_SCALE = 0.18;
-const SNOOKER_SPIN_GLOBAL_SCALE = 0.46; // keep cue-ball side/top input subtle so center-ball shots do not over-rotate
+const SNOOKER_SHOT_SPIN_SCALE = 0.115;
+const SNOOKER_SPIN_GLOBAL_SCALE = 0.32; // keep cue-ball natural-follow input subtle so center-ball shots do not over-rotate
 const SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER = 1.2;
-const SNOOKER_SIDE_SPIN_MULTIPLIER = 1.5 * SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER;
-const SNOOKER_BACKSPIN_MULTIPLIER = 2.6 * SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER;
 const SNOOKER_TOPSPIN_MULTIPLIER = 1.34 * SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER;
 const SNOOKER_CUE_CENTER_ROLL_OMEGA_FACTOR = 0.32;
 const SNOOKER_CUE_SPIN_OMEGA_MULTIPLIER = 10;
@@ -177,7 +175,8 @@ const SNOOKER_STOP_EPS = 0.0074;
 const SNOOKER_STOP_SOFTENING = 0.96;
 const SNOOKER_STOP_FINAL_EPS = SNOOKER_STOP_EPS * 0.35;
 const SNOOKER_CUSHION_NOSE_CONTACT_INSET = Math.max(0, (SNOOKER_OFFICIAL_BALL_R * 2 - SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS) * 0.5);
-const SNOOKER_PHYSICS_MAX_STEP = 1 / 240;
+const SNOOKER_CUSHION_COLLISION_SAFETY_INSET = SNOOKER_OFFICIAL_BALL_R * 0.12;
+const SNOOKER_PHYSICS_MAX_STEP = 1 / 480;
 const SNOOKER_AIMING_CAMERA_HEIGHT_THRESHOLD = -0.08;
 const SNOOKER_CAMERA_HEIGHT_STEP = 0.075;
 const SNOOKER_CAMERA_HEIGHT_MIN = -0.34;
@@ -1198,24 +1197,21 @@ function updateHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget,
 function applyCueShot(cueBall, power, yaw, out, spinInput = { x: 0, y: 0 }) {
   const p = clamp01(power);
   const dir = out.set(0, 0, -1).applyAxisAngle(Y_AXIS, yaw).normalize();
-  const side = new THREE.Vector3(dir.z, 0, -dir.x).normalize();
   const spinMappedRaw = mapSpinForPhysics(normalizeSpinInput(spinInput));
   const spinMapped = {
     x: (spinMappedRaw.x ?? 0) * SNOOKER_SPIN_GLOBAL_SCALE,
     y: (spinMappedRaw.y ?? 0) * SNOOKER_SPIN_GLOBAL_SCALE
   };
   const powerSpinScale = 0.55 + p * 0.45;
-  const rawTopSpin = (spinMapped.y ?? 0) * SNOOKER_SHOT_SPIN_SCALE * powerSpinScale;
+  const rawTopSpin = Math.max(0, spinMapped.y ?? 0) * SNOOKER_SHOT_SPIN_SCALE * powerSpinScale;
   const spin = {
-    x: (spinMapped.x ?? 0) * SNOOKER_SHOT_SPIN_SCALE * SNOOKER_SIDE_SPIN_MULTIPLIER * powerSpinScale,
-    y: rawTopSpin < 0
-      ? rawTopSpin * SNOOKER_BACKSPIN_MULTIPLIER
-      : rawTopSpin * SNOOKER_TOPSPIN_MULTIPLIER
+    x: 0,
+    y: rawTopSpin * SNOOKER_TOPSPIN_MULTIPLIER
   };
   const powerScale = SNOOKER_SHOT_MIN_FACTOR + SNOOKER_SHOT_POWER_RANGE * p;
   const speed = SNOOKER_SHOT_FULL_SPEED * powerScale;
   cueBall.vel.copy(dir.multiplyScalar(speed));
-  cueBall.vel.addScaledVector(side, (spin.x ?? 0) * p * 1.05 * CFG.scale * SNOOKER_SHOT_POWER_BOOST);
+  // Side/draw spin is disabled for Snooker Champion; shots keep only natural forward roll.
   cueBall.spin.set(spin.x ?? 0, spin.y ?? 0);
   cueBall.omega?.set(0, 0, 0);
   const launchSpeed = cueBall.vel.length();
@@ -1382,7 +1378,7 @@ function finalizeSnookerShotRules(balls, rulesState) {
 function findSnookerPocketCapture(ball, pocketPositions = []) {
   return pocketPositions.find((pocket) => {
     const radius = pocket.userData?.radius ?? SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS;
-    const captureRadius = Math.max(radius + CFG.ballR * 0.56, CFG.ballR * 1.35);
+    const captureRadius = Math.max(radius + CFG.ballR * 0.28, CFG.ballR * 1.08);
     return ball.pos.distanceToSquared(pocket) < captureRadius * captureRadius;
   });
 }
@@ -1390,7 +1386,7 @@ function findSnookerPocketCapture(ball, pocketPositions = []) {
 function isInSnookerPocketMouth(ball, axis, sign, pocketPositions = []) {
   const nearPocket = pocketPositions.some((pocket) => {
     const radius = pocket.userData?.radius ?? SNOOKER_OFFICIAL_CORNER_POCKET_RADIUS;
-    const mouth = Math.max(radius + CFG.ballR * 0.92, CFG.ballR * 1.65);
+    const mouth = Math.max(radius + CFG.ballR * 0.52, CFG.ballR * 1.24);
     if (axis === 'x') {
       return Math.sign(pocket.x || sign) === sign && Math.abs(ball.pos.z - pocket.z) <= mouth;
     }
@@ -1408,7 +1404,7 @@ function isInsideSnookerPocketThroat(ball, axis, sign, pocketPositions = []) {
 
 function getSnookerCushionCenterLimit(axis) {
   const half = axis === 'x' ? CFG.tableW / 2 : CFG.tableL / 2;
-  return half - CFG.ballR - SNOOKER_CUSHION_NOSE_CONTACT_INSET;
+  return half - CFG.ballR - SNOOKER_CUSHION_NOSE_CONTACT_INSET - SNOOKER_CUSHION_COLLISION_SAFETY_INSET;
 }
 
 function clampSnookerAimImpactToPerimeter(point) {
@@ -2131,8 +2127,8 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
       const normalized = normalizeSpinInput(clamped);
       setSpin(normalized);
       spinRef.current = normalized;
-      dot.style.left = `${50 + clamped.x * 42}%`;
-      dot.style.top = `${50 - clamped.y * 42}%`;
+      dot.style.left = `${50 + normalized.x * 42}%`;
+      dot.style.top = `${50 - normalized.y * 42}%`;
     };
 
     const clearTimer = () => {
@@ -2199,13 +2195,13 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
       const rect = pad.getBoundingClientRect();
       const rawX = ((clientX - rect.left) / rect.width - 0.5) * 2;
       const rawY = (0.5 - (clientY - rect.top) / rect.height) * 2;
-      const clamped = clampToUnitCircle(rawX, rawY);
+      const clamped = normalizeSpinInput(clampToUnitCircle(rawX, rawY));
       spinState.target = clamped;
       startSpring();
     };
     const snapTarget = () => {
       const snapped = computeQuantizedOffsetScaled(spinState.target.x, spinState.target.y);
-      spinState.target = clampToUnitCircle(snapped.x, snapped.y);
+      spinState.target = normalizeSpinInput(clampToUnitCircle(snapped.x, snapped.y));
       startSpring();
     };
     const onPointerDown = (e) => {

--- a/webapp/src/pages/Games/snookerRoyalSpinUtils.js
+++ b/webapp/src/pages/Games/snookerRoyalSpinUtils.js
@@ -14,66 +14,17 @@ export const SPIN_RESPONSE_EXPONENT = 1.32;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',
-    label: 'STUN (no spin)',
+    label: 'STUN / CENTER',
     offset: { x: 0, y: 0 },
     effect:
-      'Goditje në qendër: cue ball rrëshqet fillimisht dhe kalon në rolling pa topspin/backspin.'
+      'Goditje në qendër: cue ball rrëshqet fillimisht dhe kalon në rolling pa efekt anësor.'
   },
   {
-    id: 'topspin',
-    label: 'TOPSPIN (follow)',
+    id: 'natural-follow',
+    label: 'NATURAL FORWARD SPIN',
     offset: { x: 0, y: MAX_SPIN_OFFSET },
     effect:
-      'Goditje sipër qendrës: spin rreth boshtit horizontal në drejtim të lëvizjes, cue ball vazhdon përpara pas kontaktit.'
-  },
-  {
-    id: 'backspin',
-    label: 'BACKSPIN (draw)',
-    offset: { x: 0, y: -MAX_SPIN_OFFSET },
-    effect:
-      'Goditje poshtë qendrës: spin rreth boshtit horizontal në drejtim të kundërt, cue ball ndalon dhe kthehet mbrapsht pas kontaktit.'
-  },
-  {
-    id: 'left-english',
-    label: 'SIDESPIN LEFT',
-    offset: { x: -MAX_SPIN_OFFSET, y: 0 },
-    effect:
-      'Goditje majtas nga qendra: spin rreth boshtit vertikal, ndikon kryesisht në rebound me banda dhe në “throw”.'
-  },
-  {
-    id: 'right-english',
-    label: 'SIDESPIN RIGHT',
-    offset: { x: MAX_SPIN_OFFSET, y: 0 },
-    effect:
-      'Goditje djathtas nga qendra: spin rreth boshtit vertikal në drejtim të kundërt, me të njëjtat efekte anësore.'
-  },
-  {
-    id: 'top-left',
-    label: 'TOPSPIN + LEFT',
-    offset: { x: -SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
-    effect:
-      'Offset diagonal sipër-majtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
-  },
-  {
-    id: 'top-right',
-    label: 'TOPSPIN + RIGHT',
-    offset: { x: SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
-    effect:
-      'Offset diagonal sipër-djathtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
-  },
-  {
-    id: 'back-left',
-    label: 'BACKSPIN + LEFT',
-    offset: { x: -SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
-    effect:
-      'Offset diagonal poshtë-majtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
-  },
-  {
-    id: 'back-right',
-    label: 'BACKSPIN + RIGHT',
-    offset: { x: SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
-    effect:
-      'Offset diagonal poshtë-djathtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
+      'Goditje sipër qendrës: vetëm follow natyral përpara, pa sidespin ose draw agresiv.'
   }
 ];
 
@@ -137,12 +88,12 @@ export const computeQuantizedOffsetScaled = (
 };
 
 export const normalizeSpinInput = (spin) => {
-  let x = clamp(spin?.x ?? 0, -1, 1);
-  let y = clamp(spin?.y ?? 0, -1, 1);
+  // Snooker Champion now exposes only natural forward spin. Horizontal english
+  // and draw/backspin are intentionally suppressed so cue-ball control stays
+  // realistic and balls do not receive exaggerated airborne/side spin.
+  const x = 0;
+  let y = Math.max(0, clamp(spin?.y ?? 0, -1, 1));
 
-  // Keep straight high/low and left/right shots easier to select by gently
-  // snapping near-axis drag noise to the principal axis.
-  if (Math.abs(x) <= STRAIGHT_SPIN_DEADZONE) x = 0;
   if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) y = 0;
 
   const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);


### PR DESCRIPTION
### Motivation
- Improve Snooker Champion feel by making the GLB table visually larger and aligning the playfield mapping with the GLB bed so collisions/pocketing better match the model.
- Limit airborne/side spin to a realistic ahead-only follow so shots behave more predictably and reduce unnatural ball behaviour.
- Reduce balls slipping through cushions by tightening pocket/mouth capture radii and adding a safety inset with finer physics stepping.

### Description
- Increased GLB playfield framing and scale by updating `SNOOKER_TABLE_VISUAL_LENGTH_TRIM` and `SNOOKER_PLAYFIELD_SCALE` in `webapp/src/pages/Games/SnookerRoyalProvided.jsx` to enlarge the table fit.
- Reduced spin magnitudes and constrained spin to ahead-only (natural forward follow) by adjusting `SNOOKER_SHOT_SPIN_SCALE`, `SNOOKER_SPIN_GLOBAL_SCALE`, and removing side/draw multipliers; updated `applyCueShot` to only apply forward/topspin.
- Restricted UI spin options to two presets (`stun` and `natural-follow`) and changed `normalizeSpinInput`/spin mapping in `webapp/src/pages/Games/snookerRoyalSpinUtils.js` so horizontal/backspin input is suppressed and diagonal drags map to forward-only spin.
- Tightened cushion/pocket handling: reduced pocket capture/mouth radii, added `SNOOKER_CUSHION_COLLISION_SAFETY_INSET`, and decreased the cushion collision perimeter so near-mouth misses collide with cushions; increased physics substep precision (`SNOOKER_PHYSICS_MAX_STEP = 1/480`) to reduce tunnelling.
- Updated UI spin controller to reflect normalized spin for the visual dot and to quantize/normalize targets consistently before applying.
- Added/updated tests: `test/snookerRoyalSpinController.test.js` (new) to assert ahead-only spin behaviour and `test/snookerTableModel.test.js` (updated) to assert changed constants and GLB mapping expectations.

### Testing
- Ran unit tests: `npm test -- --runTestsByPath test/snookerTableModel.test.js test/snookerRoyalSpinController.test.js` — both suites passed (all tests green).
- Verified TypeScript build: `npm run build` completed successfully.
- Attempted a Playwright-driven screenshot of the running dev site to visually verify the GLB table, but Chromium could not be launched in this environment due to a missing system library (`libatk-1.0.so.0`), so an automated screenshot could not be captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b70517108329842ff3c82d286cd1)