### PR TITLE
Add texture fallback and centralize weapon model URLs (poly.pizza + known sources)

### DIFF
--- a/webapp/src/components/WeaponKartGame.jsx
+++ b/webapp/src/components/WeaponKartGame.jsx
@@ -49,21 +49,60 @@ const TRACK_PRESETS = {
   "storm-bend": { outerX: 45, outerZ: 27, innerX: 27.5, innerZ: 11.5, centerX: 36, centerZ: 19, wobble: 0.14, hue: 0x2b2d33 }
 };
 const WEAPON_PICKUPS = ["RIFLE", "FIREARM", "MISSILE", "DRONE", "HELICOPTER", "JET", "TRUCK"]
+const FALLBACK_TEX = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l6m9WQAAAABJRU5ErkJggg==";
+const KNOWN_WEAPON_MODEL_URLS = Object.freeze({
+  awp: "https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb",
+  awpRaw: "https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb",
+  mrtk: "https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb",
+  mrtkRaw: "https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb",
+  pistol: "https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb",
+  pistolRaw: "https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb",
+  fps: "https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf",
+  fpsRaw: "https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf"
+});
+const polyWeapon = (id) => `https://static.poly.pizza/${id}.glb`;
 const WEAPON_MODEL_CANDIDATES = {
   FIREARM: [
-    "https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb",
-    "https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb"
+    polyWeapon("3b53f0fe-f86e-451c-816d-6ab9bd265cdc"),
+    polyWeapon("9e728565-67a3-44db-9567-982320abff09"),
+    KNOWN_WEAPON_MODEL_URLS.pistol,
+    KNOWN_WEAPON_MODEL_URLS.pistolRaw,
+    KNOWN_WEAPON_MODEL_URLS.mrtk,
+    KNOWN_WEAPON_MODEL_URLS.mrtkRaw
   ],
   RIFLE: [
-    "https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb",
-    "https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb",
-    "https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb"
+    polyWeapon("b3e6be61-0299-4866-a227-58f5f3fe610b"),
+    polyWeapon("032e6589-3188-41bc-b92b-e25528344275"),
+    polyWeapon("f71d6771-f512-4374-bd23-ba00b564db68"),
+    KNOWN_WEAPON_MODEL_URLS.fps,
+    KNOWN_WEAPON_MODEL_URLS.fpsRaw,
+    KNOWN_WEAPON_MODEL_URLS.awp,
+    KNOWN_WEAPON_MODEL_URLS.awpRaw,
+    KNOWN_WEAPON_MODEL_URLS.mrtk,
+    KNOWN_WEAPON_MODEL_URLS.mrtkRaw
   ],
   MISSILE: ["https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/atlas_v.glb"],
   DRONE: ["https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb"],
   HELICOPTER: ["https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/helicopter.glb"],
   JET: ["https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/f15.glb"]
 };
+
+function patchTextures() {
+  const orig = THREE.ImageLoader.prototype.load;
+  THREE.ImageLoader.prototype.load = function patched(url, onLoad, onProgress, onError) {
+    const fail = (e) => {
+      const img = document.createElement("img");
+      img.crossOrigin = "anonymous";
+      img.onload = () => onLoad?.(img);
+      img.onerror = () => onError?.(e);
+      img.src = FALLBACK_TEX;
+    };
+    return orig.call(this, url, onLoad, onProgress, fail);
+  };
+  return () => {
+    THREE.ImageLoader.prototype.load = orig;
+  };
+}
 const DEFENSE_PICKUPS = ["MISSILE_RADAR", "DRONE_RADAR", "ANTI_MISSILE_BATTERY", "AUTO_DRIVE", "BOOST", "DEFENSE_RADAR"];
 const WEAPON_ICON = { FIREARM: "🔫", RIFLE: "🪖", MISSILE: "🚀", DRONE: "🛸", HELICOPTER: "🚁", JET: "✈️", TRUCK: "🚒", TOWER: "📡", AUTO_DRIVE:"🤖", BOOST:"⚡", DEFENSE_RADAR:"🛡️" };
 const SUPPORT_PICKUP_TYPES = ["TRUCK", "DRONE", "HELICOPTER", "JET", "TOWER"];
@@ -1100,6 +1139,7 @@ export default function SuperTuxKartPlayablePreview() {
 
     let cancelled = false;
     let frameId = 0;
+    const restoreTexturePatch = patchTextures();
     const { dracoDecoderPath } = makeLoader();
     const input = { keys: {}, steer: 0, accel: 0, brake: false, pointerId: null, startX: 0, startY: 0, lookId: null, lastX: 0, camYaw: 0, firePressed: false, fireTarget: null, autoDriveToggle:false, boostToggle:false };
     const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, powerPreference: "high-performance" });
@@ -1620,6 +1660,7 @@ hudRef.current.crash = `${ai.name} fired`;
         canvas.removeEventListener("click", onTargetClick);
       }
       renderer.dispose();
+      restoreTexturePatch();
       disposeObject3D(scene);
     };
   }, []);

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -366,6 +366,17 @@ const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
   0: 2,
   2: 0
 });
+const KNOWN_LUDO_WEAPON_SOURCES = Object.freeze({
+  awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
+  awpRaw: 'https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb',
+  mrtk: 'https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  mrtkRaw: 'https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+  pistol: 'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
+  pistolRaw: 'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
+  fps: 'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
+  fpsRaw: 'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf'
+});
+const polyWeaponSource = (id) => `https://static.poly.pizza/${id}.glb`;
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
     label: 'MRTK Gun',
