### PR TITLE
Disable Snooker Royal human character while preserving cue-stick shot behavior

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1678,6 +1678,7 @@ const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear secti
 
 
 const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const ENABLE_SNOOKER_HUMAN_CHARACTER = false;
 
 function enableShadow(obj) {
   obj.traverse((child) => {
@@ -22140,7 +22141,9 @@ const sliderResetTimerRef = useRef(null);
       cueStick.visible = false;
       table.add(cueStick);
       table.add(providedCue.group);
-      const snookerHumanPlayer = createSnookerRoyalHumanPlayer(table, renderer);
+      const snookerHumanPlayer = ENABLE_SNOOKER_HUMAN_CHARACTER
+        ? createSnookerRoyalHumanPlayer(table, renderer)
+        : null;
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
       const closeCueGallery = () => {
@@ -26688,24 +26691,26 @@ const sliderResetTimerRef = useRef(null);
           }
         }
 
-        try {
-          updateSnookerRoyalHumanPlayer(snookerHumanPlayer, deltaSeconds, {
-            cue,
-            cueStick,
-            cueLen,
-            aimDir: showingRemoteAim
-              ? new THREE.Vector2(remoteAimState?.dir?.x ?? 0, remoteAimState?.dir?.y ?? 1)
-              : activeAiPlan?.aimDir || aimDir,
-            visible: cue?.active && !currentHud?.over,
-            power: Math.max(powerRef.current ?? 0, shotVisualPowerRef.current ?? 0, activeAiPlan?.power ?? 0),
-            shooting,
-            cueAnimating
-          });
-        } catch (error) {
-          snookerHumanPlayer.disabled = true;
-          snookerHumanPlayer.root.visible = false;
-          snookerHumanPlayer.modelRoot.visible = false;
-          console.warn('Snooker Royal human player disabled after pose error', error);
+        if (snookerHumanPlayer) {
+          try {
+            updateSnookerRoyalHumanPlayer(snookerHumanPlayer, deltaSeconds, {
+              cue,
+              cueStick,
+              cueLen,
+              aimDir: showingRemoteAim
+                ? new THREE.Vector2(remoteAimState?.dir?.x ?? 0, remoteAimState?.dir?.y ?? 1)
+                : activeAiPlan?.aimDir || aimDir,
+              visible: cue?.active && !currentHud?.over,
+              power: Math.max(powerRef.current ?? 0, shotVisualPowerRef.current ?? 0, activeAiPlan?.power ?? 0),
+              shooting,
+              cueAnimating
+            });
+          } catch (error) {
+            snookerHumanPlayer.disabled = true;
+            snookerHumanPlayer.root.visible = false;
+            snookerHumanPlayer.modelRoot.visible = false;
+            console.warn('Snooker Royal human player disabled after pose error', error);
+          }
         }
 
         if (!shouldSlowAim) {


### PR DESCRIPTION
### Motivation
- Remove the visible human character from the Snooker Royal scene while keeping the existing cue-stick and shot mechanics identical to the provided implementation, including forward cue push and cue-ball contact timing.

### Description
- Introduced a feature flag `ENABLE_SNOOKER_HUMAN_CHARACTER = false` next to the `HUMAN_URL` constant to allow disabling the in-game human actor.
- Gate creation of the human rig so `createSnookerRoyalHumanPlayer` is only called when the flag is enabled, otherwise `snookerHumanPlayer` is `null`.
- Wrapped the per-frame human pose update in a guard so `updateSnookerRoyalHumanPlayer` runs only when the human player exists, preventing any human animation when disabled.
- Left all cue-stick stroke and impact logic unchanged, preserving the forward push animation and exact contact/impact timing used for applying the shot impulse.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bcdde6ae8832995ebb17894489a9e)