### PR TITLE
Pool Royale: prefer local Showood GLB, chrome side-apron mapping, and shorter wood rails

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -3,6 +3,8 @@ export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
 const POOLTOOL_RAW_BASE =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
 
+const SHOWOOD_LOCAL_ASSET_PATH = '/assets/models/pool/showood-seven-foot.glb';
+
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'showood-seven-foot',
@@ -11,9 +13,11 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
       'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the CDN GLB cannot load, Pool Royale retries the raw Showood GLB and keeps the Showood original base and legs.',
     tableSizeId: '7ft',
     baseId: 'showoodOriginal',
-    assetUrl:
+    assetUrl: SHOWOOD_LOCAL_ASSET_PATH,
+    fallbackAssetUrls: [
       'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
+      `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`
+    ],
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
@@ -32,7 +36,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
     preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'sideWoodApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
     blackMaterialSurfaceNames: [],
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -837,7 +837,7 @@ const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.24; // lean the added width furthe
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.012; // push middle chrome plates slightly outward away from table center while preserving the rounded cut
 const CHROME_SIDE_APRON_COVER_THICKNESS_SCALE = 0.055; // cover the grey middle-pocket side apron with rail-sight chrome/gold
-const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 0.82; // drop the side apron cover down the rail face behind the side-pocket jaw
+const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 1.08; // extend chrome/gold farther down so side aprons are fully covered on all sides
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.022; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.078; // trim the middle-pocket outside chrome a touch more so the outer edge ends flush with the wooden rails
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.045; // open only the corner chrome rounded cut a tiny bit more so the arc reads slightly larger
@@ -1306,7 +1306,7 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
-const RAIL_HEIGHT = TABLE.THICK * 1.9; // lift all six cushions/rails a touch more so the top profile reads higher without changing playfield size
+const RAIL_HEIGHT = TABLE.THICK * 1.62; // shorten all four wooden rails back toward the original procedural frame height
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.024; // push the corner jaws just a bit farther outward so the fascia follows the rounded rail and chrome cut
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
@@ -13495,7 +13495,10 @@ async function loadPoolRoyaleExternalTableTemplate(tableModel, renderer = null) 
   const promise = (async () => {
     const loader = createConfiguredGLTFLoader(renderer);
     let lastError = null;
-    const urls = [tableModel.assetUrl, tableModel.fallbackAssetUrl].filter(Boolean);
+    const fallbackUrls = Array.isArray(tableModel.fallbackAssetUrls)
+      ? tableModel.fallbackAssetUrls
+      : [tableModel.fallbackAssetUrl].filter(Boolean);
+    const urls = [tableModel.assetUrl, ...fallbackUrls].filter(Boolean);
     for (const url of urls) {
       try {
         // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
### Motivation
- Improve in-editor/local iteration speed by loading the Showood table from a local GLB first so the game can start faster during development and testing. 
- Expose the side apron to chrome/gold finishes so the table can render gold or chrome aprons as requested. 
- Bring wooden rails visually in line with the procedural frame height so the rails appear shorter on all four sides.

### Description
- Prefer a local Showood GLB by adding `SHOWOOD_LOCAL_ASSET_PATH = '/assets/models/pool/showood-seven-foot.glb'` and setting `assetUrl` to that path in `webapp/src/config/poolRoyaleTableModels.js`. 
- Add `fallbackAssetUrls` (array) and update the external GLTF loader to iterate `tableModel.assetUrl` then `fallbackAssetUrls` so remote CDN/raw fallbacks remain supported in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Include `sideWoodApron` in `chromeMaterialSurfaceNames` so apron parts can be tinted chrome/gold in `webapp/src/config/poolRoyaleTableModels.js`. 
- Increase the chrome cover height by changing `CHROME_SIDE_APRON_COVER_HEIGHT_SCALE` from `0.82` to `1.08` so chrome/gold extends farther down the apron face in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Shorten wooden rails by reducing `RAIL_HEIGHT` multiplier from `TABLE.THICK * 1.9` to `TABLE.THICK * 1.62` to make all four wooden rails visually shorter in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Built a production bundle successfully with `cd webapp && npm run -s build`, and the build completed without errors.
- No automated unit tests were modified; the change was validated by the successful production build only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fdf008b6883298f5d4304ace02f05)