### PR TITLE
Lower seated human arms/hands in Domino Royal and bump script version

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8346,12 +8346,12 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
   // Lower both arms/hands further so seated characters rest closer to the table edge.
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-82), THREE.MathUtils.degToRad(-7), THREE.MathUtils.degToRad(-4));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(60), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(34), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-87), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(6));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(61), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(35), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-89), THREE.MathUtils.degToRad(-7), THREE.MathUtils.degToRad(-5));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(66), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-2));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(42), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-94), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(7));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(67), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(43), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(3));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-19-human-seat-hand-position-v46';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-19-human-seat-hand-position-v47';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Players requested the human characters' arms and hands be lowered so seated characters rest closer to the table edge in Domino Battle Royal.

### Description
- Increased downward pose offsets for both left and right upper arms, forearms, and hands in `webapp/public/domino-royal-game.js` to lower the resting pose.
- Bumped the Domino Royal game script version key in `webapp/src/pages/Games/DominoRoyalArena.jsx` from `v46` to `v47` to force clients to fetch the updated script.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9eac815c83298c03b9e295e56770)