### PR TITLE
Restore Snooker Royal scene and implement natural human cue stroke with power retention

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -26,7 +26,7 @@ import {
 } from './snookerTableModel.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   isTelegramWebView,
   getTelegramUsername,
@@ -103,7 +103,6 @@ import {
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
-import SnookerRoyalProvided from './SnookerRoyalProvided.jsx';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -2129,8 +2128,20 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
   dir.normalize();
   const side = new THREE.Vector3(-dir.z, 0, dir.x).normalize();
   const cueBall = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
+  const cueOnTable = Boolean(cueStick?.visible || shooting || cueAnimating);
+  human.poseT = snookerHumanDamp(
+    human.poseT,
+    cueOnTable ? 1 : 0,
+    SNOOKER_HUMAN_CFG.poseLambda,
+    dt
+  );
+  const poseT = snookerHumanClamp01(human.poseT);
   const cueEndpoints = resolveSnookerHumanCueEndpoints(cueStick, cueLen, cueBall, dir);
-  const pullPose = THREE.MathUtils.clamp((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0), 0, 1);
+  const pullPose = THREE.MathUtils.clamp(
+    ((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0)) * poseT,
+    0,
+    1
+  );
   // Orientation is driven from the actual shot line: the root stands behind
   // the cue ball on -dir, then faces +dir back through cue ball/object ball.
   // Keeping local +Z on the shot line prevents mirrored cue/hand placement.
@@ -2157,17 +2168,35 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
   human.root.rotation.set(0, human.yaw, 0);
   human.modelRoot.position.copy(human.root.position);
   human.modelRoot.rotation.copy(human.root.rotation);
-  human.poseT = snookerHumanDamp(human.poseT, 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
   const invRoot = new THREE.Matrix4().copy(human.root.matrixWorld).invert();
   const toRootLocal = (v) => v.clone().applyMatrix4(invRoot);
-  const bridge = cueBall.clone()
+  const bridgeShot = cueBall.clone()
     .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
     .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
     .setY(CUE_Y + BALL_R * 0.08);
-  const grip = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
+  const gripShot = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
+  const idleRightHand = rootTarget.clone()
+    .addScaledVector(side, 0.24 * SNOOKER_HUMAN_WORLD_SCALE)
+    .addScaledVector(dir, 0.12 * SNOOKER_HUMAN_WORLD_SCALE)
+    .setY(SNOOKER_HUMAN_CFG.floorY + 0.95 * SNOOKER_HUMAN_WORLD_SCALE);
+  const idleLeftHand = rootTarget.clone()
+    .addScaledVector(side, -0.18 * SNOOKER_HUMAN_WORLD_SCALE)
+    .addScaledVector(dir, 0.08 * SNOOKER_HUMAN_WORLD_SCALE)
+    .setY(SNOOKER_HUMAN_CFG.floorY + 1.08 * SNOOKER_HUMAN_WORLD_SCALE);
+  const bridge = idleLeftHand.clone().lerp(bridgeShot, poseT);
+  const grip = idleRightHand.clone().lerp(gripShot, poseT);
+  const idleCueTip = idleRightHand.clone()
+    .addScaledVector(dir, 0.7 * SNOOKER_HUMAN_WORLD_SCALE)
+    .addScaledVector(side, -0.08 * SNOOKER_HUMAN_WORLD_SCALE)
+    .add(new THREE.Vector3(0, -0.22 * SNOOKER_HUMAN_WORLD_SCALE, 0));
+  const cueTipForPose = idleCueTip.clone().lerp(cueEndpoints.tip, poseT);
   updateSnookerHumanOrientationHelpers(human, { rootTarget, cueBall, playfieldTarget, dir, bridge, grip });
-  const chestWorld = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
-  const headWorld = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
+  const chestStand = rootTarget.clone().addScaledVector(dir, 0.16 * SNOOKER_HUMAN_WORLD_SCALE).setY(SNOOKER_HUMAN_CFG.floorY + 1.32 * SNOOKER_HUMAN_WORLD_SCALE);
+  const headStand = rootTarget.clone().addScaledVector(dir, 0.2 * SNOOKER_HUMAN_WORLD_SCALE).setY(SNOOKER_HUMAN_CFG.floorY + 1.72 * SNOOKER_HUMAN_WORLD_SCALE);
+  const chestShot = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
+  const headShot = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
+  const chestWorld = chestStand.lerp(chestShot, poseT);
+  const headWorld = headStand.lerp(headShot, poseT);
   const torso = toRootLocal(chestWorld).add(new THREE.Vector3(0, 0.16 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
   const chest = toRootLocal(chestWorld);
   const head = toRootLocal(headWorld);
@@ -2217,7 +2246,7 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     rightElbowWorld: rightElbowTable,
     headWorld: headWorld,
     chestWorld: chestWorld,
-    cueTipWorld: cueEndpoints.tip
+    cueTipWorld: cueTipForPose
   });
 }
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
@@ -14458,6 +14487,7 @@ const showRuleToast = useCallback((message) => {
   }, 3000);
 }, []);
 const powerRef = useRef(hud.power);
