### PR TITLE
Use full-screen game flows for mining daily streak and lucky rewards

### DIFF
--- a/webapp/public/pwa/app-build.js
+++ b/webapp/public/pwa/app-build.js
@@ -1,1 +1,1 @@
-self.__TONPLAYGRAM_APP_BUILD__ = "a587ca2";
+self.__TONPLAYGRAM_APP_BUILD__ = "122ba21";

--- a/webapp/public/version.json
+++ b/webapp/public/version.json
@@ -1,4 +1,4 @@
 {
-  "build": "a587ca2",
-  "generatedAt": "2026-05-18T09:47:24.109Z"
+  "build": "122ba21",
+  "generatedAt": "2026-05-21T03:43:21.256Z"
 }

--- a/webapp/src/components/DailyStreakShootingMini.jsx
+++ b/webapp/src/components/DailyStreakShootingMini.jsx
@@ -1,0 +1,69 @@
+import { useMemo, useState } from 'react';
+import { getTelegramId } from '../utils/telegram.js';
+import LoginOptions from './LoginOptions.jsx';
+import AdModal from './AdModal.tsx';
+import RewardPopup from './RewardPopup.tsx';
+import { getWalletBalance, updateBalance, addTransaction } from '../utils/api.js';
+
+const WEAPONS = ['Pistol', 'SMG', 'Shotgun', 'Rifle', 'Sniper'];
+const TARGET_RINGS = [
+  { label: 'Bullseye', points: 240, color: 'bg-red-500/90' },
+  { label: 'Ring 2', points: 180, color: 'bg-orange-500/80' },
+  { label: 'Ring 3', points: 130, color: 'bg-yellow-500/80' },
+  { label: 'Ring 4', points: 90, color: 'bg-green-500/70' },
+  { label: 'Ring 5', points: 60, color: 'bg-blue-500/70' },
+];
+
+export default function DailyStreakShootingMini() {
+  let telegramId;
+  try { telegramId = getTelegramId(); } catch { return <LoginOptions />; }
+
+  const [shotsLeft, setShotsLeft] = useState(5);
+  const [total, setTotal] = useState(0);
+  const [weapon, setWeapon] = useState(() => WEAPONS[Math.floor(Math.random() * WEAPONS.length)]);
+  const [showAd, setShowAd] = useState(false);
+  const [ready, setReady] = useState(false);
+  const [reward, setReward] = useState(null);
+  const [claimed, setClaimed] = useState(false);
+
+  const bestRing = useMemo(() => TARGET_RINGS[0], []);
+
+  const shoot = async (ring) => {
+    if (!ready || shotsLeft <= 0 || claimed) return;
+    const nextShots = shotsLeft - 1;
+    const nextTotal = total + ring.points;
+    setShotsLeft(nextShots);
+    setTotal(nextTotal);
+    setWeapon(WEAPONS[Math.floor(Math.random() * WEAPONS.length)]);
+
+    if (nextShots === 0) {
+      const payout = Math.max(100, Math.round((nextTotal / (bestRing.points * 5)) * 260));
+      try {
+        const balRes = await getWalletBalance(telegramId);
+        await updateBalance(telegramId, (balRes.balance || 0) + payout);
+        await addTransaction(telegramId, payout, 'daily');
+      } catch {}
+      setReward(payout);
+      setClaimed(true);
+    }
+  };
+
+  return (
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-3 text-center overflow-hidden wide-card">
+      <h3 className="text-lg font-bold text-white">Daily Streak Shooting</h3>
+      <p className="text-xs text-subtext">5 shots only • random weapon each shot • ring points decide TPC reward.</p>
+      <div className="text-sm text-white">Weapon: <span className="text-yellow-300 font-semibold">{weapon}</span></div>
+      <div className="text-sm text-white">Shots Left: {shotsLeft} • Score: {total}</div>
+      <div className="mx-auto w-52 h-52 rounded-full border border-white/20 p-4 flex flex-col justify-center gap-2 bg-black/20">
+        {TARGET_RINGS.map((ring) => (
+          <button key={ring.label} className={`rounded-full py-2 text-xs text-white ${ring.color}`} onClick={() => shoot(ring)}>
+            {ring.label} • {ring.points} pts
+          </button>
+        ))}
+      </div>
+      {!ready && <button className="btn-primary px-4 py-2 rounded" onClick={() => setShowAd(true)}>Watch Ad & Start 5 Shots</button>}
+      <AdModal open={showAd} onClose={() => setShowAd(false)} onComplete={() => { setReady(true); setShowAd(false); }} />
+      {reward != null && <RewardPopup reward={reward} onClose={() => setReward(null)} disableEffects />}
+    </div>
+  );
+}

