### PR TITLE
Tune Pool Royale shot power and restore short-rail branding plates

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -42,7 +42,7 @@ describe('Pool Royale table models', () => {
       'cornerRailSight'
     ]);
     assert.deepEqual(showood.blackMaterialSurfaceNames, []);
-    assert.equal(showood.forceGeneratedChromePlates, false);
+    assert.equal(showood.forceGeneratedChromePlates, true);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -34,7 +34,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     tintOriginalTrimGold: true,
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
     blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: false,
+    forceGeneratedChromePlates: true,
     hideSurfaceRoles: []
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1833,9 +1833,9 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 0.62; // reduce overall Pool Royale power by an additional 20%
-const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.94; // stronger Pool Royale strike speed so shots carry more power
+const SHOT_POWER_ADJUSTMENT = 0.52; // soften Pool Royale cue-force so charged shots match intended slider power more closely
+const SHOT_POWER_BOOST = 1.0; // remove extra hidden boost so release power tracks player-selected charge
+const SHOT_GLOBAL_POWER_SCALE = 0.82; // trim final strike speed so overall table pace matches prior balanced tuning
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *


### PR DESCRIPTION
### Motivation
- Bring Pool Royale shot feel back into alignment with the slider UI by softening hidden power multipliers so charged shots match player-selected power more closely.
- Restore on-rail TonPlaygram branding plates on the Showood fixed table by enabling generated chrome/branding overlays so the short-rail plates reappear.

### Description
- Adjusted shot tuning constants in `webapp/src/pages/Games/PoolRoyale.jsx`: updated `SHOT_POWER_ADJUSTMENT` to `0.52`, `SHOT_POWER_BOOST` to `1.0`, and `SHOT_GLOBAL_POWER_SCALE` to `0.82` to reduce effective strike strength.
- Re-enabled generated chrome/branding plate overlays by setting `forceGeneratedChromePlates: true` in `webapp/src/config/poolRoyaleTableModels.js` for the `showood-seven-foot` table model.
- Updated `test/poolRoyaleTableModels.test.js` to reflect the restored `forceGeneratedChromePlates: true` expectation.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleTableModels.test.js`; the test initially failed after the config change due to the test expectation, the test file was updated, and the suite then passed.
- Final automated result: `test/poolRoyaleTableModels.test.js` — all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9bd3400083298c2714dc44ba40c6)