### PR TITLE
Add 3D Pool table preview component and simplify Showood table setup to cloth + cushion

### DIFF
--- a/webapp/src/pages/Games/PoolRoyalGameTable.jsx
+++ b/webapp/src/pages/Games/PoolRoyalGameTable.jsx
@@ -1,0 +1,156 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader.js";
+import { KTX2Loader } from "three/examples/jsm/loaders/KTX2Loader.js";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
+import { MeshoptDecoder } from "three/examples/jsm/libs/meshopt_decoder.module.js";
+
+const TABLE_MODEL_URL = "https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb";
+const DRACO_DECODER_PATH = "https://www.gstatic.com/draco/versioned/decoders/1.5.7/";
+const BASIS_TRANSCODER_PATH = "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/";
+
+const PARTS = ["cloth", "cushion"];
+const PART_OPTIONS = {
+  cloth: {
+    a: { label: "Green cloth", color: "#0a7b33", metalness: 0, roughness: 1, envMapIntensity: 0.16 },
+    b: { label: "Blue cloth", color: "#0d4fb8", metalness: 0, roughness: 1, envMapIntensity: 0.16 },
+  },
+  cushion: {
+    a: { label: "Green cushions", color: "#064f23", metalness: 0, roughness: 0.94, envMapIntensity: 0.24 },
+    b: { label: "Black cushions", color: "#050505", metalness: 0, roughness: 0.88, envMapIntensity: 0.38 },
+  },
+};
+
+const DEFAULT_PALETTE = { cloth: "a", cushion: "a" };
+
+function applyMaterial(mat, option) {
+  mat.color.set(option.color);
+  mat.metalness = option.metalness;
+  mat.roughness = option.roughness;
+  mat.envMapIntensity = option.envMapIntensity;
+  mat.map = null;
+  mat.normalMap = null;
+  mat.roughnessMap = null;
+  mat.metalnessMap = null;
+  mat.needsUpdate = true;
+}
+
+export default function PoolRoyalGameTable() {
+  const hostRef = useRef(null);
+  const bucketsRef = useRef({ cloth: [], cushion: [] });
+  const [palette, setPalette] = useState(DEFAULT_PALETTE);
+
+  useEffect(() => {
+    PARTS.forEach((part) => {
+      bucketsRef.current[part].forEach((mat) => applyMaterial(mat, PART_OPTIONS[part][palette[part]]));
+    });
+  }, [palette]);
+
+  const rows = useMemo(() => PARTS.map((part) => ({ part, options: PART_OPTIONS[part], selected: palette[part] })), [palette]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return undefined;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color("#050505");
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    host.appendChild(renderer.domElement);
+
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+
+    const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 120);
+    camera.position.set(6.2, 4.2, 7.0);
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.target.set(0, 1.05, 0);
+    controls.enableDamping = true;
+
+    scene.add(new THREE.AmbientLight(0xffffff, 1.08));
+    const key = new THREE.DirectionalLight(0xffffff, 2.8);
+    key.position.set(6, 10, 7);
+    scene.add(key);
+
+    const draco = new DRACOLoader();
+    draco.setDecoderPath(DRACO_DECODER_PATH);
+    const ktx2 = new KTX2Loader();
+    ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
+    ktx2.detectSupport(renderer);
+    const loader = new GLTFLoader();
+    loader.setDRACOLoader(draco);
+    loader.setKTX2Loader(ktx2);
+    loader.setMeshoptDecoder(MeshoptDecoder);
+
+    let frame = 0;
+    let mounted = true;
+
+    loader.load(TABLE_MODEL_URL, (gltf) => {
+      if (!mounted) return;
+      const table = gltf.scene;
+      table.scale.setScalar(1.5);
+      table.rotation.y = Math.PI;
+      table.traverse((child) => {
+        if (!child.isMesh) return;
+        const mats = Array.isArray(child.material) ? child.material : [child.material];
+        child.material = mats.map((m) => {
+          const mat = new THREE.MeshPhysicalMaterial({ color: "#ffffff", roughness: 0.5, metalness: 0 });
+          const name = `${child.name || ""} ${m?.name || ""}`.toLowerCase();
+          const isCloth = /cloth|felt|bed|surface/.test(name);
+          const part = isCloth ? "cloth" : /cushion|rubber|bumper/.test(name) ? "cushion" : null;
+          if (part) {
+            mat.userData.part = part;
+            bucketsRef.current[part].push(mat);
+            applyMaterial(mat, PART_OPTIONS[part][palette[part]]);
+          } else {
+            mat.color.set("#2b2118");
+          }
+          return mat;
+        });
+      });
+      scene.add(table);
+    });
+
+    const animate = () => {
+      frame = requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      mounted = false;
+      cancelAnimationFrame(frame);
+      controls.dispose();
+      pmrem.dispose();
+      ktx2.dispose();
+      draco.dispose();
+      renderer.dispose();
+      renderer.domElement.remove();
+    };
+  }, [palette]);
+
+  return (
+    <div ref={hostRef} style={{ position: "fixed", inset: 0, background: "#050505" }}>
+      <div style={{ position: "fixed", left: 8, right: 8, bottom: 8, background: "rgba(0,0,0,0.72)", padding: 10, borderRadius: 14 }}>
+        {rows.map((row) => (
+          <div key={row.part} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+            <strong style={{ color: "white", width: 80 }}>{row.part}</strong>
+            {["a", "b"].map((choice) => (
+              <button key={choice} onClick={() => setPalette((p) => ({ ...p, [row.part]: choice }))} style={{ color: "white", borderRadius: 999, padding: "6px 10px", border: "1px solid #666", background: row.selected === choice ? "#334155" : "#111827" }}>
+                {row.options[choice].label}
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4310,6 +4310,8 @@ const SHOWOOD_TABLE_PARTS = Object.freeze([
   'topWoodRail',
   'railSight',
   'pocketCup',
+  'verticalCornerRim',
+  'baseCornerBlock',
   'leg',
   'baseFoot'
 ]);
@@ -4319,6 +4321,8 @@ const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
   topWoodRail: DEFAULT_TABLE_FINISH_ID,
   railSight: 'gold',
   pocketCup: 'black',
+  verticalCornerRim: 'gold',
+  baseCornerBlock: 'black',
   leg: DEFAULT_TABLE_FINISH_ID,
   baseFoot: 'gold'
 });
@@ -4333,17 +4337,25 @@ const SHOWOOD_TABLE_PART_OPTIONS = Object.freeze({
   ]),
   topWoodRail: Object.freeze([]),
   railSight: Object.freeze([
-    { id: 'chrome', label: 'Chrome Apron + Sights', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
-    { id: 'gold', label: 'Gold Apron + Sights', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } }
+    { id: 'gold', label: 'Gold Apron + Sights', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } },
+    { id: 'black', label: 'Black Apron + Sights', color: '#050505', material: { color: 0x050505, roughness: 0.16, metalness: 0.82, envMapIntensity: 3, clearcoat: 1, clearcoatRoughness: 0.07 } }
   ]),
   pocketCup: Object.freeze([
     { id: 'black', label: 'Black Cups', color: '#000000', keepSourceTexture: true, material: { color: 0x000000, roughness: 0.98, metalness: 0, envMapIntensity: 0.12 } },
     { id: 'leather', label: 'Dark Leather Cups', color: '#1b0c04', keepSourceTexture: true, material: { color: 0x1b0c04, roughness: 0.9, metalness: 0, envMapIntensity: 0.26 } }
   ]),
+  verticalCornerRim: Object.freeze([
+    { id: 'gold', label: 'Gold Rims + Feet', color: '#d8b23d', material: { color: 0xd8b23d, roughness: 0.06, metalness: 0.98, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 } },
+    { id: 'chrome', label: 'Chrome Rims + Feet', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } }
+  ]),
+  baseCornerBlock: Object.freeze([
+    { id: 'walnut', label: 'Walnut Corners', color: '#7b2d11', material: { color: 0x7b2d11, roughness: 0.48, metalness: 0.02, envMapIntensity: 1.1, clearcoat: 0.22, clearcoatRoughness: 0.33 } },
+    { id: 'black', label: 'Black Corners', color: '#080605', material: { color: 0x080605, roughness: 0.38, metalness: 0.03, envMapIntensity: 1.34, clearcoat: 0.34, clearcoatRoughness: 0.22 } }
+  ]),
   leg: Object.freeze([]),
   baseFoot: Object.freeze([
-    { id: 'chrome', label: 'Chrome Feet', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
-    { id: 'gold', label: 'Gold Feet', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } }
+    { id: 'gold', label: 'Gold Rounded Feet', color: '#d8b23d', material: { color: 0xd8b23d, roughness: 0.065, metalness: 1, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 } },
+    { id: 'chrome', label: 'Chrome Rounded Feet', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } }
   ])
 });
 const SHOWOOD_TABLE_PART_LABELS = Object.freeze({
@@ -4352,12 +4364,14 @@ const SHOWOOD_TABLE_PART_LABELS = Object.freeze({
   topWoodRail: 'Top Rails',
   railSight: 'Side Apron + Rail Sights',
   pocketCup: 'Pocket Cups',
+  verticalCornerRim: 'Corner Rims + Rounded Feet',
+  baseCornerBlock: 'Base Corners',
   leg: 'Legs',
-  baseFoot: 'Feet'
+  baseFoot: 'Rounded Feet'
 });
-const SHOWOOD_CHROME_LINKED_PARTS = new Set(['railSight', 'baseFoot']);
+const SHOWOOD_CHROME_LINKED_PARTS = new Set(['railSight', 'verticalCornerRim', 'baseFoot']);
 const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOptions = null) => {
-  if (part === 'cloth' || part === 'cushion') {
+  if (part === 'cloth') {
     const sourceOptions = Array.isArray(clothOptions) && clothOptions.length
       ? clothOptions
       : CLOTH_COLOR_OPTIONS;
@@ -4367,6 +4381,9 @@ const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOption
       color: toHexColor(option.color),
       material: { color: option.color, roughness: 1, metalness: 0, envMapIntensity: 0.16 }
     }));
+  }
+  if (part === 'cushion') {
+    return SHOWOOD_TABLE_PART_OPTIONS.cushion;
   }
   if (part === 'topWoodRail' || part === 'leg') {
     const sourceOptions = Array.isArray(tableFinishOptions) && tableFinishOptions.length
@@ -36128,143 +36145,77 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Chrome Plates
-                </h3>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {availableChromeOptions.map((option) => {
-                    const active = option.id === chromeColorId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => setChromeColorId(option.id)}
-                        aria-pressed={active}
-                        className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="flex items-center justify-center gap-2">
-                          <span
-                            className="h-3.5 w-3.5 rounded-full border border-white/40"
-                            style={{ backgroundColor: toHexColor(option.color) }}
-                            aria-hidden="true"
-                          />
-                          {option.label}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
               <div className="rounded-3xl border border-emerald-300/20 bg-white/[0.04] p-3">
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                      Table Personalisation
+                      Table Setup
                     </h3>
                     <p className="mt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-white/55">
-                      Select a table part, then choose the unlocked finish for that part.
+                      Keep only cloth + cushions. Other table options are fixed to the new Showood mapping.
                     </p>
                   </div>
                   <span className="rounded-full border border-emerald-200/30 px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] text-emerald-100/70">
                     Showood
                   </span>
                 </div>
-                <div className="mt-3 -mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
-                  {tablePersonalizationSections.map((section) => {
-                    const selectedSection = section.key === activeTablePersonalizationPart;
-                    return (
-                      <button
-                        key={section.key}
-                        type="button"
-                        onClick={() => setActiveTablePersonalizationPart(section.key)}
-                        className={`whitespace-nowrap rounded-full border px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.18em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          selectedSection
-                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_14px_rgba(16,185,129,0.45)]'
-                            : 'border-white/15 bg-white/5 text-white/70 hover:border-white/30 hover:text-white'
-                        }`}
-                      >
-                        {section.label}
-                      </button>
-                    );
-                  })}
-                </div>
-                {activeTablePersonalizationSection ? (
-                  <div className="mt-3 max-h-64 overflow-y-auto pr-1">
-                    <div className="mb-2 flex items-center justify-between gap-3">
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-white/60">
-                        {activeTablePersonalizationSection.label}
-                      </p>
-                      {activeTablePersonalizationSection.chromeLinked ? (
-                        <span className="text-[9px] uppercase tracking-[0.18em] text-emerald-100/55">
-                          linked to chrome plates
-                        </span>
-                      ) : null}
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      {activeTablePersonalizationSection.options.map((option) => {
-                        const part = activeTablePersonalizationSection.key;
-                        const chromeLinked = activeTablePersonalizationSection.chromeLinked;
-                        const selected = part === 'cloth'
-                          ? clothColorId
-                          : part === 'topWoodRail' || part === 'leg'
-                            ? tableFinishId
-                            : chromeLinked
-                              ? (chromeColorId === 'gold' ? 'gold' : 'chrome')
-                              : normalizeShowoodTableStyle(showoodTableStyle)[part];
-                        const active = option.id === selected;
+
+                {availableClothOptions.length > 0 ? (
+                  <div className="mt-3">
+                    <h4 className="text-[10px] uppercase tracking-[0.28em] text-emerald-100/65">Cloth Color</h4>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {availableClothOptions.map((option) => {
+                        const active = option.id === clothColorId;
+                        const thumb = option.thumbnail;
                         return (
                           <button
-                            key={`${part}-${option.id}`}
+                            key={option.id}
                             type="button"
-                            onClick={() => {
-                              if (part === 'cloth') {
-                                setClothColorId(option.id);
-                              } else if (part === 'topWoodRail' || part === 'leg') {
-                                setTableFinishId(option.id);
-                                setShowoodTableStyle((current) =>
-                                  normalizeShowoodTableStyle({ ...current, [part]: option.id })
-                                );
-                              } else if (chromeLinked) {
-                                setChromeColorId(option.id === 'gold' ? 'gold' : 'chrome');
-                              } else {
-                                setShowoodTableStyle((current) =>
-                                  normalizeShowoodTableStyle({ ...current, [part]: option.id })
-                                );
-                              }
-                            }}
+                            onClick={() => setClothColorId(option.id)}
                             aria-pressed={active}
-                            className={`flex flex-col items-center justify-between gap-2 rounded-2xl border p-2 text-center text-[10px] font-semibold uppercase tracking-[0.16em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            className={`flex min-w-[8.5rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
                               active
                                 ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
                                 : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
                             }`}
                           >
-                            {option.thumbnail ? (
-                              <img
-                                src={option.thumbnail}
-                                alt={option.label}
-                                className="h-12 w-full rounded-xl border border-white/20 object-cover"
-                                loading="lazy"
-                              />
-                            ) : (
-                              <span
-                                className="h-12 w-full rounded-xl border border-white/30"
-                                style={{ backgroundColor: option.color }}
-                                aria-hidden="true"
-                              />
-                            )}
-                            <span className="line-clamp-2">{option.label}</span>
+                            <span className="flex items-center gap-2">
+                              <span className="h-3.5 w-3.5 rounded-full border border-white/40" style={{ backgroundColor: toHexColor(option.color) }} aria-hidden="true" />
+                              <span className="truncate">{option.label}</span>
+                            </span>
+                            {thumb ? <img src={thumb} alt={option.label} className="h-6 w-10 rounded-lg border border-white/20 object-cover" loading="lazy" /> : null}
                           </button>
                         );
                       })}
                     </div>
                   </div>
                 ) : null}
+
+                <div className="mt-3">
+                  <h4 className="text-[10px] uppercase tracking-[0.28em] text-emerald-100/65">Cushion Color</h4>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {SHOWOOD_TABLE_PART_OPTIONS.cushion.map((option) => {
+                      const current = normalizeShowoodTableStyle(showoodTableStyle).cushion;
+                      const active = option.id === current;
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => setShowoodTableStyle((prev) => normalizeShowoodTableStyle({ ...prev, cushion: option.id }))}
+                          aria-pressed={active}
+                          className={`flex min-w-[8.5rem] flex-1 items-center justify-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            active
+                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                          }`}
+                        >
+                          <span className="h-3.5 w-3.5 rounded-full border border-white/40" style={{ backgroundColor: option.color }} aria-hidden="true" />
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
               </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
@@ -36300,94 +36251,6 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
-              {availableClothOptions.length > 0 ? (
-                <div>
-                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                    Cloth Library
-                  </h3>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    {availableClothOptions.map((option) => {
-                      const active = option.id === clothColorId;
-                      const thumb = option.thumbnail;
-                      return (
-                        <button
-                          key={option.id}
-                          type="button"
-                          onClick={() => setClothColorId(option.id)}
-                          aria-pressed={active}
-                          className={`flex min-w-[8.5rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                            active
-                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                          }`}
-                        >
-                          <span className="flex items-center gap-2">
-                            <span
-                              className="h-3.5 w-3.5 rounded-full border border-white/40"
-                              style={{ backgroundColor: toHexColor(option.color) }}
-                              aria-hidden="true"
-                            />
-                            <span className="truncate">{option.label}</span>
-                          </span>
-                          {thumb ? (
-                            <img
-                              src={thumb}
-                              alt={option.label}
-                              className="h-6 w-10 rounded-lg border border-white/20 object-cover"
-                              loading="lazy"
-                            />
-                          ) : null}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : null}
-              {availablePocketLiners.length > 0 ? (
-                <div>
-                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                    Pocket Jaws
-                  </h3>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    {availablePocketLiners.map((option) => {
-                      const active = option.id === pocketLinerId;
-                      const swatchColor =
-                        option.jawColor ?? option.rimColor ?? option.sheenColor ?? option.color;
-                      const thumb = option.thumbnail;
-                      return (
-                        <button
-                          key={option.id}
-                          type="button"
-                          onClick={() => setPocketLinerId(option.id)}
-                          aria-pressed={active}
-                          className={`flex min-w-[9rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                            active
-                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                          }`}
-                        >
-                          <span className="flex items-center gap-2">
-                            <span
-                              className="h-3.5 w-3.5 rounded-full border border-white/40"
-                              style={{ backgroundColor: toHexColor(swatchColor) }}
-                              aria-hidden="true"
-                            />
-                            <span className="truncate">{option.label}</span>
-                          </span>
-                          {thumb ? (
-                            <img
-                              src={thumb}
-                              alt={option.label}
-                              className="h-6 w-10 rounded-lg border border-white/20 object-cover"
-                              loading="lazy"
-                            />
-                          ) : null}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Graphics


### PR DESCRIPTION
### Motivation
- Provide an interactive 3D preview for the Pool Royale table so users can preview cloth/cushion customizations in real time via a lightweight viewer.
- Consolidate table personalization for the new Showood table mapping so only cloth and cushion are exposed in the UI while other parts are fixed to the Showood defaults.
- Introduce explicit Showood parts and material options for finer control of rims/corners/feet mapping used by the renderer and UI.

### Description
- Add a new client React component `webapp/src/pages/Games/PoolRoyalGameTable.jsx` that loads a GLTF table model with `three.js`, `GLTFLoader`, `DRACOLoader`, `KTX2Loader`, and `MeshoptDecoder`, groups materials into `cloth` and `cushion` buckets, and provides an on-screen palette UI to swap material properties at runtime.
- Update `webapp/src/pages/Games/PoolRoyale.jsx` to extend the Showood model mapping by adding `verticalCornerRim` and `baseCornerBlock` to `SHOWOOD_TABLE_PARTS`, and add corresponding options in `SHOWOOD_TABLE_PART_OPTIONS` and defaults in `DEFAULT_SHOWOOD_TABLE_STYLE`.
- Reorder and adjust material option entries (rail sight / feet) and change `SHOWOOD_CHROME_LINKED_PARTS` to include `verticalCornerRim` so chrome/gold linking behavior is preserved for the new parts, and update the label map `SHOWOOD_TABLE_PART_LABELS` for clarity.
- Simplify the table personalization UI: replace the previous multi-section editor with a compact `Table Setup` panel that only exposes `Cloth Color` and `Cushion Color` selectors, update `getShowoodTablePartOptions` to special-case `cloth` and `cushion`, and remove the prior granular controls for other table parts from the interactive UI.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11298fdde88329899a2fcb9934c5c8)