### PR TITLE
Use GLTF table finishes for Snooker & Showood and default to Showood 7ft

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -37,9 +37,9 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     preserveOriginalFootprintAspect: true,
     useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock'],
-    preserveOriginalSurfaceRoles: ['cloth', 'leg', 'baseFoot'],
+    usePoolRoyaleFinish: false,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock', 'leg', 'baseFoot'],
+    preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: true,
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'sideWoodApron', 'apronStrip', 'railSightLower', 'cornerRailSight', 'brandingPlate', 'brandingPlates', 'namePlate', 'railApron', 'stripApron'],
     blackMaterialSurfaceNames: [],
@@ -75,9 +75,9 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     preserveOriginalFootprintAspect: true,
     useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock'],
-    preserveOriginalSurfaceRoles: ['cloth', 'leg', 'baseFoot'],
+    usePoolRoyaleFinish: false,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock', 'leg', 'baseFoot'],
+    preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: false,
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'namePlate', 'railApron', 'stripApron'],
     blackMaterialSurfaceNames: [],
@@ -91,7 +91,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'snooker-generic'
+    (option) => option.id === 'showood-seven-foot'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
 
 export function resolvePoolRoyaleTableModel(modelId) {


### PR DESCRIPTION
### Motivation
- Ensure Snooker Generic and Showood tables use the GLTF-authored textures (not the procedural finish) so table finishes match other GLTF assets such as the cuestick and existing GLTF textures.
- Restore the Showood 7ft model as the default Pool Royale table to match the requested Showood-first experience.

### Description
- Disabled Pool Royale procedural finish overrides by setting `usePoolRoyaleFinish: false` for both `snooker-generic` and `showood-seven-foot` in `webapp/src/config/poolRoyaleTableModels.js`.
- Expanded `usePoolRoyaleFinishRoles` to include `cloth`, `leg`, and `baseFoot` so GLTF surface roles cover cloth, wood, trim, legs and base.
- Cleared `preserveOriginalSurfaceRoles` for both models so GLTF textures and roles are preserved and not remapped to procedural exceptions.
- Changed the `DEFAULT_POOL_ROYALE_TABLE_MODEL_ID` to `showood-seven-foot` so Showood 7ft is selected by default.

### Testing
- Inspected and validated the updated `webapp/src/config/poolRoyaleTableModels.js` diff to confirm the intended property changes.
- Ran the repository PR creation script (`make_pr`) to produce the PR record; no automated unit or integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127a4f4af483299f3ce19cd1a4aad5)