### PR TITLE
Restore Snooker Royal cue stick and shooting flow to prior baseline

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -10,7 +10,6 @@ export class PowerSlider {
       onChange,
       onStart,
       onCommit,
-      onShotRelease,
       theme = 'default',
       labels = false
     } = opts;
@@ -24,10 +23,8 @@ export class PowerSlider {
     this.onChange = onChange;
     this.onStart = onStart;
     this.onCommit = onCommit;
-    this.onShotRelease = onShotRelease;
     this.locked = false;
     this._returnAnimFrame = null;
-    this._shotAnimFrame = null;
 
     this.el = document.createElement('div');
     this.el.className = `ps ps-theme-${theme}`;
@@ -242,7 +239,6 @@ export class PowerSlider {
     if (this.locked) return;
     e.preventDefault();
     this._cancelReturnAnimation();
-    this._cancelShotAnimation();
     this.dragging = true;
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
@@ -271,7 +267,6 @@ export class PowerSlider {
     this.el.removeEventListener('pointercancel', this._onPointerUp);
     this.el.classList.remove('ps-no-animate');
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
-    this._playShotAnimation(this.value);
   }
 
   _wheel(e) {
@@ -307,39 +302,6 @@ export class PowerSlider {
         if (typeof this.onStart === 'function') this.onStart(this.value);
       }
       e.preventDefault();
-    }
-  }
-
-  _playShotAnimation(powerValue) {
-    this._cancelShotAnimation();
-    const power = this._clamp(this._step(powerValue));
-    const pullDuration = 90;
-    const resetDuration = 150;
-    const strikeOvershoot = Math.max(this.min + (this.max - this.min) * 0.14, this.min + 1);
-
-    this.animateTo(strikeOvershoot, { duration: pullDuration });
-
-    const startedAt = performance.now();
-    const step = (now) => {
-      const t = Math.min(1, Math.max(0, (now - startedAt) / resetDuration));
-      const eased = 1 - Math.pow(1 - t, 3);
-      const next = strikeOvershoot + (this.min - strikeOvershoot) * eased;
-      this.set(next, { animate: true });
-      if (t >= 1) {
-        this._shotAnimFrame = null;
-        if (typeof this.onShotRelease === 'function') this.onShotRelease(power);
-        return;
-      }
-      this._shotAnimFrame = requestAnimationFrame(step);
-    };
-
-    this._shotAnimFrame = requestAnimationFrame(step);
-  }
-
-  _cancelShotAnimation() {
-    if (this._shotAnimFrame != null) {
-      cancelAnimationFrame(this._shotAnimFrame);
-      this._shotAnimFrame = null;
     }
   }
 

--- a/webapp/public/power-slider.js
+++ b/webapp/public/power-slider.js
@@ -9,7 +9,6 @@ export class PowerSlider {
       cueSrc = '',
       onChange,
       onCommit,
-      onShotRelease,
       onStart,
       theme = 'default',
       labels = false
@@ -22,11 +21,9 @@ export class PowerSlider {
     this.step = step;
     this.onChange = onChange;
     this.onCommit = onCommit;
-    this.onShotRelease = onShotRelease;
     this.onStart = onStart;
     this.locked = false;
     this._returnAnimFrame = null;
-    this._shotAnimFrame = null;
 
     this.el = document.createElement('div');
     this.el.className = `ps ps-theme-${theme}`;
@@ -254,7 +251,6 @@ export class PowerSlider {
     if (this.locked) return;
     e.preventDefault();
     this._cancelReturnAnimation();
-    this._cancelShotAnimation();
     this.dragging = true;
     if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.classList.add('ps-no-animate');
@@ -277,7 +273,6 @@ export class PowerSlider {
     this.el.removeEventListener('pointerup', this._onPointerUp);
     this.el.classList.remove('ps-no-animate');
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
-    this._playShotAnimation(this.value);
   }
 
   _wheel(e) {
@@ -313,39 +308,6 @@ export class PowerSlider {
         if (typeof this.onStart === 'function') this.onStart(this.value);
       }
       e.preventDefault();
-    }
-  }
-
-  _playShotAnimation(powerValue) {
-    this._cancelShotAnimation();
-    const power = this._clamp(this._step(powerValue));
-    const pullDuration = 90;
-    const resetDuration = 150;
-    const strikeOvershoot = Math.max(this.min + (this.max - this.min) * 0.14, this.min + 1);
-
-    this.animateTo(strikeOvershoot, { duration: pullDuration });
-
-    const startedAt = performance.now();
-    const step = (now) => {
-      const t = Math.min(1, Math.max(0, (now - startedAt) / resetDuration));
-      const eased = 1 - Math.pow(1 - t, 3);
-      const next = strikeOvershoot + (this.min - strikeOvershoot) * eased;
-      this.set(next, { animate: true });
-      if (t >= 1) {
-        this._shotAnimFrame = null;
-        if (typeof this.onShotRelease === 'function') this.onShotRelease(power);
-        return;
-      }
-      this._shotAnimFrame = requestAnimationFrame(step);
-    };
-
-    this._shotAnimFrame = requestAnimationFrame(step);
-  }
-
-  _cancelShotAnimation() {
-    if (this._shotAnimFrame != null) {
-      cancelAnimationFrame(this._shotAnimFrame);
-      this._shotAnimFrame = null;
     }
   }
 

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -26,7 +26,7 @@ import {
 } from './snookerTableModel.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   isTelegramWebView,
   getTelegramUsername,
@@ -102,6 +102,8 @@ import {
   smoothDamp,
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
+import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import SnookerRoyalProvided from './SnookerRoyalProvided.jsx';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -1177,14 +1179,6 @@ const BALL_SIZE_SCALE = 1.14; // bump ball scale slightly so shots read larger o
 const BALL_DIAMETER = BALL_D_REF * OBJECT_MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
-const OFFICIAL_SNOOKER_BALL_DIAMETER_M = 0.0525;
-const SNOOKER_PLAYFIELD_SCALE = BALL_R / (OFFICIAL_SNOOKER_BALL_DIAMETER_M / 2);
-const UP = new THREE.Vector3(0, 1, 0);
-const CFG = {
-  scale: SNOOKER_PLAYFIELD_SCALE,
-  ballR: BALL_R,
-  cueLength: 1.78 * SNOOKER_PLAYFIELD_SCALE
-};
 const ENABLE_BALL_FLOOR_SHADOWS = true;
 const BALL_SHADOW_RADIUS_MULTIPLIER = 0.92;
 const BALL_SHADOW_OPACITY = 0.25;
@@ -1578,15 +1572,6 @@ const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
-// Keep Snooker Royal's cue-ball launch identical to SnookerRoyalProvided.jsx:
-// the visible cue stroke waits until the tip reaches the cue ball, then applies
-// this same full-size snooker strike and spin transfer model.
-const SNOOKER_PROVIDED_SHOT_POWER_BOOST = 0.455;
-const SNOOKER_PROVIDED_SHOT_FULL_SPEED =
-  12 * SNOOKER_PLAYFIELD_SCALE * SNOOKER_PROVIDED_SHOT_POWER_BOOST;
-const SNOOKER_PROVIDED_SHOT_SPIN_SCALE = 0.25;
-const SNOOKER_PROVIDED_SPIN_GLOBAL_SCALE = 0.82;
-const SNOOKER_PROVIDED_CONTACT_GAP = 0.0012 * WORLD_SCALE;
 const SPIN_POWER_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.25;
 const SPIN_POWER_MIN_SCALE = 0.35;
 const SPIN_POWER_MAX_SCALE = 1.25;
@@ -1676,134 +1661,28 @@ const CUE_CUSHION_LIFT_BIAS = BALL_R * 0.06; // lift the cue slightly more as cu
 const CUE_LENGTH_MULTIPLIER = 1.35; // extend cue stick length so the rear section feels longer without moving the tip
 
 
-const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const ENABLE_SNOOKER_HUMAN_CHARACTER = false;
-
-function enableShadow(obj) {
-  obj.traverse((child) => {
-    if (child.isMesh) {
-      child.castShadow = true;
-      child.receiveShadow = true;
-      child.frustumCulled = false;
-    }
-  });
-  return obj;
-}
-function createCue() {
-  const group = new THREE.Group();
-  const SCALE = CFG.ballR / (OFFICIAL_SNOOKER_BALL_DIAMETER_M / 2 * SNOOKER_PLAYFIELD_SCALE);
-  const shaftMaterial = new THREE.MeshPhysicalMaterial({
-    color: 0xd8b17d,
-    roughness: 0.34,
-    metalness: 0,
-    clearcoat: 0.56,
-    clearcoatRoughness: 0.24
-  });
-  const ferruleMaterial = new THREE.MeshPhysicalMaterial({
-    color: 0xf8fafc,
-    roughness: 0.22,
-    metalness: 0.04,
-    clearcoat: 0.5,
-    clearcoatRoughness: 0.18
-  });
-  const tipMaterial = new THREE.MeshStandardMaterial({ color: 0x1f3f73, roughness: 0.95, metalness: 0 });
-  const bandMaterial = new THREE.MeshPhysicalMaterial({
-    color: 0x111827,
-    roughness: 0.32,
-    metalness: 0.08,
-    clearcoat: 0.18,
-    clearcoatRoughness: 0.2
-  });
-  const ringMaterial = new THREE.MeshPhysicalMaterial({ color: 0xc07a2d, roughness: 0.38, metalness: 0.62 });
-  const makeSegment = (name, material, radialSegments = 40) => {
-    const mesh = new THREE.Mesh(new THREE.CylinderGeometry(1, 1, 1, radialSegments), material);
-    mesh.name = `snooker-royal-cue-${name}`;
-    enableShadow(mesh);
-    group.add(mesh);
-    return mesh;
-  };
-  const rearShaft = makeSegment('rear-tapered-shaft', shaftMaterial, 48);
-  const frontShaft = makeSegment('front-tapered-shaft', shaftMaterial, 48);
-  const butt = makeSegment('rounded-butt', shaftMaterial, 56);
-  const stripe = makeSegment('butt-stripe-wrap', bandMaterial, 64);
-  const ring = makeSegment('brass-ring', ringMaterial, 48);
-  const ferrule = makeSegment('ferrule', ferruleMaterial, 40);
-  const tip = makeSegment('blue-leather-tip', tipMaterial, 32);
-  const buttCap = new THREE.Mesh(new THREE.SphereGeometry(1, 32, 16), shaftMaterial);
-  buttCap.name = 'snooker-royal-cue-rounded-butt-cap';
-  enableShadow(buttCap);
-  group.add(buttCap);
-  return { group, rearShaft, frontShaft, butt, stripe, ring, ferrule, tip, buttCap, scale: SCALE };
-}
-function setSegmentTaper(mesh, a, b, radiusTop, radiusBottom = radiusTop) {
-  const dir = b.clone().sub(a);
-  const len = Math.max(0.0001, dir.length());
-  const geomKey = `${radiusTop.toFixed(5)}:${radiusBottom.toFixed(5)}:${len.toFixed(5)}`;
-  if (mesh.userData?.geomKey !== geomKey) {
-    mesh.geometry?.dispose?.();
-    mesh.geometry = new THREE.CylinderGeometry(radiusTop, radiusBottom, len, 48);
-    mesh.userData = { ...(mesh.userData || {}), geomKey };
-  }
-  mesh.position.copy(a).addScaledVector(dir, 0.5);
-  mesh.quaternion.setFromUnitVectors(UP, dir.normalize());
-  mesh.scale.set(1, 1, 1);
-}
-function setCuePose(cue, back, tip) {
-  const dir = tip.clone().sub(back).normalize();
-  const totalLength = tip.distanceTo(back);
-  const rearLength = totalLength * 0.62;
-  const frontLength = totalLength - rearLength;
-  const tipRadius = 0.008 * CFG.scale;
-  const joinRadius = 0.0165 * CFG.scale;
-  const buttRadius = 0.026 * CFG.scale;
-  const buttLength = Math.min(rearLength * 0.36, 0.52 * CFG.scale);
-  const stripeLength = Math.min(rearLength * 0.34, 0.48 * CFG.scale);
-  const ferruleLength = 0.038 * CFG.scale;
-  const tipLength = 0.024 * CFG.scale;
-  const p0 = back.clone();
-  const buttEnd = p0.clone().addScaledVector(dir, buttLength);
-  const rearEnd = back.clone().addScaledVector(dir, rearLength);
-  const ferruleBack = tip.clone().addScaledVector(dir, -(ferruleLength + tipLength));
-  const tipBack = tip.clone().addScaledVector(dir, -tipLength);
-  setSegmentTaper(cue.butt, p0, buttEnd, buttRadius, buttRadius * 1.04);
-  setSegmentTaper(cue.rearShaft, buttEnd, rearEnd, joinRadius, buttRadius * 0.92);
-  setSegmentTaper(cue.frontShaft, rearEnd, ferruleBack, tipRadius, joinRadius);
-  setSegmentTaper(cue.ferrule, ferruleBack, tipBack, tipRadius * 1.08, tipRadius * 1.18);
-  setSegmentTaper(cue.tip, tipBack, tip, tipRadius * 1.05, tipRadius * 1.05);
-  const stripeStart = back.clone().addScaledVector(dir, Math.max(buttLength * 0.28, rearLength * 0.18));
-  const stripeEnd = stripeStart.clone().addScaledVector(dir, stripeLength);
-  setSegmentTaper(cue.stripe, stripeStart, stripeEnd, buttRadius * 1.012, buttRadius * 1.012);
-  const ringStart = rearEnd.clone().addScaledVector(dir, -0.022 * CFG.scale);
-  setSegmentTaper(cue.ring, ringStart, rearEnd, joinRadius * 1.08, joinRadius * 1.12);
-  cue.buttCap.position.copy(back);
-  cue.buttCap.scale.setScalar(buttRadius * 1.08);
-}
-function cuePoseFromGrip(grip, dir, gripFromBack, length = CFG.cueLength) {
-  const n = dir.clone().normalize();
-  return { back: grip.clone().addScaledVector(n, -gripFromBack), tip: grip.clone().addScaledVector(n, length - gripFromBack) };
-}
-
 const SNOOKER_HUMAN_CHARACTER_THEME =
   MURLAN_CHARACTER_THEMES.find((theme) => theme.id === 'rpm-current') ||
   MURLAN_CHARACTER_THEMES[0];
 const SNOOKER_HUMAN_UP = new THREE.Vector3(0, 1, 0);
 const SNOOKER_HUMAN_FORWARD_LOCAL = new THREE.Vector3(0, 0, 1);
-const SNOOKER_HUMAN_WORLD_SCALE = BALL_R / (0.0525 / 2);
+const SNOOKER_HUMAN_WORLD_SCALE = BALL_R / 0.0525;
 const SNOOKER_HUMAN_CFG = Object.freeze({
-  // Keep the Royal avatar dimensions and shot stance matched to SnookerRoyalProvided.jsx.
+  // Match the larger Snooker Champion character proportions exactly so the
+  // Royal avatar reads as a full-sized player beside the GLB snooker table.
   targetHeight: 1.2 * 1.78 * SNOOKER_HUMAN_WORLD_SCALE,
   floorY: FLOOR_Y - TABLE_Y,
   idleDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
-  bridgeBackFromBall: 0.235 * SNOOKER_HUMAN_WORLD_SCALE,
-  bridgeSide: -0.115 * SNOOKER_HUMAN_WORLD_SCALE,
-  stanceSide: 0.52 * SNOOKER_HUMAN_WORLD_SCALE,
-  rightFootBack: 0.34 * SNOOKER_HUMAN_WORLD_SCALE,
-  leftFootForward: -0.34 * SNOOKER_HUMAN_WORLD_SCALE,
-  chinCueOffsetY: 0.11 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeBackFromBall: 0.27 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeSide: -0.025 * SNOOKER_HUMAN_WORLD_SCALE,
+  stanceSide: 0.25 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightFootBack: 0.38 * SNOOKER_HUMAN_WORLD_SCALE,
+  leftFootForward: 0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+  chinCueOffsetY: 0.12 * SNOOKER_HUMAN_WORLD_SCALE,
   chestCueOffsetY: 0.22 * SNOOKER_HUMAN_WORLD_SCALE,
-  rootLambda: 5.6,
-  poseLambda: 9,
-  yawFix: Math.PI
+  rootLambda: 7.5,
+  poseLambda: 10,
+  yawFix: 0
 });
 const cleanSnookerHumanBoneName = (name = '') => name.toLowerCase().replace(/[^a-z0-9]/g, '');
 const snookerHumanClamp01 = (value) => Math.max(0, Math.min(1, value));
@@ -2071,8 +1950,18 @@ function loadSnookerHumanModel(loader, url) {
   });
 }
 
-function buildSnookerHumanModelUrls(_theme = SNOOKER_HUMAN_CHARACTER_THEME) {
-  return [HUMAN_URL];
+function buildSnookerHumanModelUrls(theme = SNOOKER_HUMAN_CHARACTER_THEME) {
+  const urls = [
+    ...(theme?.modelUrls || []),
+    theme?.url,
+    ...MURLAN_CHARACTER_THEMES.flatMap((entry) => [
+      ...(entry?.modelUrls || []),
+      entry?.url
+    ]),
+    'https://threejs.org/examples/models/gltf/Xbot.glb',
+    'https://threejs.org/examples/models/gltf/Soldier.glb'
+  ].filter(Boolean);
+  return [...new Set(urls)];
 }
 
 async function loadSnookerHumanModelFromCatalog(loader, urls = buildSnookerHumanModelUrls()) {
@@ -2164,10 +2053,7 @@ function createSnookerRoyalHumanPlayer(parent, renderer) {
     walkPhase: 0,
     walkAmount: 0,
     restQuats: new Map(),
-    theme: SNOOKER_HUMAN_CHARACTER_THEME,
-    strikeClock: 0,
-    strikeRoot: new THREE.Vector3(),
-    strikeYaw: 0
+    theme: SNOOKER_HUMAN_CHARACTER_THEME
   };
   human.root.name = 'SnookerRoyalHumanPlayerRoot';
   human.modelRoot.name = 'SnookerRoyalDominoCharacterRoot';
@@ -2243,20 +2129,8 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
   dir.normalize();
   const side = new THREE.Vector3(-dir.z, 0, dir.x).normalize();
   const cueBall = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
-  const cueOnTable = Boolean(cueStick?.visible || shooting || cueAnimating);
-  human.poseT = snookerHumanDamp(
-    human.poseT,
-    cueOnTable ? 1 : 0,
-    SNOOKER_HUMAN_CFG.poseLambda,
-    dt
-  );
-  const poseT = snookerHumanClamp01(human.poseT);
   const cueEndpoints = resolveSnookerHumanCueEndpoints(cueStick, cueLen, cueBall, dir);
-  const pullPose = THREE.MathUtils.clamp(
-    ((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0)) * poseT,
-    0,
-    1
-  );
+  const pullPose = THREE.MathUtils.clamp((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0), 0, 1);
   // Orientation is driven from the actual shot line: the root stands behind
   // the cue ball on -dir, then faces +dir back through cue ball/object ball.
   // Keeping local +Z on the shot line prevents mirrored cue/hand placement.
@@ -2274,57 +2148,26 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
   const yawTarget = Math.atan2(bodyForward.x, bodyForward.z);
   human.root.visible = true;
   human.modelRoot.visible = human.loaded && human.activeGlb;
-  if (shooting || cueAnimating) {
-    if (human.strikeClock === 0) {
-      human.strikeRoot.copy(
-        human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget
-      );
-      human.strikeYaw = human.yaw;
-    }
-    human.strikeClock += dt;
-  } else {
-    human.strikeClock = 0;
-  }
-  const rootGoal = shooting || cueAnimating ? human.strikeRoot : rootTarget;
-  const yawGoal = shooting || cueAnimating ? human.strikeYaw : yawTarget;
-  const travel = human.lastRootPosition.distanceTo(rootGoal);
+  const travel = human.lastRootPosition.distanceTo(rootTarget);
   human.walkAmount = snookerHumanDamp(human.walkAmount, snookerHumanClamp01(travel / Math.max(BALL_R * 4, 1e-4)), 8, dt);
   human.walkPhase += dt * (4.5 + human.walkAmount * 5.5);
-  human.root.position.lerp(rootGoal, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
+  human.root.position.lerp(rootTarget, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
   human.lastRootPosition.copy(human.root.position);
-  human.yaw = snookerHumanDampAngle(human.yaw, yawGoal, SNOOKER_HUMAN_CFG.rootLambda, dt);
+  human.yaw = snookerHumanDampAngle(human.yaw, yawTarget, SNOOKER_HUMAN_CFG.rootLambda, dt);
   human.root.rotation.set(0, human.yaw, 0);
   human.modelRoot.position.copy(human.root.position);
   human.modelRoot.rotation.copy(human.root.rotation);
+  human.poseT = snookerHumanDamp(human.poseT, 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
   const invRoot = new THREE.Matrix4().copy(human.root.matrixWorld).invert();
   const toRootLocal = (v) => v.clone().applyMatrix4(invRoot);
-  const bridgeShot = cueBall.clone()
+  const bridge = cueBall.clone()
     .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
     .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
     .setY(CUE_Y + BALL_R * 0.08);
-  const gripShot = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
-  const idleRightHand = rootTarget.clone()
-    .addScaledVector(side, 0.24 * SNOOKER_HUMAN_WORLD_SCALE)
-    .addScaledVector(dir, 0.12 * SNOOKER_HUMAN_WORLD_SCALE)
-    .setY(SNOOKER_HUMAN_CFG.floorY + 0.95 * SNOOKER_HUMAN_WORLD_SCALE);
-  const idleLeftHand = rootTarget.clone()
-    .addScaledVector(side, -0.18 * SNOOKER_HUMAN_WORLD_SCALE)
-    .addScaledVector(dir, 0.08 * SNOOKER_HUMAN_WORLD_SCALE)
-    .setY(SNOOKER_HUMAN_CFG.floorY + 1.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const bridge = idleLeftHand.clone().lerp(bridgeShot, poseT);
-  const grip = idleRightHand.clone().lerp(gripShot, poseT);
-  const idleCueTip = idleRightHand.clone()
-    .addScaledVector(dir, 0.7 * SNOOKER_HUMAN_WORLD_SCALE)
-    .addScaledVector(side, -0.08 * SNOOKER_HUMAN_WORLD_SCALE)
-    .add(new THREE.Vector3(0, -0.22 * SNOOKER_HUMAN_WORLD_SCALE, 0));
-  const cueTipForPose = idleCueTip.clone().lerp(cueEndpoints.tip, poseT);
+  const grip = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
   updateSnookerHumanOrientationHelpers(human, { rootTarget, cueBall, playfieldTarget, dir, bridge, grip });
-  const chestStand = rootTarget.clone().addScaledVector(dir, 0.16 * SNOOKER_HUMAN_WORLD_SCALE).setY(SNOOKER_HUMAN_CFG.floorY + 1.32 * SNOOKER_HUMAN_WORLD_SCALE);
-  const headStand = rootTarget.clone().addScaledVector(dir, 0.2 * SNOOKER_HUMAN_WORLD_SCALE).setY(SNOOKER_HUMAN_CFG.floorY + 1.72 * SNOOKER_HUMAN_WORLD_SCALE);
-  const chestShot = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
-  const headShot = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const chestWorld = chestStand.lerp(chestShot, poseT);
-  const headWorld = headStand.lerp(headShot, poseT);
+  const chestWorld = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
+  const headWorld = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
   const torso = toRootLocal(chestWorld).add(new THREE.Vector3(0, 0.16 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
   const chest = toRootLocal(chestWorld);
   const head = toRootLocal(headWorld);
@@ -2374,7 +2217,7 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     rightElbowWorld: rightElbowTable,
     headWorld: headWorld,
     chestWorld: chestWorld,
-    cueTipWorld: cueTipForPose
+    cueTipWorld: cueEndpoints.tip
   });
 }
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
@@ -14615,10 +14458,6 @@ const showRuleToast = useCallback((message) => {
   }, 3000);
 }, []);
 const powerRef = useRef(hud.power);
-const shotVisualPowerRef = useRef(0);
-const committedShotPowerRef = useRef(0);
-const sliderDraggingRef = useRef(false);
-const sliderResetTimerRef = useRef(null);
   const applyPower = useCallback((nextPower) => {
     const clampedPower = THREE.MathUtils.clamp(nextPower ?? 0, 0, 1);
     powerRef.current = clampedPower;
@@ -14630,12 +14469,6 @@ const sliderResetTimerRef = useRef(null);
   useEffect(() => {
     powerRef.current = hud.power;
   }, [hud.power]);
-  useEffect(() => () => {
-    if (sliderResetTimerRef.current) {
-      clearTimeout(sliderResetTimerRef.current);
-      sliderResetTimerRef.current = null;
-    }
-  }, []);
   const hudRef = useRef(hud);
   useEffect(() => {
     hudRef.current = hud;
@@ -16230,7 +16063,6 @@ const sliderResetTimerRef = useRef(null);
           : Date.now();
       let shooting = false; // track when a shot is in progress
       let shotStartedAt = 0;
-      let shotImpulseApplied = false;
       let shotRecording = null;
       let replayPlayback = null;
       let pausedPocketDrops = null;
@@ -16248,7 +16080,6 @@ const sliderResetTimerRef = useRef(null);
         shotStartedAt = shooting ? getNow() : 0;
         if (!shooting) {
           maxPowerLiftTriggered = false;
-          shotImpulseApplied = false;
         }
         if (shotCameraHoldTimeoutRef.current) {
           clearTimeout(shotCameraHoldTimeoutRef.current);
@@ -21829,14 +21660,9 @@ const sliderResetTimerRef = useRef(null);
       const cueStick = new THREE.Group();
       const cueBody = new THREE.Group();
       cueStick.add(cueBody);
-      const providedCue = createCue();
-      providedCue.group.name = 'SnookerRoyalProvidedCueStick';
-      providedCue.group.visible = false;
-      cueStick.userData.providedCue = providedCue;
       cueStick.userData.body = cueBody;
       cueStick.userData.isCueStick = true;
       cueBodyRef.current = cueBody;
-      cueBody.visible = false;
       const buttLift = Math.min(CUE_BUTT_LIFT, cueLen);
       const buttTilt = Math.asin(
         Math.min(1, buttLift / Math.max(cueLen, 1e-4))
@@ -22139,10 +21965,7 @@ const sliderResetTimerRef = useRef(null);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      table.add(providedCue.group);
-      const snookerHumanPlayer = ENABLE_SNOOKER_HUMAN_CHARACTER
-        ? createSnookerRoyalHumanPlayer(table, renderer)
-        : null;
+      const snookerHumanPlayer = createSnookerRoyalHumanPlayer(table, renderer);
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
       const closeCueGallery = () => {
@@ -23001,7 +22824,7 @@ const sliderResetTimerRef = useRef(null);
       };
 
       // Fire (slider triggers on release)
-      const fire = (powerOverride = null) => {
+      const fire = () => {
         const currentHud = hudRef.current;
         const frameSnapshot = frameRef.current ?? frameState;
         const fullTableHandPlacement =
@@ -23017,13 +22840,6 @@ const sliderResetTimerRef = useRef(null);
           replayPlaybackRef.current
         )
           return;
-        const committedPower = THREE.MathUtils.clamp(
-          Number.isFinite(powerOverride) ? powerOverride : powerRef.current,
-          0,
-          1
-        );
-        if (committedPower <= 0.02) return;
-        shotVisualPowerRef.current = committedPower;
         if (currentHud?.inHand && (fullTableHandPlacement || inHandPlacementActive)) {
           hudRef.current = { ...currentHud, inHand: false };
           setHud((prev) => ({ ...prev, inHand: false }));
@@ -23113,7 +22929,7 @@ const sliderResetTimerRef = useRef(null);
             pocketSwitchIntentRef.current = null;
           }
           lastPocketBallRef.current = null;
-          const clampedPower = committedPower;
+          const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
           lastShotPower = clampedPower;
           const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
           const maxPowerHoldUntil = isMaxPowerShot
@@ -23140,9 +22956,10 @@ const sliderResetTimerRef = useRef(null);
           const preferZoomReplay =
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
           const frameStateCurrent = frameRef.current ?? null;
+          const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
           const isBreakCameraShot = Boolean(frameStateCurrent?.meta?.breakInProgress);
           const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * clampedPower;
-          const speedBase = SNOOKER_PROVIDED_SHOT_FULL_SPEED;
+          const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
           const base = aimDir
             .clone()
             .multiplyScalar(speedBase * powerScale);
@@ -23282,123 +23099,73 @@ const sliderResetTimerRef = useRef(null);
           const appliedSpin = applySpinConstraints(aimDir, true);
           const liftAngle = resolveUserCueLift();
           const liftStrength = normalizeCueLift(liftAngle);
-          const physicsSpinRaw = mapSpinForPhysics(normalizeSpinInput(appliedSpin));
-          const physicsSpin = {
-            x: (physicsSpinRaw.x ?? 0) * SNOOKER_PROVIDED_SPIN_GLOBAL_SCALE,
-            y: (physicsSpinRaw.y ?? 0) * SNOOKER_PROVIDED_SPIN_GLOBAL_SCALE
-          };
+          const physicsSpin = mapSpinForPhysics(appliedSpin);
+          const ranges = spinRangeRef.current || {};
           const powerSpinScale = 0.55 + clampedPower * 0.45;
-          const rawTopSpin =
-            (physicsSpin.y ?? 0) * SNOOKER_PROVIDED_SHOT_SPIN_SCALE * powerSpinScale;
-          const spinSide =
-            (physicsSpin.x ?? 0) *
-            SNOOKER_PROVIDED_SHOT_SPIN_SCALE *
-            SIDE_SPIN_MULTIPLIER *
-            powerSpinScale;
-          const spinTop =
-            rawTopSpin < 0
-              ? rawTopSpin * BACKSPIN_MULTIPLIER
-              : rawTopSpin * TOPSPIN_MULTIPLIER;
-          let contactFallbackHandle = null;
-          let shotImpactApplied = false;
-          const releasePower = clampedPower;
-          const applyShotImpactAtCueContact = () => {
-            if (shotImpactApplied) return false;
-            shotImpactApplied = true;
-            shotImpulseApplied = true;
-            if (contactFallbackHandle) {
-              clearTimeout(contactFallbackHandle);
-              contactFallbackHandle = null;
-            }
-            const impactPower = THREE.MathUtils.clamp(
-              releasePower,
+          const baseSide = physicsSpin.x * (ranges.side ?? 0);
+          let spinSide = baseSide * SIDE_SPIN_MULTIPLIER * powerSpinScale;
+          let spinTop = physicsSpin.y * (ranges.forward ?? 0) * powerSpinScale;
+          if (physicsSpin.y < 0) {
+            spinTop *= BACKSPIN_MULTIPLIER;
+          } else if (physicsSpin.y > 0) {
+            spinTop *= TOPSPIN_MULTIPLIER;
+          }
+          cue.vel.copy(base);
+          if (cue.spin) {
+            cue.spin.set(spinSide, spinTop);
+          }
+          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+          cue.spinMode = 'standard';
+          cue.swerveStrength = 0;
+          cue.swervePowerStrength = 0;
+          resetSpinRef.current?.();
+          cueLiftRef.current.lift = 0;
+          cueLiftRef.current.startLift = 0;
+          cue.impacted = false;
+          cue.launchDir = aimDir.clone().normalize();
+          maxPowerLiftTriggered = false;
+          cue.lift = 0;
+          cue.liftVel = 0;
+          const topSpinWeight = Math.max(0, physicsSpin.y || 0);
+          if (
+            clampedPower >= JUMP_SHOT_POWER_THRESHOLD &&
+            liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
+            topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
+          ) {
+            const powerRatio = THREE.MathUtils.clamp(
+              (clampedPower - JUMP_SHOT_POWER_THRESHOLD) /
+                Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
               0,
               1
             );
-            const impactPowerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * impactPower;
-            const impactBase = aimDir
-              .clone()
-              .multiplyScalar(speedBase * impactPowerScale);
-            cue.vel.copy(impactBase);
-            const sideThrow = TMP_VEC2_A
-              .set(aimDir.y, -aimDir.x)
-              .normalize()
-              .multiplyScalar(
-                (spinSide ?? 0) *
-                  impactPower *
-                  1.05 *
-                  CFG.scale *
-                  SNOOKER_PROVIDED_SHOT_POWER_BOOST
-              );
-            cue.vel.add(sideThrow);
-            if (cue.spin) {
-              cue.spin.set(spinSide, spinTop);
-            }
-            if (cue.omega) {
-              cue.omega.set(0, 0, 0);
-              const launchSpeed = cue.vel.length();
-              if (launchSpeed > 1e-6) {
-                TMP_VEC3_CUE_DIR.set(cue.vel.y, 0, -cue.vel.x).normalize();
-                cue.omega.addScaledVector(TMP_VEC3_CUE_DIR, launchSpeed / BALL_R);
-                cue.omega.x += -(spinTop ?? 0) * impactPower * 18;
-                cue.omega.z += -(spinSide ?? 0) * impactPower * 18;
-              }
-            }
-            cue.lastShotSpin = { x: spinSide ?? 0, y: spinTop ?? 0 };
-            if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-            cue.spinMode = 'standard';
-            cue.swerveStrength = 0;
-            cue.swervePowerStrength = 0;
-            resetSpinRef.current?.();
-            cueLiftRef.current.lift = 0;
-            cueLiftRef.current.startLift = 0;
-            cue.impacted = false;
-            cue.launchDir = cue.vel.lengthSq() > 1e-8 ? cue.vel.clone().normalize() : aimDir.clone().normalize();
-            maxPowerLiftTriggered = false;
-            cue.lift = 0;
-            cue.liftVel = 0;
-            const topSpinWeight = Math.max(0, physicsSpin.y || 0);
-            if (
-              impactPower >= JUMP_SHOT_POWER_THRESHOLD &&
-              liftStrength >= JUMP_SHOT_LIFT_THRESHOLD &&
-              topSpinWeight >= JUMP_SHOT_TOPSPIN_THRESHOLD
-            ) {
-              const powerRatio = THREE.MathUtils.clamp(
-                (impactPower - JUMP_SHOT_POWER_THRESHOLD) /
-                  Math.max(1 - JUMP_SHOT_POWER_THRESHOLD, 1e-4),
-                0,
-                1
-              );
-              const liftRatio = THREE.MathUtils.clamp(
-                (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
-                  Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
-                0,
-                1
-              );
-              const spinRatio = THREE.MathUtils.clamp(
-                (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
-                  Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
-                0,
-                1
-              );
-              const jumpStrength =
-                (0.25 + 0.75 * powerRatio) *
-                (0.4 + 0.6 * liftRatio) *
-                (0.55 + 0.45 * spinRatio);
-              const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
-              const physicsHeight =
-                (jumpVelocity * jumpVelocity) /
-                (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
-              const jumpHeight = Math.min(
-                MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
-                physicsHeight
-              );
-              cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
-              cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
-            }
-            playCueHit(impactPower * 0.6);
-            return true;
-          };
+            const liftRatio = THREE.MathUtils.clamp(
+              (liftStrength - JUMP_SHOT_LIFT_THRESHOLD) /
+                Math.max(1 - JUMP_SHOT_LIFT_THRESHOLD, 1e-4),
+              0,
+              1
+            );
+            const spinRatio = THREE.MathUtils.clamp(
+              (topSpinWeight - JUMP_SHOT_TOPSPIN_THRESHOLD) /
+                Math.max(1 - JUMP_SHOT_TOPSPIN_THRESHOLD, 1e-4),
+              0,
+              1
+            );
+            const jumpStrength =
+              (0.25 + 0.75 * powerRatio) *
+              (0.4 + 0.6 * liftRatio) *
+              (0.55 + 0.45 * spinRatio);
+            const jumpVelocity = MAX_POWER_BOUNCE_IMPULSE * JUMP_SHOT_LAUNCH_SCALE * jumpStrength;
+            const physicsHeight =
+              (jumpVelocity * jumpVelocity) /
+              (2 * Math.max(MAX_POWER_BOUNCE_GRAVITY, 1e-6));
+            const jumpHeight = Math.min(
+              MAX_POWER_LIFT_HEIGHT * JUMP_SHOT_HEIGHT_SCALE,
+              physicsHeight
+            );
+            cue.lift = Math.max(cue.lift ?? 0, jumpHeight);
+            cue.liftVel = Math.max(cue.liftVel ?? 0, jumpVelocity);
+          }
+          playCueHit(clampedPower * 0.6);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -23486,37 +23253,63 @@ const sliderResetTimerRef = useRef(null);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
           const pullbackDuration = 0;
-          const strikeDuration = CUE_LOGIC_STRIKE_TIME_MS;
-          const holdDuration = CUE_LOGIC_HOLD_TIME_MS;
+          const strikeDuration = 110;
+          const holdDuration = 45;
           const returnDuration = 0;
-          const contactGap = SNOOKER_PROVIDED_CONTACT_GAP;
-          const strikeStartPull = visualPull;
-          const followThroughDistance = THREE.MathUtils.clamp(
-            strikeStartPull * (0.16 + releasePower * 0.2),
-            CUE_FOLLOW_THROUGH_MIN,
-            CUE_FOLLOW_THROUGH_MAX
+          // Keep the no-character cue stroke matching the old human-rig shot:
+          // drive the tip forward from pullback into cue-ball contact instead
+          // of stopping at the original address gap.
+          const impactPush = THREE.MathUtils.clamp(
+            CUE_TIP_CLEARANCE,
+            BALL_R * 0.08,
+            BALL_R * 0.3
           );
+          const impactPos = buildCuePosition(-impactPush);
+          // Stop the visible cue at contact so it reads as a push without
+          // chasing the moving cue ball after physics takes over.
+          const followExtra = 0;
+          TMP_VEC3_FOLLOW_DIR.copy(impactPos).sub(pullPos);
+          if (TMP_VEC3_FOLLOW_DIR.lengthSq() > 1e-8) {
+            TMP_VEC3_FOLLOW_DIR.normalize();
+          }
+          const settlePos = impactPos
+            .clone()
+            .addScaledVector(TMP_VEC3_FOLLOW_DIR, followExtra);
           cueStick.visible = true;
-          cueStick.position.copy(pullPos);
+          cueStick.position.copy(idlePos);
           const startTime = performance.now();
-          const impactTime = startTime + strikeDuration;
-          contactFallbackHandle = window.setTimeout(() => {
-            applyShotImpactAtCueContact();
-          }, Math.max(0, impactTime - performance.now()));
-          const forwardPreviewHold = impactTime + Math.min(holdDuration, Math.max(180, strikeDuration * 0.9));
-          powerImpactHoldRef.current = Math.max(powerImpactHoldRef.current || 0, forwardPreviewHold);
+          const pullEndTime = startTime + pullbackDuration;
+          const impactTime = pullEndTime + strikeDuration;
+          const holdEndTime = impactTime + holdDuration;
+          const returnTime = holdEndTime + returnDuration;
+          const forwardPreviewHold =
+            impactTime +
+            Math.min(
+              holdDuration,
+              Math.max(180, strikeDuration * 0.9)
+            );
+          powerImpactHoldRef.current = Math.max(
+            powerImpactHoldRef.current || 0,
+            forwardPreviewHold
+          );
           const holdUntil = powerImpactHoldRef.current || 0;
           const holdActive = holdUntil > performance.now();
           if (holdActive) {
             if (activeShotView?.mode === 'pocket') {
               queuedPocketView = activeShotView;
               queuedPocketView.pendingActivation = true;
-              queuedPocketView.activationDelay = Math.max(queuedPocketView.activationDelay ?? 0, holdUntil);
+              queuedPocketView.activationDelay = Math.max(
+                queuedPocketView.activationDelay ?? 0,
+                holdUntil
+              );
               activeShotView = null;
               updatePocketCameraState(false);
             } else if (queuedPocketView) {
               queuedPocketView.pendingActivation = true;
-              queuedPocketView.activationDelay = Math.max(queuedPocketView.activationDelay ?? 0, holdUntil);
+              queuedPocketView.activationDelay = Math.max(
+                queuedPocketView.activationDelay ?? 0,
+                holdUntil
+              );
             }
             if (activeShotView?.mode === 'action') {
               suspendedActionView = activeShotView;
@@ -23529,8 +23322,6 @@ const sliderResetTimerRef = useRef(null);
             }
           }
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
-            const impactPos = buildCuePosition(-Math.max(0, CUE_TIP_CLEARANCE - contactGap));
-            const settlePos = buildCuePosition(-followThroughDistance);
             const strokeStartOffset = Math.max(0, startTime - (shotRecording.startTime ?? startTime));
             shotRecording.cueStroke = {
               warmup: serializeVector3Snapshot(idlePos),
@@ -23551,67 +23342,53 @@ const sliderResetTimerRef = useRef(null);
             if (!ENABLE_CUE_STROKE_ANIMATION) {
               cueStick.visible = false;
               cueAnimating = false;
-              shotVisualPowerRef.current = 0;
               cuePullCurrentRef.current = 0;
               cuePullTargetRef.current = 0;
               return;
             }
             const elapsed = Math.max(0, now - startTime);
-            const strikeNorm = THREE.MathUtils.clamp(elapsed / Math.max(strikeDuration, 1), 0, 1);
-            const striking = elapsed <= strikeDuration;
-            if (striking) {
-              const gap = THREE.MathUtils.lerp(
-                CUE_TIP_CLEARANCE + strikeStartPull,
-                contactGap,
-                easeOutCubic(strikeNorm)
-              );
-              const cuePos = buildCuePosition(gap - CUE_TIP_CLEARANCE);
-              cueStick.position.copy(cuePos);
-              if (strikeNorm > 0.88) applyShotImpactAtCueContact();
-              requestAnimationFrame(animateStroke);
+            const sample = sampleCueStrokeTimeline({
+              elapsed,
+              pullbackDuration,
+              strikeDuration,
+              holdDuration,
+              animationStyle: 'linear',
+              strikeWindowRatio: 0.12,
+              hitArmRatio: 0.88
+            });
+            if (sample.phase === 'pullback') {
+              cueStick.position.lerpVectors(idlePos, pullPos, easeInOutQuad(sample.t));
+            } else if (sample.phase === 'release' || sample.phase === 'strike') {
+              const strikeEase = easeOutCubic(sample.t);
+              const dynamicFollow =
+                followExtra * (0.55 + 0.45 * Math.sin(sample.t * Math.PI));
+              cueStick.position.lerpVectors(pullPos, impactPos, strikeEase);
+              if (dynamicFollow > 1e-6) {
+                cueStick.position.addScaledVector(TMP_VEC3_FOLLOW_DIR, dynamicFollow);
+              }
+            } else if (sample.phase === 'hold') {
+              cueStick.position.lerpVectors(impactPos, settlePos, easeInOutQuad(sample.t));
+            } else if (now <= returnTime && returnDuration > 0) {
+              const t = THREE.MathUtils.clamp((now - holdEndTime) / returnDuration, 0, 1);
+              cueStick.position.lerpVectors(settlePos, idlePos, easeInOutQuad(t));
+            } else {
+              cueStick.visible = false;
+              cueAnimating = false;
+              cuePullCurrentRef.current = 0;
+              cuePullTargetRef.current = 0;
+              if (cameraRef.current && sphRef.current) {
+                topViewRef.current = false;
+                topViewLockedRef.current = false;
+                setIsTopDownView(false);
+                const sph = sphRef.current;
+                sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
+                updateCamera();
+              }
               return;
             }
-            if (elapsed <= strikeDuration + holdDuration) {
-              const holdNorm = THREE.MathUtils.clamp(
-                (elapsed - strikeDuration) / Math.max(holdDuration, 1),
-                0,
-                1
-              );
-              const followThroughPull = THREE.MathUtils.lerp(
-                contactGap - CUE_TIP_CLEARANCE,
-                -followThroughDistance,
-                easeOutCubic(holdNorm)
-              );
-              const holdPos = buildCuePosition(followThroughPull);
-              cueStick.position.copy(holdPos);
-              applyShotImpactAtCueContact();
-              requestAnimationFrame(animateStroke);
-              return;
-            }
-            cueStick.visible = false;
-            cueAnimating = false;
-            shotVisualPowerRef.current = 0;
-            cuePullCurrentRef.current = 0;
-            cuePullTargetRef.current = 0;
-            if (cameraRef.current && sphRef.current) {
-              topViewRef.current = false;
-              topViewLockedRef.current = false;
-              setIsTopDownView(false);
-              const sph = sphRef.current;
-              sph.theta = Math.atan2(aimDir.x, aimDir.y) + Math.PI;
-              updateCamera();
-            }
-          };
-          if (ENABLE_CUE_STROKE_ANIMATION) {
             requestAnimationFrame(animateStroke);
-          } else {
-            applyShotImpactAtCueContact();
-            cueStick.visible = false;
-            cueAnimating = false;
-            shotVisualPowerRef.current = 0;
-            cuePullCurrentRef.current = 0;
-            cuePullTargetRef.current = 0;
-          }
+          };
+          requestAnimationFrame(animateStroke);
         };
         let aiThinkingHandle = null;
         const planKey = (plan) =>
@@ -26650,37 +26427,24 @@ const sliderResetTimerRef = useRef(null);
           updateChalkVisibility(null);
         }
 
-        const providedCueVisual = cueStick.userData?.providedCue;
-        if (providedCueVisual?.group) {
-          providedCueVisual.group.visible = cueStick.visible;
-          if (cueStick.visible) {
-            const endpoints = getSnookerCueEndpoints(cueStick, cueLen);
-            if (endpoints?.butt && endpoints?.tip) {
-              setCuePose(providedCueVisual, endpoints.butt, endpoints.tip);
-            }
-          }
-        }
-
-        if (snookerHumanPlayer) {
-          try {
-            updateSnookerRoyalHumanPlayer(snookerHumanPlayer, deltaSeconds, {
-              cue,
-              cueStick,
-              cueLen,
-              aimDir: showingRemoteAim
-                ? new THREE.Vector2(remoteAimState?.dir?.x ?? 0, remoteAimState?.dir?.y ?? 1)
-                : activeAiPlan?.aimDir || aimDir,
-              visible: cue?.active && !currentHud?.over,
-              power: Math.max(powerRef.current ?? 0, shotVisualPowerRef.current ?? 0, activeAiPlan?.power ?? 0),
-              shooting,
-              cueAnimating
-            });
-          } catch (error) {
-            snookerHumanPlayer.disabled = true;
-            snookerHumanPlayer.root.visible = false;
-            snookerHumanPlayer.modelRoot.visible = false;
-            console.warn('Snooker Royal human player disabled after pose error', error);
-          }
+        try {
+          updateSnookerRoyalHumanPlayer(snookerHumanPlayer, deltaSeconds, {
+            cue,
+            cueStick,
+            cueLen,
+            aimDir: showingRemoteAim
+              ? new THREE.Vector2(remoteAimState?.dir?.x ?? 0, remoteAimState?.dir?.y ?? 1)
+              : activeAiPlan?.aimDir || aimDir,
+            visible: cueStick.visible || cueAnimating || shooting,
+            power: powerRef.current ?? activeAiPlan?.power ?? 0,
+            shooting,
+            cueAnimating
+          });
+        } catch (error) {
+          snookerHumanPlayer.disabled = true;
+          snookerHumanPlayer.root.visible = false;
+          snookerHumanPlayer.modelRoot.visible = false;
+          console.warn('Snooker Royal human player disabled after pose error', error);
         }
 
         if (!shouldSlowAim) {
@@ -27394,10 +27158,7 @@ const sliderResetTimerRef = useRef(null);
             const any = balls.some(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
-            if (!shotImpulseApplied) {
-              // The shot is committed, but the cue-ball impulse waits for the
-              // visible cue tip to reach contact, matching Snooker Champion.
-            } else if (!any) {
+            if (!any) {
               resolve();
             } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
               console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');
@@ -27595,7 +27356,6 @@ const sliderResetTimerRef = useRef(null);
         activeRenderCameraRef.current = null;
         snookerHumanPlayer?.root?.removeFromParent?.();
         snookerHumanPlayer?.modelRoot?.removeFromParent?.();
-        providedCue?.group?.removeFromParent?.();
         cueBodyRef.current = null;
         tipGroupRef.current = null;
         try {
@@ -27775,7 +27535,7 @@ const sliderResetTimerRef = useRef(null);
   }, [isPortrait, uiScale]);
 
   // --------------------------------------------------
-  // Pull slider (SnookerRoyalProvided logic)
+  // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
   const sliderRef = useRef(null);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
@@ -27785,32 +27545,21 @@ const sliderResetTimerRef = useRef(null);
     }
     const mount = sliderRef.current;
     if (!mount) return undefined;
-    mount.innerHTML = '';
     const slider = new PoolRoyalePowerSlider({
       mount,
-      value: 0,
-      min: 0,
-      max: 100,
-      step: 1,
+      value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
+      onChange: (v) => applyPower(v / 100),
       onStart: () => {
-        sliderDraggingRef.current = true;
+        captureCueStickAnchor();
       },
-      onChange: (value) => {
-        const normalized = THREE.MathUtils.clamp(value / 100, 0, 1);
-        applyPower(normalized);
-        if (sliderDraggingRef.current) committedShotPowerRef.current = normalized;
-      },
-      onCommit: (value) => {
-        const normalized = THREE.MathUtils.clamp(value / 100, 0, 1);
-        committedShotPowerRef.current = normalized;
-        sliderDraggingRef.current = false;
-        applyPower(normalized);
-        if (normalized > 0.02) {
-          fireRef.current?.(normalized);
-        }
-        slider.animateToMin({ duration: 180 });
+      onCommit: () => {
+        fireRef.current?.();
+        requestAnimationFrame(() => {
+          slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
       }
     });
     sliderInstanceRef.current = slider;
@@ -27819,7 +27568,7 @@ const sliderResetTimerRef = useRef(null);
       sliderInstanceRef.current = null;
       slider.destroy();
     };
-  }, [applySliderLock, showPowerSlider]);
+  }, [applySliderLock, captureCueStickAnchor, showPowerSlider]);
   useEffect(() => {
     if (shotActive || hud.over || hud.turn !== 0) return;
     const slider = sliderInstanceRef.current;
@@ -29749,82 +29498,8 @@ const sliderResetTimerRef = useRef(null);
 }
 
 export default function SnookerRoyal() {
-  const location = useLocation();
-  const playType = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    const requested = params.get('type');
-    if (requested === 'training') return 'training';
-    if (requested === 'tournament') return 'tournament';
-    return 'regular';
-  }, [location.search]);
-  const variantKey = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return resolvePoolVariant(params.get('variant') || 'snooker').id;
-  }, [location.search]);
-  const ballSetKey = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    const normalized = normalizeBallSetKey(params.get('ballSet'));
-    return normalized || null;
-  }, [location.search]);
-  const tableSizeKey = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return resolveTableSize(params.get('tableSize')).id;
-  }, [location.search]);
-  const tableModel = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return resolveSnookerTableModel(params.get('tableModel')).id;
-  }, [location.search]);
-  const mode = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    const requested = params.get('mode');
-    if (requested === 'online') return 'online';
-    if (requested === 'local') return 'local';
-    return 'ai';
-  }, [location.search]);
-  const trainingMode = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('trainingMode') === 'ai' ? 'ai' : 'solo';
-  }, [location.search]);
-  const accountId = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('accountId') || '';
-  }, [location.search]);
-  const tgId = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('tgId') || '';
-  }, [location.search]);
-  const playerName = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('name') || getTelegramUsername() || getTelegramId() || 'Player';
-  }, [location.search]);
-  const playerAvatar = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('avatar') || getTelegramPhotoUrl() || '';
-  }, [location.search]);
-  const opponentName = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('opponent') || '';
-  }, [location.search]);
-  const opponentAvatar = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return params.get('opponentAvatar') || '';
-  }, [location.search]);
-
-  return (
-    <SnookerRoyalGame
-      variantKey={variantKey}
-      ballSetKey={ballSetKey}
-      tableSizeKey={tableSizeKey}
-      tableModel={tableModel}
-      playType={playType}
-      mode={mode}
-      trainingMode={trainingMode}
-      accountId={accountId}
-      tgId={tgId}
-      playerName={playerName}
-      playerAvatar={playerAvatar}
-      opponentName={opponentName}
-      opponentAvatar={opponentAvatar}
-    />
-  );
+  // Snooker Royal now mounts the same scene implementation used by Snooker
+  // Champion so the human character and cue stick are rendered by the shared,
+  // unmodified Champion code path.
+  return <SnookerRoyalProvided gameTitle="Snooker Royal" />;
 }

