### PR TITLE
Add Showood 7ft GLTF table options and enable prefix matching for Showood models

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -2,24 +2,69 @@ export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
-    id: 'procedural-legacy',
-    label: 'Pool Royale Legacy Procedural',
+    id: 'showood-seven-foot-procedural',
+    label: 'Showood 7ft (Procedural Materials)',
     description:
-      'Original fully procedural Pool Royale table with native chrome plates, pocket field, cushions, branding plate, diamond markings, and procedural pocket jaws.',
+      'Uses the Showood 7ft GLTF table shape and remaps Pool Royale procedural material selections onto the mapped table parts. If GLTF loading fails, fallback stays procedural.',
     tableSizeId: '7ft',
-    baseId: 'classicCylinders',
-    icon: '🎱',
-    kind: 'procedural',
+    icon: '🪵',
+    kind: 'gltf',
+    assetUrl:
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    fallbackAssetUrl:
+      'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    fitStrategy: 'showoodPreview',
+    fitReference: 'upperTabletop',
     fitScale: 1,
     fitFootprintScale: 1,
     fitHeightScale: 1,
-    usePoolRoyaleFinish: true
+    usePoolRoyaleFinish: true,
+    useOriginalLayoutSurfaces: true,
+    preserveOriginalSurfaceRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
+    clothRepeatScale: 1,
+    playfieldVisualLift: 0,
+    matchNativeUpperComponentHeight: true,
+    matchNativeHeight: false,
+    preserveOriginalFootprintAspect: true,
+    lowerBaseHeightScale: 1,
+    legLengthScale: 1,
+    verticalOffset: 0
+  },
+  {
+    id: 'showood-seven-foot-gltf',
+    label: 'Showood 7ft (Original GLTF Materials)',
+    description:
+      'Uses the Showood 7ft GLTF table with original embedded GLTF textures/materials. If GLTF loading fails, fallback stays procedural.',
+    tableSizeId: '7ft',
+    icon: '🧩',
+    kind: 'gltf',
+    assetUrl:
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    fallbackAssetUrl:
+      'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    fitStrategy: 'showoodPreview',
+    fitReference: 'upperTabletop',
+    fitScale: 1,
+    fitFootprintScale: 1,
+    fitHeightScale: 1,
+    usePoolRoyaleFinish: false,
+    useOriginalLayoutSurfaces: true,
+    preserveOriginalSurfaceRoles: ['cloth', 'cushion', 'wood', 'trim', 'pocket'],
+    clothRepeatScale: 1,
+    playfieldVisualLift: 0,
+    matchNativeUpperComponentHeight: true,
+    matchNativeHeight: false,
+    preserveOriginalFootprintAspect: true,
+    lowerBaseHeightScale: 1,
+    legLengthScale: 1,
+    verticalOffset: 0
   }
 ]);
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'procedural-legacy'
+    (option) => option.id === 'showood-seven-foot-procedural'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
 
 export function resolvePoolRoyaleTableModel(modelId) {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13124,7 +13124,7 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
 }
 
 function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInfo = null) {
-  if (!model || tableModel?.id !== 'showood-seven-foot' || !finishInfo) return;
+  if (!model || !tableModel?.id?.startsWith('showood-seven-foot') || !finishInfo) return;
   model.updateMatrixWorld(true);
   const tableBox = new THREE.Box3().setFromObject(model);
   if (tableBox.isEmpty()) return;
@@ -13182,7 +13182,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
 
 function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tableModel = null, child = null) {
   if (!material || !finishInfo) return material;
-  if (tableModel?.id === 'showood-seven-foot') {
+  if (tableModel?.id?.startsWith('showood-seven-foot')) {
     return applyShowoodStyleToExternalMaterial(material, role, tableModel, finishInfo);
   }
   const canonicalRole = role === 'pocketCup' ? 'pocket' :
@@ -13488,7 +13488,7 @@ function stretchPoolRoyaleExternalLowerBase(model, tableModel, dims) {
 
 
 function adjustPoolRoyaleExternalShowoodBaseProportions(model, tableModel) {
-  if (!model || tableModel?.id !== 'showood-seven-foot') return;
+  if (!model || !tableModel?.id?.startsWith('showood-seven-foot')) return;
   const baseScale = Number(tableModel?.lowerBaseHeightScale);
   const legScale = Number(tableModel?.legLengthScale);
   const shouldScaleBase = Number.isFinite(baseScale) && baseScale > MICRO_EPS && Math.abs(baseScale - 1) > MICRO_EPS;
@@ -13645,7 +13645,7 @@ function mountPoolRoyaleExternalTableModel({
       remapPoolRoyaleShowoodExternalParts(model, tableModel, finishInfo);
       externalRoot.clear();
       externalRoot.add(model);
-      if (tableModel.id === 'showood-seven-foot') {
+      if (tableModel.id?.startsWith('showood-seven-foot')) {
         const showOriginalBase = table.userData.showoodUsesOriginalBase !== false;
         model.traverse((child) => {
           if (!child?.isMesh) return;
@@ -14120,7 +14120,7 @@ function mountPoolRoyaleExternalTableModel({
   const applyBaseVariant = (variant) => {
     const variantId = resolveBaseVariantId(variant);
     const isShowoodExternalTable =
-      usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'showood-seven-foot';
+      usesExternalTableModel && resolvedTableOptions?.tableModel?.id?.startsWith('showood-seven-foot');
     const usesShowoodOriginalBase =
       isShowoodExternalTable && variantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID;
 
@@ -14168,7 +14168,7 @@ function mountPoolRoyaleExternalTableModel({
   };
 
   table.userData.applyExternalTableFallbackBase = () => {
-    if (usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'showood-seven-foot') {
+    if (usesExternalTableModel && resolvedTableOptions?.tableModel?.id?.startsWith('showood-seven-foot')) {
       applyBaseVariant(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
     }
   };
@@ -14417,9 +14417,9 @@ function mountPoolRoyaleExternalTableModel({
         !visible &&
         (
           (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
-          (externalTableModelForMount?.id === 'showood-seven-foot' && object.userData?.showoodGeneratedPocketSupport) ||
-          (externalTableModelForMount?.id === 'showood-seven-foot' && object.userData?.showoodGeneratedClothPocketSleeve) ||
-          (externalTableModelForMount?.id === 'showood-seven-foot' && !table.userData.showoodUsesOriginalBase && object.userData?.__basePart) ||
+          (externalTableModelForMount?.id?.startsWith('showood-seven-foot') && object.userData?.showoodGeneratedPocketSupport) ||
+          (externalTableModelForMount?.id?.startsWith('showood-seven-foot') && object.userData?.showoodGeneratedClothPocketSleeve) ||
+          (externalTableModelForMount?.id?.startsWith('showood-seven-foot') && !table.userData.showoodUsesOriginalBase && object.userData?.__basePart) ||
           (object.userData?.isChromePlate && forceGeneratedChrome)
         )
       ) {


### PR DESCRIPTION
### Motivation
- Introduce support for a Showood 7ft external table GLTF with two variants: one that remaps Pool Royale procedural finishes onto the GLTF parts and one that uses the GLTF's original materials. 
- Make runtime logic generic to handle multiple Showood variants by matching a shared id prefix instead of hardcoding a single id. 

### Description
- Replaced the single legacy procedural option with two new table model options: `showood-seven-foot-procedural` (remapped procedural finishes) and `showood-seven-foot-gltf` (original GLTF materials), including `assetUrl`, `fallbackAssetUrl`, `fitStrategy`, and multiple layout/finish configuration fields. 
- Updated the default table model id to `showood-seven-foot-procedural`. 
- Reworked multiple runtime checks that previously compared `tableModel.id === 'showood-seven-foot'` to use `tableModel.id?.startsWith('showood-seven-foot')` so both new variants are handled uniformly in remapping, finishing, proportion adjustments, visibility, and fallback logic. 
- Preserved existing procedural-fallback behavior and added flags to control use of Pool Royale finishes, surface-role preservation, footprint/aspect matching, and base/leg scaling. 

### Testing
- Ran the project's automated test suite with `yarn test`, and the tests completed successfully. 
- Performed a production build check with `yarn build`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea335cd648329bb2ee91145bb08c1)