### PR TITLE
Align bowling arena floor with HDRI (set CFG.laneY = 0)

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -286,7 +286,7 @@ const RESULT_COMPLIMENTS = {
 } as const;
 
 const CFG = {
-  laneY: -1.0,
+  laneY: 0,
   laneHalfW: 1.36,
   gutterHalfW: 1.72,
   laneCenterOffset: 1.82,


### PR DESCRIPTION
### Motivation
- Bring the bowling lane, ball return, Murlan table area, and seated human anchors onto the same world floor plane as the HDRI environment to remove vertical mismatch caused by the previous Y offset.

### Description
- Change `CFG.laneY` from `-1.0` to `0` in `webapp/src/pages/Games/BowlingRealistic.tsx` so all lane-anchored meshes and human placements inherit the HDRI ground level.

### Testing
- No automated tests were run for this visual/layout tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bdb87dbc88329afa62f6fd6b893c1)