### PR TITLE
Normalize GLTF weapon textures in Ludo Battle Royal to restore correct rendering

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1497,9 +1497,7 @@ async function loadCaptureWeaponModel(captureAnimationId) {
             // eslint-disable-next-line no-await-in-loop
             textureOverride = await withLoadTimeout(textureLoader.loadAsync(textureOverrideUrls[t]));
             if (textureOverride) {
-              textureOverride.flipY = false;
-              applySRGBColorSpace(textureOverride);
-              textureOverride.needsUpdate = true;
+              normalizeCaptureWeaponTexture(textureOverride, { isColor: true });
               break;
             }
           } catch {
@@ -1522,11 +1520,11 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         node.visible = true;
         const materials = Array.isArray(node.material) ? node.material : [node.material];
         materials.forEach((material) => {
-          if (material?.map) applySRGBColorSpace(material.map);
           if (textureOverride && (forceTextureOverride || !material?.map)) {
             material.map = textureOverride;
           }
-          if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
+          normalizeCaptureWeaponTexture(material?.map, { isColor: true });
+          normalizeCaptureWeaponTexture(material?.emissiveMap, { isColor: true });
           material.transparent = false;
           material.opacity = 1;
           material.needsUpdate = true;
@@ -1579,6 +1577,18 @@ function startCaptureWeaponAnimation({
   targetModel.userData.captureWeaponMixer = mixer;
   targetModel.userData.captureWeaponActions = actions;
   return { mixer, actions };
+}
+
+
+function normalizeCaptureWeaponTexture(texture, { isColor = false } = {}) {
+  if (!texture?.isTexture) return;
+  texture.flipY = false;
+  if (isColor) applySRGBColorSpace(texture);
+  texture.generateMipmaps = true;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.anisotropy = Math.max(texture.anisotropy ?? 1, 8);
+  texture.needsUpdate = true;
 }
 
 function stopCaptureWeaponMixersForObjectTree(rootObject, mixersStore) {


### PR DESCRIPTION
### Motivation
- Weapon textures regressed because GLTF-provided maps and externally downloaded override textures took different setup paths, producing inconsistent rendering; the change restores the unified texture settings used previously (flipY, sRGB, mipmaps, filtering, anisotropy).

### Description
- Add `normalizeCaptureWeaponTexture(texture, { isColor })` to `webapp/src/pages/Games/LudoBattleRoyal.jsx` to enforce `flipY = false`, sRGB encoding for color maps, mipmap generation, linear mip filters, anisotropy boost, and `needsUpdate` for weapon textures.
- Use the new `normalizeCaptureWeaponTexture` for loaded override textures and for each material's `map` and `emissiveMap` during `loadCaptureWeaponModel` traversal so GLTF-embedded and override textures share the same normalization pipeline.
- Maintain existing override semantics (for example weapon-specific `textureOverrideUrls` and `forceTextureOverride`) while ensuring texture appearance is consistent across all capture weapon models.

### Testing
- Executed the test script `npm --prefix webapp run -s test -- --watch=false`, which exited non-zero and did not run tests in this environment.
- No automated rendering/unit tests were available for texture appearance, so verification is intended to be performed at runtime in the game client.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d31190dac8329be47119e32642a92)