### PR TITLE
Tune Pool Royale cue stroke sync

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1880,7 +1880,7 @@ const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.86; // trim global pullback so charge-up stays readable without over-drawing the cue
 const CUE_PULL_RETURN_PUSH = 1.22; // accelerate the forward cue drive so push-through feels snappier
 const CUE_FOLLOW_THROUGH_MIN = 0; // stop the cue at impact instead of following the moving cue ball
-const CUE_FOLLOW_THROUGH_MAX = BALL_R * 0.22; // allow only a tiny visible contact settle after impact
+const CUE_FOLLOW_THROUGH_MAX = 0; // stop the cue at the cue-ball contact point instead of following through
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -2470,7 +2470,9 @@ function updatePoolRoyaleHumanPose(human, dt, state, rootTarget, aimForward, bri
   const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12 / POOL_HUMAN_CFG.scale);
   const walkAmount = poolHumanClamp01(moveAmountRaw * 18 / POOL_HUMAN_CFG.scale) * idle;
   const dragStroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75) : 0;
-  const strikeFollow = state === 'striking' ? Math.sin(poolHumanClamp01(human.strikeClock / (POOL_HUMAN_CFG.strikeTime + POOL_HUMAN_CFG.holdTime)) * Math.PI) : 0;
+  const strikeFollow = state === 'striking'
+    ? poolHumanEaseOutCubic(poolHumanClamp01(human.strikeClock / Math.max(POOL_HUMAN_CFG.strikeTime, 1e-6)))
+    : 0;
   const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(POOL_HUMAN_Y_AXIS, human.yaw).normalize();
   const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
   const local = (v) => v.clone().applyAxisAngle(POOL_HUMAN_Y_AXIS, human.yaw).add(human.root.position);
@@ -28637,7 +28639,8 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
+          // Defer physics until the animated cue reaches the cue ball so the
+          // visible stick, player hand, and ball launch all line up at impact.
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -33120,12 +33123,15 @@ const shotPowerRef = useRef(0);
           0,
           1
         ) <= POOL_HUMAN_CUE_CAMERA_POSE_BLEND_MAX;
-        const humanShotState = cueCameraLoweredForHuman && !shooting && !cueAnimating && !aiTakingShot && !replayActive
-          ? 'dragging'
-          : shooting || cueAnimating || aiTakingShot || (ENABLE_CUE_STROKE_ANIMATION && cueStrokeStateRef.current)
-            ? 'striking'
-            : replayActive
-              ? 'rolling'
+        const sliderPullingForHuman = Boolean(sliderInstanceRef.current?.dragging) || (powerRef.current ?? 0) > 0.01;
+        const humanShotState = shooting || cueAnimating || aiTakingShot || (ENABLE_CUE_STROKE_ANIMATION && cueStrokeStateRef.current)
+          ? 'striking'
+          : replayActive
+            ? 'rolling'
+            : cueCameraLoweredForHuman
+              ? sliderPullingForHuman
+                ? 'dragging'
+                : 'aiming'
               : 'idle';
         updatePoolRoyaleHumanFrame(
           humanRig,


### PR DESCRIPTION
### Motivation
- Align the visible cue/hand animation with the actual shot physics so the cue appears on the table when the camera is lowered and the visual impact and ball launch are synchronized. 
- Make the human avatar behave consistently during aiming vs power pulling by showing the cue on the table when aiming and driving the pull animation only while the slider is being pulled.
- Stop the cue from visually following the moving cue ball after impact so the strike looks crisp and matches the physics.

### Description
- Set `CUE_FOLLOW_THROUGH_MAX` to `0` to remove follow-through after impact so the cue stops at the cue-ball contact point (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Replace the previous strike easing with an ease-out cubic for the human hand `strikeFollow` so the hand pushes forward and holds through impact (`poolHumanEaseOutCubic` used in `updatePoolRoyaleHumanPose`).
- Defer applying shot physics at the moment of stroke setup (removed immediate `applyShotAtImpact` invocation) so physics are fired in the stroke impact callback when the animated cue actually reaches the ball, keeping visuals and ball launch in sync.
- Split lowered-camera human state into `aiming` vs `dragging` by checking `sliderInstanceRef.current?.dragging` and `powerRef` so lowering the camera shows the cue on the table while pulling the power slider engages the pullback animation.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully (Vite build output printed and exit code 0). 
- Ran a repository check with `git diff --check` and no whitespace or diff-check errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a07e58bec8329b340e26a639857c8)