### PR TITLE
Tune Pool Royal cushions, collision precision, and rail sight finish

### DIFF
--- a/Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs
@@ -9,8 +9,8 @@ namespace Aiming.Pockets
     [System.Serializable]
     public class PocketCollisionResolver
     {
-        [SerializeField, Min(0f)] private float positionalSlop = 0.0002f;
-        [SerializeField, Min(0f)] private float maxPushOut = 0.02f;
+        [SerializeField, Min(0f)] private float positionalSlop = 0.00045f;
+        [SerializeField, Min(0f)] private float maxPushOut = 0.03f;
 
         [Header("Jaw realism")]
         [SerializeField, Range(0f, 1f)] private float glancingRestitutionScale = 0.4f;

--- a/Assets/Scripts/Gameplay/Pockets/PocketJawDefinition.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketJawDefinition.cs
@@ -8,8 +8,8 @@ namespace Aiming.Pockets
     public class PocketJawDefinition : MonoBehaviour
     {
         [Header("Jaw bounds (local table space)")]
-        [SerializeField] private Vector2 start = new Vector2(-0.05f, 0f);
-        [SerializeField] private Vector2 end = new Vector2(0.05f, 0f);
+        [SerializeField] private Vector2 start = new Vector2(-0.042f, 0f);
+        [SerializeField] private Vector2 end = new Vector2(0.042f, 0f);
 
         [Header("Jaw contact")]
         [SerializeField, Min(0f)] private float jawRadius = 0.012f;

--- a/Assets/Scripts/Gameplay/Pockets/PocketMouth.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketMouth.cs
@@ -11,7 +11,7 @@ namespace Aiming.Pockets
         [SerializeField] private PocketJawDefinition rightJaw;
 
         [Header("Pocket shape")]
-        [SerializeField, Min(0.01f)] private float mouthWidth = 0.115f;
+        [SerializeField, Min(0.01f)] private float mouthWidth = 0.102f;
         [SerializeField, Min(0f)] private float shelfDepth = 0.028f;
         [SerializeField] private Vector2 pocketCenter = new Vector2(0f, -0.06f);
         [SerializeField] private Vector2 fallDirection = new Vector2(0f, -1f);

--- a/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver2D.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver2D.cs
@@ -19,6 +19,7 @@ namespace Aiming.Pockets
         [SerializeField] private PocketMouth pocketMouth;
         [SerializeField] private PocketCaptureZone captureZone;
         [SerializeField] private List<BallBinding> balls = new List<BallBinding>();
+        [SerializeField, Range(1, 6)] private int collisionSubsteps = 3;
 
         [SerializeField] private PocketCollisionResolver collisionResolver = new PocketCollisionResolver();
         [SerializeField] private PocketCaptureResolver captureResolver = new PocketCaptureResolver();
@@ -39,7 +40,11 @@ namespace Aiming.Pockets
                 }
 
                 var adapter = new PoolBallBody2D(b.body, b.circle, b.id);
-                collisionResolver.Resolve(adapter, pocketMouth);
+                int substeps = Mathf.Max(1, collisionSubsteps);
+                for (int step = 0; step < substeps; step++)
+                {
+                    collisionResolver.Resolve(adapter, pocketMouth);
+                }
                 captureResolver.TryCapture(adapter, pocketMouth, captureZone, out _);
             }
         }

--- a/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver3D.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver3D.cs
@@ -20,6 +20,7 @@ namespace Aiming.Pockets
         [SerializeField] private PocketCaptureZone captureZone;
         [SerializeField] private List<BallBinding> balls = new List<BallBinding>();
         [SerializeField, Min(0f)] private float downwardFallSpeed = 2.4f;
+        [SerializeField, Range(1, 6)] private int collisionSubsteps = 3;
 
         [SerializeField] private PocketCollisionResolver collisionResolver = new PocketCollisionResolver();
         [SerializeField] private PocketCaptureResolver captureResolver = new PocketCaptureResolver();
@@ -40,7 +41,11 @@ namespace Aiming.Pockets
                 }
 
                 var adapter = new PoolBallBody3D(b.body, b.sphere, b.id);
-                collisionResolver.Resolve(adapter, pocketMouth);
+                int substeps = Mathf.Max(1, collisionSubsteps);
+                for (int step = 0; step < substeps; step++)
+                {
+                    collisionResolver.Resolve(adapter, pocketMouth);
+                }
 
                 if (captureResolver.TryCapture(adapter, pocketMouth, captureZone, out bool committed) && committed)
                 {

--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -14,6 +14,13 @@ namespace Aiming.Gameplay.Rendering
         [SerializeField] private bool upgradeGltfImportShaders = true;
         [SerializeField] private Shader urpLitShader;
         [SerializeField] private Shader standardShader;
+        [Header("Rail sight material polish")]
+        [SerializeField] private bool tuneRailSightMaterials = true;
+        [SerializeField] private string[] railSightMaterialNameHints = { "railsight", "rail_sight", "rail sight", "diamond", "chrome", "gold" };
+        [SerializeField, Range(0f, 1f)] private float railSightSmoothness = 0.92f;
+        [SerializeField, Range(0f, 1f)] private float railSightMetallic = 0.86f;
+        [SerializeField, Range(0.1f, 4f)] private float railSightVerticalTextureScale = 1.28f;
+        [SerializeField, Range(-1f, 1f)] private float railSightVerticalTextureOffset = -0.12f;
 
         private static readonly int BaseMapId = Shader.PropertyToID("_BaseMap");
         private static readonly int MainTexId = Shader.PropertyToID("_MainTex");
@@ -65,8 +72,77 @@ namespace Aiming.Gameplay.Rendering
                     MaterialTextureSnapshot textureSnapshot = MaterialTextureSnapshot.Capture(mat);
                     EnsureSupportedShader(mat, textureSnapshot);
                     CopyPbrMaps(mat, textureSnapshot);
+                    ApplyRailSightTuning(mat);
                 }
             }
