### PR TITLE
Use procedural `openPortal` table by default, remove Showood GLB option, and adjust table geometry scales

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,80 +1,21 @@
 export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
-const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
-
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'classic-procedural',
-    label: 'Classic Showood 7 ft',
+    label: 'Classic Procedural 7 ft',
     description:
-      'Showood seven-foot table mapped to the original Pool Royale playfield size and height, using original-layout surface remapping.',
+      'Default procedural seven-foot Pool Royale table layout for lobby and match start.',
     tableSizeId: '7ft',
     icon: '🧩',
-    kind: 'gltf',
-    baseId: 'showoodOriginal',
-    assetUrl:
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
-    fitScale: 1,
-    fitFootprintScale: 1.105,
-    fitHeightScale: 1,
-    lowerBaseHeightScale: 1.38,
-    legLengthScale: 2.05,
-    clothRepeatScale: 7.5,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeHeight: true,
-    matchNativeUpperComponentHeight: true,
-    preserveOriginalFootprintAspect: true,
-    useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
-    preserveOriginalSurfaceRoles: [],
-    tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
-    blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: []
-  },
-  {
-    id: 'showood-seven-foot',
-    label: 'Showood 7 ft GLB',
-    description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the CDN GLB cannot load, Pool Royale retries the raw Showood GLB and keeps the Showood original base and legs.',
-    tableSizeId: '7ft',
-    baseId: 'showoodOriginal',
-    assetUrl:
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
-    icon: '🟫',
-    kind: 'gltf',
-    fitScale: 1,
-    fitFootprintScale: 1.105,
-    fitHeightScale: 1,
-    lowerBaseHeightScale: 1.38,
-    legLengthScale: 2.05,
-    clothRepeatScale: 7.5,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeHeight: true,
-    matchNativeUpperComponentHeight: true,
-    preserveOriginalFootprintAspect: true,
-    useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
-    preserveOriginalSurfaceRoles: [],
-    tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
-    blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: []
+    kind: 'procedural',
+    baseId: 'openPortal'
   }
 ])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'showood-seven-foot'
