### PR TITLE
Start Chess Battle Royal in 2D view by default

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8607,7 +8607,7 @@ function Chess3D({
   });
   const [moveMode, setMoveMode] = useState('click');
   const [seatAnchors, setSeatAnchors] = useState([]);
-  const [viewMode, setViewMode] = useState('3d');
+  const [viewMode, setViewMode] = useState('2d');
   const [canReplay, setCanReplay] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
   const [showChat, setShowChat] = useState(false);
@@ -10606,11 +10606,11 @@ function Chess3D({
     };
 
     cameraViewRef.current = { setMode: setViewModeInternal };
-    // Start every match in 3D mode by default and preserve board state when customizations change.
+    // Start every match in 2D mode by default and preserve board state when customizations change.
     restoreAutoViewTo2dRef.current = false;
-    viewModeRef.current = '3d';
-    setViewMode('3d');
-    setViewModeInternal('3d');
+    viewModeRef.current = '2d';
+    setViewMode('2d');
+    setViewModeInternal('2d');
 
     const fit = () => {
       const w = host.clientWidth;


### PR DESCRIPTION
### Motivation
- Ensure Chess Battle Royal opens in a top-down 2D view (better for portrait/mobile play) instead of defaulting to the 3D camera.

### Description
- Changed the initial camera mode by updating `viewMode` default to `'2d'` and setting `viewModeRef.current`, `setViewMode`, and `setViewModeInternal` to `'2d'` during startup in `webapp/src/pages/Games/ChessBattleRoyal.jsx` (also updated the related inline comment).

### Testing
- Verified the edits with `rg` to confirm `useState('2d')` and the initialization lines were updated and committed the change (`git commit` succeeded) and generated the PR metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d97eadbf08329bb9f804e8b17aea3)