+const shotVisualPowerRef = useRef(0);
   const applyPower = useCallback((nextPower) => {
     const clampedPower = THREE.MathUtils.clamp(nextPower ?? 0, 0, 1);
     powerRef.current = clampedPower;
@@ -22848,6 +22878,7 @@ const powerRef = useRef(hud.power);
           1
         );
         if (committedPower <= 0.02) return;
+        shotVisualPowerRef.current = committedPower;
         if (currentHud?.inHand && (fullTableHandPlacement || inHandPlacementActive)) {
           hudRef.current = { ...currentHud, inHand: false };
           setHud((prev) => ({ ...prev, inHand: false }));
@@ -23357,6 +23388,7 @@ const powerRef = useRef(hud.power);
             if (!ENABLE_CUE_STROKE_ANIMATION) {
               cueStick.visible = false;
               cueAnimating = false;
+              shotVisualPowerRef.current = 0;
               cuePullCurrentRef.current = 0;
               cuePullTargetRef.current = 0;
               return;
@@ -23392,6 +23424,7 @@ const powerRef = useRef(hud.power);
             } else {
               cueStick.visible = false;
               cueAnimating = false;
+              shotVisualPowerRef.current = 0;
               cuePullCurrentRef.current = 0;
               cuePullTargetRef.current = 0;
               if (cameraRef.current && sphRef.current) {
@@ -23412,6 +23445,7 @@ const powerRef = useRef(hud.power);
             applyShotImpactAtCueContact();
             cueStick.visible = false;
             cueAnimating = false;
+            shotVisualPowerRef.current = 0;
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
           }
@@ -26461,8 +26495,8 @@ const powerRef = useRef(hud.power);
             aimDir: showingRemoteAim
               ? new THREE.Vector2(remoteAimState?.dir?.x ?? 0, remoteAimState?.dir?.y ?? 1)
               : activeAiPlan?.aimDir || aimDir,
-            visible: cueStick.visible || cueAnimating || shooting,
-            power: powerRef.current ?? activeAiPlan?.power ?? 0,
+            visible: cue?.active && !currentHud?.over,
+            power: Math.max(powerRef.current ?? 0, shotVisualPowerRef.current ?? 0, activeAiPlan?.power ?? 0),
             shooting,
             cueAnimating
           });
@@ -29529,8 +29563,82 @@ const powerRef = useRef(hud.power);
 }
 
 export default function SnookerRoyal() {
-  // Snooker Royal now mounts the same scene implementation used by Snooker
-  // Champion so the human character and cue stick are rendered by the shared,
-  // unmodified Champion code path.
-  return <SnookerRoyalProvided gameTitle="Snooker Royal" />;
+  const location = useLocation();
+  const playType = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('type');
+    if (requested === 'training') return 'training';
+    if (requested === 'tournament') return 'tournament';
+    return 'regular';
+  }, [location.search]);
+  const variantKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return resolvePoolVariant(params.get('variant') || 'snooker').id;
+  }, [location.search]);
+  const ballSetKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const normalized = normalizeBallSetKey(params.get('ballSet'));
+    return normalized || null;
+  }, [location.search]);
+  const tableSizeKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return resolveTableSize(params.get('tableSize')).id;
+  }, [location.search]);
+  const tableModel = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return resolveSnookerTableModel(params.get('tableModel')).id;
+  }, [location.search]);
+  const mode = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('mode');
+    if (requested === 'online') return 'online';
+    if (requested === 'local') return 'local';
+    return 'ai';
+  }, [location.search]);
+  const trainingMode = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('trainingMode') === 'ai' ? 'ai' : 'solo';
+  }, [location.search]);
+  const accountId = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('accountId') || '';
+  }, [location.search]);
+  const tgId = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('tgId') || '';
+  }, [location.search]);
+  const playerName = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('name') || getTelegramUsername() || getTelegramId() || 'Player';
+  }, [location.search]);
+  const playerAvatar = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('avatar') || getTelegramPhotoUrl() || '';
+  }, [location.search]);
+  const opponentName = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('opponent') || '';
+  }, [location.search]);
+  const opponentAvatar = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('opponentAvatar') || '';
+  }, [location.search]);
+
+  return (
+    <SnookerRoyalGame
+      variantKey={variantKey}
+      ballSetKey={ballSetKey}
+      tableSizeKey={tableSizeKey}
+      tableModel={tableModel}
+      playType={playType}
+      mode={mode}
+      trainingMode={trainingMode}
+      accountId={accountId}
+      tgId={tgId}
+      playerName={playerName}
+      playerAvatar={playerAvatar}
+      opponentName={opponentName}
+      opponentAvatar={opponentAvatar}
+    />
+  );
 }


