### PR TITLE
Tune Pool Royale table size and cue follow-through

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1095,8 +1095,8 @@ function applyChromePlateDamping(material) {
 const OFFICIAL_TABLE_LENGTH_IN = 78;
 const LEGACY_TABLE_LENGTH_IN = 100;
 const OFFICIAL_TABLE_SCALE = OFFICIAL_TABLE_LENGTH_IN / LEGACY_TABLE_LENGTH_IN;
-const TABLE_SIZE_SHRINK = 0.85; // tighten the table footprint by ~8% to add breathing room without altering proportions
-const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the tighter shrink so the arena stays compact without distorting proportions
+const TABLE_SIZE_SHRINK = 0.78; // tighten the table footprint further so Pool Royale reads shorter in the arena without altering proportions
+const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the shorter table shrink so the arena stays compact without distorting proportions
 const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while keeping the table height unchanged
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
@@ -1880,8 +1880,8 @@ const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit a
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.86; // trim global pullback so charge-up stays readable without over-drawing the cue
 const CUE_PULL_RETURN_PUSH = 1.22; // accelerate the forward cue drive so push-through feels snappier
-const CUE_FOLLOW_THROUGH_MIN = 0; // stop the cue at impact instead of following the moving cue ball
-const CUE_FOLLOW_THROUGH_MAX = 0; // stop the cue at the cue-ball contact point instead of following through
+const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.18; // match Snooker Champion's visible forward push through cue-ball contact
+const CUE_FOLLOW_THROUGH_MAX = BALL_R * 1.8; // cap the forward travel so the cue never overshoots the ball too far
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -24886,8 +24886,10 @@ const shotPowerRef = useRef(0);
           if (sample.phase === 'strike') {
             const punchT = 1 - Math.pow(1 - THREE.MathUtils.clamp(sample.t, 0, 1), 4);
             const contactPos = stroke.contactPos ?? impactPos;
-            const strikeStartPos = stroke.contactPos ?? impactPos;
-            cueStick.position.lerpVectors(strikeStartPos, contactPos, punchT);
+            const followTargetPos = followPos ?? contactPos;
+            // Continue moving after cue-ball contact, matching Snooker Champion's
+            // forward push instead of leaving the cue parked at the pulled/contact pose.
+            cueStick.position.lerpVectors(contactPos, followTargetPos, punchT);
             cueStick.position.y -= (strikeDip ?? 0.003) * (0.72 + punchT * 0.38);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y =


### PR DESCRIPTION
### Motivation
- Make the Pool Royale table read shorter in the arena so it doesn't dominate the framing. 
- Make the live cue animation visibly push forward through the cue ball (match the Snooker Champion behavior) so the cue does not stay parked at the pulled/contact pose.

### Description
- Reduced the Pool Royale visual table footprint by changing `TABLE_SIZE_SHRINK` from `0.85` to `0.78` in `webapp/src/pages/Games/PoolRoyale.jsx` so the table appears shorter while preserving proportions. 
- Enabled visible cue follow-through by replacing zeroed follow-through limits with `CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.18` and `CUE_FOLLOW_THROUGH_MAX = BALL_R * 1.8` in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Updated the strike-phase animation so the strike step now advances the cue from the contact position toward the computed follow-target (`followPos`) instead of leaving the cue parked at impact, by changing the `strike` phase lerp to use `contactPos → followPos` in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran the unit test `test/poolRoyaleCueStrokeTimeline.test.js` with `jest` and it passed (4 tests, 0 failures). 
- Built the webapp (`npm --prefix webapp run build`) which completed successfully (Vite build warning about large chunk sizes only). 
- Installed Playwright and platform deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) and used Playwright to load the local dev server and capture a screenshot of `/games/poolroyale?mode=ai` saved at `/tmp/pool-royale-table-shorter.png`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a8a3f52c0832991a81f64007e2db0)