### PR TITLE
Tweak seated human reach/IK for Checkers piece pickup/place

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -125,6 +125,10 @@ const SEATED_HUMAN_PICKUP_PHASE_END = 0.34;
 const SEATED_HUMAN_CARRY_PHASE_END = 0.74;
 const SEATED_HUMAN_PICK_LIFT_HEIGHT = 0.16 * CHECKERS_ARENA_SCALE;
 const SEATED_HUMAN_HAND_DROP_CLEARANCE = 0.003 * CHECKERS_ARENA_SCALE;
+const SEATED_HUMAN_HAND_REACH_DOWN_OFFSET = 0.048 * CHECKERS_ARENA_SCALE;
+const SEATED_HUMAN_FORWARD_REACH_MIN = 0.7;
+const SEATED_HUMAN_FORWARD_REACH_MAX = 1.45;
+const SEATED_HUMAN_SIDE_REACH_SCALE = 1.28;
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
 const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
 const HDRI_UNITS_PER_METER = 1;
@@ -2567,17 +2571,26 @@ export default function CheckersBattleRoyal() {
       }
       const rawT = clamp((now - action.startedAt) / Math.max(action.duration, 1), 0, 1);
       const liftedFrom = action.from.clone();
-      liftedFrom.y += SEATED_HUMAN_HAND_DROP_CLEARANCE;
+      liftedFrom.y += SEATED_HUMAN_HAND_DROP_CLEARANCE - SEATED_HUMAN_HAND_REACH_DOWN_OFFSET;
       const liftedTo = action.to.clone();
-      liftedTo.y += SEATED_HUMAN_HAND_DROP_CLEARANCE;
+      liftedTo.y += SEATED_HUMAN_HAND_DROP_CLEARANCE - SEATED_HUMAN_HAND_REACH_DOWN_OFFSET;
       const carryArc = Math.sin(Math.PI * rawT) * (SEATED_HUMAN_PICK_LIFT_HEIGHT + action.tile * 0.18);
       const target = new THREE.Vector3().lerpVectors(liftedFrom, liftedTo, smoothEase(rawT));
       target.y += carryArc;
       const fromLocal = entry.actor.worldToLocal(action.from.clone());
       const toLocal = entry.actor.worldToLocal(action.to.clone());
       const sideSpan = Math.max(action.tile * 3, 0.001);
-      const forwardReach = clamp01(Math.max(Math.abs(fromLocal.z), Math.abs(toLocal.z)) / sideSpan, 0.55);
-      const sideReach = clamp((fromLocal.x + toLocal.x) / (sideSpan * 2), -1, 1);
+      const reachDistanceRatio = Math.max(Math.abs(fromLocal.z), Math.abs(toLocal.z)) / sideSpan;
+      const forwardReach = clamp(
+        reachDistanceRatio * 1.18 + 0.22,
+        SEATED_HUMAN_FORWARD_REACH_MIN,
+        SEATED_HUMAN_FORWARD_REACH_MAX
+      );
+      const sideReach = clamp(
+        ((fromLocal.x + toLocal.x) / (sideSpan * 2)) * SEATED_HUMAN_SIDE_REACH_SCALE,
+        -1,
+        1
+      );
       let mode = 'reachPiece';
       let intensity = 1;
       let grip = 0;


### PR DESCRIPTION
### Motivation
- Fix seated human hand floating too high during piece pickup/place so the hand reaches the board-level piece location. 
- Make the upper body lean and arm extension track source/destination squares more closely for believable pickup/place animation. 

### Description
- Added three tuning constants: `SEATED_HUMAN_HAND_REACH_DOWN_OFFSET`, `SEATED_HUMAN_FORWARD_REACH_MIN`/`MAX`, and `SEATED_HUMAN_SIDE_REACH_SCALE` to `webapp/src/pages/Games/CheckersBattleRoyal.jsx`. 
- Lowered the IK/target points by subtracting `SEATED_HUMAN_HAND_REACH_DOWN_OFFSET` from the lifted pickup/place world Y before lerping. 
- Recomputed forward reach as a scaled/clamped function of the source/destination Z distance and increased lateral responsiveness by scaling the side reach value. 
- Kept existing pickup/carry/place timing and applied the recalculated `forwardReach`/`sideReach` to the existing `applySeatedHumanPose` + `applySeatedHumanRightArmIK` flow. 

### Testing
- No automated tests were executed for this motion-tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d67299cc883299b4ec96fd03e074b)