### PR TITLE
Restore AK-47 GLTF texture overrides in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -438,7 +438,13 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
     ],
-    scale: 0.24
+    scale: 0.24,
+    forceTextureOverride: true,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/textures/Material.001_baseColor.png',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/textures/Material.001_baseColor.png',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg'
+    ]
   },
   krsvBurstAttack: {
     label: 'KRSV',


### PR DESCRIPTION
### Motivation
- Restore the original AK-47 GLTF texture mapping because recent edits removed the override and caused the model to render with unintended/default textures.

### Description
- Re-enabled `forceTextureOverride` and re-added `textureOverrideUrls` for `ak47VolleyAttack` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to use the original AK-47 baseColor texture fallbacks.

### Testing
- Verified the diff and committed the change for `webapp/src/pages/Games/LudoBattleRoyal.jsx`; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0caeb75de483298aa76ce90981c429)