### PR TITLE
Ensure cue impact fires, make stroke forward-only, and clamp power commit from slider

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24795,6 +24795,10 @@ const shotPowerRef = useRef(0);
               syncCueShadow();
               return true;
             }
+            if (!stroke.shotApplied) {
+              stroke.shotApplied = true;
+              stroke.onImpact?.();
+            }
             cueStick.position.copy(idlePos ?? followPos ?? impactPos);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
@@ -28849,7 +28853,7 @@ const shotPowerRef = useRef(0);
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
               strikeImpactThreshold: 0.88,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
-              forwardOnly: false,
+              forwardOnly: true,
               releaseStartsFromCurrentPull: true,
               onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,
@@ -34761,11 +34765,19 @@ const shotPowerRef = useRef(0);
         applyPower(normalized);
       },
       onCommit: (value) => {
-        const normalized = clampPower(value / 100, 0);
-        shotPowerRef.current = normalized;
-        powerRef.current = normalized;
+        const normalizedFromSlider = clampPower(value / 100, 0);
+        const committedPower = clampPower(
+          Math.max(
+            Number.isFinite(normalizedFromSlider) ? normalizedFromSlider : 0,
+            Number.isFinite(shotPowerRef.current) ? shotPowerRef.current : 0,
+            Number.isFinite(powerRef.current) ? powerRef.current : 0
+          ),
+          0
+        );
+        shotPowerRef.current = committedPower;
+        powerRef.current = committedPower;
         slider.animateToMin({ duration: 180 });
-        fireRef.current?.(normalized);
+        fireRef.current?.(committedPower);
         requestAnimationFrame(() => applyPower(0));
       }
     });


### PR DESCRIPTION
### Motivation

- Prevent missed shot impact callbacks and inconsistent power commits from the power slider while keeping cue stroke behavior constrained to forward motion.

### Description

- Ensure `stroke.onImpact` is invoked if it wasn't applied earlier by adding a final guard that sets `stroke.shotApplied = true` and calls `stroke.onImpact?.()` after the recover phase. 
- Change the cue stroke configuration to set `forwardOnly: true` so strokes are constrained to forward-only motion.
- Update the power slider `onCommit` logic to compute a `committedPower` as the maximum of the slider value, `shotPowerRef.current`, and `powerRef.current`, validated with `Number.isFinite`, and use that value for `shotPowerRef`, `powerRef`, and the `fireRef` callback to avoid committing a lower power than the current state.

### Testing

- Ran the existing automated test suite with `yarn test` and observed no regressions and all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bcca976e48329ab01bac42dc5aa3e)