### PR TITLE
Fix Ludo weapon GLTF texture fallback regression

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1458,10 +1458,11 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         // eslint-disable-next-line no-await-in-loop
         const patchedBuffer = await patchGlbImagesToDataUris(
           rawBuffer,
-          'fighter',
+          'firearm',
           candidateUrl,
           candidateUrls,
-          imageCache
+          imageCache,
+          { allowPlaceholder: false }
         );
         // eslint-disable-next-line no-await-in-loop
         loadedRoot = await parseObjectFromBuffer(loader, patchedBuffer);
@@ -2169,7 +2170,14 @@ function makePlaceholderTextureDataUri(primary, secondary) {
   return canvas.toDataURL('image/png');
 }
 
-async function resolveExternalImageToDataUri(imageUri, kind, sourceUrl, modelUrls, cache) {
+async function resolveExternalImageToDataUri(
+  imageUri,
+  kind,
+  sourceUrl,
+  modelUrls,
+  cache,
+  { allowPlaceholder = true } = {}
+) {
   if (isDataUri(imageUri)) return imageUri;
   const placeholderColors = {
     drone: ['#7c8791', '#4f5861'],
@@ -2196,10 +2204,17 @@ async function resolveExternalImageToDataUri(imageUri, kind, sourceUrl, modelUrl
       // ignore candidate
     }
   }
-  return placeholderDataUri;
+  return allowPlaceholder ? placeholderDataUri : null;
 }
 
-async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cache) {
+async function patchGlbImagesToDataUris(
+  buffer,
+  kind,
+  sourceUrl,
+  modelUrls,
+  cache,
+  { allowPlaceholder = true } = {}
+) {
   const { json, binChunk } = decodeGlb(buffer);
   const cloned = JSON.parse(JSON.stringify(json));
   const images = Array.isArray(cloned.images) ? cloned.images : [];
@@ -2209,7 +2224,12 @@ async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cach
     const image = images[i];
     if (typeof image.uri === 'string') {
       // eslint-disable-next-line no-await-in-loop
-      image.uri = await resolveExternalImageToDataUri(image.uri, kind, sourceUrl, modelUrls, cache);
+      image.uri = await resolveExternalImageToDataUri(image.uri, kind, sourceUrl, modelUrls, cache, {
+        allowPlaceholder
+      });
+      if (!image.uri) {
+        throw new Error(`Unable to resolve external GLB texture: ${sourceUrl} -> ${image.uri}`);
+      }
       delete image.bufferView;
       image.mimeType = image.mimeType ?? 'image/png';
       continue;


### PR DESCRIPTION
### Motivation
- Weapon GLB/GLTF loads could silently fall back to generated placeholder textures when external image URIs failed to resolve, producing visibly corrupted weapon materials after recent asset updates. 
- The loader path that patches GLB images into data URIs needs a strict mode for weapons so failed texture resolution does not lock in placeholders and instead lets other load fallbacks preserve original textures.

### Description
- Added an `allowPlaceholder` option to `resolveExternalImageToDataUri` and `patchGlbImagesToDataUris` and made the default behavior unchanged for non-strict callers. (`webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- When `allowPlaceholder` is `false` the patcher now returns `null` for unresolved images and `patchGlbImagesToDataUris` throws an error if an external image cannot be resolved, causing the patched path to fail fast instead of embedding a placeholder. (`resolveExternalImageToDataUri`, `patchGlbImagesToDataUris`)
- Switched capture-weapon patching in `loadCaptureWeaponModel` to use kind `'firearm'` and call the patcher with `{ allowPlaceholder: false }` so weapon candidate URLs that cannot fully resolve external textures will fall back to alternative loader paths (direct `GLTFLoader`), avoiding placeholder texture corruption. (`loadCaptureWeaponModel`)

### Testing
- Ran the project linter with `cd webapp && npm run -s lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12819eb7388329bf2e8fef1dd8423e)