### PR TITLE
Keep Murlan character torso stationary during play-card placement

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2753,7 +2753,7 @@ function runCharacterAction(store, rig, action) {
       rightMiddleFinger: { x: THREE.MathUtils.degToRad(7), y: THREE.MathUtils.degToRad(1) }
     };
     const reachToCards = buildPoseVariant(basePose, {
-      spine: { x: THREE.MathUtils.degToRad(-17), z: THREE.MathUtils.degToRad(-1) },
+      spine: { x: 0, z: 0 },
       leftUpperArm: { x: THREE.MathUtils.degToRad(-12), y: THREE.MathUtils.degToRad(7), z: THREE.MathUtils.degToRad(3) },
       leftForeArm: { x: THREE.MathUtils.degToRad(12), y: THREE.MathUtils.degToRad(2) },
       leftHand: { x: THREE.MathUtils.degToRad(5), y: THREE.MathUtils.degToRad(3) },
@@ -2764,7 +2764,7 @@ function runCharacterAction(store, rig, action) {
       ...openFingers
     });
     const pinchPickup = buildPoseVariant(basePose, {
-      spine: { x: THREE.MathUtils.degToRad(-18), z: THREE.MathUtils.degToRad(-1) },
+      spine: { x: 0, z: 0 },
       leftUpperArm: { x: THREE.MathUtils.degToRad(-10), y: THREE.MathUtils.degToRad(6), z: THREE.MathUtils.degToRad(2) },
       leftForeArm: { x: THREE.MathUtils.degToRad(10), y: THREE.MathUtils.degToRad(2) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(-76), y: THREE.MathUtils.degToRad(-21), z: THREE.MathUtils.degToRad(-24) },
@@ -2774,14 +2774,14 @@ function runCharacterAction(store, rig, action) {
       ...pinchFingers
     });
     const controlledCarry = buildPoseVariant(basePose, {
-      spine: { x: THREE.MathUtils.degToRad(-3) },
+      spine: { x: 0, z: 0 },
       rightUpperArm: { x: THREE.MathUtils.degToRad(-16), y: THREE.MathUtils.degToRad(-24), z: THREE.MathUtils.degToRad(-22) },
       rightForeArm: { x: THREE.MathUtils.degToRad(22), y: THREE.MathUtils.degToRad(-2) },
       rightHand: { x: THREE.MathUtils.degToRad(7), y: THREE.MathUtils.degToRad(-15), z: THREE.MathUtils.degToRad(-9) },
       ...pinchFingers
     });
     const hoverAboveTable = buildPoseVariant(basePose, {
-      spine: { x: THREE.MathUtils.degToRad(5), z: THREE.MathUtils.degToRad(1) },
+      spine: { x: 0, z: 0 },
       leftUpperArm: { x: THREE.MathUtils.degToRad(-6), y: THREE.MathUtils.degToRad(5) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(20), y: THREE.MathUtils.degToRad(-25), z: THREE.MathUtils.degToRad(-22) },
       rightForeArm: { x: THREE.MathUtils.degToRad(46), y: THREE.MathUtils.degToRad(-2) },
@@ -2789,14 +2789,14 @@ function runCharacterAction(store, rig, action) {
       ...pinchFingers
     });
     const tableContact = buildPoseVariant(basePose, {
-      spine: { x: THREE.MathUtils.degToRad(9), z: THREE.MathUtils.degToRad(1) },
+      spine: { x: 0, z: 0 },
       rightUpperArm: { x: THREE.MathUtils.degToRad(34), y: THREE.MathUtils.degToRad(-22), z: THREE.MathUtils.degToRad(-19) },
       rightForeArm: { x: THREE.MathUtils.degToRad(58), y: THREE.MathUtils.degToRad(-1) },
       rightHand: { x: THREE.MathUtils.degToRad(10), y: THREE.MathUtils.degToRad(-6), z: THREE.MathUtils.degToRad(-1) },
       ...pinchFingers
     });
     const releaseOnTable = buildPoseVariant(basePose, {
-      spine: { x: THREE.MathUtils.degToRad(7) },
+      spine: { x: 0, z: 0 },
       rightUpperArm: { x: THREE.MathUtils.degToRad(34), y: THREE.MathUtils.degToRad(-20), z: THREE.MathUtils.degToRad(-18) },
       rightForeArm: { x: THREE.MathUtils.degToRad(56) },
       rightHand: { x: THREE.MathUtils.degToRad(15), y: THREE.MathUtils.degToRad(-5) },


### PR DESCRIPTION
### Motivation
- Players requested that when a human character places a card the body should remain still and only the arm/hand moves, removing the torso lean during card placement.

### Description
- Set the `spine` rotation to neutral (`{ x: 0, z: 0 }`) for all `PLAY` action pose variants (`reachToCards`, `pinchPickup`, `controlledCarry`, `hoverAboveTable`, `tableContact`, `releaseOnTable`) inside `runCharacterAction` so the torso no longer leans during placement.
- Preserved all arm/forearm/hand/finger pose values so the pick/carry/release motion remains driven by the limb and finger transforms.
- Modified file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- No automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bcf0d3fa083298a3d0699bc01b846)