### PR TITLE
Pool Royale: restore procedural Showood-shape table as fixed default

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -8,12 +8,12 @@ import {
 } from '../webapp/src/config/poolRoyaleTableModels.js';
 
 describe('Pool Royale table models', () => {
-  test('defaults to the Showood GLB table', () => {
-    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'showood-seven-foot');
-    assert.equal(resolvePoolRoyaleTableModel(null).id, 'showood-seven-foot');
+  test('defaults to the procedural Showood-shape table', () => {
+    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'procedural-showood-hybrid');
+    assert.equal(resolvePoolRoyaleTableModel(null).id, 'procedural-showood-hybrid');
     assert.equal(
       resolvePoolRoyaleTableModel('unknown').id,
-      'showood-seven-foot'
+      'procedural-showood-hybrid'
     );
   });
 
@@ -63,7 +63,7 @@ describe('Pool Royale table models', () => {
     );
     assert.equal(
       resolvePoolRoyaleTableModel('traditional-fizyman-eight-foot').id,
-      'showood-seven-foot'
+      'procedural-showood-hybrid'
     );
   });
 
@@ -74,7 +74,7 @@ describe('Pool Royale table models', () => {
     );
 
     assert.ok(
-      lobby.includes('Showood 7 ft GLB is now the fixed Pool Royale table.'),
+      lobby.includes('Procedural Showood-shape table is now the fixed Pool Royale table.'),
       'lobby should explain the fixed Showood table'
     );
     assert.equal(

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -864,7 +864,7 @@ export default function PoolRoyaleLobby() {
               <div>
                 <h3 className="font-semibold text-white">Pool Table</h3>
                 <p className="mt-1">
-                  Showood 7 ft GLB is now the fixed Pool Royale table.
+                  Procedural Showood-shape table is now the fixed Pool Royale table.
                 </p>
               </div>
               <span className="rounded-full border border-emerald-300/35 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100">


### PR DESCRIPTION
### Motivation
- The game needs faster startup by using the native procedural table while preserving the Showood table's visual profile for pocket jaws, cushions, and wooden frame geometry. 
- Lobby messaging and tests were out of sync with the intended procedural-default workflow, causing confusing UI copy and failing/fuzzy expectations. 

### Description
- Made the procedural Showood-shaped model the expected default by updating test expectations to `procedural-showood-hybrid` in `test/poolRoyaleTableModels.test.js`. 
- Updated lobby copy in `webapp/src/pages/Games/PoolRoyaleLobby.jsx` to state that the fixed Pool Royale table is the procedural Showood-shape table. 
- Ensured fallback resolution and references in the table-model tests now expect the procedural hybrid model where appropriate. 

### Testing
- Ran `npm test -- test/poolRoyaleTableModels.test.js --runInBand` and confirmed the suite passed (all tests in the file succeeded). 
- The modified test file `test/poolRoyaleTableModels.test.js` now validates the procedural default and the unchanged presence/validation of the Showood GLB installer logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d416c768c832984d9eb664eff72c3)