--- a/webapp/src/components/MiningFreeKickChallenge.jsx
+++ b/webapp/src/components/MiningFreeKickChallenge.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { getTelegramId } from '../utils/telegram.js';
+import LoginOptions from './LoginOptions.jsx';
+import AdModal from './AdModal.tsx';
+import RewardPopup from './RewardPopup.tsx';
+import { addTransaction, getWalletBalance, updateBalance } from '../utils/api.js';
+
+const TARGETS = [220, 180, 150, 120, 90, 70];
+
+export default function MiningFreeKickChallenge() {
+  let telegramId;
+  try { telegramId = getTelegramId(); } catch { return <LoginOptions />; }
+
+  const [shotsLeft, setShotsLeft] = useState(5);
+  const [score, setScore] = useState(0);
+  const [showAd, setShowAd] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [reward, setReward] = useState(null);
+
+  const kick = async (value) => {
+    if (!enabled || shotsLeft <= 0) return;
+    const nextShots = shotsLeft - 1;
+    const nextScore = score + value;
+    setShotsLeft(nextShots);
+    setScore(nextScore);
+
+    if (nextShots === 0) {
+      const payout = Math.max(120, Math.round((nextScore / (220 * 5)) * 300));
+      try {
+        const balRes = await getWalletBalance(telegramId);
+        await updateBalance(telegramId, (balRes.balance || 0) + payout);
+        await addTransaction(telegramId, payout, 'lucky');
+      } catch {}
+      setReward(payout);
+      setEnabled(false);
+    }
+  };
+
+  return (
+    <div className="relative bg-surface border border-border rounded-xl p-4 space-y-3 text-center overflow-hidden wide-card">
+      <h3 className="text-lg font-bold text-white">Free Kick Lucky Challenge</h3>
+      <p className="text-xs text-subtext">5 free kicks • 6 goal targets • each target has its own TPC value.</p>
+      <div className="text-sm text-white">Shots Left: {shotsLeft} • Score: {score}</div>
+      <div className="grid grid-cols-3 gap-2">
+        {TARGETS.map((value, i) => (
+          <button key={i} onClick={() => kick(value)} className="rounded-lg border border-white/20 bg-emerald-500/20 py-3 text-xs text-white">
+            Target {i + 1}<br />{value} pts
+          </button>
+        ))}
+      </div>
+      {!enabled && shotsLeft === 5 && <button className="btn-primary px-4 py-2 rounded" onClick={() => setShowAd(true)}>Watch Ad & Start Kicks</button>}
+      <AdModal open={showAd} onClose={() => setShowAd(false)} onComplete={() => { setEnabled(true); setShowAd(false); }} />
+      {reward != null && <RewardPopup reward={reward} onClose={() => setReward(null)} disableEffects />}
+    </div>
+  );
+}

