### PR TITLE
Add FPS arms to firearm capture FX, AI human selection, and tuning for firearm/camera/scale

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -296,6 +296,7 @@ const CHESS_CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   polyTank01Attack: { urls: ['https://static.poly.pizza/58c387b2-636f-49dc-a900-13b0852717d6.glb'], scale: 0.125 }
 });
 const CHESS_CAPTURE_WEAPON_MODEL_CACHE = new Map();
+const CHESS_FPS_ARMS_TEMPLATE_PROMISE = { current: null };
 const CHESS_CAPTURE_WEAPON_MODEL_FAILURE = new Set();
 const CHESS_CAPTURE_WEAPON_LOAD_TIMEOUT_MS = 22000;
 const CHESS_LARGE_FIREARM_IDS = new Set([
@@ -317,24 +318,24 @@ const CHESS_LARGE_FIREARM_IDS = new Set([
 ]);
 const CHESS_FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   fpsGunAttack: 2.2,
-  glockSidearmAttack: 1,
-  uziSprayAttack: 1.65,
-  smgBurstAttack: 1.65,
+  glockSidearmAttack: 2.2,
+  uziSprayAttack: 2.2,
+  smgBurstAttack: 2.2,
   ak47VolleyAttack: 2.2,
   krsvBurstAttack: 2.2,
-  smithSidearmAttack: 1,
-  mosinMarksmanAttack: 3.5,
-  sniperShotAttack: 2.8,
+  smithSidearmAttack: 2.2,
+  mosinMarksmanAttack: 2.2,
+  sniperShotAttack: 2.2,
   shotgunBlastAttack: 2.2,
-  polyShotgun01Attack: 2.05,
-  polyAssaultRifle01Attack: 2.15,
-  polyPistol01Attack: 1.02,
-  polyRevolver01Attack: 1.08,
-  polySawedOff01Attack: 1.56,
-  polyRevolver02Attack: 1.08,
-  polyShotgun02Attack: 2.22,
-  polyShotgun03Attack: 2.1,
-  polySmg01Attack: 1.68,
+  polyShotgun01Attack: 2.2,
+  polyAssaultRifle01Attack: 2.2,
+  polyPistol01Attack: 2.2,
+  polyRevolver01Attack: 2.2,
+  polySawedOff01Attack: 2.2,
+  polyRevolver02Attack: 2.2,
+  polyShotgun02Attack: 2.2,
+  polyShotgun03Attack: 2.2,
+  polySmg01Attack: 2.2,
   polyRobotLargeGunAttack: 1.95,
   polyRobotFlyingGunAttack: 1.45,
   polyBazooka01Attack: 2.6,
@@ -347,7 +348,7 @@ const CHESS_FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
 });
 const CHESS_FIREARM_FLAT_ROTATION = Object.freeze([-Math.PI * 0.5, -Math.PI * 0.02, 0]);
 const CHESS_FIREARM_AIM_ROTATION = Object.freeze([0, Math.PI * 0.5, 0]); // flip handheld weapons so their muzzles face the target.
