### PR TITLE
Pool Royale: lock Showood table, remove human rigs, and unify rail/base chrome/gold styling

### DIFF
--- a/webapp/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/webapp/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -7,28 +7,16 @@
       "size": "20x20"
     },
     {
-      "filename": "app-icon-20x20@3x.png",
-      "idiom": "iphone",
-      "scale": "3x",
-      "size": "20x20"
-    },
-    {
-      "filename": "app-icon-29x29@3x.png",
-      "idiom": "iphone",
-      "scale": "3x",
-      "size": "29x29"
-    },
-    {
       "filename": "app-icon-40x40@2x.png",
       "idiom": "iphone",
       "scale": "2x",
       "size": "40x40"
     },
     {
-      "filename": "app-icon-60x60@2x.png",
+      "filename": "app-icon-20x20@3x.png",
       "idiom": "iphone",
-      "scale": "2x",
-      "size": "60x60"
+      "scale": "3x",
+      "size": "20x20"
     },
     {
       "filename": "app-icon-40x40@3x.png",
@@ -43,9 +31,33 @@
       "size": "29x29"
     },
     {
+      "filename": "app-icon-29x29@3x.png",
+      "idiom": "iphone",
+      "scale": "3x",
+      "size": "29x29"
+    },
+    {
+      "filename": "app-icon-60x60@2x.png",
+      "idiom": "iphone",
+      "scale": "2x",
+      "size": "60x60"
+    },
+    {
+      "filename": "app-icon-29x29@1x.png",
+      "idiom": "ipad",
+      "scale": "1x",
+      "size": "29x29"
+    },
+    {
       "filename": "app-icon-20x20@2x.png",
       "idiom": "ipad",
       "scale": "2x",
+      "size": "20x20"
+    },
+    {
+      "filename": "app-icon-20x20@1x.png",
+      "idiom": "ipad",
+      "scale": "1x",
       "size": "20x20"
     },
     {
@@ -55,16 +67,16 @@
       "size": "60x60"
     },
     {
-      "filename": "app-icon-20x20@1x.png",
+      "filename": "app-icon-29x29@2x.png",
       "idiom": "ipad",
-      "scale": "1x",
-      "size": "20x20"
+      "scale": "2x",
+      "size": "29x29"
     },
     {
-      "filename": "app-icon-29x29@1x.png",
+      "filename": "app-icon-40x40@2x.png",
       "idiom": "ipad",
-      "scale": "1x",
-      "size": "29x29"
+      "scale": "2x",
+      "size": "40x40"
     },
     {
       "filename": "app-icon-40x40@1x.png",
@@ -83,18 +95,6 @@
       "idiom": "ipad",
       "scale": "2x",
       "size": "76x76"
-    },
-    {
-      "filename": "app-icon-40x40@2x.png",
-      "idiom": "ipad",
-      "scale": "2x",
-      "size": "40x40"
-    },
-    {
-      "filename": "app-icon-29x29@2x.png",
-      "idiom": "ipad",
-      "scale": "2x",
-      "size": "29x29"
     },
     {
       "filename": "app-icon-1024x1024@1x.png",

--- a/webapp/public/pwa/app-build.js
+++ b/webapp/public/pwa/app-build.js
@@ -1,1 +1,1 @@
-self.__TONPLAYGRAM_APP_BUILD__ = "122ba21";
+self.__TONPLAYGRAM_APP_BUILD__ = "aae9225";

--- a/webapp/public/version.json
+++ b/webapp/public/version.json
@@ -1,4 +1,4 @@
 {
-  "build": "122ba21",
-  "generatedAt": "2026-05-21T03:43:21.256Z"
+  "build": "aae9225",
+  "generatedAt": "2026-05-22T12:57:55.013Z"
 }

--- a/webapp/src/config/buildInfo.js
+++ b/webapp/src/config/buildInfo.js
@@ -1,2 +1,2 @@
-export const APP_BUILD = "122ba21";
-export const APP_BUILD_GENERATED_AT = "2026-05-21T03:43:21.256Z";
+export const APP_BUILD = "aae9225";
+export const APP_BUILD_GENERATED_AT = "2026-05-22T12:57:55.013Z";

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -8,40 +8,6 @@ const SNOOKER_LOCAL_ASSET_PATH = 'https://raw.githubusercontent.com/ekiefl/poolt
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
-    id: 'procedural-legacy',
-    label: 'Legacy Procedural',
-    description:
-      'Legacy menu/mapping profile mounted on the Snooker Royal 9 ft GLB shell with full pockets, rails, and trim.',
-    tableSizeId: '9ft',
-    baseId: 'showoodOriginal',
-    assetUrl: SNOOKER_LOCAL_ASSET_PATH,
-    fallbackAssetUrls: [
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/snooker.glb',
-      `${POOLTOOL_RAW_BASE}/snooker.glb`
-    ],
-    icon: '🧱',
-    kind: 'gltf',
-    fitScale: 1,
-    fitFootprintScale: 1.04,
-    fitHeightScale: 1,
-    clothRepeatScale: 7.2,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeHeight: true,
-    preserveOriginalFootprintAspect: true,
-    useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim'],
-    preserveOriginalSurfaceRoles: ['wood'],
-    tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip'],
-    blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: [],
-    tableLogicProfile: 'showood7ft',
-    cueRigProfile: 'snookerRoyalProvided' 
-  },
-  {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
@@ -78,40 +44,6 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     useLegacyShowoodRemap: false,
     tableLogicProfile: 'showood7ft',
     cueRigProfile: 'poolRoyaleDefault'
-  },
-  {
-    id: 'chinese-8ball-snooker',
-    label: 'Chinese 8-Ball (9 ft)',
-    description:
-      'Snooker Royal GLB 9 ft table shell adapted for Pool Royale 8-ball mapping and physics.',
-    tableSizeId: '9ft',
-    baseId: 'showoodOriginal',
-    assetUrl: SNOOKER_LOCAL_ASSET_PATH,
-    fallbackAssetUrls: [
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/snooker.glb',
-      `${POOLTOOL_RAW_BASE}/snooker.glb`
-    ],
-    icon: '🇨🇳',
-    kind: 'gltf',
-    fitScale: 1,
-    fitFootprintScale: 1.04,
-    fitHeightScale: 1,
-    clothRepeatScale: 7.2,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeHeight: true,
-    preserveOriginalFootprintAspect: true,
-    useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim'],
-    preserveOriginalSurfaceRoles: ['wood'],
-    tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip'],
-    blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: [],
-    tableLogicProfile: 'chinese8Ball9ft',
-    cueRigProfile: 'snookerRoyalProvided'
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4310,7 +4310,6 @@ const SHOWOOD_TABLE_PARTS = Object.freeze([
   'topWoodRail',
   'railSight',
   'pocketCup',
-  'baseCornerBlock',
   'leg',
   'baseFoot'
 ]);
@@ -4320,7 +4319,6 @@ const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
   topWoodRail: DEFAULT_TABLE_FINISH_ID,
   railSight: 'gold',
   pocketCup: 'black',
-  baseCornerBlock: DEFAULT_TABLE_FINISH_ID,
   leg: DEFAULT_TABLE_FINISH_ID,
   baseFoot: 'gold'
 });