--- a/webapp/src/pages/Games/SnookerRoyalProvided.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalProvided.jsx
@@ -133,7 +133,7 @@ const OFFICIAL_SNOOKER_BLACK_FROM_TOP_CUSHION_M = 0.324;
 const OFFICIAL_SNOOKER_POCKET_CORNER_MOUTH_M = 0.086;
 const OFFICIAL_SNOOKER_POCKET_MIDDLE_MOUTH_M = 0.095;
 const SNOOKER_TABLE_VISUAL_LENGTH_TRIM = 1.08; // larger GLB cabinet framing so the imported snooker table wraps the official mapped cushion rectangle
-const SNOOKER_PLAYFIELD_SCALE = (2.62 * WORLD_SCALE) / OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M;
+const SNOOKER_PLAYFIELD_SCALE = (2.55 * WORLD_SCALE) / OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M;
 const SNOOKER_OFFICIAL_PLAYFIELD_W = OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M * SNOOKER_PLAYFIELD_SCALE;
 const SNOOKER_OFFICIAL_PLAYFIELD_L = OFFICIAL_SNOOKER_PLAYFIELD_LENGTH_M * SNOOKER_PLAYFIELD_SCALE;
 const SNOOKER_OFFICIAL_BALL_R = (OFFICIAL_SNOOKER_BALL_DIAMETER_M * SNOOKER_PLAYFIELD_SCALE) / 2;
