### PR TITLE
Restore Domino Battle Royal hand position to yesterday 5pm setup

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7980,8 +7980,8 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.55;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.55;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 2.9;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.8;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.02;


### PR DESCRIPTION
### Motivation
- Restore seated human characters sizing so their hand placement matches the prior (yesterday 17:00) Domino Battle Royal arrangement.

### Description
- Updated `webapp/public/domino-royal-game.js` constants to adjust character sizing: `DOMINO_CHARACTER_PROPORTION_SCALE` set to `2.9` and `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` set to `0.8`.

### Testing
- No automated tests were run for this tuning-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c16df1e8c8329841f17a0cf79cc92)