### PR TITLE
Fix Pool Royal cue release so slider pull reliably produces forward strike

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -149,23 +149,31 @@ namespace Aiming
 
             if (_shotState == ShotState.Dragging)
             {
-                float pull = PullDistanceFromPower(_power);
-                _chargedCueDepth = idleTipGap + pull;
-                _currentCueDepth = _chargedCueDepth;
-                UpdateCuePose();
-
                 bool sliderDroppedToRelease = _previousSliderPower > threshold && _power <= threshold;
                 if (sliderDroppedToRelease)
                 {
-                    if (HasValidReleaseGesture(_chargedCueDepth - idleTipGap))
+                    float releasePullDistance = Mathf.Max(
+                        Mathf.Max(0f, _chargedCueDepth - idleTipGap),
+                        Mathf.Max(0f, _currentCueDepth - idleTipGap)
+                    );
+                    if (HasValidReleaseGesture(releasePullDistance))
                     {
+                        _latchedPullDistance = releasePullDistance;
                         ReleaseAndStrike();
                     }
                     else
                     {
                         CancelCharge();
                     }
+
+                    _previousSliderPower = nextPower;
+                    return;
                 }
+
+                float pull = PullDistanceFromPower(_power);
+                _chargedCueDepth = idleTipGap + pull;
+                _currentCueDepth = _chargedCueDepth;
+                UpdateCuePose();
             }
 
             _previousSliderPower = nextPower;

--- a/Assets/Tests/PlayMode/CueControllerShotReleaseTests.cs
+++ b/Assets/Tests/PlayMode/CueControllerShotReleaseTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Aiming.Tests
+{
+    public class CueControllerShotReleaseTests
+    {
+        [Test]
+        public void SliderDropFromChargedState_TriggersStrikeImpulse()
+        {
+            var root = new GameObject("CueControllerRoot");
+            var controller = root.AddComponent<CueController>();
+
+            var cueBallGo = new GameObject("CueBall");
+            var objectBallGo = new GameObject("ObjectBall");
+            var pocketGo = new GameObject("Pocket");
+            var cueBallBody = cueBallGo.AddComponent<Rigidbody>();
+            cueBallBody.useGravity = false;
+
+            controller.cueBall = cueBallGo.transform;
+            controller.objectBall = objectBallGo.transform;
+            controller.pocket = pocketGo.transform;
+            controller.cueBallBody = cueBallBody;
+            controller.aiming = new AdaptiveAimingEngine();
+            controller.pullRange = 0.34f;
+            controller.idleTipGap = 0.01f;
+            controller.minStrikeImpulse = 0.25f;
+            controller.maxStrikeImpulse = 6.5f;
+            controller.minimumShotPowerNormalized = 0.06f;
+            controller.releaseTriggerThresholdNormalized = 0.02f;
+
+            controller.BeginCharge();
+            controller.SetChargePower(0.9f);
+            controller.SetChargePower(0f);
+
+            Assert.AreEqual(CueController.ShotState.Striking, controller.CurrentShotState);
+
+            Object.DestroyImmediate(root);
+            Object.DestroyImmediate(cueBallGo);
+            Object.DestroyImmediate(objectBallGo);
+            Object.DestroyImmediate(pocketGo);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- The cue release flow could cancel valid slider-driven shots because the charged cue depth was updated from the new (low/zero) slider value before release validation, losing the pulled-back distance used to compute shot power and preventing the cue from pushing forward and imparting impulse to the cue ball.
- The change ensures slider drop-to-release produces a forward push from the cue stick that matches the power set by the slider and allows shoots to occur when expected.

### Description
- Reordered `CueController.SetChargePower` so the slider "dropped-to-release" case is evaluated before updating `_chargedCueDepth` from the incoming slider value, preserving the true pull distance at release. 
- Compute `releasePullDistance` as the max of `_chargedCueDepth - idleTipGap` and `_currentCueDepth - idleTipGap`, latch it into `_latchedPullDistance`, and call `ReleaseAndStrike()` when the release gesture is valid to transition immediately into `Striking` with the correct context. 
- Avoid overwriting the latched pull by returning early after handling a slider-drop release, and keep the existing depth update for non-release slider updates. 
- Added a new PlayMode NUnit test `Assets/Tests/PlayMode/CueControllerShotReleaseTests.cs` that simulates a charged slider release and asserts the controller enters `ShotState.Striking`.

### Testing
- Added the automated PlayMode test `CueControllerShotReleaseTests` to cover the slider-charged release path (test file committed but not executed in this environment). 
- Attempted to run the test assembly with `dotnet test billiards.Tests/Billiards.Tests.csproj` but the run failed due to `dotnet` not being installed in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf24e7bf48329af448d6bb00cb23d)