### PR TITLE
Fix Pool Royale cue strike timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -28192,6 +28192,11 @@ const shotPowerRef = useRef(0);
           y: physicsSpin?.y ?? 0
         };
         applyPoolRoyaleCueShot(cue, p, aimDir, spin);
+        // Start the rolling-shot timeout only after the cue has physically
+        // reached the cue ball. This matches SnookerRoyalProvided.jsx, where
+        // the balls are not allowed to resolve while the cue/hand strike is
+        // still travelling toward contact.
+        shotStartedAt = getNow();
         if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
         cue.spinMode = 'standard';
         cue.swerveStrength = 0;
@@ -34231,23 +34236,33 @@ const shotPowerRef = useRef(0);
             recordReplayFrame(now);
           }
           if (shooting) {
-            const any = balls.some(
-              (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
+            const activeCueStroke = ENABLE_CUE_STROKE_ANIMATION
+              ? cueStrokeStateRef.current
+              : null;
+            const waitingForPhysicalCueImpact = Boolean(
+              activeCueStroke &&
+                !activeCueStroke.shotApplied &&
+                typeof activeCueStroke.onImpact === 'function'
             );
-            if (!any) {
-              resolve();
-            } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
-              console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');
-              balls.forEach((ball) => {
-                if (!ball) return;
-                if (ball.vel) ball.vel.set(0, 0);
-                if (ball.spin) ball.spin.set(0, 0);
-                if (ball.omega) ball.omega.set(0, 0, 0);
-                if (ball.pendingSpin) ball.pendingSpin.set(0, 0);
-                ball.launchDir = null;
-                ball.impacted = false;
-              });
-              resolve();
+            if (!waitingForPhysicalCueImpact) {
+              const any = balls.some(
+                (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
+              );
+              if (!any) {
+                resolve();
+              } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
+                console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');
+                balls.forEach((ball) => {
+                  if (!ball) return;
+                  if (ball.vel) ball.vel.set(0, 0);
+                  if (ball.spin) ball.spin.set(0, 0);
+                  if (ball.omega) ball.omega.set(0, 0, 0);
+                  if (ball.pendingSpin) ball.pendingSpin.set(0, 0);
+                  ball.launchDir = null;
+                  ball.impacted = false;
+                });
+                resolve();
+              }
             }
           }
           if (pocketDropRef.current.size > 0) {


### PR DESCRIPTION
### Motivation
- Pool Royale was resolving shots before the animated cue/hand push reached the cue ball, causing slider-powered strikes to sometimes apply no velocity to the cue ball.
- The Snooker implementation waits until the visible cue reaches the contact gap before allowing physics to resolve, so Pool Royale needs the same behavior and timing parity.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to set `shotStartedAt = getNow()` immediately after `applyPoolRoyaleCueShot(...)` so the rolling-shot timeout begins only once the cue has physically impacted the ball.
- Added a guard in the main shot-update loop that detects an active animated cue stroke (`cueStrokeStateRef.current`) and, while the stroke is not yet applied, delays shot resolution so the animated cue/hand can reach the contact gap and call the impact handler.
- The new logic mirrors the strike/impact flow used by `SnookerRoyalProvided.jsx` and ensures slider-powered strikes are given time to move the cue ball before the engine checks for stopped balls or a stuck-shot timeout.
- All changes are limited to `webapp/src/pages/Games/PoolRoyale.jsx` and do not change shot physics models themselves, only the timing and resolution gating.

### Testing
- Ran the production build via `npm --prefix webapp run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0a53e0f48329bdffb9e19e895612)