### PR TITLE
Remove forced AK-47 texture override in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -439,7 +439,6 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
     ],
     scale: 0.24,
-    forceTextureOverride: true,
     textureOverrideUrls: [
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/textures/Material.001_baseColor.png',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/textures/Material.001_baseColor.png',


### PR DESCRIPTION
### Motivation
- Restore the AK-47 GLTF texture handling to the prior (AK45-like) behavior so the model follows the existing texture-map fallback flow instead of always replacing the material map.

### Description
- Removed `forceTextureOverride: true` from the `ak47VolleyAttack` entry in `webapp/src/pages/Games/LudoBattleRoyal.jsx`, allowing the loader logic to only apply `textureOverrideUrls` when appropriate rather than forcing an override.

### Testing
- No automated tests were run for this config-only change; local repo status was checked with `git status` after committing and showed the working tree as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c85b186008329b0a1303258f76d40)