### PR TITLE
Add Showood 7ft table option and lobby table selector; refactor PoolRoyal preview

### DIFF
--- a/frontend/src/pool-royale/PoolRoyal.jsx
+++ b/frontend/src/pool-royale/PoolRoyal.jsx
@@ -1,9 +1,36 @@
-import SevenFootShowoodPreview from './SevenFootShowoodPreview';
+import React, { useState } from 'react';
+import SevenFootShowoodPreview, { TABLES } from './SevenFootShowoodPreview';
 
-/**
- * Pool Royal screen entry (JSX wrapper requested by product feedback).
- * Keeps PoolRoyal JSX integration point while rendering the full TSX Three.js implementation.
- */
 export default function PoolRoyal() {
-  return <SevenFootShowoodPreview />;
+  const [selected, setSelected] = useState(null);
+
+  if (selected) {
+    return <SevenFootShowoodPreview selectedTable={selected} onBack={() => setSelected(null)} />;
+  }
+
+  const tableKeys = Object.keys(TABLES);
+
+  return (
+    <main style={{ minHeight: '100vh', background: '#020202', color: 'white', fontFamily: 'system-ui, sans-serif', padding: '14px 10px' }}>
+      <section style={{ border: '1px solid rgba(255,255,255,0.18)', borderRadius: 14, padding: 12, background: 'rgba(255,255,255,0.03)' }}>
+        <div style={{ fontWeight: 900, fontSize: 16 }}>Pool Royal Lobby</div>
+        <div style={{ fontSize: 11, marginTop: 4, color: '#cbd5e1' }}>Choose your table to play.</div>
+      </section>
+
+      <section style={{ marginTop: 10, display: 'grid', gap: 10 }}>
+        {tableKeys.map((key) => (
+          <article key={key} style={{ border: '1px solid rgba(255,255,255,0.2)', borderRadius: 14, padding: 12, background: 'rgba(0,0,0,0.4)' }}>
+            <div style={{ fontWeight: 900, fontSize: 14 }}>{TABLES[key].title}</div>
+            <div style={{ marginTop: 4, fontSize: 11, color: '#cbd5e1' }}>{TABLES[key].subtitle}</div>
+            <button
+              onClick={() => setSelected(key)}
+              style={{ marginTop: 10, width: '100%', padding: '10px 12px', borderRadius: 12, border: '1px solid #93c5fd', background: 'rgba(59,130,246,0.24)', color: 'white', fontWeight: 800, fontSize: 12 }}
+            >
+              Play on {TABLES[key].mapping.sizeFt}
+            </button>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
 }

--- a/frontend/src/pool-royale/PoolRoyal.tsx
+++ b/frontend/src/pool-royale/PoolRoyal.tsx
@@ -1,5 +1,0 @@
-import SevenFootShowoodPreview from './SevenFootShowoodPreview';
-
-export default function PoolRoyal() {
-  return <SevenFootShowoodPreview />;
-}

--- a/frontend/src/pool-royale/SevenFootShowoodPreview.tsx
+++ b/frontend/src/pool-royale/SevenFootShowoodPreview.tsx
@@ -1,245 +1,84 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 
-type TableKey = 'snookerRoyal' | 'chinese8BallShowood7ft';
+export type TableKey = 'snooker9ft' | 'showood7ft';
 type ClothKey = 'tournamentGreen' | 'royalBlue';
 type FinishKey = 'cueWoodWalnut' | 'cueWoodBlack';
 type PocketId = 'topLeft' | 'topMiddle' | 'topRight' | 'bottomLeft' | 'bottomMiddle' | 'bottomRight';
-type CushionId =
-  | 'topLeft'
-  | 'topMiddle'
-  | 'topRight'
-  | 'leftTop'
-  | 'leftBottom'
-  | 'rightTop'
-  | 'rightBottom'
-  | 'bottomLeft'
-  | 'bottomMiddle'
-  | 'bottomRight';
+type CushionId = 'topLeft' | 'topMiddle' | 'topRight' | 'leftTop' | 'leftBottom' | 'rightTop' | 'rightBottom' | 'bottomLeft' | 'bottomMiddle' | 'bottomRight';
+type PocketMap = { id: PocketId; center: { x: number; z: number }; radius: number; jawInset: number };
+type CushionMap = { id: CushionId; from: { x: number; z: number }; to: { x: number; z: number }; normal: { x: number; z: number }; restitution: number };
+type TableMapping = { name: string; sizeFt: '7ft' | '9ft'; playfield: { width: number; length: number; cornerCut: number }; pockets: PocketMap[]; cushions: CushionMap[] };
 
-type PocketMap = {
-  id: PocketId;
-  center: { x: number; z: number };
-  radius: number;
-  jawInset: number;
-};
-
-type CushionMap = {
-  id: CushionId;
-  from: { x: number; z: number };
-  to: { x: number; z: number };
-  normal: { x: number; z: number };
-  restitution: number;
-};
-
-type TableMapping = {
-  name: string;
-  playfield: { width: number; length: number; cornerCut: number };
-  pockets: PocketMap[];
-  cushions: CushionMap[];
-};
-
-const TABLES: Record<TableKey, { title: string; subtitle: string; hasTableMenu: boolean }> = {
-  snookerRoyal: {
-    title: 'Snooker Royal (Match Table)',
-    subtitle: 'Default competitive snooker table.',
-    hasTableMenu: false,
+export const TABLES: Record<TableKey, { title: string; subtitle: string; mapping: TableMapping }> = {
+  snooker9ft: {
+    title: '9ft Snooker Table',
+    subtitle: 'Full-size competitive table with its own 9ft mapping.',
+    mapping: { name: 'Snooker 9ft precise mapping', sizeFt: '9ft', playfield: { width: 2.54, length: 1.27, cornerCut: 0.145 }, pockets: [
+      { id: 'topLeft', center: { x: -1.15, z: -0.58 }, radius: 0.069, jawInset: 0.04 }, { id: 'topMiddle', center: { x: 0, z: -0.62 }, radius: 0.056, jawInset: 0.03 }, { id: 'topRight', center: { x: 1.15, z: -0.58 }, radius: 0.069, jawInset: 0.04 },
+      { id: 'bottomLeft', center: { x: -1.15, z: 0.58 }, radius: 0.069, jawInset: 0.04 }, { id: 'bottomMiddle', center: { x: 0, z: 0.62 }, radius: 0.056, jawInset: 0.03 }, { id: 'bottomRight', center: { x: 1.15, z: 0.58 }, radius: 0.069, jawInset: 0.04 },
+    ], cushions: [
+      { id: 'topLeft', from: { x: -0.95, z: -0.605 }, to: { x: -0.18, z: -0.63 }, normal: { x: 0, z: 1 }, restitution: 0.92 }, { id: 'topMiddle', from: { x: -0.09, z: -0.635 }, to: { x: 0.09, z: -0.635 }, normal: { x: 0, z: 1 }, restitution: 0.91 }, { id: 'topRight', from: { x: 0.18, z: -0.63 }, to: { x: 0.95, z: -0.605 }, normal: { x: 0, z: 1 }, restitution: 0.92 },
+      { id: 'leftTop', from: { x: -1.21, z: -0.47 }, to: { x: -1.24, z: -0.08 }, normal: { x: 1, z: 0 }, restitution: 0.9 }, { id: 'leftBottom', from: { x: -1.24, z: 0.08 }, to: { x: -1.21, z: 0.47 }, normal: { x: 1, z: 0 }, restitution: 0.9 }, { id: 'rightTop', from: { x: 1.21, z: -0.47 }, to: { x: 1.24, z: -0.08 }, normal: { x: -1, z: 0 }, restitution: 0.9 },
+      { id: 'rightBottom', from: { x: 1.24, z: 0.08 }, to: { x: 1.21, z: 0.47 }, normal: { x: -1, z: 0 }, restitution: 0.9 }, { id: 'bottomLeft', from: { x: -0.95, z: 0.605 }, to: { x: -0.18, z: 0.63 }, normal: { x: 0, z: -1 }, restitution: 0.92 }, { id: 'bottomMiddle', from: { x: -0.09, z: 0.635 }, to: { x: 0.09, z: 0.635 }, normal: { x: 0, z: -1 }, restitution: 0.91 }, { id: 'bottomRight', from: { x: 0.18, z: 0.63 }, to: { x: 0.95, z: 0.605 }, normal: { x: 0, z: -1 }, restitution: 0.92 },
+    ] },
   },
-  chinese8BallShowood7ft: {
-    title: 'Chinese 8-Ball (7ft Showood)',
-    subtitle: 'Lobby option with dedicated pocket/jaw mapping + custom setup menu.',
-    hasTableMenu: true,
+  showood7ft: {
+    title: '7ft Showood Table',
+    subtitle: 'Compact Showood table with independent 7ft geometry mapping.',
+    mapping: { name: 'Showood 7ft precise mapping', sizeFt: '7ft', playfield: { width: 1.98, length: 0.99, cornerCut: 0.12 }, pockets: [
+      { id: 'topLeft', center: { x: -0.9, z: -0.45 }, radius: 0.063, jawInset: 0.034 }, { id: 'topMiddle', center: { x: 0, z: -0.48 }, radius: 0.053, jawInset: 0.028 }, { id: 'topRight', center: { x: 0.9, z: -0.45 }, radius: 0.063, jawInset: 0.034 },
+      { id: 'bottomLeft', center: { x: -0.9, z: 0.45 }, radius: 0.063, jawInset: 0.034 }, { id: 'bottomMiddle', center: { x: 0, z: 0.48 }, radius: 0.053, jawInset: 0.028 }, { id: 'bottomRight', center: { x: 0.9, z: 0.45 }, radius: 0.063, jawInset: 0.034 },
+    ], cushions: [
+      { id: 'topLeft', from: { x: -0.72, z: -0.47 }, to: { x: -0.15, z: -0.49 }, normal: { x: 0, z: 1 }, restitution: 0.92 }, { id: 'topMiddle', from: { x: -0.08, z: -0.495 }, to: { x: 0.08, z: -0.495 }, normal: { x: 0, z: 1 }, restitution: 0.91 }, { id: 'topRight', from: { x: 0.15, z: -0.49 }, to: { x: 0.72, z: -0.47 }, normal: { x: 0, z: 1 }, restitution: 0.92 },
+      { id: 'leftTop', from: { x: -0.95, z: -0.36 }, to: { x: -0.975, z: -0.06 }, normal: { x: 1, z: 0 }, restitution: 0.9 }, { id: 'leftBottom', from: { x: -0.975, z: 0.06 }, to: { x: -0.95, z: 0.36 }, normal: { x: 1, z: 0 }, restitution: 0.9 }, { id: 'rightTop', from: { x: 0.95, z: -0.36 }, to: { x: 0.975, z: -0.06 }, normal: { x: -1, z: 0 }, restitution: 0.9 },
+      { id: 'rightBottom', from: { x: 0.975, z: 0.06 }, to: { x: 0.95, z: 0.36 }, normal: { x: -1, z: 0 }, restitution: 0.9 }, { id: 'bottomLeft', from: { x: -0.72, z: 0.47 }, to: { x: -0.15, z: 0.49 }, normal: { x: 0, z: -1 }, restitution: 0.92 }, { id: 'bottomMiddle', from: { x: -0.08, z: 0.495 }, to: { x: 0.08, z: 0.495 }, normal: { x: 0, z: -1 }, restitution: 0.91 }, { id: 'bottomRight', from: { x: 0.15, z: 0.49 }, to: { x: 0.72, z: 0.47 }, normal: { x: 0, z: -1 }, restitution: 0.92 },
+    ] },
   },
 };
 
-const CLOTH_PRESETS: Record<ClothKey, { label: string; color: string }> = {
-  tournamentGreen: { label: 'Procedural Cloth · Tournament Green', color: '#0f6f34' },
-  royalBlue: { label: 'Procedural Cloth · Royal Blue', color: '#0f4cb3' },
-};
+const CLOTH_PRESETS: Record<ClothKey, { label: string; color: string }> = { tournamentGreen: { label: 'Procedural Cloth · Tournament Green', color: '#0f6f34' }, royalBlue: { label: 'Procedural Cloth · Royal Blue', color: '#0f4cb3' } };
+const FINISH_PRESETS: Record<FinishKey, { label: string; color: string; metalness: number; roughness: number }> = { cueWoodWalnut: { label: 'Cue Finish · Walnut', color: '#553118', metalness: 0.08, roughness: 0.43 }, cueWoodBlack: { label: 'Cue Finish · Piano Black', color: '#141414', metalness: 0.28, roughness: 0.22 } };
 
-const FINISH_PRESETS: Record<FinishKey, { label: string; color: string; metalness: number; roughness: number }> = {
-  cueWoodWalnut: { label: 'Cue Finish · Walnut', color: '#553118', metalness: 0.08, roughness: 0.43 },
-  cueWoodBlack: { label: 'Cue Finish · Piano Black', color: '#141414', metalness: 0.28, roughness: 0.22 },
-};
+function proceduralClothTexture(renderer: THREE.WebGLRenderer, tint: string) { const canvas = document.createElement('canvas'); canvas.width = 256; canvas.height = 256; const ctx = canvas.getContext('2d'); if (!ctx) return null; ctx.fillStyle = tint; ctx.fillRect(0, 0, 256, 256); for (let y = 0; y < 256; y += 4) { const a = 0.03 + ((y / 256) % 1) * 0.02; ctx.fillStyle = `rgba(255,255,255,${a.toFixed(3)})`; ctx.fillRect(0, y, 256, 2); } const t = new THREE.CanvasTexture(canvas); t.wrapS = THREE.RepeatWrapping; t.wrapT = THREE.RepeatWrapping; t.repeat.set(4, 2); t.anisotropy = renderer.capabilities.getMaxAnisotropy(); return t; }
 
-const CHINESE_8BALL_7FT_MAPPING: TableMapping = {
-  name: 'Chinese 8-ball 7ft Showood precise mapping',
-  playfield: { width: 1.98, length: 0.99, cornerCut: 0.12 },
-  pockets: [
-    { id: 'topLeft', center: { x: -0.9, z: -0.45 }, radius: 0.063, jawInset: 0.034 },
-    { id: 'topMiddle', center: { x: 0, z: -0.48 }, radius: 0.053, jawInset: 0.028 },
-    { id: 'topRight', center: { x: 0.9, z: -0.45 }, radius: 0.063, jawInset: 0.034 },
-    { id: 'bottomLeft', center: { x: -0.9, z: 0.45 }, radius: 0.063, jawInset: 0.034 },
-    { id: 'bottomMiddle', center: { x: 0, z: 0.48 }, radius: 0.053, jawInset: 0.028 },
-    { id: 'bottomRight', center: { x: 0.9, z: 0.45 }, radius: 0.063, jawInset: 0.034 },
-  ],
-  cushions: [
-    { id: 'topLeft', from: { x: -0.72, z: -0.47 }, to: { x: -0.15, z: -0.49 }, normal: { x: 0, z: 1 }, restitution: 0.92 },
-    { id: 'topMiddle', from: { x: -0.08, z: -0.495 }, to: { x: 0.08, z: -0.495 }, normal: { x: 0, z: 1 }, restitution: 0.91 },
-    { id: 'topRight', from: { x: 0.15, z: -0.49 }, to: { x: 0.72, z: -0.47 }, normal: { x: 0, z: 1 }, restitution: 0.92 },
-    { id: 'leftTop', from: { x: -0.95, z: -0.36 }, to: { x: -0.975, z: -0.06 }, normal: { x: 1, z: 0 }, restitution: 0.9 },
-    { id: 'leftBottom', from: { x: -0.975, z: 0.06 }, to: { x: -0.95, z: 0.36 }, normal: { x: 1, z: 0 }, restitution: 0.9 },
-    { id: 'rightTop', from: { x: 0.95, z: -0.36 }, to: { x: 0.975, z: -0.06 }, normal: { x: -1, z: 0 }, restitution: 0.9 },
-    { id: 'rightBottom', from: { x: 0.975, z: 0.06 }, to: { x: 0.95, z: 0.36 }, normal: { x: -1, z: 0 }, restitution: 0.9 },
-    { id: 'bottomLeft', from: { x: -0.72, z: 0.47 }, to: { x: -0.15, z: 0.49 }, normal: { x: 0, z: -1 }, restitution: 0.92 },
-    { id: 'bottomMiddle', from: { x: -0.08, z: 0.495 }, to: { x: 0.08, z: 0.495 }, normal: { x: 0, z: -1 }, restitution: 0.91 },
-    { id: 'bottomRight', from: { x: 0.15, z: 0.49 }, to: { x: 0.72, z: 0.47 }, normal: { x: 0, z: -1 }, restitution: 0.92 },
-  ],
-};
-
-function proceduralClothTexture(renderer: THREE.WebGLRenderer, tint: string) {
-  const size = 256;
-  const canvas = document.createElement('canvas');
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return null;
-
-  ctx.fillStyle = tint;
-  ctx.fillRect(0, 0, size, size);
-
-  for (let y = 0; y < size; y += 4) {
-    const alpha = 0.03 + ((y / size) % 1) * 0.02;
-    ctx.fillStyle = `rgba(255,255,255,${alpha.toFixed(3)})`;
-    ctx.fillRect(0, y, size, 2);
-  }
-
-  const texture = new THREE.CanvasTexture(canvas);
-  texture.wrapS = THREE.RepeatWrapping;
-  texture.wrapT = THREE.RepeatWrapping;
-  texture.repeat.set(4, 2);
-  texture.anisotropy = renderer.capabilities.getMaxAnisotropy();
-  return texture;
-}
-
-export default function SevenFootShowoodPreview() {
+export default function SevenFootShowoodPreview({ selectedTable, onBack }: { selectedTable: TableKey; onBack: () => void }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
-  const [selectedTable, setSelectedTable] = useState<TableKey>('snookerRoyal');
   const [cloth, setCloth] = useState<ClothKey>('tournamentGreen');
   const [finish, setFinish] = useState<FinishKey>('cueWoodWalnut');
-
-  const currentMapping = useMemo(() => (selectedTable === 'chinese8BallShowood7ft' ? CHINESE_8BALL_7FT_MAPPING : null), [selectedTable]);
+  const currentMapping = useMemo(() => TABLES[selectedTable].mapping, [selectedTable]);
 
   useEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
-
-    const scene = new THREE.Scene();
-    scene.background = new THREE.Color('#020202');
-
-    const camera = new THREE.PerspectiveCamera(46, host.clientWidth / host.clientHeight, 0.1, 80);
-    camera.position.set(0, 2.2, 2.2);
-    camera.lookAt(0, 0.2, 0);
-
-    const renderer = new THREE.WebGLRenderer({ antialias: true });
-    renderer.setSize(host.clientWidth, host.clientHeight);
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    host.appendChild(renderer.domElement);
-
-    scene.add(new THREE.AmbientLight(0xffffff, 0.8));
-    const key = new THREE.DirectionalLight(0xffffff, 1.5);
-    key.position.set(1.8, 3.2, 2);
-    scene.add(key);
-
-    const tableGroup = new THREE.Group();
-    scene.add(tableGroup);
-
-    const tableBody = new THREE.Mesh(
-      new THREE.BoxGeometry(2.1, 0.28, 1.1),
-      new THREE.MeshStandardMaterial({ color: FINISH_PRESETS[finish].color, metalness: FINISH_PRESETS[finish].metalness, roughness: FINISH_PRESETS[finish].roughness })
-    );
-    tableBody.position.y = -0.12;
-    tableGroup.add(tableBody);
-
+    const host = hostRef.current; if (!host) return;
+    const scene = new THREE.Scene(); scene.background = new THREE.Color('#020202');
+    const camera = new THREE.PerspectiveCamera(46, host.clientWidth / host.clientHeight, 0.1, 80); camera.position.set(0, 2.2, 2.2); camera.lookAt(0, 0.2, 0);
+    const renderer = new THREE.WebGLRenderer({ antialias: true }); renderer.setSize(host.clientWidth, host.clientHeight); renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2)); host.appendChild(renderer.domElement);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.8)); const key = new THREE.DirectionalLight(0xffffff, 1.5); key.position.set(1.8, 3.2, 2); scene.add(key);
+    const tableGroup = new THREE.Group(); scene.add(tableGroup);
+    const scale = currentMapping.sizeFt === '9ft' ? 1.22 : 1;
+    const mat = new THREE.MeshStandardMaterial({ color: FINISH_PRESETS[finish].color, metalness: FINISH_PRESETS[finish].metalness, roughness: FINISH_PRESETS[finish].roughness });
+    const tableBody = new THREE.Mesh(new THREE.BoxGeometry(currentMapping.playfield.width * scale * 1.08, 0.28, currentMapping.playfield.length * scale * 1.12), mat); tableBody.position.y = -0.12; tableGroup.add(tableBody);
     const clothTexture = proceduralClothTexture(renderer, CLOTH_PRESETS[cloth].color);
-    const clothMesh = new THREE.Mesh(
-      new THREE.PlaneGeometry(1.98, 0.99),
-      new THREE.MeshStandardMaterial({ color: '#ffffff', map: clothTexture, roughness: 0.96, metalness: 0 })
-    );
-    clothMesh.rotation.x = -Math.PI / 2;
-    clothMesh.position.y = 0.03;
-    tableGroup.add(clothMesh);
-
-    if (selectedTable === 'chinese8BallShowood7ft') {
-      CHINESE_8BALL_7FT_MAPPING.pockets.forEach((pocket) => {
-        const hole = new THREE.Mesh(new THREE.CylinderGeometry(pocket.radius, pocket.radius, 0.04, 20), new THREE.MeshStandardMaterial({ color: '#040404' }));
-        hole.rotation.x = -Math.PI / 2;
-        hole.position.set(pocket.center.x, 0.025, pocket.center.z);
-        tableGroup.add(hole);
-      });
-    }
-
-    let frame = 0;
-    const animate = () => {
-      frame = requestAnimationFrame(animate);
-      tableGroup.rotation.y += 0.002;
-      renderer.render(scene, camera);
-    };
-    animate();
-
-    const onResize = () => {
-      if (!host) return;
-      camera.aspect = host.clientWidth / host.clientHeight;
-      camera.updateProjectionMatrix();
-      renderer.setSize(host.clientWidth, host.clientHeight);
-    };
-
+    const clothMesh = new THREE.Mesh(new THREE.PlaneGeometry(currentMapping.playfield.width * scale, currentMapping.playfield.length * scale), new THREE.MeshStandardMaterial({ color: '#ffffff', map: clothTexture, roughness: 0.96, metalness: 0 })); clothMesh.rotation.x = -Math.PI / 2; clothMesh.position.y = 0.03; tableGroup.add(clothMesh);
+    currentMapping.pockets.forEach((p) => { const hole = new THREE.Mesh(new THREE.CylinderGeometry(p.radius * scale, p.radius * scale, 0.04, 20), new THREE.MeshStandardMaterial({ color: '#040404' })); hole.rotation.x = -Math.PI / 2; hole.position.set(p.center.x * scale, 0.025, p.center.z * scale); tableGroup.add(hole); });
+    let frame = 0; const animate = () => { frame = requestAnimationFrame(animate); tableGroup.rotation.y += 0.002; renderer.render(scene, camera); }; animate();
+    const onResize = () => { camera.aspect = host.clientWidth / host.clientHeight; camera.updateProjectionMatrix(); renderer.setSize(host.clientWidth, host.clientHeight); };
     window.addEventListener('resize', onResize);
-    return () => {
-      window.removeEventListener('resize', onResize);
-      cancelAnimationFrame(frame);
-      clothTexture?.dispose();
-      renderer.dispose();
-      renderer.domElement.remove();
-    };
-  }, [cloth, finish, selectedTable]);
+    return () => { window.removeEventListener('resize', onResize); cancelAnimationFrame(frame); clothTexture?.dispose(); renderer.dispose(); renderer.domElement.remove(); };
+  }, [cloth, finish, currentMapping]);
 
-  return (
-    <main style={{ minHeight: '100vh', background: '#020202', color: 'white', fontFamily: 'system-ui,sans-serif' }}>
-      <div ref={hostRef} style={{ position: 'fixed', inset: 0 }} />
-
-      <section style={{ position: 'fixed', top: 8, left: 8, right: 8, background: 'rgba(0,0,0,0.66)', border: '1px solid rgba(255,255,255,0.18)', borderRadius: 14, padding: 10 }}>
-        <div style={{ fontWeight: 900, fontSize: 13 }}>Pool Royal Lobby · Table Select</div>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 8, marginTop: 8 }}>
-          {(Object.keys(TABLES) as TableKey[]).map((key) => (
-            <button
-              key={key}
-              onClick={() => setSelectedTable(key)}
-              style={{ textAlign: 'left', borderRadius: 12, border: selectedTable === key ? '1px solid #93c5fd' : '1px solid rgba(255,255,255,0.2)', background: selectedTable === key ? 'rgba(59,130,246,0.2)' : 'rgba(255,255,255,0.06)', color: 'white', padding: 8 }}
-            >
-              <div style={{ fontWeight: 800, fontSize: 12 }}>{TABLES[key].title}</div>
-              <div style={{ fontSize: 10, color: '#cbd5e1', marginTop: 2 }}>{TABLES[key].subtitle}</div>
-            </button>
-          ))}
-        </div>
-      </section>
-
-      {TABLES[selectedTable].hasTableMenu ? (
-        <section style={{ position: 'fixed', left: 8, right: 8, bottom: 8, background: 'rgba(0,0,0,0.7)', border: '1px solid rgba(255,255,255,0.18)', borderRadius: 14, padding: 10 }}>
-          <div style={{ fontWeight: 900, fontSize: 12 }}>7ft Showood Setup (Chinese 8-Ball only)</div>
-          <div style={{ marginTop: 8, display: 'grid', gap: 8 }}>
-            <label style={{ display: 'grid', gap: 3, fontSize: 11 }}>
-              Cloth (procedural only)
-              <select value={cloth} onChange={(e) => setCloth(e.target.value as ClothKey)}>
-                {(Object.keys(CLOTH_PRESETS) as ClothKey[]).map((k) => (
-                  <option value={k} key={k}>{CLOTH_PRESETS[k].label}</option>
-                ))}
-              </select>
-            </label>
-            <label style={{ display: 'grid', gap: 3, fontSize: 11 }}>
-              Table finish (same style as cue finish)
-              <select value={finish} onChange={(e) => setFinish(e.target.value as FinishKey)}>
-                {(Object.keys(FINISH_PRESETS) as FinishKey[]).map((k) => (
-                  <option value={k} key={k}>{FINISH_PRESETS[k].label}</option>
-                ))}
-              </select>
-            </label>
-            <div style={{ fontSize: 10, color: '#cbd5e1' }}>
-              Mapping loaded: {currentMapping?.name} · pockets {currentMapping?.pockets.length ?? 0} · cushion segments {currentMapping?.cushions.length ?? 0}
-            </div>
-          </div>
-        </section>
-      ) : null}
-    </main>
-  );
+  return <main style={{ minHeight: '100vh', background: '#020202', color: 'white', fontFamily: 'system-ui,sans-serif' }}><div ref={hostRef} style={{ position: 'fixed', inset: 0 }} />
+    <section style={{ position: 'fixed', top: 8, left: 8, right: 8, background: 'rgba(0,0,0,0.66)', border: '1px solid rgba(255,255,255,0.18)', borderRadius: 14, padding: 10 }}>
+      <button onClick={onBack} style={{ border: '1px solid rgba(255,255,255,0.35)', borderRadius: 10, color: 'white', background: 'rgba(255,255,255,0.08)', padding: '6px 10px', fontSize: 11 }}>← Back to Lobby</button>
+      <div style={{ fontWeight: 900, fontSize: 13, marginTop: 8 }}>{TABLES[selectedTable].title}</div>
+      <div style={{ fontSize: 10, color: '#cbd5e1', marginTop: 2 }}>{TABLES[selectedTable].subtitle}</div>
+    </section>
+    <section style={{ position: 'fixed', left: 8, right: 8, bottom: 8, background: 'rgba(0,0,0,0.7)', border: '1px solid rgba(255,255,255,0.18)', borderRadius: 14, padding: 10 }}>
+      <div style={{ fontWeight: 900, fontSize: 12 }}>Table Setup Menu ({currentMapping.sizeFt})</div>
+      <div style={{ marginTop: 8, display: 'grid', gap: 8 }}>
+        <label style={{ display: 'grid', gap: 3, fontSize: 11 }}>Table cloth (same on both)<select value={cloth} onChange={(e) => setCloth(e.target.value as ClothKey)}>{(Object.keys(CLOTH_PRESETS) as ClothKey[]).map((k) => <option value={k} key={k}>{CLOTH_PRESETS[k].label}</option>)}</select></label>
+        <label style={{ display: 'grid', gap: 3, fontSize: 11 }}>Cushion/table finish (same on both)<select value={finish} onChange={(e) => setFinish(e.target.value as FinishKey)}>{(Object.keys(FINISH_PRESETS) as FinishKey[]).map((k) => <option value={k} key={k}>{FINISH_PRESETS[k].label}</option>)}</select></label>
+      </div>
+    </section>
+  </main>;
 }

