### PR TITLE
Shrink Checkers Battle Royal board setup

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -73,9 +73,9 @@ const clamp01 = (value, fallback = 0) => {
 const smoothEase = (t) => t * t * (3 - 2 * t);
 const CHECKERS_ARENA_BASE_SCALE = 0.48;
 // Requested visual tuning: keep the Checkers Battle Royal table/board setup
-// a bit smaller while preserving layout relationships between the board, table,
+// compact while preserving layout relationships between the board, table,
 // pieces, chairs, and seated humans.
-const CHECKERS_ARENA_SCALE = CHECKERS_ARENA_BASE_SCALE * 0.8;
+const CHECKERS_ARENA_SCALE = CHECKERS_ARENA_BASE_SCALE * 0.68;
 const MODEL_SCALE = 0.75 * CHECKERS_ARENA_SCALE;
 const STOOL_SCALE = 0.92 * CHECKERS_ARENA_SCALE;
 const TABLE_RADIUS = 3.0 * MODEL_SCALE;
@@ -137,9 +137,10 @@ const CHECKERS_TABLE_BASE_HEIGHT_SCALE = 1.22;
 const CHECKERS_TABLE_BASE_RADIUS_SCALE = 1.08;
 const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.94;
 const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.9;
-const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.08;
+const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.3;
 const PLAYER_FACE_CAMERA_SEAT_ANGLE = Math.PI / 2;
-const PLAYER_FACE_CAMERA_RADIUS = TABLE_RADIUS * 0.98;
+const PLAYER_FACE_CAMERA_RADIUS =
+  TABLE_RADIUS * 0.98 * CHECKERS_CAMERA_FRAME_COMPENSATION;
 const PLAYER_FACE_CAMERA_EYE_HEIGHT = 1.68 * CHECKERS_ARENA_SCALE;
 const PLAYER_FACE_CAMERA_TARGET_HEIGHT = 0.18 * CHECKERS_ARENA_SCALE;
 const PLAYER_FACE_CAMERA_YAW_LIMIT = THREE.MathUtils.degToRad(18);
@@ -3824,7 +3825,8 @@ export default function CheckersBattleRoyal() {
     if (viewMode === '2d') {
       camera.position.set(
         0,
-        TABLE_HEIGHT + 9.2 * CHECKERS_ARENA_SCALE,
+        TABLE_HEIGHT +
+          9.2 * CHECKERS_ARENA_SCALE * CHECKERS_CAMERA_FRAME_COMPENSATION,
         0.001
       );
       controls.enableRotate = false;


### PR DESCRIPTION
### Motivation
- Make the Checkers Battle Royal table, board and pieces render more compactly on portrait/mobile screens while preserving layout relationships between board, table, pieces, chairs and seated humans.

### Description
- Reduced the arena scale by changing `CHECKERS_ARENA_SCALE` to a smaller multiplier so `MODEL_SCALE`, `TABLE_RADIUS`, `BOARD_TILE_SIZE` and related sizes shrink proportionally in `webapp/src/pages/Games/CheckersBattleRoyal.jsx`.
- Increased `CHECKERS_CAMERA_FRAME_COMPENSATION` and applied it to `PLAYER_FACE_CAMERA_RADIUS` so the player-facing camera framing scales with the smaller arena.
- Applied the same camera compensation to the 2D top-down camera height to keep the board/table visually smaller in the 2D view.
- Small comment/text tweak to reflect the new compact layout intent.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Launched the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1` and the app served at `http://127.0.0.1:5173/`.
- Installed Playwright browsers and deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) and executed a Playwright smoke screenshot of `/games/checkersbattleroyal?table=local-test&mode=solo`, which produced `/tmp/tonplaygram-screenshots/checkers-battle-royal-compact.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b388a9bb083298f5b0d25933199a8)