### PR TITLE
Pool Royale: hide procedural lobby table and enable Snooker 9ft human rig

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27173,7 +27173,10 @@ const shotPowerRef = useRef(0);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      const humanRig = null; // Human character/rig disabled: cue stick now stays table-driven only.
+      const humanRig =
+        activeTableModel?.cueRigProfile === 'snookerRoyalProvided'
+          ? createPoolRoyaleHumanRig(table, renderer)
+          : null;
       const cueShadow = ENABLE_CUE_CLOTH_SHADOW
         ? (() => {
             const shadowWidth = Math.max(BALL_R * CUE_SHADOW_WIDTH_RATIO, BALL_R * 0.4);

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -85,6 +85,13 @@ export default function PoolRoyaleLobby() {
     }
   });
   const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(tableModelId), [tableModelId]);
+  const lobbyTableModelOptions = useMemo(
+    () =>
+      POOL_ROYALE_TABLE_MODEL_OPTIONS.filter(
+        (model) => model.id !== 'procedural-legacy'
+      ),
+    []
+  );
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -902,7 +909,7 @@ export default function PoolRoyaleLobby() {
               <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Models</span>
             </div>
             <div className="grid grid-cols-1 gap-3">
-              {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((model) => {
+              {lobbyTableModelOptions.map((model) => {
                 const active = selectedTableModel?.id === model.id;
                 return (
                   <button


### PR DESCRIPTION
### Motivation
- Remove the legacy procedural 9ft table option from the Pool Royale lobby so players no longer see or select it from the UI.
- Reuse the existing Snooker human rig for table models that provide the snooker character profile so the 9ft GLB path displays the same human character and pose logic as Snooker.

### Description
- In `PoolRoyaleLobby.jsx` a memoized `lobbyTableModelOptions` was added to filter out the `procedural-legacy` entry and the lobby table picker now renders `lobbyTableModelOptions` instead of `POOL_ROYALE_TABLE_MODEL_OPTIONS`.
- In `PoolRoyale.jsx` the hard-disabled `humanRig = null` was replaced with a conditional creation that calls `createPoolRoyaleHumanRig(table, renderer)` when `activeTableModel?.cueRigProfile === 'snookerRoyalProvided'` and otherwise leaves the rig null.
- Modified files: `webapp/src/pages/Games/PoolRoyaleLobby.jsx` and `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran `git status --short` and `git diff` to inspect changes, which completed successfully.
- Committed the changes with `git commit -m "Pool Royale: hide procedural lobby table and enable snooker 9ft human rig"`, which succeeded.
- No automated unit/integration tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104815764083299a1d3b8b507b2f08)