### PR TITLE
Sync cue visibility with camera stance and adjust human grip in SnookerRoyal.jsx

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -2116,7 +2116,17 @@ function getSnookerCueEndpoints(cueStick, cueLen) {
 
 function updateSnookerRoyalHumanPlayer(human, dt, options) {
   if (!human?.root || human.disabled) return;
-  const { cue, cueStick, cueLen, aimDir, visible, power = 0, shooting = false, cueAnimating = false } = options || {};
+  const {
+    cue,
+    cueStick,
+    cueLen,
+    aimDir,
+    visible,
+    power = 0,
+    shooting = false,
+    cueAnimating = false,
+    tableCueVisible = true
+  } = options || {};
   const cuePos = cue?.pos;
   if (!cuePos || !cue?.active || !visible) {
     human.root.visible = false;
@@ -2163,7 +2173,12 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
     .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
     .setY(CUE_Y + BALL_R * 0.08);
-  const grip = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
+  const gripBlend = tableCueVisible ? (0.37 + pullPose * 0.08) : 0.62;
+  const grip = cueEndpoints.butt
+    .clone()
+    .lerp(cueEndpoints.tip, gripBlend)
+    .addScaledVector(side, tableCueVisible ? 0 : BALL_R * 0.18)
+    .setY(tableCueVisible ? cueEndpoints.butt.y : CUE_Y + BALL_R * 0.52);
   updateSnookerHumanOrientationHelpers(human, { rootTarget, cueBall, playfieldTarget, dir, bridge, grip });
   const chestWorld = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
   const headWorld = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
@@ -23274,7 +23289,16 @@ const powerRef = useRef(hud.power);
           const settlePos = impactPos
             .clone()
             .addScaledVector(TMP_VEC3_FOLLOW_DIR, followExtra);
-          cueStick.visible = true;
+          const cameraForCueVisibility =
+            activeRenderCameraRef.current ?? cameraRef.current ?? camera;
+          const cueBallY = cue?.pos ? CUE_Y : BALL_CENTER_Y;
+          const cameraHeightAboveCue =
+            (cameraForCueVisibility?.position?.y ?? cueBallY) - cueBallY;
+          const isStandingCueView =
+            !shooting &&
+            !cueAnimating &&
+            cameraHeightAboveCue > BALL_R * 3.4;
+          cueStick.visible = !isStandingCueView;
           cueStick.position.copy(idlePos);
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
@@ -26437,7 +26461,8 @@ const powerRef = useRef(hud.power);
             visible: cueStick.visible || cueAnimating || shooting,
             power: powerRef.current ?? activeAiPlan?.power ?? 0,
             shooting,
-            cueAnimating
+            cueAnimating,
+            tableCueVisible: cueStick.visible
           });
         } catch (error) {
           snookerHumanPlayer.disabled = true;


### PR DESCRIPTION
### Motivation
- Ensure the player character keeps a correct cue-in-hand posture when the camera is in a standing/high view while preserving the existing on-table cue behavior for low/shot cameras. 
- Keep the existing pull/push stroke timing and strike mechanics unchanged while making the human rig follow the cue visibility state.

### Description
- Updated `updateSnookerRoyalHumanPlayer` to accept a new `tableCueVisible` option and use it to influence right-hand/grip targets so the hand holds a sensible cue pose when the table cue is hidden. 
- When building the grip target, introduced `gripBlend` and conditional Y/side offsets so the hand placement differs when `tableCueVisible` is false (standing camera). 
- During shot setup, compute camera height relative to the cue and toggle `cueStick.visible` for a standing-height threshold, so a standing camera hides the table cue while lower cameras keep it visible. 
- Wired the computed `tableCueVisible` state into the call to `updateSnookerRoyalHumanPlayer` so the human pose logic and cue visibility remain synchronized.

### Testing
- Ran the linter on the modified file with `npm -s run lint -- webapp/src/pages/Games/SnookerRoyal.jsx`, which produced an environment warning about React detection but no code errors reported in this environment. 
- No unit/integration tests were executed as part of this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d38935f1083298826155f42dd4a04)