### PR TITLE
Align Pool Royale cue stroke and pull visuals with Snooker Champion

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1114,7 +1114,7 @@ const POOL_ROYALE_REPLAY_ENABLED = true;
 const POOL_ROYALE_VOICE_COMMENTARY_ENABLED = false;
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
-const DEFAULT_CUE_STROKE_STYLE = 'featherLine';
+const DEFAULT_CUE_STROKE_STYLE = 'classic';
 const COMMENTARY_QUEUE_LIMIT = 4;
 const COMMENTARY_MIN_INTERVAL_MS = 1200;
 const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
@@ -1866,14 +1866,14 @@ const CUE_TIP_GAP = BALL_R * 1.42 + CUE_TIP_CLEARANCE; // pull the cue tip sligh
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
-const CUE_PULL_VISUAL_MULTIPLIER = 1.28;
+const CUE_PULL_VISUAL_MULTIPLIER = 2.08;
 const CUE_PULL_DISTANCE_SCALE = 0.5;
 const CUE_PULL_SMOOTHING = 0.55;
 const CUE_PULL_ALIGNMENT_BOOST = 0.32; // amplify visible pull when the camera looks straight down the cue, reducing foreshortening
 const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while keeping more of the stroke visible in cue view
 const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
-const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.86; // trim global pullback so charge-up stays readable without over-drawing the cue
+const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.24; // match Snooker Champion pullback depth and readability
 const CUE_PULL_RETURN_PUSH = 1.22; // accelerate the forward cue drive so push-through feels snappier
 const CUE_FOLLOW_THROUGH_MIN = 0; // stop the cue at impact instead of following the moving cue ball
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 0.22; // allow only a tiny visible contact settle after impact
@@ -28650,47 +28650,42 @@ const shotPowerRef = useRef(0);
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
           const idlePos = buildCuePosition(0);
