### PR TITLE
Shorten Chess Battle Royal procedural table pedestals while keeping board surface level

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -3194,7 +3194,12 @@ const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
   diamondEdge: 0.024
 });
 const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable', 'grandOval', 'diamondEdge']);
-const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0.06;
+const SHORT_PEDESTAL_SCALE_BY_SHAPE = Object.freeze({
+  classicOctagon: 0.74,
+  hexagonTable: 0.72,
+  grandOval: 0.72,
+  diamondEdge: 0.7
+});
 const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 20.5; // make parked jet/helicopter/drone read large beside the table
 const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -4.2; // push parked vehicles and parked weapons farther to the arena sides
 const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.26; // lift pad markers/parked units from floor to board/table level
@@ -3235,9 +3240,16 @@ function pickRandomAiHumanCharacterOption(playerOption) {
 
 function getTableHeightForShape(shapeId) {
   if (LOWER_PROFILE_TABLE_SHAPE_IDS.has(shapeId)) {
-    return TABLE_HEIGHT - LOWER_PROFILE_TABLE_HEIGHT_DELTA;
+    // Keep cloth/board surface aligned with other tables while shortening the visible pedestal only.
+    return TABLE_HEIGHT;
   }
   return TABLE_HEIGHT;
+}
+
+function getPedestalHeightScaleForShape(shapeId) {
+  const override = SHORT_PEDESTAL_SCALE_BY_SHAPE[shapeId];
+  if (Number.isFinite(override)) return override;
+  return 1.14;
 }
 
 function normalizeAppearance(value = {}) {
@@ -3584,6 +3596,7 @@ async function buildTableFromTheme(theme, options = {}) {
       renderer,
       tableRadius,
       tableHeight,
+      pedestalHeightScale: getPedestalHeightScaleForShape(shapeOption?.id),
       woodOption,
       clothOption,
       baseOption,


### PR DESCRIPTION
### Motivation
- Several procedural table shapes (octagon, hexagon, grand oval, diamond-edge) rendered with tall pedestals causing the board/cloth to appear too low and the chess board to be obscured. 
- The goal is to make these shapes read shorter on portrait/mobile screens while keeping the tabletop/felt surface aligned with standard tables.

### Description
- Added a `SHORT_PEDESTAL_SCALE_BY_SHAPE` mapping with per-shape pedestal scale overrides for `classicOctagon`, `hexagonTable`, `grandOval`, and `diamondEdge`. 
- Kept the table top/cloth height aligned by making `getTableHeightForShape` return the standard `TABLE_HEIGHT` for lowered-profile shapes. 
- Added `getPedestalHeightScaleForShape(shapeId)` to pick the per-shape pedestal scale (falling back to `1.14`). 
- Wired the pedestal override into the procedural fallback by passing `pedestalHeightScale: getPedestalHeightScaleForShape(shapeOption?.id)` into `createMurlanStyleTable` in `ChessBattleRoyal`.

### Testing
- No automated tests were executed for this visual tuning change; it is a non-functional rendering adjustment and requires a visual/preview verification in the game client.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0daaab13c483299f4c96b76cb310ed)