### PR TITLE
Restore Pool Royale legacy power and short-rail brand plate placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1833,9 +1833,9 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 0.62; // reduce overall Pool Royale power by an additional 20%
-const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.78; // tone down Pool Royale strike speed so shots match the requested game power pacing
+const SHOT_POWER_ADJUSTMENT = 1; // restore legacy shot scaling used before the May 19 power retune
+const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
+const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -11944,7 +11944,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.62;
+  const brandPlateOutwardShift = endRailW * 0.92;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale gameplay feel by reverting the recent power retune so shot strength and cue launch match the legacy (pre–May 19) behavior.
- Ensure TonPlaygram branding plates on the short rails are visible above the rail surface as previously designed.

### Description
- Reverted power tuning constants in `webapp/src/pages/Games/PoolRoyale.jsx` by restoring `SHOT_POWER_ADJUSTMENT`, `SHOT_POWER_BOOST`, and `SHOT_GLOBAL_POWER_SCALE` to their legacy values used before the May 19 retune.
- Repositioned the short-rail brand plates by updating `brandPlateOutwardShift` so the `TonPlaygram` plates sit outward and visibly above the top rail on both short-rail sides.
- Changes are limited to `webapp/src/pages/Games/PoolRoyale.jsx` and do not affect other tables or game modes.

### Testing
- Ran a repository diff to confirm the intended edits with `git diff -- webapp/src/pages/Games/PoolRoyale.jsx` and validated the modified lines show the restored constants and brand plate offset.
- Committed the change locally with `git commit -m "Restore Pool Royale legacy power and short-rail brand plate position"` which completed successfully.
- Created PR metadata via the repository `make_pr` helper confirming the change; no automated unit or integration tests were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d331da1cc8329a3a56510772299a6)