### PR TITLE
Add 3D Showood pool table viewer and simplify table personalization to cloth + cushions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyalGameTable.jsx
+++ b/webapp/src/pages/Games/PoolRoyalGameTable.jsx
@@ -1,0 +1,156 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader.js";
+import { KTX2Loader } from "three/examples/jsm/loaders/KTX2Loader.js";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
+import { MeshoptDecoder } from "three/examples/jsm/libs/meshopt_decoder.module.js";
+
+const TABLE_MODEL_URL = "https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb";
+const DRACO_DECODER_PATH = "https://www.gstatic.com/draco/versioned/decoders/1.5.7/";
+const BASIS_TRANSCODER_PATH = "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/";
+
+const PARTS = ["cloth", "cushion"];
+const PART_OPTIONS = {
+  cloth: {
+    a: { label: "Green cloth", color: "#0a7b33", metalness: 0, roughness: 1, envMapIntensity: 0.16 },
+    b: { label: "Blue cloth", color: "#0d4fb8", metalness: 0, roughness: 1, envMapIntensity: 0.16 },
+  },
+  cushion: {
+    a: { label: "Green cushions", color: "#064f23", metalness: 0, roughness: 0.94, envMapIntensity: 0.24 },
+    b: { label: "Black cushions", color: "#050505", metalness: 0, roughness: 0.88, envMapIntensity: 0.38 },
+  },
+};
+
+const DEFAULT_PALETTE = { cloth: "a", cushion: "a" };
+
+function applyMaterial(mat, option) {
+  mat.color.set(option.color);
+  mat.metalness = option.metalness;
+  mat.roughness = option.roughness;
+  mat.envMapIntensity = option.envMapIntensity;
+  mat.map = null;
+  mat.normalMap = null;
+  mat.roughnessMap = null;
+  mat.metalnessMap = null;
+  mat.needsUpdate = true;
+}
+
+export default function PoolRoyalGameTable() {
+  const hostRef = useRef(null);
+  const bucketsRef = useRef({ cloth: [], cushion: [] });
+  const [palette, setPalette] = useState(DEFAULT_PALETTE);
+
+  useEffect(() => {
+    PARTS.forEach((part) => {
+      bucketsRef.current[part].forEach((mat) => applyMaterial(mat, PART_OPTIONS[part][palette[part]]));
+    });
+  }, [palette]);
+
+  const rows = useMemo(() => PARTS.map((part) => ({ part, options: PART_OPTIONS[part], selected: palette[part] })), [palette]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return undefined;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color("#050505");
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    host.appendChild(renderer.domElement);
+
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+
+    const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 120);
+    camera.position.set(6.2, 4.2, 7.0);
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.target.set(0, 1.05, 0);
+    controls.enableDamping = true;
+
+    scene.add(new THREE.AmbientLight(0xffffff, 1.08));
+    const key = new THREE.DirectionalLight(0xffffff, 2.8);
+    key.position.set(6, 10, 7);
+    scene.add(key);
+
+    const draco = new DRACOLoader();
+    draco.setDecoderPath(DRACO_DECODER_PATH);
+    const ktx2 = new KTX2Loader();
+    ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
+    ktx2.detectSupport(renderer);
+    const loader = new GLTFLoader();
+    loader.setDRACOLoader(draco);
+    loader.setKTX2Loader(ktx2);
+    loader.setMeshoptDecoder(MeshoptDecoder);
+
+    let frame = 0;
+    let mounted = true;
+
+    loader.load(TABLE_MODEL_URL, (gltf) => {
+      if (!mounted) return;
+      const table = gltf.scene;
+      table.scale.setScalar(1.5);
+      table.rotation.y = Math.PI;
+      table.traverse((child) => {
+        if (!child.isMesh) return;
+        const mats = Array.isArray(child.material) ? child.material : [child.material];
+        child.material = mats.map((m) => {
+          const mat = new THREE.MeshPhysicalMaterial({ color: "#ffffff", roughness: 0.5, metalness: 0 });
+          const name = `${child.name || ""} ${m?.name || ""}`.toLowerCase();
+          const isCloth = /cloth|felt|bed|surface/.test(name);
+          const part = isCloth ? "cloth" : /cushion|rubber|bumper/.test(name) ? "cushion" : null;
+          if (part) {
+            mat.userData.part = part;
+            bucketsRef.current[part].push(mat);
+            applyMaterial(mat, PART_OPTIONS[part][palette[part]]);
+          } else {
+            mat.color.set("#2b2118");
+          }
+          return mat;
+        });
+      });
+      scene.add(table);
+    });
+
+    const animate = () => {
+      frame = requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      mounted = false;
+      cancelAnimationFrame(frame);
+      controls.dispose();
+      pmrem.dispose();
+      ktx2.dispose();
+      draco.dispose();
+      renderer.dispose();
+      renderer.domElement.remove();
+    };
+  }, [palette]);
+
+  return (
+    <div ref={hostRef} style={{ position: "fixed", inset: 0, background: "#050505" }}>
+      <div style={{ position: "fixed", left: 8, right: 8, bottom: 8, background: "rgba(0,0,0,0.72)", padding: 10, borderRadius: 14 }}>
+        {rows.map((row) => (
+          <div key={row.part} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+            <strong style={{ color: "white", width: 80 }}>{row.part}</strong>
+            {["a", "b"].map((choice) => (
+              <button key={choice} onClick={() => setPalette((p) => ({ ...p, [row.part]: choice }))} style={{ color: "white", borderRadius: 999, padding: "6px 10px", border: "1px solid #666", background: row.selected === choice ? "#334155" : "#111827" }}>
+                {row.options[choice].label}
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -36128,143 +36128,77 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Chrome Plates
-                </h3>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {availableChromeOptions.map((option) => {
-                    const active = option.id === chromeColorId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setChromeColorId(option.id)}
-                        aria-pressed={active}
-                        className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="flex items-center justify-center gap-2">
-                          <span
-                            className="h-3.5 w-3.5 rounded-full border border-white/40"
-                            style={{ backgroundColor: toHexColor(option.color) }}
-                            aria-hidden="true"
-                          />
-                          {option.label}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
               <div className="rounded-3xl border border-emerald-300/20 bg-white/[0.04] p-3">
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                      Table Personalisation
+                      Table Setup
                     </h3>
                     <p className="mt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-white/55">
-                      Select a table part, then choose the unlocked finish for that part.
+                      Keep only cloth + cushions. Other table options are fixed to the new Showood mapping.
                     </p>
                   </div>
                   <span className="rounded-full border border-emerald-200/30 px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] text-emerald-100/70">
                     Showood
                   </span>
                 </div>
-                <div className="mt-3 -mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
-                  {tablePersonalizationSections.map((section) => {
-                    const selectedSection = section.key === activeTablePersonalizationPart;
-                    return (
-                      <button
-                        key={section.key}
-                        type="button"
-                        onClick={() => setActiveTablePersonalizationPart(section.key)}
-                        className={`whitespace-nowrap rounded-full border px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.18em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          selectedSection
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_14px_rgba(16,185,129,0.45)]'
-                            : 'border-white/15 bg-white/5 text-white/70 hover:border-white/30 hover:text-white'
-                        }`}
-                      >
-                        {section.label}
-                      </button>
-                    );
-                  })}
-                </div>
-                {activeTablePersonalizationSection ? (
-                  <div className="mt-3 max-h-64 overflow-y-auto pr-1">
-                    <div className="mb-2 flex items-center justify-between gap-3">
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-white/60">
-                        {activeTablePersonalizationSection.label}
-                      </p>
-                      {activeTablePersonalizationSection.chromeLinked ? (
-                        <span className="text-[9px] uppercase tracking-[0.18em] text-emerald-100/55">
-                          linked to chrome plates
-                        </span>
-                      ) : null}
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      {activeTablePersonalizationSection.options.map((option) => {
-                        const part = activeTablePersonalizationSection.key;
-                        const chromeLinked = activeTablePersonalizationSection.chromeLinked;
-                        const selected = part === 'cloth'
-                          ? clothColorId
-                          : part === 'topWoodRail' || part === 'leg'
-                            ? tableFinishId
-                            : chromeLinked
-                              ? (chromeColorId === 'gold' ? 'gold' : 'chrome')
-                              : normalizeShowoodTableStyle(showoodTableStyle)[part];
-                        const active = option.id === selected;
+
+                {availableClothOptions.length > 0 ? (
+                  <div className="mt-3">
+                    <h4 className="text-[10px] uppercase tracking-[0.28em] text-emerald-100/65">Cloth Color</h4>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {availableClothOptions.map((option) => {
+                        const active = option.id === clothColorId;
+                        const thumb = option.thumbnail;
                         return (
                           <button
-                            key={`${part}-${option.id}`}
+                            key={option.id}
                             type="button"
-                            onClick={() => {
-                              if (part === 'cloth') {
-                                setClothColorId(option.id);
-                              } else if (part === 'topWoodRail' || part === 'leg') {
-                                setTableFinishId(option.id);
-                                setShowoodTableStyle((current) =>
-                                  normalizeShowoodTableStyle({ ...current, [part]: option.id })
-                                );
-                              } else if (chromeLinked) {
-                                setChromeColorId(option.id === 'gold' ? 'gold' : 'chrome');
-                              } else {
-                                setShowoodTableStyle((current) =>
-                                  normalizeShowoodTableStyle({ ...current, [part]: option.id })
-                                );
-                              }
-                            }}
+                            onClick={() => setClothColorId(option.id)}
                             aria-pressed={active}
-                            className={`flex flex-col items-center justify-between gap-2 rounded-2xl border p-2 text-center text-[10px] font-semibold uppercase tracking-[0.16em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            className={`flex min-w-[8.5rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
                               active
                                 ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
                                 : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
                             }`}
                           >
-                            {option.thumbnail ? (
-                              <img
-                                src={option.thumbnail}
-                                alt={option.label}
-                                className="h-12 w-full rounded-xl border border-white/20 object-cover"
-                                loading="lazy"
-                              />
-                            ) : (
-                              <span
-                                className="h-12 w-full rounded-xl border border-white/30"
-                                style={{ backgroundColor: option.color }}
-                                aria-hidden="true"
-                              />
-                            )}
-                            <span className="line-clamp-2">{option.label}</span>
+                            <span className="flex items-center gap-2">
+                              <span className="h-3.5 w-3.5 rounded-full border border-white/40" style={{ backgroundColor: toHexColor(option.color) }} aria-hidden="true" />
+                              <span className="truncate">{option.label}</span>
+                            </span>
+                            {thumb ? <img src={thumb} alt={option.label} className="h-6 w-10 rounded-lg border border-white/20 object-cover" loading="lazy" /> : null}
                           </button>
                         );
                       })}
                     </div>
                   </div>
                 ) : null}
+
+                <div className="mt-3">
+                  <h4 className="text-[10px] uppercase tracking-[0.28em] text-emerald-100/65">Cushion Color</h4>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {SHOWOOD_TABLE_PART_OPTIONS.cushion.map((option) => {
+                      const current = normalizeShowoodTableStyle(showoodTableStyle).cushion;
+                      const active = option.id === current;
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => setShowoodTableStyle((prev) => normalizeShowoodTableStyle({ ...prev, cushion: option.id }))}
+                          aria-pressed={active}
+                          className={`flex min-w-[8.5rem] flex-1 items-center justify-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            active
+                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                          }`}
+                        >
+                          <span className="h-3.5 w-3.5 rounded-full border border-white/40" style={{ backgroundColor: option.color }} aria-hidden="true" />
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
               </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
@@ -36300,94 +36234,6 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
-              {availableClothOptions.length > 0 ? (
-                <div>
-                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                    Cloth Library
-                  </h3>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    {availableClothOptions.map((option) => {
-                      const active = option.id === clothColorId;
-                      const thumb = option.thumbnail;
-                      return (
-                        <button
-                          key={option.id}
-                          type="button"
-                          onClick={() => setClothColorId(option.id)}
-                          aria-pressed={active}
-                          className={`flex min-w-[8.5rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                            active
-                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                          }`}
-                        >
-                          <span className="flex items-center gap-2">
-                            <span
-                              className="h-3.5 w-3.5 rounded-full border border-white/40"
-                              style={{ backgroundColor: toHexColor(option.color) }}
-                              aria-hidden="true"
-                            />
-                            <span className="truncate">{option.label}</span>
-                          </span>
-                          {thumb ? (
-                            <img
-                              src={thumb}
-                              alt={option.label}
-                              className="h-6 w-10 rounded-lg border border-white/20 object-cover"
-                              loading="lazy"
-                            />
-                          ) : null}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : null}
-              {availablePocketLiners.length > 0 ? (
-                <div>
-                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                    Pocket Jaws
-                  </h3>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    {availablePocketLiners.map((option) => {
-                      const active = option.id === pocketLinerId;
-                      const swatchColor =
-                        option.jawColor ?? option.rimColor ?? option.sheenColor ?? option.color;
-                      const thumb = option.thumbnail;
-                      return (
-                        <button
-                          key={option.id}
-                          type="button"
-                          onClick={() => setPocketLinerId(option.id)}
-                          aria-pressed={active}
-                          className={`flex min-w-[9rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                            active
-                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                          }`}
-                        >
-                          <span className="flex items-center gap-2">
-                            <span
-                              className="h-3.5 w-3.5 rounded-full border border-white/40"
-                              style={{ backgroundColor: toHexColor(swatchColor) }}
-                              aria-hidden="true"
-                            />
-                            <span className="truncate">{option.label}</span>
-                          </span>
-                          {thumb ? (
-                            <img
-                              src={thumb}
-                              alt={option.label}
-                              className="h-6 w-10 rounded-lg border border-white/20 object-cover"
-                              loading="lazy"
-                            />
-                          ) : null}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Graphics


### PR DESCRIPTION
### Motivation
- Converge the in-app table experience on a single "Showood" table mapping and reduce the number of per-part personalization options to only cloth and cushions for a simpler, more consistent UX. 
- Provide an in-scene interactive 3D preview so users can see cloth and cushion choices applied in realtime using the GLTF Showood table model. 

### Description
- Added a new React component `PoolRoyalGameTable.jsx` that creates a Three.js scene, loads the Showood GLB with DRACO/KTX2/Meshopt support, and exposes a small palette UI to toggle cloth and cushion materials at runtime. 
- Implemented material application logic (`applyMaterial`) and part buckets so cloth and cushion MeshPhysicalMaterials are updated when the selected palette changes. 
- Updated `PoolRoyale.jsx` to remove legacy table personalization sections (including chrome plates and other parts) and replaced them with simplified Cloth and Cushion controls that map to the new Showood model and style state. 
- Adjusted labels, button styles, and wiring so `clothColorId` and `showoodTableStyle.cushion` are the primary table customization points while other table parts are fixed to the Showood mapping. 

### Testing
- Ran the frontend unit test suite with `yarn test`, and all tests passed. 
- Ran linting with `yarn lint`, and no lint errors were reported. 
- Built the app with `next build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11298fdde88329899a2fcb9934c5c8)