### PR TITLE
Match Chess Battle Royal 3D camera framing/limits to Checkers behavior

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -615,6 +615,8 @@ const FPV_BOB_AMPLITUDE = 0.0;
 const FPV_LOOK_DRAG_SPEED = 0.0045;
 const FPV_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(18);
 const FPV_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(12);
+const CHECKERS_MATCH_CAMERA_YAW_LIMIT = THREE.MathUtils.degToRad(18);
+const CHECKERS_MATCH_CAMERA_PITCH_LIMIT = THREE.MathUtils.degToRad(12);
 const SEATED_HUMAN_MOVE_DURATION_MS = 520; // Slightly longer to keep finger contact readable during pickup/carry/place.
 const SEATED_HUMAN_PICKUP_PHASE_END = 0.24;
 const SEATED_HUMAN_CARRY_PHASE_END = 0.8;
@@ -10365,23 +10367,22 @@ function Chess3D({
     controls.target.copy(boardLookTarget);
     const cameraOffset = camera.position.clone().sub(boardLookTarget);
     const cameraSpherical = new THREE.Spherical().setFromVector3(cameraOffset);
-    const horizontalSwing = THREE.MathUtils.degToRad(isPortrait ? 95 : 80);
-    const verticalAllowanceUp = THREE.MathUtils.degToRad(isPortrait ? 38 : 28);
-    const verticalAllowanceDown = THREE.MathUtils.degToRad(isPortrait ? 42 : 30);
     controls.minPolarAngle = clamp(
-      cameraSpherical.phi - verticalAllowanceUp,
+      cameraSpherical.phi - CHECKERS_MATCH_CAMERA_PITCH_LIMIT,
       CAMERA_PULL_FORWARD_MIN,
       CAM.phiMax
     );
     controls.maxPolarAngle = clamp(
-      cameraSpherical.phi + verticalAllowanceDown,
+      cameraSpherical.phi + CHECKERS_MATCH_CAMERA_PITCH_LIMIT,
       CAMERA_PULL_FORWARD_MIN,
       CAM.phiMax
     );
-    controls.minAzimuthAngle = cameraSpherical.theta - horizontalSwing;
-    controls.maxAzimuthAngle = cameraSpherical.theta + horizontalSwing;
-    controls.minDistance = CAMERA_3D_MIN_RADIUS;
-    controls.maxDistance = CAMERA_3D_MAX_RADIUS;
+    controls.minAzimuthAngle = cameraSpherical.theta - CHECKERS_MATCH_CAMERA_YAW_LIMIT;
+    controls.maxAzimuthAngle = cameraSpherical.theta + CHECKERS_MATCH_CAMERA_YAW_LIMIT;
+    // Match Checkers Battle Royal framing: allow left/right/up/down look only,
+    // while keeping the camera position locked (no in/out movement).
+    controls.minDistance = cameraSpherical.radius;
+    controls.maxDistance = cameraSpherical.radius;
     controls.update();
     controlsRef.current = controls;
     syncSkyboxToCamera = () => {
@@ -10488,12 +10489,20 @@ function Chess3D({
         controls.enableRotate = true;
         controls.enablePan = false;
         controls.enableZoom = true;
-        controls.minPolarAngle = CAMERA_PULL_FORWARD_MIN;
-        controls.maxPolarAngle = CAM.phiMax;
-        controls.minAzimuthAngle = -Infinity;
-        controls.maxAzimuthAngle = Infinity;
-        controls.minDistance = CAMERA_3D_MIN_RADIUS;
-        controls.maxDistance = CAMERA_3D_MAX_RADIUS;
+        controls.minPolarAngle = clamp(
+          current.phi - CHECKERS_MATCH_CAMERA_PITCH_LIMIT,
+          CAMERA_PULL_FORWARD_MIN,
+          CAM.phiMax
+        );
+        controls.maxPolarAngle = clamp(
+          current.phi + CHECKERS_MATCH_CAMERA_PITCH_LIMIT,
+          CAMERA_PULL_FORWARD_MIN,
+          CAM.phiMax
+        );
+        controls.minAzimuthAngle = current.theta - CHECKERS_MATCH_CAMERA_YAW_LIMIT;
+        controls.maxAzimuthAngle = current.theta + CHECKERS_MATCH_CAMERA_YAW_LIMIT;
+        controls.minDistance = current.radius;
+        controls.maxDistance = current.radius;
         const restore = cameraMemory.last3d || default3d;
         const targetPhi = clamp(
           restore.phi - (isForcedCapture3dView ? CAMERA_CAPTURE_VIEW_UPWARD_BIAS : 0),


### PR DESCRIPTION
### Motivation
- Ensure consistent camera framing and player experience across Battle Royal games by matching Chess 3D look controls to the constrained look behavior used in Checkers so the table, chairs, board, and seated humans remain visually fixed while allowing limited look-around.

### Description
- Introduced `CHECKERS_MATCH_CAMERA_YAW_LIMIT` and `CHECKERS_MATCH_CAMERA_PITCH_LIMIT` (±18° yaw, ±12° pitch) near other FPV/look constants in `ChessBattleRoyal.jsx`.
- Replaced the previous horizontal/vertical allowance calculations in the initial `OrbitControls` setup with clamps using the new limits and locked `controls.minDistance`/`controls.maxDistance` to the camera's current spherical radius so the camera cannot move in/out.
- Applied the same yaw/pitch and distance locking constraints when restoring or switching back into 3D view so the framing/behavior remains consistent after view-mode changes.

### Testing
- Applied the code patch to `webapp/src/pages/Games/ChessBattleRoyal.jsx` and inspected the resulting diff to confirm the new constants and control constraint replacements (24 insertions, 15 deletions in the file). 
- Verified the modified `OrbitControls` initialization and 3D view-restore blocks contain the clamped polar/azimuth limits and locked distance; no runtime/unit tests were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c406a6f848329a396ab69b5a5fc48)