### PR TITLE
Fix Snooker Royal cue strike timing

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -2164,7 +2164,10 @@ function createSnookerRoyalHumanPlayer(parent, renderer) {
     walkPhase: 0,
     walkAmount: 0,
     restQuats: new Map(),
-    theme: SNOOKER_HUMAN_CHARACTER_THEME
+    theme: SNOOKER_HUMAN_CHARACTER_THEME,
+    strikeClock: 0,
+    strikeRoot: new THREE.Vector3(),
+    strikeYaw: 0
   };
   human.root.name = 'SnookerRoyalHumanPlayerRoot';
   human.modelRoot.name = 'SnookerRoyalDominoCharacterRoot';
@@ -2271,12 +2274,25 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
   const yawTarget = Math.atan2(bodyForward.x, bodyForward.z);
   human.root.visible = true;
   human.modelRoot.visible = human.loaded && human.activeGlb;
-  const travel = human.lastRootPosition.distanceTo(rootTarget);
+  if (shooting || cueAnimating) {
+    if (human.strikeClock === 0) {
+      human.strikeRoot.copy(
+        human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget
+      );
+      human.strikeYaw = human.yaw;
+    }
+    human.strikeClock += dt;
+  } else {
+    human.strikeClock = 0;
+  }
+  const rootGoal = shooting || cueAnimating ? human.strikeRoot : rootTarget;
+  const yawGoal = shooting || cueAnimating ? human.strikeYaw : yawTarget;
+  const travel = human.lastRootPosition.distanceTo(rootGoal);
   human.walkAmount = snookerHumanDamp(human.walkAmount, snookerHumanClamp01(travel / Math.max(BALL_R * 4, 1e-4)), 8, dt);
   human.walkPhase += dt * (4.5 + human.walkAmount * 5.5);
-  human.root.position.lerp(rootTarget, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
+  human.root.position.lerp(rootGoal, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
   human.lastRootPosition.copy(human.root.position);
-  human.yaw = snookerHumanDampAngle(human.yaw, yawTarget, SNOOKER_HUMAN_CFG.rootLambda, dt);
+  human.yaw = snookerHumanDampAngle(human.yaw, yawGoal, SNOOKER_HUMAN_CFG.rootLambda, dt);
   human.root.rotation.set(0, human.yaw, 0);
   human.modelRoot.position.copy(human.root.position);
   human.modelRoot.rotation.copy(human.root.rotation);
@@ -23281,11 +23297,16 @@ const sliderResetTimerRef = useRef(null);
             rawTopSpin < 0
               ? rawTopSpin * BACKSPIN_MULTIPLIER
               : rawTopSpin * TOPSPIN_MULTIPLIER;
+          let contactFallbackHandle = null;
           let shotImpactApplied = false;
           const applyShotImpactAtCueContact = () => {
             if (shotImpactApplied) return false;
             shotImpactApplied = true;
             shotImpulseApplied = true;
+            if (contactFallbackHandle) {
+              clearTimeout(contactFallbackHandle);
+              contactFallbackHandle = null;
+            }
             const impactPower = THREE.MathUtils.clamp(
               committedShotPowerRef.current || clampedPower,
               0,
@@ -23491,6 +23512,12 @@ const sliderResetTimerRef = useRef(null);
           const impactTime = pullEndTime + strikeDuration;
           const holdEndTime = impactTime + holdDuration;
           const returnTime = holdEndTime + returnDuration;
+          contactFallbackHandle = window.setTimeout(() => {
+            // Same commit point as SnookerRoyalProvided: if a throttled frame
+            // misses the contact sample, still transfer the slider power exactly
+            // when the cue tip reaches the cue ball.
+            applyShotImpactAtCueContact();
+          }, Math.max(0, impactTime - performance.now()));
           const forwardPreviewHold =
             impactTime +
             Math.min(


### PR DESCRIPTION
### Motivation
- The in-scene human rig could drift/reposition during the visual cue stroke and a throttled animation frame could miss the exact contact sample, causing the cue ball to receive no impulse or the hand to appear to slide instead of push.
- Make the Snooker Royal player behavior match the proven technique in SnookerRoyalProvided.jsx by locking the avatar root/yaw during the strike and guaranteeing the committed slider power is applied at contact time.

### Description
- Added strike state to the snooker human object (`strikeClock`, `strikeRoot`, `strikeYaw`) and compute a `rootGoal`/`yawGoal` so the avatar is anchored while `shooting` or `cueAnimating`, keeping the hand driving the cue forward instead of the whole body shifting. (file: `webapp/src/pages/Games/SnookerRoyal.jsx`)
- Added a contact-time fallback (`contactFallbackHandle`) that schedules `applyShotImpactAtCueContact()` at the cue-tip impact timestamp and clears it when the normal hit path executes, ensuring the committed slider power transfers to the cue ball even if an animation frame is missed. (file: `webapp/src/pages/Games/SnookerRoyal.jsx`)
- Kept the rest of the visual stroke logic but changed the human pose interpolation to use the strike-anchored goals during the active strike window so the visual hand/cue push reads correctly.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully. 
- Ran `cd webapp && npx vite build` which completed successfully and produced the production bundles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0a74cfbc83298f2d0b2b2f2375ae)