### PR TITLE
Align TonPlaygram branding, enable rail markers, and adjust rail/apron/leg geometry for Pool Royale table

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1623,7 +1623,7 @@ const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.225; // lift the cushion base higher 
 const CUSHION_HEIGHT_DROP = 0; // keep the cushion tops fully raised to match the Showood rail profile
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
-const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH * 0.64; // shorten the short/top rail drop further from the bottom while keeping side aprons unchanged
+const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH * 0.54; // shorten the short/top rail drop from the bottom side while keeping all four cushions/panels unchanged
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.085; // round exterior wooden rail edge profile to remove sharp octagon-like corners
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
@@ -1876,11 +1876,11 @@ const TABLE_H = 0.75 * LEG_SCALE * TABLE_HEIGHT_REDUCTION * TABLE_HEIGHT_SCALE;
 const TABLE_LIFT =
   BASE_TABLE_LIFT + TABLE_H * (LEG_HEIGHT_FACTOR - 1);
 const BASE_LEG_HEIGHT = TABLE.THICK * 2 * 3 * 1.15 * LEG_HEIGHT_MULTIPLIER;
-const LEG_RADIUS_SCALE = 1.32; // expand leg thickness so the larger base and legs read sturdier from all sides
+const LEG_RADIUS_SCALE = 1.4; // expand leg thickness on all four sides so the base stays visually stronger in portrait framing
 const BASE_LEG_LENGTH_SCALE = 0.72; // previous leg extension factor used for baseline stance
 const LEG_ELEVATION_SCALE = 0.96; // shorten the current leg extension to lower the playfield
-const LEG_LENGTH_SHRINK = 0.96; // extend legs downward a bit more so playfield height stays stable after shortening short-rail bottoms
-const BASE_HEIGHT_REDUCTION = 0.69; // trim table bases slightly more from the bottom to shorten the table stance
+const LEG_LENGTH_SHRINK = 1.02; // extend legs downward to preserve the same playfield height after trimming the short-rail bottoms
+const BASE_HEIGHT_REDUCTION = 0.73; // expand the leg-base body while keeping the table stance height stable
 const LEG_LENGTH_SCALE =
   BASE_LEG_LENGTH_SCALE * LEG_ELEVATION_SCALE * LEG_LENGTH_SHRINK * BASE_HEIGHT_REDUCTION;
 const LEG_HEIGHT_OFFSET = FRAME_TOP_Y - 0.3; // relationship between leg room and visible leg height
@@ -1910,7 +1910,7 @@ const BASE_HEIGHT_FILL = BASE_HEIGHT_REDUCTION; // keep custom bases aligned wit
 const BASE_TABLE_Y = -2 + (TABLE_H - 0.75) + TABLE_H + TABLE_LIFT - TABLE_DROP;
 const TABLE_HEIGHT_DROP = (TABLE_H + TABLE.THICK) * 0.24; // lower the full table assembly a bit more so portal leg bottoms sit down onto their chrome levelers
 const TABLE_Y = BASE_TABLE_Y + LEG_ELEVATION_DELTA - TABLE_HEIGHT_DROP;
-const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.42; // expand/deepen the leg base so the body trim change does not visually lift the playfield
+const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.5; // deepen the leg-base and legs together so the table height stays unchanged
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.07;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
@@ -11938,7 +11938,7 @@ export function Table3D(
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
   const brandPlateOutwardShift = endRailW * 0.62;
-  const externalLayoutBrandPlateYOffset = externalTableUsesOriginalLayout ? railH * 0.03 : 0;
+  const externalLayoutBrandPlateYOffset = 0; // keep branding plates at the exact same visual height/position used by the procedural table
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -12098,10 +12098,8 @@ export function Table3D(
     });
     activeRailMarkerStyle = { shape: shapeId, colorId: colorOpt.id };
   };
