### PR TITLE
Domino Royal: adjust chair size and vertical position

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -983,7 +983,8 @@ const CHAIR_RADIUS =
   TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
 const CHAIR_GLOBAL_PUSHBACK = 0.68 * MODEL_SCALE;
 const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.82 * MODEL_SCALE;
-const CHAIR_VISUAL_SCALE = 1.3;
+const CHAIR_VISUAL_SCALE = 1.26;
+const CHAIR_VERTICAL_DROP = 0.035 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = LEGACY_BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
@@ -8792,7 +8793,7 @@ function placeChairsWithOption(option, chairData, token) {
 
     const chair = cloneChairWithTheme(chairData, option);
     chair.scale.multiplyScalar(CHAIR_VISUAL_SCALE);
-    chair.position.y = -seatBottomOffset;
+    chair.position.y = -seatBottomOffset - CHAIR_VERTICAL_DROP;
     wrapper.add(chair);
     wrapper.userData.dominoCharacterChair = chair;
     wrapper.userData.dominoCharacterSeatLift = TABLE_HEIGHT - 0.06 * MODEL_SCALE;


### PR DESCRIPTION
### Motivation
- Make the Domino Battle Royal chairs appear slightly smaller and sit a bit lower to better match visual design and user feedback.

### Description
- Reduced `CHAIR_VISUAL_SCALE` from `1.3` to `1.26` and added `CHAIR_VERTICAL_DROP` (`0.035 * MODEL_SCALE`) and applied it to chair placement in `placeChairsWithOption` in `webapp/public/domino-royal-game.js` so chairs are scaled down and their `y` is offset lower.

### Testing
- Ran a syntax check with `node --check webapp/public/domino-royal-game.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d9cb19ae083299fbc0c00bd42d89a)