### PR TITLE
Refactor snooker power slider: initialize to 0, simplify handlers and remove reset timer

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -27775,7 +27775,7 @@ const sliderResetTimerRef = useRef(null);
   }, [isPortrait, uiScale]);
 
   // --------------------------------------------------
-  // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
+  // Power slider (SnookerRoyalProvided behavior)
   // --------------------------------------------------
   const sliderRef = useRef(null);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
@@ -27785,19 +27785,23 @@ const sliderResetTimerRef = useRef(null);
     }
     const mount = sliderRef.current;
     if (!mount) return undefined;
+    mount.innerHTML = '';
     const slider = new PoolRoyalePowerSlider({
       mount,
-      value: powerRef.current * 100,
+      value: 0,
+      min: 0,
+      max: 100,
+      step: 1,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
-      onChange: (v) => applyPower(v / 100),
       onStart: () => {
         sliderDraggingRef.current = true;
-        if (sliderResetTimerRef.current) {
-          clearTimeout(sliderResetTimerRef.current);
-          sliderResetTimerRef.current = null;
-        }
-        captureCueStickAnchor();
+        setShotActive(false);
+      },
+      onChange: (value) => {
+        const normalized = THREE.MathUtils.clamp(value / 100, 0, 1);
+        applyPower(normalized);
+        if (sliderDraggingRef.current) committedShotPowerRef.current = normalized;
       },
       onCommit: (value) => {
         const normalized = THREE.MathUtils.clamp(value / 100, 0, 1);
@@ -27809,18 +27813,6 @@ const sliderResetTimerRef = useRef(null);
           fireRef.current?.(normalized);
         }
         slider.animateToMin({ duration: 180 });
-        if (sliderResetTimerRef.current) {
-          clearTimeout(sliderResetTimerRef.current);
-          sliderResetTimerRef.current = null;
-        }
-        const resetDelay = normalized > 0.02
-          ? CUE_LOGIC_STRIKE_TIME_MS + CUE_LOGIC_HOLD_TIME_MS + 180
-          : 180;
-        sliderResetTimerRef.current = window.setTimeout(() => {
-          sliderResetTimerRef.current = null;
-          committedShotPowerRef.current = 0;
-          applyPower(0);
-        }, resetDelay);
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Standardize the Snooker power slider behavior by replacing the previous custom "big pull" behavior and removing fragile reset-timer and capture logic so power is always applied from a clean initial state.
- Ensure power values are normalized and consistently applied during drag and commit events to avoid out-of-range values and stale state.

### Description
- Clear the slider mount with `mount.innerHTML = ''` and initialize the slider with `value: 0` plus `min: 0`, `max: 100`, and `step: 1`.
- Replace the old `onStart` logic with a simple `setShotActive(false)` and remove uses of the slider reset timer and `captureCueStickAnchor` cleanup.
- Change `onChange` to compute a normalized power via `THREE.MathUtils.clamp(value / 100, 0, 1)`, call `applyPower(normalized)`, and update `committedShotPowerRef` while dragging.
- Simplify `onCommit` to normalize the value, update refs/flags (`sliderDraggingRef`, `committedShotPowerRef`, `shotVisualPowerRef`), call `applyPower(normalized)`, invoke `fireRef.current(normalized)` when above threshold, and animate the slider back to minimum; all previous timeout/reset-timer logic was removed.

### Testing
- Ran the automated unit test suite with `yarn test`, which passed.
- Ran the frontend build with `yarn build`, which completed successfully.
- Ran component/UI tests (snapshot and interaction tests) for the slider area, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bed44a76c8329aa36060adb2202a3)