### PR TITLE
Restore Snooker Royal cue stick + shot release behavior from 5 days ago

### DIFF
--- a/webapp/public/power-slider.js
+++ b/webapp/public/power-slider.js
@@ -9,7 +9,6 @@ export class PowerSlider {
       cueSrc = '',
       onChange,
       onCommit,
-      onShotRelease,
       onStart,
       theme = 'default',
       labels = false
@@ -22,11 +21,9 @@ export class PowerSlider {
     this.step = step;
     this.onChange = onChange;
     this.onCommit = onCommit;
-    this.onShotRelease = onShotRelease;
     this.onStart = onStart;
     this.locked = false;
     this._returnAnimFrame = null;
-    this._shotAnimFrame = null;
 
     this.el = document.createElement('div');
     this.el.className = `ps ps-theme-${theme}`;
@@ -254,7 +251,6 @@ export class PowerSlider {
     if (this.locked) return;
     e.preventDefault();
     this._cancelReturnAnimation();
-    this._cancelShotAnimation();
     this.dragging = true;
     if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.classList.add('ps-no-animate');
@@ -277,7 +273,6 @@ export class PowerSlider {
     this.el.removeEventListener('pointerup', this._onPointerUp);
     this.el.classList.remove('ps-no-animate');
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
-    this._playShotAnimation(this.value);
   }
 
   _wheel(e) {
@@ -313,39 +308,6 @@ export class PowerSlider {
         if (typeof this.onStart === 'function') this.onStart(this.value);
       }
       e.preventDefault();
-    }
-  }
-
-  _playShotAnimation(powerValue) {
-    this._cancelShotAnimation();
-    const power = this._clamp(this._step(powerValue));
-    const pullDuration = 90;
-    const resetDuration = 150;
-    const strikeOvershoot = Math.max(this.min + (this.max - this.min) * 0.14, this.min + 1);
-
-    this.animateTo(strikeOvershoot, { duration: pullDuration });
-
-    const startedAt = performance.now();
-    const step = (now) => {
-      const t = Math.min(1, Math.max(0, (now - startedAt) / resetDuration));
-      const eased = 1 - Math.pow(1 - t, 3);
-      const next = strikeOvershoot + (this.min - strikeOvershoot) * eased;
-      this.set(next, { animate: true });
-      if (t >= 1) {
-        this._shotAnimFrame = null;
-        if (typeof this.onShotRelease === 'function') this.onShotRelease(power);
-        return;
-      }
-      this._shotAnimFrame = requestAnimationFrame(step);
-    };
-
-    this._shotAnimFrame = requestAnimationFrame(step);
-  }
-
-  _cancelShotAnimation() {
-    if (this._shotAnimFrame != null) {
-      cancelAnimationFrame(this._shotAnimFrame);
-      this._shotAnimFrame = null;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Restore the previous Snooker Royal cue-stick and shooting feel by removing a recently added shot-release animation and callback that changed the timing and strike behavior.

### Description
- Reverted `webapp/public/power-slider.js` to the earlier interaction model by removing the `onShotRelease` option, the `_shotAnimFrame` field, and the `_playShotAnimation` / `_cancelShotAnimation` functions, and by removing the shot-animation invocation on pointer release and pointer-down cancel.
- The slider now uses the existing `onCommit`/release path (wheel/Enter/pointerup) to commit the shot immediately, restoring the prior cue strike synchronization.

### Testing
- Ran `npm test -- --runTestsByPath test/poolRoyaleCueStrokeTimeline.test.js` and the suite passed (4 tests: all PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1dc6ed208329961c53b3edeb0f7b)