### PR TITLE
Domino Battle Royal: restore 4pm human character pose tuning

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8629,14 +8629,14 @@ function runDominoCharacterAction(seatIndex, type = 'PLAY') {
       z: THREE.MathUtils.degToRad(-17)
     },
     rightForeArm: {
-      x: THREE.MathUtils.degToRad(-48),
-      y: THREE.MathUtils.degToRad(11) + inwardElbowYaw,
-      z: THREE.MathUtils.degToRad(-3)
+      x: THREE.MathUtils.degToRad(-46),
+      y: THREE.MathUtils.degToRad(16) + inwardElbowYaw,
+      z: THREE.MathUtils.degToRad(-2)
     },
     rightHand: {
-      x: THREE.MathUtils.degToRad(-24),
-      y: THREE.MathUtils.degToRad(-18),
-      z: THREE.MathUtils.degToRad(-12)
+      x: THREE.MathUtils.degToRad(-21),
+      y: THREE.MathUtils.degToRad(-13),
+      z: THREE.MathUtils.degToRad(-8)
     },
     rightThumb: { x: playFingerOpen, y: THREE.MathUtils.degToRad(15), z: THREE.MathUtils.degToRad(12) },
     rightIndex: { x: playFingerOpen, y: THREE.MathUtils.degToRad(-13), z: THREE.MathUtils.degToRad(-6) },
@@ -8651,14 +8651,14 @@ function runDominoCharacterAction(seatIndex, type = 'PLAY') {
       z: THREE.MathUtils.degToRad(-18)
     },
     rightForeArm: {
-      x: THREE.MathUtils.degToRad(-38),
-      y: THREE.MathUtils.degToRad(12) + inwardElbowYaw,
-      z: THREE.MathUtils.degToRad(-4)
+      x: THREE.MathUtils.degToRad(-36),
+      y: THREE.MathUtils.degToRad(18) + inwardElbowYaw,
+      z: THREE.MathUtils.degToRad(-3)
     },
     rightHand: {
-      x: THREE.MathUtils.degToRad(-30),
-      y: THREE.MathUtils.degToRad(-19),
-      z: THREE.MathUtils.degToRad(-13)
+      x: THREE.MathUtils.degToRad(-26),
+      y: THREE.MathUtils.degToRad(-13),
+      z: THREE.MathUtils.degToRad(-9)
     },
     rightThumb: { x: THREE.MathUtils.degToRad(-4), y: THREE.MathUtils.degToRad(18), z: THREE.MathUtils.degToRad(14) },
     rightIndex: { x: THREE.MathUtils.degToRad(6), y: THREE.MathUtils.degToRad(-16), z: THREE.MathUtils.degToRad(-7) },
@@ -8689,6 +8689,17 @@ function runDominoCharacterAction(seatIndex, type = 'PLAY') {
     head: { x: THREE.MathUtils.degToRad(5) }
   });
   const release = makeDominoPose(carry, {
+    rightUpperArm: {
+      x: THREE.MathUtils.degToRad(92),
+      y: THREE.MathUtils.degToRad(-1) + inwardReachYaw * 0.38,
+      z: THREE.MathUtils.degToRad(2)
+    },
+    rightForeArm: {
+      x: THREE.MathUtils.degToRad(24),
+      y: THREE.MathUtils.degToRad(-3) + inwardElbowYaw * 0.2,
+      z: THREE.MathUtils.degToRad(0)
+    },
+    rightHand: { x: THREE.MathUtils.degToRad(4), y: THREE.MathUtils.degToRad(3), z: THREE.MathUtils.degToRad(1) },
     rightThumb: { x: THREE.MathUtils.degToRad(6), y: THREE.MathUtils.degToRad(-10), z: THREE.MathUtils.degToRad(-9) },
     rightIndex: { x: THREE.MathUtils.degToRad(-14), y: THREE.MathUtils.degToRad(9), z: THREE.MathUtils.degToRad(4) },
     rightMiddle: { x: THREE.MathUtils.degToRad(-9), y: THREE.MathUtils.degToRad(4), z: THREE.MathUtils.degToRad(2) }


### PR DESCRIPTION
### Motivation
- Restore the Domino Battle Royal human character arm/hand poses to the 4pm tuning baseline as requested, targeting visual/animation fidelity only.
- Keep the scope strictly to the human character animation values to avoid touching gameplay or non-human assets.

### Description
- Adjusted numeric pose values inside `runDominoCharacterAction` in `webapp/public/domino-royal-game.js` to restore the prior right forearm and right hand angles for the `approach` and `hover` poses.
- Added explicit `rightUpperArm`, `rightForeArm`, and `rightHand` entries to the `release` pose in the same function to match the 4pm tuning.
- Changes are limited to pose definitions and do not modify gameplay logic or other files.

### Testing
- No automated unit or integration tests were executed as part of this change.
- The change is a targeted numeric restoration of pose values and should be validated visually in the running game; no automated checks were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c24eaafec8329a08507687abfcf1c)