### PR TITLE
Improve Checkers Battle Royal hand contact during piece pickup/place

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -121,10 +121,10 @@ const SEATED_HUMAN_TARGET_HEIGHT =
 const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = SEAT_DEPTH * 0.08;
 const SEATED_HUMAN_MOVE_DURATION_MS = 700;
-const SEATED_HUMAN_PICKUP_PHASE_END = 0.26;
-const SEATED_HUMAN_CARRY_PHASE_END = 0.78;
+const SEATED_HUMAN_PICKUP_PHASE_END = 0.34;
+const SEATED_HUMAN_CARRY_PHASE_END = 0.74;
 const SEATED_HUMAN_PICK_LIFT_HEIGHT = 0.16 * CHECKERS_ARENA_SCALE;
-const SEATED_HUMAN_HAND_DROP_CLEARANCE = 0.012 * CHECKERS_ARENA_SCALE;
+const SEATED_HUMAN_HAND_DROP_CLEARANCE = 0.003 * CHECKERS_ARENA_SCALE;
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
 const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
 const HDRI_UNITS_PER_METER = 1;
@@ -2600,13 +2600,15 @@ export default function CheckersBattleRoyal() {
       applySeatedHumanRightArmIK(entry.rig, target, 0.98);
       entry.actor.updateMatrixWorld(true);
       const gripWorld = getSeatedHumanGripWorldPosition(entry.rig);
-      const isHandCarrying = rawT > SEATED_HUMAN_PICKUP_PHASE_END * 0.72 && rawT < 0.9;
+      const pickupContactStart = SEATED_HUMAN_PICKUP_PHASE_END * 0.56;
+      const placeContactEnd = Math.min(0.985, SEATED_HUMAN_CARRY_PHASE_END + (1 - SEATED_HUMAN_CARRY_PHASE_END) * 0.94);
+      const isHandCarrying = rawT >= pickupContactStart && rawT <= placeContactEnd;
       const linkedAnim = activeAnimationsRef.current.find((anim) => anim.object === action.object);
       if (linkedAnim) linkedAnim.handCarried = isHandCarrying;
       if (action.object) action.object.userData.handCarried = isHandCarrying;
       if (action.object && isHandCarrying) {
         action.object.position.copy(gripWorld || target);
-        action.object.position.y -= action.tile * 0.16;
+        action.object.position.y -= action.tile * 0.06;
         action.object.rotation.z = Math.sin(rawT * Math.PI * 2) * 0.05;
       }
       if (rawT >= 1) {

--- a/webapp/src/pages/Games/shared/seatedHumanActors.js
+++ b/webapp/src/pages/Games/shared/seatedHumanActors.js
@@ -236,27 +236,27 @@ export function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip
   const sideReach = THREE.MathUtils.clamp(motionProfile?.sideReach ?? 0, -1, 1);
 
   if (mode === 'reachPiece') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.92, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.06, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.18, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -0.74, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.2, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.28, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.18, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.16, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.22, t);
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -1.22, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.14, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.34, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.04, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.28, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.38, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.4, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.2, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.34, t);
     chestX = THREE.MathUtils.lerp(chestX, 0.28, t);
     headX = THREE.MathUtils.lerp(headX, 0.07, t);
   } else if (mode === 'gripPiece') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.96, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.06, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.12, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -0.82, t);
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -1.28, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.14, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.32, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.14, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.2, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.26, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.16, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.16, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.3, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.46, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.2, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.28, t);
     chestX = THREE.MathUtils.lerp(chestX, 0.31, t);
     headX = THREE.MathUtils.lerp(headX, 0.09, t);
   } else if (mode === 'carryPiece') {
@@ -267,20 +267,20 @@ export function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip
     forearmY = THREE.MathUtils.lerp(forearmY, -0.14, t);
     forearmZ = THREE.MathUtils.lerp(forearmZ, -0.09, t);
     wristX = THREE.MathUtils.lerp(wristX, -0.02, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.14, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.2, t);
     wristZ = THREE.MathUtils.lerp(wristZ, -0.1, t);
     chestX = THREE.MathUtils.lerp(chestX, 0.27, t);
     headX = THREE.MathUtils.lerp(headX, 0.05, t);
   } else if (mode === 'placePiece') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.86, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.02, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.02, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -0.88, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.2, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.28, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.28, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.14, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.2, t);
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -1.2, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.1, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.26, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.18, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.28, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.38, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.48, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.2, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.32, t);
     chestX = THREE.MathUtils.lerp(chestX, 0.3, t);
     headX = THREE.MathUtils.lerp(headX, 0.11, t);
   }


### PR DESCRIPTION
### Motivation

- Improve visual clarity of human characters picking and placing checkers so the arm/hand posture is more downward and diagonal and fingers visibly maintain physical contact with pieces. 
- Keep the change focused on animation/pose tuning so game rules and networking remain untouched. 

### Description

- Tuned pickup/carry/place timing by adjusting `SEATED_HUMAN_PICKUP_PHASE_END` and `SEATED_HUMAN_CARRY_PHASE_END` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` so pickup lasts longer and placement contact persists later. 
- Reduced `SEATED_HUMAN_HAND_DROP_CLEARANCE` and tightened the carried-piece vertical offset so the checker stays closer to the fingers while carried. 
- Retargeted right-arm / forearm / wrist pose lerps for `reachPiece`, `gripPiece`, and `placePiece` modes in `webapp/src/pages/Games/shared/seatedHumanActors.js` to push the arm and wrist further downward and diagonally while preserving existing finger curl logic. 
- Adjusted the pickup/carry contact window logic so `handCarried` is enabled across a larger portion of the move animation for clearer visible contact. 

### Testing

- No automated tests were run for this motion/pose tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d62619ba483298972ef3d214a005d)