-          // Start the release exactly from the computed pull position so the
-          // cue always pushes forward from the same pulled depth the player set.
-          const releaseStartPos = buildCuePosition(visualPull);
-          cueStick.position.copy(releaseStartPos);
+          const pullPos = buildCuePosition(visualPull);
+          cueStick.position.copy(idlePos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
-          cueStick.visible = true;
-          if (shotRecording) {
-            recordReplayFrame(performance.now());
-          }
-          const strikeDuration = strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS;
-          const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
-          const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
-          const startTime = performance.now();
-          const impactPos = idlePos.clone();
-          const contactAdvance = THREE.MathUtils.lerp(
-            BALL_R * 0.28,
-            BALL_R * 0.62,
-            clampedPower
+          const pullbackDuration = 0;
+          const strikeDuration = 110;
+          const holdDuration = 45;
+          const returnDuration = 0;
+          // Match Snooker Champion: the cue drives from the player's pulled
+          // depth into cue-ball contact with the same short, linear stroke.
+          const impactPush = THREE.MathUtils.clamp(
+            CUE_TIP_CLEARANCE,
+            BALL_R * 0.08,
+            BALL_R * 0.3
           );
-          shotImpactPayload.contactAdvance = contactAdvance;
-          shotImpactPayload.pullDistance = visualPull;
-          const contactPos = impactPos
+          const impactPos = buildCuePosition(-impactPush);
+          const followExtra = 0;
+          TMP_VEC3_FOLLOW_DIR.copy(impactPos).sub(pullPos);
+          if (TMP_VEC3_FOLLOW_DIR.lengthSq() > 1e-8) {
+            TMP_VEC3_FOLLOW_DIR.normalize();
+          }
+          const settlePos = impactPos
             .clone()
-            .addScaledVector(dir, contactAdvance);
-          // Match Snooker Champion's visible cue behavior for Pool Royale:
-          // pull back, drive forward, then stop at cue-ball contact instead of
-          // visually spearing through the ball after impact.
-          const followPos = contactPos.clone();
-          const followDurationResolved = strikeHoldDuration;
-          const recoverDuration = strokeProfile.recoverDuration ?? 0;
+            .addScaledVector(TMP_VEC3_FOLLOW_DIR, followExtra);
+          cueStick.visible = true;
+          cueStick.position.copy(idlePos);
+          const startTime = performance.now();
+          const pullEndTime = startTime + pullbackDuration;
+          const impactTime = pullEndTime + strikeDuration;
+          const holdEndTime = impactTime + holdDuration;
+          const returnTime = holdEndTime + returnDuration;
           const forwardPreviewHold =
-            startTime +
-            Math.max(
-              pullbackDuration +
-                strikeDuration +
-                followDurationResolved +
-                recoverDuration +
-                (strokeProfile.cameraExtraHoldMs ?? 240) +
-                CUE_STROKE_POST_HIT_CAMERA_HOLD_MS,
-              980
+            impactTime +
+            Math.min(
+              holdDuration,
+              Math.max(180, strikeDuration * 0.9)
             );
           powerImpactHoldRef.current = Math.max(
             powerImpactHoldRef.current || 0,
@@ -28756,75 +28751,78 @@ const shotPowerRef = useRef(0);
             }
           }
           openingShotViewSuppressedRef.current = false;
-          let shotImpactApplied = false;
-          const applyShotImpactOnce = () => {
-            if (shotImpactApplied) return;
-            shotImpactApplied = true;
-            applyShotAtImpact(shotImpactPayload);
-          };
+          applyShotAtImpact(shotImpactPayload);
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
-            const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
+            const strokeStartOffset = Math.max(
+              0,
+              startTime - (shotRecording.startTime ?? startTime)
+            );
             shotRecording.cueStroke = {
+              warmup: serializeVector3Snapshot(idlePos),
+              start: serializeVector3Snapshot(pullPos),
+              impact: serializeVector3Snapshot(impactPos),
+              settle: serializeVector3Snapshot(settlePos),
               idle: serializeVector3Snapshot(idlePos),
-              pull: serializeVector3Snapshot(releaseStartPos),
-              impact: serializeVector3Snapshot(contactPos),
-              follow: serializeVector3Snapshot(followPos),
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y,
               pullbackDuration,
-              releaseDuration: strikeDuration,
-              followDuration: followDurationResolved,
-              recoverDuration,
+              forwardDuration: strikeDuration,
+              settleDuration: holdDuration,
+              returnDuration,
               startOffset: strokeStartOffset
             };
           }
-          if (ENABLE_CUE_STROKE_ANIMATION) {
-            cueStick.visible = true;
-            cueAnimating = true;
-            lastCueIdlePoseRef.current = {
-              position: idlePos.clone(),
-              rotationX: cueStick.rotation.x,
-              rotationY: cueStick.rotation.y
-            };
-            cueStrokeStateRef.current = {
-              startTime,
-              idlePos: idlePos.clone(),
-              pullPos: releaseStartPos.clone(),
-              impactPos: impactPos.clone(),
-              contactPos: contactPos.clone(),
-              followPos: followPos.clone(),
+          const animateStroke = (now) => {
+            if (!ENABLE_CUE_STROKE_ANIMATION) {
+              cueStick.visible = false;
+              cueAnimating = false;
+              cuePullCurrentRef.current = 0;
+              cuePullTargetRef.current = 0;
+              return;
+            }
+            const elapsed = Math.max(0, now - startTime);
+            const sample = sampleCueStrokeTimeline({
+              elapsed,
               pullbackDuration,
               strikeDuration,
-              holdDuration: followDurationResolved,
-              recoverDuration,
-              baseRotationX: cueStick.rotation.x,
-              baseRotationY: cueStick.rotation.y,
-              strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
-              wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
-              strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
-              forwardOnly: false,
-              onImpact: () => applyShotImpactOnce(),
-              animationStyle: strokeStyle,
-              motionTechnique: strokeProfile.motion ?? strokeStyle,
-              releaseStartsFromCurrentPull: false
-            };
-          } else {
-            applyShotImpactOnce();
-            cueStick.visible = false;
-            cueAnimating = false;
-            cuePullCurrentRef.current = 0;
-            cuePullTargetRef.current = 0;
-            cueStrokeStateRef.current = null;
-            if (cameraRef.current && sphRef.current) {
-              topViewRef.current = false;
-              topViewLockedRef.current = false;
-              setIsTopDownView(false);
-              const sph = sphRef.current;
-              sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
-              updateCamera();
+              holdDuration,
+              animationStyle: 'linear',
+              strikeWindowRatio: 0.12,
+              hitArmRatio: 0.88
+            });
+            if (sample.phase === 'pullback') {
+              cueStick.position.lerpVectors(idlePos, pullPos, easeInOutQuad(sample.t));
+            } else if (sample.phase === 'release' || sample.phase === 'strike') {
+              const strikeEase = easeOutCubic(sample.t);
+              const dynamicFollow =
+                followExtra * (0.55 + 0.45 * Math.sin(sample.t * Math.PI));
+              cueStick.position.lerpVectors(pullPos, impactPos, strikeEase);
+              if (dynamicFollow > 1e-6) {
+                cueStick.position.addScaledVector(TMP_VEC3_FOLLOW_DIR, dynamicFollow);
+              }
+            } else if (sample.phase === 'hold') {
+              cueStick.position.lerpVectors(impactPos, settlePos, easeInOutQuad(sample.t));
+            } else if (now <= returnTime && returnDuration > 0) {
+              const t = THREE.MathUtils.clamp((now - holdEndTime) / returnDuration, 0, 1);
+              cueStick.position.lerpVectors(settlePos, idlePos, easeInOutQuad(t));
+            } else {
+              cueStick.visible = false;
+              cueAnimating = false;
+              cuePullCurrentRef.current = 0;
+              cuePullTargetRef.current = 0;
+              if (cameraRef.current && sphRef.current) {
+                topViewRef.current = false;
+                topViewLockedRef.current = false;
+                setIsTopDownView(false);
+                const sph = sphRef.current;
+                sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
+                updateCamera();
+              }
+              return;
             }
-          }
+            requestAnimationFrame(animateStroke);
+          };
+          requestAnimationFrame(animateStroke);
         };
         let aiThinkingHandle = null;
         const planKey = (plan) =>


### PR DESCRIPTION
### Motivation
- Make the Pool Royale shooting feel and behave identically to the Snooker Champion/ Royal flow so the cue stick, slider and shot release mechanics match the snooker experience.
- Improve visible pullback readability and ensure the same short pull→impact→settle stroke timing is used so players get the same tactile feedback when using the power slider.

### Description
- Updated Pool Royale defaults to use the Snooker-style stroke by changing `DEFAULT_CUE_STROKE_STYLE` to `classic` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Matched pullback visuals to the Snooker profile by increasing `CUE_PULL_VISUAL_MULTIPLIER` and `CUE_PULL_GLOBAL_VISIBILITY_BOOST` so visible cue draw depth and responsiveness align with the snooker champion implementation.
- Reworked the Pool Royale shot release path so the cue drives from the player’s pulled depth into impact with the same short linear stroke used by Snooker; this applies the shot immediately on release via the existing `applyShotAtImpact` flow and records the same `cueStroke` snapshot fields for replay compatibility (idle/start/impact/settle/idle).
- Aligned stroke timing constants and the cue stroke animation sampling to use the snooker-style timeline (`sampleCueStrokeTimeline`) and simplified the Pool Royale animation to the same pull→strike→hold→settle phases for consistent visuals.

### Testing
- Parsed the modified source with Babel via `@babel/parser` and the file parsed successfully (`parse ok`).
- Ran `npx eslint` on the edited file (invoked with `--no-warn-ignored`) and validated syntax/format expectations for the change (no blocking errors).
- Built the webapp with `npm --prefix webapp run build` and Vite completed a production build successfully (bundles produced).
- Attempted a headless browser screenshot via Playwright to visually validate the slider and cue stroke, but Playwright failed to launch the downloaded headless shell due to a missing system browser dependency (`libatk-1.0.so.0`) in the environment; the browser installation step completed but the runtime lacks the native library so automated screenshot was not captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ca761d9083299dee54663f657b6b)