### PR TITLE
Preserve original GLTF weapon materials by removing compatibility adapters

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -197,7 +197,11 @@ namespace TonPlaygram.Gameplay.Weapons
             BuildProfileMap();
             CacheTokenPieces();
             CacheStaticAnchors();
-            if (!preserveOriginalWeaponMaterials)
+            if (preserveOriginalWeaponMaterials)
+            {
+                RemoveWeaponMaterialCompatibility();
+            }
+            else
             {
                 ApplyWeaponMaterialCompatibility();
             }
@@ -747,6 +751,22 @@ namespace TonPlaygram.Gameplay.Weapons
             return yaw * Quaternion.AngleAxis(-signedPitch, Vector3.right);
         }
 
+
+        private void RemoveWeaponMaterialCompatibility()
+        {
+            RemoveMaterialCompatibility(weaponRoot);
+
+            for (int i = 0; i < weaponProfiles.Count; i++)
+            {
+                WeaponBallisticsProfile profile = weaponProfiles[i];
+                Animator animator = profile != null && profile.gripPose != null ? profile.gripPose.animator : null;
+                if (animator != null)
+                {
+                    RemoveMaterialCompatibility(animator.transform);
+                }
+            }
+        }
+
         private void ApplyWeaponMaterialCompatibility()
         {
             ApplyMaterialCompatibility(weaponRoot);
@@ -758,6 +778,21 @@ namespace TonPlaygram.Gameplay.Weapons
                 if (animator != null)
                 {
                     ApplyMaterialCompatibility(animator.transform);
+                }
+            }
+        }
+
+        private static void RemoveMaterialCompatibility(Transform root)
+        {
+            if (root == null)
+                return;
+
+            GltfMaterialCompatibilityAdapter[] adapters = root.GetComponentsInChildren<GltfMaterialCompatibilityAdapter>(true);
+            for (int i = 0; i < adapters.Length; i++)
+            {
+                if (adapters[i] != null)
+                {
+                    Destroy(adapters[i]);
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Certain imported GLTF/GLB weapon models (e.g. AK-style rifles and SIG-style pistols) were rendering with altered shaders/textures because existing `GltfMaterialCompatibilityAdapter` components remained attached even when `preserveOriginalWeaponMaterials` was enabled. 
- The previous startup flow only skipped applying the compatibility pass but did not remove pre-existing adapters, so original authored textures could still be overridden.

### Description
- Changed startup logic in `BattleRoyaleWeaponDirector.Awake()` to call `RemoveWeaponMaterialCompatibility()` when `preserveOriginalWeaponMaterials` is `true`, and to call `ApplyWeaponMaterialCompatibility()` when it is `false`.
- Added `RemoveWeaponMaterialCompatibility()` which clears compatibility adapters from the `weaponRoot` and from any animator hierarchies referenced by each `WeaponBallisticsProfile`.
- Added `RemoveMaterialCompatibility(Transform)` helper that finds and destroys all `GltfMaterialCompatibilityAdapter` components in the provided hierarchy; left `ApplyMaterialCompatibility(Transform)` and the compatibility pass behavior unchanged.

### Testing
- Attempted to run unit tests via `dotnet test billiards.Tests/Billiards.Tests.csproj --nologo`, but the environment lacks `dotnet` so the test command could not be executed (`dotnet: command not found`).
- No other automated test runs were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c4b689748329af29db0afa1f556b)