### PR TITLE
Preserve original GLTF/GLB weapon materials to restore firearm textures

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -146,6 +146,10 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private float maxLookUpDegrees = 8f;
         [SerializeField] private float maxLookDownDegrees = 26f;
 
+        [Header("Material import behavior")]
+        [Tooltip("Keeps imported GLTF/GLB weapon materials untouched so original weapon textures stay exactly as authored.")]
+        [SerializeField] private bool preserveOriginalWeaponMaterials = true;
+
 
         private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();
         private readonly List<TokenPieceHealth> _tokenPieces = new List<TokenPieceHealth>();
@@ -193,7 +197,10 @@ namespace TonPlaygram.Gameplay.Weapons
             BuildProfileMap();
             CacheTokenPieces();
             CacheStaticAnchors();
-            ApplyWeaponMaterialCompatibility();
+            if (!preserveOriginalWeaponMaterials)
+            {
+                ApplyWeaponMaterialCompatibility();
+            }
             _eventListeners = GetComponentsInParent<ILudoWeaponEvents>(true);
             _projectileListeners = GetComponentsInParent<ILudoProjectileBroadcastEvents>(true);
             Equip(startingWeapon);


### PR DESCRIPTION
### Motivation
- Weapon GLTF/GLB imports were having their authored textures/ shaders overridden by a compatibility pass, which changed the original weapon appearance and caused texture regressions.

### Description
- Added a new serialized toggle `preserveOriginalWeaponMaterials` (default `true`) to `Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs` and updated `Awake()` to only run `ApplyWeaponMaterialCompatibility()` when that toggle is disabled so imported weapon materials remain untouched by default.

### Testing
- No automated Unity/runtime rendering tests were executed in this environment, so no runtime render/scene validation was performed; change is limited to a conditional and serialized field and compiles as a C# change in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11138a878083298f94985c5a748fcb)