### PR TITLE
Add fallback texture URLs for Gunify GLTF weapons in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -430,7 +430,11 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf'
     ],
-    scale: 0.2
+    scale: 0.2,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Uzi.png',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Uzi.png'
+    ]
   },
   ak47VolleyAttack: {
     label: 'AK-47',
@@ -452,7 +456,11 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf'
     ],
-    scale: 0.24
+    scale: 0.24,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/KRSV.jpg',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/KRSV.jpg'
+    ]
   },
   smithSidearmAttack: {
     label: 'Smith',
@@ -460,7 +468,11 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf'
     ],
-    scale: 0.13
+    scale: 0.13,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Smith.jpeg',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Smith.jpeg'
+    ]
   },
   mosinMarksmanAttack: {
     label: 'Mosin',
@@ -468,7 +480,11 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'
     ],
-    scale: 0.5125
+    scale: 0.5125,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Mosin.png',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Mosin.png'
+    ]
   },
   sigsauerTacticalAttack: {
     label: 'SigSauer Tactical',
@@ -517,7 +533,11 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
       'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb'
     ],
-    scale: 0.2
+    scale: 0.2,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Uzi.png',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Uzi.png'
+    ]
   },
   compactCarbineAttack: {
     label: 'Compact Carbine',
@@ -598,7 +618,11 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   polyGrenadeLauncher01Attack: {
     label: 'CreativeTrio Grenade Launcher',
     urls: ['https://static.poly.pizza/503bb2c5-4a69-404b-9b82-13e85e8f8467.glb'],
-    scale: 0.2
+    scale: 0.2,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Uzi.png',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Uzi.png'
+    ]
   },
   polyDynamiteBomb01Attack: {
     label: 'CreativeTrio Dynamite Bomb',


### PR DESCRIPTION
### Motivation
- Some remote GLTF/GLB weapon models occasionally load without their intended textures due to external asset path/CORS or hosting reliability issues, causing untextured weapons in the Ludo Battle Royal experience. 
- Provide resilient fallback image URLs so `GLTFLoader`/patched buffer path can assign a working texture when embedded or referenced textures fail. 

### Description
- Added `textureOverrideUrls` entries to several `CAPTURE_WEAPON_MODEL_CONFIG` weapon definitions in `webapp/src/pages/Games/LudoBattleRoyal.jsx`, covering Uzi, KRSV, Smith, Mosin (and related entries that reuse those skins such as `smgBurstAttack` and `polyGrenadeLauncher`).
- Each override includes both `raw.githubusercontent.com` and `cdn.jsdelivr.net` endpoints so the loader can fetch the image from an alternate CDN if one host is unavailable. 
- No existing model URLs were changed; the loader still prefers embedded/bundled GLTF textures but will apply these fallbacks when needed. 

### Testing
- Verified upstream texture filenames exist by querying the `Gunify` repo index via the GitHub API using a Python `urllib.request` script, which returned the expected image names (e.g. `AK47.jpeg`, `KRSV.jpg`, `Mosin.png`, `Smith.jpeg`, `Uzi.png`).
- Confirmed the modified `CAPTURE_WEAPON_MODEL_CONFIG` now contains the added `textureOverrideUrls` entries via local file inspection (`nl`/`sed`/`rg`).
- Committed the change successfully to the current branch (commit created).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8e5a5f088329898fa9387b63ff0d)