### PR TITLE
Tune Murlan right-arm pick and place animation

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8629,14 +8629,14 @@ function runDominoCharacterAction(seatIndex, type = 'PLAY') {
       z: THREE.MathUtils.degToRad(-17)
     },
     rightForeArm: {
-      x: THREE.MathUtils.degToRad(-48),
-      y: THREE.MathUtils.degToRad(11) + inwardElbowYaw,
-      z: THREE.MathUtils.degToRad(-3)
+      x: THREE.MathUtils.degToRad(-46),
+      y: THREE.MathUtils.degToRad(16) + inwardElbowYaw,
+      z: THREE.MathUtils.degToRad(-2)
     },
     rightHand: {
-      x: THREE.MathUtils.degToRad(-24),
-      y: THREE.MathUtils.degToRad(-18),
-      z: THREE.MathUtils.degToRad(-12)
+      x: THREE.MathUtils.degToRad(-21),
+      y: THREE.MathUtils.degToRad(-13),
+      z: THREE.MathUtils.degToRad(-8)
     },
     rightThumb: { x: playFingerOpen, y: THREE.MathUtils.degToRad(15), z: THREE.MathUtils.degToRad(12) },
     rightIndex: { x: playFingerOpen, y: THREE.MathUtils.degToRad(-13), z: THREE.MathUtils.degToRad(-6) },
@@ -8651,14 +8651,14 @@ function runDominoCharacterAction(seatIndex, type = 'PLAY') {
       z: THREE.MathUtils.degToRad(-18)
     },
     rightForeArm: {
-      x: THREE.MathUtils.degToRad(-38),
-      y: THREE.MathUtils.degToRad(12) + inwardElbowYaw,
-      z: THREE.MathUtils.degToRad(-4)
+      x: THREE.MathUtils.degToRad(-36),
+      y: THREE.MathUtils.degToRad(18) + inwardElbowYaw,
+      z: THREE.MathUtils.degToRad(-3)
     },
     rightHand: {
-      x: THREE.MathUtils.degToRad(-30),
-      y: THREE.MathUtils.degToRad(-19),
-      z: THREE.MathUtils.degToRad(-13)
+      x: THREE.MathUtils.degToRad(-26),
+      y: THREE.MathUtils.degToRad(-13),
+      z: THREE.MathUtils.degToRad(-9)
     },
     rightThumb: { x: THREE.MathUtils.degToRad(-4), y: THREE.MathUtils.degToRad(18), z: THREE.MathUtils.degToRad(14) },
     rightIndex: { x: THREE.MathUtils.degToRad(6), y: THREE.MathUtils.degToRad(-16), z: THREE.MathUtils.degToRad(-7) },
@@ -8689,6 +8689,17 @@ function runDominoCharacterAction(seatIndex, type = 'PLAY') {
     head: { x: THREE.MathUtils.degToRad(5) }
   });
   const release = makeDominoPose(carry, {
+    rightUpperArm: {
+      x: THREE.MathUtils.degToRad(92),
+      y: THREE.MathUtils.degToRad(-1) + inwardReachYaw * 0.38,
+      z: THREE.MathUtils.degToRad(2)
+    },
+    rightForeArm: {
+      x: THREE.MathUtils.degToRad(24),
+      y: THREE.MathUtils.degToRad(-3) + inwardElbowYaw * 0.2,
+      z: THREE.MathUtils.degToRad(0)
+    },
+    rightHand: { x: THREE.MathUtils.degToRad(4), y: THREE.MathUtils.degToRad(3), z: THREE.MathUtils.degToRad(1) },
     rightThumb: { x: THREE.MathUtils.degToRad(6), y: THREE.MathUtils.degToRad(-10), z: THREE.MathUtils.degToRad(-9) },
     rightIndex: { x: THREE.MathUtils.degToRad(-14), y: THREE.MathUtils.degToRad(9), z: THREE.MathUtils.degToRad(4) },
     rightMiddle: { x: THREE.MathUtils.degToRad(-9), y: THREE.MathUtils.degToRad(4), z: THREE.MathUtils.degToRad(2) }


### PR DESCRIPTION
### Motivation
- Make the Murlan Domino Royale human-character pick/place motion look more natural by keeping the overall arm posture stable while moving primarily the right forearm and hand for pick-up, and extending the right arm straighter for placement and release.

### Description
- Adjusted pose data in `webapp/public/domino-royal-game.js` for the pick sequence by tuning the `approach` forearm/hand Euler angles to move the elbow-to-hand inward with minimal whole-arm change.
- Tuned the `hover`/`pinch` poses so the hand/forearm motion is subtler and focused on fingers/forearm rather than the upper arm.
- Added a more extended `release` pose that straightens the right upper arm and forearm before releasing fingers to match a stretch-and-let-go placement.
- Changes are localized to the `runDominoCharacterAction` animation poses (about ~23 insertions / 12 deletions in the single modified file).

### Testing
- No automated tests were run for this animation tuning change.
- Change was validated by code inspection and basic repository commands (`git diff`, `git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bdfdd2aa48329ad0b8ff6cb8e44eb)