### PR TITLE
Restore Domino Battle Royal to state from one hour ago

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8345,13 +8345,13 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  // Lower both arms further and pitch wrists inward so hands sit closer to the domino line.
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-73), THREE.MathUtils.degToRad(-7), THREE.MathUtils.degToRad(-3.5));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(69), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1.5));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(41), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1.5));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-78), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(5.5));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(71), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(43), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2.5));
+  // Lower both arms and pitch wrists inward so hands rest closer to the domino line.
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-66), THREE.MathUtils.degToRad(-6), THREE.MathUtils.degToRad(-3));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(61), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(33), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-71), THREE.MathUtils.degToRad(9), THREE.MathUtils.degToRad(5));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(62), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(35), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-19-human-seat-hand-position-v47';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-19-human-seat-hand-position-v46';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Revert recent Domino Battle Royal adjustments to the stable configuration from one hour prior to restore character pose and script version behavior. 
- Ensure seated human arm/hand positions and held-rack behavior match the previous gameplay appearance and behavior.

### Description
- Restored `webapp/public/domino-royal-game.js` to the earlier runtime state, including prior bone offsets in `createDominoCharacterRig` to move arms/wrists to the previous pose and a small comment text change. 
- Reverted the in-app script version constant in `webapp/src/pages/Games/DominoRoyalArena.jsx` from `v47` back to `v46`. 
- Only the two Domino Battle Royal files were changed (`webapp/public/domino-royal-game.js` and `webapp/src/pages/Games/DominoRoyalArena.jsx`) with a net change of 8 insertions and 8 deletions. 

### Testing
- Verified the historical snapshot was applied and file contents updated as expected by inspecting the file diffs and statistics, and this check succeeded. 
- Confirmed the Domino entry page now references the restored script version (`v46`) in the arena component and the runtime script file includes the previous bone offset values, and this content verification succeeded. 
- Confirmed no other gameplay files were affected and a pre-existing unrelated local change in iOS app icon metadata remains unchanged, and this status check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c85020a3083298c1e512b7e49d0db)