### PR TITLE
Adjust Domino Arena seated character distance from table

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7992,10 +7992,10 @@ const DOMINO_CHARACTER_PROPORTION_SCALE = 3.8;
 const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 1.35;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
-const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = -0.03;
+const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.14;
 // Slide only the AI/upper-seat characters inward so their hands sit closer to their domino racks.
-const DOMINO_CHARACTER_INWARD_DOMINO_REACH_BIAS = 0.14;
-const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0;
+const DOMINO_CHARACTER_INWARD_DOMINO_REACH_BIAS = 0.04;
+const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.06;
 const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 1.68;
 const DOMINO_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = -0.08;
 const ENABLE_DOMINO_CHARACTER_HELD_RACKS = false;


### PR DESCRIPTION
### Motivation
- Seated human characters in the Domino Battle Royale arena needed to appear visually farther away from the table (including on portrait mobile), so their anchors and hand reach no longer overlap the table edge.

### Description
- Updated seating/reach bias constants in `webapp/public/domino-royal-game.js` to move characters outward and reduce AI inward pull by changing `DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS`, `DOMINO_CHARACTER_INWARD_DOMINO_REACH_BIAS`, and `DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS`.
- The new values make the human seat slightly more outward and reduce the inward reach used for non-human seats so AI characters are not pulled as close to the table.
- Changes are limited to Domino character seat positioning constants and do not alter other game systems or assets.

### Testing
- Ran `npm test -- test/dominoRoyalCharacterScale.test.js` and the test passed.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116219dd5083299d7d2468c9fe1bee)