### PR TITLE
Lower Domino Royal seated arms/hands and add extra drop for bottom player

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8345,13 +8345,15 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  // Lower both arms further and pitch wrists inward so hands sit closer to the domino line.
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-73), THREE.MathUtils.degToRad(-7), THREE.MathUtils.degToRad(-3.5));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(69), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1.5));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(41), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1.5));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-78), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5.5));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(71), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(43), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
+  // Lower both arms/hands closer to the domino line, with extra drop for the bottom user seat.
+  const isBottomSeat = seatIndex === human;
+  const bottomSeatExtraDrop = isBottomSeat ? 7 : 0;
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-78 - bottomSeatExtraDrop), THREE.MathUtils.degToRad(-7), THREE.MathUtils.degToRad(-3.5));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(74 + bottomSeatExtraDrop * 0.55), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1.5));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(47 + bottomSeatExtraDrop * 0.45), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1.5));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-83 - bottomSeatExtraDrop), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5.5));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(76 + bottomSeatExtraDrop * 0.55), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(49 + bottomSeatExtraDrop * 0.45), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-19-human-seat-hand-position-v47';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-19-human-seat-hand-position-v48';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Bring human characters' arms and hands visually closer to the domino line, with an additional downward offset for the bottom (user) seat, and ensure clients pick up the updated runtime.

### Description
- Adjusted bone rotation offsets in `webapp/public/domino-royal-game.js` to lower left/right upper-arm, forearm and hand poses and added a `bottomSeatExtraDrop` when `seatIndex === human` so the bottom player's hands are lowered more.
- Bumped the Domino Royal runtime script version in `webapp/src/pages/Games/DominoRoyalArena.jsx` from `v47` to `v48` to force clients to fetch the updated `domino-royal-game.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7a56a6348329b5155f56ce5c2e56)