### PR TITLE
Add Pool Royale lobby table selector with legacy + Chinese 8-ball table options

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -8,12 +8,12 @@ import {
 } from '../webapp/src/config/poolRoyaleTableModels.js';
 
 describe('Pool Royale table models', () => {
-  test('defaults to the Showood GLB table', () => {
-    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'showood-seven-foot');
-    assert.equal(resolvePoolRoyaleTableModel(null).id, 'showood-seven-foot');
+  test('defaults to the legacy procedural table', () => {
+    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'legacy-procedural');
+    assert.equal(resolvePoolRoyaleTableModel(null).id, 'legacy-procedural');
     assert.equal(
       resolvePoolRoyaleTableModel('unknown').id,
-      'showood-seven-foot'
+      'legacy-procedural'
     );
   });
 
@@ -63,35 +63,26 @@ describe('Pool Royale table models', () => {
     );
     assert.equal(
       resolvePoolRoyaleTableModel('traditional-fizyman-eight-foot').id,
-      'showood-seven-foot'
+      'legacy-procedural'
     );
   });
 
-  test('Pool Royale lobby uses the fixed Showood table without model choices', async () => {
+  test('Pool Royale lobby renders selectable table model cards', async () => {
     const lobby = await readFile(
       'webapp/src/pages/Games/PoolRoyaleLobby.jsx',
       'utf8'
     );
 
     assert.ok(
-      lobby.includes('Showood 7 ft GLB is now the fixed Pool Royale table.'),
-      'lobby should explain the fixed Showood table'
-    );
-    assert.equal(
       lobby.includes('POOL_ROYALE_TABLE_MODEL_OPTIONS.map'),
-      false,
-      'lobby should not render table model option cards'
+      'lobby should render table model cards'
     );
     assert.equal(
       lobby.includes('setTableModelId'),
-      false,
-      'lobby should not allow switching table models'
+      true,
+      'lobby should allow switching table models'
     );
-    assert.equal(
-      lobby.includes('traditional-fizyman-eight-foot'),
-      false,
-      'lobby should not reference the removed 8 ft glTF table'
-    );
+
   });
 
   test('Traditional table installer fetches and validates the authentic Sketchfab glTF', async () => {

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -7,6 +7,51 @@ const SHOWOOD_LOCAL_ASSET_PATH = '/assets/models/pool/showood-seven-foot.glb';
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
+    id: 'legacy-procedural',
+    label: 'Legacy Procedural',
+    description:
+      'Original Pool Royale procedural table mapping with the legacy geometry/menu flow used before GLB-only mode.',
+    tableSizeId: '7ft',
+    baseId: 'legacyProcedural',
+    icon: '🧩',
+    kind: 'procedural'
+  },
+  {
+    id: 'chinese-eightball-snooker',
+    label: 'Chinese 8-Ball (9 ft Snooker)',
+    description:
+      'Uses the same 9 ft snooker GLB footprint but with Pool Royale 8-ball markings and gameplay mapping.',
+    tableSizeId: '9ft',
+    baseId: 'chineseEightBall',
+    assetUrl: SHOWOOD_LOCAL_ASSET_PATH,
+    fallbackAssetUrls: [
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+      `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`
+    ],
+    icon: '🐉',
+    kind: 'gltf',
+    fitScale: 1,
+    fitFootprintScale: 1.105,
+    fitHeightScale: 1,
+    lowerBaseHeightScale: 1.38,
+    legLengthScale: 2.05,
+    clothRepeatScale: 7.5,
+    fitStrategy: 'exact',
+    fitReference: 'upperTabletop',
+    matchNativeHeight: true,
+    matchNativeUpperComponentHeight: true,
+    preserveOriginalFootprintAspect: true,
+    useOriginalLayoutSurfaces: true,
+    usePoolRoyaleFinish: true,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim'],
+    preserveOriginalSurfaceRoles: ['wood'],
+    tintOriginalTrimGold: true,
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'sideWoodApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
+    blackMaterialSurfaceNames: [],
+    forceGeneratedChromePlates: false,
+    hideSurfaceRoles: []
+  },
+  {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
@@ -45,7 +90,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'showood-seven-foot'
+    (option) => option.id === 'legacy-procedural'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
 
 export function resolvePoolRoyaleTableModel(modelId) {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,6 +13,8 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
+  POOL_ROYALE_TABLE_MODEL_OPTIONS,
+  POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
 import { socket } from '../../utils/socket.js';
@@ -75,7 +77,8 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(), []);
+  const [tableModelId, setTableModelId] = useState(() => resolvePoolRoyaleTableModel().id);
+  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(tableModelId), [tableModelId]);
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -113,10 +116,17 @@ export default function PoolRoyaleLobby() {
     playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
   const selectedTableModelReady = true;
-  const showTableModelSelector = false;
+  const showTableModelSelector = true;
 
 
 
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY);
+      if (stored) setTableModelId(resolvePoolRoyaleTableModel(stored).id);
+    } catch {}
+  }, []);
   useEffect(() => {
     try {
       const saved = loadAvatar();
@@ -232,9 +242,7 @@ export default function PoolRoyaleLobby() {
     setMatchStatus('');
     setMatchingError('');
     try {
-      window.localStorage?.setItem(
-              selectedTableModel.id
-      );
+      window.localStorage?.setItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY, selectedTableModel.id);
       if (selectedTableModel.finishId) {
         window.localStorage?.setItem(
           TABLE_FINISH_STORAGE_KEY,
@@ -859,12 +867,39 @@ export default function PoolRoyaleLobby() {
         )}
 
 
-        {!hasActiveTournament && !showTableModelSelector && (
-          <div className="space-y-2">
-            <h3 className="font-semibold text-white">Pool Table</h3>
-            <p className="text-xs text-white/60">
-              Showood 7 ft GLB is now the fixed Pool Royale table.
-            </p>
+        {!hasActiveTournament && showTableModelSelector && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Pool Table</h3>
+              <span className="text-[11px] uppercase tracking-[0.2em] text-white/45">Layout</span>
+            </div>
+            <div className="grid grid-cols-1 gap-3">
+              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
+                const active = selectedTableModel.id === option.id;
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => setTableModelId(option.id)}
+                    className={`lobby-option-card ${
+                      active
+                        ? 'lobby-option-card-active'
+                        : 'lobby-option-card-inactive'
+                    }`}
+                  >
+                    <div className="lobby-option-thumb bg-gradient-to-br from-indigo-400/25 via-sky-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
+                        <span className="text-2xl">{option.icon || '🎱'}</span>
+                      </div>
+                    </div>
+                    <div className="text-left">
+                      <p className="lobby-option-label">{option.label}</p>
+                      <p className="lobby-option-subtitle">{option.description}</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
### Motivation
- Restore multi-table choices in Pool Royale so players can pick different table layouts and mapping (legacy procedural vs GLB-based) instead of a fixed Showood-only flow.
- Provide a Chinese 8-ball option that uses the snooker-style GLB footprint but maps visuals/logic for 8-ball play.
- Re-introduce the original procedural table path to recover legacy mapping/menu behavior and avoid regressions introduced when GLB-only mode was enforced.

### Description
- Added two new table model entries to `webapp/src/config/poolRoyaleTableModels.js`: `legacy-procedural` (kind `procedural`) and `chinese-eightball-snooker` (GLB-based with snooker footprint and Pool Royale 8-ball mapping). 
- Changed default pool-royale table model id to `legacy-procedural` and preserved the existing `showood-seven-foot` model settings. 
- Restored a selectable table model UI in `webapp/src/pages/Games/PoolRoyaleLobby.jsx` by adding `tableModelId` state, rendering cards from `POOL_ROYALE_TABLE_MODEL_OPTIONS`, and persisting selection using `POOL_ROYALE_TABLE_MODEL_STORAGE_KEY` in `localStorage`.
- Updated `test/poolRoyaleTableModels.test.js` to reflect the new defaults and lobby selector expectations.

### Testing
- Ran the focused unit test file `npm test -- test/poolRoyaleTableModels.test.js`, and the suite passed (all tests in that file succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10328c11488329905ab026687bedad)