### PR TITLE
Pool Royale: shorten wooden rails, trim side aprons, and add fast local table model

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -5,6 +5,16 @@ const POOLTOOL_RAW_BASE =
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
+    id: 'royal-original-native',
+    label: 'Royal Original (Fast Local)',
+    description:
+      'Uses the built-in procedural Showood-compatible table visuals with no external GLB download for fastest local startup.',
+    tableSizeId: '7ft',
+    baseId: 'showoodOriginal',
+    icon: '⚡',
+    kind: 'native'
+  },
+  {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
@@ -41,7 +51,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'showood-seven-foot'
+    (option) => option.id === 'royal-original-native'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
 
 export function resolvePoolRoyaleTableModel(modelId) {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1306,7 +1306,7 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
-const RAIL_HEIGHT = TABLE.THICK * 1.9; // lift all six cushions/rails a touch more so the top profile reads higher without changing playfield size
+const RAIL_HEIGHT = TABLE.THICK * 1.62; // shorten all wooden rails so their visual height matches the procedural rail frame reference
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.024; // push the corner jaws just a bit farther outward so the fascia follows the rounded rail and chrome cut
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -1622,8 +1622,8 @@ const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.32; // overlap between cus
 const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.225; // lift the cushion base higher so native and Showood cushions sit on the same raised field plane
 const CUSHION_HEIGHT_DROP = 0; // keep the cushion tops fully raised to match the Showood rail profile
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
-const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
-const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
+const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 0.74; // shorten the side apron drop so chrome/gold apron band sits tighter to the rail body
+const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // keep short-rail apron depth matched to the trimmed side aprons
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.085; // round exterior wooden rail edge profile to remove sharp octagon-like corners
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim


### PR DESCRIPTION
### Motivation
- Make the Pool Royale table visuals match the shorter procedural wooden rail frame so all four rails read at the same height. 
- Tighten the side-apron drop so chrome/gold apron bands sit visually flush with the rail body for gold/chrome apron styling. 
- Provide a local, native table option to avoid waiting for an external Showood GLB download and speed local startup.

### Description
- Shortened the generated wooden rail height by changing `RAIL_HEIGHT` from `TABLE.THICK * 1.9` to `TABLE.THICK * 1.62` in `webapp/src/pages/Games/PoolRoyale.jsx` so rails match the procedural frame reference. 
- Reduced the side and end apron drop by changing `SIDE_RAIL_EXTRA_DEPTH` (and `END_RAIL_EXTRA_DEPTH`) from `TABLE.THICK * 1.12` to `TABLE.THICK * 0.74` in `webapp/src/pages/Games/PoolRoyale.jsx` so apron chrome/gold bands sit tighter to the rails. 
- Added a new native table model option `royal-original-native` (kind: `native`) to `webapp/src/config/poolRoyaleTableModels.js` and made it the default `DEFAULT_POOL_ROYALE_TABLE_MODEL_ID` so the app uses the built-in procedural visuals by default instead of downloading the external Showood GLB. 
- Kept the `showood-seven-foot` GLB option available as an explicit selectable model so the external Showood visuals remain supported.

### Testing
- Executed a production build with `npm --prefix webapp run -s build` and the build completed successfully. 
- No runtime test failures were observed during the build step (bundle emitted and artifacts generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fdf008b6883298f5d4304ace02f05)