### PR TITLE
Align Snake & Ladder dice roll timing with Ludo/Pool dice behavior

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -190,6 +190,9 @@ const AI_ROLL_DELAY_MS = 1300;
 const AI_EXTRA_ROLL_DELAY_MS = 850;
 const TURN_ADVANCE_AFTER_DICE_MS = 0;
 const DICE_RESULT_HOLD_MS = 2000;
+// Match the 3D Snake board dice timing to Ludo Battle Royal and Pool Royale.
+const DICE_BOARD_ROLL_MS = 900;
+const DICE_BOARD_SETTLE_MS = 220;
 const DICE_SFX_MIN_INTERVAL_MS = 850;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
@@ -1450,6 +1453,7 @@ export default function SnakeAndLadder() {
 
   const diceRollerDivRef = useRef(null);
   const activeDiceBoardRollRef = useRef(null);
+  const diceVisualReadyAtRef = useRef(0);
   const slideStateRef = useRef(null);
   const slideIdRef = useRef(0);
   const [slideAnimation, setSlideAnimation] = useState(null);
@@ -1512,7 +1516,25 @@ export default function SnakeAndLadder() {
   }, []);
 
   const startDiceBoardAnimation = useCallback((phase) => {
+    if (phase?.phase === 'start') {
+      diceVisualReadyAtRef.current = Date.now() + DICE_BOARD_ROLL_MS + DICE_BOARD_SETTLE_MS;
+    } else if (phase?.phase === 'end') {
+      diceVisualReadyAtRef.current = Math.max(
+        diceVisualReadyAtRef.current,
+        Date.now() + DICE_BOARD_SETTLE_MS
+      );
+    }
     setDiceBoardEvent(phase);
+  }, []);
+
+  const runAfterDiceVisual = useCallback((callback) => {
+    if (typeof callback !== 'function') return;
+    const waitMs = Math.max(0, diceVisualReadyAtRef.current - Date.now());
+    if (waitMs <= 0) {
+      callback();
+      return;
+    }
+    window.setTimeout(callback, waitMs);
   }, []);
 
   const normalizeAuthoritativeDiceValues = useCallback((value, fallbackCount = 1) => {
@@ -2181,68 +2203,72 @@ export default function SnakeAndLadder() {
       }, maxPlayers);
     };
     const onMove = ({ playerId, from = 0, to }) => {
-      const updatePosition = (pos) => {
-        updateMpPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: pos } : pl)));
-        if (playerId === myAccountId) setPos(pos);
-      };
-      const ctx = {
-        updatePosition,
-        setHighlight,
-        setTrail,
-        moveSoundRef,
-        hahaSoundRef,
-        snakes,
-        ladders,
-        setOffsetPopup,
-        snakeSoundRef,
-        oldSnakeSoundRef,
-        ladderSoundRef,
-        badLuckSoundRef,
-        muted,
-        FINAL_TILE,
-      };
-      const finalizeMove = (finalPos, type) => {
-        updatePosition(finalPos);
-        setHighlight({ cell: finalPos, type, color: playerColors[0] });
-        setTrail([]);
-        setTimeout(() => setHighlight(null), 2300);
-        setMoving(false);
-      };
-      const seq = [];
-      for (let i = from + 1; i <= to; i++) seq.push(i);
-      setMoving(true);
-      moveSeq(seq, 'normal', ctx, () => finalizeMove(to, 'normal'), 'forward');
+      runAfterDiceVisual(() => {
+        const updatePosition = (pos) => {
+          updateMpPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: pos } : pl)));
+          if (playerId === myAccountId) setPos(pos);
+        };
+        const ctx = {
+          updatePosition,
+          setHighlight,
+          setTrail,
+          moveSoundRef,
+          hahaSoundRef,
+          snakes,
+          ladders,
+          setOffsetPopup,
+          snakeSoundRef,
+          oldSnakeSoundRef,
+          ladderSoundRef,
+          badLuckSoundRef,
+          muted,
+          FINAL_TILE,
+        };
+        const finalizeMove = (finalPos, type) => {
+          updatePosition(finalPos);
+          setHighlight({ cell: finalPos, type, color: playerColors[0] });
+          setTrail([]);
+          setTimeout(() => setHighlight(null), 2300);
+          setMoving(false);
+        };
+        const seq = [];
+        for (let i = from + 1; i <= to; i++) seq.push(i);
+        setMoving(true);
+        moveSeq(seq, 'normal', ctx, () => finalizeMove(to, 'normal'), 'forward');
+      });
     };
     const onSnakeOrLadder = ({ playerId, from, to }) => {
-      const updatePosition = (pos) => {
-        updateMpPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: pos } : pl)));
-        if (playerId === myAccountId) setPos(pos);
-      };
-      const ctx = {
-        updatePosition,
-        setHighlight,
-        setTrail,
-        moveSoundRef,
-        hahaSoundRef,
-        snakes,
-        ladders,
-        setOffsetPopup,
-        snakeSoundRef,
-        oldSnakeSoundRef,
-        ladderSoundRef,
-        badLuckSoundRef,
-        muted,
-        FINAL_TILE,
-      };
-      const finalizeMove = (finalPos, type) => {
-        updatePosition(finalPos);
-        setHighlight({ cell: finalPos, type, color: playerColors[0] });
-        setTrail([]);
-        setTimeout(() => setHighlight(null), 2300);
-        setMoving(false);
-      };
-      setMoving(true);
-      applyEffectHelper(from, ctx, finalizeMove);
+      runAfterDiceVisual(() => {
+        const updatePosition = (pos) => {
+          updateMpPlayers((p) => p.map((pl) => (pl.id === playerId ? { ...pl, position: pos } : pl)));
+          if (playerId === myAccountId) setPos(pos);
+        };
+        const ctx = {
+          updatePosition,
+          setHighlight,
+          setTrail,
+          moveSoundRef,
+          hahaSoundRef,
+          snakes,
+          ladders,
+          setOffsetPopup,
+          snakeSoundRef,
+          oldSnakeSoundRef,
+          ladderSoundRef,
+          badLuckSoundRef,
+          muted,
+          FINAL_TILE,
+        };
+        const finalizeMove = (finalPos, type) => {
+          updatePosition(finalPos);
+          setHighlight({ cell: finalPos, type, color: playerColors[0] });
+          setTrail([]);
+          setTimeout(() => setHighlight(null), 2300);
+          setMoving(false);
+        };
+        setMoving(true);
+        applyEffectHelper(from, ctx, finalizeMove);
+      });
     };
     const onReset = ({ playerId }) => {
       const idx = playersRef.current.findIndex((pl) => pl.id === playerId);
@@ -2349,6 +2375,12 @@ export default function SnakeAndLadder() {
         });
       }
 