-const CHESS_FIREARM_HANDHELD_SCALE_MULTIPLIER = 1.72;
+const CHESS_FIREARM_HANDHELD_SCALE_MULTIPLIER = 1.9;
 const CHESS_FIREARM_MUZZLE_YAW_CORRECTION_BY_ID = Object.freeze({
   ak47VolleyAttack: Math.PI,
   krsvBurstAttack: Math.PI
@@ -607,11 +608,11 @@ const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.44;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.32;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.08;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.68;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.08; // raise player camera while keeping the perspective looking upward toward table/pieces.
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.78;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.24; // raise player camera while keeping the perspective looking upward toward table/pieces.
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.92;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 1.35;
 const PLAYER_VIEW_LOOK_TARGET_UP_BIAS = 0.6; // increase upward aim so the table/pieces/opponent sit higher in view.
-const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 9.7; // push table/chairs/humans further down in frame toward the bottom edge.
+const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 10.9; // push table/chairs/humans further down in frame toward the bottom edge.
 const FPV_FACE_FORWARD_OFFSET = 0.012; // keep the camera almost exactly at the eyes for a true first-person perspective.
 const FPV_FACE_UP_OFFSET = 0.0; // slight lift so the board edge does not clip while still feeling eye-level.
 const FPV_LOOK_AHEAD_DISTANCE = BOARD.tile * BOARD_SCALE * 5.8; // prioritize looking down the board journey toward the opponent side.
@@ -2208,11 +2209,11 @@ const CHESS_FIREARM_BULLET_PROFILE_BY_TYPE = Object.freeze({
 });
 
 const CHESS_LUDO_PROJECTILE_PROFILE_BY_TYPE = Object.freeze({
-  Pistol: Object.freeze({ projectileKind: 'pistol-round', caliberLabel: '9mm sidearm round', bulletRadius: 0.0034, bulletLength: 0.027, bulletSpeed: 0.21, shellRadius: 0.0026, shellLength: 0.014, shellArc: 0.042 }),
-  SMG: Object.freeze({ projectileKind: 'smg-round', caliberLabel: '9mm SMG round', bulletRadius: 0.0032, bulletLength: 0.028, bulletSpeed: 0.23, shellRadius: 0.0025, shellLength: 0.014, shellArc: 0.058 }),
-  Rifle: Object.freeze({ projectileKind: 'rifle-round', caliberLabel: '5.56 rifle round', bulletRadius: 0.0038, bulletLength: 0.041, bulletSpeed: 0.26, shellRadius: 0.003, shellLength: 0.021, shellArc: 0.054 }),
-  Sniper: Object.freeze({ projectileKind: 'marksman-round', caliberLabel: '7.62 marksman round', bulletRadius: 0.0042, bulletLength: 0.052, bulletSpeed: 0.29, shellRadius: 0.0032, shellLength: 0.024, shellArc: 0.036 }),
-  Shotgun: Object.freeze({ projectileKind: 'buckshot-pellet', caliberLabel: '12-gauge buckshot', bulletRadius: 0.0032, bulletLength: 0.013, bulletSpeed: 0.17, shellRadius: 0.004, shellLength: 0.023, shellArc: 0.061 }),
+  Pistol: Object.freeze({ projectileKind: 'pistol-round', caliberLabel: '9mm sidearm round', bulletRadius: 0.0034, bulletLength: 0.027, bulletSpeed: 0.28, shellRadius: 0.0026, shellLength: 0.014, shellArc: 0.042 }),
+  SMG: Object.freeze({ projectileKind: 'smg-round', caliberLabel: '9mm SMG round', bulletRadius: 0.0032, bulletLength: 0.028, bulletSpeed: 0.3, shellRadius: 0.0025, shellLength: 0.014, shellArc: 0.058 }),
+  Rifle: Object.freeze({ projectileKind: 'rifle-round', caliberLabel: '5.56 rifle round', bulletRadius: 0.0038, bulletLength: 0.041, bulletSpeed: 0.34, shellRadius: 0.003, shellLength: 0.021, shellArc: 0.054 }),
+  Sniper: Object.freeze({ projectileKind: 'marksman-round', caliberLabel: '7.62 marksman round', bulletRadius: 0.0042, bulletLength: 0.052, bulletSpeed: 0.37, shellRadius: 0.0032, shellLength: 0.024, shellArc: 0.036 }),
+  Shotgun: Object.freeze({ projectileKind: 'buckshot-pellet', caliberLabel: '12-gauge buckshot', bulletRadius: 0.0032, bulletLength: 0.013, bulletSpeed: 0.24, shellRadius: 0.004, shellLength: 0.023, shellArc: 0.061 }),
   GrenadeLauncher: Object.freeze({ projectileKind: 'explosive-warhead', caliberLabel: 'explosive warhead', bulletRadius: 0.0064, bulletLength: 0.046, bulletSpeed: 0.14, shellRadius: 0.0046, shellLength: 0.03, shellArc: 0.03 })
 });
 
@@ -3192,6 +3193,14 @@ function createRandomAiCaptureLoadout() {
     knight: chooseRandomCaptureAnimationId('drone', 'droneAttack'),
     pawn: chooseRandomCaptureAnimationId('truck', 'missileJavelin')
   };
+}
+
+function pickRandomAiHumanCharacterOption(playerOption) {
+  const fallback = HUMAN_CHARACTER_OPTIONS[0] ?? null;
+  const playerId = playerOption?.id ?? null;
+  const pool = HUMAN_CHARACTER_OPTIONS.filter((option) => option?.id && option.id !== playerId);
+  if (!pool.length) return fallback;
+  return pool[Math.floor(Math.random() * pool.length)] ?? fallback;
 }
 
 function getTableHeightForShape(shapeId) {
@@ -4278,6 +4287,28 @@ async function loadChessCaptureWeaponModel(captureAnimationId) {
     (id) => id !== captureAnimationId && !CHESS_CAPTURE_WEAPON_MODEL_FAILURE.has(id) && CHESS_CAPTURE_WEAPON_MODEL_CONFIG[id]
   );
   return fallbackId ? loadChessCaptureWeaponModel(fallbackId) : null;
+}
+
+async function loadChessFpsArmsTemplate() {
+  if (CHESS_FPS_ARMS_TEMPLATE_PROMISE.current) return CHESS_FPS_ARMS_TEMPLATE_PROMISE.current;
+  CHESS_FPS_ARMS_TEMPLATE_PROMISE.current = (async () => {
+    const fpsModel = await loadChessCaptureWeaponModel('fpsGunAttack');
+    if (!fpsModel) return null;
+    const armsRoot = fpsModel.clone(true);
+    armsRoot.traverse((node) => {
+      if (!node?.isMesh) return;
+      const name = String(node.name || '').toLowerCase();
+      const keep = /(arm|hand|wrist|finger|glove)/.test(name);
+      node.visible = keep;
+      if (!keep) return;
+      node.castShadow = true;
+      node.receiveShadow = true;
+    });
+    fitObjectToTargetSize(armsRoot, 0.18);
+    alignObjectBottomToY(armsRoot, 0);
+    return armsRoot;
+  })();
+  return CHESS_FPS_ARMS_TEMPLATE_PROMISE.current;
 }
 
 function prepareCaptureModel(root) {
@@ -8264,6 +8295,9 @@ function Chess3D({
     return { ...DEFAULT_APPEARANCE };
   });
   const appearanceRef = useRef(appearance);
+  const aiHumanCharacterOptionRef = useRef(
+    pickRandomAiHumanCharacterOption(HUMAN_CHARACTER_OPTIONS[normalizeAppearance(appearance).humanCharacter])
+  );
   const paletteRef = useRef(createChessPalette(appearance));
   const [activeCustomizationKey, setActiveCustomizationKey] = useState(
     CUSTOMIZATION_SECTIONS[0]?.key ?? 'tables'
@@ -9609,28 +9643,36 @@ function Chess3D({
     }
 
     const selectedHumanCharacterId = humanCharacterOption?.id ?? HUMAN_CHARACTER_OPTIONS[0]?.id ?? 'default';
+    const aiHumanCharacterOption =
+      aiHumanCharacterOptionRef.current?.id &&
+      aiHumanCharacterOptionRef.current.id !== selectedHumanCharacterId
+        ? aiHumanCharacterOptionRef.current
+        : pickRandomAiHumanCharacterOption(humanCharacterOption);
+    aiHumanCharacterOptionRef.current = aiHumanCharacterOption;
     if (selectedHumanCharacterId !== (arena.selectedHumanCharacterId ?? 'default')) {
-      void loadSeatedHumanTemplate(
-        humanCharacterOption,
-        arena.renderer,
-        arena.maxAnisotropy || 1
+      const perSeatOptions = [humanCharacterOption, aiHumanCharacterOptionRef.current];
+      void Promise.all(
+        perSeatOptions.map((option) =>
+          loadSeatedHumanTemplate(option, arena.renderer, arena.maxAnisotropy || 1)
+        )
       )
-        .then((humanTemplate) => {
+        .then((templates) => {
           if (!arenaRef.current) return;
-          const baseScale =
-            humanTemplate?.userData?.seatedHumanScale ?? computeSeatedHumanScale(humanTemplate);
-          const seatedYawOffset = Number.isFinite(humanTemplate?.userData?.seatedYawOffset)
-            ? humanTemplate.userData.seatedYawOffset
-            : 0;
-          const seatedYOffset = Number.isFinite(humanTemplate?.userData?.seatedYOffset)
-            ? humanTemplate.userData.seatedYOffset
-            : 0;
-          const seatedZOffset = Number.isFinite(humanTemplate?.userData?.seatedZOffset)
-            ? humanTemplate.userData.seatedZOffset
-            : 0;
           const nextActors = [];
           (arena.chairs || []).forEach((chair, playerIndex) => {
             if (!chair?.group) return;
+            const humanTemplate = templates[playerIndex] || templates[0];
+            const baseScale =
+              humanTemplate?.userData?.seatedHumanScale ?? computeSeatedHumanScale(humanTemplate);
+            const seatedYawOffset = Number.isFinite(humanTemplate?.userData?.seatedYawOffset)
+              ? humanTemplate.userData.seatedYawOffset
+              : 0;
+            const seatedYOffset = Number.isFinite(humanTemplate?.userData?.seatedYOffset)
+              ? humanTemplate.userData.seatedYOffset
+              : 0;
+            const seatedZOffset = Number.isFinite(humanTemplate?.userData?.seatedZOffset)
+              ? humanTemplate.userData.seatedZOffset
+              : 0;
             const actor = cloneSkinned(humanTemplate);
             actor.scale.setScalar(baseScale);
             actor.position.set(
@@ -10215,23 +10257,23 @@ function Chess3D({
     seatedHumanMoveActionsRef.current.forEach((action) => disposeSeatedHumanMoveAction(action));
     seatedHumanMoveActionsRef.current.clear();
     try {
-      const humanTemplate = await loadSeatedHumanTemplate(
-        humanCharacterOption,
-        renderer,
-        maxAnisotropy || 1
-      );
-      const baseScale =
-        humanTemplate?.userData?.seatedHumanScale ?? computeSeatedHumanScale(humanTemplate);
-      const seatedYawOffset = Number.isFinite(humanTemplate?.userData?.seatedYawOffset)
-        ? humanTemplate.userData.seatedYawOffset
-        : 0;
-      const seatedYOffset = Number.isFinite(humanTemplate?.userData?.seatedYOffset)
-        ? humanTemplate.userData.seatedYOffset
-        : 0;
-      const seatedZOffset = Number.isFinite(humanTemplate?.userData?.seatedZOffset)
-        ? humanTemplate.userData.seatedZOffset
-        : 0;
-      chairs.forEach((chair, playerIndex) => {
+      aiHumanCharacterOptionRef.current = pickRandomAiHumanCharacterOption(humanCharacterOption);
+      const perSeatOptions = [humanCharacterOption, aiHumanCharacterOptionRef.current];
+      for (let playerIndex = 0; playerIndex < chairs.length; playerIndex += 1) {
+        const chair = chairs[playerIndex];
+        const option = perSeatOptions[playerIndex] || humanCharacterOption;
+        const humanTemplate = await loadSeatedHumanTemplate(option, renderer, maxAnisotropy || 1);
+        const baseScale =
+          humanTemplate?.userData?.seatedHumanScale ?? computeSeatedHumanScale(humanTemplate);
+        const seatedYawOffset = Number.isFinite(humanTemplate?.userData?.seatedYawOffset)
+          ? humanTemplate.userData.seatedYawOffset
+          : 0;
+        const seatedYOffset = Number.isFinite(humanTemplate?.userData?.seatedYOffset)
+          ? humanTemplate.userData.seatedYOffset
+          : 0;
+        const seatedZOffset = Number.isFinite(humanTemplate?.userData?.seatedZOffset)
+          ? humanTemplate.userData.seatedZOffset
+          : 0;
         const actor = cloneSkinned(humanTemplate);
         actor.scale.setScalar(baseScale);
         actor.position.set(
@@ -10253,7 +10295,7 @@ function Chess3D({
         });
         positionSeatedHumanChestAvatarAnchor(chair, actor);
         seatedHumanActorsRef.current.push({ playerIndex, chair, actor, rig, fpvMeshes });
-      });
+      }
       arena.selectedHumanCharacterId = humanCharacterOption?.id ?? HUMAN_CHARACTER_OPTIONS[0]?.id ?? 'default';
     } catch (error) {
       console.warn('Chess Battle Royal: unable to attach seated human actors', error);
@@ -12451,6 +12493,9 @@ function Chess3D({
         const firearmFx = new THREE.Group();
         firearmFx.visible = false;
         captureFxGroup.add(firearmFx);
+        const fpsArmsFx = new THREE.Group();
+        fpsArmsFx.visible = false;
+        captureFxGroup.add(fpsArmsFx);
         const aerodynamicRings = createLudoBulletAerodynamicRingsFx();
         captureFxGroup.add(aerodynamicRings);
         void loadChessCaptureWeaponModel(firearmAnimationId).then((template) => {
@@ -12463,6 +12508,12 @@ function Chess3D({
           weaponClone.position.y = -0.04;
           firearmFx.add(weaponClone);
         });
+        void loadChessFpsArmsTemplate().then((armsTemplate) => {
+          if (!armsTemplate || !fpsArmsFx.parent) return;
+          fpsArmsFx.clear();
+          const armsClone = armsTemplate.clone(true);
+          fpsArmsFx.add(armsClone);
+        });
         activeCaptureFx.push({
           type: 'firearm',
           t: 0,
@@ -12472,6 +12523,7 @@ function Chess3D({
           targetMesh,
           missileFx,
           firearmFx,
+          fpsArmsFx,
           aerodynamicRings,
           bulletCount: firearmProfile.bulletCount,
           impactAt: firearmProfile.impactAt,
@@ -12482,6 +12534,7 @@ function Chess3D({
           liveBullets: [],
           liveShells: [],
           shooterSeatIndex: movingMesh?.userData?.w ? 0 : 1,
+          movingMesh,
           muzzleOffset: new THREE.Vector3(0.24, 0.14, 0)
         });
         const finalBulletTravelMs = CHESS_FIREARM_FATAL_BULLET_TRAVEL_MS;
@@ -14841,6 +14894,10 @@ function Chess3D({
                 captureFxGroup.remove(fx.firearmFx);
                 disposeObject3D(fx.firearmFx);
               }
+              if (fx.fpsArmsFx) {
+                captureFxGroup.remove(fx.fpsArmsFx);
+                disposeObject3D(fx.fpsArmsFx);
+              }
               if (fx.aerodynamicRings) {
                 captureFxGroup.remove(fx.aerodynamicRings);
                 disposeObject3D(fx.aerodynamicRings);
@@ -14850,29 +14907,11 @@ function Chess3D({
           } else if (fx.type === 'firearm') {
             const targetPos = getLiveTargetPosition(fx.to, fx.targetMesh, 0);
             fx.to.copy(targetPos);
-            const shooterActor = seatedHumanActorsRef.current.find((entry) => entry?.playerIndex === fx.shooterSeatIndex);
-            let shooterPos = fx.from.clone().lerp(targetPos, 0.24);
-            shooterPos.y += 0.24;
-            if (shooterActor?.rig) {
-              applySeatedHumanPose(shooterActor.rig, 'firearmAim', 1, 1, { forwardReach: 0.95, sideReach: 0 });
-              const gripWorld = getThreeFingerGripWorldPosition(shooterActor.rig) || shooterActor.rig.rightHand?.getWorldPosition?.(new THREE.Vector3());
-              if (gripWorld) {
-                const towardTarget = targetPos.clone().sub(gripWorld).normalize();
-                const side = new THREE.Vector3().crossVectors(WORLD_UP, towardTarget).normalize();
-                shooterPos = gripWorld
-                  .clone()
-                  .addScaledVector(towardTarget, SEATED_HUMAN_FIREARM_HAND_FORWARD)
-                  .addScaledVector(side, fx.shooterSeatIndex === 0 ? SEATED_HUMAN_FIREARM_HAND_SIDE : -SEATED_HUMAN_FIREARM_HAND_SIDE);
-                shooterPos.y += SEATED_HUMAN_FIREARM_HAND_UP;
-                applyRightArmContactIK(shooterActor.rig, shooterPos, SEATED_HUMAN_FIREARM_IK_STRENGTH);
-                const supportPos = gripWorld
-                  .clone()
-                  .addScaledVector(towardTarget, SEATED_HUMAN_FIREARM_SUPPORT_FORWARD)
-                  .addScaledVector(side, fx.shooterSeatIndex === 0 ? -SEATED_HUMAN_FIREARM_SUPPORT_SIDE : SEATED_HUMAN_FIREARM_SUPPORT_SIDE);
-                supportPos.y += SEATED_HUMAN_FIREARM_SUPPORT_UP;
-                applyLeftArmContactIK(shooterActor.rig, supportPos, SEATED_HUMAN_FIREARM_IK_STRENGTH * 0.86);
-              }
-            }
+            const pieceWorld = new THREE.Vector3();
+            fx.movingMesh?.getWorldPosition?.(pieceWorld);
+            let shooterPos = pieceWorld.lengthSq() ? pieceWorld : fx.from.clone().lerp(targetPos, 0.24);
+            shooterPos = shooterPos.clone();
+            shooterPos.y += 0.26;
             const aimDir = targetPos.clone().sub(shooterPos).normalize();
             const muzzlePos = shooterPos.clone().addScaledVector(aimDir, LUDO_FIREARM_BROADCAST_PROFILE.aimLift ?? 0.064);
             fx.missileFx.root.visible = true;
@@ -14885,6 +14924,12 @@ function Chess3D({
               orientForwardKeepingUp(fx.firearmFx, aimDir);
               const recoil = Math.sin(Math.min(1, u * Math.max(1, fx.bulletCount || 1)) * Math.PI) * 0.025;
               fx.firearmFx.position.addScaledVector(aimDir, -recoil);
+            }
+            if (fx.fpsArmsFx) {
+              fx.fpsArmsFx.visible = true;
+              fx.fpsArmsFx.position.copy(shooterPos).addScaledVector(aimDir, -(LUDO_FIREARM_BROADCAST_PROFILE.aimRearPullback ?? 0.124));
+              fx.fpsArmsFx.position.y += 0.02 + Math.sin(u * Math.PI * 8) * 0.006;
+              orientForwardKeepingUp(fx.fpsArmsFx, aimDir);
             }
 
             (fx.liveBullets || []).forEach((bullet) => {
@@ -15054,6 +15099,10 @@ function Chess3D({
               if (fx.firearmFx) {
                 captureFxGroup.remove(fx.firearmFx);
                 disposeObject3D(fx.firearmFx);
+              }
+              if (fx.fpsArmsFx) {
+                captureFxGroup.remove(fx.fpsArmsFx);
+                disposeObject3D(fx.fpsArmsFx);
               }
               if (fx.aerodynamicRings) {
                 captureFxGroup.remove(fx.aerodynamicRings);


### PR DESCRIPTION
### Motivation
- Surface first-person arms during firearm capture FX to improve visual clarity and cinematic feel. 
- Ensure AI uses a different human character than the player to increase visual variety. 
- Adjust firearm, projectile, and camera scaling/spacing to better match intended gameplay and broadcast profiles.

### Description
- Introduces `CHESS_FPS_ARMS_TEMPLATE_PROMISE` and new loader `loadChessFpsArmsTemplate()` which extracts arm meshes from the `fpsGunAttack` capture model for reuse in capture FX. 
- Adds an `fpsArmsFx` group to capture FX and integrates the arms template into the firearm capture lifecycle (spawn, position/recoil, and disposal). 
- Adds `pickRandomAiHumanCharacterOption()` and updates seated human template loading to preload per-seat templates so AI and player can have different characters. 
- Uses piece world position (`fx.movingMesh`) for shooter origin when available and passes `movingMesh` into active capture entries for more accurate aiming. 
- Tweaks numerous constants: broadens many firearm rack size multipliers to `2.2`, increases `CHESS_FIREARM_HANDHELD_SCALE_MULTIPLIER` to `1.9`, raises projectile `bulletSpeed` values in `CHESS_LUDO_PROJECTILE_PROFILE_BY_TYPE`, and adjusts camera/player framing constants (`PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_*`, `TABLE_BOTTOM_PLAYER_BIAS_Z`) for improved composition.

### Testing
- Ran a production build with `yarn build` which completed successfully. 
- Executed the test suite with `yarn test` and UI/unit tests covering capture FX and seated human loading; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8940b3708329ac5f56344d021314)