### PR TITLE
Adjust Four In Row human character size and vertical placement

### DIFF
--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -145,6 +145,8 @@ const TARGET_CHAIR_SIZE = new THREE.Vector3(
 const FOUR_IN_ROW_CHARACTER_PROPORTION_SCALE = 2.15;
 const FOUR_IN_ROW_CHARACTER_EXTRA_LOWER_OFFSET = 0.32;
 const FOUR_IN_ROW_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.42;
+const FOUR_IN_ROW_HUMAN_CHARACTER_SCALE_MULTIPLIER = 0.93;
+const FOUR_IN_ROW_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.07;
 const FOUR_IN_ROW_CHARACTER_MODEL_CACHE = new Map();
 const FOUR_IN_ROW_CHESS_HUMAN_OPTIONS = Object.freeze(
   CHESS_HUMAN_CHARACTER_OPTIONS.filter((option) => Array.isArray(option?.modelUrls) && option.modelUrls.length)
@@ -1127,14 +1129,15 @@ function attachFourInRowSeatedCharacter({ template, chair, theme, isHumanSeat = 
   const measuredHeight = Math.max(0.01, bounds.max.y - bounds.min.y);
   const targetHeight = Math.max(TARGET_CHAIR_SIZE.y * 1.16, 0.01);
   const adapterScale = instance.userData?.seatedScaleMultiplier ?? 1;
-  const seatScale = (targetHeight / measuredHeight) * adapterScale * FOUR_IN_ROW_CHARACTER_PROPORTION_SCALE;
+  const humanScaleMultiplier = isHumanSeat ? FOUR_IN_ROW_HUMAN_CHARACTER_SCALE_MULTIPLIER : 1;
+  const seatScale = (targetHeight / measuredHeight) * adapterScale * FOUR_IN_ROW_CHARACTER_PROPORTION_SCALE * humanScaleMultiplier;
   const scaleDelta = Math.max(0, FOUR_IN_ROW_CHARACTER_PROPORTION_SCALE - 1);
   seatRoot.scale.multiplyScalar(seatScale);
   const adapterYOffset = instance.userData?.seatedYOffset ?? 0;
   const adapterZOffset = instance.userData?.seatedZOffset ?? 0;
   seatRoot.position.set(
     0,
-    -0.42 - scaleDelta * 0.08 - FOUR_IN_ROW_CHARACTER_EXTRA_LOWER_OFFSET + adapterYOffset,
+    -0.42 - scaleDelta * 0.08 - FOUR_IN_ROW_CHARACTER_EXTRA_LOWER_OFFSET - (isHumanSeat ? FOUR_IN_ROW_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET : 0) + adapterYOffset,
     0.5 - 0.03 - FOUR_IN_ROW_CHARACTER_EXTRA_OUTWARD_OFFSET + adapterZOffset
   );
   seatRoot.rotation.set(0, instance.userData?.seatedYawOffset ?? 0, 0);
@@ -1202,10 +1205,11 @@ function attachFourInRowFallbackSeatedCharacter({ chair, theme, isHumanSeat = fa
   const seatRoot = new THREE.Group();
   const character = createFourInRowFallbackSeatedHuman(theme, isHumanSeat);
   const scaleDelta = Math.max(0, FOUR_IN_ROW_CHARACTER_PROPORTION_SCALE - 1);
-  seatRoot.scale.setScalar(TARGET_CHAIR_SIZE.y * 0.52);
+  const humanScaleMultiplier = isHumanSeat ? FOUR_IN_ROW_HUMAN_CHARACTER_SCALE_MULTIPLIER : 1;
+  seatRoot.scale.setScalar(TARGET_CHAIR_SIZE.y * 0.52 * humanScaleMultiplier);
   seatRoot.position.set(
     0,
-    -0.42 - scaleDelta * 0.08 - FOUR_IN_ROW_CHARACTER_EXTRA_LOWER_OFFSET,
+    -0.42 - scaleDelta * 0.08 - FOUR_IN_ROW_CHARACTER_EXTRA_LOWER_OFFSET - (isHumanSeat ? FOUR_IN_ROW_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET : 0),
     0.5 - 0.03 - FOUR_IN_ROW_CHARACTER_EXTRA_OUTWARD_OFFSET
   );
   seatRoot.add(character);


### PR DESCRIPTION
### Motivation
- The human player's seated character should appear slightly smaller and sit a bit lower than AI seats for better visual balance and less occlusion.
- Ensure the visual tweak applies consistently to both loaded GLTF characters and the procedural fallback character.

### Description
- Added two new constants `FOUR_IN_ROW_HUMAN_CHARACTER_SCALE_MULTIPLIER = 0.93` and `FOUR_IN_ROW_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.07` to control human-only scaling and vertical offset in `webapp/src/pages/Games/FourInRowRoyal.jsx`.
- When attaching loaded character models in `attachFourInRowSeatedCharacter`, multiply the computed `seatScale` by the human-only scale multiplier and subtract the human extra lower offset from `seatRoot.position.y` when `isHumanSeat` is true.
- Applied the same human-only scale multiplier and extra lower offset to the fallback path in `attachFourInRowFallbackSeatedCharacter` so procedural avatars match the behavior of GLTF models.

### Testing
- No automated tests were run for this visual tuning change; changes were committed to `webapp/src/pages/Games/FourInRowRoyal.jsx` and verified via local `git diff`/commit operations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7466c40483299ec846575025e1a7)