### PR TITLE
Restore original weapon GLTF textures in Ludo Battle Royale

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -420,9 +420,6 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
     ],
     scale: 0.13,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg'
-    ]
   },
   uziSprayAttack: {
     label: 'Uzi',
@@ -471,9 +468,6 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf'
     ],
     scale: 0.13,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/SigSauer.jpg'
-    ]
   },
   grenadeBlastAttack: {
     label: 'Grenade Blast',
@@ -483,9 +477,6 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.statically.io/gh/friuns2/bingextension/main/grenade.glb'
     ],
     scale: 0.11,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/SigSauer.jpg'
-    ]
   },
   shotgunBlastAttack: {
     label: 'Shotgun Blast',


### PR DESCRIPTION
### Motivation
- External hard-coded `textureOverrideUrls` were overriding the original GLTF/GLB material textures for several weapons, changing their intended appearance.

### Description
- Removed `textureOverrideUrls` entries for `assaultRifleAttack`, `sigsauerTacticalAttack`, and `grenadeBlastAttack` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so those models use their embedded source textures again.

### Testing
- Verified the modification by running `rg -n "textureOverrideUrls|assaultRifleAttack|sigsauerTacticalAttack|grenadeBlastAttack" webapp/src/pages/Games/LudoBattleRoyal.jsx`, inspected the `git diff`, and committed the change as `92358bb`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0caeb75de483298aa76ce90981c429)