### PR DESCRIPTION
### Motivation
- Snooker Royal was mounting the shared "Provided/Champion" wrapper which prevented the original Snooker Royal scene and human cue behavior from being used. The game should mount its original `SnookerRoyalGame` with full query-driven options. 
- The human player cue/hand animation needed to reflect the visible cue on the table and the committed shot power so the stroke looks natural (pull -> forward push -> stop at impact).
- Preserve the committed slider power through the cue stroke animation so the character's right-hand motion matches the actual shot even while the UI slider animates back.

### Description
- Restored the Snooker Royal entrypoint to mount the original `SnookerRoyalGame` and wired query param parsing for `variant`, `ballSet`, `tableSize`, `tableModel`, `type`, `mode`, `trainingMode`, `accountId`, `tgId`, `name`, `avatar`, `opponent`, and `opponentAvatar` so lobby navigation behaves correctly (file: `webapp/src/pages/Games/SnookerRoyal.jsx`).
- Replaced the `SnookerRoyalProvided` wrapper usage and added `useLocation` + param `useMemo` calls to derive props for `SnookerRoyalGame` (file: `webapp/src/pages/Games/SnookerRoyal.jsx`).
- Implemented human pose blending when the cue is visible: introduced a pose blend `poseT` (driven by cue visibility/shooting state) and adjusted bridge/grip/idle hand targets and cue-tip target to smoothly transition between idle (cue in hand) and shot posture (files: `webapp/src/pages/Games/SnookerRoyal.jsx`, functions `updateSnookerRoyalHumanPlayer` and helpers).
- Preserved committed shot power across the cue stroke: added `shotVisualPowerRef` to hold the committed power on `fire()` and fed `Math.max(powerRef, shotVisualPowerRef, aiPlan?.power)` into the human update driver so the right-hand stroke matches the shot until impact; reset `shotVisualPowerRef` when the stroke completes (file: `webapp/src/pages/Games/SnookerRoyal.jsx`).

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully and produced updated bundles that include the modified Snooker Royal chunk.
- Ran repository checks including `git diff --check` and validated the changed file (`webapp/src/pages/Games/SnookerRoyal.jsx`) and a commit was created (local commit recorded).
- Attempted an automated visual smoke check via Playwright: installed Playwright Chromium and platform deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) but the headless screenshot attempt timed out / closed in this environment, so full end-to-end screenshot capture could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a94bc0e108329a8969dfa1a0038b8)