### PR TITLE
Restore bottom Domino seat human/chair proportions

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -985,6 +985,8 @@ const CHAIR_GLOBAL_PUSHBACK = 0.09 * MODEL_SCALE;
 const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.14 * MODEL_SCALE;
 const CHAIR_VISUAL_SCALE = 0.38;
 const CHAIR_VERTICAL_DROP = 0.085 * MODEL_SCALE;
+const HUMAN_BOTTOM_CHAIR_VISUAL_SCALE = 0.42;
+const HUMAN_BOTTOM_CHAIR_VERTICAL_DROP = 0.055 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = LEGACY_BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
@@ -7990,6 +7992,7 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
 ]);
 const DOMINO_CHARACTER_PROPORTION_SCALE = 3.8;
 const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 1.8;
+const DOMINO_BOTTOM_HUMAN_CHARACTER_SCALE_BOOST = 1.5;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = -0.03;
@@ -8514,8 +8517,10 @@ function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   normalizeDominoCharacterRoot(instance);
   const seatRoot = new THREE.Group();
   const isHumanSeat = seatIndex === HUMAN_SEAT_INDEX;
-  const characterScale = DOMINO_CHARACTER_PROPORTION_SCALE +
-    (isHumanSeat ? DOMINO_HUMAN_CHARACTER_SCALE_BOOST : 0);
+  const humanScaleBoost = isHumanSeat
+    ? DOMINO_BOTTOM_HUMAN_CHARACTER_SCALE_BOOST
+    : 0;
+  const characterScale = DOMINO_CHARACTER_PROPORTION_SCALE + humanScaleBoost;
   const seatScale = (theme.scale || 1) * characterScale;
   const scaleDelta = Math.max(0, characterScale - 1);
   seatRoot.scale.setScalar(seatScale);
@@ -8799,8 +8804,15 @@ function placeChairsWithOption(option, chairData, token) {
     wrapper.lookAt(new THREE.Vector3(0, wrapper.position.y, 0));
 
     const chair = cloneChairWithTheme(chairData, option);
-    chair.scale.multiplyScalar(CHAIR_VISUAL_SCALE);
-    chair.position.y = -seatBottomOffset - CHAIR_VERTICAL_DROP;
+    const isHumanSeat = index === HUMAN_SEAT_INDEX;
+    const chairVisualScale = isHumanSeat
+      ? HUMAN_BOTTOM_CHAIR_VISUAL_SCALE
+      : CHAIR_VISUAL_SCALE;
+    const chairVerticalDrop = isHumanSeat
+      ? HUMAN_BOTTOM_CHAIR_VERTICAL_DROP
+      : CHAIR_VERTICAL_DROP;
+    chair.scale.multiplyScalar(chairVisualScale);
+    chair.position.y = -seatBottomOffset - chairVerticalDrop;
     wrapper.add(chair);
     wrapper.userData.dominoCharacterChair = chair;
     wrapper.userData.dominoCharacterSeatLift = TABLE_HEIGHT - 0.06 * MODEL_SCALE;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-23-human-scale-chair-tune-v46';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-23-human-bottom-seat-restore-v47';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Ensure the bottom (human) seat appearance matches the previous portrait/mobile proportions while preserving recent tuning for all other chairs and AI/upper-seat characters.
- Keep seated character alignment and table framing for portrait devices by applying the previous human-seat scale/drop and character scale boost only to `HUMAN_SEAT_INDEX`.

### Description
- Added `HUMAN_BOTTOM_CHAIR_VISUAL_SCALE` and `HUMAN_BOTTOM_CHAIR_VERTICAL_DROP` and apply them for `HUMAN_SEAT_INDEX` when placing chairs in `placeChairsWithOption` in `webapp/public/domino-royal-game.js`.
- Introduced `DOMINO_BOTTOM_HUMAN_CHARACTER_SCALE_BOOST` and use it to compute the bottom human character scale in `attachDominoCharacterToChair`, leaving other seats using the current global boost.
- Kept existing chair/character tuning for non-human seats unchanged and preserved previous alignment logic via `resolveDominoCharacterSeatPosition`.
- Bumped `DOMINO_ROYAL_SCRIPT_VERSION` in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-05-23-human-bottom-seat-restore-v47` so clients will fetch the updated script.

### Testing
- Ran `git diff --check` and it completed with no errors (passed).
- Verified repo state with `git status --short` and staged/committed the changes with `git add`/`git commit` (commit created successfully).
- Created PR metadata via the `make_pr` helper which generated the PR title and body (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11378a177c83298bec135f02204744)