### PR TITLE
Pool Royale: cue stick visibility, stroke timing, and human pose updates

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1880,7 +1880,7 @@ const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.86; // trim global pullback so charge-up stays readable without over-drawing the cue
 const CUE_PULL_RETURN_PUSH = 1.22; // accelerate the forward cue drive so push-through feels snappier
 const CUE_FOLLOW_THROUGH_MIN = 0; // stop the cue at impact instead of following the moving cue ball
-const CUE_FOLLOW_THROUGH_MAX = BALL_R * 0.22; // allow only a tiny visible contact settle after impact
+const CUE_FOLLOW_THROUGH_MAX = 0; // stop the cue at contact once it has hit the cue ball
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -28637,7 +28637,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -28739,10 +28738,9 @@ const shotPowerRef = useRef(0);
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
-          const contactAdvance = THREE.MathUtils.lerp(
-            BALL_R * 0.28,
-            BALL_R * 0.62,
-            clampedPower
+          const contactAdvance = Math.max(
+            0,
+            CUE_TIP_GAP - (POOL_HUMAN_CFG.contactGap ?? BALL_R * 0.08)
           );
           shotImpactPayload.contactAdvance = contactAdvance;
           const contactPos = impactPos
@@ -32115,6 +32113,7 @@ const shotPowerRef = useRef(0);
           0,
           1
         );
+        const cueCameraLoweredForHuman = cameraBlend <= POOL_HUMAN_CUE_CAMERA_POSE_BLEND_MAX;
         const baseAimLerp = THREE.MathUtils.lerp(
           CUE_VIEW_AIM_LINE_LERP,
           STANDING_VIEW_AIM_LINE_LERP,
@@ -32728,7 +32727,13 @@ const shotPowerRef = useRef(0);
             });
           }
           updateChalkVisibility(visibleChalkIndex);
-          cueStick.visible = true;
+          cueStick.visible =
+            cueCameraLoweredForHuman ||
+            Boolean(sliderInstanceRef.current?.dragging) ||
+            (powerRef.current ?? 0) > 0.001 ||
+            previewingAiShot ||
+            aiCueViewActive ||
+            showingRemoteAim;
           if (targetDir && targetBall) {
             const travelScale = BALL_R * (14 + targetPowerStrength * 22);
             const rawTargetDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
@@ -33115,12 +33120,15 @@ const shotPowerRef = useRef(0);
         } else {
           aimForwardForHuman.normalize();
         }
-        const cueCameraLoweredForHuman = THREE.MathUtils.clamp(
-          cameraBlendRef.current ?? 1,
-          0,
-          1
-        ) <= POOL_HUMAN_CUE_CAMERA_POSE_BLEND_MAX;
-        const humanShotState = cueCameraLoweredForHuman && !shooting && !cueAnimating && !aiTakingShot && !replayActive
+        const humanPreparingShot =
+          (cueCameraLoweredForHuman ||
+            Boolean(sliderInstanceRef.current?.dragging) ||
+            (powerRef.current ?? 0) > 0.001) &&
+          !shooting &&
+          !cueAnimating &&
+          !aiTakingShot &&
+          !replayActive;
+        const humanShotState = humanPreparingShot
           ? 'dragging'
           : shooting || cueAnimating || aiTakingShot || (ENABLE_CUE_STROKE_ANIMATION && cueStrokeStateRef.current)
             ? 'striking'


### PR DESCRIPTION
### Motivation
- Make the visual cue behavior match the intended UX: the cue should appear on the table when the player lowers the camera or pulls the power slider, the human avatar should visibly pull the cue while charging and push it forward to strike, and the cue should stop at contact with the cue ball rather than overshooting.

### Description
- Stop follow-through by setting `CUE_FOLLOW_THROUGH_MAX = 0` so the cue halts at contact and compute contact position from the cue-tip gap (`CUE_TIP_GAP` / `POOL_HUMAN_CFG.contactGap`).
- Delay applying shot physics by removing the immediate `applyShotAtImpact(shotImpactPayload)` call on slider release and instead apply the shot via the cue-stroke impact callback so physics run at the animated impact moment.
- Show the cue stick when the cue camera is lowered, the power slider is being dragged, or there is a non-zero power charge by making `cueStick.visible` conditional on camera blend / slider / power state.
- Let the human rig enter the pulling pose while preparing the shot by treating a lowered camera OR active slider/power as a preparation condition (`humanPreparingShot`) so the avatar pulls when the slider is pulled or camera is low.
- Minor cleanup: adjusted recorded replay stroke/contact positions so replay and live animation share the same cue timing and transforms (changes localized in `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and the cue stroke timeline tests passed (4 tests, all green).
- Web build: `npm --prefix webapp run build` completed successfully and produced production chunks.
- Playwright: attempted an automated headless screenshot, ran `npx playwright install chromium`, but Chromium launch failed in this environment due to a missing system library (`libatk-1.0.so.0`), so screenshot execution did not complete (browser install succeeded, but runtime launch failed on this host).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a07e58bec8329b340e26a639857c8)