### PR TITLE
Pool Royale: default to procedural table + Open Portal base

### DIFF
--- a/webapp/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/webapp/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -7,10 +7,10 @@
       "size": "20x20"
     },
     {
-      "filename": "app-icon-20x20@3x.png",
+      "filename": "app-icon-40x40@2x.png",
       "idiom": "iphone",
-      "scale": "3x",
-      "size": "20x20"
+      "scale": "2x",
+      "size": "40x40"
     },
     {
       "filename": "app-icon-29x29@3x.png",
@@ -19,39 +19,21 @@
       "size": "29x29"
     },
     {
-      "filename": "app-icon-40x40@2x.png",
-      "idiom": "iphone",
-      "scale": "2x",
-      "size": "40x40"
-    },
-    {
-      "filename": "app-icon-60x60@2x.png",
-      "idiom": "iphone",
-      "scale": "2x",
-      "size": "60x60"
-    },
-    {
-      "filename": "app-icon-40x40@3x.png",
-      "idiom": "iphone",
-      "scale": "3x",
-      "size": "40x40"
-    },
-    {
       "filename": "app-icon-29x29@2x.png",
       "idiom": "iphone",
       "scale": "2x",
       "size": "29x29"
     },
     {
-      "filename": "app-icon-20x20@2x.png",
-      "idiom": "ipad",
-      "scale": "2x",
+      "filename": "app-icon-20x20@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
       "size": "20x20"
     },
     {
-      "filename": "app-icon-60x60@3x.png",
+      "filename": "app-icon-60x60@2x.png",
       "idiom": "iphone",
-      "scale": "3x",
+      "scale": "2x",
       "size": "60x60"
     },
     {
@@ -61,33 +43,27 @@
       "size": "20x20"
     },
     {
+      "filename": "app-icon-40x40@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "40x40"
+    },
+    {
       "filename": "app-icon-29x29@1x.png",
       "idiom": "ipad",
       "scale": "1x",
       "size": "29x29"
     },
     {
+      "filename": "app-icon-60x60@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "60x60"
+    },
+    {
       "filename": "app-icon-40x40@1x.png",
       "idiom": "ipad",
       "scale": "1x",
-      "size": "40x40"
-    },
-    {
-      "filename": "app-icon-76x76@1x.png",
-      "idiom": "ipad",
-      "scale": "1x",
-      "size": "76x76"
-    },
-    {
-      "filename": "app-icon-76x76@2x.png",
-      "idiom": "ipad",
-      "scale": "2x",
-      "size": "76x76"
-    },
-    {
-      "filename": "app-icon-40x40@2x.png",
-      "idiom": "ipad",
-      "scale": "2x",
       "size": "40x40"
     },
     {
@@ -97,16 +73,40 @@
       "size": "29x29"
     },
     {
-      "filename": "app-icon-1024x1024@1x.png",
-      "idiom": "ios-marketing",
-      "scale": "1x",
-      "size": "1024x1024"
+      "filename": "app-icon-40x40@2x.png",
+      "idiom": "ipad",
+      "scale": "2x",
+      "size": "40x40"
+    },
+    {
+      "filename": "app-icon-76x76@2x.png",
+      "idiom": "ipad",
+      "scale": "2x",
+      "size": "76x76"
+    },
+    {
+      "filename": "app-icon-20x20@2x.png",
+      "idiom": "ipad",
+      "scale": "2x",
+      "size": "20x20"
     },
     {
       "filename": "app-icon-83.5x83.5@2x.png",
       "idiom": "ipad",
       "scale": "2x",
       "size": "83.5x83.5"
+    },
+    {
+      "filename": "app-icon-1024x1024@1x.png",
+      "idiom": "ios-marketing",
+      "scale": "1x",
+      "size": "1024x1024"
+    },
+    {
+      "filename": "app-icon-76x76@1x.png",
+      "idiom": "ipad",
+      "scale": "1x",
+      "size": "76x76"
     }
   ],
   "info": {

--- a/webapp/public/pwa/app-build.js
+++ b/webapp/public/pwa/app-build.js
@@ -1,1 +1,1 @@
-self.__TONPLAYGRAM_APP_BUILD__ = "122ba21";
+self.__TONPLAYGRAM_APP_BUILD__ = "cbe77f5";

--- a/webapp/public/version.json
+++ b/webapp/public/version.json
@@ -1,4 +1,4 @@
 {
-  "build": "122ba21",
-  "generatedAt": "2026-05-21T03:43:21.256Z"
+  "build": "cbe77f5",
+  "generatedAt": "2026-05-21T11:13:37.863Z"
 }

--- a/webapp/src/config/buildInfo.js
+++ b/webapp/src/config/buildInfo.js
@@ -1,2 +1,2 @@
-export const APP_BUILD = "122ba21";
-export const APP_BUILD_GENERATED_AT = "2026-05-21T03:43:21.256Z";
+export const APP_BUILD = "cbe77f5";
+export const APP_BUILD_GENERATED_AT = "2026-05-21T11:13:37.863Z";

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -6,49 +6,16 @@ const POOLTOOL_RAW_BASE =
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'classic-procedural',
-    label: 'Classic Showood 7 ft',
+    label: 'Classic Procedural 7 ft',
     description:
-      'Showood seven-foot table mapped to the original Pool Royale playfield size and height, using original-layout surface remapping.',
+      'Default Pool Royale procedural table using Showood GLB surface references (field, cushions, pocket cutouts, and jaws) with generated base options.',
     tableSizeId: '7ft',
     icon: '🧩',
     kind: 'gltf',
-    baseId: 'showoodOriginal',
+    baseId: 'openPortal',
     assetUrl:
       'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
-    fitScale: 1,
-    fitFootprintScale: 1.105,
-    fitHeightScale: 1,
-    lowerBaseHeightScale: 1.38,
-    legLengthScale: 2.05,
-    clothRepeatScale: 7.5,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeHeight: true,
-    matchNativeUpperComponentHeight: true,
-    preserveOriginalFootprintAspect: true,
-    useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
-    preserveOriginalSurfaceRoles: [],
-    tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
-    blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: []
-  },
-  {
-    id: 'showood-seven-foot',
-    label: 'Showood 7 ft GLB',
-    description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the CDN GLB cannot load, Pool Royale retries the raw Showood GLB and keeps the Showood original base and legs.',
-    tableSizeId: '7ft',
-    baseId: 'showoodOriginal',
-    assetUrl:
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
-    icon: '🟫',
-    kind: 'gltf',
     fitScale: 1,
     fitFootprintScale: 1.105,
     fitHeightScale: 1,
@@ -74,7 +41,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'showood-seven-foot'
+    (option) => option.id === 'classic-procedural'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
 export function resolvePoolRoyaleTableModel (modelId) {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -848,7 +848,7 @@ const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.958; // shrink the wooden corner round
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_CORNER_POCKET_CUT_CENTER_OUTSET_SCALE = -0.018; // push only the wooden corner rounded cut outward a touch without moving side-pocket cuts
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.045; // keep middle rail rounded cuts identical to the corner/showood-style pocket arcs
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.01; // keep middle rail rounded cuts identical to the corner/showood-style pocket arcs
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.068; // move middle wooden relief outward a bit more with the shifted side-pocket geometry
 
 function buildChromePlateGeometry({
@@ -1268,8 +1268,8 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
 const SHOWOOD_ORIGINAL_TABLE_BASE_ID = 'showoodOriginal';
-const DEFAULT_PROCEDURAL_TABLE_BASE_ID = 'classicCylinders';
-const DEFAULT_TABLE_BASE_ID = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
+const DEFAULT_PROCEDURAL_TABLE_BASE_ID = 'openPortal';
+const DEFAULT_TABLE_BASE_ID = DEFAULT_PROCEDURAL_TABLE_BASE_ID;
 const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
 const ENABLE_CUE_STROKE_ANIMATION = true;
@@ -15767,8 +15767,8 @@ function PoolRoyaleGame({
   const activeTableBase = useMemo(
     () =>
       availableTableBases.find((variant) => variant.id === tableBaseId) ??
-      availableTableBases.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
-      POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
+      availableTableBases.find((variant) => variant.id === DEFAULT_PROCEDURAL_TABLE_BASE_ID) ??
+      POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === DEFAULT_PROCEDURAL_TABLE_BASE_ID) ??
       POOL_ROYALE_BASE_VARIANTS[0],
     [availableTableBases, tableBaseId]
   );


### PR DESCRIPTION
### Motivation
- Make the procedural table the lobby default and stop using the separate Showood GLB base so procedural visuals (field, cushions, pocket/jaw mappings) are used by default.
- Prefer the Open Portal procedural base as the default table base so the generated base appears in the lobby without forcing the external Showood base.
- Slightly reduce the wooden rail rounded pocket relief so the visible rounded cut on the wooden rails becomes a bit smaller.
- Simplify the table model options to reduce fallback complexity when external GLB models are unavailable.

### Description
- Removed the `showood-seven-foot` table model and retained a single `classic-procedural` model in `webapp/src/config/poolRoyaleTableModels.js`, changed that model's `baseId` to `openPortal`, and made it the default table model.
- Switched Pool Royale defaults in `webapp/src/pages/Games/PoolRoyale.jsx` so `DEFAULT_PROCEDURAL_TABLE_BASE_ID` is `openPortal` and `DEFAULT_TABLE_BASE_ID` now defaults to the procedural base.
- Updated the active table base fallback logic to prefer the procedural default base instead of the Showood original base in `PoolRoyale.jsx`.
- Reduced `WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE` from `1.045` to `1.01` to make the rounded cut on the wooden side rails slightly smaller.
- Build metadata and artifacts were regenerated (`webapp/public/version.json`, `webapp/public/pwa/app-build.js`, `webapp/src/config/buildInfo.js`) as part of the validation build.

### Testing
- Ran the production build with `npm -C webapp run -s build`, which completed successfully and produced the updated `dist` artifacts.
- No additional automated unit or integration tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee89890cc832994e3850f7c497042)