### PR TITLE
Adjust AK47 GLTF texture override to legacy single-map config

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -439,10 +439,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
     ],
     scale: 0.24,
-    forceTextureOverride: true,
     textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/textures/Material.001_baseColor.png',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/textures/Material.001_baseColor.png',
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg'
     ]
   },


### PR DESCRIPTION
### Motivation
- Restore the AK47 GLTF texture behavior to the previous, lightweight configuration used for the AK45 so the model can preserve its embedded GLTF texture mappings when available.
- Reduce runtime texture substitution complexity and avoid forcing overrides that replaced native PBR maps.

### Description
- Updated the `ak47VolleyAttack` entry in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to remove `forceTextureOverride` and simplify `textureOverrideUrls` to a single legacy `AK47.jpeg` map.
- The change keeps the model URL list and `scale` unchanged while allowing `prepareLoadedModel`/`normalizeMaterialTextures` to preserve GLTF mappings when present.
- This mirrors the older single-map override pattern used previously for this weapon family to improve visual consistency.

### Testing
- Performed a file-level diff inspection of `webapp/src/pages/Games/LudoBattleRoyal.jsx` to confirm `ak47VolleyAttack` no longer includes `forceTextureOverride` and now references only the `AK47.jpeg` override, and this check succeeded.
- Ran a repository search for `ak47`/texture override occurrences to ensure no other configs were inadvertently modified, and the search succeeded.
- Generated the PR metadata via the repository automation to record the change, and that operation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c85b186008329b0a1303258f76d40)