### PR TITLE
Increase Domino Battle Royal human character scale

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7981,7 +7981,7 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
   }
 ]);
 const DOMINO_CHARACTER_PROPORTION_SCALE = 2.9;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.8;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 1.1;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.02;


### PR DESCRIPTION
### Motivation
- Make seated human characters in Domino Battle Royal larger and more readable at the table by increasing their rendered scale.

### Description
- Bumped `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` from `0.8` to `1.1` in `webapp/public/domino-royal-game.js` so human avatars render bigger when seated.

### Testing
- Ran `npm test -- dominoRoyalCharacterScale.test.js --runInBand` and the test `Domino Royal seated human characters stay large and readable` passed (1 test, 1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5c29075c832985fe649b5681d549)