### PR TITLE
Tweak seated character arm/hand bone offsets for domino pose

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8345,13 +8345,13 @@ function createDominoCharacterRig(instance, seatRoot, seatIndex, player) {
   addDominoBoneOffset(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
   addDominoBoneOffset(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
   addDominoBoneOffset(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
-  // Lower both arms/hands further so seated characters rest closer to the table edge.
-  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-82), THREE.MathUtils.degToRad(-7), THREE.MathUtils.degToRad(-4));
-  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(60), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(34), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
-  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-87), THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(6));
-  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(61), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
-  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(35), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
+  // Lower both arms/hands further while keeping wrists pitched inward near the domino line.
+  addDominoBoneOffset(bones.leftUpperArm, THREE.MathUtils.degToRad(-74), THREE.MathUtils.degToRad(-6), THREE.MathUtils.degToRad(-3));
+  addDominoBoneOffset(bones.leftForeArm, THREE.MathUtils.degToRad(67), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.leftHand, THREE.MathUtils.degToRad(42), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
+  addDominoBoneOffset(bones.rightUpperArm, THREE.MathUtils.degToRad(-79), THREE.MathUtils.degToRad(9), THREE.MathUtils.degToRad(5));
+  addDominoBoneOffset(bones.rightForeArm, THREE.MathUtils.degToRad(68), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
+  addDominoBoneOffset(bones.rightHand, THREE.MathUtils.degToRad(44), THREE.MathUtils.degToRad(5), THREE.MathUtils.degToRad(2));
   addDominoBoneOffset(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   addDominoBoneOffset(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
   addDominoBoneOffset(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));


### PR DESCRIPTION
### Motivation
- Adjust the seated character arm and wrist pose so hands sit closer to the domino line with wrists pitched inward for a more natural domino-holding posture.

### Description
- Updated the bone rotation offsets in `createDominoCharacterRig` (file `webapp/public/domino-royal-game.js`) for `leftUpperArm`, `leftForeArm`, `leftHand`, `rightUpperArm`, `rightForeArm`, and `rightHand` to new radian values and clarified the inline comment describing the pose intent.

### Testing
- No automated tests were run for this visual/pose tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca8956d3083298fe22566b939c02b)