+    (option) => option.id === 'classic-procedural'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
 export function resolvePoolRoyaleTableModel (modelId) {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -830,12 +830,12 @@ const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.34; // trim the side fascia reach 
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.14; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
 const CHROME_SIDE_PLATE_CENTER_TRIM_SCALE = 0.228; // trim the side opposite the rounded middle cut a touch more while staying stable
 const CHROME_SIDE_PLATE_WIDTH_EXPANSION_SCALE = 1.11; // widen the middle fascia slightly so both flanks expand toward the corner pockets
-const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 0.8; // trim the outside body of middle-pocket chrome plates a little more while preserving the rounded cut
+const CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE = 1; // trim the outside body of middle-pocket chrome plates a little more while preserving the rounded cut
 const CHROME_SIDE_PLATE_CORNER_EXTENSION_SCALE = 1.22; // extend the plate ends a bit farther toward the corner pockets (green-marked areas)
 const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.9; // tighten the middle fascia slightly so both flanks gain a touch more trim
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.24; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
-const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.012; // push middle chrome plates slightly outward away from table center while preserving the rounded cut
+const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0; // push middle chrome plates slightly outward away from table center while preserving the rounded cut
 const CHROME_SIDE_APRON_COVER_THICKNESS_SCALE = 0.055; // cover the grey middle-pocket side apron with rail-sight chrome/gold
 const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 0.82; // drop the side apron cover down the rail face behind the side-pocket jaw
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.022; // trim the outer fascia edge a hair more for a tighter outside finish
@@ -844,11 +844,11 @@ const CHROME_CORNER_POCKET_CUT_SCALE = 1.045; // open only the corner chrome rou
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.03; // open middle-pocket chrome rounded cuts a tiny bit more so the arc reads slightly larger
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // reduce inward pull so middle pocket chrome cuts sit a bit farther out
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 1.045; // match the wooden rail pocket relief to the Showood jaw outside diameter
-const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.958; // shrink the wooden corner rounded cut a touch more so only the wood corner radius reads slightly tighter
+const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.972; // shrink the wooden corner rounded cut a touch more so only the wood corner radius reads slightly tighter
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_CORNER_POCKET_CUT_CENTER_OUTSET_SCALE = -0.018; // push only the wooden corner rounded cut outward a touch without moving side-pocket cuts
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.045; // keep middle rail rounded cuts identical to the corner/showood-style pocket arcs
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.02; // keep middle rail rounded cuts identical to the corner/showood-style pocket arcs
 const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.068; // move middle wooden relief outward a bit more with the shifted side-pocket geometry
 
 function buildChromePlateGeometry({
@@ -1268,8 +1268,8 @@ const POOL_ROYALE_COMMENTARY_PRESETS = Object.freeze([
 ]);
 const DEFAULT_COMMENTARY_PRESET_ID = POOL_ROYALE_COMMENTARY_PRESETS[0]?.id || 'english';
 const SHOWOOD_ORIGINAL_TABLE_BASE_ID = 'showoodOriginal';
-const DEFAULT_PROCEDURAL_TABLE_BASE_ID = 'classicCylinders';
-const DEFAULT_TABLE_BASE_ID = SHOWOOD_ORIGINAL_TABLE_BASE_ID;
+const DEFAULT_PROCEDURAL_TABLE_BASE_ID = 'openPortal';
+const DEFAULT_TABLE_BASE_ID = DEFAULT_PROCEDURAL_TABLE_BASE_ID;
 const ENABLE_CUE_GALLERY = false;
 const ENABLE_TRIPOD_CAMERAS = false;
 const ENABLE_CUE_STROKE_ANIMATION = true;

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,7 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
@@ -873,43 +872,6 @@ export default function PoolRoyaleLobby() {
           </div>
         )}
 
-        {!hasActiveTournament && (
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Pool Table</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-                Layout
-              </span>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
-                const active = selectedTableModel.id === option.id;
-                return (
-                  <button
-                    key={option.id}
-                    type="button"
-                    onClick={() => setTableModelId(option.id)}
-                    className={`lobby-option-card ${
-                      active
-                        ? 'lobby-option-card-active'
-                        : 'lobby-option-card-inactive'
-                    }`}
-                  >
-                    <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-teal-500/10 to-transparent">
-                      <div className="lobby-option-thumb-inner text-2xl">
-                        {option.icon || '🎱'}
-                      </div>
-                    </div>
-                    <div className="text-center">
-                      <p className="lobby-option-label">{option.label}</p>
-                      <p className="lobby-option-subtitle">{option.description}</p>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        )}
 
 
         {playType === 'training' && (


### PR DESCRIPTION
### Motivation
- Replace the external Showood GLB showroom table with a lightweight, default procedural table to simplify assets and ensure consistent lobby/match start visuals.
- Tweak chrome and wood geometry scale constants to better align pocket, rail and fascia visuals with the new procedural base.
- Remove the in-lobby table model chooser to avoid exposing removed/unsupported table models.

### Description
- Updated `poolRoyaleTableModels.js` to change the `classic-procedural` option label and description, set its `kind` to `procedural`, and set `baseId` to `openPortal`, and removed the Showood GLB entries and raw CDN fallback code.
- Set `DEFAULT_POOL_ROYALE_TABLE_MODEL_ID` to use `classic-procedural` by default and removed the `POOLTOOL_RAW_BASE` constant.
- In `PoolRoyale.jsx` changed `DEFAULT_PROCEDURAL_TABLE_BASE_ID` to `openPortal` and made `DEFAULT_TABLE_BASE_ID` use that procedural base, and adjusted multiple rendering constants: `CHROME_SIDE_PLATE_OUTER_EXTENSION_SCALE`, `CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE`, `WOOD_CORNER_RELIEF_INWARD_SCALE`, and `WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE` to new values.
- In `PoolRoyaleLobby.jsx` removed the lobby UI block that rendered the table model selection grid and references to `POOL_ROYALE_TABLE_MODEL_OPTIONS` so the table layout choice is no longer shown in the lobby.

### Testing
- Ran the frontend unit test suite (`yarn test`); all tests passed.
- Ran linting and type checks (`yarn lint` / typecheck); no errors reported.
- Performed a development build (`yarn build` / `yarn start`) and verified the lobby and match pages load with the procedural `openPortal` table and no runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee89890cc832994e3850f7c497042)