### PR TITLE
Adjust Murlan Royale human and chair visual scales

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -433,7 +433,7 @@ const HUMAN_AVATAR_BOTTOM_OFFSET = 'calc(2.85rem + env(safe-area-inset-bottom, 0
 // Keep Murlan table/chairs at the exact shared Battle Royale baseline scale.
 const TABLE_AND_CHAIR_VISUAL_SHRINK = 1;
 const CARD_VISUAL_TRIM = TABLE_AND_CHAIR_VISUAL_SHRINK;
-const AVATAR_VISUAL_SCALE = 0.95;
+const AVATAR_VISUAL_SCALE = 0.98;
 
 const TABLE_RADIUS = 3.4 * MODEL_SCALE * 0.83 * TABLE_AND_CHAIR_VISUAL_SHRINK;
 const TABLE_HORIZONTAL_SHRINK = 1;
@@ -2606,7 +2606,7 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   normalizeCharacterPivot(instance);
 
   const seatRoot = new THREE.Group();
-  const seatScale = (characterTheme.scale ?? 0.82) * CHARACTER_PROPORTION_SCALE;
+  const seatScale = (characterTheme.scale ?? 0.82) * CHARACTER_PROPORTION_SCALE * 1.06;
   const scaleDelta = Math.max(0, CHARACTER_PROPORTION_SCALE - 1);
   seatRoot.scale.multiplyScalar(seatScale);
   const baseSeatOffsetY = (characterTheme.normalizedSeatOffsetY ?? characterTheme.seatOffsetY ?? -0.92) - 0.2;
@@ -3209,7 +3209,7 @@ const CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP;
 const AI_CHAIR_GAP = CHAIR_GAP;
 const AI_CHAIR_RADIUS = CHAIR_RADIUS;
 const CHAIR_SEAT_INWARD_FACTOR = 1;
-const CHAIR_VISUAL_SCALE = 1.36;
+const CHAIR_VISUAL_SCALE = 1.28;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: 0, landscape: 0 });
 const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({
   portrait: 0.82,


### PR DESCRIPTION
### Motivation
- Make seated human characters appear slightly larger and chairs slightly smaller in the Murlan Royale arena to match the requested visual framing on portrait/mobile screens.

### Description
- Increased avatar UI scale by changing `AVATAR_VISUAL_SCALE` from `0.95` to `0.98` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to maintain UI balance with larger characters.
- Scaled up seated characters by multiplying the computed `seatScale` by `1.06` so characters render a bit bigger on screen, and reduced chairs by lowering `CHAIR_VISUAL_SCALE` from `1.36` to `1.28` in the same file.

### Testing
- No automated test suites were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd75a72048329a7de7a6ec3fe08e4)