### PR TITLE
Fix GLTF texture path resolution for Ludo Battle Royal weapons

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1427,6 +1427,17 @@ async function loadCaptureWeaponModel(captureAnimationId) {
   const promise = (async () => {
     const loader = createConfiguredGLTFLoader();
     loader.setCrossOrigin?.('anonymous');
+    const setLoaderPathsForUrl = (url = '') => {
+      if (!url) return;
+      try {
+        const resolved = new URL(url, typeof window !== 'undefined' ? window.location?.href : url);
+        const resourcePath = resolved.href.substring(0, resolved.href.lastIndexOf('/') + 1);
+        loader.setResourcePath(resourcePath);
+      } catch {
+        loader.setResourcePath('');
+      }
+      loader.setPath('');
+    };
     const imageCache = new Map();
     let loadedRoot = null;
     const isGltfAssetUrl = (url = '') => {
@@ -1444,6 +1455,7 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     for (let i = 0; i < candidateUrls.length; i += 1) {
       const candidateUrl = candidateUrls[i];
       try {
+        setLoaderPathsForUrl(candidateUrl);
         if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl)) {
           // Poly Pizza GLBs already ship with their own material/texture data. Load them
           // directly first so GLTFLoader can keep the exact embedded PBR texture bindings.
@@ -1470,6 +1482,7 @@ async function loadCaptureWeaponModel(captureAnimationId) {
       }
       if (loadedRoot) break;
       try {
+        setLoaderPathsForUrl(candidateUrl);
         // eslint-disable-next-line no-await-in-loop
         const gltf = await withLoadTimeout(loader.loadAsync(candidateUrl));
         loadedRoot = assignLoadedGltf(gltf);


### PR DESCRIPTION
### Motivation
- GLTF weapon textures started failing when the weapon candidate list mixed GLB and GLTF sources because the shared `GLTFLoader` could keep a stale resource path between loads. 
- `.gltf` assets that reference external texture files must resolve those texture URLs against the model's own folder so textures load correctly.

### Description
- Added a helper `setLoaderPathsForUrl(url)` inside `loadCaptureWeaponModel` to compute and set `loader.setResourcePath(...)` and clear `loader.setPath('')` for each candidate URL. 
- Invoked the helper before both the patched-buffer parse path and the fallback `loader.loadAsync(candidateUrl)` branch so each GLTF/GLB candidate resolves texture requests from its correct base path. 
- Preserved existing handling for Poly Pizza GLBs and patched-buffer parsing while ensuring relative texture resolution for external `.gltf` textures.

### Testing
- Ran `npx eslint --no-ignore src/pages/Games/LudoBattleRoyal.jsx`, which produced no lint errors and only the project ignore-pattern warning. 
- Verified the modified `loadCaptureWeaponModel` function compiles under the project linter with no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12819eb7388329bf2e8fef1dd8423e)