### PR TITLE
Pool Royale: remove procedural lobby option and enable snooker 9ft human rig

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -8,40 +8,6 @@ const SNOOKER_LOCAL_ASSET_PATH = 'https://raw.githubusercontent.com/ekiefl/poolt
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
-    id: 'procedural-legacy',
-    label: 'Legacy Procedural',
-    description:
-      'Legacy menu/mapping profile mounted on the Snooker Royal 9 ft GLB shell with full pockets, rails, and trim.',
-    tableSizeId: '9ft',
-    baseId: 'showoodOriginal',
-    assetUrl: SNOOKER_LOCAL_ASSET_PATH,
-    fallbackAssetUrls: [
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/snooker.glb',
-      `${POOLTOOL_RAW_BASE}/snooker.glb`
-    ],
-    icon: '🧱',
-    kind: 'gltf',
-    fitScale: 1,
-    fitFootprintScale: 1.04,
-    fitHeightScale: 1,
-    clothRepeatScale: 7.2,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeHeight: true,
-    preserveOriginalFootprintAspect: true,
-    useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim'],
-    preserveOriginalSurfaceRoles: ['wood'],
-    tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip'],
-    blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: [],
-    tableLogicProfile: 'showood7ft',
-    cueRigProfile: 'snookerRoyalProvided' 
-  },
-  {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27173,7 +27173,10 @@ const shotPowerRef = useRef(0);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      const humanRig = null; // Human character/rig disabled: cue stick now stays table-driven only.
+      const humanRigProfile = resolvedTableOptions?.tableModel?.cueRigProfile || 'poolRoyaleDefault';
+      const humanRig = humanRigProfile === 'snookerRoyalProvided'
+        ? createPoolRoyaleHumanRig(table, renderer)
+        : null;
       const cueShadow = ENABLE_CUE_CLOTH_SHADOW
         ? (() => {
             const shadowWidth = Math.max(BALL_R * CUE_SHADOW_WIDTH_RATIO, BALL_R * 0.4);


### PR DESCRIPTION
### Motivation
- Remove the legacy procedural 9ft table option from the Pool Royale lobby so players no longer select the procedural table variant. 
- Make the 9ft snooker GLB use the same human character logic as the SnookerRoyalProvided profile so the human rig and cue behavior match the snooker table experience.

### Description
- Deleted the `procedural-legacy` entry from `POOL_ROYALE_TABLE_MODEL_OPTIONS` in `webapp/src/config/poolRoyaleTableModels.js` so it no longer appears as a selectable lobby option. 
- Replaced the unconditional `humanRig = null` in `webapp/src/pages/Games/PoolRoyale.jsx` with a conditional creation that reads `resolvedTableOptions?.tableModel?.cueRigProfile` and calls `createPoolRoyaleHumanRig(table, renderer)` when the profile equals `'snookerRoyalProvided'`, otherwise leaves the rig `null`.
- Preserved existing default behavior for other table models (`cueRigProfile` falls back to `'poolRoyaleDefault'`).

### Testing
- Built the webapp with `npm --prefix webapp run -s build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104815764083299a1d3b8b507b2f08)