@@ -151,7 +151,7 @@ const SNOOKER_SHOT_POWER_RANGE = 0.75;
 const SNOOKER_SHOT_FULL_SPEED = 12 * WORLD_SCALE * SNOOKER_SHOT_POWER_BOOST;
 const SNOOKER_BALL_MASS = 0.17;
 const SNOOKER_SHOT_SPIN_SCALE = 0.25;
-const SNOOKER_SPIN_GLOBAL_SCALE = 0.68; // match Pool Royale's reduced cue-spin input so centre-ball shots do not over-rotate
+const SNOOKER_SPIN_GLOBAL_SCALE = 0.82; // match Pool Royale's reduced cue-spin input so centre-ball shots do not over-rotate
 const SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER = 1.2;
 const SNOOKER_SIDE_SPIN_MULTIPLIER = 1.5 * SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER;
 const SNOOKER_BACKSPIN_MULTIPLIER = 2.6 * SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER;
@@ -237,7 +237,7 @@ const CFG = {
   tableTopY: 0.84 * WORLD_SCALE,
   tableW: SNOOKER_OFFICIAL_PLAYFIELD_W,
   tableL: SNOOKER_OFFICIAL_PLAYFIELD_L,
-  tableVisualMultiplier: 1.12 * SNOOKER_TABLE_VISUAL_LENGTH_TRIM,
+  tableVisualMultiplier: 1.08 * SNOOKER_TABLE_VISUAL_LENGTH_TRIM,
   railH: 0.08 * WORLD_SCALE,
   ballR: SNOOKER_OFFICIAL_BALL_R,
   friction: 1.18,
@@ -1211,8 +1211,8 @@ function applyCueShot(cueBall, power, yaw, out, spinInput = { x: 0, y: 0 }) {
   if (launchSpeed > 1e-6 && cueBall.omega) {
     const rollingAxis = new THREE.Vector3(cueBall.vel.z, 0, -cueBall.vel.x).normalize();
     cueBall.omega.addScaledVector(rollingAxis, launchSpeed / CFG.ballR);
-    cueBall.omega.x += -(spin.y ?? 0) * p * 11;
-    cueBall.omega.z += -(spin.x ?? 0) * p * 11;
+    cueBall.omega.x += -(spin.y ?? 0) * p * 18;
+    cueBall.omega.z += -(spin.x ?? 0) * p * 18;
   }
   cueBall.launchDir = cueBall.vel.lengthSq() > 1e-8 ? cueBall.vel.clone().normalize() : null;
   cueBall.impacted = false;
@@ -2310,10 +2310,7 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
       let gap = CFG.idleGap;
       const spinOffset = mapSpinForPhysics(spinRef.current);
       if (state === 'dragging') gap += pull + practiceStroke;
-      if (state === 'striking') {
-        const strikeMotionNorm = didHit ? 0.88 : strikeNorm;
-        gap = lerp(CFG.idleGap + pull, CFG.contactGap, easeOutCubic(strikeMotionNorm));
-      }
+      if (state === 'striking') gap = lerp(CFG.idleGap + pull, CFG.contactGap, easeOutCubic(strikeNorm));
       const cueTipShoot = cueBallWorld.clone()
         .addScaledVector(aimForward, -(CFG.ballR + gap))
         .addScaledVector(aimSide, (spinOffset.x ?? 0) * CFG.ballR * 0.52)
@@ -2528,6 +2525,44 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
                 <span className={railOverheadSide === 'front' ? 'text-emerald-100' : 'text-white/65'}>▼</span>
               </span>
             </button>
+            <button
+              type="button"
+              disabled={!hasReplay}
+              onClick={() => {
+                if (!hasReplay) return;
+                replayStartedAtRef.current = performance.now();
+                setReplayActive(true);
+              }}
+              className={`flex h-12 w-12 items-center justify-center rounded-full border text-[15px] font-semibold shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
+                replayActive
+                  ? 'border-amber-200 bg-amber-300/25 text-amber-100'
+                  : hasReplay
+                    ? 'border-white/30 bg-black/70 text-white hover:bg-black/60'
+                    : 'border-white/10 bg-black/45 text-white/35'
+              }`}
+              aria-label="Replay last snooker shot"
+            >
+              <span aria-hidden="true">↻</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setReplaySkipAll((prev) => {
+                  const next = !prev;
+                  replaySkipAllRef.current = next;
+                  if (next) setReplayActive(false);
+                  return next;
+                });
+              }}
+              className={`flex h-12 w-12 items-center justify-center rounded-full border text-[10px] font-black uppercase tracking-[0.08em] shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
+                replaySkipAll
+                  ? 'border-rose-300 bg-rose-500/25 text-rose-100'
+                  : 'border-white/30 bg-black/70 text-white hover:bg-black/60'
+              }`}
+              aria-label="Skip all replays"
+            >
+              Skip
+            </button>
           </div>
         </div>
 
