### PR TITLE
Revert "Preserve original GLTF weapon textures by disabling automatic URP shader upgrade"

### DIFF
--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -10,8 +10,8 @@ namespace Aiming.Gameplay.Rendering
     {
         [SerializeField] private Renderer[] targetRenderers;
         [SerializeField] private bool runOnAwake = true;
-        [SerializeField] private bool forceUrpLitShader = false;
-        [SerializeField] private bool upgradeGltfImportShaders = false;
+        [SerializeField] private bool forceUrpLitShader = true;
+        [SerializeField] private bool upgradeGltfImportShaders = true;
         [SerializeField] private Shader urpLitShader;
         [SerializeField] private Shader standardShader;
 


### PR DESCRIPTION
Reverts TonPlaygramBot/TonPlaygramWebApp#24107