### PR TITLE
Align Pool Royale procedural table with Showood GLB and adjust Showood customization

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -4,7 +4,7 @@ const POOLTOOL_RAW_BASE =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
 
 const SHOWOOD_LOCAL_ASSET_PATH = '/assets/models/pool/showood-seven-foot.glb';
-const SNOOKER_LOCAL_ASSET_PATH = '/assets/models/snooker/snooker.glb';
+const SNOOKER_LOCAL_ASSET_PATH = 'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker.glb';
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
@@ -38,7 +38,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     blackMaterialSurfaceNames: [],
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: [],
-    tableLogicProfile: 'legacyProcedural',
+    tableLogicProfile: 'showood7ft',
     cueRigProfile: 'snookerRoyalProvided' 
   },
   {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4259,7 +4259,7 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
 ]);
 
 const DEFAULT_CHROME_PLATE_STYLE_ID =
-  POOL_ROYALE_DEFAULT_UNLOCKS.chromePlateStyle?.[0] ?? 'showood-rounded';
+  POOL_ROYALE_DEFAULT_UNLOCKS.chromePlateStyle?.[0] ?? 'royal-classic';
 const CHROME_PLATE_STYLE_OPTIONS = Object.freeze([
   {
     id: 'showood-rounded',
@@ -15681,20 +15681,38 @@ function PoolRoyaleGame({
     [isCueFinishUnlocked, poolInventory]
   );
   const tablePersonalizationSections = useMemo(
-    () =>
-      SHOWOOD_TABLE_PARTS.map((part) => ({
-        key: part,
-        label: SHOWOOD_TABLE_PART_LABELS[part] || part,
-        chromeLinked: SHOWOOD_CHROME_LINKED_PARTS.has(part),
-        options: getShowoodTablePartOptions(part, availableClothOptions, availableTableFinishes)
-      })).filter((section) => section.options.length > 0),
-    [availableClothOptions, availableTableFinishes]
+    () => {
+      const hideBasePart = activeTableModel?.id === 'showood-seven-foot';
+      return SHOWOOD_TABLE_PARTS
+        .filter((part) => !(hideBasePart && part === 'baseCornerBlock'))
+        .map((part) => ({
+          key: part,
+          label: SHOWOOD_TABLE_PART_LABELS[part] || part,
+          chromeLinked: SHOWOOD_CHROME_LINKED_PARTS.has(part),
+          options: getShowoodTablePartOptions(part, availableClothOptions, availableTableFinishes)
+        }))
+        .filter((section) => section.options.length > 0);
+    },
+    [activeTableModel?.id, availableClothOptions, availableTableFinishes]
   );
   useEffect(() => {
     if (!tablePersonalizationSections.some((section) => section.key === activeTablePersonalizationPart)) {
       setActiveTablePersonalizationPart(tablePersonalizationSections[0]?.key ?? 'topWoodRail');
     }
   }, [activeTablePersonalizationPart, tablePersonalizationSections]);
+
+  useEffect(() => {
+    if (activeTableModel?.id !== 'showood-seven-foot') return;
+    setShowoodTableStyle((prev) => {
+      const normalized = normalizeShowoodTableStyle(prev);
+      if (normalized.baseCornerBlock === normalized.topWoodRail) return prev;
+      return {
+        ...normalized,
+        baseCornerBlock: normalized.topWoodRail
+      };
+    });
+  }, [activeTableModel?.id]);
+
   const activeTablePersonalizationSection = useMemo(
     () =>
       tablePersonalizationSections.find((section) => section.key === activeTablePersonalizationPart) ??


### PR DESCRIPTION
### Motivation
- Ensure procedural Pool Royale tables (including the Chinese 9ft 8‑ball variant) use the same Snooker GLB source and layout rules as the Showood model so chrome plates, pockets, jaws and cushions match the Showood geometry and load consistently.
- Restore the classic generated chrome fascia as the default so chrome plates behave like they did previously.
- Remove an inappropriate base customization option for the Showood 7ft GLB and keep the base corner finish in sync with the top rail for visual consistency.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to point `SNOOKER_LOCAL_ASSET_PATH` to the Pooltool snooker GLB URL and changed the `procedural-legacy` entry `tableLogicProfile` to `showood7ft` so procedural mapping uses Showood-style layout rules.
- Changed the Pool Royale default chrome plate fallback from `showood-rounded` to `royal-classic` by updating `DEFAULT_CHROME_PLATE_STYLE_ID` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Filtered out the `baseCornerBlock` (the "Table Base" personalization) from the Showood personalization sections when `activeTableModel?.id === 'showood-seven-foot'` so the base option is removed from the menu for that model.
- Added a Showood-specific effect in `PoolRoyale.jsx` that synchronizes `baseCornerBlock` finish to the `topWoodRail` finish whenever the Showood 7ft model is active.

### Testing
- Ran `npx eslint webapp/src/config/poolRoyaleTableModels.js webapp/src/pages/Games/PoolRoyale.jsx` and the command completed with only ignore-pattern warnings and no lint errors.
- No other automated tests were added or modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104277eb70832988aff1424ecbc398)