### PR TITLE
Preserve original GLTF weapon textures by disabling automatic URP shader upgrade

### DIFF
--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -10,8 +10,8 @@ namespace Aiming.Gameplay.Rendering
     {
         [SerializeField] private Renderer[] targetRenderers;
         [SerializeField] private bool runOnAwake = true;
-        [SerializeField] private bool forceUrpLitShader = true;
-        [SerializeField] private bool upgradeGltfImportShaders = true;
+        [SerializeField] private bool forceUrpLitShader = false;
+        [SerializeField] private bool upgradeGltfImportShaders = false;
         [SerializeField] private Shader urpLitShader;
         [SerializeField] private Shader standardShader;
 


### PR DESCRIPTION
### Motivation
- The GLTF compatibility adapter was automatically replacing imported GLTF/GLB shaders with a URP/compatibility shader which altered the original weapon textures, so the defaults were changed to preserve the imported look.

### Description
- Changed defaults in `Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs` to set `forceUrpLitShader = false` and `upgradeGltfImportShaders = false` so imported shaders/textures are kept by default.

### Testing
- Verified the change and commit by inspecting the working tree and diffs with `git diff` / `nl` and confirmed the file update and commit succeeded; no automated Unity runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11138a878083298f94985c5a748fcb)