### PR TITLE
Pool Royale: use procedural Showood-shape table only (faster startup)

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,14 +1,12 @@
 export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
 
-const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'procedural-showood-hybrid',
     label: 'Procedural (Showood Shape)',
     description:
-      'Native procedural Pool Royale table with restored procedural bases and Showood-matched jaw/cushion/frame geometry profile for faster startup.',
+      'Fast native procedural Pool Royale table with restored procedural base variants, procedural-size pocket jaws/cushions, and Showood-matched jaw/cushion/wood-rail geometry profile.',
     tableSizeId: '7ft',
     baseId: 'classicCylinders',
     icon: '🧩',
@@ -17,39 +15,6 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitFootprintScale: 1,
     fitHeightScale: 1,
     usePoolRoyaleFinish: true
-  },
-  {
-    id: 'showood-seven-foot',
-    label: 'Showood 7 ft GLB',
-    description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the CDN GLB cannot load, Pool Royale retries the raw Showood GLB and keeps the Showood original base and legs.',
-    tableSizeId: '7ft',
-    baseId: 'showoodOriginal',
-    assetUrl:
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
-    icon: '🟫',
-    kind: 'gltf',
-    fitScale: 1,
-    fitFootprintScale: 1.105,
-    fitHeightScale: 1,
-    lowerBaseHeightScale: 1.38,
-    legLengthScale: 2.05,
-    clothRepeatScale: 7.5,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeHeight: true,
-    matchNativeUpperComponentHeight: true,
-    preserveOriginalFootprintAspect: true,
-    useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
-    preserveOriginalSurfaceRoles: [],
-    tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
-    blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: []
   }
 ]);
 


### PR DESCRIPTION
### Motivation
- The table must load faster by avoiding remote GLB downloads and restore the native procedural table with the previously used procedural bases.  
- Pocket jaws, cushions and wooden frame rails should remain procedural-sized but match the Showood geometry/profile to preserve appearance while improving startup performance.  

### Description
- Removed the external Showood GLB option and its CDN/fallback references so only the procedural Showood-shape hybrid model remains in `webapp/src/config/poolRoyaleTableModels.js`.  
- Updated the procedural model entry description to state restored procedural base variants, procedural-size pocket jaws/cushions, and Showood-matched jaw/cushion/wood-rail geometry profile.  
- Kept the default model resolution pinned to `procedural-showood-hybrid` so legacy IDs still resolve to the procedural table.  

### Testing
- Verified the config module imports successfully with `node -e "import('./webapp/src/config/poolRoyaleTableModels.js').then(()=>console.log('ok'))"`, which printed `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d416c768c832984d9eb664eff72c3)