### PR TITLE
Increase Checkers Battle Royal seated human size

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -110,7 +110,7 @@ const ARM_DEPTH = SEAT_DEPTH * 0.75;
 const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 // Checkers uses the shared Chess Battle seated avatars in a smaller arena;
 // boost only their visual target height so the humans read larger at gameplay camera distance.
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.25;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.45;
 const SEATED_HUMAN_TARGET_HEIGHT =
   BACK_HEIGHT * 2.95 * SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;


### PR DESCRIPTION
### Motivation
- Make the seated human avatars in the Checkers Battle Royal scene appear larger at gameplay camera distance so the characters read better visually.

### Description
- Updated the `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `1.25` to `1.45` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` to boost the human target height used when loading seated human templates.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0af7bb7c808329b6951a896f4d4baa)