### PR TITLE
Restore Snooker Royal to original in-file game component

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -103,7 +103,6 @@ import {
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
-import SnookerRoyalProvided from './SnookerRoyalProvided.jsx';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -29498,8 +29497,5 @@ const powerRef = useRef(hud.power);
 }
 
 export default function SnookerRoyal() {
-  // Snooker Royal now mounts the same scene implementation used by Snooker
-  // Champion so the human character and cue stick are rendered by the shared,
-  // unmodified Champion code path.
-  return <SnookerRoyalProvided gameTitle="Snooker Royal" />;
+  return <SnookerRoyalGame gameTitle="Snooker Royal" />;
 }


### PR DESCRIPTION
### Motivation
- The Snooker Royal page was mounting `SnookerRoyalProvided.jsx` instead of the original in-file game implementation, so the route opened the provided wrapper rather than the original `SnookerRoyalGame` experience.

### Description
- Removed the `import SnookerRoyalProvided from './SnookerRoyalProvided.jsx'` and changed the default export to return the original in-file component by using `return <SnookerRoyalGame gameTitle="Snooker Royal" />;` in `webapp/src/pages/Games/SnookerRoyal.jsx`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2b2ba1548329a2c938ed9d4baa0c)