### PR TITLE
Default to procedural table base and enforce Showood procedural-base hybrid

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1269,7 +1269,8 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
 const SHOWOOD_ORIGINAL_TABLE_BASE_ID = 'showoodOriginal';
 const DEFAULT_PROCEDURAL_TABLE_BASE_ID = 'classicCylinders';
-const DEFAULT_TABLE_BASE_ID = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
+const DEFAULT_TABLE_BASE_ID = DEFAULT_PROCEDURAL_TABLE_BASE_ID;
+const ENFORCE_SHOWOOD_PROCEDURAL_BASE_HYBRID = true; // keep Showood field+cushions+rails+pockets+jaws, but always use procedural table bases
 const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
 const ENABLE_CUE_STROKE_ANIMATION = true;
@@ -1306,7 +1307,7 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.24; // shorten all 4 table sides by reducing outer frame overhang while keeping playfield dimensions stable
-const RAIL_HEIGHT = TABLE.THICK * 1.9; // lift all six cushions/rails a touch more so the top profile reads higher without changing playfield size
+const RAIL_HEIGHT = TABLE.THICK * 1.6; // procedural-era rail stack height used for gameplay/collision alignment against Showood visual rails
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.024; // push the corner jaws just a bit farther outward so the fascia follows the rounded rail and chrome cut
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -14255,9 +14256,15 @@ function mountPoolRoyaleExternalTableModel({
   };
 
   const applyBaseVariant = (variant) => {
-    const variantId = resolveBaseVariantId(variant);
+    const requestedVariantId = resolveBaseVariantId(variant);
     const isShowoodExternalTable =
       usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'showood-seven-foot';
+    const variantId =
+      ENFORCE_SHOWOOD_PROCEDURAL_BASE_HYBRID &&
+      isShowoodExternalTable &&
+      requestedVariantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID
+        ? DEFAULT_PROCEDURAL_TABLE_BASE_ID
+        : requestedVariantId;
     const usesShowoodOriginalBase =
       isShowoodExternalTable && variantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID;
 
@@ -15619,10 +15626,8 @@ function PoolRoyaleGame({
   );
   const availableTableBases = useMemo(
     () =>
-      POOL_ROYALE_BASE_VARIANTS.filter(
-        (variant) =>
-          variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID &&
-          isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
+      POOL_ROYALE_BASE_VARIANTS.filter((variant) =>
+        isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
       ),
     [poolInventory]
   );
@@ -15721,10 +15726,12 @@ function PoolRoyaleGame({
   );
   const activeTableBase = useMemo(
     () =>
-      availableTableBases.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
-      POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
+      availableTableBases.find((variant) => variant.id === tableBaseId) ??
+      availableTableBases.find((variant) => variant.id === DEFAULT_TABLE_BASE_ID) ??
+      POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === DEFAULT_TABLE_BASE_ID) ??
+      availableTableBases[0] ??
       POOL_ROYALE_BASE_VARIANTS[0],
-    [availableTableBases]
+    [availableTableBases, tableBaseId]
   );
   const resolvedHdriResolution = useMemo(() => {
     return autoHdriResolutionFromGraphics;
@@ -15778,12 +15785,19 @@ function PoolRoyaleGame({
   }, []);
 
   useEffect(() => {
+    const usingShowoodModel = activeTableModelOption?.id === 'showood-seven-foot';
+    if (
+      ENFORCE_SHOWOOD_PROCEDURAL_BASE_HYBRID &&
+      usingShowoodModel &&
+      tableBaseId === SHOWOOD_ORIGINAL_TABLE_BASE_ID
+    ) {
+      setTableBaseId(DEFAULT_PROCEDURAL_TABLE_BASE_ID);
+      return;
+    }
     if (!isPoolOptionUnlocked('tableFinish', tableFinishId, poolInventory)) {
       setTableFinishId(DEFAULT_TABLE_FINISH_ID);
     }
-    if (tableBaseId !== SHOWOOD_ORIGINAL_TABLE_BASE_ID) {
-      setTableBaseId(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
-    } else if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
+    if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
       setTableBaseId(DEFAULT_TABLE_BASE_ID);
     }
     if (!isPoolOptionUnlocked('clothColor', clothColorId, poolInventory)) {
@@ -15805,6 +15819,7 @@ function PoolRoyaleGame({
       setEnvironmentHdriId(POOL_ROYALE_DEFAULT_HDRI_ID);
     }
   }, [
+    activeTableModelOption,
     chromeColorId,
     chromePlateStyleId,
     clothColorId,


### PR DESCRIPTION
### Motivation
- Prefer procedural table bases by default while preserving Showood visual components for the external Showood table model.
- Ensure table physics/collision alignment uses procedural base geometry rather than the original Showood base to avoid mismatches between visuals and gameplay.

### Description
- Change default base identifier from `SHOWOOD_ORIGINAL_TABLE_BASE_ID` to `DEFAULT_PROCEDURAL_TABLE_BASE_ID` via `DEFAULT_TABLE_BASE_ID`.
- Add `ENFORCE_SHOWOOD_PROCEDURAL_BASE_HYBRID` flag and enforce hybrid behavior so `showood-seven-foot` visuals keep Showood field/cushions/rails/pockets/jaws but always use procedural table base geometry in `applyBaseVariant` and when initializing state.
- Adjust rail stack height constant from `TABLE.THICK * 1.9` to `TABLE.THICK * 1.6` with a comment explaining the procedural-era alignment rationale.
- Broaden availability and selection logic for table bases by updating `availableTableBases` filtering and `activeTableBase` resolution to prefer the requested `tableBaseId` and fall back to `DEFAULT_TABLE_BASE_ID` and available variants.
- Update the initialization `useEffect` to switch `tableBaseId` to the procedural default when the enforced hybrid flag is active and the active model is `showood-seven-foot`.

### Testing
- Ran unit test suite (`yarn test`) which completed successfully.
- Performed a production build (`yarn build`) which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d69bff83c8329ae3e672d78c49240)