### PR TITLE
Table Tennis: improve visual scale, swipe-to-shot precision, and AI bounce timing

### DIFF
--- a/frontend/src/table-tennis/AIController.ts
+++ b/frontend/src/table-tennis/AIController.ts
@@ -13,10 +13,12 @@ export class AIController {
   private reactionTimer = 0;
   private committedLanding: THREE.Vector3 | null = null;
   private readonly shotCommand: ShotCommand = { aimX: 0, power: 0.76, lift: 0.42, curve: 0, spin: 0.34 };
+  private bounceReadyTimer = 0;
 
   constructor(private root: THREE.Group, private hand: THREE.Object3D, private paddle: THREE.Object3D) {}
 
   update(dt: number, ball: BallPhysics) {
+    this.bounceReadyTimer = Math.max(0, this.bounceReadyTimer - dt);
     const cfg = GAME_CONFIG.ai.difficulty;
     this.reactionTimer -= dt;
     if (this.reactionTimer <= 0) {
@@ -27,7 +29,11 @@ export class AIController {
         this.prepareShotCommand(ball);
       }
       const speedRead = THREE.MathUtils.clamp(ball.velocity.length() / 7, 0, 0.055);
-      this.reactionTimer = Math.max(0.075, cfg.reactionTime - speedRead);
+      this.reactionTimer = Math.max(0.045, cfg.reactionTime - speedRead);
+    }
+
+    if (ball.bounces.ai === 1 && ball.lastTouch !== 'ai' && ball.velocity.y > 0 && this.canReach(ball.position)) {
+      this.bounceReadyTimer = 0.085;
     }
 
     this.root.position.x = THREE.MathUtils.damp(this.root.position.x, this.targetX.value, cfg.moveSpeed, dt);
@@ -74,4 +80,13 @@ export class AIController {
     return new THREE.Vector3(0, 0, 1).applyQuaternion(this.paddle.getWorldQuaternion(new THREE.Quaternion())).normalize();
   }
 
+  shouldStrikeAfterBounce(ball: BallPhysics) {
+    if (ball.bounces.ai !== 1 || ball.lastTouch === 'ai') return false;
+    const risingAfterBounce = ball.velocity.y >= -0.08;
+    const headingToPlayerSide = ball.position.z < -0.02;
+    return this.bounceReadyTimer > 0 && risingAfterBounce && headingToPlayerSide && this.canReach(ball.position);
+  }
 }
+
+
+

--- a/frontend/src/table-tennis/GameManager.ts
+++ b/frontend/src/table-tennis/GameManager.ts
@@ -164,7 +164,7 @@ export class GameManager {
   }
 
   private tryAiHit() {
-    if (this.ball.lastTouch === 'ai' || this.ball.bounces.ai < 1 || this.ball.bounces.ai > 1 || !this.ai.canReach(this.ball.position) || this.ai.shouldMiss()) return;
+    if (!this.ai.shouldStrikeAfterBounce(this.ball) || this.ai.shouldMiss()) return;
     const shot = this.ai.currentShot as ShotType;
     const result = this.hitDetector.detect({
       side: 'ai',
@@ -191,16 +191,21 @@ export class GameManager {
     const dx = end.x - start.x;
     const dy = start.y - end.y;
     const distance = Math.hypot(dx, dy);
-    const horizontalIntent = THREE.MathUtils.clamp(dx / Math.max(distance, 0.001), -1, 1);
-    const verticalIntent = THREE.MathUtils.clamp(dy / Math.max(distance, 0.001), -1, 1);
-    const swipeSpeed = distance / Math.max(durationMs / 1000, 0.08);
-    const speedPower = THREE.MathUtils.clamp(swipeSpeed / 4.4, 0, 1);
-    const distancePower = THREE.MathUtils.clamp(distance / 1.35, 0, 1);
-    const aimX = THREE.MathUtils.clamp(end.x * 0.62 + horizontalIntent * 0.38 + dx * 0.18, -1, 1);
-    const power = THREE.MathUtils.clamp(distancePower * 0.58 + speedPower * 0.42, 0.14, 1);
-    const lift = THREE.MathUtils.clamp(0.22 + Math.max(verticalIntent, -0.25) * 0.44 + dy * 0.18, 0, 1);
-    const curve = THREE.MathUtils.clamp(dx * 0.62 + horizontalIntent * 0.22, -1, 1);
-    const spin = THREE.MathUtils.clamp(verticalIntent * 0.52 + dy * 0.28 + power * 0.24 - Math.abs(curve) * 0.08, -1, 1);
+    const safeDistance = Math.max(distance, 0.001);
+    const horizontalIntent = THREE.MathUtils.clamp(dx / safeDistance, -1, 1);
+    const verticalIntent = THREE.MathUtils.clamp(dy / safeDistance, -1, 1);
+    const swipeDuration = Math.max(durationMs / 1000, 0.05);
+    const swipeSpeed = distance / swipeDuration;
+    const speedPower = THREE.MathUtils.clamp(swipeSpeed / 3.4, 0, 1);
+    const distancePower = THREE.MathUtils.clamp(distance / 1.05, 0, 1);
+
+    // Keep portrait-screen intuition: swipe visually right => aim right, swipe left => aim left.
+    const aimX = THREE.MathUtils.clamp(horizontalIntent * 0.86 + end.x * 0.12 + dx * 0.18, -1, 1);
+    const power = THREE.MathUtils.clamp(distancePower * 0.52 + speedPower * 0.48, 0.16, 1);
+    const lift = THREE.MathUtils.clamp(0.18 + Math.max(verticalIntent, -0.3) * 0.62 + dy * 0.14, 0, 1);
+    const curve = THREE.MathUtils.clamp(horizontalIntent * 0.72 + dx * 0.22, -1, 1);
+    const spin = THREE.MathUtils.clamp(verticalIntent * 0.66 + dy * 0.22 + power * 0.18 - Math.abs(curve) * 0.05, -1, 1);
+
     return { aimX, power, lift, curve, spin };
   }
 

--- a/frontend/src/table-tennis/gameConfig.ts
+++ b/frontend/src/table-tennis/gameConfig.ts
@@ -30,7 +30,7 @@ export interface DifficultyConfig {
 const POOL_ROYALE_TABLE_WIDTH = 61.651044;
 const POOL_ROYALE_TABLE_LENGTH = 90.4215312;
 const POOL_ROYALE_TO_TABLE_TENNIS_BASE_SCALE = 0.045;
-const TABLE_TENNIS_SIZE_MULTIPLIER = 1.3;
+const TABLE_TENNIS_SIZE_MULTIPLIER = 1.58;
 const POOL_ROYALE_TO_TABLE_TENNIS_SCALE = POOL_ROYALE_TO_TABLE_TENNIS_BASE_SCALE * TABLE_TENNIS_SIZE_MULTIPLIER;
 const TABLE_WIDTH = POOL_ROYALE_TABLE_WIDTH * POOL_ROYALE_TO_TABLE_TENNIS_SCALE;
 const TABLE_LENGTH = POOL_ROYALE_TABLE_LENGTH * POOL_ROYALE_TO_TABLE_TENNIS_SCALE;
@@ -76,16 +76,16 @@ export const GAME_CONFIG = {
     maxReach: 0.58 * TABLE_WIDTH_SCALE,
     avatarScale: 1.62 * TABLE_TENNIS_SIZE_MULTIPLIER,
     difficulty: {
-      reactionTime: 0.14,
+      reactionTime: 0.1,
       moveSpeed: 3.05 * TABLE_WIDTH_SCALE,
-      accuracy: 0.84,
+      accuracy: 0.94,
       shotPower: 1.18,
-      mistakeChance: 0.1,
+      mistakeChance: 0.035,
     } satisfies DifficultyConfig,
   },
   paddle: {
     hitRadius: 0.18 * TABLE_WIDTH_SCALE,
-    timingWindow: 0.12,
+    timingWindow: 0.15,
     minFacingDot: 0.22,
     drivePower: 3.35 * TABLE_LENGTH_SCALE,
     pushPower: 2.55 * TABLE_LENGTH_SCALE,
@@ -93,7 +93,7 @@ export const GAME_CONFIG = {
     powerShotMultiplier: 1.18,
     spin: 3.6,
     sideSpin: 4.2,
-    accuracy: 0.96,
+    accuracy: 0.985,
   },
   camera: {
     position: new THREE.Vector3(0, 2.7 * TABLE_TENNIS_SIZE_MULTIPLIER, 6.1 * TABLE_TENNIS_SIZE_MULTIPLIER),


### PR DESCRIPTION
### Motivation

- Make in-scene objects (table, avatars, net, paddle, ball) visually match HDRI scale so the player and props read correctly against environment lighting.  
- Make touch swipe -> shot translation faithful to portrait-screen visual direction and extract power/lift/spin more precisely for reliable aiming.  
- Improve AI behavior so the bot hits immediately after the first bounce on its side and reduces spurious misses for tighter rallies.

### Description

- Increased overall world scale by raising `TABLE_TENNIS_SIZE_MULTIPLIER` from `1.3` to `1.58` so table, avatars, net and ball are larger and proportionate (`frontend/src/table-tennis/gameConfig.ts`).
- Tuned paddle and AI constants: increased `paddle.timingWindow` to `0.15`, raised `paddle.accuracy` to `0.985`, and adjusted AI difficulty (`reactionTime`, `accuracy`, `mistakeChance`) for faster, more consistent play (`frontend/src/table-tennis/gameConfig.ts`).
- Reworked swipe mapping in `buildShotCommandFromSwipe` to use portrait-screen visual intent (swipe right => aim right) and improved extraction of `aimX`, `power`, `lift`, `curve`, and `spin` using safer clamping and new speed/distance scaling parameters (`frontend/src/table-tennis/GameManager.ts`).
- Implemented AI post-bounce strike logic by adding `bounceReadyTimer` and `shouldStrikeAfterBounce` to `AIController`, reduced minimum reaction latency, and switched `GameManager.tryAiHit` to use the new gate so AI attempts a precise hit soon after the ball’s first bounce (`frontend/src/table-tennis/AIController.ts` and `frontend/src/table-tennis/GameManager.ts`).

### Testing

- Ran a production build with `cd frontend && npm run build` and the build completed successfully; only non-blocking Vite/Rollup warnings about chunk size and externalized modules were emitted.  
- Verified the game compiles and the modified modules load without TypeScript or bundler errors during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e752b964c8329824a0f7060a841d6)