@@ -4342,10 +4340,6 @@ const SHOWOOD_TABLE_PART_OPTIONS = Object.freeze({
     { id: 'black', label: 'Black Cups', color: '#000000', keepSourceTexture: true, material: { color: 0x000000, roughness: 0.98, metalness: 0, envMapIntensity: 0.12 } },
     { id: 'leather', label: 'Dark Leather Cups', color: '#1b0c04', keepSourceTexture: true, material: { color: 0x1b0c04, roughness: 0.9, metalness: 0, envMapIntensity: 0.26 } }
   ]),
-  baseCornerBlock: Object.freeze([
-    { id: 'brown', label: 'Brown Base', color: '#7b2d11', material: { color: 0x7b2d11, roughness: 0.48, metalness: 0.02, envMapIntensity: 1.1, clearcoat: 0.22, clearcoatRoughness: 0.33 } },
-    { id: 'black', label: 'Black Base', color: '#080605', material: { color: 0x080605, roughness: 0.38, metalness: 0.03, envMapIntensity: 1.34, clearcoat: 0.34, clearcoatRoughness: 0.22 } }
-  ]),
   leg: Object.freeze([]),
   baseFoot: Object.freeze([
     { id: 'chrome', label: 'Chrome Feet', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
@@ -4358,7 +4352,6 @@ const SHOWOOD_TABLE_PART_LABELS = Object.freeze({
   topWoodRail: 'Top Rails',
   railSight: 'Side Apron + Rail Sights',
   pocketCup: 'Pocket Cups',
-  baseCornerBlock: 'Table Base',
   leg: 'Legs',
   baseFoot: 'Feet'
 });
@@ -4375,7 +4368,7 @@ const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOption
       material: { color: option.color, roughness: 1, metalness: 0, envMapIntensity: 0.16 }
     }));
   }
