### PR TITLE
Adjust Domino Royal character & chair sizing for portrait/mobile

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -977,13 +977,13 @@ const COLUMN_RADIUS_BOTTOM = 0.26 * MODEL_SCALE;
 const BASE_RADIUS = 0.72 * MODEL_SCALE;
 const FOOT_RING_RADIUS = 0.52 * MODEL_SCALE;
 const FOOT_RING_TUBE = 0.04 * MODEL_SCALE;
-const CHAIR_GAP = 0.03 * MODEL_SCALE; // move chairs inward, closer to the table for portrait framing
+const CHAIR_GAP = -0.02 * MODEL_SCALE; // pull chairs inward so players sit closer to the table in portrait
 const CHAIR_OUTWARD_OFFSET = 0;
 const CHAIR_RADIUS =
   TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
-const CHAIR_GLOBAL_PUSHBACK = 0.28 * MODEL_SCALE;
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.36 * MODEL_SCALE;
-const CHAIR_VISUAL_SCALE = 0.82;
+const CHAIR_GLOBAL_PUSHBACK = 0.2 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.26 * MODEL_SCALE;
+const CHAIR_VISUAL_SCALE = 0.76;
 const CHAIR_VERTICAL_DROP = 0.035 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = LEGACY_BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
@@ -999,7 +999,7 @@ const CHAIR_SEAT_ANGLES = Object.freeze([
   THREE.MathUtils.degToRad(180)
 ]);
 const SIDE_TABLE_RADIUS_DELTA = TABLE_RADIUS * (1 - TABLE_LEFT_RIGHT_SHRINK_FACTOR);
-const SIDE_PLAYER_TABLE_PULL_IN = 0.42 * MODEL_SCALE;
+const SIDE_PLAYER_TABLE_PULL_IN = 0.56 * MODEL_SCALE;
 const CHAIR_SEAT_RADII = Object.freeze([
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK + SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK,
   CHAIR_RADIUS -
@@ -7988,7 +7988,7 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.95;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 3.3;
 const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.95;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-18-pass-pick-hand-polish-v45';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-21-character-chair-layout-v46';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Improve visual readability on phones in portrait by making human characters appear larger and nearer to the table. 
- Bring player avatars/chairs (left/right and other seats) inward toward the table so hands/dominoes are closer to the play area on narrow screens. 
- Slightly reduce chair size to keep overall composition balanced while increasing character prominence.

### Description
- Tweak seat/character layout constants in `webapp/public/domino-royal-game.js`: updated `CHAIR_GAP`, `CHAIR_GLOBAL_PUSHBACK`, `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK`, `CHAIR_VISUAL_SCALE`, `SIDE_PLAYER_TABLE_PULL_IN`, and `DOMINO_CHARACTER_PROPORTION_SCALE` to pull chairs inward, shrink chairs, and enlarge seated characters. 
- Bumped the Domino Royal script version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-05-21-character-chair-layout-v46` so clients load the revised layout parameters. 
- Changes preserve existing layout math and only adjust tuning constants that control chair radii, pushback, visual scale, and character proportion.

### Testing
- Ran the focused unit test `npm test -- test/dominoRoyalCharacterScale.test.js` and it passed (`PASS test/dominoRoyalCharacterScale.test.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e885620e48329a03fdc7d17cb2e0a)