### PR TITLE
Stop Snooker Champion cue at impact

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -74,6 +74,15 @@ describe('snooker table model selection', () => {
     assert.match(source, /const cueBackShoot = cueTipShoot\.clone\(\)\.addScaledVector\(aimForward, -CFG\.cueLength\)/);
   });
 
+  test('Snooker Champion freezes the cue stick at cue-ball impact', async () => {
+    const source = await readFile('webapp/src/pages/Games/SnookerRoyalProvided.jsx', 'utf8');
+    assert.match(source, /let impactCueBack = null, impactCueTip = null/);
+    assert.match(source, /impactCueBack = cueBackShoot\.clone\(\)/);
+    assert.match(source, /impactCueTip = cueTipShoot\.clone\(\)/);
+    assert.match(source, /didHit && impactCueBack \? impactCueBack : cueBackShoot/);
+    assert.match(source, /didHit && impactCueTip \? impactCueTip : cueTipShoot/);
+  });
+
   test('uses procedural rail decor only for the classic table model', () => {
     assert.equal(usesProceduralSnookerTableRailDecor('classic'), true);
     assert.equal(usesProceduralSnookerTableRailDecor('opensource'), false);

--- a/webapp/src/pages/Games/SnookerRoyalProvided.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalProvided.jsx
@@ -2364,6 +2364,7 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
     const tmpA = new THREE.Vector3(), tmpB = new THREE.Vector3(), tmpC = new THREE.Vector3();
     let strikeT = 0, didHit = false, frameId = 0, last = performance.now(), isAiming = false, lastAimX = 0, lastAimY = 0;
     let recordingReplay = false, replayStartedAt = 0, lastReplaySampleAt = 0;
+    let impactCueBack = null, impactCueTip = null;
     let lastScore = rulesRef.current.score;
     let lastOpponentScore = rulesRef.current.scores?.[1] ?? 0;
     let lastActivePlayer = rulesRef.current.activePlayer ?? 0;
@@ -2438,12 +2439,14 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
       const idleLeftHandTarget = humanRootTarget.clone().add(new THREE.Vector3(-0.18 * CFG.scale, 1.08 * CFG.scale, 0.03 * CFG.scale).applyAxisAngle(Y_AXIS, standingYaw));
       const idleDir = CFG.idleCueDir.clone().applyAxisAngle(Y_AXIS, standingYaw).normalize();
       const idleCue = cuePoseFromGrip(idleRightHandTarget, idleDir, CFG.idleCueGripFromBack, CFG.cueLength);
-      if (state === 'idle') { strikeT = 0; didHit = false; }
-      else if (state === 'dragging') { strikeT = 0; didHit = false; }
+      if (state === 'idle') { strikeT = 0; didHit = false; impactCueBack = null; impactCueTip = null; }
+      else if (state === 'dragging') { strikeT = 0; didHit = false; impactCueBack = null; impactCueTip = null; }
       else {
         strikeT += dt;
         if (!didHit && strikeNorm > 0.88) {
           didHit = true;
+          impactCueBack = cueBackShoot.clone();
+          impactCueTip = cueTipShoot.clone();
           beginSnookerShotRules(rulesRef.current);
           applyCueShot(cueBall, shotPowerRef.current, aimYawRef.current, tmpC, spinRef.current);
           playCueHit(shotPowerRef.current);
@@ -2459,8 +2462,8 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
       }
       const loweredShootingView = cameraModeRef.current === 'cue-follow' && cameraHeightOffsetRef.current <= SNOOKER_AIMING_CAMERA_HEIGHT_THRESHOLD;
       const visualState = state === 'idle' && loweredShootingView ? 'aiming' : state;
-      const activeCueBack = visualState === 'idle' ? idleCue.back : cueBackShoot;
-      const activeCueTip = visualState === 'idle' ? idleCue.tip : cueTipShoot;
+      const activeCueBack = visualState === 'idle' ? idleCue.back : (didHit && impactCueBack ? impactCueBack : cueBackShoot);
+      const activeCueTip = visualState === 'idle' ? idleCue.tip : (didHit && impactCueTip ? impactCueTip : cueTipShoot);
       setCuePose(cue, activeCueBack, activeCueTip);
       if (replayModeRef.current && replayFramesRef.current.length > 1) {
         const frames = replayFramesRef.current;


### PR DESCRIPTION
### Motivation
- Prevent the visual cue stick from continuing to follow the moving cue ball after contact by freezing the cue pose at the moment of impact so shots look and read correctly.

### Description
- Capture the cue pose at impact by adding `impactCueBack` and `impactCueTip` and assigning them to `cueBackShoot.clone()` / `cueTipShoot.clone()` when the shot registers (`didHit`).
- Reset the cached impact pose when the shot state returns to `idle` or `dragging` so subsequent shots recompute the pose normally.
- Render the cue using the cached impact pose after contact by selecting `(didHit && impactCueBack ? impactCueBack : cueBackShoot)` and `(didHit && impactCueTip ? impactCueTip : cueTipShoot)` for the active cue endpoints.
- Add a regression test `test/snookerTableModel.test.js` that asserts the new variables and selection logic are present in `webapp/src/pages/Games/SnookerRoyalProvided.jsx`.

### Testing
- Ran the unit test file with `npm test -- --runInBand test/snookerTableModel.test.js` which passed (12 tests, 1 suite).
- Ran `npx eslint webapp/src/pages/Games/SnookerRoyalProvided.jsx test/snookerTableModel.test.js` which completed with existing ignore-file warnings only and no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c36538688329ae7e9b8e71796b12)