### PR TITLE
Align Snake & Ladder dice roll timing

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -297,7 +297,11 @@ export class GameRoom {
       if (!result) return;
 
       const total = result.dice.reduce((a, b) => a + b, 0);
-      this.io.to(this.id).emit('diceRolled', { playerId: player.playerId, value: total });
+      this.io.to(this.id).emit('diceRolled', {
+        playerId: player.playerId,
+        value: total,
+        dice: result.dice
+      });
       const from = prevPositions[playerIndex];
       const to = result.path.length ? result.path[result.path.length - 1] : from;
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -190,6 +190,9 @@ const AI_ROLL_DELAY_MS = 1300;
 const AI_EXTRA_ROLL_DELAY_MS = 850;
 const TURN_ADVANCE_AFTER_DICE_MS = 0;
 const DICE_RESULT_HOLD_MS = 2000;
+// Match the 3D Ludo/Pool dice: a server-authoritative value should only
+// replace the rolling face after the physical throw has had time to land.
+const DICE_BOARD_ROLL_REVEAL_DELAY_MS = 930;
 const DICE_SFX_MIN_INTERVAL_MS = 850;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
@@ -2357,7 +2360,7 @@ export default function SnakeAndLadder() {
           seatIndex
         });
         activeDiceBoardRollRef.current = { id: rollId, seatIndex, phase: 'end' };
-      }, canReuseActiveRoll ? 0 : 80);
+      }, canReuseActiveRoll ? 0 : DICE_BOARD_ROLL_REVEAL_DELAY_MS);
 
       setRollResult(resultTotal);
       setTimeout(() => setRollResult(null), DICE_RESULT_HOLD_MS);


### PR DESCRIPTION
### Motivation
- Make Snake & Ladder dice visuals match the Ludo/Pool behaviour so the 3D throw and landing complete before the authoritative face(s) snap into view.
- Ensure clients can display the exact faces used by server logic so multiplayer visuals and movement mapping remain consistent.

### Description
- Add `DICE_BOARD_ROLL_REVEAL_DELAY_MS = 930` to `webapp/src/pages/Games/SnakeAndLadder.jsx` and use it to delay applying the server-authoritative result so the physical throw animation finishes before the final face is shown.
- Replace the short hardcoded reveal delay with `DICE_BOARD_ROLL_REVEAL_DELAY_MS` where the board receives the server-end phase transition for dice rolls.
- Include the authoritative face array in the multiplayer event by adding `dice: result.dice` to the `diceRolled` emission from `bot/gameEngine.js` so clients receive the exact faces used by game logic.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Ran `npx eslint webapp/src/pages/Games/SnakeAndLadder.jsx bot/gameEngine.js` (normal config); command completed with warnings about ignored files but no blocking errors.
- Ran `node --check bot/gameEngine.js` and the server-side file passed Node syntax checks.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/SnakeAndLadder.jsx bot/gameEngine.js` which surfaced existing repository lint/style issues (reported errors unrelated to the functional change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad0cfd76083298c598aea2c91fb51)