### PR TITLE
Add procedural Showood-hybrid table model, make table model selectable in lobby, and fix base variant handling

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -5,6 +5,20 @@ const POOLTOOL_RAW_BASE =
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
+    id: 'procedural-showood-hybrid',
+    label: 'Procedural (Showood Shape)',
+    description:
+      'Native procedural Pool Royale table with restored procedural bases and Showood-matched jaw/cushion/frame geometry profile for faster startup.',
+    tableSizeId: '7ft',
+    baseId: 'classicCylinders',
+    icon: '🧩',
+    kind: 'procedural',
+    fitScale: 1,
+    fitFootprintScale: 1,
+    fitHeightScale: 1,
+    usePoolRoyaleFinish: true
+  },
+  {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
@@ -41,7 +55,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'showood-seven-foot'
+    (option) => option.id === 'procedural-showood-hybrid'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
 
 export function resolvePoolRoyaleTableModel(modelId) {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14286,23 +14286,26 @@ function mountPoolRoyaleExternalTableModel({
   };
 
   const applyBaseVariant = (variant) => {
-    const requestedVariantId = resolveBaseVariantId(variant);
+    const variantId = resolveBaseVariantId(variant);
     const isShowoodExternalTable =
       usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'showood-seven-foot';
-    const variantId =
-      isShowoodExternalTable && requestedVariantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID
-        ? DEFAULT_PROCEDURAL_TABLE_BASE_ID
-        : requestedVariantId;
-    const usesShowoodOriginalBase = false;
+    const usesShowoodOriginalBase =
+      isShowoodExternalTable && variantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID;
 
     table.userData.showoodUsesOriginalBase = usesShowoodOriginalBase;
-    setExternalOriginalBaseVisible(!isShowoodExternalTable);
+    setExternalOriginalBaseVisible(usesShowoodOriginalBase || !isShowoodExternalTable);
     refreshGeneratedVisualVisibility();
 
     if (usesExternalTableModel && !isShowoodExternalTable) {
       clearBaseMeshes();
       finishParts.baseVariantId = 'externalModelOwnBase';
       table.userData.baseVariantId = 'externalModelOwnBase';
+      return;
+    }
+    if (usesShowoodOriginalBase) {
+      clearBaseMeshes();
+      finishParts.baseVariantId = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
+      table.userData.baseVariantId = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
       return;
     }
     const builder = baseBuilders[variantId] ?? baseBuilders[DEFAULT_PROCEDURAL_TABLE_BASE_ID];

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,6 +13,7 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
+  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
@@ -76,7 +77,19 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(), []);
+  const [selectedTableModelId, setSelectedTableModelId] = useState(() => {
+    const requested = (searchParams.get('tableModel') || '').trim();
+    if (requested) return resolvePoolRoyaleTableModel(requested).id;
+    try {
+      const stored = window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY);
+      if (stored) return resolvePoolRoyaleTableModel(stored).id;
+    } catch {}
+    return resolvePoolRoyaleTableModel().id;
+  });
+  const selectedTableModel = useMemo(
+    () => resolvePoolRoyaleTableModel(selectedTableModelId),
+    [selectedTableModelId]
+  );
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -859,17 +872,33 @@ export default function PoolRoyaleLobby() {
         )}
 
         {!hasActiveTournament && (
-          <div className="rounded-2xl border border-emerald-300/20 bg-white/[0.04] p-4 text-xs text-white/60">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <h3 className="font-semibold text-white">Pool Table</h3>
-                <p className="mt-1">
-                  Showood 7 ft GLB is now the fixed Pool Royale table.
-                </p>
-              </div>
-              <span className="rounded-full border border-emerald-300/35 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100">
-                Default
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Pool Table</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+                Layout
               </span>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((tableModel) => {
+                const active = selectedTableModel.id === tableModel.id;
+                return (
+                  <button
+                    key={tableModel.id}
+                    type="button"
+                    onClick={() => setSelectedTableModelId(tableModel.id)}
+                    className={`lobby-option-card ${active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
+                  >
+                    <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-sky-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner text-2xl">{tableModel.icon || '🎱'}</div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{tableModel.label}</p>
+                      <p className="lobby-option-subtitle">{tableModel.kind === 'gltf' ? 'GLB model' : 'Procedural model'}</p>
+                    </div>
+                  </button>
+                );
+              })}
             </div>
           </div>
         )}


### PR DESCRIPTION
### Motivation

- Introduce a native procedural table variant that matches Showood geometry for faster startup and make it the default table model.  
- Expose table model choices in the Pool Royale lobby so users can pick between GLB and procedural layouts.  
- Fix logic applying base variants and visibility when using external Showood GLB models so the original base/legs can be shown or replaced correctly.

### Description

- Added a new `procedural-showood-hybrid` entry to `POOL_ROYALE_TABLE_MODEL_OPTIONS` with metadata and set `DEFAULT_POOL_ROYALE_TABLE_MODEL_ID` to it in `poolRoyaleTableModels.js`.  
- Updated `applyBaseVariant` in `PoolRoyale.jsx` to rename `requestedVariantId` to `variantId`, compute `usesShowoodOriginalBase`, adjust when the external original base is visible, and handle the Showood-original-base early-return path to set `finishParts.baseVariantId` and `table.userData.baseVariantId` appropriately.  
- In `PoolRoyaleLobby.jsx` added import of `POOL_ROYALE_TABLE_MODEL_OPTIONS`, replaced the static default table card with a selectable grid, introduced `selectedTableModelId` state initialized from URL or `localStorage`, and wired `selectedTableModel` via `resolvePoolRoyaleTableModel` so the UI and table size use the chosen model.

### Testing

- Ran project linter and a development build; both completed successfully.  
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d962ed3fc8329a6af3f7b20686b6c)