### PR TITLE
Polish Mining cards; add Free Kick target HUD; randomize Shooting Range weapon selection

### DIFF
--- a/webapp/src/pages/Games/FreeKickArena.tsx
+++ b/webapp/src/pages/Games/FreeKickArena.tsx
@@ -212,6 +212,14 @@ const TEAM_KITS: Record<TeamKey, { primary: number; secondary: number; shorts: n
   blue: { primary: 0x1d69ff, secondary: 0xffffff, shorts: 0x102a6b, shoes: 0xffffff, name: 'Blue' },
   red: { primary: 0xdc2626, secondary: 0xfacc15, shorts: 0x7f1d1d, shoes: 0x111827, name: 'Red' }
 };
+const LUCKY_CARD_TARGETS = [
+  { label: 'TOP', tpc: 220, left: '16%', top: '24%' },
+  { label: 'TOP', tpc: 180, left: '84%', top: '24%' },
+  { label: 'MID', tpc: 150, left: '50%', top: '30%' },
+  { label: 'MID', tpc: 120, left: '28%', top: '42%' },
+  { label: 'MID', tpc: 90, left: '72%', top: '42%' },
+  { label: 'LOW', tpc: 70, left: '50%', top: '52%' }
+] as const;
 const POLYHAVEN_TEXTURES = {
   // Poly Haven CC0 texture files used as lightweight 1K maps for uniforms/shoes.
   fabricBlue: 'https://dl.polyhaven.org/file/ph-assets/Textures/png/1k/terlenka/terlenka_diff_1k.png',
@@ -3897,6 +3905,39 @@ export default function FreeKickGame() {
           }}
         />
       </div>
