### PR TITLE
Restore Domino Battle Royal game state to May 18 18:00 UTC

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7980,8 +7980,8 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.9;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 1.1;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 2.55;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.55;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.02;


### PR DESCRIPTION
### Motivation
- Revert unintended Domino-only character scale changes by restoring the Domino Battle Royal runtime constants to the repository state from before 2026-05-18 18:00 UTC.

### Description
- Reset `DOMINO_CHARACTER_PROPORTION_SCALE` from `2.9` to `2.55` and `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` from `1.1` to `0.55` in `webapp/public/domino-royal-game.js`.

### Testing
- Verified the change and repository state using `git status --short` and `git show --stat -- webapp/public/domino-royal-game.js`, and created the PR; the commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0e286e8c83299b805bbd80bdae65)