### PR TITLE
Default to procedural table base, remove Showood-original base special-case, and adjust rail height

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1269,7 +1269,7 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
 const SHOWOOD_ORIGINAL_TABLE_BASE_ID = 'showoodOriginal';
 const DEFAULT_PROCEDURAL_TABLE_BASE_ID = 'classicCylinders';
-const DEFAULT_TABLE_BASE_ID = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
+const DEFAULT_TABLE_BASE_ID = DEFAULT_PROCEDURAL_TABLE_BASE_ID;
 const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
 const ENABLE_CUE_STROKE_ANIMATION = true;
@@ -1306,7 +1306,7 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.24; // shorten all 4 table sides by reducing outer frame overhang while keeping playfield dimensions stable
-const RAIL_HEIGHT = TABLE.THICK * 1.9; // lift all six cushions/rails a touch more so the top profile reads higher without changing playfield size
+const RAIL_HEIGHT = TABLE.THICK * 1.48; // match Showood side top-wood rail height to the older procedural rail profile
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.024; // push the corner jaws just a bit farther outward so the fascia follows the rounded rail and chrome cut
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -14255,26 +14255,23 @@ function mountPoolRoyaleExternalTableModel({
   };
 
   const applyBaseVariant = (variant) => {
-    const variantId = resolveBaseVariantId(variant);
+    const requestedVariantId = resolveBaseVariantId(variant);
     const isShowoodExternalTable =
       usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'showood-seven-foot';
-    const usesShowoodOriginalBase =
-      isShowoodExternalTable && variantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID;
+    const variantId =
+      isShowoodExternalTable && requestedVariantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID
+        ? DEFAULT_PROCEDURAL_TABLE_BASE_ID
+        : requestedVariantId;
+    const usesShowoodOriginalBase = false;
 
     table.userData.showoodUsesOriginalBase = usesShowoodOriginalBase;
-    setExternalOriginalBaseVisible(usesShowoodOriginalBase || !isShowoodExternalTable);
+    setExternalOriginalBaseVisible(!isShowoodExternalTable);
     refreshGeneratedVisualVisibility();
 
     if (usesExternalTableModel && !isShowoodExternalTable) {
       clearBaseMeshes();
       finishParts.baseVariantId = 'externalModelOwnBase';
       table.userData.baseVariantId = 'externalModelOwnBase';
-      return;
-    }
-    if (usesShowoodOriginalBase) {
-      clearBaseMeshes();
-      finishParts.baseVariantId = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
-      table.userData.baseVariantId = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
       return;
     }
     const builder = baseBuilders[variantId] ?? baseBuilders[DEFAULT_PROCEDURAL_TABLE_BASE_ID];
@@ -14306,7 +14303,7 @@ function mountPoolRoyaleExternalTableModel({
 
   table.userData.applyExternalTableFallbackBase = () => {
     if (usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'showood-seven-foot') {
-      applyBaseVariant(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
+      applyBaseVariant(DEFAULT_PROCEDURAL_TABLE_BASE_ID);
     }
   };
 
@@ -15619,10 +15616,9 @@ function PoolRoyaleGame({
   );
   const availableTableBases = useMemo(
     () =>
-      POOL_ROYALE_BASE_VARIANTS.filter(
-        (variant) =>
-          variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID &&
-          isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
+      POOL_ROYALE_BASE_VARIANTS.filter((variant) =>
+        variant.id !== SHOWOOD_ORIGINAL_TABLE_BASE_ID &&
+        isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
       ),
     [poolInventory]
   );
@@ -15721,10 +15717,12 @@ function PoolRoyaleGame({
   );
   const activeTableBase = useMemo(
     () =>
-      availableTableBases.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
-      POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
+      availableTableBases.find((variant) => variant.id === tableBaseId) ??
+      availableTableBases.find((variant) => variant.id === DEFAULT_TABLE_BASE_ID) ??
+      POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === DEFAULT_TABLE_BASE_ID) ??
+      availableTableBases[0] ??
       POOL_ROYALE_BASE_VARIANTS[0],
-    [availableTableBases]
+    [availableTableBases, tableBaseId]
   );
   const resolvedHdriResolution = useMemo(() => {
     return autoHdriResolutionFromGraphics;
@@ -15781,9 +15779,7 @@ function PoolRoyaleGame({
     if (!isPoolOptionUnlocked('tableFinish', tableFinishId, poolInventory)) {
       setTableFinishId(DEFAULT_TABLE_FINISH_ID);
     }
-    if (tableBaseId !== SHOWOOD_ORIGINAL_TABLE_BASE_ID) {
-      setTableBaseId(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
-    } else if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
+    if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
       setTableBaseId(DEFAULT_TABLE_BASE_ID);
     }
     if (!isPoolOptionUnlocked('clothColor', clothColorId, poolInventory)) {


### PR DESCRIPTION
### Motivation
- Stop preferring the Showood original base for external Showood models and use the procedural base as the default to avoid mixing incompatible base geometry. 
- Bring rail profile visuals back in line with the older procedural rails by adjusting the rail height. 
- Simplify base selection and UI options so the Showood-original base is not exposed as a selectable option when it would conflict with the external model.

### Description
- Change `DEFAULT_TABLE_BASE_ID` to `DEFAULT_PROCEDURAL_TABLE_BASE_ID` so the procedural base is the default. 
- Reduce `RAIL_HEIGHT` from `TABLE.THICK * 1.9` to `TABLE.THICK * 1.48` to match the procedural rail profile. 
- Update `applyBaseVariant`/`resolveBaseVariant` logic to remap requests for `SHOWOOD_ORIGINAL_TABLE_BASE_ID` to the procedural base when using the external Showood model and remove the `usesShowoodOriginalBase` code path. 
- Remove `SHOWOOD_ORIGINAL_TABLE_BASE_ID` from `availableTableBases` filtering and update `activeTableBase` selection and the table base validation in the `useEffect` to fall back to `DEFAULT_TABLE_BASE_ID` when a base is not unlocked.

### Testing
- Ran unit tests with `yarn test` and the test suite completed successfully. 
- Built the application with `yarn build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d69bff83c8329ae3e672d78c49240)