### PR TITLE
Adjust Domino Royal hand spacing

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6715,26 +6715,26 @@ const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.0025; // keep chain tiles touching without visible overlap
 const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
-// Keep player-hand dominoes compact, with opponent hands tucked lower and
-// closer to the tabletop center while the bottom player's hand anchor stays fixed.
+// Keep player-hand dominoes compact while nudging opponent hands slightly
+// higher and farther outward; the bottom player's hand anchor stays fixed.
 const PLAYER_HAND_TILE_SCALE = 0.9;
 const HUMAN_PLAYER_HAND_TILE_SCALE = 0.74;
 const PLAYER_HAND_GAP_SCALE = 0.5;
 const PLAYER_HAND_MIN_GAP_SCALE = 0.76;
 const PLAYER_HAND_OPPONENT_MIN_GAP_SCALE = 0.8;
 const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 7.6;
-const PLAYER_HAND_OPPONENT_OUTWARD_EXTRA = DOMINO_WIDTH * 0.28;
-const PLAYER_HAND_SIDE_OUTWARD_EXTRA = DOMINO_WIDTH * 0.22;
+const PLAYER_HAND_OPPONENT_OUTWARD_EXTRA = DOMINO_WIDTH * 0.44;
+const PLAYER_HAND_SIDE_OUTWARD_EXTRA = DOMINO_WIDTH * 0.3;
 const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 7.8;
 const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 5.45;
-const PLAYER_HAND_OPPONENT_VERTICAL_EXTRA = DOMINO_WIDTH * 0.18;
+const PLAYER_HAND_OPPONENT_VERTICAL_EXTRA = DOMINO_WIDTH * 0.34;
 const PLAYER_HAND_CENTER_VERTICAL_DROP = DOMINO_WIDTH * 2.4;
 const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 6.7;
 const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.0;
 const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 1.45;
 const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 5.7;
 // Keep the bottom player's upright tiles separated by a small visible gap.
-const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.96;
+const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.88;
 const DOMINO_DOUBLE_NEIGHBOR_EXTRA_GAP = 0;
 const DOMINO_OPENING_DOUBLE_SIDE_GAP = DOMINO_LENGTH * 0.11;
 const TILE_UP_H = 0.2 * DOMINO_WORLD_SCALE * DOMINO_HEIGHT_ADJUST;
@@ -8281,17 +8281,17 @@ function normalizeDominoCharacterRoot(root) {
   if (!bounds.isEmpty()) root.position.y -= bounds.min.y;
 }
 
-const DOMINO_HELD_RACK_HAND_LIFT = 1.02 * MODEL_SCALE;
+const DOMINO_HELD_RACK_HAND_LIFT = 1.08 * MODEL_SCALE;
 // Keep the non-bottom players' held domino fans lifted and pushed farther
 // outward so their hands read clearly around the top and side seats.
-const DOMINO_HELD_RACK_OUTWARD_OFFSET = 1.0 * MODEL_SCALE;
+const DOMINO_HELD_RACK_OUTWARD_OFFSET = 1.06 * MODEL_SCALE;
 const DOMINO_HELD_RACK_BOTTOM_HAND_LIFT = 1.04 * MODEL_SCALE;
 const DOMINO_HELD_RACK_BOTTOM_OUTWARD_OFFSET = 1.04 * MODEL_SCALE;
 
 function createHeldDominoRack(seatIndex, handTiles = []) {
   const rack = new THREE.Group();
   const isBottom = seatIndex === human;
-  const horizontalTileSpacing = isBottom ? 0.092 : 0.12;
+  const horizontalTileSpacing = isBottom ? 0.084 : 0.12;
   const visibleTiles = Array.isArray(handTiles) ? handTiles.slice(0, 5) : [];
   const desiredSignature = visibleTiles.map((tile) => `${tile.a}:${tile.b}`).join('|');
   const tiles = visibleTiles.length ? visibleTiles : [{ a: 6, b: 6 }, { a: 5, b: 4 }];

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-18-hand-spacing-outward-v43';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-18-hand-spacing-outward-v44';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Tweak Domino Royal hand placement so opponent hands (top/left/right) sit slightly higher and more outward for readability while the bottom player's hand remains anchored but with a tighter gap between tiles.
- Ensure held domino racks for non-bottom characters match the new hand placement so visuals remain consistent.

### Description
- Increased opponent outward offsets by changing `PLAYER_HAND_OPPONENT_OUTWARD_EXTRA` and `PLAYER_HAND_SIDE_OUTWARD_EXTRA` in `webapp/public/domino-royal-game.js` to push top/side hands farther outward. 
- Raised opponent hand height by increasing `PLAYER_HAND_OPPONENT_VERTICAL_EXTRA` and increased `DOMINO_HELD_RACK_HAND_LIFT`/`DOMINO_HELD_RACK_OUTWARD_OFFSET` to lift and push held racks outward in `webapp/public/domino-royal-game.js`.
- Tightened the bottom-player spacing by reducing `HUMAN_BOTTOM_HAND_GAP_SCALE` and slightly reduced bottom held-rack `horizontalTileSpacing` in `webapp/public/domino-royal-game.js` so upright bottom tiles show a smaller gap.
- Bumped the script cache version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` from `2026-05-18-hand-spacing-outward-v43` to `2026-05-18-hand-spacing-outward-v44` so clients will load the updated placement script.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which passed without syntax errors. 
- Ran `npm --prefix webapp run build` (Vite production build) which completed successfully. 
- Installed Playwright browsers with `npx playwright install chromium` and system deps with `npx playwright install-deps chromium` which both completed successfully. 
- Launched the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1` and captured a Playwright screenshot saved at `artifacts/domino-royal-hand-spacing.png` (artifact present, 86175 bytes), verifying the visual change in an automated render.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad9c423fc83299d584b1d34850a0c)