### PR TITLE
Refine Murlan human right-arm card pickup and straightened release motion

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2758,8 +2758,9 @@ function runCharacterAction(store, rig, action) {
       leftForeArm: { x: THREE.MathUtils.degToRad(12), y: THREE.MathUtils.degToRad(2) },
       leftHand: { x: THREE.MathUtils.degToRad(5), y: THREE.MathUtils.degToRad(3) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(-74), y: THREE.MathUtils.degToRad(-20), z: THREE.MathUtils.degToRad(-24) },
-      rightForeArm: { x: THREE.MathUtils.degToRad(-28), y: THREE.MathUtils.degToRad(-4) },
-      rightHand: { x: THREE.MathUtils.degToRad(-11), y: THREE.MathUtils.degToRad(-20), z: THREE.MathUtils.degToRad(-14) },
+      // Keep shoulder/upper-arm mostly fixed; only forearm+hand move inward for pickup.
+      rightForeArm: { x: THREE.MathUtils.degToRad(-20), y: THREE.MathUtils.degToRad(-10), z: THREE.MathUtils.degToRad(-8) },
+      rightHand: { x: THREE.MathUtils.degToRad(-8), y: THREE.MathUtils.degToRad(-24), z: THREE.MathUtils.degToRad(-16) },
       head: { x: THREE.MathUtils.degToRad(-11), y: THREE.MathUtils.degToRad(-2) },
       ...openFingers
     });
@@ -2768,38 +2769,39 @@ function runCharacterAction(store, rig, action) {
       leftUpperArm: { x: THREE.MathUtils.degToRad(-10), y: THREE.MathUtils.degToRad(6), z: THREE.MathUtils.degToRad(2) },
       leftForeArm: { x: THREE.MathUtils.degToRad(10), y: THREE.MathUtils.degToRad(2) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(-76), y: THREE.MathUtils.degToRad(-21), z: THREE.MathUtils.degToRad(-24) },
-      rightForeArm: { x: THREE.MathUtils.degToRad(-31), y: THREE.MathUtils.degToRad(-5) },
-      rightHand: { x: THREE.MathUtils.degToRad(-14), y: THREE.MathUtils.degToRad(-22), z: THREE.MathUtils.degToRad(-16) },
+      rightForeArm: { x: THREE.MathUtils.degToRad(-24), y: THREE.MathUtils.degToRad(-12), z: THREE.MathUtils.degToRad(-9) },
+      rightHand: { x: THREE.MathUtils.degToRad(-10), y: THREE.MathUtils.degToRad(-25), z: THREE.MathUtils.degToRad(-18) },
       head: { x: THREE.MathUtils.degToRad(-12), y: THREE.MathUtils.degToRad(-2) },
       ...pinchFingers
     });
     const controlledCarry = buildPoseVariant(basePose, {
       spine: { x: 0, z: 0 },
       rightUpperArm: { x: THREE.MathUtils.degToRad(-16), y: THREE.MathUtils.degToRad(-24), z: THREE.MathUtils.degToRad(-22) },
-      rightForeArm: { x: THREE.MathUtils.degToRad(22), y: THREE.MathUtils.degToRad(-2) },
-      rightHand: { x: THREE.MathUtils.degToRad(7), y: THREE.MathUtils.degToRad(-15), z: THREE.MathUtils.degToRad(-9) },
+      rightForeArm: { x: THREE.MathUtils.degToRad(10), y: THREE.MathUtils.degToRad(-1), z: THREE.MathUtils.degToRad(-2) },
+      rightHand: { x: THREE.MathUtils.degToRad(4), y: THREE.MathUtils.degToRad(-12), z: THREE.MathUtils.degToRad(-6) },
       ...pinchFingers
     });
     const hoverAboveTable = buildPoseVariant(basePose, {
       spine: { x: 0, z: 0 },
       leftUpperArm: { x: THREE.MathUtils.degToRad(-6), y: THREE.MathUtils.degToRad(5) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(20), y: THREE.MathUtils.degToRad(-25), z: THREE.MathUtils.degToRad(-22) },
-      rightForeArm: { x: THREE.MathUtils.degToRad(46), y: THREE.MathUtils.degToRad(-2) },
-      rightHand: { x: THREE.MathUtils.degToRad(15), y: THREE.MathUtils.degToRad(-10), z: THREE.MathUtils.degToRad(-6) },
+      rightForeArm: { x: THREE.MathUtils.degToRad(8), y: THREE.MathUtils.degToRad(0), z: THREE.MathUtils.degToRad(-1) },
+      rightHand: { x: THREE.MathUtils.degToRad(2), y: THREE.MathUtils.degToRad(-8), z: THREE.MathUtils.degToRad(-4) },
       ...pinchFingers
     });
     const tableContact = buildPoseVariant(basePose, {
       spine: { x: 0, z: 0 },
       rightUpperArm: { x: THREE.MathUtils.degToRad(34), y: THREE.MathUtils.degToRad(-22), z: THREE.MathUtils.degToRad(-19) },
-      rightForeArm: { x: THREE.MathUtils.degToRad(58), y: THREE.MathUtils.degToRad(-1) },
-      rightHand: { x: THREE.MathUtils.degToRad(10), y: THREE.MathUtils.degToRad(-6), z: THREE.MathUtils.degToRad(-1) },
+      rightForeArm: { x: THREE.MathUtils.degToRad(2), y: THREE.MathUtils.degToRad(0), z: THREE.MathUtils.degToRad(0) },
+      rightHand: { x: THREE.MathUtils.degToRad(0), y: THREE.MathUtils.degToRad(-3), z: THREE.MathUtils.degToRad(0) },
       ...pinchFingers
     });
     const releaseOnTable = buildPoseVariant(basePose, {
       spine: { x: 0, z: 0 },
       rightUpperArm: { x: THREE.MathUtils.degToRad(34), y: THREE.MathUtils.degToRad(-20), z: THREE.MathUtils.degToRad(-18) },
-      rightForeArm: { x: THREE.MathUtils.degToRad(56) },
-      rightHand: { x: THREE.MathUtils.degToRad(15), y: THREE.MathUtils.degToRad(-5) },
+      // Straightened release: arm extends and card is let go with minimal wrist bend.
+      rightForeArm: { x: THREE.MathUtils.degToRad(0), y: THREE.MathUtils.degToRad(0), z: THREE.MathUtils.degToRad(0) },
+      rightHand: { x: THREE.MathUtils.degToRad(-2), y: THREE.MathUtils.degToRad(-2), z: THREE.MathUtils.degToRad(0) },
       ...releaseFingers
     });
 


### PR DESCRIPTION
### Motivation
- Improve the Murlan Royale seated human character animation so the shoulder/upper-arm remains stable and only the elbow-to-hand (forearm + hand) moves inward for picking up cards, and so the placing/release uses a straighter extended arm with minimal wrist bend for a more natural look.

### Description
- Tweak PLAY action pose targets in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (variants: `reachToCards`, `pinchPickup`, `controlledCarry`, `hoverAboveTable`, `tableContact`, `releaseOnTable`) to reduce shoulder motion and drive pickup with the right forearm and hand. 
- Adjusted numeric rotation targets for `rightForeArm` and `rightHand` across the pickup, carry, hover, contact and release phases and added clarifying comments for the straightened release.
- Kept the overall animation flow and timing intact while making the right-arm motion less exaggerated and the release straighter.

### Testing
- No automated tests were run for this animation tuning change because it is a visual/pose adjustment and there are no existing animation unit tests in the repo. 
- The change was committed successfully to the working branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bdfdd2aa48329ad0b8ff6cb8e44eb)