### PR TITLE
Lower Domino Royal seated character arms so hands sit closer to dominoes

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8345,13 +8345,13 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  // Lower both arms and pitch wrists inward so hands rest closer to the domino line.
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-66), THREE.MathUtils.degToRad(-6), THREE.MathUtils.degToRad(-3));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(61), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(33), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-71), THREE.MathUtils.degToRad(9), THREE.MathUtils.degToRad(5));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(62), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(35), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
+  // Lower both arms further and pitch wrists inward so hands sit closer to the domino line.
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-73), THREE.MathUtils.degToRad(-7), THREE.MathUtils.degToRad(-3.5));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(69), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1.5));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(41), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1.5));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-78), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5.5));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(71), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(43), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-19-human-seat-hand-position-v46';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-19-human-seat-hand-position-v47';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Human seated characters' hands were sitting too far from the domino line, so the pose needs to be lowered and pitched inward to better align with the domino racks. 
- Clients must fetch the updated pose tuning reliably, so the Domino script version needs a cache-busting bump.

### Description
- Tuned bone offsets in `createDominoCharacterRig` to lower and pitch wrists/forearms/hands for both sides by increasing the rotation angles in `webapp/public/domino-royal-game.js` so hands rest closer to the domino line. 
- Updated the inlined Domino Royal script version token from `2026-05-19-human-seat-hand-position-v46` to `2026-05-19-human-seat-hand-position-v47` in `webapp/src/pages/Games/DominoRoyalArena.jsx` so browsers fetch the new script. 
- Adjusted an inline comment to reflect the stronger lowering/pitching intent.

### Testing
- Ran `npm -s test -- test/dominoRoyalCharacterScale.test.js` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c76da270c8329a42649f8a7071267)