### PR TITLE
Restore Murlan Royale player-card hand layout to previous fan geometry

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2241,11 +2241,9 @@ function createCharacterCards({ handLift = 0.96, handCardsInput = [], cardTheme 
   const managedTextures = [backTexture];
   const managedMaterials = [edgeMaterial];
 
-  // Anchor the fan around the lower/thumb side of the cards so nearby
-  // bottoms stay tucked together while the upper edges flare open clearly.
-  const cardHeight = 0.316 * MODEL_SCALE;
-  const bottomSpread = 0.018 * MODEL_SCALE;
-  const topFanDegrees = 20;
+  // Narrow centers and wider rotations make held helper decks pinch at the
+  // thumb/bottom while opening gradually toward the card tops.
+  const spread = 0.082 * MODEL_SCALE;
   for (let idx = 0; idx < safeCount; idx++) {
     const handCard = handCards[idx] || handCards[handCards.length - 1];
     const faceTexture = makeCardFace(handCard.rank, handCard.suit, cardTheme, cardTextureSize?.heldW, cardTextureSize?.heldH);
@@ -2270,14 +2268,11 @@ function createCharacterCards({ handLift = 0.96, handCardsInput = [], cardTheme 
     const sideMaterials = [edgeMaterial, edgeMaterial, edgeMaterial, edgeMaterial, frontMaterial, backMaterial];
     const card = new THREE.Mesh(cardGeometry, sideMaterials);
     const centered = idx - (safeCount - 1) / 2;
-    const fanRotationZ = THREE.MathUtils.degToRad(-centered * topFanDegrees);
-    const bottomAnchorX = centered * bottomSpread;
-    const centerX = bottomAnchorX - Math.sin(fanRotationZ) * cardHeight * 0.5;
-    card.position.set(centerX, handLift * MODEL_SCALE + Math.abs(centered) * 0.008, idx * 0.004);
+    card.position.set(centered * spread, handLift * MODEL_SCALE + Math.abs(centered) * 0.008, idx * 0.004);
     card.rotation.set(
       THREE.MathUtils.degToRad(-72),
       THREE.MathUtils.degToRad(-centered * 12),
-      fanRotationZ
+      THREE.MathUtils.degToRad(centered * 16)
     );
     card.castShadow = true;
     card.receiveShadow = true;


### PR DESCRIPTION
### Motivation
- Restore the Murlan Royale player hand-card layout to the exact pre-change fan geometry by undoing a recent held-card fan experiment so players see the earlier, tighter-bottom/wider-top hand arrangement.

### Description
- Reverted the fan geometry in `createCharacterCards` inside `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by removing the anchored-bottom/top-fan math (`cardHeight`, `bottomSpread`, `topFanDegrees`) and restoring the prior `spread = 0.082 * MODEL_SCALE` with the original `card.position` and `card.rotation` calculations so held cards render using the earlier fan/pinched-bottom layout; the change is localized to that function in the single file.

### Testing
- No automated tests were run for this UI-only layout rollback.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca826b558832998e0333d9781310e)