### PR TITLE
Unify Pool Royal apron/rail-sight/rounded-feet finishes into Gold/Chrome/Black option

### DIFF
--- a/webapp/src/pages/Games/PoolRoyalGameTable.tsx
+++ b/webapp/src/pages/Games/PoolRoyalGameTable.tsx
@@ -31,7 +31,7 @@ type TablePart =
   | "railSight"
   | "underside";
 
-type ChoiceKey = "a" | "b";
+type ChoiceKey = "a" | "b" | "c";
 type Palette = Record<TablePart, ChoiceKey>;
 type WorkingMaterial = THREE.MeshPhysicalMaterial;
 type MaterialBuckets = Record<TablePart, WorkingMaterial[]>;
@@ -150,8 +150,8 @@ const ALWAYS_SPATIAL_PARTS = new Set<TablePart>([
   "underside",
 ]);
 
-const LINKED_TO_RAIL_SIGHT = new Set<TablePart>(["sideWoodApron", "railSight"]);
-const LINKED_TO_CORNER_RIM = new Set<TablePart>(["baseFoot", "verticalCornerRim"]);
+const LINKED_TO_RAIL_SIGHT = new Set<TablePart>(["sideWoodApron", "railSight", "verticalCornerRim", "baseFoot"]);
+const LINKED_TO_CORNER_RIM = new Set<TablePart>([]);
 
 const PART_META: Record<TablePart, PartMeta> = {
   cloth: {
@@ -191,7 +191,7 @@ const PART_META: Record<TablePart, PartMeta> = {
   },
   verticalCornerRim: {
     label: "Corner rims + rounded feet",
-    description: "Controls the original 4 outside vertical base-corner rim strips and the rounded feet below the actual feet.",
+    description: "Linked with side apron + rail sights. Applies one finish to corner rims and rounded feet.",
     keepSourceTexture: false,
   },
   baseCornerBlock: {
@@ -206,7 +206,7 @@ const PART_META: Record<TablePart, PartMeta> = {
   },
   baseFoot: {
     label: "Rounded feet",
-    description: "Hidden row. Controlled by Corner rims + rounded feet.",
+    description: "Hidden row. Linked with the side apron + rail sights finish option.",
     keepSourceTexture: false,
   },
   lowerTrim: {
@@ -215,8 +215,8 @@ const PART_META: Record<TablePart, PartMeta> = {
     keepSourceTexture: false,
   },
   railSight: {
-    label: "Side apron + rail sights",
-    description: "Linked option for the side apron and rail sight dots.",
+    label: "Apron + rail sights + rounded feet",
+    description: "One linked option for side apron, rail sights, corner rims, and rounded feet.",
     keepSourceTexture: false,
   },
   underside: {
@@ -241,7 +241,8 @@ const PART_OPTIONS: Record<TablePart, Record<ChoiceKey, ColorOption>> = {
   },
   sideWoodApron: {
     a: { label: "Gold side apron", color: "#d8a928", metalness: 0.9, roughness: 0.11, envMapIntensity: 5.9, clearcoat: 1, clearcoatRoughness: 0.045 },
-    b: { label: "Black side apron", color: "#050505", metalness: 0.82, roughness: 0.17, envMapIntensity: 3.15, clearcoat: 1, clearcoatRoughness: 0.07 },
+    b: { label: "Chrome side apron", color: "#d7dde7", metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 },
+    c: { label: "Black side apron", color: "#050505", metalness: 0.82, roughness: 0.17, envMapIntensity: 3.15, clearcoat: 1, clearcoatRoughness: 0.07 },
   },
   pocketCup: {
     a: { label: "Black cups", color: "#000000", metalness: 0, roughness: 0.98, envMapIntensity: 0.12 },
@@ -258,6 +259,7 @@ const PART_OPTIONS: Record<TablePart, Record<ChoiceKey, ColorOption>> = {
   verticalCornerRim: {
     a: { label: "Gold rims + feet", color: "#d8b23d", metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 },
     b: { label: "Chrome rims + feet", color: "#d7dde7", metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 },
+    c: { label: "Black rims + feet", color: "#050505", metalness: 0.82, roughness: 0.16, envMapIntensity: 3, clearcoat: 1, clearcoatRoughness: 0.07 },
   },
   baseCornerBlock: {
     a: { label: "Walnut corners", color: "#7b2d11", metalness: 0.02, roughness: 0.48, envMapIntensity: 1.1, clearcoat: 0.22, clearcoatRoughness: 0.33 },
@@ -270,14 +272,16 @@ const PART_OPTIONS: Record<TablePart, Record<ChoiceKey, ColorOption>> = {
   baseFoot: {
     a: { label: "Gold rounded feet", color: "#d8b23d", metalness: 1, roughness: 0.065, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 },
     b: { label: "Chrome rounded feet", color: "#d7dde7", metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 },
+    c: { label: "Black rounded feet", color: "#050505", metalness: 0.82, roughness: 0.16, envMapIntensity: 3, clearcoat: 1, clearcoatRoughness: 0.07 },
   },
   lowerTrim: {
     a: { label: "Gold trim", color: "#d8b23d", metalness: 0.94, roughness: 0.085, envMapIntensity: 5.8, clearcoat: 1, clearcoatRoughness: 0.04 },
     b: { label: "Black trim", color: "#070707", metalness: 0.82, roughness: 0.15, envMapIntensity: 3.2, clearcoat: 1, clearcoatRoughness: 0.07 },
   },
   railSight: {
-    a: { label: "Gold apron + gold sights", color: "#f5d978", metalness: 1, roughness: 0.065, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 },
-    b: { label: "Black apron + black sights", color: "#050505", metalness: 0.82, roughness: 0.16, envMapIntensity: 3, clearcoat: 1, clearcoatRoughness: 0.07 },
+    a: { label: "Gold linked trim", color: "#f5d978", metalness: 1, roughness: 0.065, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 },
+    b: { label: "Chrome linked trim", color: "#d7dde7", metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 },
+    c: { label: "Black linked trim", color: "#050505", metalness: 0.82, roughness: 0.16, envMapIntensity: 3, clearcoat: 1, clearcoatRoughness: 0.07 },
   },
   underside: {
     a: { label: "Dark underside", color: "#1e130b", metalness: 0.01, roughness: 0.72, envMapIntensity: 0.58 },
@@ -1005,10 +1009,26 @@ export default function PoolRoyalGameTable() {
   const setPartChoice = (part: TablePart, choice: ChoiceKey) => {
     setPalette((current) => {
       const next = { ...current, [part]: choice };
-      if (part === "railSight") next.sideWoodApron = choice;
-      if (part === "sideWoodApron") next.railSight = choice;
-      if (part === "verticalCornerRim") next.baseFoot = choice;
-      if (part === "baseFoot") next.verticalCornerRim = choice;
+      if (part === "railSight") {
+        next.sideWoodApron = choice;
+        next.verticalCornerRim = choice;
+        next.baseFoot = choice;
+      }
+      if (part === "sideWoodApron") {
+        next.railSight = choice;
+        next.verticalCornerRim = choice;
+        next.baseFoot = choice;
+      }
+      if (part === "verticalCornerRim") {
+        next.baseFoot = choice;
+        next.railSight = choice;
+        next.sideWoodApron = choice;
+      }
+      if (part === "baseFoot") {
+        next.verticalCornerRim = choice;
+        next.railSight = choice;
+        next.sideWoodApron = choice;
+      }
       return next;
     });
   };
@@ -1272,7 +1292,7 @@ export default function PoolRoyalGameTable() {
                   <div style={{ fontSize: 9.4, color: "#94a3b8", lineHeight: 1.2 }}>{row.description}</div>
                 </div>
                 <div style={{ display: "flex", flexWrap: "wrap", gap: 7 }}>
-                  {(["a", "b"] as ChoiceKey[]).map((choice) => (
+                  {(Object.keys(row.options) as ChoiceKey[]).map((choice) => (
                     <ColorButton
                       key={`${row.part}-${choice}`}
                       active={row.selected === choice}


### PR DESCRIPTION
### Motivation
- Provide a single linked finish option that controls the side apron, rail sights, original vertical corner rims and the rounded feet and offer three finish choices (gold, chrome, black) while keeping the existing material/bucket application technique intact.

### Description
- Added a third choice by changing `type ChoiceKey` to include `"c"` and expanded `PART_OPTIONS` for `sideWoodApron`, `railSight`, `verticalCornerRim`, and `baseFoot` to include Gold/Chrome/Black entries.
- Linked the parts by expanding `LINKED_TO_RAIL_SIGHT` to include `verticalCornerRim` and `baseFoot`, cleared the unused `LINKED_TO_CORNER_RIM`, and updated `PART_META` descriptions to reflect the unified behavior.
- Updated `setPartChoice` so selecting any linked trim part synchronizes `sideWoodApron`, `railSight`, `verticalCornerRim`, and `baseFoot`, and changed the UI mapping to iterate `Object.keys(row.options)` so the new third option renders automatically.
- Preserved the existing material bucketing and application pipeline (`splitTableIntoMappedParts`, `createRoundedFootCaps`, etc.) so textures/finishes are applied using the same technique as before.

### Testing
- No automated tests were executed as part of this rollout.
- Changes were validated via local repository inspection and committed (`webapp/src/pages/Games/PoolRoyalGameTable.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11603f4c308329b8f068f49afe1a0b)