--- a/webapp/src/config/buildInfo.js
+++ b/webapp/src/config/buildInfo.js
@@ -1,2 +1,2 @@
-export const APP_BUILD = "a587ca2";
-export const APP_BUILD_GENERATED_AT = "2026-05-18T09:47:24.109Z";
+export const APP_BUILD = "122ba21";
+export const APP_BUILD_GENERATED_AT = "2026-05-21T03:43:21.256Z";

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -119,15 +119,6 @@ const gamesCatalog = [
   },
 
   {
-    name: 'Shooting Range',
-    route: '/games/shootingrange/lobby',
-    slug: 'shootingrange',
-    image: '/assets/icons/shooting-range.svg',
-    description:
-      'Pick a 3D weapon, take your lane, and outscore three AI shooters.'
-  },
-
-  {
     name: 'Free Kick Arena',
     route: '/games/freekickarena/lobby',
     slug: 'freekickarena',

--- a/webapp/src/pages/Games/FreeKickArena.tsx
+++ b/webapp/src/pages/Games/FreeKickArena.tsx
@@ -6,6 +6,8 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js';
 import { MURLAN_CHARACTER_THEMES } from '../../config/murlanCharacterThemes.js';
+import { addTransaction } from '../../utils/api.js';
+import { getTelegramId } from '../../utils/telegram.js';
 
 type AnimName = 'Idle' | 'Walk' | 'Run';
 type ShotState = 'aim' | 'runup' | 'keeperAim' | 'aiRunup' | 'flight' | 'var' | 'replay' | 'result';
@@ -3220,6 +3222,10 @@ function placeCameraForNextShot(
 }
 
 export default function FreeKickGame() {
+  const challengeMode =
+    typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search).get('challenge')
+      : null;
   const hostRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const swipeRef = useRef<SwipeState>({
@@ -3246,6 +3252,7 @@ export default function FreeKickGame() {
     state: 'You shoot first: swipe precisely on the pitch and release to shoot',
     feedback: DEFAULT_FEEDBACK
   });
+  const [challengeReward, setChallengeReward] = useState<number | null>(null);
   useEffect(() => {
     const host = hostRef.current;
     const canvas = canvasRef.current;
@@ -3384,7 +3391,9 @@ export default function FreeKickGame() {
       if (activeShooter === 'user') {
         match.userShots += 1;
         if (decision === 'GOAL') match.userGoals += 1;
-        if (match.userShots >= 5) match.phase = 'aiShoot';
+        if (match.userShots >= 5) {
+          match.phase = challengeMode === 'luckyCard' ? 'finished' : 'aiShoot';
+        }
       } else {
         match.aiShots += 1;
         if (decision === 'GOAL') match.aiGoals += 1;
@@ -3402,6 +3411,9 @@ export default function FreeKickGame() {
     };
     const nextStatusText = () => {
       if (match.phase === 'finished') {
+        if (challengeMode === 'luckyCard') {
+          return `Challenge complete · ${match.userGoals}/5 goals`;
+        }
         const verdict = match.userGoals === match.aiGoals ? 'DRAW' : match.userGoals > match.aiGoals ? 'YOU WIN' : 'AI WINS';
         return `${verdict} · ${match.userGoals}-${match.aiGoals} after 5 shots each`;
       }
@@ -3737,6 +3749,16 @@ export default function FreeKickGame() {
           setReplaySkippable(false);
           skipReplayRef.current = false;
           if (match.phase === 'finished') {
+            if (challengeMode === 'luckyCard' && challengeReward === null) {
+              const payout = Math.max(80, Math.min(160, 80 + match.userGoals * 16));
+              setChallengeReward(payout);
+              void (async () => {
+                try {
+                  const telegramId = getTelegramId();
+                  await addTransaction(telegramId, payout, 'lucky');
+                } catch {}
+              })();
+            }
             state = 'result';
             resultTimer = 999;
             syncHudScore(nextStatusText());
@@ -3843,7 +3865,7 @@ export default function FreeKickGame() {
       audio.dispose();
       renderer.dispose();
     };
-  }, []);
+  }, [challengeMode, challengeReward]);
 
 
   const selectedHdri = POLYHAVEN_HDRI_OPTIONS.find((option) => option.id === selectedHdriId) ?? POLYHAVEN_HDRI_OPTIONS[0];
@@ -3892,7 +3914,9 @@ export default function FreeKickGame() {
         }}
       >
         <div style={{ fontWeight: 900, fontSize: 18 }}>
-          YOU {hud.goals}/{hud.userShots} · AI {hud.aiGoals}/{hud.aiShots}
+          {challengeMode === 'luckyCard'
+            ? `YOU ${hud.goals}/${hud.userShots}`
+            : `YOU ${hud.goals}/${hud.userShots} · AI ${hud.aiGoals}/${hud.aiShots}`}
         </div>
         <div
           style={{
@@ -3905,6 +3929,14 @@ export default function FreeKickGame() {
           {hud.state}
         </div>
       </div>
+      {challengeMode === 'luckyCard' && hud.phase === 'finished' && (
+        <button
+          onClick={() => window.location.assign('/mining')}
+          style={{ position: 'fixed', left: 14, right: 14, bottom: 20, padding: '12px 16px', borderRadius: 14, background: '#34d399', color: '#052e16', fontWeight: 900, border: 'none' }}
+        >
+          Return to Mining {challengeReward ? `· +${challengeReward} TPC` : ''}
+        </button>
+      )}
 
       <div
         style={{

--- a/webapp/src/pages/Games/ShootingRange.tsx
+++ b/webapp/src/pages/Games/ShootingRange.tsx
@@ -11,6 +11,8 @@ import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { clone as cloneScene } from 'three/examples/jsm/utils/SkeletonUtils.js';
+import { addTransaction } from '../../utils/api.js';
+import { getTelegramId } from '../../utils/telegram.js';
 
 type WeaponClass =
   | 'pistol'
@@ -2517,6 +2519,7 @@ export default function ShootingRange() {
       requestedDistance && requestedDistance in RANGE_DISTANCE_CONFIG
         ? requestedDistance
         : 'standard';
+    const challenge = params.get('challenge');
     return {
       mode:
         params.get('mode') === 'online'
@@ -2530,9 +2533,11 @@ export default function ShootingRange() {
       scenarioSeed:
         params.get('tableId') ||
         params.get('accountId') ||
-        `${distance}-${params.get('name') || 'Player'}`
+        `${distance}-${params.get('name') || 'Player'}`,
+      challenge
     };
   }, []);
+  const [challengeReward, setChallengeReward] = useState<number | null>(null);
 
   const phaseRef = useRef<GamePhase>('loading');
   const viewModeRef = useRef<ViewMode>('tables');
@@ -3538,6 +3543,17 @@ export default function ShootingRange() {
           `Lane ${i + 1} · ${target.score}`
         );
       });
+      if (queryConfig.challenge === 'dailyStreak') {
+        const userScore = scores[userLaneRef.current] || 0;
+        const payout = Math.max(70, Math.min(140, Math.round(userScore * 0.24)));
+        setChallengeReward(payout);
+        void (async () => {
+          try {
+            const telegramId = getTelegramId();
+            await addTransaction(telegramId, payout, 'daily');
+          } catch {}
+        })();
+      }
     }
 
     function addLaneScore(laneIndex: number, points: number) {
@@ -4678,12 +4694,25 @@ export default function ShootingRange() {
                 : 'Free vs AI'}
             </span>
             <span>{status}</span>
+            {queryConfig.challenge === 'dailyStreak' && (
+              <span style={{ color: '#fde68a' }}>Daily mode: 5 shots then return</span>
+            )}
             {lastHitText && (
               <span style={{ color: '#86efac' }}>{lastHitText}</span>
             )}
           </div>
         </div>
       </div>
+      {queryConfig.challenge === 'dailyStreak' && phase === 'results' && (
+        <div style={{ position: 'absolute', inset: 0, zIndex: 20, display: 'grid', placeItems: 'center', background: 'rgba(5,7,12,.72)' }}>
+          <button
+            onClick={() => window.location.assign('/mining')}
+            style={{ padding: '12px 18px', borderRadius: 12, background: '#facc15', color: '#111827', fontWeight: 900 }}
+          >
+            Return to Mining {challengeReward ? `· +${challengeReward} TPC` : ''}
+          </button>
+        </div>
+      )}
 
       {viewMode === 'range' && (
         <div

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -4,10 +4,8 @@ import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LoginOptions from '../components/LoginOptions.jsx';
 import { getTelegramId, getTelegramPhotoUrl, getPlayerId } from '../utils/telegram.js';
 import { FaCircle } from 'react-icons/fa';
-import DailyCheckIn from '../components/DailyCheckIn.jsx';
 import SpinGame from '../components/SpinGame.jsx';
 import MiningCard from '../components/MiningCard.tsx';
-import LuckyNumber from '../components/LuckyNumber.jsx';
 import RouletteMini from '../components/RouletteMini.jsx';
 import MiningTransactionsCard from '../components/MiningTransactionsCard.jsx';
 import {
@@ -199,9 +197,19 @@ export default function Mining() {
           <p className="text-xs text-subtext">
             These actions improve your consistency and help you compound mining rewards every day.
           </p>
-          <DailyCheckIn />
+          <Link
+            to="/games/shootingrange?challenge=dailyStreak"
+            className="block rounded-xl border border-yellow-400/40 bg-yellow-500/10 px-4 py-3 text-sm font-semibold text-yellow-100"
+          >
+            Daily Streak Challenge · Open full screen Shooting Range (5 shots)
+          </Link>
           <SpinGame />
-          <LuckyNumber />
+          <Link
+            to="/games/freekickarena?challenge=luckyCard"
+            className="block rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-sm font-semibold text-emerald-100"
+          >
+            Lucky Card Challenge · Open full screen Free Kick (5 kicks)
+          </Link>
           <RouletteMini />
         </section>
 


### PR DESCRIPTION
### Motivation
- The Mining page should route players into the existing full-screen games for Daily Streak and Lucky Card flows instead of embedding simplified mini-components, so users play the real game experience and then return to Mining. 
- Reward assignment must be done after the full-game run and recorded in the mining transaction feed to preserve reporting and grouping semantics.

### Description
- Replaced inline Daily Check-In / Lucky Card UI on the Mining page with links that open the actual games in challenge mode: `?challenge=dailyStreak` launches the Shooting Range and `?challenge=luckyCard` launches Free Kick Arena. 
- Added challenge-mode handling to Shooting Range: it reads `challenge` from query params, computes a bounded payout from the player’s score, records a `daily` transaction via `addTransaction`, and shows a return-to-Mining CTA on results. 
- Added challenge-mode handling to Free Kick Arena: it reads `challenge` from query params, optionally ends after the user’s 5 kicks (skipping the AI half in `luckyCard` mode), computes a bounded payout from user goals, records a `lucky` transaction via `addTransaction`, and shows a return-to-Mining CTA. 
- Removed the Shooting Range catalog entry so the large Shooting Range no longer appears in the games lobby, and updated build metadata generated by the build script.

### Testing
- Ran a production build with `cd webapp && npm run build`, which completed successfully and produced updated chunks and build metadata; Vite emitted non-blocking chunk-size warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e7ac2a3f483298c5877ae4c467dc9)