### PR TITLE
Tune Pool Royale power, pocket mapping, chrome surfaces, and HDRI load profile

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -40,7 +40,12 @@ describe('Pool Royale table models', () => {
       'sideWoodApron',
       'apronStrip',
       'railSightLower',
-      'cornerRailSight'
+      'cornerRailSight',
+      'brandingPlate',
+      'brandingPlates',
+      'namePlate',
+      'railApron',
+      'stripApron'
     ]);
     assert.deepEqual(showood.blackMaterialSurfaceNames, []);
     assert.equal(showood.forceGeneratedChromePlates, false);

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -37,7 +37,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim'],
     preserveOriginalSurfaceRoles: ['wood'],
     tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'sideWoodApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'sideWoodApron', 'apronStrip', 'railSightLower', 'cornerRailSight', 'brandingPlate', 'brandingPlates', 'namePlate', 'railApron', 'stripApron'],
     blackMaterialSurfaceNames: [],
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: [],

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1354,7 +1354,7 @@ const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // 
 const CORNER_POCKET_JAW_EDGE_TRIM_START = SIDE_POCKET_JAW_EDGE_TRIM_START; // keep corner jaw taper start aligned with middle pockets
 const CORNER_POCKET_JAW_EDGE_TRIM_SCALE = SIDE_POCKET_JAW_EDGE_TRIM_SCALE; // match the middle pocket jaw thin/thick profile
 const CORNER_POCKET_JAW_EDGE_TRIM_CURVE = SIDE_POCKET_JAW_EDGE_TRIM_CURVE; // reuse the same taper curve for corner jaws
-const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.035; // slightly expand jaw collision arcs so physics cannot slip through visible jaw/chrome edges
+const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.01; // tighten jaw collision arcs so balls do not bounce early before reaching cushion noses
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span to the corner profile
 const POCKET_RIM_DEPTH_RATIO = 0; // remove the separate pocket rims so the chrome fascias meet the jaws directly
@@ -1835,7 +1835,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.62; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.82; // raise strike speed a touch so shots carry slightly more power
+const SHOT_GLOBAL_POWER_SCALE = 0.9; // add a bit more carry so medium-power and break shots feel stronger
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -4699,8 +4699,8 @@ const updateRuntimeTextureProfile = ({ fps } = {}) => {
     polyHavenPreferredResolutions: tier.preferredResolutions ?? Object.freeze([tier.key]),
     polyHavenFallbackResolution:
       tier.fallbackResolution ?? tier.preferredResolutions?.[tier.preferredResolutions.length - 1] ?? tier.key,
-    hdriPreferredResolutions: Object.freeze(['4k']),
-    hdriFallbackResolution: '4k',
+    hdriPreferredResolutions: Object.freeze(['2k']),
+    hdriFallbackResolution: '2k',
     enforceTableFinishTextureSize: textureSize,
     cueTextureSize: textureSize,
     pocketTextureSize: Math.max(512, Math.min(textureSize, 4096))


### PR DESCRIPTION
### Motivation
- Address gameplay feedback: slightly increase shot carry so the game feels more powerful. 
- Fix visible early bounces by tightening pocket/jaw collision mapping so balls don’t appear to bounce before hitting cushions. 
- Ensure branding plates and strip-apron/rail-apron parts pick up chrome/material styling so visible plates and rails render correctly. 
- Reduce HDRI load preference to cut initial scene payload and improve load time on mobile.

### Description
- Increased global shot carry by raising `SHOT_GLOBAL_POWER_SCALE` from `0.82` to `0.9` in `webapp/src/pages/Games/PoolRoyale.jsx` to give medium-power and break shots more carry. 
- Tightened pocket collision mapping by changing `POCKET_JAW_MAPPING_RADIUS_SCALE` from `1.035` to `1.01` in `webapp/src/pages/Games/PoolRoyale.jsx` to reduce early visual bounces before cushion contact. 
- Expanded `chromeMaterialSurfaceNames` for the Showood table in `webapp/src/config/poolRoyaleTableModels.js` to include `brandingPlate`, `brandingPlates`, `namePlate`, `railApron`, and `stripApron` so those meshes can receive chrome/plate styling. 
- Lowered default HDRI/runtime preferences from `4k` to `2k` in `webapp/src/pages/Games/PoolRoyale.jsx` to reduce startup texture/HDRI payload for faster initial loads on constrained devices. 
- Updated `test/poolRoyaleTableModels.test.js` expected chrome surface list to reflect the added surface aliases.

### Testing
- Ran `jest` tests targeting pocket aim and table model assertions and they passed: `test/poolRoyalePocketAim.test.js` (all tests passed). 
- Ran the specific table-model mapping test `test/poolRoyaleTableModels.test.js -t "Showood keeps GLB wood textures while using Pool Royale procedural finish for non-wood surfaces"` and it passed after the config update. 
- No other automated test suites were modified; targeted tests were used to validate this change and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a110feb33908329bfc9d2903f88d2bb)