### PR TITLE
Animate cue-forward strike on power release and add `onShotRelease` callback

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -10,6 +10,7 @@ export class PowerSlider {
       onChange,
       onStart,
       onCommit,
+      onShotRelease,
       theme = 'default',
       labels = false
     } = opts;
@@ -23,8 +24,10 @@ export class PowerSlider {
     this.onChange = onChange;
     this.onStart = onStart;
     this.onCommit = onCommit;
+    this.onShotRelease = onShotRelease;
     this.locked = false;
     this._returnAnimFrame = null;
+    this._shotAnimFrame = null;
 
     this.el = document.createElement('div');
     this.el.className = `ps ps-theme-${theme}`;
@@ -239,6 +242,7 @@ export class PowerSlider {
     if (this.locked) return;
     e.preventDefault();
     this._cancelReturnAnimation();
+    this._cancelShotAnimation();
     this.dragging = true;
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
@@ -267,6 +271,7 @@ export class PowerSlider {
     this.el.removeEventListener('pointercancel', this._onPointerUp);
     this.el.classList.remove('ps-no-animate');
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
+    this._playShotAnimation(this.value);
   }
 
   _wheel(e) {
@@ -302,6 +307,39 @@ export class PowerSlider {
         if (typeof this.onStart === 'function') this.onStart(this.value);
       }
       e.preventDefault();
+    }
+  }
+
+  _playShotAnimation(powerValue) {
+    this._cancelShotAnimation();
+    const power = this._clamp(this._step(powerValue));
+    const pullDuration = 90;
+    const resetDuration = 150;
+    const strikeOvershoot = Math.max(this.min + (this.max - this.min) * 0.14, this.min + 1);
+
+    this.animateTo(strikeOvershoot, { duration: pullDuration });
+
+    const startedAt = performance.now();
+    const step = (now) => {
+      const t = Math.min(1, Math.max(0, (now - startedAt) / resetDuration));
+      const eased = 1 - Math.pow(1 - t, 3);
+      const next = strikeOvershoot + (this.min - strikeOvershoot) * eased;
+      this.set(next, { animate: true });
+      if (t >= 1) {
+        this._shotAnimFrame = null;
+        if (typeof this.onShotRelease === 'function') this.onShotRelease(power);
+        return;
+      }
+      this._shotAnimFrame = requestAnimationFrame(step);
+    };
+
+    this._shotAnimFrame = requestAnimationFrame(step);
+  }
+
+  _cancelShotAnimation() {
+    if (this._shotAnimFrame != null) {
+      cancelAnimationFrame(this._shotAnimFrame);
+      this._shotAnimFrame = null;
     }
   }
 

--- a/webapp/public/power-slider.js
+++ b/webapp/public/power-slider.js
@@ -9,6 +9,7 @@ export class PowerSlider {
       cueSrc = '',
       onChange,
       onCommit,
+      onShotRelease,
       onStart,
       theme = 'default',
       labels = false
@@ -21,9 +22,11 @@ export class PowerSlider {
     this.step = step;
     this.onChange = onChange;
     this.onCommit = onCommit;
+    this.onShotRelease = onShotRelease;
     this.onStart = onStart;
     this.locked = false;
     this._returnAnimFrame = null;
+    this._shotAnimFrame = null;
 
     this.el = document.createElement('div');
     this.el.className = `ps ps-theme-${theme}`;
@@ -251,6 +254,7 @@ export class PowerSlider {
     if (this.locked) return;
     e.preventDefault();
     this._cancelReturnAnimation();
+    this._cancelShotAnimation();
     this.dragging = true;
     if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.classList.add('ps-no-animate');
@@ -273,6 +277,7 @@ export class PowerSlider {
     this.el.removeEventListener('pointerup', this._onPointerUp);
     this.el.classList.remove('ps-no-animate');
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
+    this._playShotAnimation(this.value);
   }
 
   _wheel(e) {
@@ -308,6 +313,39 @@ export class PowerSlider {
         if (typeof this.onStart === 'function') this.onStart(this.value);
       }
       e.preventDefault();
+    }
+  }
+
+  _playShotAnimation(powerValue) {
+    this._cancelShotAnimation();
+    const power = this._clamp(this._step(powerValue));
+    const pullDuration = 90;
+    const resetDuration = 150;
+    const strikeOvershoot = Math.max(this.min + (this.max - this.min) * 0.14, this.min + 1);
+
+    this.animateTo(strikeOvershoot, { duration: pullDuration });
+
+    const startedAt = performance.now();
+    const step = (now) => {
+      const t = Math.min(1, Math.max(0, (now - startedAt) / resetDuration));
+      const eased = 1 - Math.pow(1 - t, 3);
+      const next = strikeOvershoot + (this.min - strikeOvershoot) * eased;
+      this.set(next, { animate: true });
+      if (t >= 1) {
+        this._shotAnimFrame = null;
+        if (typeof this.onShotRelease === 'function') this.onShotRelease(power);
+        return;
+      }
+      this._shotAnimFrame = requestAnimationFrame(step);
+    };
+
+    this._shotAnimFrame = requestAnimationFrame(step);
+  }
+
+  _cancelShotAnimation() {
+    if (this._shotAnimFrame != null) {
+      cancelAnimationFrame(this._shotAnimFrame);
+      this._shotAnimFrame = null;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Implement a physical cue behavior so when the pull slider is released the cue pushes forward to strike the cue ball rather than visually remaining pulled back. 
- Preserve existing cue art/design and keep the same snooker/pool UX while exposing the selected shot power to game logic. 

### Description
- Add an optional `onShotRelease` option to the `PowerSlider` constructor and store it as `this.onShotRelease`. 
- Introduce internal state `this._shotAnimFrame` and two new methods ` _playShotAnimation (powerValue)` and ` _cancelShotAnimation ()` to drive a short forward-strike + return animation and safely cancel it. 
- Trigger the shot animation on pointer release (after `onCommit`) and call `onShotRelease(power)` when the forward strike completes so the game can apply an impulse using the committed slider power. 
- Mirror the same changes in `webapp/public/power-slider.js` so runtime/public assets remain consistent. 

### Testing
- Ran `node --check power-slider.js` which succeeded. 
- Ran `node --check webapp/public/power-slider.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be674e9f8832983f6ebecf1970e07)