--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -49,7 +49,7 @@ describe('Pool Royale table models', () => {
     assert.equal(snookerGeneric.fitHeightScale, 1);
   });
 
-  test('Traditional Sketchfab 8 ft glTF table is no longer selectable', () => {
+  test('Traditional Sketchfab 8 ft glTF table remains non-selectable', () => {
     assert.equal(
       POOL_ROYALE_TABLE_MODEL_OPTIONS.some(
         (option) => option.id === 'traditional-fizyman-eight-foot'
@@ -62,7 +62,7 @@ describe('Pool Royale table models', () => {
     );
   });
 
-  test('Pool Royale lobby no longer references removed Showood/Traditional messaging', async () => {
+  test('Pool Royale lobby exposes both Snooker Generic and Showood table options', async () => {
     const lobby = await readFile(
       'webapp/src/pages/Games/PoolRoyaleLobby.jsx',
       'utf8'
@@ -70,8 +70,8 @@ describe('Pool Royale table models', () => {
 
     assert.equal(
       lobby.includes('showood-seven-foot'),
-      false,
-      'lobby should not reference the removed Showood model id'
+      true,
+      'lobby should include the Showood model id option'
     );
     assert.equal(
       lobby.includes('traditional-fizyman-eight-foot'),

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -6,6 +6,10 @@ const POOLTOOL_RAW_BASE =
 const SNOOKER_GENERIC_GLB_URL =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
 
+
+const SHOWOOD_7FT_GLB_URL =
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/showood_7ft/showood_7ft.glb';
+
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'snooker-generic',
@@ -43,6 +47,44 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     hideSurfaceRoles: [],
     useLegacyShowoodRemap: false,
     tableLogicProfile: 'snookerGenericSnooker9ft',
+    cueRigProfile: 'poolRoyaleDefault'
+  },
+  {
+    id: 'showood-seven-foot',
+    label: 'Showood 7ft GLB',
+    description:
+      'Open-source Pooltool showood 7ft GLB matched to the compact 7ft gameplay footprint.',
+    tableSizeId: '7ft',
+    baseId: 'showood7ft',
+    assetUrl: SHOWOOD_7FT_GLB_URL,
+    fallbackAssetUrls: [
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/showood_7ft/showood_7ft.glb',
+      `${POOLTOOL_RAW_BASE}/showood_7ft/showood_7ft.glb`
+    ],
+    icon: '🪵',
+    kind: 'gltf',
+    fitScale: 1,
+    fitFootprintScale: 1,
+    fitHeightScale: 1,
+    lowerBaseHeightScale: 1,
+    legLengthScale: 1,
+    clothRepeatScale: 1,
+    fitStrategy: 'exact',
+    fitReference: 'upperTabletop',
+    matchNativeHeight: true,
+    matchNativeUpperComponentHeight: true,
+    preserveOriginalFootprintAspect: true,
+    useOriginalLayoutSurfaces: true,
+    usePoolRoyaleFinish: true,
+    usePoolRoyaleFinishRoles: ['cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock'],
+    preserveOriginalSurfaceRoles: ['cloth', 'leg', 'baseFoot'],
+    tintOriginalTrimGold: false,
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'namePlate', 'railApron', 'stripApron'],
+    blackMaterialSurfaceNames: [],
+    forceGeneratedChromePlates: false,
+    hideSurfaceRoles: [],
+    useLegacyShowoodRemap: false,
+    tableLogicProfile: 'showood7ft',
     cueRigProfile: 'poolRoyaleDefault'
   }
 ]);

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -85,13 +85,19 @@ export default function PoolRoyaleLobby() {
     }
   });
   const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(tableModelId), [tableModelId]);
-  const lobbyTableModelOptions = useMemo(
-    () =>
-      POOL_ROYALE_TABLE_MODEL_OPTIONS.filter(
-        (model) => model.id !== 'procedural-legacy'
-      ),
-    []
-  );
+  const lobbyTableModelOptions = useMemo(() => {
+    const base = POOL_ROYALE_TABLE_MODEL_OPTIONS.filter(
+      (model) => model.id !== 'procedural-legacy'
+    );
+    const priority = ['snooker-generic', 'showood-seven-foot'];
+    const ordered = [
+      ...priority
+        .map((id) => base.find((model) => model.id === id))
+        .filter(Boolean),
+      ...base.filter((model) => !priority.includes(model.id))
+    ];
+    return ordered;
+  }, []);
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -905,9 +911,10 @@ export default function PoolRoyaleLobby() {
         {!hasActiveTournament && showTableModelSelector && (
           <div className="space-y-3">
             <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Pool Table</h3>
+              <h3 className="font-semibold text-white">Pool Table (2 options)</h3>
               <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Models</span>
             </div>
+            <p className="text-xs text-white/60">Choose either 9ft Snooker Generic GLB or 7ft Showood GLB.</p>
             <div className="grid grid-cols-1 gap-3">
               {lobbyTableModelOptions.map((model) => {
                 const active = selectedTableModel?.id === model.id;


### PR DESCRIPTION
### Motivation
- Expose an explicit lobby for Pool Royale so players can pick between table variants (9ft Snooker and 7ft Showood) and configure a preview before entering play.
- Consolidate table geometry/mapping data into the preview component and make the preview selectable from a simple JSX entry point used by the app.

### Description
- Replace the previous `PoolRoyal.tsx` with a new `PoolRoyal.jsx` that implements a simple lobby list and uses state to mount `SevenFootShowoodPreview` with `selectedTable` and `onBack` props.
- Refactor `SevenFootShowoodPreview.tsx` to export a `TABLES` mapping, accept a `selectedTable` prop and an `onBack` callback, and derive table geometry from `TABLES` to render cloth, pockets, and scaled table body dynamically.
- Add cloth and finish presets and a procedural cloth texture function, and tidy up Three.js setup/animation/resizing and cleanup logic in the preview component.
- Add a new `showood-seven-foot` entry to `webapp/src/config/poolRoyaleTableModels.js` and update lobby model ordering in `PoolRoyaleLobby.jsx` to prioritize `snooker-generic` and `showood-seven-foot`, plus UI copy indicating two options.
- Update test expectations in `test/poolRoyaleTableModels.test.js` to assert presence of the Showood option and adjust a test name for clarity.

### Testing
- Ran the unit test file `test/poolRoyaleTableModels.test.js` via `npm test` and the updated assertions passed.
- Ran the full frontend unit test suite via `npm test` and no regressions were reported in automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11cc64e5908329b94f7c46ee3e06c6)