### PR TITLE
Adjust Domino Royal held-rack positions (raise/outward for opponents, tighter bottom spacing)

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8277,15 +8277,17 @@ function normalizeDominoCharacterRoot(root) {
   if (!bounds.isEmpty()) root.position.y -= bounds.min.y;
 }
 
-const DOMINO_HELD_RACK_HAND_LIFT = 0.72 * MODEL_SCALE;
-// Keep the character-held domino fan slightly tucked in toward the tabletop
-// so seated hands read closer to their dominoes instead of floating outward.
-const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.68 * MODEL_SCALE;
+const DOMINO_HELD_RACK_HAND_LIFT = 0.98 * MODEL_SCALE;
+// Keep the non-bottom players' held domino fans lifted and pushed farther
+// outward so their hands read clearly around the top and side seats.
+const DOMINO_HELD_RACK_OUTWARD_OFFSET = 0.96 * MODEL_SCALE;
 const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 1.04 * MODEL_SCALE;
 const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 1.04 * MODEL_SCALE;
 
 function createHeldDominoRack(seatIndex, handTiles = []) {
   const rack = new THREE.Group();
+  const isBottom = seatIndex === human;
+  const horizontalTileSpacing = isBottom ? 0.092 : 0.12;
   const visibleTiles = Array.isArray(handTiles) ? handTiles.slice(0, 5) : [];
   const desiredSignature = visibleTiles.map((tile) => `${tile.a}:${tile.b}`).join('|');
   const tiles = visibleTiles.length ? visibleTiles : [{ a: 6, b: 6 }, { a: 5, b: 4 }];
@@ -8293,11 +8295,10 @@ function createHeldDominoRack(seatIndex, handTiles = []) {
     const mini = makeDomino(tile.a ?? 0, tile.b ?? 0, { flat: false, faceUp: true });
     const centered = index - (tiles.length - 1) / 2;
     mini.scale.setScalar(0.3);
-    mini.position.set(centered * 0.12 * MODEL_SCALE, (1.42 + Math.abs(centered) * 0.014) * MODEL_SCALE, 0.5 * MODEL_SCALE + index * 0.006);
+    mini.position.set(centered * horizontalTileSpacing * MODEL_SCALE, (1.42 + Math.abs(centered) * 0.014) * MODEL_SCALE, 0.5 * MODEL_SCALE + index * 0.006);
     mini.rotation.set(THREE.MathUtils.degToRad(-74), THREE.MathUtils.degToRad(centered * -7), THREE.MathUtils.degToRad(centered * 10));
     rack.add(mini);
   });
-  const isBottom = seatIndex === human;
   const handLift = isBottom ? DOMINO_HELD_RACK_BOTTOM_HAND_LIFT : DOMINO_HELD_RACK_HAND_LIFT;
   const outwardOffset = isBottom ? DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET : DOMINO_HELD_RACK_OUTWARD_OFFSET;
   rack.position.set(

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-15-raised-player-dominoes-v39';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-18-raised-outward-player-dominoes-v40';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Improve readability of opponents' held dominoes by raising and pushing non-bottom players' domino racks farther outward. 
- Preserve the bottom player's existing look while slightly tightening horizontal spacing to reduce gaps between their held tiles.

### Description
- Increased non-bottom held-rack lift and outward offsets by updating `DOMINO_HELD_RACK_HAND_LIFT` and `DOMINO_HELD_RACK_OUTWARD_OFFSET` in `webapp/public/domino-royal-game.js` so opponent racks sit higher and more outward. 
- Introduced a `horizontalTileSpacing` (per-seat) in `createHeldDominoRack` and use it for tile X positions so the bottom player uses a smaller spacing while other seats keep the original spacing. 
- Kept bottom-specific lift/outward constants (`DOMINO_HELD_RACK_BOTTOM_*`) and switched `createHeldDominoRack` positioning to use the `isBottom` condition consistently. 
- Bumped `DOMINO_ROYAL_SCRIPT_VERSION` in `webapp/src/pages/Games/DominoRoyalArena.jsx` so clients will load the updated scene script.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed successfully. 
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build produced the `dist` output). 
- Executed `npx playwright install chromium` and `npx playwright install-deps chromium` to install browser and system deps successfully. 
- Attempted an automated Playwright screenshot of the local dev page, but the full 3D scene capture did not complete in this environment due to external asset/HDRI fetch failures and runtime limitations; Vite dev server did start and the page began loading in the headless browser logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac311d8b88329a90a1e4935fa6c0c)