### PR TITLE
Pool Royale: restore all unlocked table-base options in customization

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15649,10 +15649,8 @@ function PoolRoyaleGame({
   );
   const availableTableBases = useMemo(
     () =>
-      POOL_ROYALE_BASE_VARIANTS.filter(
-        (variant) =>
-          variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID &&
-          isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
+      POOL_ROYALE_BASE_VARIANTS.filter((variant) =>
+        isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
       ),
     [poolInventory]
   );
@@ -15751,10 +15749,11 @@ function PoolRoyaleGame({
   );
   const activeTableBase = useMemo(
     () =>
+      availableTableBases.find((variant) => variant.id === tableBaseId) ??
       availableTableBases.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
       POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
       POOL_ROYALE_BASE_VARIANTS[0],
-    [availableTableBases]
+    [availableTableBases, tableBaseId]
   );
   const resolvedHdriResolution = useMemo(() => {
     return autoHdriResolutionFromGraphics;
@@ -15811,10 +15810,10 @@ function PoolRoyaleGame({
     if (!isPoolOptionUnlocked('tableFinish', tableFinishId, poolInventory)) {
       setTableFinishId(DEFAULT_TABLE_FINISH_ID);
     }
-    if (tableBaseId !== SHOWOOD_ORIGINAL_TABLE_BASE_ID) {
-      setTableBaseId(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
-    } else if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
-      setTableBaseId(DEFAULT_TABLE_BASE_ID);
+    if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
+      const fallbackBaseId =
+        availableTableBases[0]?.id || DEFAULT_PROCEDURAL_TABLE_BASE_ID || DEFAULT_TABLE_BASE_ID;
+      setTableBaseId(fallbackBaseId);
     }
     if (!isPoolOptionUnlocked('clothColor', clothColorId, poolInventory)) {
       setClothColorId(DEFAULT_CLOTH_COLOR_ID);
@@ -15843,7 +15842,8 @@ function PoolRoyaleGame({
     poolInventory,
     railMarkerColorId,
     tableBaseId,
-    tableFinishId
+    tableFinishId,
+    availableTableBases
   ]);
   const isTraining = playType === 'training';
   const hasCareerTaskId = Boolean(careerStageId);


### PR DESCRIPTION
### Motivation
- The UI was forcing the Pool Royale customization to only expose the Showood original base even when other procedural bases were unlocked, which hid inventory options like Classic Cylinders and Open Portal.
- Users should be able to select any unlocked table-base and preserve their current selection when it remains available.

### Description
- Allow all unlocked `POOL_ROYALE_BASE_VARIANTS` in the customization by changing `availableTableBases` filter to include every unlocked variant instead of forcing `showoodOriginal` only.
- Resolve `activeTableBase` to prefer the current `tableBaseId` first, then fall back to Showood original and global defaults, and add `tableBaseId` to the memo dependencies.
- Replace the previous forced reset to Showood Original with unlock-aware fallback logic that sets `tableBaseId` to the first unlocked base or default IDs when the selected base is not unlocked.
- Add `availableTableBases` to the effect dependency list so the fallback reacts when available bases change.

### Testing
- No automated test suite was executed for this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eca2b28d8832998202fe7978ca240)