### PR TITLE
Adjust Domino Royale chair sizing/positioning and increase human character scale

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -977,13 +977,13 @@ const COLUMN_RADIUS_BOTTOM = 0.26 * MODEL_SCALE;
 const BASE_RADIUS = 0.72 * MODEL_SCALE;
 const FOOT_RING_RADIUS = 0.52 * MODEL_SCALE;
 const FOOT_RING_TUBE = 0.04 * MODEL_SCALE;
-const CHAIR_GAP = 0.06 * MODEL_SCALE; // tighter to table for mobile portrait framing
+const CHAIR_GAP = 0.03 * MODEL_SCALE; // move chairs inward, closer to the table for portrait framing
 const CHAIR_OUTWARD_OFFSET = 0;
 const CHAIR_RADIUS =
   TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
-const CHAIR_GLOBAL_PUSHBACK = 0.44 * MODEL_SCALE;
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.54 * MODEL_SCALE;
-const CHAIR_VISUAL_SCALE = 0.92;
+const CHAIR_GLOBAL_PUSHBACK = 0.28 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.36 * MODEL_SCALE;
+const CHAIR_VISUAL_SCALE = 0.82;
 const CHAIR_VERTICAL_DROP = 0.035 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = LEGACY_BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
@@ -7989,7 +7989,7 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
   }
 ]);
 const DOMINO_CHARACTER_PROPORTION_SCALE = 2.55;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.63;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.9;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.02;


### PR DESCRIPTION
### Motivation

- Update Domino Royale portrait framing so seated human characters appear larger while chairs read smaller and sit closer to the table to better match mobile-portrait visuals.
- Keep changes localized to presentation/layout constants so gameplay and logic remain unchanged.

### Description

- Modified seating/layout constants in `webapp/public/domino-royal-game.js` to pull chairs inward and reduce their visual prominence by changing `CHAIR_GAP` from `0.06 * MODEL_SCALE` to `0.03 * MODEL_SCALE`, `CHAIR_GLOBAL_PUSHBACK` from `0.44 * MODEL_SCALE` to `0.28 * MODEL_SCALE`, `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` from `0.54 * MODEL_SCALE` to `0.36 * MODEL_SCALE`, and `CHAIR_VISUAL_SCALE` from `0.92` to `0.82`.
- Increased human-seat character size boost by changing `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` from `0.63` to `0.9` so the player avatar reads larger against the table.
- No gameplay, state machine, or networking logic was modified; this is strictly a visual/layout tuning change to Three.js scene constants.

### Testing

- No automated tests were executed for these constant-only visual adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e7bd87dec8329b5210f7a48cb5218)