### PR TITLE
Restore Domino Battle Royal human hand framing to yesterday 5pm scale

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7980,8 +7980,8 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.55;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.55;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 2.9;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 1.1;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.02;


### PR DESCRIPTION
### Motivation
- Restore the Domino Battle Royal seated human character framing so player hands return to the visual position used around yesterday 5pm by undoing recent scale/tuning that moved hands away from the table.

### Description
- Reverted two scale constants in `webapp/public/domino-royal-game.js` by setting `DOMINO_CHARACTER_PROPORTION_SCALE = 2.9` and `DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 1.1` to restore prior human/hand proportions.

### Testing
- Ran the focused unit test `npm test -- --runInBand test/dominoRoyalCharacterScale.test.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c16df1e8c8329841f17a0cf79cc92)