### PR TITLE
Lower Domino Royale character arms toward dominoes (extra for bottom player)

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8345,13 +8345,17 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  // Lower both arms further and pitch wrists inward so hands sit closer to the domino line.
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-73), THREE.MathUtils.degToRad(-7), THREE.MathUtils.degToRad(-3.5));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(69), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1.5));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(41), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1.5));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-78), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5.5));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(71), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(43), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
+  // Lower both arms toward the domino line; drop the bottom (human) seat a bit more.
+  const isBottomSeat = seatIndex === human;
+  const upperArmDropDeg = isBottomSeat ? 8 : 4;
+  const foreArmDropDeg = isBottomSeat ? 6 : 3;
+  const handDropDeg = isBottomSeat ? 5 : 2.5;
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-73 - upperArmDropDeg), THREE.MathUtils.degToRad(-7), THREE.MathUtils.degToRad(-3.5));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(69 + foreArmDropDeg), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1.5));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(41 + handDropDeg), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1.5));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-78 - upperArmDropDeg), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5.5));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(71 + foreArmDropDeg), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(43 + handDropDeg), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));


### PR DESCRIPTION
### Motivation
- Players requested the human characters' arms and hands be positioned closer to their dominoes, with the bottom (local) player lowered more than others.

### Description
- Adjusted the seated character rig pose in `webapp/public/domino-royal-game.js` inside `createDominoCharacterRig` to be seat-aware. 
- Added `upperArmDropDeg`, `foreArmDropDeg`, and `handDropDeg` that use `seatIndex === human` to apply stronger lowering for the bottom seat. 
- Applied the computed degree offsets to both left and right arm chains via `addDominoBoneOffset` for upper arm, forearm, and hand bones. 
- All other pose offsets remain unchanged and the change is isolated to the Domino Royale rig pose logic. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7a56a6348329b5155f56ce5c2e56)