### PR TITLE
Tune PoolRoyale table/physics, simplify table model selection, and update weapon model assets/texture handling

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -160,22 +160,6 @@ function scratchRiskAlongLine (cue, aimPoint, pockets, radius) {
   return false
 }
 
-
-function tableCushionInset (state) {
-  const r = Number(state?.ballRadius) || 0
-  return Math.max(r * 0.82, Math.min((state?.width || 0), (state?.height || 0)) * 0.012)
-}
-
-function effectiveTableBounds (state) {
-  const inset = tableCushionInset(state)
-  return {
-    minX: inset,
-    maxX: state.width - inset,
-    minY: inset,
-    maxY: state.height - inset,
-    inset
-  }
-}
 function pocketNormal (pocket, width, height) {
   const center = { x: width / 2, y: height / 2 }
   const dir = { x: center.x - pocket.x, y: center.y - pocket.y }
@@ -184,11 +168,10 @@ function pocketNormal (pocket, width, height) {
 }
 
 function classifyPocket (pocket, width, height, tolerance = 1e-3) {
-  const edgeTolerance = Math.max(tolerance, Math.min(width, height) * 0.02)
-  const isLeft = Math.abs(pocket.x) <= edgeTolerance
-  const isRight = Math.abs(pocket.x - width) <= edgeTolerance
-  const isTop = Math.abs(pocket.y) <= edgeTolerance
-  const isBottom = Math.abs(pocket.y - height) <= edgeTolerance
+  const isLeft = Math.abs(pocket.x) <= tolerance
+  const isRight = Math.abs(pocket.x - width) <= tolerance
+  const isTop = Math.abs(pocket.y) <= tolerance
+  const isBottom = Math.abs(pocket.y - height) <= tolerance
 
   if ((isLeft || isRight) && (isTop || isBottom)) return 'corner'
   if (isTop || isBottom) return 'side'
@@ -199,8 +182,8 @@ function pocketMouthGeometry (pocket, radius, width, height, target = null) {
   const normal = pocketNormal(pocket, width, height)
   const pocketType = classifyPocket(pocket, width, height)
   const axis = { x: -normal.y, y: normal.x }
-  const mouthHalfWidth = radius * (pocketType === 'side' ? 2.72 : 2.38)
-  const playableHalfWidth = Math.max(radius * 0.7, mouthHalfWidth - radius * 1.02)
+  const mouthHalfWidth = radius * (pocketType === 'side' ? 2.95 : 2.55)
+  const playableHalfWidth = Math.max(radius * 0.7, mouthHalfWidth - radius * 1.08)
   const mouthCenter = {
     x: pocket.x - normal.x * radius * 1.04,
     y: pocket.y - normal.y * radius * 1.04
@@ -231,8 +214,7 @@ function pocketMouthGeometry (pocket, radius, width, height, target = null) {
 }
 
 function cornerPocketRailClearance (pocket, point, width, height) {
-  const bounds = effectiveTableBounds({ width, height, ballRadius: Math.max(width, height) * 0.017 })
-  const tolerance = Math.max(1e-3, bounds.inset * 0.2)
+  const tolerance = 1e-3
   const nearLeft = Math.abs(pocket.x) <= tolerance
   const nearRight = Math.abs(pocket.x - width) <= tolerance
   const nearTop = Math.abs(pocket.y) <= tolerance
@@ -259,8 +241,8 @@ function cornerPocketLaneSafety (target, entry, pocket, req) {
   const startGap = cornerPocketRailClearance(pocket, target, req.state.width, req.state.height)
   const endGap = cornerPocketRailClearance(pocket, entry, req.state.width, req.state.height)
   const laneGap = Math.min(startGap, endGap)
-  const safeGap = radius * 1.62
-  const hardFailGap = radius * 0.96
+  const safeGap = radius * 1.45
+  const hardFailGap = radius * 0.82
   if (laneGap <= hardFailGap) return 0
   return Math.max(0, Math.min((laneGap - hardFailGap) / Math.max(safeGap - hardFailGap, 1e-6), 1))
 }
@@ -284,7 +266,7 @@ function pocketEntry (pocket, radius, width, height, target) {
     dir = { x: dir.x / blendedLen, y: dir.y / blendedLen }
   }
 
-  const offset = radius * 1.12
+  const offset = radius * 1.05
   const centerDriven = {
     x: pocket.x - dir.x * offset,
     y: pocket.y - dir.y * offset
@@ -296,7 +278,7 @@ function pocketEntry (pocket, radius, width, height, target) {
   }
   if (classifyPocket(pocket, width, height) !== 'corner') return entry
 
-  const minRailGap = radius * 1.18
+  const minRailGap = radius * 0.95
   const tolerance = 1e-3
   if (Math.abs(pocket.x) <= tolerance) entry.x = Math.max(entry.x, minRailGap)
   if (Math.abs(pocket.x - width) <= tolerance) entry.x = Math.min(entry.x, width - minRailGap)
@@ -822,12 +804,11 @@ function projectedScratchRisk (cueAfter, req) {
 }
 
 function mirrorPointAcrossRail (point, rail, state) {
-  const b = effectiveTableBounds(state)
   switch (rail) {
-    case 'left': return { x: b.minX * 2 - point.x, y: point.y }
-    case 'right': return { x: b.maxX * 2 - point.x, y: point.y }
-    case 'top': return { x: point.x, y: b.minY * 2 - point.y }
-    case 'bottom': return { x: point.x, y: b.maxY * 2 - point.y }
+    case 'left': return { x: -point.x, y: point.y }
+    case 'right': return { x: state.width * 2 - point.x, y: point.y }
+    case 'top': return { x: point.x, y: -point.y }
+    case 'bottom': return { x: point.x, y: state.height * 2 - point.y }
     default: return null
   }
 }
@@ -836,22 +817,21 @@ function firstRailContact (cue, mirroredTarget, rail, state) {
   const dx = mirroredTarget.x - cue.x
   const dy = mirroredTarget.y - cue.y
   if (Math.abs(dx) < 1e-6 && Math.abs(dy) < 1e-6) return null
-  const b = effectiveTableBounds(state)
   if (rail === 'left' || rail === 'right') {
-    const xRail = rail === 'left' ? b.minX : b.maxX
+    const xRail = rail === 'left' ? 0 : state.width
     if (Math.abs(dx) < 1e-6) return null
     const t = (xRail - cue.x) / dx
     if (t <= 0 || t >= 1) return null
     const y = cue.y + dy * t
-    if (y <= b.minY || y >= b.maxY) return null
+    if (y <= 0 || y >= state.height) return null
     return { x: xRail, y }
   }
-  const yRail = rail === 'top' ? b.minY : b.maxY
+  const yRail = rail === 'top' ? 0 : state.height
   if (Math.abs(dy) < 1e-6) return null
   const t = (yRail - cue.y) / dy
   if (t <= 0 || t >= 1) return null
   const x = cue.x + dx * t
-  if (x <= b.minX || x >= b.maxX) return null
+  if (x <= 0 || x >= state.width) return null
   return { x, y: yRail }
 }
 
@@ -891,8 +871,7 @@ function oneCushionKickShot (req) {
 
 function clampPointToTable (point, table, margin = 1) {
   if (!table) return { ...point }
-  const bounds = effectiveTableBounds(table)
-  const inset = bounds.inset + (table.ballRadius || 0) * Math.max(0, margin - 1)
+  const inset = (table.ballRadius || 0) * margin
   const clampedX = Math.min(Math.max(point.x, inset), table.width - inset)
   const clampedY = Math.min(Math.max(point.y, inset), table.height - inset)
   return { x: clampedX, y: clampedY }

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -5,20 +5,6 @@ const POOLTOOL_RAW_BASE =
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
-    id: 'procedural-showood-hybrid',
-    label: 'Procedural (Showood Shape)',
-    description:
-      'Native procedural Pool Royale table with restored procedural bases and Showood-matched jaw/cushion/frame geometry profile for faster startup.',
-    tableSizeId: '7ft',
-    baseId: 'classicCylinders',
-    icon: '🧩',
-    kind: 'procedural',
-    fitScale: 1,
-    fitFootprintScale: 1,
-    fitHeightScale: 1,
-    usePoolRoyaleFinish: true
-  },
-  {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
@@ -55,7 +41,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'procedural-showood-hybrid'
+    (option) => option.id === 'showood-seven-foot'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
 
 export function resolvePoolRoyaleTableModel(modelId) {

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -366,17 +366,6 @@ const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
   0: 2,
   2: 0
 });
-const KNOWN_LUDO_WEAPON_SOURCES = Object.freeze({
-  awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
-  awpRaw: 'https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb',
-  mrtk: 'https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
-  mrtkRaw: 'https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
-  pistol: 'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
-  pistolRaw: 'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
-  fps: 'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
-  fpsRaw: 'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf'
-});
-const polyWeaponSource = (id) => `https://static.poly.pizza/${id}.glb`;
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
     label: 'MRTK Gun',
@@ -391,11 +380,8 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   pistolHolsterAttack: {
     label: 'Pistol Holster',
     urls: [
-      polyWeaponSource('3b53f0fe-f86e-451c-816d-6ab9bd265cdc'),
-      polyWeaponSource('9e728565-67a3-44db-9567-982320abff09'),
-      KNOWN_LUDO_WEAPON_SOURCES.pistol,
-      KNOWN_LUDO_WEAPON_SOURCES.pistolRaw,
-      KNOWN_LUDO_WEAPON_SOURCES.mrtk
+      'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
+      'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb'
     ],
     scale: 0.138
   },
@@ -412,33 +398,31 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   glockSidearmAttack: {
     label: 'Glock',
     urls: [
-      polyWeaponSource('3b53f0fe-f86e-451c-816d-6ab9bd265cdc'),
-      KNOWN_LUDO_WEAPON_SOURCES.pistol,
-      KNOWN_LUDO_WEAPON_SOURCES.pistolRaw
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb',
+      'https://raw.githubusercontent.com/webaverse/pistol/master/glock.glb'
     ],
     scale: 0.13
   },
   pistolSidearmAttack: {
     label: 'Pistol Sidearm',
     urls: [
-      polyWeaponSource('3b53f0fe-f86e-451c-816d-6ab9bd265cdc'),
-      KNOWN_LUDO_WEAPON_SOURCES.pistol,
-      KNOWN_LUDO_WEAPON_SOURCES.pistolRaw,
-      KNOWN_LUDO_WEAPON_SOURCES.mrtk
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb',
+      'https://raw.githubusercontent.com/webaverse/pistol/master/pistol.glb',
+      'https://cdn.statically.io/gh/webaverse/pistol/master/pistol.glb'
     ],
     scale: 0.115
   },
   assaultRifleAttack: {
     label: 'Assault Rifle',
     urls: [
-      polyWeaponSource('b3e6be61-0299-4866-a227-58f5f3fe610b'),
-      polyWeaponSource('032e6589-3188-41bc-b92b-e25528344275'),
-      KNOWN_LUDO_WEAPON_SOURCES.fps,
-      KNOWN_LUDO_WEAPON_SOURCES.fpsRaw,
-      KNOWN_LUDO_WEAPON_SOURCES.mrtk,
-      KNOWN_LUDO_WEAPON_SOURCES.awp
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
+      'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
+      'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
     ],
-    scale: 0.13
+    scale: 0.13,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg'
+    ]
   },
   uziSprayAttack: {
     label: 'Uzi',
@@ -446,11 +430,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf'
     ],
-    scale: 0.2,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Uzi.png',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Uzi.png'
-    ]
+    scale: 0.2
   },
   ak47VolleyAttack: {
     label: 'AK-47',
@@ -472,11 +452,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf'
     ],
-    scale: 0.24,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/KRSV.jpg',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/KRSV.jpg'
-    ]
+    scale: 0.24
   },
   smithSidearmAttack: {
     label: 'Smith',
@@ -484,11 +460,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf'
     ],
-    scale: 0.13,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Smith.jpeg',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Smith.jpeg'
-    ]
+    scale: 0.13
   },
   mosinMarksmanAttack: {
     label: 'Mosin',
@@ -496,11 +468,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'
     ],
