### PR TITLE
Preserve committed slider power for Pool Royale shots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -34761,11 +34761,19 @@ const shotPowerRef = useRef(0);
         applyPower(normalized);
       },
       onCommit: (value) => {
-        const normalized = clampPower(value / 100, 0);
+        const sliderPower = Number.isFinite(value)
+          ? clampPower(value / 100, 0)
+          : null;
+        const normalized = sliderPower ?? Math.max(
+          Number.isFinite(shotPowerRef.current) ? shotPowerRef.current : 0,
+          Number.isFinite(powerRef.current) ? powerRef.current : 0
+        );
         shotPowerRef.current = normalized;
         powerRef.current = normalized;
-        slider.animateToMin({ duration: 180 });
+        // Fire first so the shot always uses the committed slider value,
+        // then animate the handle back to zero for the next stroke.
         fireRef.current?.(normalized);
+        slider.animateToMin({ duration: 180 });
         requestAnimationFrame(() => applyPower(0));
       }
     });


### PR DESCRIPTION
### Motivation
- Fix a bug where the cue stick could hit the cue ball with no power after slider release when the slider emitted a non-finite commit value or the slider reset interfered with the shot.

### Description
- Hardened the slider `onCommit` handler in `webapp/src/pages/Games/PoolRoyale.jsx` to compute `normalized` power from the committed value when finite, otherwise fall back to the most recently tracked power (`shotPowerRef.current` / `powerRef.current`).
- Reordered the commit flow so `fireRef.current?.(normalized)` is called before `slider.animateToMin(...)` to ensure the shot uses the committed value.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bcca976e48329ab01bac42dc5aa3e)