### PR TITLE
Adjust Four In Row camera framing to be closer and higher

### DIFF
--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -1837,11 +1837,11 @@ export default function FourInRowRoyal() {
     const isPortrait = mount.clientHeight > mount.clientWidth;
     const cameraSeatAngle = Math.PI / 2;
     const cameraBackOffset =
-      ((isPortrait ? 2.18 : 1.52) + 0.28) * CAMERA_FRAME_MATCH_SCALE;
+      ((isPortrait ? 1.98 : 1.36) + 0.24) * CAMERA_FRAME_MATCH_SCALE;
     const cameraForwardOffset =
-      (isPortrait ? 0.36 : 0.42) * CAMERA_FRAME_MATCH_SCALE;
+      (isPortrait ? 0.44 : 0.5) * CAMERA_FRAME_MATCH_SCALE;
     const cameraHeightOffset =
-      (isPortrait ? 0.92 : 0.76) *
+      (isPortrait ? 1.08 : 0.9) *
       CAMERA_FRAME_MATCH_SCALE *
       TABLE_AND_CHAIR_SIZE_MULTIPLIER *
       CAMERA_HEIGHT_MATCH_BOOST;
@@ -1859,7 +1859,7 @@ export default function FourInRowRoyal() {
     controls.enablePan = false;
     controls.enableDamping = true;
     controls.dampingFactor = 0.08;
-    controls.target.set(0, arenaRoot.position.y + TABLE_HEIGHT - 0.07, 0);
+    controls.target.set(0, arenaRoot.position.y + TABLE_HEIGHT + 0.08, 0);
     controls.minPolarAngle = THREE.MathUtils.degToRad(30);
     controls.maxPolarAngle =
       ARENA_CAMERA_DEFAULTS.phiMax + THREE.MathUtils.degToRad(16);


### PR DESCRIPTION
### Motivation
- Improve the default camera framing for the Four In Row scene so the camera sits a bit closer to the table, higher above it, and looks slightly upward for a clearer at-table perspective.

### Description
- Tweaked camera offsets in `webapp/src/pages/Games/FourInRowRoyal.jsx` to reduce the back offset and increase the forward offset for both portrait and landscape layouts. 
- Increased the `cameraHeightOffset` values so the camera is positioned higher above the table. 
- Raised the `OrbitControls` target Y from `arenaRoot.position.y + TABLE_HEIGHT - 0.07` to `arenaRoot.position.y + TABLE_HEIGHT + 0.08` so the camera looks slightly upward by default. 
- These are visual tuning changes only and affect how the `PerspectiveCamera` and controls compute the camera position and target.

### Testing
- No automated tests were run for this visual/tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7c4499788329bca163fd4ea861bc)