### PR TITLE
Default Snooker Royal to GLB (open-source) table model

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -7580,7 +7580,7 @@ function Table3D(
   railMarkerStyle = null,
   baseVariant = null,
   renderer = null,
-  tableVisualModel = TABLE_MODEL_CLASSIC
+  tableVisualModel = TABLE_MODEL_OPENSOURCE
 ) {
   const tableSizeMeta =
     tableSpecMeta && typeof tableSpecMeta === 'object' ? tableSpecMeta : null;
@@ -12410,7 +12410,7 @@ function SnookerRoyalGame({
   variantKey,
   ballSetKey,
   tableSizeKey,
-  tableModel = TABLE_MODEL_CLASSIC,
+  tableModel = TABLE_MODEL_OPENSOURCE,
   playType = 'regular',
   mode = 'ai',
   trainingMode = 'solo',


### PR DESCRIPTION
### Motivation
- Make the GLB snooker table the default visual and runtime model for Snooker Royal so the scene and gameplay use the Pooltool/open-source GLB instead of the procedural classic table.

### Description
- Updated `webapp/src/pages/Games/SnookerRoyal.jsx` to set `tableVisualModel` default in `Table3D` to `TABLE_MODEL_OPENSOURCE` and to set the `tableModel` default in `SnookerRoyalGame` to `TABLE_MODEL_OPENSOURCE`.

### Testing
- Ran `npm test -- --runInBand test/snookerTableModel.test.js` and all tests passed (`8/8`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d59b5262083299b07f0802f81b4d0)