### PR TITLE
Bowling: lower field, extend lanes, and use wood side panels

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -287,7 +287,7 @@ const RESULT_COMPLIMENTS = {
 } as const;
 
 const CFG = {
-  laneY: -1.5,
+  laneY: -1.9,
   laneHalfW: 1.36,
   gutterHalfW: 1.72,
   laneCenterOffset: 1.82,
@@ -2318,11 +2318,6 @@ function createEnvironment(
     roughness: 0.9,
     metalness: 0.01
   });
-  const sideFloorMat = new THREE.MeshStandardMaterial({
-    color: 0x171417,
-    roughness: 0.78,
-    metalness: 0.02
-  });
   const rubberMat = new THREE.MeshStandardMaterial({
     color: 0x05070a,
     roughness: 0.86,
@@ -2341,13 +2336,22 @@ function createEnvironment(
     toneMapped: false
   });
 
-  const sideFloor = new THREE.Mesh(
-    new THREE.PlaneGeometry(8.4, 27.8),
-    sideFloorMat
-  );
-  sideFloor.rotation.x = -Math.PI / 2;
-  sideFloor.position.set(0, CFG.laneY - 0.024, -3.72);
-  group.add(sideFloor);
+  const sidePanelMat =
+    (woodMat as THREE.Material).clone?.() || (woodMat as THREE.Material);
+  const sidePanelLength = 34.2;
+  const sidePanelWidth = 1.95;
+  const sidePanelZ = -6.2;
+  const sidePanelX =
+    CFG.laneCenterOffset + CFG.gutterHalfW + sidePanelWidth * 0.5 + 0.05;
+  for (const side of [-1, 1]) {
+    const sideFloor = new THREE.Mesh(
+      new THREE.PlaneGeometry(sidePanelWidth, sidePanelLength),
+      sidePanelMat
+    );
+    sideFloor.rotation.x = -Math.PI / 2;
+    sideFloor.position.set(side * sidePanelX, CFG.laneY - 0.024, sidePanelZ);
+    group.add(sideFloor);
+  }
   const loungeCarpet = new THREE.Mesh(
     new THREE.PlaneGeometry(3.8, 4.95),
     carpetMat
@@ -2414,11 +2418,11 @@ function createEnvironment(
 
   for (const [laneIndex, laneCenter] of LANE_CENTERS.entries()) {
     const lane = new THREE.Mesh(
-      new THREE.PlaneGeometry(CFG.laneHalfW * 2, 28.8, 72, 420),
+      new THREE.PlaneGeometry(CFG.laneHalfW * 2, 34.2, 72, 500),
       laneMat
     );
     lane.rotation.x = -Math.PI / 2;
-    lane.position.set(laneCenter, CFG.laneY, -7.2);
+    lane.position.set(laneCenter, CFG.laneY, -9.9);
     lane.receiveShadow = true;
     group.add(lane);
 


### PR DESCRIPTION
### Motivation
- Make the bowling field feel more grounded by lowering the entire field geometry. 
- Make the brown side floor panels visually match the table/approach wood finish. 
- Increase visible runout so the lanes appear longer down-lane while keeping the pin area aligned.

### Description
- Move the shared lane baseline by changing `CFG.laneY` from `-1.5` to `-1.9` to lower the whole field and attached props (`webapp/src/pages/Games/BowlingRealistic.tsx`).
- Replace the single dark side slab with two left/right side panels that reuse the table/approach wood material via `(woodMat as THREE.Material).clone?.()` and configurable `sidePanelLength`/`sidePanelWidth`/positions. 
- Extend each lane plane depth by changing the lane `PlaneGeometry` height from `28.8` to `34.2` and shift lane placement from `z = -7.2` to `z = -9.9` to increase down-lane length; increased geometry segments to preserve detail. 
- Remove the previous `sideFloorMat` and wire the side panels into the existing `woodMat` finish logic.

### Testing
- Ran `git diff -- webapp/src/pages/Games/BowlingRealistic.tsx` to verify the source changes, which succeeded. 
- Committed the change with `git commit -m "Adjust bowling lane layout, side floor texture, and vertical placement"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0db9571c8329ba737270d81200de)