### PR TITLE
Tune Snooker camera proximity and reduce cue-ball spin deflection

### DIFF
--- a/Assets/Scripts/Gameplay/CueStrikePhysics.cs
+++ b/Assets/Scripts/Gameplay/CueStrikePhysics.cs
@@ -23,9 +23,11 @@ namespace Aiming
         [Tooltip("Reverse impulse for back spin (draw).")]
         public float backSpinReverseImpulseScale = 0.10f;
         [Tooltip("Torque multiplier for side spin (left/right english).")]
-        public float sideSpinTorqueScale = 0.05f;
+        public float sideSpinTorqueScale = 0.02f;
         [Tooltip("Torque multiplier for top/back spin.")]
-        public float verticalSpinTorqueScale = 0.06f;
+        public float verticalSpinTorqueScale = 0.025f;
+        [Tooltip("Reduces cue-ball path deflection caused by off-center hit/spin while keeping visible spin.")]
+        [Range(0f, 1f)] public float spinDeflectionReduction = 0.8f;
 
         public void Apply(Rigidbody cueBallBody, Vector3 strikeDirection, float impulseMagnitude, Vector2 spinInput, float ballRadius)
         {
@@ -46,7 +48,8 @@ namespace Aiming
 
             Vector2 clampedSpin = Vector2.ClampMagnitude(spinInput, maxSpinInput);
             Vector3 right = Vector3.Cross(Vector3.up, planarDirection).normalized;
-            Vector3 contactOffset = ((right * clampedSpin.x) + (Vector3.up * clampedSpin.y)) * (ballRadius * contactRadiusFactor);
+            float deflectionCarry = 1f - Mathf.Clamp01(spinDeflectionReduction);
+            Vector3 contactOffset = ((right * clampedSpin.x) + (Vector3.up * clampedSpin.y)) * (ballRadius * contactRadiusFactor * deflectionCarry);
             Vector3 contactPoint = cueBallBody.worldCenterOfMass + contactOffset;
 
             cueBallBody.AddForceAtPosition(planarDirection * impulseMagnitude, contactPoint, ForceMode.Impulse);
@@ -64,8 +67,8 @@ namespace Aiming
                     straightTopSpinBoost = clampedSpin.y * straightTopSpinFollowBoost * straightFactor;
                 }
 
-                float follow = Mathf.Max(0f, clampedSpin.y) * topSpinForwardImpulseScale + straightTopSpinBoost;
-                float draw = Mathf.Max(0f, -clampedSpin.y) * backSpinReverseImpulseScale;
+                float follow = (Mathf.Max(0f, clampedSpin.y) * topSpinForwardImpulseScale + straightTopSpinBoost) * deflectionCarry;
+                float draw = (Mathf.Max(0f, -clampedSpin.y) * backSpinReverseImpulseScale) * deflectionCarry;
                 float spinLinearImpulse = (follow - draw) * impulseMagnitude;
                 if (Mathf.Abs(spinLinearImpulse) > Mathf.Epsilon)
                 {

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -176,7 +176,7 @@ public class CueCamera : MonoBehaviour
     public float broadcastHeightPadding = 0.08f;
     // Extra inward push for the short-rail broadcast camera so it sits a bit
     // closer to the table action.
-    public float broadcastDistanceInset = 0.08f;
+    public float broadcastDistanceInset = 0.12f;
     // Additional downward look offset to tilt the broadcast camera a little more
     // toward the cloth.
     public float broadcastLookDownOffset = 0.06f;
@@ -199,7 +199,7 @@ public class CueCamera : MonoBehaviour
     // Height offset above the table focus, captured on start.
     public float standingCameraHeight = 0.48f;
     // Pull the standing camera inward so the framing matches the Pool Royale view.
-    public float standingCameraDistanceInset = 0.12f;
+    public float standingCameraDistanceInset = 0.16f;
     // Additional height offset applied after caching the standing camera pose.
     public float standingCameraHeightOffset = -0.06f;
 


### PR DESCRIPTION
### Motivation

- Improve visual framing on portrait-mobile by bringing the broadcast/standing camera slightly closer to the table so the action appears nearer/larger on screen.
- Reduce unexpected cue-ball path deflection from off-center hits and spin so the ball and target trajectories more closely follow the on-screen aim/target lines.

### Description

- Increased `broadcastDistanceInset` from `0.08` to `0.12` and `standingCameraDistanceInset` from `0.12` to `0.16` in `billiards.Unity/CueCamera.cs` to pull broadcast and standing cameras slightly inward.
- Reduced spin-driven torque by lowering `sideSpinTorqueScale` from `0.05` to `0.02` and `verticalSpinTorqueScale` from `0.06` to `0.025` in `Assets/Scripts/Gameplay/CueStrikePhysics.cs`.
- Added new parameter `spinDeflectionReduction` (default `0.8`) and applied a `deflectionCarry` factor to scale the contact offset and top/draw follow-through calculations so off-center hits retain visible spin but produce less linear path bend.

### Testing

- Performed local sanity checks by inspecting diffs and file contents with `git diff` and file listings, which confirmed the intended edits to `billiards.Unity/CueCamera.cs` and `Assets/Scripts/Gameplay/CueStrikePhysics.cs`.
- No project unit/CI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ec1880fac8329b6112b91f6b4c818)