### PR TITLE
Lower Domino Royale character arms and hands toward table

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8345,12 +8345,12 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-65), THREE.MathUtils.degToRad(-5), THREE.MathUtils.degToRad(-2));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(39), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(11), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-72), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(41), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(12), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-77), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-2));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(53), THREE.MathUtils.degToRad(-1), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(19), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-83), THREE.MathUtils.degToRad(8), THREE.MathUtils.degToRad(4));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(55), THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(2));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(20), THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(2));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));


### PR DESCRIPTION
### Motivation
- Bring seated human avatars' arms and hands closer to the domino play surface so their interaction with held/played tiles appears more natural.

### Description
- Adjusted runtime pose offsets in `webapp/public/domino-royal-game.js` inside `createDominoCharacterRig` to lower both upper-arms and increase forearm/hand bends. 
- Left side changes: `leftUpperArm` -65° → -77°, `leftForeArm` 39° → 53°, `leftHand` 11° → 19° (values are in `THREE.MathUtils.degToRad`).
- Right side changes: `rightUpperArm` -72° → -83°, `rightForeArm` 41° → 55°, `rightHand` 12° → 20° (values are in `THREE.MathUtils.degToRad`).
- No other bone offsets (hips, spine, head, legs) were modified to preserve the seated silhouette.

### Testing
- No automated tests were run for this pose-tuning change since it updates animation constants only and requires visual verification in the running game.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c72dc001c8329a6110b7b11c78ec3)