### PR TITLE
Fix Pool Royale shot commit power fallback

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -34761,11 +34761,19 @@ const shotPowerRef = useRef(0);
         applyPower(normalized);
       },
       onCommit: (value) => {
-        const normalized = clampPower(value / 100, 0);
-        shotPowerRef.current = normalized;
-        powerRef.current = normalized;
+        const normalizedFromSlider = clampPower(value / 100, 0);
+        const committedPower = clampPower(
+          Math.max(
+            Number.isFinite(normalizedFromSlider) ? normalizedFromSlider : 0,
+            Number.isFinite(shotPowerRef.current) ? shotPowerRef.current : 0,
+            Number.isFinite(powerRef.current) ? powerRef.current : 0
+          ),
+          0
+        );
+        shotPowerRef.current = committedPower;
+        powerRef.current = committedPower;
         slider.animateToMin({ duration: 180 });
-        fireRef.current?.(normalized);
+        fireRef.current?.(committedPower);
         requestAnimationFrame(() => applyPower(0));
       }
     });


### PR DESCRIPTION
### Motivation
- Prevent cases where the power slider `onCommit` event could pass a low or zero value and the cue stick would not transfer the visible pull strength to the cue ball.

### Description
- Update the slider `onCommit` handler in `webapp/src/pages/Games/PoolRoyale.jsx` to compute a robust `committedPower` from the max of the normalized slider value, `shotPowerRef.current`, and `powerRef.current` and clamp it with `clampPower`.
- Assign the resolved `committedPower` to `shotPowerRef.current` and `powerRef.current` and pass it into `fire()` so the applied impulse matches the intended slider power.
- Preserve the existing UI reset flow (`slider.animateToMin` and `applyPower(0)`) and other shot logic.

### Testing
- Ran `git diff` to inspect the patch and `git commit` to persist the change; both commands completed successfully.
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bcca976e48329ab01bac42dc5aa3e)