-  if (part === 'topWoodRail' || part === 'baseCornerBlock' || part === 'leg') {
+  if (part === 'topWoodRail' || part === 'leg') {
     const sourceOptions = Array.isArray(tableFinishOptions) && tableFinishOptions.length
       ? tableFinishOptions
       : TABLE_FINISH_OPTIONS;
@@ -4384,7 +4377,7 @@ const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOption
       const swatch = option.swatches?.[0] ?? finish?.colors?.rail ?? finish?.colors?.base ?? 0x5a2608;
       return {
         id: option.id,
-        label: `${option.label || finish?.label || option.id} ${part === 'topWoodRail' ? 'Rails' : part === 'baseCornerBlock' ? 'Base' : 'Legs'}`,
+        label: `${option.label || finish?.label || option.id} ${part === 'topWoodRail' ? 'Rails' : 'Legs'}`,
         color: toHexColor(swatch),
         thumbnail: option.thumbnail,
         useTableFinishTexture: true
@@ -4409,7 +4402,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -13135,7 +13128,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
   } else if (part === 'pocketCup') {
     copyMaterialLook(materials.pocketJaw ?? materials.pocketRim);
     applyShowoodTint();
-  } else if (part === 'topWoodRail' || part === 'baseCornerBlock' || part === 'leg') {
+  } else if (part === 'topWoodRail' || part === 'leg') {
     const surface = part === 'topWoodRail'
       ? finishInfo?.parts?.woodSurfaces?.rail
       : finishInfo?.parts?.woodSurfaces?.frame || finishInfo?.parts?.woodSurfaces?.rail;
@@ -17215,7 +17208,7 @@ function PoolRoyaleGame({
           material.needsUpdate = true;
         };
         applyShowoodPartMaterial(materials.rail, 'topWoodRail');
-        applyShowoodPartMaterial(materials.frame, 'baseCornerBlock');
+        applyShowoodPartMaterial(materials.frame, 'topWoodRail');
         applyShowoodPartMaterial(materials.leg, 'leg');
         const liners = createPocketLinerMaterials(linerSelection);
         materials.pocketJaw = liners.jawMaterial;
@@ -27174,9 +27167,7 @@ const shotPowerRef = useRef(0);
       cueStick.visible = false;
       table.add(cueStick);
       const humanRig =
-        activeTableModel?.cueRigProfile === 'snookerRoyalProvided'
-          ? createPoolRoyaleHumanRig(table, renderer)
-          : null;
+        null;
       const cueShadow = ENABLE_CUE_CLOTH_SHADOW
         ? (() => {
             const shadowWidth = Math.max(BALL_R * CUE_SHADOW_WIDTH_RATIO, BALL_R * 0.4);


### PR DESCRIPTION
### Motivation
- Remove the Snooker/9ft and procedural table options so the lobby loads the Showood 7ft table by default and SKU confusion is avoided.
- Remove the on-table human rigs and procedural table artifacts from the Pool Royale cue scene to simplify visuals and rendering costs.
- Make rail sight / side apron / feet chrome/gold controlled from a single linked option and ensure the table base uses the same texture as the top rail for consistent mapping.
- Simplify the Showood personalization menu by removing the separate "Table Base" selector so base and top-rail always match.

### Description
- Kept only the Showood model in `webapp/src/config/poolRoyaleTableModels.js` by removing the `procedural-legacy` and `chinese-8ball-snooker` entries so `showood-seven-foot` is the default and sole option.
- Removed `baseCornerBlock` from `SHOWOOD_TABLE_PARTS`, its options and label entries in `webapp/src/pages/Games/PoolRoyale.jsx` so the UI no longer exposes a separate Table Base selector.
- Mapped side-apron/base lookups to use the top-rail choice by changing `getShowoodPartOption` and applying the top-rail material to `materials.frame` in the showood material application path so base/frame textures follow the `topWoodRail` selection.
- Disabled mounting of the Pool Royale human rig in the cue scene by replacing the `createPoolRoyaleHumanRig(...)` call with `null` to remove those character rigs from this path.
- Updated build metadata files (`webapp/public/pwa/app-build.js`, `webapp/public/version.json`, `webapp/src/config/buildInfo.js`) as part of a production build run.

### Testing
- Ran a production build with `cd webapp && npm run -s build` which completed successfully producing the `dist/` output (build warnings about chunk sizes only; build succeeded).
- Verified the modified files were staged/committed and the repository status reflected the changes (commit created for these edits).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1052821b8083299df4872c5211a92e)