+      // If this client did not already show the full hidden DiceRoller cycle
+      // (spectators and opponents), let the 3D board dice complete the same
+      // 900 ms roll used by Ludo Battle Royal / Pool Royale before landing on
+      // the authoritative result.
+      const resultDelayMs = canReuseActiveRoll ? 0 : DICE_BOARD_ROLL_MS;
+      diceVisualReadyAtRef.current = Date.now() + resultDelayMs + DICE_BOARD_SETTLE_MS;
       window.setTimeout(() => {
         startDiceBoardAnimation({
           id: rollId,
@@ -2357,7 +2389,7 @@ export default function SnakeAndLadder() {
           seatIndex
         });
         activeDiceBoardRollRef.current = { id: rollId, seatIndex, phase: 'end' };
-      }, canReuseActiveRoll ? 0 : 80);
+      }, resultDelayMs);
 
       setRollResult(resultTotal);
       setTimeout(() => setRollResult(null), DICE_RESULT_HOLD_MS);
@@ -2556,7 +2588,7 @@ export default function SnakeAndLadder() {
         }
       }
     };
-  }, [accountId, applyTableCapacity, isMultiplayer, myName, photoUrl, refreshPlayersNeeded, tableId, updateMpPlayers, watchOnly]);
+  }, [accountId, applyTableCapacity, isMultiplayer, myName, photoUrl, refreshPlayersNeeded, runAfterDiceVisual, tableId, updateMpPlayers, watchOnly]);
 
   const fastForward = (elapsed, state) => {
     let p = state.pos ?? 0;


### PR DESCRIPTION
### Motivation
- The Snake & Ladder board showed dice landing earlier than the 3D dice animation used by other games, producing an unnatural feel and desynchronised token movement.
- The goal is to replicate the same roll/settle cadence and result mapping used by Ludo Battle Royal and Pool Royale so visual roll, sound and authoritative results stay in sync.

### Description
- Introduced roll/settle timing constants `DICE_BOARD_ROLL_MS` and `DICE_BOARD_SETTLE_MS` and a visual readiness tracker `diceVisualReadyAtRef` in `webapp/src/pages/Games/SnakeAndLadder.jsx` so the client knows when the board dice has finished its visible animation. 
- Updated `startDiceBoardAnimation` to mark when the 3D dice start and finish so downstream logic can wait for the full visual cadence before proceeding. 
- Delayed the authoritative remote-result handling so spectators/opponents see the same ~900ms roll + 220ms settle used by Ludo/Pool before the dice snaps to the server-provided face. 
- Queued multiplayer movement and `snake`/`ladder` effects via `runAfterDiceVisual` so token movement and effects run only after the dice visual has settled, preventing movement from racing ahead of the dice landing.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production bundles. 
- Verified no immediate code-style/diff warnings via `git diff --check`. 
- Installed and ran Playwright browser setup with `npx playwright install chromium` and `npx playwright install-deps chromium` and captured a verification screenshot of the Snake board at `/tmp/snake-dice-update.png`. 
- Started the dev server (Vite) and exercised the game page to confirm the 3D dice roll/settle visually completes before movement logic executes, with the build and screenshot steps succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad0cfd76083298c598aea2c91fb51)