+        }
+
+        private void ApplyRailSightTuning(Material material)
+        {
+            if (!tuneRailSightMaterials || material == null || !IsRailSightMaterial(material.name))
+            {
+                return;
+            }
+
+            if (material.HasProperty("_Smoothness"))
+            {
+                material.SetFloat("_Smoothness", railSightSmoothness);
+            }
+
+            if (material.HasProperty("_Metallic"))
+            {
+                material.SetFloat("_Metallic", railSightMetallic);
+            }
+
+            if (material.HasProperty("_BumpScale"))
+            {
+                material.SetFloat("_BumpScale", 0.7f);
+            }
+
+            if (material.HasProperty(BaseMapId))
+            {
+                Vector2 scale = material.GetTextureScale(BaseMapId);
+                Vector2 offset = material.GetTextureOffset(BaseMapId);
+                scale.y *= railSightVerticalTextureScale;
+                offset.y += railSightVerticalTextureOffset;
+                material.SetTextureScale(BaseMapId, scale);
+                material.SetTextureOffset(BaseMapId, offset);
+            }
+
+            if (material.HasProperty(MainTexId))
+            {
+                Vector2 scale = material.GetTextureScale(MainTexId);
+                Vector2 offset = material.GetTextureOffset(MainTexId);
+                scale.y *= railSightVerticalTextureScale;
+                offset.y += railSightVerticalTextureOffset;
+                material.SetTextureScale(MainTexId, scale);
+                material.SetTextureOffset(MainTexId, offset);
+            }
+        }
+
+        private bool IsRailSightMaterial(string materialName)
+        {
+            if (string.IsNullOrWhiteSpace(materialName) || railSightMaterialNameHints == null)
+            {
+                return false;
+            }
+
+            string lowered = materialName.ToLowerInvariant();
+            for (int i = 0; i < railSightMaterialNameHints.Length; i++)
+            {
+                string hint = railSightMaterialNameHints[i];
+                if (string.IsNullOrWhiteSpace(hint))
+                {
+                    continue;
+                }
+
+                if (lowered.Contains(hint.ToLowerInvariant()))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private Renderer[] ResolveRenderers()


### PR DESCRIPTION
### Motivation
- Make table sides play shorter by tightening pocket mouth and jaw defaults so pockets feel smaller on Pool Royal tables.
- Prevent balls from passing through cushions/jaws by increasing collision fidelity and improving push-out behavior for extreme-precision pocket interactions.
- Improve chrome/gold rail finishes by smoothing material parameters and extending textures downward to avoid visible harsh edges.

### Description
- Reduced default pocket geometry: changed `mouthWidth` from `0.115f` to `0.102f` in `Assets/Scripts/Gameplay/Pockets/PocketMouth.cs` and shortened jaw endpoints (`start`/`end`) in `Assets/Scripts/Gameplay/Pockets/PocketJawDefinition.cs` from `±0.05f` to `±0.042f`.
- Increased collision robustness by adding a serialized `collisionSubsteps` (`Range(1,6)`, default `3`) to `PocketPhysicsDriver2D` and `PocketPhysicsDriver3D` and running the collision resolver multiple substeps per physics update.
- Tuned collision solver parameters in `PocketCollisionResolver` by increasing `positionalSlop` and `maxPushOut` to reduce tunneling and better separate interpenetrating contacts.
- Added an optional rail-sight material polish pass in `GltfMaterialCompatibilityAdapter`: new serialized controls (`tuneRailSightMaterials`, `railSightSmoothness`, `railSightMetallic`, `railSightVerticalTextureScale`, `railSightVerticalTextureOffset`, and `railSightMaterialNameHints`) and new methods `ApplyRailSightTuning` / `IsRailSightMaterial` that adjust `_Smoothness`, `_Metallic`, `_BumpScale` and vertically scale/offset `BaseMap`/`_MainTex` UVs for identified rail materials.

### Testing
- Verified diffs and file contents using `git status --short` and `git diff` for the modified files; these commands completed successfully.
- Printed updated files with `nl -ba` to inspect changes in `PocketMouth.cs`, `PocketJawDefinition.cs`, `PocketCollisionResolver.cs`, `PocketPhysicsDriver2D.cs`, `PocketPhysicsDriver3D.cs`, and `GltfMaterialCompatibilityAdapter.cs`; output matched the intended edits.
- Changes were committed with message `"Tune Pool Royal cushions, jaw collision precision, and rail sight material finish"` and the commit succeeded.
- No automated unit tests were executed as part of this change in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5ee02bbc83299ab0eb5acf528122)