### PR TITLE
Pool Royale: align snooker/showood GLTF finish behavior

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -38,8 +38,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     preserveOriginalFootprintAspect: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock'],
-    preserveOriginalSurfaceRoles: ['cloth', 'leg', 'baseFoot'],
+    usePoolRoyaleFinishRoles: ['cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock', 'leg', 'baseFoot'],
+    preserveOriginalSurfaceRoles: ['cloth'],
     tintOriginalTrimGold: true,
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'sideWoodApron', 'apronStrip', 'railSightLower', 'cornerRailSight', 'brandingPlate', 'brandingPlates', 'namePlate', 'railApron', 'stripApron'],
     blackMaterialSurfaceNames: [],
@@ -75,9 +75,9 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     preserveOriginalFootprintAspect: true,
     useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock'],
-    preserveOriginalSurfaceRoles: ['cloth', 'leg', 'baseFoot'],
+    usePoolRoyaleFinish: false,
+    usePoolRoyaleFinishRoles: [],
+    preserveOriginalSurfaceRoles: ['cloth', 'cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock', 'leg', 'baseFoot'],
     tintOriginalTrimGold: false,
     chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'namePlate', 'railApron', 'stripApron'],
     blackMaterialSurfaceNames: [],
@@ -91,7 +91,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-    (option) => option.id === 'snooker-generic'
+    (option) => option.id === 'showood-seven-foot'
   )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
 
 export function resolvePoolRoyaleTableModel(modelId) {


### PR DESCRIPTION
### Motivation
- Ensure the snooker-generic GLTF table receives the same Pool Royale finish mapping as cue-driven finishes so wood/leg/base parts follow the table-finish selection expectations. 
- Preserve the original Showood GLTF material look by disabling procedural finish overrides so the Showood table uses its native GLTF textures. 
- Make the Showood 7ft GLTF the default table model for Pool Royale to surface the requested Showood view by default.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to expand `usePoolRoyaleFinishRoles` for `snooker-generic` to include `leg` and `baseFoot` and to preserve only the cloth surface (`preserveOriginalSurfaceRoles: ['cloth']`).
- Updated `showood-seven-foot` entry to disable Pool Royale finish remapping (`usePoolRoyaleFinish: false`) and to preserve the GLTF original surfaces by listing them in `preserveOriginalSurfaceRoles` so its GLTF textures remain untouched.
- Changed the default table model selection (`DEFAULT_POOL_ROYALE_TABLE_MODEL_ID`) to `showood-seven-foot` so the Showood GLTF is loaded by default.
- This is a configuration-only change limited to `webapp/src/config/poolRoyaleTableModels.js` and does not alter runtime rendering logic beyond how finishes are applied to GLTF models.

### Testing
- No automated unit or integration tests were executed for this config-only change.
- Performed static validation and inspection of the updated file using repository search and file-viewing commands (`rg`, `sed`) which completed successfully.
- Verified the configuration file content was updated as intended by inspecting `webapp/src/config/poolRoyaleTableModels.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127a4f4af483299f3ce19cd1a4aad5)