@@ -2738,18 +2773,6 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
             />
           </div>
         </div>
-        {replayActive ? (
-          <div className="pointer-events-none absolute inset-y-0 right-0 z-[70] flex items-center pr-2">
-            <button
-              type="button"
-              onClick={() => setReplayActive(false)}
-              className="pointer-events-auto rounded-l-xl border border-white/30 bg-black/70 px-3 py-2 text-[11px] font-black uppercase tracking-[0.12em] text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition hover:bg-black/60"
-              aria-label="Skip current replay"
-            >
-              Skip
-            </button>
-          </div>
-        ) : null}
         {lastQuickMessage ? (
           <div className="pointer-events-none absolute left-1/2 top-24 z-40 -translate-x-1/2 rounded-full border border-white/15 bg-black/70 px-4 py-2 text-sm font-semibold text-white shadow-xl backdrop-blur">
             {lastQuickMessage}


### PR DESCRIPTION
### Motivation
- Restore the Snooker Royal cue-stick visuals and the pull/release shooting mechanism to the previous baseline so the game uses the same cue and shot timing/flow as it had five days ago. 
- Re-align the runtime `PowerSlider` behavior with the older pull→release commit flow used by the Snooker implementation to ensure shot commits map to the restored cue strike.

### Description
- Reverted `power-slider.js` and `webapp/public/power-slider.js` to the earlier implementation that removes the inline shot animation and `onShotRelease` wiring and returns the slider to a pull/release commit model. 
- Restored `webapp/src/pages/Games/SnookerRoyal.jsx` to the prior cue, human pose, and shooting flow: re-enabled the provided/Champion cue path, reworked cue stroke timing, sampling of the cue stroke timeline via `sampleCueStrokeTimeline`, and restored power/spin/launch math consistent with the prior baseline. 
- Updated `webapp/src/pages/Games/SnookerRoyalProvided.jsx` constants and CFG to match the expected Champion-provided cue/table/shot parameters and tuned spin/power multipliers and cue strike timing to match the restored behavior. 
- Files changed: `power-slider.js`, `webapp/public/power-slider.js`, `webapp/src/pages/Games/SnookerRoyal.jsx`, `webapp/src/pages/Games/SnookerRoyalProvided.jsx` (commit created: `b98f6ad`).

### Testing
- Verified repository state and diffs with `git diff --name-only f121511..HEAD`, `git status --short`, and `git diff --cached --stat`, and confirmed the intended files were staged and included in the commit; these checks completed successfully. 
- Created the commit with message `Restore Snooker Royal cue stick and shot mechanism to pre-May-14 state` and confirmed the commit succeeded. 
- Performed targeted file inspections (`nl`, `rg`) to validate the restored slider and Snooker code paths were updated as expected; these inspections succeeded. 
- No automated unit or playmode tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1dc6ed208329961c53b3edeb0f7b)