### PR TITLE
Adjust Chess Battle Royale portrait framing and first-load layout

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -534,7 +534,7 @@ const BOARD_VISUAL_Y_OFFSET = -0.03;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.0359 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR * 0.69;
+const BOARD_SCALE = 0.0359 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR * 0.78;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
@@ -565,11 +565,11 @@ const CAMERA_TABLE_SPAN_FACTOR = 2.6;
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
 const CHAIR_SCALE = 0.94 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR;
-const CHAIR_WIDTH_SCALE = 1.22; // Make chairs a bit smaller for a cleaner board-facing framing.
+const CHAIR_WIDTH_SCALE = 1.14; // Make chairs a bit smaller for a cleaner board-facing framing.
 const CHAIR_VERTICAL_OFFSET = -0.065 * MODEL_SCALE;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
-const PLAYER_CHAIR_EXTRA_CLEARANCE = 0.22 * MODEL_SCALE; // push local bottom chair/human farther away from the table than the opponent.
-const OPPONENT_CHAIR_EXTRA_CLEARANCE = 0.14 * MODEL_SCALE; // push opponent chair/human slightly outward from the table.
+const PLAYER_CHAIR_EXTRA_CLEARANCE = 0.08 * MODEL_SCALE; // bring local bottom chair/human closer to the table.
+const OPPONENT_CHAIR_EXTRA_CLEARANCE = 0.05 * MODEL_SCALE; // bring opponent chair/human slightly closer to the table.
 const CHAIR_TABLE_PUSHBACK = 0.04 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MIN = 0.08 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MAX = 0.42 * MODEL_SCALE;
@@ -593,10 +593,10 @@ const FALLBACK_SEAT_POSITIONS = [
 ];
 const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_PULL_FORWARD_MIN = THREE.MathUtils.degToRad(15);
-const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(21); // raise forced 3D animation camera for a stronger portrait top-down feel.
+const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(24); // raise forced 3D animation camera for a stronger portrait top-down feel.
 const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 1.18; // keep forced 3D animation wider during capture so the board stays fully readable
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 0; // keep projected avatars pinned to the seated character chest anchors
-const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(72); // raise the locked 3D angle a bit for a higher camera view over the board/table/chairs.
+const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(64); // keep camera higher above the arena in portrait framing.
 const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.6; // pull locked 3D camera back slightly for a small zoom-out in portrait play.
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.06;
 const PLAYER_FACE_CAMERA_SEAT_ANGLE = Math.PI / 2;
@@ -623,11 +623,11 @@ const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.44;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.32;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.08;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.68;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.24; // raise player camera while keeping the perspective looking upward toward table/pieces.
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.34; // raise player camera while keeping the perspective looking upward toward table/pieces.
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.92;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 1.35;
 const PLAYER_VIEW_LOOK_TARGET_UP_BIAS = 0.6; // increase upward aim so the table/pieces/opponent sit higher in view.
-const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 10.9; // push table/chairs/humans further down in frame toward the bottom edge.
+const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 12.2; // push table/chairs/humans further down in frame toward the bottom edge.
 const FPV_FACE_FORWARD_OFFSET = 0.012; // keep the camera almost exactly at the eyes for a true first-person perspective.
 const FPV_FACE_UP_OFFSET = 0.0; // slight lift so the board edge does not clip while still feeling eye-level.
 const FPV_LOOK_AHEAD_DISTANCE = BOARD.tile * BOARD_SCALE * 5.8; // prioritize looking down the board journey toward the opponent side.
@@ -10605,13 +10605,6 @@ function Chess3D({
       }
     };
 
-    cameraViewRef.current = { setMode: setViewModeInternal };
-    // Start every match in 3D mode by default and preserve board state when customizations change.
-    restoreAutoViewTo2dRef.current = false;
-    viewModeRef.current = '3d';
-    setViewMode('3d');
-    setViewModeInternal('3d');
-
     const fit = () => {
       const w = host.clientWidth;
       const h = host.clientHeight;
@@ -10636,6 +10629,16 @@ function Chess3D({
     };
     fitRef.current = fit;
     fit();
+    cameraViewRef.current = { setMode: setViewModeInternal };
+    // Start every match in 3D mode after the initial fit so the first frame
+    // uses the exact device aspect ratio (prevents "bad first layout" until refresh/reselect).
+    restoreAutoViewTo2dRef.current = false;
+    viewModeRef.current = '3d';
+    setViewMode('3d');
+    setViewModeInternal('3d');
+    requestAnimationFrame(() => {
+      if (!disposed) fitRef.current?.();
+    });
     baseCameraRadiusRef.current = camera.position.distanceTo(boardLookTarget);
     baseSkyboxScaleRef.current =
       envSkyboxRef.current?.scale?.x ?? baseSkyboxScaleRef.current ?? 1;


### PR DESCRIPTION
### Motivation
- Improve portrait phone experience by making chairs slightly smaller and moving seated humans/avatars closer to the table so they read better on narrow screens.
- Make the chess board and pieces visually larger so tokens are more prominent in portrait framing.
- Raise the camera and push the table/chairs/humans toward the bottom of the viewport to match the visual composition requested for portrait mode.
- Fix a first-load layout issue where the scene requires a manual reselect/refresh to produce the correct initial framing.

### Description
- Tweaked arena sizing constants in `ChessBattleRoyal.jsx`, including `BOARD_SCALE` (increased), `CHAIR_WIDTH_SCALE` (reduced), `PLAYER_CHAIR_EXTRA_CLEARANCE` and `OPPONENT_CHAIR_EXTRA_CLEARANCE` (both reduced to bring chairs closer), `CAMERA_CAPTURE_VIEW_UPWARD_BIAS` and `PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT` (increased), and `TABLE_BOTTOM_PLAYER_BIAS_Z` (increased) to push the cluster downward.
- Adjusted locked camera phi via `CAMERA_LOCKED_3D_PHI` to change the locked 3D framing for portrait presentation.
- Reordered initial setup so the initial viewport `fit()` runs before applying the default 3D view and added a `requestAnimationFrame`-scheduled extra `fit()` to ensure the first rendered frame uses the final device aspect ratio (prevents the bad-first-layout until refresh/reselect); this uses the existing `setViewMode`/`setViewModeInternal` and `fitRef` flow.
- File changed: `webapp/src/pages/Games/ChessBattleRoyal.jsx`.

### Testing
- Ran the production build with `cd webapp && npm run -s build`, which completed successfully.
- The build produced updated metadata in `webapp/public/version.json` and related artifacts and the app bundle containing the modified `ChessBattleRoyal` chunk; no runtime test failures were reported by the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6868cf448329beb754b70c37782b)