### PR TITLE
Fix Pool Royale cue strike contact

### DIFF
--- a/test/poolRoyaleCueStrokeTimeline.test.js
+++ b/test/poolRoyaleCueStrokeTimeline.test.js
@@ -1,4 +1,4 @@
-import { sampleCueStrokeTimeline } from '../webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js';
+import { resolveCueContactPush, sampleCueStrokeTimeline } from '../webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js';
 
 describe('Pool Royale cue stroke timeline', () => {
   const options = {
@@ -42,5 +42,19 @@ describe('Pool Royale cue stroke timeline', () => {
     expect(holding.done).toBe(false);
     expect(done.phase).toBe('done');
     expect(done.done).toBe(true);
+  });
+
+  it('computes enough forward push for the cue tip to physically reach the cue ball', () => {
+    const ballRadius = 10;
+    const contactGap = 0.3;
+    const cueTipGap = 16.6;
+    const push = resolveCueContactPush({
+      cueTipGap,
+      ballRadius,
+      contactGap,
+      minPush: 2.4
+    });
+    expect(push).toBeCloseTo(6.3, 5);
+    expect(cueTipGap - push).toBeCloseTo(ballRadius + contactGap, 5);
   });
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -117,7 +117,7 @@ import {
   buildPoolSuggestionKey,
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
-import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import { resolveCueContactPush, sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
@@ -1798,7 +1798,7 @@ const SHOT_FORCE_BOOST =
   SHOT_GLOBAL_POWER_SCALE;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
-const SHOT_MIN_FACTOR = 0;
+const SHOT_MIN_FACTOR = 0.25; // match Snooker Royal's minimum cue drive so every released stroke can move the cue ball
 const SHOT_POWER_RANGE = 1;
 const SPIN_POWER_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.25;
 const SPIN_POWER_MIN_SCALE = 0.35;
@@ -1862,6 +1862,7 @@ const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.07;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.24; // widen the visible air gap so the cue sits a little farther from the cue ball
+const CUE_CONTACT_GAP = BALL_R * 0.03; // Snooker-style impact clearance: the cue tip reaches the cue-ball surface before physics applies
 const CUE_TIP_GAP = BALL_R * 1.42 + CUE_TIP_CLEARANCE; // pull the cue tip slightly farther back so the blue tip remains visible
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
@@ -28660,11 +28661,12 @@ const shotPowerRef = useRef(0);
           const pullPos = buildCuePosition(visualPull);
           // Snooker Champion strike path: release from the already-pulled cue,
           // drive into the cue-ball contact point, hold briefly, then hide.
-          const impactPush = THREE.MathUtils.clamp(
-            CUE_TIP_CLEARANCE,
-            BALL_R * 0.08,
-            BALL_R * 0.3
-          );
+          const impactPush = resolveCueContactPush({
+            cueTipGap: CUE_TIP_GAP,
+            ballRadius: BALL_R,
+            contactGap: CUE_CONTACT_GAP,
+            minPush: CUE_TIP_CLEARANCE
+          });
           const impactPos = buildCuePosition(-impactPush);
           const contactPos = impactPos.clone();
           const followPos = impactPos.clone();

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -1,5 +1,19 @@
 import * as THREE from 'three'
 
+export const resolveCueContactPush = ({
+  cueTipGap = 0,
+  ballRadius = 0,
+  contactGap = 0,
+  minPush = 0
+} = {}) => {
+  const safeCueTipGap = Number.isFinite(cueTipGap) ? Math.max(0, cueTipGap) : 0
+  const safeBallRadius = Number.isFinite(ballRadius) ? Math.max(0, ballRadius) : 0
+  const safeContactGap = Number.isFinite(contactGap) ? Math.max(0, contactGap) : 0
+  const safeMinPush = Number.isFinite(minPush) ? Math.max(0, minPush) : 0
+  const physicalContactPush = safeCueTipGap - (safeBallRadius + safeContactGap)
+  return Math.max(safeMinPush, physicalContactPush)
+}
+
 export const sampleCueStrokeTimeline = ({
   elapsed = 0,
   pullbackDuration = 0,


### PR DESCRIPTION
### Motivation
- Ensure the Pool Royale cue stick physically reaches the cue-ball surface on impact instead of stopping at the visible idle gap so released strokes actually transfer momentum like the Snooker implementation.
- Avoid cases where very low released power produced no ball motion by matching Pool Royale's minimum released shot drive to the Snooker baseline.

### Description
- Added `resolveCueContactPush` in `webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js` to compute the required forward push so the cue tip reaches the cue-ball surface given `cueTipGap`, `ballRadius`, `contactGap`, and `minPush`.
- Wired the new resolver into `webapp/src/pages/Games/PoolRoyale.jsx` replacing the previous hard-clamped `impactPush` and introduced `CUE_CONTACT_GAP` to model a Snooker-style contact clearance.
- Raised `SHOT_MIN_FACTOR` from `0` to `0.25` in `PoolRoyale.jsx` so released strokes carry a minimum drive consistent with Snooker Royal.
- Added a unit test in `test/poolRoyaleCueStrokeTimeline.test.js` that imports `resolveCueContactPush` and verifies the computed push makes the tip reach `ballRadius + contactGap`.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and the suite passed (5/5 tests passed), including the new contact-push assertion.
- Installed Playwright browsers (`npx playwright install chromium`) and attempted an automated screenshot of the running webapp; Playwright dependencies were installed but the page stayed on the loading screen due to external asset / wallet resource failures in the environment, however the screenshot was saved to `/tmp/pool-royale-cue-stroke.png`.
- Resolved a transient apt dependency (`libice6`) when provisioning Playwright system deps (`npx playwright install-deps chromium`) during CI/debug runs; tests remained green after dependency installation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e0a1d4e48329bdac43b817cb1d24)