### PR TITLE
Increase Domino Royal seated human character scale

### DIFF
--- a/test/dominoRoyalCharacterScale.test.js
+++ b/test/dominoRoyalCharacterScale.test.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DOMINO_PUBLIC_SCRIPT = path.resolve(__dirname, '../webapp/public/domino-royal-game.js');
+
+function readNumericConstant(source, name) {
+  const match = source.match(new RegExp(`const\\s+${name}\\s*=\\s*([0-9.]+);`));
+  if (!match) throw new Error(`Missing ${name} constant`);
+  return Number(match[1]);
+}
+
+test('Domino Royal seated human characters stay large and readable', () => {
+  const source = fs.readFileSync(DOMINO_PUBLIC_SCRIPT, 'utf8');
+  const baseScale = readNumericConstant(source, 'DOMINO_CHARACTER_PROPORTION_SCALE');
+  const humanBoost = readNumericConstant(source, 'DOMINO_HUMAN_CHARACTER_SCALE_BOOST');
+
+  expect(baseScale).toBeGreaterThanOrEqual(2.9);
+  expect(baseScale + humanBoost).toBeGreaterThanOrEqual(3.7);
+});

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7980,8 +7980,8 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.55;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.55;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 2.9;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.8;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.02;


### PR DESCRIPTION
### Motivation
- Make seated human avatars in Domino Royal larger and more readable around the table by increasing the base and local-human scale factors.

### Description
- Bumped `DOMINO_CHARACTER_PROPORTION_SCALE` from `2.55` to `2.9` and `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` from `0.55` to `0.8` in `webapp/public/domino-royal-game.js` so the computed `seatScale` renders humans larger. 
- Left all positioning and pose logic unchanged so the visual fit and hand placement continue to be computed from the new scale values. 
- Added a Jest regression test `test/dominoRoyalCharacterScale.test.js` that reads the public script and asserts `DOMINO_CHARACTER_PROPORTION_SCALE >= 2.9` and `DOMINO_CHARACTER_PROPORTION_SCALE + DOMINO_HUMAN_CHARACTER_SCALE_BOOST >= 3.7` to prevent future regressions.

### Testing
- Ran the unit test with `npm test -- dominoRoyalCharacterScale.test.js --runInBand`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b576d13d083298aa99bf887d5d827)