### PR TITLE
Pool Royale: add table selector, Chinese 8‑Ball and legacy procedural model; speed up Showood load

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -4,8 +4,20 @@ const POOLTOOL_RAW_BASE =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
 
 const SHOWOOD_LOCAL_ASSET_PATH = '/assets/models/pool/showood-seven-foot.glb';
+const SNOOKER_LOCAL_ASSET_PATH = '/assets/models/snooker/snooker.glb';
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
+  {
+    id: 'procedural-legacy',
+    label: 'Legacy Procedural',
+    description:
+      'Original procedural Pool Royale table layout and menu mapping from the legacy build.',
+    tableSizeId: '7ft',
+    baseId: 'standard',
+    icon: '🧱',
+    kind: 'procedural',
+    fitScale: 1
+  },
   {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
@@ -37,6 +49,39 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     preserveOriginalSurfaceRoles: ['wood'],
     tintOriginalTrimGold: true,
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'sideWoodApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
+    blackMaterialSurfaceNames: [],
+    forceGeneratedChromePlates: false,
+    hideSurfaceRoles: [],
+    useLegacyShowoodRemap: false
+  },
+  {
+    id: 'chinese-8ball-snooker',
+    label: 'Chinese 8-Ball (9 ft)',
+    description:
+      'Snooker Royal GLB 9 ft table shell adapted for Pool Royale 8-ball mapping and physics.',
+    tableSizeId: '9ft',
+    baseId: 'showoodOriginal',
+    assetUrl: SNOOKER_LOCAL_ASSET_PATH,
+    fallbackAssetUrls: [
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/snooker.glb',
+      `${POOLTOOL_RAW_BASE}/snooker.glb`
+    ],
+    icon: '🇨🇳',
+    kind: 'gltf',
+    fitScale: 1,
+    fitFootprintScale: 1.04,
+    fitHeightScale: 1,
+    clothRepeatScale: 7.2,
+    fitStrategy: 'exact',
+    fitReference: 'upperTabletop',
+    matchNativeHeight: true,
+    preserveOriginalFootprintAspect: true,
+    useOriginalLayoutSurfaces: true,
+    usePoolRoyaleFinish: true,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim'],
+    preserveOriginalSurfaceRoles: ['wood'],
+    tintOriginalTrimGold: true,
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip'],
     blackMaterialSurfaceNames: [],
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13782,7 +13782,9 @@ function mountPoolRoyaleExternalTableModel({
       if (disposed || !template) return;
       const model = clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo);
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
-      remapPoolRoyaleShowoodExternalParts(model, tableModel, finishInfo);
+      if (tableModel?.useLegacyShowoodRemap !== false) {
+        remapPoolRoyaleShowoodExternalParts(model, tableModel, finishInfo);
+      }
       externalRoot.clear();
       externalRoot.add(model);
       if (tableModel.id === 'showood-seven-foot') {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,6 +13,8 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
+  POOL_ROYALE_TABLE_MODEL_OPTIONS,
+  POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
 import { socket } from '../../utils/socket.js';
@@ -75,7 +77,14 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(), []);
+  const [tableModelId, setTableModelId] = useState(() => {
+    try {
+      return window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY) || '';
+    } catch {
+      return '';
+    }
+  });
+  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(tableModelId), [tableModelId]);
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -113,9 +122,19 @@ export default function PoolRoyaleLobby() {
     playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
   const selectedTableModelReady = true;
-  const showTableModelSelector = false;
+  const showTableModelSelector = true;
 
 
+
+
+
+  useEffect(() => {
+    try {
+      if (selectedTableModel?.id) {
+        window.localStorage?.setItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY, selectedTableModel.id);
+      }
+    } catch {}
+  }, [selectedTableModel?.id]);
 
   useEffect(() => {
     try {
@@ -858,6 +877,33 @@ export default function PoolRoyaleLobby() {
           </div>
         )}
 
+
+        {!hasActiveTournament && showTableModelSelector && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Pool Table</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Models</span>
+            </div>
+            <div className="grid grid-cols-1 gap-3">
+              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((model) => {
+                const active = selectedTableModel?.id === model.id;
+                return (
+                  <button
+                    key={model.id}
+                    type="button"
+                    onClick={() => setTableModelId(model.id)}
+                    className={`lobby-option-card ${active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
+                  >
+                    <div className="text-left">
+                      <p className="lobby-option-label">{model.icon || '🎱'} {model.label}</p>
+                      <p className="lobby-option-subtitle">{model.description}</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
         {!hasActiveTournament && !showTableModelSelector && (
           <div className="space-y-2">


### PR DESCRIPTION
### Motivation
- Provide players a choice of Pool Royale table models (legacy procedural, existing Showood GLB, and a Snooker-based Chinese 8‑Ball) so they can pick the table that matches rules/visuals. 
- Restore the legacy procedural mapping/menu option so older table logic and menu mapping are available again. 
- Improve load performance for the Showood GLB by skipping an expensive legacy remap path when not required. 

### Description
- Added `POOL_ROYALE_TABLE_MODEL_OPTIONS` entries in `webapp/src/config/poolRoyaleTableModels.js` for `procedural-legacy` and `chinese-8ball-snooker`, and introduced `SNOOKER_LOCAL_ASSET_PATH` and `POOL_ROYALE_TABLE_MODEL_STORAGE_KEY` constants. 
- Enabled a Pool Table selector UI in the lobby (`PoolRoyaleLobby.jsx`) by exposing `showTableModelSelector`, adding `tableModelId` state, rendering `POOL_ROYALE_TABLE_MODEL_OPTIONS` as selectable cards, and persisting the chosen model to `localStorage`. 
- Made external table mounting respect a config flag by adding `useLegacyShowoodRemap` and changing `mountPoolRoyaleExternalTableModel` (`PoolRoyale.jsx`) to conditionally call `remapPoolRoyaleShowoodExternalParts` only when the flag allows it, so the Showood path can skip the heavy remap. 

### Testing
- Ran lint: `npm -C webapp run lint`, and the lint step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10328c11488329905ab026687bedad)