### PR TITLE
Adjust Domino Royal player domino placement

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6715,20 +6715,20 @@ const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.0025; // keep chain tiles touching without visible overlap
 const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
-// Keep player-hand dominoes compact, with opponent hands tucked lower and
-// closer to the tabletop center while the bottom player's hand anchor stays fixed.
+// Keep player-hand dominoes compact, with every seat tucked a little lower
+// and closer to the tabletop center.
 const PLAYER_HAND_TILE_SCALE = 0.82;
 const HUMAN_PLAYER_HAND_TILE_SCALE = 0.72;
 const PLAYER_HAND_GAP_SCALE = 0.5;
 const PLAYER_HAND_MIN_GAP_SCALE = 0.76;
-const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 5.65;
-const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 7.8;
-const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 4.0;
-const PLAYER_HAND_CENTER_VERTICAL_DROP = DOMINO_WIDTH * 3.0;
-const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 6.7;
+const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 5.18;
+const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 7.18;
+const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 3.68;
+const PLAYER_HAND_CENTER_VERTICAL_DROP = DOMINO_WIDTH * 3.18;
+const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 6.12;
 const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.0;
-const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 1.45;
-const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 6.9;
+const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 1.25;
+const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 6.42;
 // Keep the bottom player's upright tiles separated by a small visible gap.
 const HUMAN_BOTTOM_HAND_GAP_SCALE = 1.04;
 const DOMINO_DOUBLE_NEIGHBOR_EXTRA_GAP = 0;
@@ -8277,12 +8277,12 @@ function normalizeDominoCharacterRoot(root) {
   if (!bounds.isEmpty()) root.position.y -= bounds.min.y;
 }
 
-const DOMINO_HELD_RACK_HAND_LIFT = 0.72 * MODEL_SCALE;
+const DOMINO_HELD_RACK_HAND_LIFT = 0.66 * MODEL_SCALE;
 // Keep the character-held domino fan slightly tucked in toward the tabletop
 // so seated hands read closer to their dominoes instead of floating outward.
-const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.68 * MODEL_SCALE;
-const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 1.04 * MODEL_SCALE;
-const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 1.04 * MODEL_SCALE;
+const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.6 * MODEL_SCALE;
+const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 0.96 * MODEL_SCALE;
+const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 0.94 * MODEL_SCALE;
 
 function createHeldDominoRack(seatIndex, handTiles = []) {
   const rack = new THREE.Group();

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-15-raised-player-dominoes-v39';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-18-lower-closer-player-dominoes-v40';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation

- Player dominoes in Domino Royal needed to sit slightly closer to the table and a bit lower so seated hands and held racks read more naturally at gameplay camera angles.

### Description

- Tuned player hand placement constants in `webapp/public/domino-royal-game.js` to bring player tiles closer to the tabletop and lower their vertical offsets (several `PLAYER_*` / `HUMAN_*` constants updated).
- Lowered and brought-in character-held rack offsets in `webapp/public/domino-royal-game.js` so held racks align with the adjusted seated hand presentation (`DOMINO_HELD_RACK_*` constants updated).
- Bumped the in-app Domino script cache version in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-05-18-lower-closer-player-dominoes-v40` so clients load the updated script.

### Testing

- Ran `git diff --check` which reported no issues (success).
- Built the webapp with `npm --prefix webapp run build` which completed successfully (Vite build completed).
- Installed Playwright browsers and OS deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully.
- Launched a local dev server and captured a Playwright screenshot (`artifacts/domino-royal-player-dominoes-lower-closer.png`) to verify visual placement (screenshot produced after the build/dev run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a9f1d296483298129b6c0cfab908a)