### PR TITLE
Tune Pool Royal cushions, pocket mapping, and rail sight materials

### DIFF
--- a/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver3D.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver3D.cs
@@ -20,6 +20,7 @@ namespace Aiming.Pockets
         [SerializeField] private PocketCaptureZone captureZone;
         [SerializeField] private List<BallBinding> balls = new List<BallBinding>();
         [SerializeField, Min(0f)] private float downwardFallSpeed = 2.4f;
+        [SerializeField, Range(1, 6)] private int collisionSubsteps = 3;
 
         [SerializeField] private PocketCollisionResolver collisionResolver = new PocketCollisionResolver();
         [SerializeField] private PocketCaptureResolver captureResolver = new PocketCaptureResolver();
@@ -40,7 +41,11 @@ namespace Aiming.Pockets
                 }
 
                 var adapter = new PoolBallBody3D(b.body, b.sphere, b.id);
-                collisionResolver.Resolve(adapter, pocketMouth);
+                int substeps = Mathf.Max(1, collisionSubsteps);
+                for (int step = 0; step < substeps; step++)
+                {
+                    collisionResolver.Resolve(adapter, pocketMouth);
+                }
 
                 if (captureResolver.TryCapture(adapter, pocketMouth, captureZone, out bool committed) && committed)
                 {

--- a/Assets/Scripts/Gameplay/Rendering/RailSightMaterialTuner.cs
+++ b/Assets/Scripts/Gameplay/Rendering/RailSightMaterialTuner.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+
+namespace Gameplay.Rendering
+{
+    /// <summary>
+    /// Tunes rail sight chrome/gold finish by smoothing edge response and extending texture mapping downward.
+    /// Intended for GLTF/GLB imported rail sight meshes.
+    /// </summary>
+    public sealed class RailSightMaterialTuner : MonoBehaviour
+    {
+        [SerializeField] private Renderer[] railSightRenderers;
+        [SerializeField, Min(0.1f)] private float verticalTextureScaleMultiplier = 1.28f;
+        [SerializeField, Range(0f, 1f)] private float smoothness = 0.92f;
+        [SerializeField, Range(0f, 1f)] private float metallic = 0.88f;
+
+        private static readonly int MainTex = Shader.PropertyToID("_MainTex");
+        private static readonly int BaseMap = Shader.PropertyToID("_BaseMap");
+        private static readonly int Smoothness = Shader.PropertyToID("_Smoothness");
+        private static readonly int Glossiness = Shader.PropertyToID("_Glossiness");
+        private static readonly int Metallic = Shader.PropertyToID("_Metallic");
+
+        [ContextMenu("Apply Rail Sight Tuning")]
+        public void Apply()
+        {
+            for (int i = 0; i < railSightRenderers.Length; i++)
+            {
+                Renderer r = railSightRenderers[i];
+                if (r == null) continue;
+
+                Material[] materials = r.materials;
+                for (int m = 0; m < materials.Length; m++)
+                {
+                    Material material = materials[m];
+                    if (material == null) continue;
+
+                    ExpandTextureDownward(material, MainTex);
+                    ExpandTextureDownward(material, BaseMap);
+
+                    if (material.HasProperty(Smoothness)) material.SetFloat(Smoothness, smoothness);
+                    if (material.HasProperty(Glossiness)) material.SetFloat(Glossiness, smoothness);
+                    if (material.HasProperty(Metallic)) material.SetFloat(Metallic, metallic);
+                }
+            }
+        }
+
+        private void OnValidate() => Apply();
+
+        private void ExpandTextureDownward(Material material, int texProperty)
+        {
+            if (!material.HasProperty(texProperty)) return;
+            Vector2 scale = material.GetTextureScale(texProperty);
+            Vector2 offset = material.GetTextureOffset(texProperty);
+            float nextY = Mathf.Max(0.01f, scale.y / verticalTextureScaleMultiplier);
+            float deltaY = scale.y - nextY;
+            material.SetTextureScale(texProperty, new Vector2(scale.x, nextY));
+            material.SetTextureOffset(texProperty, new Vector2(offset.x, offset.y - deltaY * 0.5f));
+        }
+    }
+}

--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -160,6 +160,22 @@ function scratchRiskAlongLine (cue, aimPoint, pockets, radius) {
   return false
 }
 
+
+function tableCushionInset (state) {
+  const r = Number(state?.ballRadius) || 0
+  return Math.max(r * 0.82, Math.min((state?.width || 0), (state?.height || 0)) * 0.012)
+}
+
+function effectiveTableBounds (state) {
+  const inset = tableCushionInset(state)
+  return {
+    minX: inset,
+    maxX: state.width - inset,
+    minY: inset,
+    maxY: state.height - inset,
+    inset
+  }
+}
 function pocketNormal (pocket, width, height) {
   const center = { x: width / 2, y: height / 2 }
   const dir = { x: center.x - pocket.x, y: center.y - pocket.y }
@@ -168,10 +184,11 @@ function pocketNormal (pocket, width, height) {
 }
 
 function classifyPocket (pocket, width, height, tolerance = 1e-3) {
-  const isLeft = Math.abs(pocket.x) <= tolerance
-  const isRight = Math.abs(pocket.x - width) <= tolerance
-  const isTop = Math.abs(pocket.y) <= tolerance
-  const isBottom = Math.abs(pocket.y - height) <= tolerance
+  const edgeTolerance = Math.max(tolerance, Math.min(width, height) * 0.02)
+  const isLeft = Math.abs(pocket.x) <= edgeTolerance
+  const isRight = Math.abs(pocket.x - width) <= edgeTolerance
+  const isTop = Math.abs(pocket.y) <= edgeTolerance
+  const isBottom = Math.abs(pocket.y - height) <= edgeTolerance
 
   if ((isLeft || isRight) && (isTop || isBottom)) return 'corner'
   if (isTop || isBottom) return 'side'
@@ -182,8 +199,8 @@ function pocketMouthGeometry (pocket, radius, width, height, target = null) {
   const normal = pocketNormal(pocket, width, height)
   const pocketType = classifyPocket(pocket, width, height)
   const axis = { x: -normal.y, y: normal.x }
-  const mouthHalfWidth = radius * (pocketType === 'side' ? 2.95 : 2.55)
-  const playableHalfWidth = Math.max(radius * 0.7, mouthHalfWidth - radius * 1.08)
+  const mouthHalfWidth = radius * (pocketType === 'side' ? 2.72 : 2.38)
+  const playableHalfWidth = Math.max(radius * 0.7, mouthHalfWidth - radius * 1.02)
   const mouthCenter = {
     x: pocket.x - normal.x * radius * 1.04,
     y: pocket.y - normal.y * radius * 1.04
@@ -214,7 +231,8 @@ function pocketMouthGeometry (pocket, radius, width, height, target = null) {
 }
 
 function cornerPocketRailClearance (pocket, point, width, height) {
-  const tolerance = 1e-3
+  const bounds = effectiveTableBounds({ width, height, ballRadius: Math.max(width, height) * 0.017 })
+  const tolerance = Math.max(1e-3, bounds.inset * 0.2)
   const nearLeft = Math.abs(pocket.x) <= tolerance
   const nearRight = Math.abs(pocket.x - width) <= tolerance
   const nearTop = Math.abs(pocket.y) <= tolerance
@@ -241,8 +259,8 @@ function cornerPocketLaneSafety (target, entry, pocket, req) {
   const startGap = cornerPocketRailClearance(pocket, target, req.state.width, req.state.height)
   const endGap = cornerPocketRailClearance(pocket, entry, req.state.width, req.state.height)
   const laneGap = Math.min(startGap, endGap)
-  const safeGap = radius * 1.45
-  const hardFailGap = radius * 0.82
+  const safeGap = radius * 1.62
+  const hardFailGap = radius * 0.96
   if (laneGap <= hardFailGap) return 0
   return Math.max(0, Math.min((laneGap - hardFailGap) / Math.max(safeGap - hardFailGap, 1e-6), 1))
 }
@@ -266,7 +284,7 @@ function pocketEntry (pocket, radius, width, height, target) {
     dir = { x: dir.x / blendedLen, y: dir.y / blendedLen }
   }
 
-  const offset = radius * 1.05
+  const offset = radius * 1.12
   const centerDriven = {
     x: pocket.x - dir.x * offset,
     y: pocket.y - dir.y * offset
@@ -278,7 +296,7 @@ function pocketEntry (pocket, radius, width, height, target) {
   }
   if (classifyPocket(pocket, width, height) !== 'corner') return entry
 
-  const minRailGap = radius * 0.95
+  const minRailGap = radius * 1.18
   const tolerance = 1e-3
   if (Math.abs(pocket.x) <= tolerance) entry.x = Math.max(entry.x, minRailGap)
   if (Math.abs(pocket.x - width) <= tolerance) entry.x = Math.min(entry.x, width - minRailGap)
@@ -804,11 +822,12 @@ function projectedScratchRisk (cueAfter, req) {
 }
 
 function mirrorPointAcrossRail (point, rail, state) {
+  const b = effectiveTableBounds(state)
   switch (rail) {
-    case 'left': return { x: -point.x, y: point.y }
-    case 'right': return { x: state.width * 2 - point.x, y: point.y }
-    case 'top': return { x: point.x, y: -point.y }
-    case 'bottom': return { x: point.x, y: state.height * 2 - point.y }
+    case 'left': return { x: b.minX * 2 - point.x, y: point.y }
+    case 'right': return { x: b.maxX * 2 - point.x, y: point.y }
+    case 'top': return { x: point.x, y: b.minY * 2 - point.y }
+    case 'bottom': return { x: point.x, y: b.maxY * 2 - point.y }
     default: return null
   }
 }
@@ -817,21 +836,22 @@ function firstRailContact (cue, mirroredTarget, rail, state) {
   const dx = mirroredTarget.x - cue.x
   const dy = mirroredTarget.y - cue.y
   if (Math.abs(dx) < 1e-6 && Math.abs(dy) < 1e-6) return null
+  const b = effectiveTableBounds(state)
   if (rail === 'left' || rail === 'right') {
-    const xRail = rail === 'left' ? 0 : state.width
+    const xRail = rail === 'left' ? b.minX : b.maxX
     if (Math.abs(dx) < 1e-6) return null
     const t = (xRail - cue.x) / dx
     if (t <= 0 || t >= 1) return null
     const y = cue.y + dy * t
-    if (y <= 0 || y >= state.height) return null
+    if (y <= b.minY || y >= b.maxY) return null
     return { x: xRail, y }
   }
-  const yRail = rail === 'top' ? 0 : state.height
+  const yRail = rail === 'top' ? b.minY : b.maxY
   if (Math.abs(dy) < 1e-6) return null
   const t = (yRail - cue.y) / dy
   if (t <= 0 || t >= 1) return null
   const x = cue.x + dx * t
-  if (x <= 0 || x >= state.width) return null
+  if (x <= b.minX || x >= b.maxX) return null
   return { x, y: yRail }
 }
 
@@ -871,7 +891,8 @@ function oneCushionKickShot (req) {
 
 function clampPointToTable (point, table, margin = 1) {
   if (!table) return { ...point }
-  const inset = (table.ballRadius || 0) * margin
+  const bounds = effectiveTableBounds(table)
+  const inset = bounds.inset + (table.ballRadius || 0) * Math.max(0, margin - 1)
   const clampedX = Math.min(Math.max(point.x, inset), table.width - inset)
   const clampedY = Math.min(Math.max(point.y, inset), table.height - inset)
   return { x: clampedX, y: clampedY }


### PR DESCRIPTION
### Motivation
- Match in-game Pool Royal table footprint to the physical table by effectively shortening all four playable sides so rail reflections and cushion contacts align with real cushions.
- Stop balls leaking through cushions/pockets by tightening pocket mouth/jaw geometry and corner-lane safety so collisions reject more accurately.
- Improve rail chrome/gold appearance by smoothing edge response and expanding texture projection downward for a cleaner finish on rails/sights.

### Description
- Added an effective table inset and bounds (`tableCushionInset` / `effectiveTableBounds`) and routed rail mirroring, first-rail contact, and clamping through those bounds to shorten playable table sides and tighten cushion math (`lib/poolAi.js`).
- Tuned pocket geometry parameters (mouth/playable widths, entry offset, corner safety thresholds and min rail gaps) to better model jaws and prevent seam leakage (`lib/poolAi.js`).
- Introduced a configurable `collisionSubsteps` loop to `PocketPhysicsDriver3D` to run the jaw collision resolver multiple times per `FixedUpdate` for higher-precision 3D pocket collisions (`Assets/Scripts/Gameplay/Pockets/PocketPhysicsDriver3D.cs`).
- Added `RailSightMaterialTuner` component to adjust rail sight material properties (smoothness/metallic) and to expand texture Y-scale/offset downward for chrome/gold rails on imported GLTF/GLB meshes (`Assets/Scripts/Gameplay/Rendering/RailSightMaterialTuner.cs`).

### Testing
- Ran syntax check `node --check lib/poolAi.js` and it completed without errors (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5ee02bbc83299ab0eb5acf528122)