### PR TITLE
Nudge Murlan player cards upward

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3313,6 +3313,7 @@ const PLAYER_HAND_TABLE_OUTWARD_PUSH = 0.4 * MODEL_SCALE;
 const PLAYER_HAND_OUTWARD_PUSH_ONE_CARD = CARD_H;
 const PLAYER_HAND_UP_LIFT_ONE_CARD = CARD_H;
 const PLAYER_HAND_LOWER_OFFSET = 0.05 * MODEL_SCALE;
+const PLAYER_HAND_SCREEN_TOP_NUDGE = 0.045 * MODEL_SCALE;
 
 function resolveSeatHandRadius(tableRadius, isHumanSeat) {
   const safeTableRadius = Number.isFinite(tableRadius) ? tableRadius : TABLE_RADIUS;
@@ -4845,7 +4846,11 @@ export default function MurlanRoyaleArena({ search }) {
             ? AI_TOP_HAND_EXTRA_OUTWARD_PUSH
             : 0;
         target.addScaledVector(forward, isHumanCard ? HUMAN_HAND_CLOSER_OFFSET : AI_HAND_CLOSER_OFFSET);
-        target.addScaledVector(forward, aiExtraOutwardPush - (HUMAN_HAND_EXTRA_INWARD_PULL + aiExtraInwardPull));
+        target.addScaledVector(
+          forward,
+          aiExtraOutwardPush -
+            (HUMAN_HAND_EXTRA_INWARD_PULL + aiExtraInwardPull + PLAYER_HAND_SCREEN_TOP_NUDGE)
+        );
         target.addScaledVector(layoutAxis, (isHumanCard ? HUMAN_HAND_LEFT_SHIFT : AI_HAND_LEFT_SHIFT) + aiPalmLateralShift + aiSideTopwardShift);
         target.y =
           baseHeight +


### PR DESCRIPTION
### Motivation
- Improve Murlan Royale portrait framing by moving player hand cards slightly toward the top of the screen so they sit just a bit higher in the view.

### Description
- Added a small constant `PLAYER_HAND_SCREEN_TOP_NUDGE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to hold the shared top-screen nudge value.
- Applied the nudge to the hand-card positioning calculation (reduce the forward outward push) so human and AI hand layouts, fan angles, selection offsets and deal animations are preserved while shifting cards upward a small amount.

### Testing
- Ran `npm run build` in `webapp` and the production build completed successfully (Vite build finished).
- Started the dev server with `npm run dev` and the site served locally (Vite ready), but automated screenshot capture with Playwright failed because `npx playwright install chromium` could not download browsers due to CDN DNS resolution errors, so a headless screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a9f59f1a48329b3c4ba68caac3571)