### PR TITLE
Enlarge Checkers Battle Royal human characters

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -108,7 +108,11 @@ const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE;
 const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
 const ARM_DEPTH = SEAT_DEPTH * 0.75;
 const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.95;
+// Checkers uses the shared Chess Battle seated avatars in a smaller arena;
+// boost only their visual target height so the humans read larger at gameplay camera distance.
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.25;
+const SEATED_HUMAN_TARGET_HEIGHT =
+  BACK_HEIGHT * 2.95 * SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_MOVE_DURATION_MS = 700;


### PR DESCRIPTION
### Motivation
- Make seated human characters read larger in the smaller Checkers Battle Royal arena by increasing their visual target scale so they appear bigger at gameplay camera distance.

### Description
- Added `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.25` and updated `SEATED_HUMAN_TARGET_HEIGHT` calculation in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` so Checkers uses a boosted target height for shared seated human avatars.

### Testing
- Ran `npm run build` which completed successfully, and verified the app bundles were produced; running `npm run dev -- --host 127.0.0.1` started the dev server successfully; `npx playwright install chromium` and `npx playwright install-deps chromium` completed to allow headless checks; Playwright navigation/screenshot attempt for `/games/checkersbattleroyal` ran but external model/API requests failed in the test environment (network/certificate issues), so visual confirmation of loaded seated humans could not be completed despite the commands executing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0af30996848329b3576875b4d96d60)