### PR TITLE
Restore Snooker Royal scene and disable human rig; add regression tests

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -74,6 +74,21 @@ describe('snooker table model selection', () => {
     assert.match(source, /const cueBackShoot = cueTipShoot\.clone\(\)\.addScaledVector\(aimForward, -CFG\.cueLength\)/);
   });
 
+
+  test('Snooker Royal route mounts the original Royal scene instead of Champion scene', async () => {
+    const source = await readFile('webapp/src/pages/Games/SnookerRoyal.jsx', 'utf8');
+    assert.doesNotMatch(source, /import SnookerRoyalProvided/);
+    assert.match(source, /<SnookerRoyalGame/);
+    assert.doesNotMatch(source, /<SnookerRoyalProvided gameTitle="Snooker Royal"/);
+  });
+
+  test('Snooker Royal scene leaves the human character rig unmounted', async () => {
+    const source = await readFile('webapp/src/pages/Games/SnookerRoyal.jsx', 'utf8');
+    assert.match(source, /const snookerHumanPlayer = null;/);
+    assert.doesNotMatch(source, /const snookerHumanPlayer = createSnookerRoyalHumanPlayer\(/);
+    assert.match(source, /if \(snookerHumanPlayer\) updateSnookerRoyalHumanPlayer/);
+  });
+
   test('uses procedural rail decor only for the classic table model', () => {
     assert.equal(usesProceduralSnookerTableRailDecor('classic'), true);
     assert.equal(usesProceduralSnookerTableRailDecor('opensource'), false);

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -26,7 +26,7 @@ import {
 } from './snookerTableModel.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   isTelegramWebView,
   getTelegramUsername,
@@ -103,7 +103,6 @@ import {
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
-import SnookerRoyalProvided from './SnookerRoyalProvided.jsx';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -21891,7 +21890,9 @@ const powerRef = useRef(hud.power);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      const snookerHumanPlayer = createSnookerRoyalHumanPlayer(table, renderer);
+      // Snooker Royal uses the original table/cue scene without the human character rig.
+      // Keep the cue stick animation independent so it matches the Champion-style stroke timing.
+      const snookerHumanPlayer = null;
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
       const closeCueGallery = () => {
@@ -26354,7 +26355,7 @@ const powerRef = useRef(hud.power);
         }
 
         try {
-          updateSnookerRoyalHumanPlayer(snookerHumanPlayer, deltaSeconds, {
+          if (snookerHumanPlayer) updateSnookerRoyalHumanPlayer(snookerHumanPlayer, deltaSeconds, {
             cue,
             cueStick,
             cueLen,
@@ -29424,8 +29425,158 @@ const powerRef = useRef(hud.power);
 }
 
 export default function SnookerRoyal() {
-  // Snooker Royal now mounts the same scene implementation used by Snooker
-  // Champion so the human character and cue stick are rendered by the shared,
-  // unmodified Champion code path.
-  return <SnookerRoyalProvided gameTitle="Snooker Royal" />;
+  const location = useLocation();
+  const tableModel = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return resolveSnookerTableModel(params.get('tableModel'));
+  }, [location.search]);
+
+  const navigate = useNavigate();
+  const variantKey = useMemo(() => {
+    return 'snooker';
+  }, [location.search]);
+  const ballSetKey = useMemo(() => {
+    return null;
+  }, [location.search]);
+  const tableSizeKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('tableSize');
+    return resolveTableSize(requested).id;
+  }, [location.search]);
+  const playType = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('type');
+    if (requested === 'training') return 'training';
+    if (requested === 'tournament') return 'tournament';
+    return 'regular';
+  }, [location.search]);
+  const mode = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('mode');
+    if (requested === 'online') return 'online';
+    if (requested === 'local') return 'local';
+    return 'ai';
+  }, [location.search]);
+  const trainingMode = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('mode');
+    return requested === 'solo' ? 'solo' : 'ai';
+  }, [location.search]);
+  const trainingRulesEnabled = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('rules') !== 'off';
+  }, [location.search]);
+  const accountId = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('accountId') || '';
+  }, [location.search]);
+  const tgId = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('tgId') || '';
+  }, [location.search]);
+  const playerName = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return (
+      params.get('name') ||
+      getTelegramUsername() ||
+      getTelegramId() ||
+      'Player'
+    );
+  }, [location.search]);
+  const playerAvatar = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('avatar') || '';
+  }, [location.search]);
+  const stakeAmount = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return Number(params.get('amount')) || 0;
+  }, [location.search]);
+  const stakeToken = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('token') || 'TPC';
+  }, [location.search]);
+  const exitMessage = useMemo(
+    () =>
+      stakeAmount > 0
+        ? `Are you sure you want to exit? Your ${stakeAmount} ${stakeToken} stake will be lost.`
+        : 'Are you sure you want to exit the match?',
+    [stakeAmount, stakeToken]
+  );
+  const confirmExit = useCallback(() => {
+    return new Promise((resolve) => {
+      const tg = window?.Telegram?.WebApp;
+      if (tg?.showPopup) {
+        tg.showPopup(
+          {
+            title: 'Exit game?',
+            message: exitMessage,
+            buttons: [
+              { id: 'yes', type: 'destructive', text: 'Yes' },
+              { id: 'no', type: 'default', text: 'No' }
+            ]
+          },
+          (buttonId) => resolve(buttonId === 'yes')
+        );
+        return;
+      }
+
+      resolve(window.confirm(exitMessage));
+    });
+  }, [exitMessage]);
+  useTelegramBackButton(() => {
+    confirmExit().then((confirmed) => {
+      if (confirmed) {
+        navigate('/games/snookerroyale/lobby');
+      }
+    });
+  });
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      event.preventDefault();
+      event.returnValue = exitMessage;
+      return exitMessage;
+    };
+    const handlePopState = () => {
+      confirmExit().then((confirmed) => {
+        if (!confirmed) {
+          window.history.pushState(null, '', window.location.href);
+        } else {
+          navigate('/games/snookerroyale/lobby');
+        }
+      });
+    };
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [confirmExit, exitMessage, navigate]);
+  const opponentName = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('opponent') || '';
+  }, [location.search]);
+  const opponentAvatar = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('opponentAvatar') || '';
+  }, [location.search]);
+  return (
+    <SnookerRoyalGame
+      variantKey={variantKey}
+      ballSetKey={ballSetKey}
+      tableSizeKey={tableSizeKey}
+      tableModel={tableModel}
+      playType={playType}
+      mode={mode}
+      trainingMode={trainingMode}
+      trainingRulesEnabled={trainingRulesEnabled}
+      accountId={accountId}
+      tgId={tgId}
+      playerName={playerName}
+      playerAvatar={playerAvatar}
+      opponentName={opponentName}
+      opponentAvatar={opponentAvatar}
+    />
+  );
 }


