### PR TITLE
Adjust Checkers bottom avatar position and chair sizing

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -323,7 +323,7 @@ const CHAIR_GROUND_SINK = 0.44;
 // additional breathing room around the smaller board.
 const CHAIR_VISUAL_SCALE = 0.9;
 const CHAIR_VISUAL_HEIGHT_SCALE = 0.93;
-const CHAIR_NON_POLYHAVEN_SIDE_SCALE = 0.6;
+const CHAIR_NON_POLYHAVEN_SIDE_SCALE = 1;
 const CHAIR_TARGET_SCALE_FACTOR = 0.72;
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
   1.3162499970197679 * CHAIR_TARGET_SCALE_FACTOR,
@@ -432,7 +432,7 @@ const CHECKERS_CHIP_SET_BY_ID = Object.freeze({
 
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '18%' },
-  { left: '50%', top: '82%' }
+  { left: '50%', top: '88%' }
 ];
 const RULE_SUMMARY =
   'Forced captures are ON. Chain captures are mandatory. Reach the far rank to crown a king.';


### PR DESCRIPTION
### Motivation
- Align the bottom player's avatar closer to the bottom of the screen and make non-PolyHaven chairs visually match the PolyHaven chair sizing for a more consistent arena presentation.

### Description
- In `webapp/src/pages/Games/CheckersBattleRoyal.jsx` set `CHAIR_NON_POLYHAVEN_SIDE_SCALE` from `0.6` to `1` and changed the fallback bottom seat `top` value from `82%` to `88%` to move the local avatar lower on the page.

### Testing
- No automated tests were run for this visual-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c04f25a5c832987f30cf7b08cda72)