### PR TITLE
Align Snooker Royal cue stick/power slider logic with provided implementation

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -14507,6 +14507,8 @@ const showRuleToast = useCallback((message) => {
   }, 3000);
 }, []);
 const powerRef = useRef(hud.power);
+const shotPowerRef = useRef(hud.power);
+const draggingSliderRef = useRef(false);
   const applyPower = useCallback((nextPower) => {
     const clampedPower = THREE.MathUtils.clamp(nextPower ?? 0, 0, 1);
     powerRef.current = clampedPower;
@@ -14517,6 +14519,9 @@ const powerRef = useRef(hud.power);
   }, [inHandPlacementMode]);
   useEffect(() => {
     powerRef.current = hud.power;
+    if (!draggingSliderRef.current) {
+      shotPowerRef.current = hud.power;
+    }
   }, [hud.power]);
   const hudRef = useRef(hud);
   useEffect(() => {
@@ -27615,15 +27620,32 @@ const powerRef = useRef(hud.power);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
-      onChange: (v) => applyPower(v / 100),
       onStart: () => {
+        draggingSliderRef.current = true;
         captureCueStickAnchor();
       },
+      onChange: (v) => {
+        const normalized = THREE.MathUtils.clamp((v ?? 0) / 100, 0, 1);
+        applyPower(normalized);
+        if (draggingSliderRef.current) {
+          shotPowerRef.current = normalized;
+        }
+      },
       onCommit: () => {
+        const committedPower = THREE.MathUtils.clamp(
+          shotPowerRef.current ?? powerRef.current ?? 0,
+          0,
+          1
+        );
+        shotPowerRef.current = committedPower;
+        powerRef.current = committedPower;
+        draggingSliderRef.current = false;
         fireRef.current?.();
         requestAnimationFrame(() => {
+          slider.animateToMin?.({ duration: 180 });
           slider.set(slider.min, { animate: true });
           applyPower(0);
+          shotPowerRef.current = 0;
         });
       }
     });
@@ -27640,6 +27662,8 @@ const powerRef = useRef(hud.power);
     if (slider) {
       slider.set(slider.min, { animate: true });
     }
+    draggingSliderRef.current = false;
+    shotPowerRef.current = 0;
     applyPower(0);
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;


### PR DESCRIPTION
### Motivation
- Make the cue stick and power-slider interaction in `SnookerRoyal.jsx` match the control flow used in `SnookerRoyalProvided.jsx` so drag/commit behavior is consistent while preserving the existing visual design and power tuning.

### Description
- Added `shotPowerRef` and `draggingSliderRef` to track the committed shot power and whether the slider is being dragged. 
- Updated the `hud.power` sync so `shotPowerRef` follows `hud.power` only when the slider is not being dragged. 
- Rewrote the slider callbacks so `onStart` marks dragging and captures the cue anchor, `onChange` normalizes and applies live power while updating `shotPowerRef` during drag, and `onCommit` computes the committed power, sets `powerRef`/`shotPowerRef`, calls `fireRef.current()`, and animates the slider back to minimum. 
- Cleared dragging and committed-power refs when the slider is removed or shot/turn state changes to ensure consistent resets. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e8588fb308329a94d8fa57da25d51)