### PR DESCRIPTION
### Motivation

- Preserve the original Snooker Royal game scene and behavior instead of routing `/games/snookerroyale` to the Champion-provided wrapper. 
- Ensure the visible cue stick and power-slider behavior remain identical to the Champion implementation while removing the on-screen human character/rig for Royal.
- Add regression checks to prevent accidental remapping of Snooker Royal to the Champion wrapper and to ensure the human rig is not mounted.

### Description

- Reworked `webapp/src/pages/Games/SnookerRoyal.jsx` to stop importing/returning the `SnookerRoyalProvided` wrapper and instead mount the internal `SnookerRoyalGame` with full query-parameter parsing (table model, table size, play type, mode, account/player/opponent info) via `useLocation` and `useMemo` for routing/props. 
- Disabled the Snooker Royal human character mount by replacing the `createSnookerRoyalHumanPlayer(...)` call with `const snookerHumanPlayer = null;` and guarded the `updateSnookerRoyalHumanPlayer(...)` call with `if (snookerHumanPlayer) ...` so cue animation remains but the human rig is not attached. 
- Kept the shared `PoolRoyalePowerSlider` and `sampleCueStrokeTimeline` imports and cue-stroke logic so cue/power behavior remains consistent with Snooker Champion. 
- Added two unit tests to `test/snookerTableModel.test.js` asserting that `SnookerRoyal.jsx` mounts `SnookerRoyalGame` (not `SnookerRoyalProvided`) and that the `snookerHumanPlayer` is left `null` with guarded updates.

### Testing

- Ran the targeted Jest suites with `npm test -- --runInBand test/snookerTableModel.test.js test/poolRoyaleCueStrokeTimeline.test.js test/cueShotImpact.test.js`, and all suites passed (tests executed and passed). 
- The new regression tests in `test/snookerTableModel.test.js` confirming the Royal route and human-rig behavior were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c343e1e48329aa1f92d595573c86)