### PR TITLE
Fix Pool Royale Showood table setup and lock lobby model selection

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -5,7 +5,7 @@ const POOLTOOL_RAW_BASE =
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
-    id: 'classic-procedural',
+    id: 'showood-seven-foot',
     label: 'Classic Procedural 7 ft',
     description:
       'Procedural Pool Royale seven-foot table with Showood GLB playfield/cushion/jaw surfaces preserved for accurate pocket cuts and rail fit.',
@@ -29,19 +29,19 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     preserveOriginalFootprintAspect: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['wood', 'trim'],
-    preserveOriginalSurfaceRoles: ['cloth', 'cushion', 'pocket'],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
+    preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: true,
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
     blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: true,
+    forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }
 ])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'classic-procedural'
+    (option) => option.id === 'showood-seven-foot'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
 export function resolvePoolRoyaleTableModel (modelId) {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,8 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_TABLE_MODEL_OPTIONS,
-  POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
 import { socket } from '../../utils/socket.js';
@@ -77,21 +75,7 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const [tableModelId, setTableModelId] = useState(() => {
-    const requested = (searchParams.get('tableModel') || '').trim();
-    if (requested) return resolvePoolRoyaleTableModel(requested).id;
-    try {
-      return resolvePoolRoyaleTableModel(
-        window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY) || ''
-      ).id;
-    } catch {
-      return resolvePoolRoyaleTableModel().id;
-    }
-  });
-  const selectedTableModel = useMemo(
-    () => resolvePoolRoyaleTableModel(tableModelId),
-    [tableModelId]
-  );
+  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(), []);
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -129,15 +113,9 @@ export default function PoolRoyaleLobby() {
     playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
   const selectedTableModelReady = true;
-  const showTableModelSelector = POOL_ROYALE_TABLE_MODEL_OPTIONS.length > 1;
+  const showTableModelSelector = false;
 
 
-
-  useEffect(() => {
-    if (tableModelId !== selectedTableModel.id) {
-      setTableModelId(selectedTableModel.id);
-    }
-  }, [tableModelId, selectedTableModel.id]);
 
   useEffect(() => {
     try {
@@ -255,8 +233,7 @@ export default function PoolRoyaleLobby() {
     setMatchingError('');
     try {
       window.localStorage?.setItem(
-        POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
-        selectedTableModel.id
+              selectedTableModel.id
       );
       if (selectedTableModel.finishId) {
         window.localStorage?.setItem(
@@ -881,44 +858,15 @@ export default function PoolRoyaleLobby() {
           </div>
         )}
 
-        {!hasActiveTournament && showTableModelSelector && (
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Pool Table</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-                Layout
-              </span>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
-                const active = selectedTableModel.id === option.id;
-                return (
-                  <button
-                    key={option.id}
-                    type="button"
-                    onClick={() => setTableModelId(option.id)}
-                    className={`lobby-option-card ${
-                      active
-                        ? 'lobby-option-card-active'
-                        : 'lobby-option-card-inactive'
-                    }`}
-                  >
-                    <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-teal-500/10 to-transparent">
-                      <div className="lobby-option-thumb-inner text-2xl">
-                        {option.icon || '🎱'}
-                      </div>
-                    </div>
-                    <div className="text-center">
-                      <p className="lobby-option-label">{option.label}</p>
-                      <p className="lobby-option-subtitle">{option.description}</p>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
+
+        {!hasActiveTournament && !showTableModelSelector && (
+          <div className="space-y-2">
+            <h3 className="font-semibold text-white">Pool Table</h3>
+            <p className="text-xs text-white/60">
+              Showood 7 ft GLB is now the fixed Pool Royale table.
+            </p>
           </div>
         )}
-
 
         {playType === 'training' && (
           <div className="space-y-3 rounded-2xl border border-emerald-300/30 bg-gradient-to-br from-emerald-500/10 via-black/35 to-cyan-500/10 p-4">


### PR DESCRIPTION
### Motivation

- Restore the Showood GLB-driven table assembly so chrome plates, cushions, pocket jaws and base behavior match the GLB (same visual pipeline used by the procedural Snooker table). 
- Ensure the table base and GLB-provided cushion/jaw geometry are used instead of generated fallbacks so the original Showood visuals show correctly. 
- Prevent players from switching table models in the lobby so Pool Royale consistently uses the fixed Showood table.

### Description

- Renamed the Pool Royale table model ID to `showood-seven-foot` and made it the default in `webapp/src/config/poolRoyaleTableModels.js` so the Showood-specific assembly logic is applied. 
- Updated the Showood model configuration to include Pool Royale finish roles `['cloth','cushion','wood','pocket','trim']`, cleared `preserveOriginalSurfaceRoles`, and disabled `forceGeneratedChromePlates` so GLB chrome plates, cushions, jaws and base are honored. 
- Simplified the lobby UI in `webapp/src/pages/Games/PoolRoyaleLobby.jsx` by removing the table model selector and related state, forcing `showTableModelSelector = false`, and adding a fixed message that the Showood 7 ft GLB is the Pool Royale table. 
- Removed imports/state tied to selectable models and adjusted localStorage usage to use the resolved Showood model, preventing model switching at runtime.

### Testing

- Ran the focused unit tests with `npm test -- test/poolRoyaleTableModels.test.js` and all tests passed (6/6). 
- The `Pool Royale table models` test suite validated default model ID, Showood surface/finish configuration, removal of the old 8ft option, and lobby behavior, and returned `PASS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f19e70ae88329ab2eeab5bb5b9778)