### PR TITLE
Shorten Chess Battle Royal lower-profile table bases

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -3194,7 +3194,7 @@ const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
   diamondEdge: 0.024
 });
 const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable', 'grandOval', 'diamondEdge']);
-const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0;
+const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0.06;
 const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 20.5; // make parked jet/helicopter/drone read large beside the table
 const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -4.2; // push parked vehicles and parked weapons farther to the arena sides
 const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.26; // lift pad markers/parked units from floor to board/table level


### PR DESCRIPTION
### Motivation
- Shorten octagon/hexagon/oval/diamond-edge table bases so the table cloth plane matches other tables and the board sits visually above the cloth surface.

### Description
- Raise `LOWER_PROFILE_TABLE_HEIGHT_DELTA` from `0` to `0.06` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to lower the base for the lower-profile table shapes.

### Testing
- Ran `npm test -- test/chessBattleInventoryConfig.test.js --runInBand`; the test suite failed with two pre-existing inventory/avatar expectation mismatches that are unrelated to this height constant change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da12e57708329a961964b886ea5d8)