### PR TITLE
Tune Checkers seated human scale and add relaxed idle arm pose

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -110,11 +110,12 @@ const ARM_DEPTH = SEAT_DEPTH * 0.75;
 const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 // Checkers uses the shared Chess Battle seated avatars in a smaller arena;
 // boost only their visual target height so the humans read larger at gameplay camera distance.
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.45;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.72;
 const SEATED_HUMAN_TARGET_HEIGHT =
   BACK_HEIGHT * 2.95 * SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = SEAT_DEPTH * 0.2;
+const CHECKERS_SEATED_HUMAN_IDLE_PROFILE = Object.freeze({ relaxedArmsDown: true });
 const SEATED_HUMAN_MOVE_DURATION_MS = 700;
 const SEATED_HUMAN_PICKUP_PHASE_END = 0.26;
 const SEATED_HUMAN_CARRY_PHASE_END = 0.78;
@@ -2315,7 +2316,7 @@ export default function CheckersBattleRoyal() {
           });
           chair.add(actor);
           const rig = saveSeatedHumanBoneRig(actor);
-          applySeatedHumanPose(rig, 'idle', 1, 0);
+          applySeatedHumanPose(rig, 'idle', 1, 0, CHECKERS_SEATED_HUMAN_IDLE_PROFILE);
           seatedHumanActorsRef.current.push({ playerIndex, chair, actor, rig });
         });
       } catch (error) {
@@ -2485,7 +2486,7 @@ export default function CheckersBattleRoyal() {
       if (!entry?.rig) return;
       const action = seatedHumanMoveActionsRef.current.get(entry.playerIndex);
       if (!action) {
-        applySeatedHumanPose(entry.rig, 'idle', 1, 0);
+        applySeatedHumanPose(entry.rig, 'idle', 1, 0, CHECKERS_SEATED_HUMAN_IDLE_PROFILE);
         return;
       }
       const rawT = clamp((now - action.startedAt) / Math.max(action.duration, 1), 0, 1);
@@ -2535,7 +2536,7 @@ export default function CheckersBattleRoyal() {
       if (rawT >= 1) {
         const linkedAnim = activeAnimationsRef.current.find((anim) => anim.object === action.object);
         if (linkedAnim) linkedAnim.handCarried = false;
-        applySeatedHumanPose(entry.rig, 'idle', 1, 0);
+        applySeatedHumanPose(entry.rig, 'idle', 1, 0, CHECKERS_SEATED_HUMAN_IDLE_PROFILE);
         seatedHumanMoveActionsRef.current.delete(entry.playerIndex);
       }
     });

--- a/webapp/src/pages/Games/shared/seatedHumanActors.js
+++ b/webapp/src/pages/Games/shared/seatedHumanActors.js
@@ -218,18 +218,60 @@ export function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip
   addBoneRot(rig, rig.rightLowerLeg, -1.2, -0.02, -0.01);
   addBoneRot(rig, rig.rightFoot, 0.14, -0.03, -0.02);
 
-  addBoneRot(rig, rig.leftUpperArm, -0.36, 0.1, 1.02);
-  addBoneRot(rig, rig.leftForeArm, -0.56, 0.06, -0.22);
-  addBoneRot(rig, rig.leftHand, -0.14, 0.02, 0.02);
-  let shoulderX = -0.36;
-  let shoulderY = -0.03;
-  let shoulderZ = -1.02;
-  let forearmX = -0.56;
-  let forearmY = -0.06;
-  let forearmZ = 0.22;
-  let wristX = -0.14;
-  let wristY = 0.02;
-  let wristZ = 0.02;
+  const relaxedArmsDown = mode === 'idle' && motionProfile?.relaxedArmsDown === true;
+  const leftIdleArmPose = relaxedArmsDown
+    ? {
+        shoulderX: -0.12,
+        shoulderY: 0.16,
+        shoulderZ: 1.36,
+        forearmX: -0.18,
+        forearmY: 0.02,
+        forearmZ: -0.06,
+        wristX: -0.04,
+        wristY: 0,
+        wristZ: 0.01
+      }
+    : {
+        shoulderX: -0.36,
+        shoulderY: 0.1,
+        shoulderZ: 1.02,
+        forearmX: -0.56,
+        forearmY: 0.06,
+        forearmZ: -0.22,
+        wristX: -0.14,
+        wristY: 0.02,
+        wristZ: 0.02
+      };
+  addBoneRot(
+    rig,
+    rig.leftUpperArm,
+    leftIdleArmPose.shoulderX,
+    leftIdleArmPose.shoulderY,
+    leftIdleArmPose.shoulderZ
+  );
+  addBoneRot(
+    rig,
+    rig.leftForeArm,
+    leftIdleArmPose.forearmX,
+    leftIdleArmPose.forearmY,
+    leftIdleArmPose.forearmZ
+  );
+  addBoneRot(
+    rig,
+    rig.leftHand,
+    leftIdleArmPose.wristX,
+    leftIdleArmPose.wristY,
+    leftIdleArmPose.wristZ
+  );
+  let shoulderX = relaxedArmsDown ? -0.12 : -0.36;
+  let shoulderY = relaxedArmsDown ? -0.16 : -0.03;
+  let shoulderZ = relaxedArmsDown ? -1.36 : -1.02;
+  let forearmX = relaxedArmsDown ? -0.18 : -0.56;
+  let forearmY = relaxedArmsDown ? -0.02 : -0.06;
+  let forearmZ = relaxedArmsDown ? 0.06 : 0.22;
+  let wristX = relaxedArmsDown ? -0.04 : -0.14;
+  let wristY = relaxedArmsDown ? 0 : 0.02;
+  let wristZ = relaxedArmsDown ? -0.01 : 0.02;
   let chestX = 0.16;
   let headX = -0.03;
   const forwardReach = clamp01(motionProfile?.forwardReach, 0);


### PR DESCRIPTION
### Motivation
- Make Checkers Battle Royal seated human characters visually larger in the arena and give them a relaxed arms-down idle pose when they are not moving a piece.

### Description
- Increase visual height scaling for Checkers seated humans by changing `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `1.45` to `1.72` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` so characters read larger at gameplay camera distance. 
- Add a Checkers-specific idle profile `CHECKERS_SEATED_HUMAN_IDLE_PROFILE = Object.freeze({ relaxedArmsDown: true })` and pass it to `applySeatedHumanPose` when seated actors are created, idle, or returned to idle after moves in `CheckersBattleRoyal.jsx` so only idle uses the relaxed arms pose. 
- Extend the shared seated-human pose solver `applySeatedHumanPose` in `webapp/src/pages/Games/shared/seatedHumanActors.js` to accept an opt-in `motionProfile?.relaxedArmsDown` and apply an alternate left-arm/wrist/forearm baseline for the relaxed arms-down idle pose while preserving existing reach/grip/carry/place animations. 
- Preserve all existing active motion logic and only apply the relaxed arms when `mode === 'idle'` and the profile is present.

### Testing
- Ran `git diff --check` with no issues found. 
- Built the webapp with `npm --prefix webapp run build`, which completed successfully. 
- Installed Playwright and platform deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed. 
- Executed a Playwright smoke screenshot test of `/games/checkersbattleroyal?mode=ai` which saved `/tmp/checkers-battle-human-scale-arms.png`, but the run reported external 3D asset fetch failures in this environment and fell back to local/fallback assets (visual change validated where assets could load).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b17247914832986192089bdd2553b)