### PR TITLE
Domino Royal: enlarge seated human characters and bump script version

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7980,8 +7980,8 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.55;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.55;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 2.95;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.65;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.02;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-18-pass-pick-hand-polish-v45';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-18-larger-seated-humans-v46';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Seated human characters in Domino Royal were too small to read clearly on many viewports, so the visible scale needs increasing for better readability and presence.

### Description
- Increased the global seated character scale by updating `DOMINO_CHARACTER_PROPORTION_SCALE` from `2.55` to `2.95` and the player-seat boost `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` from `0.55` to `0.65` in `webapp/public/domino-royal-game.js` to make humans visibly larger. 
- Updated the Domino Royal public script cache-busting version string to `2026-05-18-larger-seated-humans-v46` in `webapp/src/pages/Games/DominoRoyalArena.jsx` so clients will load the new sizing change.
- Kept existing character theming, offsets and layout logic unchanged so behavior and seating positions remain consistent.

### Testing
- Ran `node --test test/dominoRoyalHdriCatalog.test.js` and it passed. 
- Ran `git diff --check -- webapp/public/domino-royal-game.js webapp/src/pages/Games/DominoRoyalArena.jsx` with no problems. 
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully. 
- Performed a Playwright smoke screenshot against the local Vite dev server which saved a screenshot; the page logged several network fetch warnings (external GLTF/HDRI fetches) but the render completed and the screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b576d13d083298aa99bf887d5d827)