### PR TITLE
Tweak Murlan Royale player card placement

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3310,10 +3310,12 @@ const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
 const HUMAN_SELECTION_OFFSET = 0.14 * MODEL_SCALE;
 const AI_CARD_LIFT = 0.076 * MODEL_SCALE;
 const PLAYER_HAND_TABLE_OUTWARD_PUSH = 0.4 * MODEL_SCALE;
+const PLAYER_HAND_SUBTLE_OUTWARD_NUDGE = 0.034 * MODEL_SCALE;
 const PLAYER_HAND_OUTWARD_PUSH_ONE_CARD = CARD_H;
 const PLAYER_HAND_UP_LIFT_ONE_CARD = CARD_H;
-const PLAYER_HAND_LOWER_OFFSET = 0.05 * MODEL_SCALE;
+const PLAYER_HAND_LOWER_OFFSET = 0.064 * MODEL_SCALE;
 const PLAYER_HAND_SCREEN_TOP_NUDGE = 0.045 * MODEL_SCALE;
+const PLAYER_HAND_SCREEN_TOP_SHIFT = 0.032 * MODEL_SCALE;
 
 function resolveSeatHandRadius(tableRadius, isHumanSeat) {
   const safeTableRadius = Number.isFinite(tableRadius) ? tableRadius : TABLE_RADIUS;
@@ -4848,9 +4850,11 @@ export default function MurlanRoyaleArena({ search }) {
         target.addScaledVector(forward, isHumanCard ? HUMAN_HAND_CLOSER_OFFSET : AI_HAND_CLOSER_OFFSET);
         target.addScaledVector(
           forward,
-          aiExtraOutwardPush -
+          PLAYER_HAND_SUBTLE_OUTWARD_NUDGE +
+            aiExtraOutwardPush -
             (HUMAN_HAND_EXTRA_INWARD_PULL + aiExtraInwardPull + PLAYER_HAND_SCREEN_TOP_NUDGE)
         );
+        target.z -= PLAYER_HAND_SCREEN_TOP_SHIFT;
         target.addScaledVector(layoutAxis, (isHumanCard ? HUMAN_HAND_LEFT_SHIFT : AI_HAND_LEFT_SHIFT) + aiPalmLateralShift + aiSideTopwardShift);
         target.y =
           baseHeight +


### PR DESCRIPTION
### Motivation
- Make player-held cards in the Murlan Royale arena sit visually a little closer to the top of the viewport, a touch more outward, and a hair lower so portrait/portrait-like framings read better.

### Description
- Added two small tuning constants `PLAYER_HAND_SUBTLE_OUTWARD_NUDGE` and `PLAYER_HAND_SCREEN_TOP_SHIFT` and increased `PLAYER_HAND_LOWER_OFFSET` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to provide subtle placement offsets.
- Applied the outward nudge and screen-top Z shift to the hand-card placement math so all player hands are adjusted consistently when computing `target` positions.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Ran `git diff --check` and no diff-check issues were reported.
- Captured an automated Playwright screenshot of the running dev page (saved to `/tmp/murlan-royale-card-adjustment.png`) after installing required Playwright dependencies, and the screenshot step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa5720c7c8329af8681b29606c888)