### PR TITLE
Set Chess Battle Royal default table to octagon

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -384,7 +384,7 @@ export const CHESS_TABLE_OPTIONS = Object.freeze([
 ]);
 
 const CHESS_BATTLE_REMOVED_TABLE_IDS = new Set(['diamondEdge']);
-const CHESS_BATTLE_DEFAULT_TABLE_ID = 'CoffeeTable_01';
+const CHESS_BATTLE_DEFAULT_TABLE_ID = 'murlan-default';
 
 export const CHESS_BATTLE_TABLE_OPTIONS = Object.freeze(
   CHESS_TABLE_OPTIONS


### PR DESCRIPTION
### Motivation
- Make the Chess Battle Royal UI and inventory use the octagon procedural table as the default selection so battle-royale matches and store ordering reflect the shared royale proportions.

### Description
- Change `CHESS_BATTLE_DEFAULT_TABLE_ID` from `'CoffeeTable_01'` to `'murlan-default'` in `webapp/src/config/chessBattleInventoryConfig.js` so the octagon (`murlan-default`) appears first in `CHESS_BATTLE_TABLE_OPTIONS`.

### Testing
- Ran `npm test -- test/chessBattleInventoryConfig.test.js --runInBand`; the `defaults to octagon table for battle royal` test now passes while the suite reports two other unrelated failures (`includes LT table finishes in both options and store purchasables` and `keeps current avatar free by default and sells exactly the 5 requested WebGL humans`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d9c8d06948329b9f318e878386cda)