### PR TITLE
Pool Royale: use exact slider commit for shot power and sync slider callbacks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -28323,11 +28323,15 @@ const shotPowerRef = useRef(0);
         } else {
           aimDir.normalize();
         }
-        const sourcePower = Math.max(
-          Number.isFinite(committedPowerOverride) ? committedPowerOverride : 0,
-          Number.isFinite(shotPowerRef.current) ? shotPowerRef.current : 0,
-          Number.isFinite(powerRef.current) ? powerRef.current : 0
-        );
+        const committedPower = Number.isFinite(committedPowerOverride)
+          ? committedPowerOverride
+          : null;
+        const sourcePower = committedPower !== null
+          ? committedPower
+          : Math.max(
+              Number.isFinite(shotPowerRef.current) ? shotPowerRef.current : 0,
+              Number.isFinite(powerRef.current) ? powerRef.current : 0
+            );
         const clampedPower = clampPower(sourcePower, 0);
         if (clampedPower < MIN_SHOT_POWER_TO_FIRE) {
           setShootingState(false);
@@ -34733,14 +34737,29 @@ const shotPowerRef = useRef(0);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
-      onChange: (v) => applyPower(v / 100),
-      onStart: () => {
+      onStart: (value) => {
         captureCueStickAnchor();
+        const normalized = clampPower(
+          (Number.isFinite(value) ? value : slider.min) / 100,
+          0
+        );
+        shotPowerRef.current = normalized;
       },
-      onCommit: () => {
-        fireRef.current?.();
+      onChange: (v) => {
+        const normalized = clampPower(v / 100, 0);
+        shotPowerRef.current = normalized;
+        applyPower(normalized);
+      },
+      onCommit: (value) => {
+        const commitValue = Number.isFinite(value)
+          ? value
+          : (slider.get?.() ?? slider.min);
+        const normalized = clampPower(commitValue / 100, 0);
+        shotPowerRef.current = normalized;
+        powerRef.current = normalized;
+        fireRef.current?.(normalized);
         requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
+          slider.animateToMin?.({ duration: 180 });
           applyPower(0);
         });
       }
@@ -34759,6 +34778,7 @@ const shotPowerRef = useRef(0);
       slider.set(slider.min, { animate: true });
     }
     applyPower(0);
+    shotPowerRef.current = 0;
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;
   }, [applyPower, hud.over, hud.turn, shotActive]);


### PR DESCRIPTION
### Motivation
- Fix a mismatch between the visible pull slider and the shot firing path where tiny/stale power values could produce tiny cue-ball nudges and fouls. 
- Make the Pool Royale power slider behavior consistent with the Snooker implementation by ensuring the cue-stick animation and the physics impulse share a single authoritative power value. 
- Prevent stale cached shot power from leaking across turns when the slider resets.

### Description
- Changed the shot firing source to prefer an explicit `committedPowerOverride` when present and otherwise use the current pulled `shotPowerRef`/`powerRef` values, so the fired impulse uses the exact committed slider value. 
- Reworked `PoolRoyalePowerSlider` callbacks to synchronize `shotPowerRef` on `onStart`, `onChange`, and `onCommit`, and to pass the normalized committed value into `fireRef` on commit so cue animation and physics use the same power. 
- Updated slider reset logic to clear `shotPowerRef.current` when controls are reset, and switched slider return to use `animateToMin` for smoother UX. 
- File modified: `webapp/src/pages/Games/PoolRoyale.jsx` (power/shot commit and slider callback wiring).

### Testing
- Ran the webapp production build with `npm --prefix webapp run build` and the build completed successfully. 
- No automated unit tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac241683c8329a30fbd7a0959b2aa)