@@ -380,8 +391,11 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   pistolHolsterAttack: {
     label: 'Pistol Holster',
     urls: [
-      'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
-      'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb'
+      polyWeaponSource('3b53f0fe-f86e-451c-816d-6ab9bd265cdc'),
+      polyWeaponSource('9e728565-67a3-44db-9567-982320abff09'),
+      KNOWN_LUDO_WEAPON_SOURCES.pistol,
+      KNOWN_LUDO_WEAPON_SOURCES.pistolRaw,
+      KNOWN_LUDO_WEAPON_SOURCES.mrtk
     ],
     scale: 0.138
   },
@@ -398,31 +412,33 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   glockSidearmAttack: {
     label: 'Glock',
     urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb',
-      'https://raw.githubusercontent.com/webaverse/pistol/master/glock.glb'
+      polyWeaponSource('3b53f0fe-f86e-451c-816d-6ab9bd265cdc'),
+      KNOWN_LUDO_WEAPON_SOURCES.pistol,
+      KNOWN_LUDO_WEAPON_SOURCES.pistolRaw
     ],
     scale: 0.13
   },
   pistolSidearmAttack: {
     label: 'Pistol Sidearm',
     urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb',
-      'https://raw.githubusercontent.com/webaverse/pistol/master/pistol.glb',
-      'https://cdn.statically.io/gh/webaverse/pistol/master/pistol.glb'
+      polyWeaponSource('3b53f0fe-f86e-451c-816d-6ab9bd265cdc'),
+      KNOWN_LUDO_WEAPON_SOURCES.pistol,
+      KNOWN_LUDO_WEAPON_SOURCES.pistolRaw,
+      KNOWN_LUDO_WEAPON_SOURCES.mrtk
     ],
     scale: 0.115
   },
   assaultRifleAttack: {
     label: 'Assault Rifle',
     urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
-      'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
-      'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
+      polyWeaponSource('b3e6be61-0299-4866-a227-58f5f3fe610b'),
+      polyWeaponSource('032e6589-3188-41bc-b92b-e25528344275'),
+      KNOWN_LUDO_WEAPON_SOURCES.fps,
+      KNOWN_LUDO_WEAPON_SOURCES.fpsRaw,
+      KNOWN_LUDO_WEAPON_SOURCES.mrtk,
+      KNOWN_LUDO_WEAPON_SOURCES.awp
     ],
-    scale: 0.13,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg'
-    ]
+    scale: 0.13
   },
   uziSprayAttack: {
     label: 'Uzi',
@@ -512,10 +528,13 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   shotgunBlastAttack: {
     label: 'Shotgun Blast',
     urls: [
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf'
+      polyWeaponSource('032e6589-3188-41bc-b92b-e25528344275'),
+      polyWeaponSource('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e'),
+      polyWeaponSource('08f27141-8e64-425a-9161-1bbd6956dfca'),
+      KNOWN_LUDO_WEAPON_SOURCES.fps,
+      KNOWN_LUDO_WEAPON_SOURCES.fpsRaw,
+      KNOWN_LUDO_WEAPON_SOURCES.awp,
+      KNOWN_LUDO_WEAPON_SOURCES.awpRaw
     ],
     scale: 0.24
   },
@@ -530,8 +549,11 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   smgBurstAttack: {
     label: 'SMG',
     urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb'
+      polyWeaponSource('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710'),
+      KNOWN_LUDO_WEAPON_SOURCES.mrtk,
+      KNOWN_LUDO_WEAPON_SOURCES.fps,
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf'
     ],
     scale: 0.2,
     textureOverrideUrls: [


### PR DESCRIPTION
### Motivation
- Reduce runtime failures when weapon model textures or images fail to load by providing a guaranteed fallback image and patching the image loader.
- Consolidate and prefer alternative model hosts (including `static.poly.pizza`) and known CDN/raw URLs to improve asset availability and selection for weapon pickups.
- Make the texture-loading patch reversible to avoid leaking runtime modifications when the component unmounts.

### Description
- Added a small base64 `FALLBACK_TEX` and implemented `patchTextures()` which overrides `THREE.ImageLoader.prototype.load` to call the fallback image on load errors and returns a restore function.  The patch is applied during component startup and restored on cleanup via `restoreTexturePatch()`.
- Introduced `KNOWN_WEAPON_MODEL_URLS` and `KNOWN_LUDO_WEAPON_SOURCES` to centralize common CDN/raw model URLs and added `polyWeapon`/`polyWeaponSource` helpers to prefer `https://static.poly.pizza/<id>.glb` candidates; replaced many inline model URLs in `WeaponKartGame.jsx` and `LudoBattleRoyal.jsx` with these constants and helpers.
- Updated `WEAPON_MODEL_CANDIDATES` and `CAPTURE_WEAPON_MODEL_CONFIG` entries to include the new poly.pizza sources and known source constants; removed one `textureOverrideUrls` entry that was redundant.
- Ensure the texture patch is cleaned up in the component `useEffect` return handler to restore the original `THREE.ImageLoader.prototype.load` implementation.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d93f3b2948329a109b16e7194cd95)