-    scale: 0.5125,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Mosin.png',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Mosin.png'
-    ]
+    scale: 0.5125
   },
   sigsauerTacticalAttack: {
     label: 'SigSauer Tactical',
@@ -528,13 +496,10 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   shotgunBlastAttack: {
     label: 'Shotgun Blast',
     urls: [
-      polyWeaponSource('032e6589-3188-41bc-b92b-e25528344275'),
-      polyWeaponSource('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e'),
-      polyWeaponSource('08f27141-8e64-425a-9161-1bbd6956dfca'),
-      KNOWN_LUDO_WEAPON_SOURCES.fps,
-      KNOWN_LUDO_WEAPON_SOURCES.fpsRaw,
-      KNOWN_LUDO_WEAPON_SOURCES.awp,
-      KNOWN_LUDO_WEAPON_SOURCES.awpRaw
+      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
+      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf'
     ],
     scale: 0.24
   },
@@ -549,17 +514,10 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   smgBurstAttack: {
     label: 'SMG',
     urls: [
-      polyWeaponSource('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710'),
-      KNOWN_LUDO_WEAPON_SOURCES.mrtk,
-      KNOWN_LUDO_WEAPON_SOURCES.fps,
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf',
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf'
+      'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb'
     ],
-    scale: 0.2,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Uzi.png',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Uzi.png'
-    ]
+    scale: 0.2
   },
   compactCarbineAttack: {
     label: 'Compact Carbine',
@@ -640,11 +598,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   polyGrenadeLauncher01Attack: {
     label: 'CreativeTrio Grenade Launcher',
     urls: ['https://static.poly.pizza/503bb2c5-4a69-404b-9b82-13e85e8f8467.glb'],
-    scale: 0.2,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Uzi.png',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/images/Uzi.png'
-    ]
+    scale: 0.2
   },
   polyDynamiteBomb01Attack: {
     label: 'CreativeTrio Dynamite Bomb',
@@ -1543,7 +1497,9 @@ async function loadCaptureWeaponModel(captureAnimationId) {
             // eslint-disable-next-line no-await-in-loop
             textureOverride = await withLoadTimeout(textureLoader.loadAsync(textureOverrideUrls[t]));
             if (textureOverride) {
-              normalizeCaptureWeaponTexture(textureOverride, { isColor: true });
+              textureOverride.flipY = false;
+              applySRGBColorSpace(textureOverride);
+              textureOverride.needsUpdate = true;
               break;
             }
           } catch {
@@ -1566,11 +1522,11 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         node.visible = true;
         const materials = Array.isArray(node.material) ? node.material : [node.material];
         materials.forEach((material) => {
+          if (material?.map) applySRGBColorSpace(material.map);
           if (textureOverride && (forceTextureOverride || !material?.map)) {
             material.map = textureOverride;
           }
-          normalizeCaptureWeaponTexture(material?.map, { isColor: true });
-          normalizeCaptureWeaponTexture(material?.emissiveMap, { isColor: true });
+          if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
           material.transparent = false;
           material.opacity = 1;
           material.needsUpdate = true;
@@ -1623,18 +1579,6 @@ function startCaptureWeaponAnimation({
   targetModel.userData.captureWeaponMixer = mixer;
   targetModel.userData.captureWeaponActions = actions;
   return { mixer, actions };
-}
-
-
-function normalizeCaptureWeaponTexture(texture, { isColor = false } = {}) {
-  if (!texture?.isTexture) return;
-  texture.flipY = false;
-  if (isColor) applySRGBColorSpace(texture);
-  texture.generateMipmaps = true;
-  texture.minFilter = THREE.LinearMipmapLinearFilter;
-  texture.magFilter = THREE.LinearFilter;
-  texture.anisotropy = Math.max(texture.anisotropy ?? 1, 8);
-  texture.needsUpdate = true;
 }
 
 function stopCaptureWeaponMixersForObjectTree(rootObject, mixersStore) {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -813,18 +813,18 @@ const CHROME_CORNER_POCKET_EDGE_ROUND_SCALE = 0.9; // strongly round the outer c
 const CHROME_SIDE_POCKET_RADIUS_SCALE =
   CORNER_POCKET_INWARD_SCALE *
   CHROME_CORNER_POCKET_RADIUS_SCALE; // match the middle chrome arches to the corner pocket radius
-const WOOD_RAIL_CORNER_RADIUS_SCALE = 1.38; // round the wooden outer frame corners a bit more so the procedural frame follows the Showood silhouette
+const WOOD_RAIL_CORNER_RADIUS_SCALE = 1.28; // match the native wooden rail outline more closely to the Showood pocket-jaw silhouette
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0; // disable secondary throat so the side chrome uses a single arch
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // reuse snooker notch height profile
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
 const CHROME_SIDE_NOTCH_DEPTH_SCALE = 1; // keep the notch depth identical to the pocket cylinder so the chrome kisses the jaw edge
 const CHROME_SIDE_FIELD_PULL_SCALE = 0;
 const CHROME_PLATE_REFLECTION_SCALE = 0.28; // kill pocket-cut reflections by damping env-map intensity on fascia cuts
-const CHROME_PLATE_ROUGHNESS_LIFT = 0.14; // smooth chrome/gold highlight rolloff on rail sights for a softer edge finish
+const CHROME_PLATE_ROUGHNESS_LIFT = 0.08; // lift roughness on fascia cuts so pocket arches stop casting hot spots on cloth
 const CHROME_PLATE_THICKNESS_SCALE = 0.0306; // match diamond thickness on the wooden rails for fascia depth
 const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18; // thicken the middle fascia so its depth now matches the corner plates
 const CHROME_PLATE_VERTICAL_LIFT_SCALE = 0.06; // lift fascia slightly with the raised rail/cushion profile so chrome stays aligned on all six pockets
-const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0.12; // reduce downward chrome coverage so more wooden rail face stays visible
+const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical to snooker
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.34; // trim the side fascia reach so the middle chrome ends cleanly before the pocket curve
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.14; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
@@ -837,7 +837,7 @@ const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.24; // lean the added width furthe
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.012; // push middle chrome plates slightly outward away from table center while preserving the rounded cut
 const CHROME_SIDE_APRON_COVER_THICKNESS_SCALE = 0.055; // cover the grey middle-pocket side apron with rail-sight chrome/gold
-const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 1.08; // extend side rail-sight chrome/gold lower so the texture coverage continues further downward
+const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 0.82; // drop the side apron cover down the rail face behind the side-pocket jaw
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.022; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.078; // trim the middle-pocket outside chrome a touch more so the outer edge ends flush with the wooden rails
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.045; // open only the corner chrome rounded cut a tiny bit more so the arc reads slightly larger
@@ -1269,7 +1269,7 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
 const SHOWOOD_ORIGINAL_TABLE_BASE_ID = 'showoodOriginal';
 const DEFAULT_PROCEDURAL_TABLE_BASE_ID = 'classicCylinders';
-const DEFAULT_TABLE_BASE_ID = DEFAULT_PROCEDURAL_TABLE_BASE_ID;
+const DEFAULT_TABLE_BASE_ID = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
 const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
 const ENABLE_CUE_STROKE_ANIMATION = true;
@@ -1305,19 +1305,19 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
     WALL: 2.6 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
-const FRAME_RAIL_OUTWARD_SCALE = 1.36; // expose more of the wooden frame rail so it remains clearly visible around the Showood table in portrait view
-const RAIL_HEIGHT = TABLE.THICK * 1.48; // match Showood side top-wood rail height to the older procedural rail profile
+const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
+const RAIL_HEIGHT = TABLE.THICK * 1.9; // lift all six cushions/rails a touch more so the top profile reads higher without changing playfield size
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.024; // push the corner jaws just a bit farther outward so the fascia follows the rounded rail and chrome cut
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
 const POCKET_JAW_CORNER_INNER_SCALE = 1.62; // stretch the inner lip into a longer Showood-style rounded pocket jaw while keeping playable mouth size
 const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1.03; // round and widen the middle jaws slightly more while keeping the corner match
-const POCKET_JAW_CORNER_OUTER_SCALE = 1.8; // keep the Showood-style jaw shoulder but make it just a bit slimmer
+const POCKET_JAW_CORNER_OUTER_SCALE = 1.86; // broaden the outer jaw shoulder to mirror the Showood rounded pocket cup profile
 const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
 const POCKET_JAW_CORNER_OUTER_EXPANSION = TABLE.THICK * 0.036; // nudge corner jaws a touch farther outward to keep the jaw shoulder aligned with the rail cut
 const SIDE_POCKET_JAW_OUTER_EXPANSION = POCKET_JAW_CORNER_OUTER_EXPANSION; // keep the outer fascia consistent with the corner jaws
-const POCKET_JAW_DEPTH_SCALE = 1.04; // keep Showood depth while making jaws a touch smaller overall
+const POCKET_JAW_DEPTH_SCALE = 1.08; // deepen all jaw bodies so the default pockets carry the same Showood jaw depth
 const POCKET_JAW_VERTICAL_LIFT = TABLE.THICK * 0.094; // lower all six jaws a hair more so the mouths sit slightly deeper
 const POCKET_JAW_BOTTOM_CLEARANCE = TABLE.THICK * 0.036; // trim a little more from the jaw bottoms
 const POCKET_JAW_CORNER_BOTTOM_CLEARANCE = TABLE.THICK * 0.012; // keep corner jaw bottom trim aligned with the global bottom reduction
@@ -1331,7 +1331,7 @@ const POCKET_JAW_SIDE_CENTER_TAPER_HOLD = POCKET_JAW_CENTER_TAPER_HOLD; // keep 
 const POCKET_JAW_SIDE_EDGE_TAPER_SCALE = POCKET_JAW_EDGE_TAPER_SCALE; // reuse the corner taper scale so edge thickness matches exactly
 const POCKET_JAW_SIDE_EDGE_TAPER_PROFILE_POWER = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // maintain the identical taper curve across all six jaws
 const POCKET_JAW_CENTER_THICKNESS_MIN = 0.2; // make all six jaws a bit thinner from the inside while preserving outside profile and height
-const POCKET_JAW_CENTER_THICKNESS_MAX = 0.51; // trim center jaw mass a little more for a subtly smaller mouth surround
+const POCKET_JAW_CENTER_THICKNESS_MAX = 0.54; // keep the centre mass but slim it slightly so jaw interiors look cleaner
 const POCKET_JAW_OUTER_EXPONENT_MIN = 0.58; // controls arc falloff toward the chrome rim
 const POCKET_JAW_OUTER_EXPONENT_MAX = 1.2;
 const POCKET_JAW_INNER_EXPONENT_MIN = 0.78; // controls inner lip easing toward the cushion
@@ -1354,7 +1354,7 @@ const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // 
 const CORNER_POCKET_JAW_EDGE_TRIM_START = SIDE_POCKET_JAW_EDGE_TRIM_START; // keep corner jaw taper start aligned with middle pockets
 const CORNER_POCKET_JAW_EDGE_TRIM_SCALE = SIDE_POCKET_JAW_EDGE_TRIM_SCALE; // match the middle pocket jaw thin/thick profile
 const CORNER_POCKET_JAW_EDGE_TRIM_CURVE = SIDE_POCKET_JAW_EDGE_TRIM_CURVE; // reuse the same taper curve for corner jaws
-const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.08; // expand jaw collision mapping further so gameplay collisions match visible jaws and prevent pass-throughs
+const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.035; // slightly expand jaw collision arcs so physics cannot slip through visible jaw/chrome edges
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span to the corner profile
 const POCKET_RIM_DEPTH_RATIO = 0; // remove the separate pocket rims so the chrome fascias meet the jaws directly
@@ -1550,7 +1550,7 @@ const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
 const ROLLING_RESISTANCE = 0.011;
 const BALL_BALL_FRICTION = 0.105;
-const BALL_CONTACT_EPS = BALL_R * 0.016; // increase grazing-contact tolerance so fast shots cannot tunnel through cushion/jaw boundaries
+const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
 const BALL_COLLISION_SLOP = BALL_R * 0.001; // tighter tolerance so visible ball overlap is corrected faster
 const BALL_COLLISION_BAUMGARTE = 0.92; // stronger overlap correction so touching balls settle at true physical spacing
 const RAIL_FRICTION = 0.16;
@@ -1560,7 +1560,7 @@ const STOP_FINAL_EPS = STOP_EPS * 0.35;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3; // allow up to 3 frames of catch-up when recovering from slow frames
 const MIN_FRAME_SCALE = 1e-6; // prevent zero-length frames from collapsing physics updates
 const MAX_FRAME_SCALE = 2.4; // clamp slow-frame recovery so physics catch-up cannot stall the render loop
-const MAX_PHYSICS_SUBSTEPS = 8; // add extra substeps for higher cushion/pocket collision precision on slower frames
+const MAX_PHYSICS_SUBSTEPS = 5; // keep catch-up updates smooth without exploding work per frame
 const STUCK_SHOT_TIMEOUT_MS = 4500; // auto-resolve shots if motion stops but the turn never clears
 const MAX_POWER_BOUNCE_THRESHOLD = 0.995; // treat slider max as the hard cap threshold
 const MAX_POWER_BOUNCE_IMPULSE = BALL_R * 1.9; // push full-power launches higher so cue-ball jumps read stronger
@@ -1833,9 +1833,9 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 1; // restore legacy shot scaling used before the May 19 power retune
-const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
-const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
+const SHOT_POWER_ADJUSTMENT = 0.62; // reduce overall Pool Royale power by an additional 20%
+const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
+const SHOT_GLOBAL_POWER_SCALE = 0.78; // tone down Pool Royale strike speed so shots match the requested game power pacing
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -5728,43 +5728,12 @@ function updateClothTexturesForFinish (
   }
   finishInfo.parts?.underlayMeshes?.forEach((mesh) => {
     if (!mesh?.material) return;
-    const underlayMat = mesh.material;
-    if (underlayMat.color && finishInfo.clothMat?.color) {
-      underlayMat.color.copy(finishInfo.clothMat.color);
+    mesh.material.map = null;
+    mesh.material.bumpMap = null;
+    if (mesh.material.color && finishInfo.clothMat?.color) {
+      mesh.material.color.copy(finishInfo.clothMat.color);
     }
-    if (finishInfo.clothMat) {
-      underlayMat.map = finishInfo.clothMat.map ?? null;
-      underlayMat.normalMap = finishInfo.clothMat.normalMap ?? null;
-      underlayMat.roughnessMap = finishInfo.clothMat.roughnessMap ?? null;
-      underlayMat.bumpMap = finishInfo.clothMat.bumpMap ?? null;
-      if (underlayMat.map && finishInfo.clothMat.map?.repeat) {
-        underlayMat.map.repeat.copy(finishInfo.clothMat.map.repeat);
-        underlayMat.map.rotation = finishInfo.clothMat.map.rotation ?? underlayMat.map.rotation ?? 0;
-        underlayMat.map.needsUpdate = true;
-      }
-      if (underlayMat.normalMap && finishInfo.clothMat.normalMap?.repeat) {
-        underlayMat.normalMap.repeat.copy(finishInfo.clothMat.normalMap.repeat);
-        underlayMat.normalMap.rotation = finishInfo.clothMat.normalMap.rotation ?? underlayMat.normalMap.rotation ?? 0;
-        underlayMat.normalMap.needsUpdate = true;
-      }
-      if (underlayMat.roughnessMap && finishInfo.clothMat.roughnessMap?.repeat) {
-        underlayMat.roughnessMap.repeat.copy(finishInfo.clothMat.roughnessMap.repeat);
-        underlayMat.roughnessMap.rotation = finishInfo.clothMat.roughnessMap.rotation ?? underlayMat.roughnessMap.rotation ?? 0;
-        underlayMat.roughnessMap.needsUpdate = true;
-      }
-      if (underlayMat.bumpMap && finishInfo.clothMat.bumpMap?.repeat) {
-        underlayMat.bumpMap.repeat.copy(finishInfo.clothMat.bumpMap.repeat);
-        underlayMat.bumpMap.rotation = finishInfo.clothMat.bumpMap.rotation ?? underlayMat.bumpMap.rotation ?? 0;
-        underlayMat.bumpMap.needsUpdate = true;
-      }
-      if ('roughness' in underlayMat && Number.isFinite(finishInfo.clothMat.roughness)) {
-        underlayMat.roughness = finishInfo.clothMat.roughness;
-      }
-      if ('metalness' in underlayMat && Number.isFinite(finishInfo.clothMat.metalness)) {
-        underlayMat.metalness = finishInfo.clothMat.metalness;
-      }
-    }
-    underlayMat.needsUpdate = true;
+    mesh.material.needsUpdate = true;
   });
   finishInfo.clothTextureKey = textureKey;
   finishInfo.clothTextureSource = textureSource;
@@ -11975,7 +11944,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.92;
+  const brandPlateOutwardShift = endRailW * 0.62;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -14337,7 +14306,7 @@ function mountPoolRoyaleExternalTableModel({
 
   table.userData.applyExternalTableFallbackBase = () => {
     if (usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'showood-seven-foot') {
-      applyBaseVariant(DEFAULT_PROCEDURAL_TABLE_BASE_ID);
+      applyBaseVariant(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
     }
   };
 
@@ -15650,9 +15619,10 @@ function PoolRoyaleGame({
   );
   const availableTableBases = useMemo(
     () =>
-      POOL_ROYALE_BASE_VARIANTS.filter((variant) =>
-        variant.id !== SHOWOOD_ORIGINAL_TABLE_BASE_ID &&
-        isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
+      POOL_ROYALE_BASE_VARIANTS.filter(
+        (variant) =>
+          variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID &&
+          isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
       ),
     [poolInventory]
   );
@@ -15751,12 +15721,10 @@ function PoolRoyaleGame({
   );
   const activeTableBase = useMemo(
     () =>
-      availableTableBases.find((variant) => variant.id === tableBaseId) ??
-      availableTableBases.find((variant) => variant.id === DEFAULT_TABLE_BASE_ID) ??
-      POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === DEFAULT_TABLE_BASE_ID) ??
-      availableTableBases[0] ??
+      availableTableBases.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
+      POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
       POOL_ROYALE_BASE_VARIANTS[0],
-    [availableTableBases, tableBaseId]
+    [availableTableBases]
   );
   const resolvedHdriResolution = useMemo(() => {
     return autoHdriResolutionFromGraphics;
@@ -15813,7 +15781,9 @@ function PoolRoyaleGame({
     if (!isPoolOptionUnlocked('tableFinish', tableFinishId, poolInventory)) {
       setTableFinishId(DEFAULT_TABLE_FINISH_ID);
     }
-    if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
+    if (tableBaseId !== SHOWOOD_ORIGINAL_TABLE_BASE_ID) {
+      setTableBaseId(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
+    } else if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
       setTableBaseId(DEFAULT_TABLE_BASE_ID);
     }
     if (!isPoolOptionUnlocked('clothColor', clothColorId, poolInventory)) {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,7 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
@@ -77,19 +76,7 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const [selectedTableModelId, setSelectedTableModelId] = useState(() => {
-    const requested = (searchParams.get('tableModel') || '').trim();
-    if (requested) return resolvePoolRoyaleTableModel(requested).id;
-    try {
-      const stored = window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY);
-      if (stored) return resolvePoolRoyaleTableModel(stored).id;
-    } catch {}
-    return resolvePoolRoyaleTableModel().id;
-  });
-  const selectedTableModel = useMemo(
-    () => resolvePoolRoyaleTableModel(selectedTableModelId),
-    [selectedTableModelId]
-  );
+  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(), []);
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -872,33 +859,17 @@ export default function PoolRoyaleLobby() {
         )}
 
         {!hasActiveTournament && (
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Pool Table</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-                Layout
+          <div className="rounded-2xl border border-emerald-300/20 bg-white/[0.04] p-4 text-xs text-white/60">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h3 className="font-semibold text-white">Pool Table</h3>
+                <p className="mt-1">
+                  Showood 7 ft GLB is now the fixed Pool Royale table.
+                </p>
+              </div>
+              <span className="rounded-full border border-emerald-300/35 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100">
+                Default
               </span>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((tableModel) => {
-                const active = selectedTableModel.id === tableModel.id;
-                return (
-                  <button
-                    key={tableModel.id}
-                    type="button"
-                    onClick={() => setSelectedTableModelId(tableModel.id)}
-                    className={`lobby-option-card ${active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
-                  >
-                    <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-sky-500/10 to-transparent">
-                      <div className="lobby-option-thumb-inner text-2xl">{tableModel.icon || '🎱'}</div>
-                    </div>
-                    <div className="text-center">
-                      <p className="lobby-option-label">{tableModel.label}</p>
-                      <p className="lobby-option-subtitle">{tableModel.kind === 'gltf' ? 'GLB model' : 'Procedural model'}</p>
-                    </div>
-                  </button>
-                );
-              })}
             </div>
           </div>
         )}


### PR DESCRIPTION
### Motivation

- Align Pool Royale visual/table defaults to the Showood 7ft GLB and tighten up pocket/rail/play logic to match the Showood silhouette and desired play feel.
- Adjust physics and shot-power tuning to change contact tolerances, substep budget and global shot scaling for more consistent behavior.
- Simplify lobby/table model selection by fixing the default table and remove legacy/procedural model options.
- Replace several external weapon model URLs and streamline capture-weapon texture normalization to use the shared SRGB color-space handling.

### Description

- Pool AI / play math: removed legacy `effectiveTableBounds` usage and updated pocket/classification/geometry heuristics including `classifyPocket`, `pocketMouthGeometry`, `cornerPocketRailClearance`, `cornerPocketLaneSafety`, `pocketEntry`, `pocketMouthGeometry` tuning constants, `mirrorPointAcrossRail`, `firstRailContact`, and `clampPointToTable` to rely on absolute table bounds (0..width/height) and adjusted margins.
- PoolRoyale tuning: switched default table/base to the Showood 7ft GLB, locked the lobby UI to a fixed Showood table card, and changed many visual/mesh/layout constants (rail/brand/plate scales, jaw mapping, chrome/wood scales) as well as physics/power constants including `BALL_CONTACT_EPS`, `MAX_PHYSICS_SUBSTEPS`, `SHOT_POWER_ADJUSTMENT`, `SHOT_POWER_BOOST`, and `SHOT_GLOBAL_POWER_SCALE` to rebalance play feel.
- Weapon / capture models: removed some deprecated helpers and vendor lists, updated many weapon asset URLs to new CDN/raw locations, added a `textureOverrideUrls` entry for some models, and modified model setup to apply `applySRGBColorSpace` and explicit `flipY`/`needsUpdate` instead of the old `normalizeCaptureWeaponTexture` helper (which was removed).
- Material & texture updates: simplified underlay material handling in table finish code by clearing `map` and `bumpMap` on underlay meshes and copying `color` where appropriate, and applied sRGB handling for imported capture weapon material textures.

### Testing

- Performed a local webapp build and smoke-start of the PoolRoyale UI to validate the lobby change and that the fixed Showood table renders without selection errors (`yarn build` / dev start smoke); the build completed successfully.
- Verified capture weapon model loading path exercises the new texture override code by attempting to load configured `textureOverrideUrls` and applying sRGB conversion; no runtime errors observed in dev logs.
- No new automated unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da9e7b76c8329be13a15844a46235)