### PR TITLE
Ludo: lock camera pitch, restore AK-47 GLTF textures, and tweak AK‑47 projectile visuals

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -438,12 +438,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
     ],
-    scale: 0.24,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/textures/Material.001_baseColor.png',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/textures/Material.001_baseColor.png',
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg'
-    ]
+    scale: 0.24
   },
   krsvBurstAttack: {
     label: 'KRSV',
@@ -4814,8 +4809,8 @@ const PORTRAIT_CAMERA_EXTRA_LIFT = 0.14;
 const CAMERA_PLAYER_CENTER_X_EPSILON = 0.0001;
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
-const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(7);
-const CAMERA_LOOK_MIN_PITCH = THREE.MathUtils.degToRad(-8);
+const CAMERA_LOOK_PITCH_LIMIT = 0;
+const CAMERA_LOOK_MIN_PITCH = 0;
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
 const CAMERA_LOOK_YAW_RECENTER_SPEED = 0.055;
 const LUDO_CAMERA_CUSTOM_LOOK_ENABLED = true;
@@ -11942,6 +11937,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const tracers = Array.from({ length: 10 }, () => createCaptureBulletTracerFx('#ffe39a'));
           const shells = Array.from({ length: Math.max(16, Math.min(42, shots + 6)) }, () => createCaliberShellCasingFx(mergedBallistics, servicePistolAmmo));
           const pelletsPerShot = FIREARM_SCATTER_PROJECTILE_IDS.has(resolvedCaptureAnimationId) ? 14 : 1;
+          const useHeadOnlyProjectileVisuals = resolvedCaptureAnimationId === 'ak47VolleyAttack';
           const projectileCount = shots * pelletsPerShot;
           const finalProjectileStartIndex = Math.max(0, projectileCount - 1);
           const bullets = Array.from({ length: projectileCount }, (_, index) => {
@@ -11962,18 +11958,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             mesh.userData.prelaunchMs = useServicePistolAmmo && isFinalCinematic ? FIREARM_SERVICE_PISTOL_PRELAUNCH_MS : 0;
             mesh.userData.insideBarrelOffset = useServicePistolAmmo && isFinalCinematic ? FIREARM_SERVICE_PISTOL_INSIDE_BARREL_OFFSET : 0;
             mesh.userData.completed = false;
-            mesh.userData.trail = createShootingRangeBulletTrailFx({
-              nineMm: isFinalCinematic && useServicePistolAmmo,
-              longGun: isFinalCinematic && isLongGunRound,
-              pumpShotgun: !isFinalCinematic,
-              distance: startPosition.distanceTo(targetPosition)
-            });
-            mesh.userData.wake = isFinalCinematic && (useServicePistolAmmo || isLongGunRound)
+            mesh.userData.trail = useHeadOnlyProjectileVisuals
+              ? null
+              : createShootingRangeBulletTrailFx({
+                nineMm: isFinalCinematic && useServicePistolAmmo,
+                longGun: isFinalCinematic && isLongGunRound,
+                pumpShotgun: !isFinalCinematic,
+                distance: startPosition.distanceTo(targetPosition)
+              });
+            mesh.userData.wake = useHeadOnlyProjectileVisuals
+              ? null
+              : isFinalCinematic && (useServicePistolAmmo || isLongGunRound)
               ? createShootingRangeBulletWakeFx()
               : null;
             mesh.userData.isShotgunPellet = isShotgunPellet;
             scene.add(mesh);
-            scene.add(mesh.userData.trail);
+            if (mesh.userData.trail) scene.add(mesh.userData.trail);
             if (mesh.userData.wake) scene.add(mesh.userData.wake);
             return mesh;
           });


### PR DESCRIPTION
### Motivation
- Players requested disabling vertical head/look movement so avatars only look left/right (yaw) in Ludo Battle Royal. 
- The AK‑47 GLTF lost its original authored texture mapping because a forced texture override was applied, so we must restore the original mapping. 
- The AK‑47 firing animation should show only bullet heads impacting the target while spent casings eject from the weapon side.

### Description
- Locked vertical camera look by setting `CAMERA_LOOK_PITCH_LIMIT` and `CAMERA_LOOK_MIN_PITCH` to `0` to force pitch to zero and allow only yaw rotation. (changed in `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Restored the AK‑47 original GLTF materials by removing the `textureOverrideUrls` block from the `ak47VolleyAttack` entry in the capture weapon config so authored material maps are preserved. (changed in `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Adjusted projectile visuals for AK‑47 by introducing `useHeadOnlyProjectileVisuals` for `ak47VolleyAttack` and conditionally skipping creation/attachment of trail and wake FX for AK rounds so only the bullet head meshes are visible; shell ejection code and muzzle effects remain unchanged and still spawn spent casings from the configured `spentCasingEjectionPort`. (changed in `webapp/src/pages/Games/LudoBattleRoyal.jsx`).

### Testing
- Ran the targeted unit test suite `npm -s test -- test/inventoryCrossGameConfig.test.js`, which completed successfully with `PASS` (9 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9e5783108329b0ba30297d8cc1f5)