### PR TITLE
Pool Royale: use snooker GLB cushions/base (disable procedural variants)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -9303,6 +9303,8 @@ export function Table3D(
     CHROME_PLATE_STYLE_BY_ID[DEFAULT_CHROME_PLATE_STYLE_ID] ??
     CHROME_PLATE_STYLE_OPTIONS[0];
   const usesExternalTableModel = resolvedTableOptions?.tableModel?.kind === 'gltf';
+  const isSnookerGenericExternalTable =
+    usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'snooker-generic';
   const externalTableUsesOriginalLayout =
     usesExternalTableModel && resolvedTableOptions?.tableModel?.useOriginalLayoutSurfaces === true;
   const externalPlayfieldVisualLift =
@@ -12612,13 +12614,15 @@ export function Table3D(
   const leftX = -halfW;
   const rightX = halfW;
 
-  addCushion(0, bottomZ, horizontalCushionLength, true, false);
-  addCushion(0, topZ, horizontalCushionLength, true, true);
+  if (!isSnookerGenericExternalTable) {
+    addCushion(0, bottomZ, horizontalCushionLength, true, false);
+    addCushion(0, topZ, horizontalCushionLength, true, true);
 
-  addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
-  addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
-  addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
-  addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
+    addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
+    addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
+    addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
+    addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
+  }
 
   const shortRailCushionWordmarkTexture = createCushionWordmarkTexture({
     width: 2048,
@@ -14260,10 +14264,10 @@ function mountPoolRoyaleExternalTableModel({
 
   const applyBaseVariant = (variant) => {
     const variantId = resolveBaseVariantId(variant);
-    const isShowoodExternalTable =
-      usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'snooker-generic';
+    const isShowoodExternalTable = isSnookerGenericExternalTable;
     const usesShowoodOriginalBase =
-      isShowoodExternalTable && variantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID;
+      isShowoodExternalTable &&
+      (variantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID || variantId === DEFAULT_TABLE_BASE_ID);
 
     table.userData.showoodUsesOriginalBase = usesShowoodOriginalBase;
     setExternalOriginalBaseVisible(usesShowoodOriginalBase || !isShowoodExternalTable);
@@ -14309,7 +14313,7 @@ function mountPoolRoyaleExternalTableModel({
   };
 
   table.userData.applyExternalTableFallbackBase = () => {
-    if (usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'snooker-generic') {
+    if (isSnookerGenericExternalTable) {
       applyBaseVariant(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
     }
   };


### PR DESCRIPTION
### Motivation
- Ensure Pool Royale uses the actual `snooker-generic` GLB table visuals for cushions and base so the playable surface matches the imported model. 
- Prevent procedural cushions and procedural base parts from being generated on top of the GLB snooker table which caused visual and layout mismatches.

### Description
- Introduced a flag `isSnookerGenericExternalTable` in `webapp/src/pages/Games/PoolRoyale.jsx` to detect the `snooker-generic` external GLB model. 
- Disabled procedural cushion creation by wrapping `addCushion(...)` calls in an `if (!isSnookerGenericExternalTable)` guard so only GLB cushions are visible for the snooker GLB path. 
- Adjusted `applyBaseVariant` to treat the `snooker-generic` external table as using the original GLB base (treating `DEFAULT_TABLE_BASE_ID` as the GLB base when appropriate) and updated `table.userData.applyExternalTableFallbackBase` to use the new flag. 
- Changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and preserve existing behavior for non-snooker external tables.

### Testing
- Repo-level commands were executed: `git status --short` and the change was committed with `git commit`, both commands succeeded. 
- No automated unit or integration tests were executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119e1da8308329923a79d796a18479)