### PR TITLE
Lower bowling lane elevation to match HDRI floor

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -286,7 +286,7 @@ const RESULT_COMPLIMENTS = {
 } as const;
 
 const CFG = {
-  laneY: -1.0,
+  laneY: -1.22,
   laneHalfW: 1.36,
   gutterHalfW: 1.72,
   laneCenterOffset: 1.82,


### PR DESCRIPTION
### Motivation
- Align the bowling lane, ball-return mechanism, seating tables, and human rigs with the HDRI floor by lowering the shared scene baseline so all major props remain vertically consistent.

### Description
- Change `CFG.laneY` from `-1.0` to `-1.22` in `webapp/src/pages/Games/BowlingRealistic.tsx`, which shifts the lane floor, return assembly, tables, and character rigs downward together.

### Testing
- Ran `npm test -- bowlingTenPinRules.test.js --runInBand` and the bowling ten-pin rules test suite passed (6 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bdb87dbc88329afa62f6fd6b893c1)