### PR TITLE
Restore Murlan Royale play-card spine/torso poses

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2753,7 +2753,7 @@ function runCharacterAction(store, rig, action) {
       rightMiddleFinger: { x: THREE.MathUtils.degToRad(7), y: THREE.MathUtils.degToRad(1) }
     };
     const reachToCards = buildPoseVariant(basePose, {
-      spine: { x: 0, z: 0 },
+      spine: { x: THREE.MathUtils.degToRad(-17), z: THREE.MathUtils.degToRad(-1) },
       leftUpperArm: { x: THREE.MathUtils.degToRad(-12), y: THREE.MathUtils.degToRad(7), z: THREE.MathUtils.degToRad(3) },
       leftForeArm: { x: THREE.MathUtils.degToRad(12), y: THREE.MathUtils.degToRad(2) },
       leftHand: { x: THREE.MathUtils.degToRad(5), y: THREE.MathUtils.degToRad(3) },
@@ -2764,7 +2764,7 @@ function runCharacterAction(store, rig, action) {
       ...openFingers
     });
     const pinchPickup = buildPoseVariant(basePose, {
-      spine: { x: 0, z: 0 },
+      spine: { x: THREE.MathUtils.degToRad(-18), z: THREE.MathUtils.degToRad(-1) },
       leftUpperArm: { x: THREE.MathUtils.degToRad(-10), y: THREE.MathUtils.degToRad(6), z: THREE.MathUtils.degToRad(2) },
       leftForeArm: { x: THREE.MathUtils.degToRad(10), y: THREE.MathUtils.degToRad(2) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(-76), y: THREE.MathUtils.degToRad(-21), z: THREE.MathUtils.degToRad(-24) },
@@ -2774,14 +2774,14 @@ function runCharacterAction(store, rig, action) {
       ...pinchFingers
     });
     const controlledCarry = buildPoseVariant(basePose, {
-      spine: { x: 0, z: 0 },
+      spine: { x: THREE.MathUtils.degToRad(-3) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(-16), y: THREE.MathUtils.degToRad(-24), z: THREE.MathUtils.degToRad(-22) },
       rightForeArm: { x: THREE.MathUtils.degToRad(22), y: THREE.MathUtils.degToRad(-2) },
       rightHand: { x: THREE.MathUtils.degToRad(7), y: THREE.MathUtils.degToRad(-15), z: THREE.MathUtils.degToRad(-9) },
       ...pinchFingers
     });
     const hoverAboveTable = buildPoseVariant(basePose, {
-      spine: { x: 0, z: 0 },
+      spine: { x: THREE.MathUtils.degToRad(5), z: THREE.MathUtils.degToRad(1) },
       leftUpperArm: { x: THREE.MathUtils.degToRad(-6), y: THREE.MathUtils.degToRad(5) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(20), y: THREE.MathUtils.degToRad(-25), z: THREE.MathUtils.degToRad(-22) },
       rightForeArm: { x: THREE.MathUtils.degToRad(46), y: THREE.MathUtils.degToRad(-2) },
@@ -2789,14 +2789,14 @@ function runCharacterAction(store, rig, action) {
       ...pinchFingers
     });
     const tableContact = buildPoseVariant(basePose, {
-      spine: { x: 0, z: 0 },
+      spine: { x: THREE.MathUtils.degToRad(9), z: THREE.MathUtils.degToRad(1) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(34), y: THREE.MathUtils.degToRad(-22), z: THREE.MathUtils.degToRad(-19) },
       rightForeArm: { x: THREE.MathUtils.degToRad(58), y: THREE.MathUtils.degToRad(-1) },
       rightHand: { x: THREE.MathUtils.degToRad(10), y: THREE.MathUtils.degToRad(-6), z: THREE.MathUtils.degToRad(-1) },
       ...pinchFingers
     });
     const releaseOnTable = buildPoseVariant(basePose, {
-      spine: { x: 0, z: 0 },
+      spine: { x: THREE.MathUtils.degToRad(7) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(34), y: THREE.MathUtils.degToRad(-20), z: THREE.MathUtils.degToRad(-18) },
       rightForeArm: { x: THREE.MathUtils.degToRad(56) },
       rightHand: { x: THREE.MathUtils.degToRad(15), y: THREE.MathUtils.degToRad(-5) },


### PR DESCRIPTION
### Motivation
- Restore Domino/Murlan play-card animation behavior to the pre-5:00am baseline by undoing recent spine/torso pose adjustments. 
- Ensure the Murlan Royale seated-character posture during card play matches the earlier morning experience for consistent gameplay and visuals.

### Description
- Reverted spine/torso pose values in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` for the `PLAY` action pose variants `reachToCards`, `pinchPickup`, `controlledCarry`, `hoverAboveTable`, `tableContact`, and `releaseOnTable`. 
- Re-applied the earlier Euler rotations using `THREE.MathUtils.degToRad(...)` for the `spine` entries so the seated torso angles match the previous baseline. 
- Change is limited to numeric pose deltas in that single file and does not alter other game logic or assets.

### Testing
- No automated runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c03cb0a30832996e2a78b70e53a6c)