### PR TITLE
Pool Royale: add Showood GLB table model and robust GLTF loader; add lint script

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "lint": "eslint --no-ignore --no-warn-ignored",
     "build": "node scripts/write-build-metadata.mjs && node scripts/run-vite-build.mjs",
     "preview": "vite preview",
     "generate:native-assets": "node scripts/generate-native-assets.mjs",

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,17 +1,41 @@
-export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
 const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'classic-procedural',
-    label: 'Classic Procedural',
+    label: 'Classic Showood 7 ft',
     description:
-      'Original Pool Royale procedural table with dynamic finish materials.',
+      'Showood seven-foot table mapped to the original Pool Royale playfield size and height, using original-layout surface remapping.',
     tableSizeId: '7ft',
     icon: '🧩',
-    kind: 'procedural'
+    kind: 'gltf',
+    baseId: 'showoodOriginal',
+    assetUrl:
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
+    fitScale: 1,
+    fitFootprintScale: 1.105,
+    fitHeightScale: 1,
+    lowerBaseHeightScale: 1.38,
+    legLengthScale: 2.05,
+    clothRepeatScale: 7.5,
+    fitStrategy: 'exact',
+    fitReference: 'upperTabletop',
+    matchNativeHeight: true,
+    matchNativeUpperComponentHeight: true,
+    preserveOriginalFootprintAspect: true,
+    useOriginalLayoutSurfaces: true,
+    usePoolRoyaleFinish: true,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
+    preserveOriginalSurfaceRoles: [],
+    tintOriginalTrimGold: true,
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
+    blackMaterialSurfaceNames: [],
+    forceGeneratedChromePlates: false,
+    hideSurfaceRoles: []
   },
   {
     id: 'showood-seven-foot',
@@ -46,20 +70,20 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }
-]);
+])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
     (option) => option.id === 'showood-seven-foot'
-  )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+  )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
-export function resolvePoolRoyaleTableModel(modelId) {
-  const key = typeof modelId === 'string' ? modelId.trim() : '';
+export function resolvePoolRoyaleTableModel (modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : ''
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
       (option) => option.id === DEFAULT_POOL_ROYALE_TABLE_MODEL_ID
     ) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  )
 }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13494,21 +13494,51 @@ async function loadPoolRoyaleExternalTableTemplate(tableModel, renderer = null) 
   }
   const promise = (async () => {
     const loader = createConfiguredGLTFLoader(renderer);
-    let lastError = null;
     const urls = [tableModel.assetUrl, tableModel.fallbackAssetUrl].filter(Boolean);
-    for (const url of urls) {
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const gltf = await loader.loadAsync(url);
-        const scene = gltf?.scene || gltf?.scenes?.[0];
-        if (!scene) throw new Error(`Missing GLTF scene for ${tableModel.id}`);
-        poolRoyaleExternalTableTemplates.set(tableModel.id, scene);
-        return scene;
-      } catch (error) {
-        lastError = error;
-      }
+    if (!urls.length) {
+      throw new Error(`Missing table model URLs for ${tableModel.id}`);
     }
-    throw lastError || new Error(`Failed to load Pool Royale table model: ${tableModel.id}`);
+
+    const LOAD_TIMEOUT_MS = 9000;
+    const withTimeout = (loadPromise, url) =>
+      new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          reject(new Error(`Timed out after ${LOAD_TIMEOUT_MS}ms while loading ${url}`));
+        }, LOAD_TIMEOUT_MS);
+        loadPromise
+          .then((value) => {
+            clearTimeout(timeoutId);
+            resolve(value);
+          })
+          .catch((error) => {
+            clearTimeout(timeoutId);
+            reject(error);
+          });
+      });
+
+    const loaders = urls.map((url) =>
+      withTimeout(loader.loadAsync(url), url).then((gltf) => ({ gltf, url }))
+    );
+    let result = null;
+    try {
+      result = await Promise.any(loaders);
+    } catch (error) {
+      const aggregate = error instanceof AggregateError ? error.errors : [error];
+      const messages = aggregate
+        .map((entry) => (entry instanceof Error ? entry.message : String(entry)))
+        .filter(Boolean)
+        .join(' | ');
+      throw new Error(
+        `Failed to load Pool Royale table model: ${tableModel.id}${messages ? ` | ${messages}` : ''}`
+      );
+    }
+
+    const scene = result?.gltf?.scene || result?.gltf?.scenes?.[0];
+    if (!scene) {
+      throw new Error(`Missing GLTF scene for ${tableModel.id}`);
+    }
+    poolRoyaleExternalTableTemplates.set(tableModel.id, scene);
+    return scene;
   })();
   poolRoyaleExternalTablePromises.set(tableModel.id, promise);
   promise.catch(() => poolRoyaleExternalTablePromises.delete(tableModel.id));


### PR DESCRIPTION
### Motivation
- Add an explicit Showood 7 ft GLB-based table option and map the legacy procedural entry to the Showood model to better match original Pool Royale layout and finishes. 
- Make external GLTF loading more robust and faster by attempting parallel fetches with timeouts and clearer error reporting. 
- Expose a project `lint` script for consistent static analysis.

### Description
- Added a `lint` script to `webapp/package.json` as `eslint --no-ignore --no-warn-ignored`.
- Introduced a new/updated `classic-procedural` table option in `webapp/src/config/poolRoyaleTableModels.js` that is now configured as a GLB-based Showood seven-foot model and includes asset URLs, fit/scaling parameters, finish role mappings, and other model metadata.
- Kept the existing `showood-seven-foot` option and adjusted default resolution and formatting/whitespace for constants and the `resolvePoolRoyaleTableModel` function.
- Rewrote `loadPoolRoyaleExternalTableTemplate` in `webapp/src/pages/Games/PoolRoyale.jsx` to validate URLs, run parallel `loadAsync` calls wrapped with a `9000ms` timeout, use `Promise.any` to pick the first successful load, produce aggregated error messages on failure, and continue to cache templates and manage promise state.

### Testing
- Ran the webapp build with `npm run build` in the `webapp` package and the build completed successfully.
- Executed the project's automated test suite with `npm test` and all tests passed.
- Ran the new `lint` command with `npm run lint` against the webapp source and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ec2d8045883298973a2fa9c305322)