### PR TITLE
Add Showood 7ft GLTF table model option for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -2,6 +2,36 @@ export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
+    id: 'showood-seven-foot',
+    label: 'Showood 7ft GLTF',
+    description:
+      'Loads the seven-foot Showood GLTF table and remaps Pool Royale cloth/wood/chrome menu finishes onto mapped parts. Falls back to the native procedural table if GLTF loading fails.',
+    tableSizeId: '7ft',
+    icon: '🪵',
+    kind: 'gltf',
+    assetUrl:
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    fallbackAssetUrl:
+      'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    fitStrategy: 'showoodPreview',
+    fitReference: 'upperTabletop',
+    fitScale: 1,
+    fitFootprintScale: 1,
+    fitHeightScale: 1,
+    usePoolRoyaleFinish: true,
+    useOriginalLayoutSurfaces: true,
+    preserveOriginalSurfaceRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
+    clothRepeatScale: 1,
+    playfieldVisualLift: 0,
+    matchNativeUpperComponentHeight: true,
+    matchNativeHeight: false,
+    preserveOriginalFootprintAspect: true,
+    lowerBaseHeightScale: 1,
+    legLengthScale: 1,
+    verticalOffset: 0
+  },
+  {
     id: 'procedural-legacy',
     label: 'Pool Royale Legacy Procedural',
     description:


### PR DESCRIPTION
### Motivation
- Provide an option to use the seven-foot Showood GLTF table as a visual replacement in Pool Royale while keeping existing gameplay and physics unchanged.
- Allow existing Pool Royale menu material controls (cloth, cushion, wood, chrome/trim, pockets) to remap onto the imported GLTF surfaces so users can keep the same customization flow.
- Ensure a robust fallback to the native procedural table when the GLTF or its textures fail to load so visual failures do not impact play.

### Description
- Added a new table model entry `showood-seven-foot` in `webapp/src/config/poolRoyaleTableModels.js` that points to the primary jsDelivr GLB and a raw GitHub fallback GLB and marks the model `kind: 'gltf'`.
- Configured the new model to enable Pool Royale finish remapping via flags like `usePoolRoyaleFinish`, `preserveOriginalSurfaceRoles`, and `usePoolRoyaleFinishRoles` so menu options map to `cloth`, `cushion`, `wood`, `trim`, and `pocket` parts.
- Tuned fitting properties for the model (`fitStrategy`, `fitReference`, `fitScale`, `preserveOriginalFootprintAspect`, etc.) so the GLTF integrates with the existing table-fitting pipeline and relies on the existing external-table mount/load functions and fallback logic.

### Testing
- Ran a basic module import sanity check with `node -e "import('./webapp/src/config/poolRoyaleTableModels.js')..."` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea335cd648329bb2ee91145bb08c1)