### PR TITLE
Adjust Checkers Battle Royal camera and chairs

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -135,8 +135,8 @@ const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.94;
 const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.9;
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.08;
 const PLAYER_FACE_CAMERA_SEAT_ANGLE = Math.PI / 2;
-const PLAYER_FACE_CAMERA_INSET = 0.22 * CHECKERS_ARENA_SCALE;
-const PLAYER_FACE_CAMERA_EYE_HEIGHT = 1.42 * CHECKERS_ARENA_SCALE;
+const PLAYER_FACE_CAMERA_INSET = 0.12 * CHECKERS_ARENA_SCALE;
+const PLAYER_FACE_CAMERA_EYE_HEIGHT = 1.56 * CHECKERS_ARENA_SCALE;
 const PLAYER_FACE_CAMERA_TARGET_HEIGHT = 0.18 * CHECKERS_ARENA_SCALE;
 const PLAYER_FACE_CAMERA_YAW_LIMIT = THREE.MathUtils.degToRad(18);
 const PLAYER_FACE_CAMERA_PITCH_LIMIT = THREE.MathUtils.degToRad(12);
@@ -313,8 +313,9 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
 const CHAIR_GROUND_SINK = 0.44;
-// Visual tuning for portrait screens: make chairs 20% bigger.
+// Visual tuning for portrait screens: make chairs 20% bigger and slightly taller.
 const CHAIR_VISUAL_SCALE = 1.2;
+const CHAIR_VISUAL_HEIGHT_SCALE = 1.06;
 const CHAIR_TARGET_SCALE_FACTOR = 0.8;
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
   1.3162499970197679 * CHAIR_TARGET_SCALE_FACTOR,
@@ -2271,7 +2272,11 @@ export default function CheckersBattleRoyal() {
             });
           });
         }
-        g.scale.setScalar(CHAIR_VISUAL_SCALE);
+        g.scale.set(
+          CHAIR_VISUAL_SCALE,
+          CHAIR_VISUAL_SCALE * CHAIR_VISUAL_HEIGHT_SCALE,
+          CHAIR_VISUAL_SCALE
+        );
         g.position.set(0, CHAIR_HEIGHT, z);
         g.rotation.y = ry;
         groundGroupToFloor(g, -CHAIR_GROUNDING_EPSILON - CHAIR_GROUND_SINK);
@@ -2295,7 +2300,11 @@ export default function CheckersBattleRoyal() {
         console.error('Checkers chairs load failed, using fallback:', error);
         const makeFallback = (z, ry) => {
           const g = createProceduralChairFallback(chairColor, legColor);
-          g.scale.setScalar(CHAIR_VISUAL_SCALE);
+          g.scale.set(
+            CHAIR_VISUAL_SCALE,
+            CHAIR_VISUAL_SCALE * CHAIR_VISUAL_HEIGHT_SCALE,
+            CHAIR_VISUAL_SCALE
+          );
           g.position.set(0, CHAIR_HEIGHT, z);
           g.rotation.y = ry;
           groundGroupToFloor(g, -CHAIR_GROUNDING_EPSILON - CHAIR_GROUND_SINK);
@@ -3003,7 +3012,7 @@ export default function CheckersBattleRoyal() {
       pointerDown.lookDragged = true;
       const look = playerFaceLookRef.current;
       look.yaw = clamp(
-        look.yaw - dx * PLAYER_FACE_CAMERA_LOOK_DRAG_SPEED,
+        look.yaw + dx * PLAYER_FACE_CAMERA_LOOK_DRAG_SPEED,
         -PLAYER_FACE_CAMERA_YAW_LIMIT,
         PLAYER_FACE_CAMERA_YAW_LIMIT
       );


### PR DESCRIPTION
### Motivation
- Improve the Checkers Battle Royal presentation by raising and pulling the player-facing camera for a clearer view, make audience chairs slightly taller so they read better at portrait distances, and fix the horizontal drag mapping so left/right drags move the view in the expected direction.

### Description
- Tuned camera framing constants in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` by changing `PLAYER_FACE_CAMERA_INSET` from `0.22 * CHECKERS_ARENA_SCALE` to `0.12 * CHECKERS_ARENA_SCALE` and `PLAYER_FACE_CAMERA_EYE_HEIGHT` from `1.42 * CHECKERS_ARENA_SCALE` to `1.56 * CHECKERS_ARENA_SCALE` to raise / pull back the face camera.
- Added `CHAIR_VISUAL_HEIGHT_SCALE = 1.06` and applied it to loaded chair models and procedural fallback chairs by replacing `g.scale.setScalar(CHAIR_VISUAL_SCALE)` with `g.scale.set(CHAIR_VISUAL_SCALE, CHAIR_VISUAL_SCALE * CHAIR_VISUAL_HEIGHT_SCALE, CHAIR_VISUAL_SCALE)` so chairs are slightly taller while preserving width/depth scale.
- Reversed horizontal look-drag mapping in pointer handling by changing the yaw update from `look.yaw - dx * PLAYER_FACE_CAMERA_LOOK_DRAG_SPEED` to `look.yaw + dx * PLAYER_FACE_CAMERA_LOOK_DRAG_SPEED` so dragging left/right behaves naturally.
- Kept other layout math intact and only adjusted presentation/interaction constants and chair scaling logic in `CheckersBattleRoyal.jsx`.

### Testing
- Ran `npm --prefix webapp run build` to produce a production build which completed successfully.
- Started the local dev server with `npm --prefix webapp run dev` and confirmed the page served the Checkers Battle Royal route successfully.
- Installed Playwright browsers with `npx playwright install chromium` and installed required system dependencies with `npx playwright install-deps chromium`, both of which completed successfully.
- Executed a headless Playwright page capture against `http://127.0.0.1:5173/games/checkersbattleroyal?ai=1` to validate camera/chair appearance and pointer behavior after the change; the environment required extra deps which were installed and the capture run was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b259cb4ec8329800b17ce2dce5997)