### PR TITLE
Add selectable external pool table models and lobby selector (Snooker/Chinese 8-Ball)

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -4,8 +4,43 @@ const POOLTOOL_RAW_BASE =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
 
 const SHOWOOD_LOCAL_ASSET_PATH = '/assets/models/pool/showood-seven-foot.glb';
+const SNOOKER_LOCAL_ASSET_PATH = '/assets/models/snooker/snooker.glb';
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
+  {
+    id: 'procedural-legacy',
+    label: 'Legacy Procedural',
+    description:
+      'Legacy menu/mapping profile mounted on the Snooker Royal 9 ft GLB shell with full pockets, rails, and trim.',
+    tableSizeId: '9ft',
+    baseId: 'showoodOriginal',
+    assetUrl: SNOOKER_LOCAL_ASSET_PATH,
+    fallbackAssetUrls: [
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/snooker.glb',
+      `${POOLTOOL_RAW_BASE}/snooker.glb`
+    ],
+    icon: '🧱',
+    kind: 'gltf',
+    fitScale: 1,
+    fitFootprintScale: 1.04,
+    fitHeightScale: 1,
+    clothRepeatScale: 7.2,
+    fitStrategy: 'exact',
+    fitReference: 'upperTabletop',
+    matchNativeHeight: true,
+    preserveOriginalFootprintAspect: true,
+    useOriginalLayoutSurfaces: true,
+    usePoolRoyaleFinish: true,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim'],
+    preserveOriginalSurfaceRoles: ['wood'],
+    tintOriginalTrimGold: true,
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip'],
+    blackMaterialSurfaceNames: [],
+    forceGeneratedChromePlates: false,
+    hideSurfaceRoles: [],
+    tableLogicProfile: 'legacyProcedural',
+    cueRigProfile: 'snookerRoyalProvided' 
+  },
   {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
@@ -39,7 +74,44 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'sideWoodApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
     blackMaterialSurfaceNames: [],
     forceGeneratedChromePlates: false,
-    hideSurfaceRoles: []
+    hideSurfaceRoles: [],
+    useLegacyShowoodRemap: false,
+    tableLogicProfile: 'showood7ft',
+    cueRigProfile: 'poolRoyaleDefault'
+  },
+  {
+    id: 'chinese-8ball-snooker',
+    label: 'Chinese 8-Ball (9 ft)',
+    description:
+      'Snooker Royal GLB 9 ft table shell adapted for Pool Royale 8-ball mapping and physics.',
+    tableSizeId: '9ft',
+    baseId: 'showoodOriginal',
+    assetUrl: SNOOKER_LOCAL_ASSET_PATH,
+    fallbackAssetUrls: [
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/snooker.glb',
+      `${POOLTOOL_RAW_BASE}/snooker.glb`
+    ],
+    icon: '🇨🇳',
+    kind: 'gltf',
+    fitScale: 1,
+    fitFootprintScale: 1.04,
+    fitHeightScale: 1,
+    clothRepeatScale: 7.2,
+    fitStrategy: 'exact',
+    fitReference: 'upperTabletop',
+    matchNativeHeight: true,
+    preserveOriginalFootprintAspect: true,
+    useOriginalLayoutSurfaces: true,
+    usePoolRoyaleFinish: true,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim'],
+    preserveOriginalSurfaceRoles: ['wood'],
+    tintOriginalTrimGold: true,
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip'],
+    blackMaterialSurfaceNames: [],
+    forceGeneratedChromePlates: false,
+    hideSurfaceRoles: [],
+    tableLogicProfile: 'chinese8Ball9ft',
+    cueRigProfile: 'snookerRoyalProvided'
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13782,7 +13782,9 @@ function mountPoolRoyaleExternalTableModel({
       if (disposed || !template) return;
       const model = clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo);
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
-      remapPoolRoyaleShowoodExternalParts(model, tableModel, finishInfo);
+      if (tableModel?.useLegacyShowoodRemap !== false) {
+        remapPoolRoyaleShowoodExternalParts(model, tableModel, finishInfo);
+      }
       externalRoot.clear();
       externalRoot.add(model);
       if (tableModel.id === 'showood-seven-foot') {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,6 +13,8 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
+  POOL_ROYALE_TABLE_MODEL_OPTIONS,
+  POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
 import { socket } from '../../utils/socket.js';
@@ -75,7 +77,14 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(), []);
+  const [tableModelId, setTableModelId] = useState(() => {
+    try {
+      return window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY) || '';
+    } catch {
+      return '';
+    }
+  });
+  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(tableModelId), [tableModelId]);
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -113,10 +122,37 @@ export default function PoolRoyaleLobby() {
     playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
   const selectedTableModelReady = true;
-  const showTableModelSelector = false;
+  const showTableModelSelector = true;
 
 
 
+
+
+  useEffect(() => {
+    try {
+      if (selectedTableModel?.id) {
+
+        window.localStorage?.setItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY, selectedTableModel.id);
+      }
+    } catch {}
+  }, [selectedTableModel?.id]);
+
+
+  useEffect(() => {
+    const urls = [selectedTableModel?.assetUrl, ...(selectedTableModel?.fallbackAssetUrls || [])]
+      .filter((url) => typeof url === 'string' && url.length);
+    if (!urls.length || typeof window === 'undefined' || typeof window.fetch !== 'function') return;
+    const controller = new AbortController();
+    urls.slice(0, 1).forEach((url) => {
+      window.fetch(url, {
+        method: 'GET',
+        cache: 'force-cache',
+        mode: 'cors',
+        signal: controller.signal
+      }).catch(() => {});
+    });
+    return () => controller.abort();
+  }, [selectedTableModel?.id]);
   useEffect(() => {
     try {
       const saved = loadAvatar();
@@ -858,6 +894,33 @@ export default function PoolRoyaleLobby() {
           </div>
         )}
 
+
+        {!hasActiveTournament && showTableModelSelector && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-white">Pool Table</h3>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Models</span>
+            </div>
+            <div className="grid grid-cols-1 gap-3">
+              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((model) => {
+                const active = selectedTableModel?.id === model.id;
+                return (
+                  <button
+                    key={model.id}
+                    type="button"
+                    onClick={() => setTableModelId(model.id)}
+                    className={`lobby-option-card ${active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
+                  >
+                    <div className="text-left">
+                      <p className="lobby-option-label">{model.icon || '🎱'} {model.label}</p>
+                      <p className="lobby-option-subtitle">{model.description}</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
         {!hasActiveTournament && !showTableModelSelector && (
           <div className="space-y-2">


### PR DESCRIPTION
### Motivation
- Expose additional external table models (Snooker-based shells) and allow players to choose the table model from the lobby UI to support alternative visuals and mapping/physics profiles.
- Make the legacy Showood remapping opt-in/opt-out per model so non-Showood shells can avoid incorrect remapping.

### Description
- Added a snooker local asset path constant `SNOOKER_LOCAL_ASSET_PATH` and two new table model options `procedural-legacy` and `chinese-8ball-snooker` with appropriate fallback URLs and table/profile metadata in `poolRoyaleTableModels.js`.
- Updated `showood-seven-foot` model entry to include `useLegacyShowoodRemap: false`, `tableLogicProfile`, and `cueRigProfile` fields.
- Made remapping conditional in `PoolRoyale.jsx` by only calling `remapPoolRoyaleShowoodExternalParts` when `tableModel?.useLegacyShowoodRemap !== false`.
- Added lobby-side table model selection UI and persistence in `PoolRoyaleLobby.jsx` including state for `tableModelId`, saving to `localStorage` under `POOL_ROYALE_TABLE_MODEL_STORAGE_KEY`, prefetching model asset URLs, and rendering selectable cards for each `POOL_ROYALE_TABLE_MODEL_OPTIONS` entry.

### Testing
- Ran the frontend linting (`npm run lint`) and it completed without errors.
- Executed the test suite (`npm test`) and all tests passed.
- Performed a development build (`npm run build`) to validate bundling and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10328c11488329905ab026687bedad)