+      {challengeMode === 'luckyCard' && hud.phase !== 'finished' && (
+        <div style={{ position: 'fixed', inset: 0, pointerEvents: 'none' }}>
+          {LUCKY_CARD_TARGETS.map((target) => (
+            <div
+              key={`${target.left}-${target.top}`}
+              style={{
+                position: 'absolute',
+                left: target.left,
+                top: target.top,
+                transform: 'translate(-50%,-50%)',
+                width: 56,
+                height: 56,
+                borderRadius: 999,
+                border: '2px solid rgba(253,224,71,.95)',
+                background: 'radial-gradient(circle at 35% 35%, rgba(254,249,195,.9), rgba(245,158,11,.36))',
+                boxShadow: '0 0 20px rgba(251,191,36,.55)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#111827',
+                fontWeight: 900,
+                fontSize: 10,
+                textAlign: 'center',
+                lineHeight: 1.1
+              }}
+            >
+              {target.label}
+              <br />
+              {target.tpc} TPC
+            </div>
+          ))}
+        </div>
+      )}
       <div
         style={{
           position: 'fixed',
@@ -3952,7 +3993,9 @@ export default function FreeKickGame() {
           textShadow: '0 2px 8px #000'
         }}
       >
-        User takes 5 shots first, then AI takes 5. Swipe on the pitch in the exact visual shot direction and release to shoot. During AI shots, the camera starts on the goalkeeper face looking at the ball; swipe in the same screen direction to dive.
+        {challengeMode === 'luckyCard'
+          ? 'Lucky Card mode: you take only 5 shots total. Hit the goal targets shown on-screen; each target shows its own TPC value.'
+          : 'User takes 5 shots first, then AI takes 5. Swipe on the pitch in the exact visual shot direction and release to shoot. During AI shots, the camera starts on the goalkeeper face looking at the ball; swipe in the same screen direction to dive.'}
       </div>
 
       <div

--- a/webapp/src/pages/Games/ShootingRange.tsx
+++ b/webapp/src/pages/Games/ShootingRange.tsx
@@ -3410,44 +3410,29 @@ export default function ShootingRange() {
       startPickPhase();
     }
 
+    function pruneTableForWeapon(weaponIndex: number) {
+      tableWeaponsRef.current.forEach((tw) => {
+        if (tw.weaponIndex === weaponIndex) return;
+        scene.remove(tw.root);
+        disposeObject(tw.root);
+      });
+      tableWeaponsRef.current = tableWeaponsRef.current.filter(
+        (tw) => tw.weaponIndex === weaponIndex
+      );
+      pickTargetsRef.current = [];
+    }
+
     function startPickPhase() {
-      setPhaseSafe('pick');
-      setViewMode('tables');
-      setStatus('Pick a weapon from your lane table');
-      setPickTimer(PICK_SECONDS);
-
-      let left = PICK_SECONDS;
-
-      if (pickInterval) window.clearInterval(pickInterval);
-
-      pickInterval = window.setInterval(() => {
-        left -= 1;
-        setPickTimer(left);
-
-        if (left > 0) {
-          setStatus(`Pick a weapon from your lane table · ${left}s`);
-        } else {
-          if (pickInterval) window.clearInterval(pickInterval);
-          pickInterval = null;
-          startShootPhase();
-        }
-      }, 1000);
-
-      lanesRef.current
-        .filter((lane) => lane?.controller === 'AI')
-        .forEach((lane, idx) => {
-          window.setTimeout(
-            () => {
-              if (disposed || phaseRef.current !== 'pick') return;
-              const aiPick = pickAiWeaponIndex(
-                idx,
-                tableWeaponIndicesForLane(lane.laneIndex)
-              );
-              setHeldWeapon(lane.laneIndex, aiPick, true);
-            },
-            850 + idx * 650
-          );
-        });
+      const forcedWeapon = Math.floor(Math.random() * WEAPONS.length);
+      setHeldWeapon(userLaneRef.current, forcedWeapon, true);
+      pruneTableForWeapon(forcedWeapon);
+      setPhaseSafe('shoot');
+      setViewMode('range');
+      setStatus(`Random weapon ready: ${WEAPONS[forcedWeapon].name}`);
+      setPickTimer(0);
+      window.setTimeout(() => {
+        if (!disposed) startShootPhase();
+      }, 400);
     }
 
     function startShootPhase() {

--- a/webapp/src/pages/Mining.jsx
+++ b/webapp/src/pages/Mining.jsx
@@ -199,14 +199,14 @@ export default function Mining() {
           </p>
           <Link
             to="/games/shootingrange?challenge=dailyStreak"
-            className="block rounded-xl border border-yellow-400/40 bg-yellow-500/10 px-4 py-3 text-sm font-semibold text-yellow-100"
+            className="block rounded-2xl border border-yellow-300/70 bg-gradient-to-br from-yellow-400/30 via-amber-300/15 to-orange-500/20 px-4 py-3 text-sm font-semibold text-yellow-50 shadow-[0_0_0_1px_rgba(253,224,71,.24),0_14px_30px_rgba(245,158,11,.24)]"
           >
             Daily Streak Challenge · Open full screen Shooting Range (5 shots)
           </Link>
           <SpinGame />
           <Link
             to="/games/freekickarena?challenge=luckyCard"
-            className="block rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-sm font-semibold text-emerald-100"
+            className="block rounded-2xl border border-emerald-300/70 bg-gradient-to-br from-emerald-400/30 via-teal-400/15 to-cyan-500/20 px-4 py-3 text-sm font-semibold text-emerald-50 shadow-[0_0_0_1px_rgba(52,211,153,.22),0_14px_30px_rgba(16,185,129,.24)]"
           >
             Lucky Card Challenge · Open full screen Free Kick (5 kicks)
           </Link>


### PR DESCRIPTION
### Motivation
- Improve visual prominence of Mining mini-game entry cards so challenges stand out on mobile portrait screens. 
- Expose explicit goal-target indicators and TPC values for the Free Kick Lucky Card flow so players know where to aim and what each target awards. 
- Simplify Shooting Range onboarding by auto-selecting a single random weapon and hiding the rest to reduce choice friction and match the requested behavior.

### Description
- Updated Mining UI cards in `webapp/src/pages/Mining.jsx` to use rounded-2xl, gradient backgrounds, stronger borders and shadows to create a more stylish framed appearance for the Shooting Range and Free Kick challenge links. 
- Added a `LUCKY_CARD_TARGETS` constant and an on-screen HUD overlay in `webapp/src/pages/Games/FreeKickArena.tsx` that renders visible target signs with label and `TPC` values and updated the on-screen instructions to emphasise the 5-shot user-only Lucky Card mode. 
- Changed Shooting Range pick flow in `webapp/src/pages/Games/ShootingRange.tsx` to pick a random weapon at the start, call a new `pruneTableForWeapon` helper that removes and disposes other table weapon nodes from the scene, set the held weapon for the user, and move directly into the shoot phase (removes the timed pick UI). 
- Performed safe disposal of removed Three.js objects when pruning table items to avoid leaking geometries/materials.

### Testing
- Built the webapp production bundle successfully with `cd webapp && npm run build` (Vite production build completed). 
- No automated unit tests were added or run as part of this change; the build output containing `FreeKickArena` and `ShootingRange` bundles was generated and reviewed for errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e8a13441083298d61378ef39f8d5f)