### PR TITLE
Tune Pool Royale table size, shot power, and cushion collision mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1150,7 +1150,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.85; // shrink the table just a bit in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.82; // shrink the table a touch more in portrait while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1354,7 +1354,7 @@ const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // 
 const CORNER_POCKET_JAW_EDGE_TRIM_START = SIDE_POCKET_JAW_EDGE_TRIM_START; // keep corner jaw taper start aligned with middle pockets
 const CORNER_POCKET_JAW_EDGE_TRIM_SCALE = SIDE_POCKET_JAW_EDGE_TRIM_SCALE; // match the middle pocket jaw thin/thick profile
 const CORNER_POCKET_JAW_EDGE_TRIM_CURVE = SIDE_POCKET_JAW_EDGE_TRIM_CURVE; // reuse the same taper curve for corner jaws
-const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.035; // slightly expand jaw collision arcs so physics cannot slip through visible jaw/chrome edges
+const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.015; // keep jaw collision arcs tighter so balls do not bounce before reaching the visible cushions
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span to the corner profile
 const POCKET_RIM_DEPTH_RATIO = 0; // remove the separate pocket rims so the chrome fascias meet the jaws directly
@@ -1835,7 +1835,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.62; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.82; // raise strike speed a touch so shots carry slightly more power
+const SHOT_GLOBAL_POWER_SCALE = 0.86; // raise strike speed a bit more so shots carry slightly stronger power
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -2654,8 +2654,8 @@ let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.58; // pull long-rail cushions farther inward toward the table center
-const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.44; // move short-rail cushions a touch outward while keeping pocket cuts stable
+const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.5; // keep long-rail collision faces closer to the visible cushion noses
+const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.36; // keep short-rail collision faces aligned with the visible cushion noses
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 


### PR DESCRIPTION
### Motivation
- Make the Pool Royale presentation match the physical Showood 7ft table more closely by tightening visual footprint and collision mapping.
- Increase shot feel slightly so player shots carry a bit more power while preserving slider responsiveness.
- Eliminate instances where balls appeared to bounce before visually contacting cushions by tightening jaw/cushion collision geometry.

### Description
- Reduced the portrait table render scale by changing `TABLE_DISPLAY_SCALE` from `0.85` to `0.82` in `webapp/src/pages/Games/PoolRoyale.jsx` to make the table a bit smaller on mobile screens.
- Increased overall strike strength by raising `SHOT_GLOBAL_POWER_SCALE` from `0.82` to `0.86` to give shots a modest power boost.
- Tightened pocket/jaw collision by changing `POCKET_JAW_MAPPING_RADIUS_SCALE` from `1.035` to `1.015` so collisions align with visible pocket edges.
- Aligned cushion collision faces with visible cushion noses by reducing `CUSHION_FACE_INSET_LONG` and `CUSHION_FACE_INSET_SHORT` (multipliers changed to `0.5` and `0.36` respectively).

### Testing
- Ran targeted test suites with `npm test -- --runInBand test/poolRoyaleTableModels.test.js test/cueShotImpact.test.js`, and both suites passed.
- No other automated tests were modified; these changes were limited to `webapp/src/pages/Games/PoolRoyale.jsx` and validated by the focused tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e7b71ca548329a0cf18c5a034a18a)