-  if (!externalTableUsesOriginalLayout) {
-    applyRailMarkerStyleFn(activeRailMarkerStyle);
-    railsGroup.add(railMarkerGroup);
-  }
+  applyRailMarkerStyleFn(activeRailMarkerStyle);
+  railsGroup.add(railMarkerGroup);
 
   const shortRailWordmarkTexture = createBrandPlateLabelTexture({
     width: 2048,
@@ -12906,8 +12904,8 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
     : [];
   if (chromeSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
   if (blackSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
-  if (/rail[_\s-]*sight|railsight|rail[_\s-]*sight[_\s-]*lower|corner[_\s-]*rail[_\s-]*sight|diamond|sight|marker|inlay|apron[_\s-]*strip/.test(childName)) return 'railSight';
-  if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|side[_\s-]*apron|apron(?![_\s-]*strip)/.test(childName)) return 'sideWoodApron';
+  if (/rail[_\s-]*sight|railsight|rail[_\s-]*sight[_\s-]*lower|corner[_\s-]*rail[_\s-]*sight|diamond|sight|marker|inlay|apron[_\s-]*strip|side[_\s-]*rail[_\s-]*trim|rail[_\s-]*trim/.test(childName)) return 'railSight';
+  if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|side[_\s-]*apron|apron(?![_\s-]*strip)|rail[_\s-]*skirt|lower[_\s-]*rail[_\s-]*panel/.test(childName)) return 'sideWoodApron';
   if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(childName)) return 'cushion';
   if (/pocket|liner|leather|net|basket|drop|holder|cup/.test(childName)) return 'pocketCup';
   if (/vertical.*(rim|plate|cap)|corner.*(rim|plate|cap)|rim|foot|feet|base[_\s-]*foot/.test(childName)) return 'verticalCornerRim';
@@ -12918,11 +12916,11 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   if (/slate|cloth|felt|baize|bed|playfield|playing[_\s-]*surface/.test(childName)) return 'cloth';
   if (/cloth|felt|baize|slate|bed|playfield|playing[_\s-]*surface/.test(label)) return 'cloth';
   if (/pocket|liner|leather|net|basket|drop|cup/.test(label)) return 'pocketCup';
-  if (/metal|chrome|gold|diamond|sight|marker|plate|trim|screw|bolt/.test(label)) return 'railSight';
+  if (/metal|chrome|gold|diamond|sight|marker|plate|trim|screw|bolt|rail[_\s-]*trim/.test(label)) return 'railSight';
   if (/leg|support/.test(label)) return 'leg';
   if (/foot|rim/.test(label)) return 'verticalCornerRim';
   if (/base|cabinet/.test(label)) return 'baseCornerBlock';
-  if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|side[_\s-]*apron|apron(?![_\s-]*strip)/.test(label)) return 'sideWoodApron';
+  if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|side[_\s-]*apron|apron(?![_\s-]*strip)|rail[_\s-]*skirt|lower[_\s-]*rail[_\s-]*panel/.test(label)) return 'sideWoodApron';
   if (/frame|wood|rail|showood|bevel/.test(label)) return 'topWoodRail';
   return 'wood';
 }


### PR DESCRIPTION
### Motivation
- Ensure TonPlaygram brand plates on external/original-layout tables sit at the exact same visual baseline used by the procedural table. 
- Make `railSight` and side-apron surfaces on imported/GLTF tables detect correctly so textures and chrome/trim materials apply to the intended meshes. 
- Adjust top-rail lower drop and beef up leg/leg-base geometry so the table silhouette matches the requested portrait framing while keeping playfield height and wooden panels/cushions visually unchanged.

### Description
- Removed the original extra Y offset for external table brand plates by setting `externalLayoutBrandPlateYOffset = 0` and kept brand plates positioned identically to the procedural table. 
- Always apply rail markers for external/original-layout tables by removing the `externalTableUsesOriginalLayout` conditional around `applyRailMarkerStyleFn(...)` and `railsGroup.add(railMarkerGroup)`. 
- Broadened the external-surface classifier to better catch trim/skirt/lower-panel names by adding additional regex patterns for `rail_*trim`, `rail_*skirt`, and `lower_*rail_*panel` in `classifyPoolRoyaleExternalTableSurface`. 
- Tuned table geometry constants to match the new silhouette: changed `END_RAIL_EXTRA_DEPTH` (previously `* 0.64`) to `* 0.54`, increased `LEG_RADIUS_SCALE` from `1.32` to `1.4`, adjusted `LEG_LENGTH_SHRINK` from `0.96` to `1.02`, raised `BASE_HEIGHT_REDUCTION` from `0.69` to `0.73`, and increased `LEG_BASE_DROP` multiplier from `0.42` to `0.5` (all edits in `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran repository searches and file inspections with `rg`/`sed` to confirm affected blocks and patterns were updated and consistent, which succeeded. 
- Verified the code changes with `git diff -- webapp/src/pages/Games/PoolRoyale.jsx` and committed the change using `git commit`, both of which succeeded. 
- No automated rendering/unit tests were executed in this rollout; changes are limited to material/role mapping and tuning constants only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1060587ac08329b98be240ee47a938)