### PR TITLE
Fix Showood top rail classification for Pool Royale table

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13286,7 +13286,7 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   if (low) return 'baseFoot';
   if ((brown || namedWood || black) && baseCornerZone) return 'baseCornerBlock';
   if (midBody && s.sideFace && !(s.longN > 0.64 && s.shortN > 0.64)) return 'leg';
-  if (veryTop && (s.upFace || topRailBand) && !green) return 'topWoodRail';
+  if (veryTop && (s.upFace || topRailBand)) return 'topWoodRail';
   if (high && s.sideFace && !green && !anyPocketZone) return 'sideWoodApron';
   return namedCushion ? 'cushion' : 'sideWoodApron';
 }


### PR DESCRIPTION
### Motivation
- Very-top faces on the imported Showood GLB could be misclassified as cloth/cushion when source materials were green-tinted, making the wooden top rails invisible in Pool Royale scenes.

### Description
- Removed the color gate from the Showood triangle-part resolver so `veryTop` up-face/top-rail-band triangles are always classified as `topWoodRail` in `webapp/src/pages/Games/PoolRoyale.jsx` (single-line condition change).

### Testing
- Ran the targeted test suite with `npm test -- test/poolRoyaleTableModels.test.js` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8d150a1c83299e1f038d477ff3c2)