### PR TITLE
Pool Royale: defer physics until visible cue impact and stop cue on impact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24819,6 +24819,19 @@ const shotPowerRef = useRef(0);
           if (!stroke.shotApplied && sample.hitArmed) {
             stroke.shotApplied = true;
             stroke.onImpact?.();
+            if (stroke.stopAtImpact) {
+              const stopPos = stroke.contactPos ?? impactPos ?? pullPos ?? idlePos;
+              if (stopPos) cueStick.position.copy(stopPos);
+              cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+              cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
+              cueAnimating = false;
+              cuePullCurrentRef.current = 0;
+              cuePullTargetRef.current = 0;
+              cueStrokeStateRef.current = null;
+              pendingImpactRef.current = null;
+              syncCueShadow();
+              return false;
+            }
           }
           if (sample.phase === 'pullback') {
             const eased = easeInOutCubic(sample.t);
@@ -28637,7 +28650,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -28881,6 +28893,7 @@ const shotPowerRef = useRef(0);
               strikeImpactThreshold: 0.9,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
               forwardOnly: false,
+              stopAtImpact: true,
               onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,


### PR DESCRIPTION
### Motivation
- Make the player-visible cue stroke and the physics shot application stay in sync so the cue ball is launched when the on-screen shove reaches the contact point rather than firing early. 
- Ensure the human avatar / hand and cue animation visibly push the cue to the ball when the player uses the power slider, avoiding a mismatch between animation and game logic.
- Provide a simple way to stop the cue stick animation at the contact point so the stick/hand look correct after impact.

### Description
- Added a live `stopAtImpact` flag to the cue-stroke state and the cue stroke processing path so strokes can be configured to halt the cue at the contact position and clear the stroke state. (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Deferred the physics shot application for live strokes so `applyShotAtImpact` is executed only after the stroke reaches its armed impact point; the visible cue now remains the authoritative visual for timing. (moved invocation in `PoolRoyale.jsx`).
- Enabled `stopAtImpact` for the live power-slider shot path so player-initiated shots visibly stop at the contact position and the cue animation and human rig are reset cleanly after impact. (file: `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Built the webapp production bundle with `npm --prefix webapp run build` and the build completed successfully.
- No unit tests were changed or executed as part of this PR; the change was validated by compiling the frontend and inspecting the produced build artifacts.
- Smoke-checked in-headless build that cue-stroke code paths compile and bundle without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a07e58bec8329b340e26a639857c8)