### PR TITLE
Restore Pool Royal-related game code to May 20 baseline

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -8,48 +8,53 @@ import {
 } from '../webapp/src/config/poolRoyaleTableModels.js';
 
 describe('Pool Royale table models', () => {
-  test('defaults to the Snooker Generic GLB table', () => {
-    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'snooker-generic');
-    assert.equal(resolvePoolRoyaleTableModel(null).id, 'snooker-generic');
+  test('defaults to the Showood GLB table', () => {
+    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'showood-seven-foot');
+    assert.equal(resolvePoolRoyaleTableModel(null).id, 'showood-seven-foot');
     assert.equal(
       resolvePoolRoyaleTableModel('unknown').id,
-      'snooker-generic'
+      'showood-seven-foot'
     );
   });
 
-  test('snooker generic table keeps Pool Royale dimensions while using the shared open-source GLB', () => {
-    const snookerGeneric = POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
-      (option) => option.id === 'snooker-generic'
+  test('Showood uses original GLB surface layout with Pool Royale finish textures', () => {
+    const showood = POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
+      (option) => option.id === 'showood-seven-foot'
     );
 
-    assert.ok(snookerGeneric, 'snooker generic table model must be configured');
-    assert.equal(snookerGeneric.kind, 'gltf');
-    assert.equal(snookerGeneric.fitScale, 1);
-    assert.equal(snookerGeneric.preserveOriginalFootprintAspect, true);
-    assert.equal(snookerGeneric.lowerBaseHeightScale, 1.38);
-    assert.equal(snookerGeneric.legLengthScale, 2.05);
-    assert.equal(snookerGeneric.clothRepeatScale, 7.5);
-    assert.deepEqual(snookerGeneric.hideSurfaceRoles, []);
-    assert.equal(snookerGeneric.tintOriginalTrimGold, true);
-    assert.deepEqual(snookerGeneric.usePoolRoyaleFinishRoles, [
+    assert.ok(showood, 'Showood table model must be configured');
+    assert.equal(showood.kind, 'gltf');
+    assert.equal(showood.useOriginalLayoutSurfaces, true);
+    assert.equal(showood.fitScale, 1);
+    assert.equal(showood.preserveOriginalFootprintAspect, true);
+    assert.equal(showood.lowerBaseHeightScale, 1.38);
+    assert.equal(showood.legLengthScale, 2.05);
+    assert.equal(showood.clothRepeatScale, 7.5);
+    assert.deepEqual(showood.hideSurfaceRoles, []);
+    assert.deepEqual(showood.preserveOriginalSurfaceRoles, []);
+    assert.equal(showood.tintOriginalTrimGold, true);
+    assert.deepEqual(showood.chromeMaterialSurfaceNames, [
+      'diamonds',
+      'railSight',
+      'sideApron',
+      'apronStrip',
+      'railSightLower',
+      'cornerRailSight'
+    ]);
+    assert.deepEqual(showood.blackMaterialSurfaceNames, []);
+    assert.equal(showood.forceGeneratedChromePlates, false);
+    assert.deepEqual(showood.usePoolRoyaleFinishRoles, [
       'cloth',
       'cushion',
-      'pocket',
-      'trim',
       'wood',
-      'topWoodRail',
-      'sideWoodApron',
-      'railSight',
-      'verticalCornerRim',
-      'baseCornerBlock',
-      'leg',
-      'baseFoot'
+      'pocket',
+      'trim'
     ]);
-    assert.equal('playfieldVisualLift' in snookerGeneric, false);
-    assert.equal(snookerGeneric.fitHeightScale, 1);
+    assert.equal('playfieldVisualLift' in showood, false);
+    assert.equal(showood.fitHeightScale, 1);
   });
 
-  test('Traditional Sketchfab 8 ft glTF table remains non-selectable', () => {
+  test('Traditional Sketchfab 8 ft glTF table is no longer selectable', () => {
     assert.equal(
       POOL_ROYALE_TABLE_MODEL_OPTIONS.some(
         (option) => option.id === 'traditional-fizyman-eight-foot'
@@ -58,20 +63,29 @@ describe('Pool Royale table models', () => {
     );
     assert.equal(
       resolvePoolRoyaleTableModel('traditional-fizyman-eight-foot').id,
-      'snooker-generic'
+      'showood-seven-foot'
     );
   });
 
-  test('Pool Royale lobby exposes both Snooker Generic and Showood table options', async () => {
+  test('Pool Royale lobby uses the fixed Showood table without model choices', async () => {
     const lobby = await readFile(
       'webapp/src/pages/Games/PoolRoyaleLobby.jsx',
       'utf8'
     );
 
+    assert.ok(
+      lobby.includes('Showood 7 ft GLB is now the fixed Pool Royale table.'),
+      'lobby should explain the fixed Showood table'
+    );
     assert.equal(
-      lobby.includes('showood-seven-foot'),
-      true,
-      'lobby should include the Showood model id option'
+      lobby.includes('POOL_ROYALE_TABLE_MODEL_OPTIONS.map'),
+      false,
+      'lobby should not render table model option cards'
+    );
+    assert.equal(
+      lobby.includes('setTableModelId'),
+      false,
+      'lobby should not allow switching table models'
     );
     assert.equal(
       lobby.includes('traditional-fizyman-eight-foot'),

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -3,34 +3,25 @@ export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
 const POOLTOOL_RAW_BASE =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
 
-const SNOOKER_GENERIC_GLB_URL =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
-
-
-const SHOWOOD_7FT_GLB_URL =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/showood_7ft/showood_7ft.glb';
-
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
-    id: 'snooker-generic',
-    label: 'Snooker Generic GLB',
+    id: 'showood-seven-foot',
+    label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool snooker table GLB matched to the original snooker footprint, rails, and leg geometry.',
-    tableSizeId: '9ft',
-    baseId: 'snookerGeneric',
-    assetUrl: SNOOKER_GENERIC_GLB_URL,
-    fallbackAssetUrls: [
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/snooker_generic/snooker_generic.glb',
-      `${POOLTOOL_RAW_BASE}/snooker_generic/snooker_generic.glb`
-    ],
-    icon: '🎱',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the CDN GLB cannot load, Pool Royale retries the raw Showood GLB and keeps the Showood original base and legs.',
+    tableSizeId: '7ft',
+    baseId: 'showoodOriginal',
+    assetUrl:
+      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb',
+    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
+    icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
-    fitFootprintScale: 1,
+    fitFootprintScale: 1.105,
     fitHeightScale: 1,
-    lowerBaseHeightScale: 1,
-    legLengthScale: 1,
-    clothRepeatScale: 1,
+    lowerBaseHeightScale: 1.38,
+    legLengthScale: 2.05,
+    clothRepeatScale: 7.5,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
@@ -38,54 +29,13 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     preserveOriginalFootprintAspect: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock', 'leg', 'baseFoot'],
-    preserveOriginalSurfaceRoles: ['cloth'],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
+    preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: true,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'sideWoodApron', 'apronStrip', 'railSightLower', 'cornerRailSight', 'brandingPlate', 'brandingPlates', 'namePlate', 'railApron', 'stripApron'],
+    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'sideApron', 'apronStrip', 'railSightLower', 'cornerRailSight'],
     blackMaterialSurfaceNames: [],
     forceGeneratedChromePlates: false,
-    hideSurfaceRoles: [],
-    useLegacyShowoodRemap: false,
-    tableLogicProfile: 'snookerGenericSnooker9ft',
-    cueRigProfile: 'poolRoyaleDefault'
-  },
-  {
-    id: 'showood-seven-foot',
-    label: 'Showood 7ft GLB',
-    description:
-      'Open-source Pooltool showood 7ft GLB matched to the compact 7ft gameplay footprint.',
-    tableSizeId: '7ft',
-    baseId: 'showood7ft',
-    assetUrl: SHOWOOD_7FT_GLB_URL,
-    fallbackAssetUrls: [
-      'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/showood_7ft/showood_7ft.glb',
-      `${POOLTOOL_RAW_BASE}/showood_7ft/showood_7ft.glb`
-    ],
-    icon: '🪵',
-    kind: 'gltf',
-    fitScale: 1,
-    fitFootprintScale: 1,
-    fitHeightScale: 1,
-    lowerBaseHeightScale: 1,
-    legLengthScale: 1,
-    clothRepeatScale: 1,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeHeight: true,
-    matchNativeUpperComponentHeight: true,
-    preserveOriginalFootprintAspect: true,
-    useOriginalLayoutSurfaces: true,
-    usePoolRoyaleFinish: false,
-    usePoolRoyaleFinishRoles: [],
-    preserveOriginalSurfaceRoles: ['cloth', 'cushion', 'pocket', 'trim', 'wood', 'topWoodRail', 'sideWoodApron', 'railSight', 'verticalCornerRim', 'baseCornerBlock', 'leg', 'baseFoot'],
-    tintOriginalTrimGold: false,
-    chromeMaterialSurfaceNames: ['diamonds', 'railSight', 'namePlate', 'railApron', 'stripApron'],
-    blackMaterialSurfaceNames: [],
-    forceGeneratedChromePlates: false,
-    hideSurfaceRoles: [],
-    useLegacyShowoodRemap: false,
-    tableLogicProfile: 'showood7ft',
-    cueRigProfile: 'poolRoyaleDefault'
+    hideSurfaceRoles: []
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -83,11 +83,6 @@ import {
   POOL_ROYALE_BASE_VARIANTS,
   POOL_ROYALE_OPTION_LABELS
 } from '../../config/poolRoyaleInventoryConfig.js';
-import {
-  SNOOKER_ROYALE_BASE_VARIANTS,
-  SNOOKER_ROYALE_HDRI_VARIANTS,
-  SNOOKER_ROYALE_HDRI_VARIANT_MAP
-} from '../../config/snookerRoyalInventoryConfig.js';
 import { BILARDO_MIN_RELEASE_POWER } from './shared/bilardoShotModel';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothPresets.js';
 import {
@@ -829,7 +824,7 @@ const CHROME_PLATE_ROUGHNESS_LIFT = 0.08; // lift roughness on fascia cuts so po
 const CHROME_PLATE_THICKNESS_SCALE = 0.0306; // match diamond thickness on the wooden rails for fascia depth
 const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18; // thicken the middle fascia so its depth now matches the corner plates
 const CHROME_PLATE_VERTICAL_LIFT_SCALE = 0.06; // lift fascia slightly with the raised rail/cushion profile so chrome stays aligned on all six pockets
-const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0.28; // expand rail-sight fascia downward so it fully covers rail-sight faces and corner rims
+const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical to snooker
 const CHROME_PLATE_RENDER_ORDER = 3.5; // ensure chrome fascias stay visually above the wood rails without z-fighting
 const CHROME_SIDE_PLATE_POCKET_SPAN_SCALE = 1.34; // trim the side fascia reach so the middle chrome ends cleanly before the pocket curve
 const CHROME_SIDE_PLATE_HEIGHT_SCALE = 3.14; // extend fascia reach so the middle pocket cut gains a broader surround on the remaining three sides
@@ -841,14 +836,14 @@ const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.9; // tighten the middle fasci
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.24; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.012; // push middle chrome plates slightly outward away from table center while preserving the rounded cut
-const CHROME_SIDE_APRON_COVER_THICKNESS_SCALE = 0.038; // keep middle-pocket apron cover as a slim strip, not a full side panel overlay
-const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 0.58; // limit middle-pocket apron cover to the small strip beside each jaw
+const CHROME_SIDE_APRON_COVER_THICKNESS_SCALE = 0.055; // cover the grey middle-pocket side apron with rail-sight chrome/gold
+const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 0.82; // drop the side apron cover down the rail face behind the side-pocket jaw
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.022; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.078; // trim the middle-pocket outside chrome a touch more so the outer edge ends flush with the wooden rails
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.045; // open only the corner chrome rounded cut a tiny bit more so the arc reads slightly larger
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.03; // open middle-pocket chrome rounded cuts a tiny bit more so the arc reads slightly larger
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // reduce inward pull so middle pocket chrome cuts sit a bit farther out
-const WOOD_RAIL_POCKET_RELIEF_SCALE = 1; // keep procedural wooden rail pocket relief identical to the GLB Showood profile
+const WOOD_RAIL_POCKET_RELIEF_SCALE = 1.045; // match the wooden rail pocket relief to the Showood jaw outside diameter
 const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.958; // shrink the wooden corner rounded cut a touch more so only the wood corner radius reads slightly tighter
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
@@ -1155,7 +1150,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.85; // shrink the table just a bit in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.86; // make the table read just a bit larger in portrait while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1311,12 +1306,12 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   };
 const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
-const RAIL_HEIGHT = TABLE.THICK * 1.62; // shorten all four wooden rails back toward the original procedural frame height
+const RAIL_HEIGHT = TABLE.THICK * 1.9; // lift all six cushions/rails a touch more so the top profile reads higher without changing playfield size
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.024; // push the corner jaws just a bit farther outward so the fascia follows the rounded rail and chrome cut
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
 const POCKET_JAW_CORNER_INNER_SCALE = 1.62; // stretch the inner lip into a longer Showood-style rounded pocket jaw while keeping playable mouth size
-const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE; // keep middle jaw inner profile identical to the GLB Showood corner-jaw family
+const POCKET_JAW_SIDE_INNER_SCALE = POCKET_JAW_CORNER_INNER_SCALE * 1.03; // round and widen the middle jaws slightly more while keeping the corner match
 const POCKET_JAW_CORNER_OUTER_SCALE = 1.86; // broaden the outer jaw shoulder to mirror the Showood rounded pocket cup profile
 const POCKET_JAW_SIDE_OUTER_SCALE =
   POCKET_JAW_CORNER_OUTER_SCALE * 1; // match the middle fascia thickness to the corners so the jaws read equally robust
@@ -1348,10 +1343,10 @@ const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thi
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
 const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.74; // pull both corner-jaw flanks inward a bit more while keeping current jaw height
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.5; // expand both middle-jaw flanks slightly so all six jaws open up evenly
-const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // use the same arc radius as GLB Showood jaws so all six pockets match
-const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1; // keep middle jaw depth identical to GLB Showood pocket jaws
-const SIDE_POCKET_JAW_VERTICAL_TWEAK = 0; // align middle-pocket jaw vertical placement with the GLB Showood corner-jaw height
-const SIDE_POCKET_JAW_OUTWARD_SHIFT = 0; // keep middle-pocket jaw lateral placement identical to the GLB Showood layout
+const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.995; // keep middle jaw arcs slightly tighter so side jaws look a bit smaller
+const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.12; // add Showood-like extra depth so side jaws match the corner jaw type
+const SIDE_POCKET_JAW_VERTICAL_TWEAK = -TABLE.THICK * 0.01; // pull middle-pocket jaws a bit farther downward than corners
+const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.028; // reduce the outward shift so middle-pocket jaws sit a bit more inward toward table center
 const POCKET_JAW_INWARD_PULL = 0; // keep the jaw centers aligned with the snooker pocket layout
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.66; // shorten middle jaw side edges a bit more so all six jaws finish cleaner at the shoulders
@@ -1359,7 +1354,7 @@ const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // 
 const CORNER_POCKET_JAW_EDGE_TRIM_START = SIDE_POCKET_JAW_EDGE_TRIM_START; // keep corner jaw taper start aligned with middle pockets
 const CORNER_POCKET_JAW_EDGE_TRIM_SCALE = SIDE_POCKET_JAW_EDGE_TRIM_SCALE; // match the middle pocket jaw thin/thick profile
 const CORNER_POCKET_JAW_EDGE_TRIM_CURVE = SIDE_POCKET_JAW_EDGE_TRIM_CURVE; // reuse the same taper curve for corner jaws
-const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.01; // tighten jaw collision arcs so balls do not bounce early before reaching cushion noses
+const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.035; // slightly expand jaw collision arcs so physics cannot slip through visible jaw/chrome edges
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span to the corner profile
 const POCKET_RIM_DEPTH_RATIO = 0; // remove the separate pocket rims so the chrome fascias meet the jaws directly
@@ -1411,7 +1406,6 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   );
 const MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION;
 const BALL_SIZE_SCALE = 0.96; // trim ball size slightly while keeping every helper tied to BALL_R/BALL_DIAMETER
-const SNOOKER_TABLE_BALL_RADIUS_SCALE = 0.9; // make balls visibly smaller only when the snooker table model is active
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1551,10 +1545,10 @@ const BALL_INERTIA = (2 / 5) * BALL_MASS * BALL_R * BALL_R;
 const SPIN_FIXED_DT = 1 / 120;
 const SPIN_SLIDE_EPS = 0.02;
 const SPIN_KINETIC_FRICTION = 0.22;
-const SPIN_ROLL_DAMPING = 0.08;
+const SPIN_ROLL_DAMPING = 0.1;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const ROLLING_RESISTANCE = 0.01;
+const ROLLING_RESISTANCE = 0.011;
 const BALL_BALL_FRICTION = 0.105;
 const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
 const BALL_COLLISION_SLOP = BALL_R * 0.001; // tighter tolerance so visible ball overlap is corrected faster
@@ -1629,7 +1623,7 @@ const CUSHION_EXTRA_LIFT = TABLE.THICK * 0.225; // lift the cushion base higher 
 const CUSHION_HEIGHT_DROP = 0; // keep the cushion tops fully raised to match the Showood rail profile
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
-const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH * 0.48; // shorten the short/top rail drop from the lower side while keeping side aprons unchanged
+const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
 const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.085; // round exterior wooden rail edge profile to remove sharp octagon-like corners
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
@@ -1839,9 +1833,9 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 0.62; // reduce overall Pool Royale power by an additional 20%
-const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.9; // add a bit more carry so medium-power and break shots feel stronger
+const SHOT_POWER_ADJUSTMENT = 1; // restore legacy shot scaling used before the May 19 power retune
+const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
+const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1882,10 +1876,10 @@ const TABLE_H = 0.75 * LEG_SCALE * TABLE_HEIGHT_REDUCTION * TABLE_HEIGHT_SCALE;
 const TABLE_LIFT =
   BASE_TABLE_LIFT + TABLE_H * (LEG_HEIGHT_FACTOR - 1);
 const BASE_LEG_HEIGHT = TABLE.THICK * 2 * 3 * 1.15 * LEG_HEIGHT_MULTIPLIER;
-const LEG_RADIUS_SCALE = 1.42; // expand leg thickness so the larger base and legs read sturdier from all sides
+const LEG_RADIUS_SCALE = 1.2; // 20% thicker cylindrical legs
 const BASE_LEG_LENGTH_SCALE = 0.72; // previous leg extension factor used for baseline stance
 const LEG_ELEVATION_SCALE = 0.96; // shorten the current leg extension to lower the playfield
-const LEG_LENGTH_SHRINK = 0.96; // extend legs downward a bit more so playfield height stays stable after shortening short-rail bottoms
+const LEG_LENGTH_SHRINK = 0.867; // lengthen legs to extend the base downward with the taller table stance
 const BASE_HEIGHT_REDUCTION = 0.69; // trim table bases slightly more from the bottom to shorten the table stance
 const LEG_LENGTH_SCALE =
   BASE_LEG_LENGTH_SCALE * LEG_ELEVATION_SCALE * LEG_LENGTH_SHRINK * BASE_HEIGHT_REDUCTION;
@@ -1916,7 +1910,7 @@ const BASE_HEIGHT_FILL = BASE_HEIGHT_REDUCTION; // keep custom bases aligned wit
 const BASE_TABLE_Y = -2 + (TABLE_H - 0.75) + TABLE_H + TABLE_LIFT - TABLE_DROP;
 const TABLE_HEIGHT_DROP = (TABLE_H + TABLE.THICK) * 0.24; // lower the full table assembly a bit more so portal leg bottoms sit down onto their chrome levelers
 const TABLE_Y = BASE_TABLE_Y + LEG_ELEVATION_DELTA - TABLE_HEIGHT_DROP;
-const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.5; // expand/deepen the leg base so the body trim change does not visually lift the playfield
+const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.07;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
@@ -4265,7 +4259,7 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
 ]);
 
 const DEFAULT_CHROME_PLATE_STYLE_ID =
-  POOL_ROYALE_DEFAULT_UNLOCKS.chromePlateStyle?.[0] ?? 'royal-classic';
+  POOL_ROYALE_DEFAULT_UNLOCKS.chromePlateStyle?.[0] ?? 'showood-rounded';
 const CHROME_PLATE_STYLE_OPTIONS = Object.freeze([
   {
     id: 'showood-rounded',
@@ -4314,43 +4308,21 @@ const SHOWOOD_TABLE_PARTS = Object.freeze([
   'cloth',
   'cushion',
   'topWoodRail',
-  'sideWoodApron',
+  'railSight',
   'pocketCup',
-  'cornerPocketPlate',
-  'middlePocketPlate',
-  'verticalCornerRim',
   'baseCornerBlock',
   'leg',
-  'baseFoot',
-  'lowerTrim',
-  'railSight',
-  'underside'
-]);
-const SHOWOOD_CONTROL_PARTS = Object.freeze([
-  'cloth',
-  'cushion',
-  'topWoodRail',
-  'railSight',
-  'pocketCup',
-  'verticalCornerRim',
-  'baseCornerBlock',
-  'leg'
+  'baseFoot'
 ]);
 const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
   cloth: 'green',
   cushion: 'green',
-  topWoodRail: 'walnut',
-  sideWoodApron: 'gold',
-  pocketCup: 'black',
-  cornerPocketPlate: 'gold',
-  middlePocketPlate: 'black',
-  verticalCornerRim: 'gold',
-  baseCornerBlock: 'black',
-  leg: 'walnut',
-  baseFoot: 'gold',
-  lowerTrim: 'gold',
+  topWoodRail: DEFAULT_TABLE_FINISH_ID,
   railSight: 'gold',
-  underside: 'dark'
+  pocketCup: 'black',
+  baseCornerBlock: DEFAULT_TABLE_FINISH_ID,
+  leg: DEFAULT_TABLE_FINISH_ID,
+  baseFoot: 'gold'
 });
 const SHOWOOD_TABLE_PART_OPTIONS = Object.freeze({
   cloth: Object.freeze([
@@ -4361,60 +4333,64 @@ const SHOWOOD_TABLE_PART_OPTIONS = Object.freeze({
     { id: 'green', label: 'Green Cushions', color: '#064f23', material: { color: 0x064f23, roughness: 0.94, metalness: 0, envMapIntensity: 0.24 } },
     { id: 'black', label: 'Black Cushions', color: '#050505', material: { color: 0x050505, roughness: 0.88, metalness: 0, envMapIntensity: 0.38 } }
   ]),
-  sideWoodApron: Object.freeze([
-    { id: 'gold', label: 'Gold Side Apron', color: '#d8a928', material: { color: 0xd8a928, roughness: 0.11, metalness: 0.9, envMapIntensity: 5.9, clearcoat: 1, clearcoatRoughness: 0.045 } },
-    { id: 'black', label: 'Black Side Apron', color: '#050505', material: { color: 0x050505, roughness: 0.17, metalness: 0.82, envMapIntensity: 3.15, clearcoat: 1, clearcoatRoughness: 0.07 } }
-  ]),
-  topWoodRail: Object.freeze([
-    { id: 'walnut', label: 'Walnut Rails', color: '#5a2608', keepSourceTexture: true, material: { color: 0x5a2608, roughness: 0.38, metalness: 0.02, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 } },
-    { id: 'black', label: 'Black Rails', color: '#070605', keepSourceTexture: true, material: { color: 0x070605, roughness: 0.28, metalness: 0.04, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 } }
+  topWoodRail: Object.freeze([]),
+  railSight: Object.freeze([
+    { id: 'chrome', label: 'Chrome Apron + Sights', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
+    { id: 'gold', label: 'Gold Apron + Sights', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } }
   ]),
   pocketCup: Object.freeze([
     { id: 'black', label: 'Black Cups', color: '#000000', keepSourceTexture: true, material: { color: 0x000000, roughness: 0.98, metalness: 0, envMapIntensity: 0.12 } },
     { id: 'leather', label: 'Dark Leather Cups', color: '#1b0c04', keepSourceTexture: true, material: { color: 0x1b0c04, roughness: 0.9, metalness: 0, envMapIntensity: 0.26 } }
   ]),
-  cornerPocketPlate: Object.freeze([
-    { id: 'gold', label: 'Gold Corners', color: '#f7c943', material: { color: 0xf7c943, roughness: 0.045, metalness: 1, envMapIntensity: 8.4, clearcoat: 1, clearcoatRoughness: 0.025 } },
-    { id: 'black', label: 'Black Corners', color: '#050505', material: { color: 0x050505, roughness: 0.11, metalness: 0.9, envMapIntensity: 4.2, clearcoat: 1, clearcoatRoughness: 0.045 } }
-  ]),
-  middlePocketPlate: Object.freeze([
-    { id: 'black', label: 'Black Side Plates', color: '#050505', material: { color: 0x050505, roughness: 0.12, metalness: 0.88, envMapIntensity: 4, clearcoat: 1, clearcoatRoughness: 0.05 } },
-    { id: 'gold', label: 'Gold Side Plates', color: '#f7c943', material: { color: 0xf7c943, roughness: 0.045, metalness: 1, envMapIntensity: 8.4, clearcoat: 1, clearcoatRoughness: 0.025 } }
-  ]),
-  verticalCornerRim: Object.freeze([
-    { id: 'gold', label: 'Gold Rims + Feet', color: '#d8b23d', material: { color: 0xd8b23d, roughness: 0.06, metalness: 0.98, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 } },
-    { id: 'chrome', label: 'Chrome Rims + Feet', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } }
-  ]),
   baseCornerBlock: Object.freeze([
-    { id: 'walnut', label: 'Walnut Corners', color: '#7b2d11' },
-    { id: 'black', label: 'Black Corners', color: '#080605' }
+    { id: 'brown', label: 'Brown Base', color: '#7b2d11', material: { color: 0x7b2d11, roughness: 0.48, metalness: 0.02, envMapIntensity: 1.1, clearcoat: 0.22, clearcoatRoughness: 0.33 } },
+    { id: 'black', label: 'Black Base', color: '#080605', material: { color: 0x080605, roughness: 0.38, metalness: 0.03, envMapIntensity: 1.34, clearcoat: 0.34, clearcoatRoughness: 0.22 } }
   ]),
-  leg: Object.freeze([
-    { id: 'walnut', label: 'Walnut Legs', color: '#3d1706', keepSourceTexture: true, material: { color: 0x3d1706, roughness: 0.52, metalness: 0.02, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 } },
-    { id: 'black', label: 'Black Legs', color: '#070504', keepSourceTexture: true, material: { color: 0x070504, roughness: 0.4, metalness: 0.04, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 } }
-  ]),
+  leg: Object.freeze([]),
   baseFoot: Object.freeze([
-    { id: 'gold', label: 'Gold Rounded Feet', color: '#d8b23d', material: { color: 0xd8b23d, roughness: 0.065, metalness: 1, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 } },
-    { id: 'chrome', label: 'Chrome Rounded Feet', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } }
-  ]),
-  lowerTrim: Object.freeze([
-    { id: 'gold', label: 'Gold Trim', color: '#d8b23d' },
-    { id: 'black', label: 'Black Trim', color: '#070707' }
-  ]),
-  railSight: Object.freeze([
-    { id: 'gold', label: 'Gold Apron + Gold Sights', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } },
-    { id: 'black', label: 'Black Apron + Black Sights', color: '#050505', material: { color: 0x050505, roughness: 0.16, metalness: 0.82, envMapIntensity: 3, clearcoat: 1, clearcoatRoughness: 0.07 } }
-  ]),
-  underside: Object.freeze([
-    { id: 'dark', label: 'Dark Underside', color: '#1e130b', keepSourceTexture: true },
-    { id: 'black', label: 'Black Underside', color: '#050505', keepSourceTexture: true }
+    { id: 'chrome', label: 'Chrome Feet', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
+    { id: 'gold', label: 'Gold Feet', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } }
   ])
 });
 const SHOWOOD_TABLE_PART_LABELS = Object.freeze({
-  cloth: 'Field Cloth', cushion: 'Cushions', topWoodRail: 'Top Rails', railSight: 'Side Apron + Rail Sights', pocketCup: 'Pocket Cups', verticalCornerRim: 'Corner Rims + Rounded Feet', baseCornerBlock: 'Base Corners', leg: 'Legs'
+  cloth: 'Field Cloth',
+  cushion: 'Cushions',
+  topWoodRail: 'Top Rails',
+  railSight: 'Side Apron + Rail Sights',
+  pocketCup: 'Pocket Cups',
+  baseCornerBlock: 'Table Base',
+  leg: 'Legs',
+  baseFoot: 'Feet'
 });
-const SHOWOOD_CHROME_LINKED_PARTS = new Set(['railSight', 'verticalCornerRim']);
-const getShowoodTablePartOptions = (part) => {
+const SHOWOOD_CHROME_LINKED_PARTS = new Set(['railSight', 'baseFoot']);
+const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOptions = null) => {
+  if (part === 'cloth' || part === 'cushion') {
+    const sourceOptions = Array.isArray(clothOptions) && clothOptions.length
+      ? clothOptions
+      : CLOTH_COLOR_OPTIONS;
+    return sourceOptions.map((option) => ({
+      id: option.id,
+      label: option.label,
+      color: toHexColor(option.color),
+      material: { color: option.color, roughness: 1, metalness: 0, envMapIntensity: 0.16 }
+    }));
+  }
+  if (part === 'topWoodRail' || part === 'baseCornerBlock' || part === 'leg') {
+    const sourceOptions = Array.isArray(tableFinishOptions) && tableFinishOptions.length
+      ? tableFinishOptions
+      : TABLE_FINISH_OPTIONS;
+    return sourceOptions.map((option) => {
+      const finish = TABLE_FINISHES[option.id] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
+      const swatch = option.swatches?.[0] ?? finish?.colors?.rail ?? finish?.colors?.base ?? 0x5a2608;
+      return {
+        id: option.id,
+        label: `${option.label || finish?.label || option.id} ${part === 'topWoodRail' ? 'Rails' : part === 'baseCornerBlock' ? 'Base' : 'Legs'}`,
+        color: toHexColor(swatch),
+        thumbnail: option.thumbnail,
+        useTableFinishTexture: true
+      };
+    });
+  }
   return SHOWOOD_TABLE_PART_OPTIONS[part] || [];
 };
 const normalizeShowoodTableStyle = (value = {}) => {
@@ -4433,11 +4409,14 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'verticalCornerRim' ? 'verticalCornerRim' : part;
+  const optionPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
 };
+
+// Palettes derived from CC0 textile scans (ambientCG FabricWool series) and
+// popular tournament felts so every option mirrors a real pool cloth.
 const BASE_CLOTH_DETAIL = Object.freeze({
   bumpMultiplier: 1.18,
   sheen: 0.62,
@@ -4727,8 +4706,8 @@ const updateRuntimeTextureProfile = ({ fps } = {}) => {
     polyHavenPreferredResolutions: tier.preferredResolutions ?? Object.freeze([tier.key]),
     polyHavenFallbackResolution:
       tier.fallbackResolution ?? tier.preferredResolutions?.[tier.preferredResolutions.length - 1] ?? tier.key,
-    hdriPreferredResolutions: Object.freeze(['2k']),
-    hdriFallbackResolution: '2k',
+    hdriPreferredResolutions: Object.freeze(['4k']),
+    hdriFallbackResolution: '4k',
     enforceTableFinishTextureSize: textureSize,
     cueTextureSize: textureSize,
     pocketTextureSize: Math.max(512, Math.min(textureSize, 4096))
@@ -6764,7 +6743,7 @@ function applySnookerScaling({
     }
   }
   if (Array.isArray(balls)) {
-    const expectedRadius = BALL_D_REF * mmToUnits * BALL_SIZE_SCALE * 0.5 * SNOOKER_TABLE_BALL_RADIUS_SCALE;
+    const expectedRadius = BALL_D_REF * mmToUnits * BALL_SIZE_SCALE * 0.5;
     balls.forEach((ball) => {
       if (!ball) return;
       ball.colliderRadius = expectedRadius;
@@ -9309,8 +9288,6 @@ export function Table3D(
     CHROME_PLATE_STYLE_BY_ID[DEFAULT_CHROME_PLATE_STYLE_ID] ??
     CHROME_PLATE_STYLE_OPTIONS[0];
   const usesExternalTableModel = resolvedTableOptions?.tableModel?.kind === 'gltf';
-  const isSnookerGenericExternalTable =
-    usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'snooker-generic';
   const externalTableUsesOriginalLayout =
     usesExternalTableModel && resolvedTableOptions?.tableModel?.useOriginalLayoutSurfaces === true;
   const externalPlayfieldVisualLift =
@@ -10020,7 +9997,20 @@ export function Table3D(
   baulkLine.position.set(0, markingHeight, baulkLineZ);
   markingsGroup.add(baulkLine);
 
-  const dArc = null;
+  const dRadius = D_RADIUS;
+  const dThickness = Math.max(lineThickness * 0.75, BALL_R * 0.07);
+  const dGeom = new THREE.RingGeometry(
+    Math.max(0.001, dRadius - dThickness),
+    dRadius,
+    64,
+    1,
+    0,
+    Math.PI
+  );
+  const dArc = new THREE.Mesh(dGeom, markingMat.clone());
+  dArc.rotation.x = -Math.PI / 2;
+  dArc.position.set(0, markingHeight, baulkLineZ);
+  markingsGroup.add(dArc);
 
   const spotRadius = BALL_R * 0.26;
   const spotMeshes = [];
@@ -10032,7 +10022,13 @@ export function Table3D(
     markingsGroup.add(spot);
     spotMeshes.push(spot);
   };
+  addSpot(-D_RADIUS, baulkLineZ);
   addSpot(0, baulkLineZ);
+  addSpot(D_RADIUS, baulkLineZ);
+  addSpot(0, 0);
+  const topCushionZ = PLAY_H / 2;
+  addSpot(0, (topCushionZ + 0) / 2);
+  addSpot(0, topCushionZ - BLACK_FROM_TOP);
   markingsGroup.traverse((child) => {
     if (child.isMesh) {
       child.renderOrder = cloth.renderOrder + 1;
@@ -11209,7 +11205,7 @@ export function Table3D(
         MICRO_EPS,
         railH * CHROME_SIDE_APRON_COVER_HEIGHT_SCALE
       );
-      const apronLength = Math.max(MICRO_EPS, sideChromePlateRadius * 1.32); // confine apron texture strip to the jaw-side zone around middle pockets
+      const apronLength = Math.max(MICRO_EPS, sideChromePlateHeight * 0.96);
       const apron = new THREE.Mesh(
         new THREE.BoxGeometry(apronThickness, apronHeight, apronLength),
         chromePlateMat
@@ -11948,8 +11944,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.62;
-  const externalLayoutBrandPlateYOffset = 0; // keep TonPlaygram plates in the exact same vertical position used by the procedural table
+  const brandPlateOutwardShift = endRailW * 0.92;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -11965,7 +11960,7 @@ export function Table3D(
       createBrandSideMaterial()
     ];
     const plate = new THREE.Mesh(brandPlateGeom, materials);
-    plate.position.set(0, brandPlateY + externalLayoutBrandPlateYOffset, dirZ * (shortRailCenterZ + brandPlateOutwardShift));
+    plate.position.set(0, brandPlateY, dirZ * (shortRailCenterZ + brandPlateOutwardShift));
     plate.rotation.y = dirZ > 0 ? 0 : Math.PI;
     plate.castShadow = true;
     plate.receiveShadow = true;
@@ -12620,15 +12615,13 @@ export function Table3D(
   const leftX = -halfW;
   const rightX = halfW;
 
-  if (!isSnookerGenericExternalTable) {
-    addCushion(0, bottomZ, horizontalCushionLength, true, false);
-    addCushion(0, topZ, horizontalCushionLength, true, true);
+  addCushion(0, bottomZ, horizontalCushionLength, true, false);
+  addCushion(0, topZ, horizontalCushionLength, true, true);
 
-    addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
-    addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
-    addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
-    addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
-  }
+  addCushion(leftX, -verticalCushionCenter, verticalCushionLength, false, false);
+  addCushion(leftX, verticalCushionCenter, verticalCushionLength, false, false);
+  addCushion(rightX, -verticalCushionCenter, verticalCushionLength, false, true);
+  addCushion(rightX, verticalCushionCenter, verticalCushionLength, false, true);
 
   const shortRailCushionWordmarkTexture = createCushionWordmarkTexture({
     width: 2048,
@@ -12919,8 +12912,8 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
     : [];
   if (chromeSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
   if (blackSurfaceNames.some((name) => label.includes(`${name}`.toLowerCase()))) return 'railSight';
-  if (/rail[_\s-]*sight|railsight|rail[_\s-]*sight[_\s-]*lower|corner[_\s-]*rail[_\s-]*sight|diamond|sight|marker|inlay|apron[_\s-]*strip/.test(childName)) return 'railSight';
-  if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|side[_\s-]*apron|apron(?![_\s-]*strip)/.test(childName)) return 'sideWoodApron';
+  if (/rail[_\s-]*sight|railsight|diamond|sight|marker|inlay/.test(childName)) return 'railSight';
+  if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|apron/.test(childName)) return 'sideWoodApron';
   if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(childName)) return 'cushion';
   if (/pocket|liner|leather|net|basket|drop|holder|cup/.test(childName)) return 'pocketCup';
   if (/vertical.*(rim|plate|cap)|corner.*(rim|plate|cap)|rim|foot|feet|base[_\s-]*foot/.test(childName)) return 'verticalCornerRim';
@@ -12935,7 +12928,7 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   if (/leg|support/.test(label)) return 'leg';
   if (/foot|rim/.test(label)) return 'verticalCornerRim';
   if (/base|cabinet/.test(label)) return 'baseCornerBlock';
-  if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|side[_\s-]*apron|apron(?![_\s-]*strip)/.test(label)) return 'sideWoodApron';
+  if (/side[_\s-]*wood[_\s-]*apron|sidewoodapron|apron/.test(label)) return 'sideWoodApron';
   if (/frame|wood|rail|showood|bevel/.test(label)) return 'topWoodRail';
   return 'wood';
 }
@@ -13066,12 +13059,12 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'sideWoodApron',
+    sideWoodApron: 'baseCornerBlock',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',
     pocketCup: 'pocketCup',
-    verticalCornerRim: 'verticalCornerRim',
+    verticalCornerRim: 'baseFoot',
     baseFoot: 'baseFoot',
     baseCornerBlock: 'baseCornerBlock',
     leg: 'leg'
@@ -13142,28 +13135,21 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
   } else if (part === 'pocketCup') {
     copyMaterialLook(materials.pocketJaw ?? materials.pocketRim);
     applyShowoodTint();
-  } else if (part === 'topWoodRail' || part === 'leg') {
-    if (option.keepSourceTexture) {
-      mat.map = clonePoolRoyaleMaterialTexture(material.map, { isColor: true });
-      mat.normalMap = clonePoolRoyaleMaterialTexture(material.normalMap);
-      mat.roughnessMap = clonePoolRoyaleMaterialTexture(material.roughnessMap);
-      mat.aoMap = clonePoolRoyaleMaterialTexture(material.aoMap);
-      mat.metalnessMap = clonePoolRoyaleMaterialTexture(material.metalnessMap);
-      mat.bumpMap = clonePoolRoyaleMaterialTexture(material.bumpMap);
+  } else if (part === 'topWoodRail' || part === 'baseCornerBlock' || part === 'leg') {
+    const surface = part === 'topWoodRail'
+      ? finishInfo?.parts?.woodSurfaces?.rail
+      : finishInfo?.parts?.woodSurfaces?.frame || finishInfo?.parts?.woodSurfaces?.rail;
+    if (materials.rail?.color && mat.color) mat.color.copy(materials.rail.color);
+    applyWoodTextureToMaterial(mat, surface || { woodRepeatScale: finishInfo?.woodRepeatScale });
+    applyTableFinishDulling(mat);
+    applyTableWoodVisibilityTuning(mat);
+    if (finish?.surfaceStyle === 'matte') {
+      if (finish?.preserveFinishTintOnWood) applyMatteSurfacePropsOnly(mat);
+      else applyMonoMattePlasticSurface(mat);
     }
     applyShowoodTint();
   } else {
     applyShowoodTint();
-  }
-
-
-  if (!option?.keepSourceTexture) {
-    mat.map = null;
-    mat.normalMap = null;
-    mat.roughnessMap = null;
-    mat.aoMap = null;
-    mat.metalnessMap = null;
-    mat.bumpMap = null;
   }
 
   mat.transparent = false;
@@ -13232,8 +13218,6 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   const namedPocket = /pocket|hole|drop|net|liner|leather|cup/i.test(name);
   const namedHardware = /trim|bezel|ring|metal|chrome|brass|gold|plate|cap|rim|guard|insert|hardware|bolt|screw/i.test(name);
   const namedSight = /sight|diamond|marker|dot|inlay/i.test(name);
-  const namedRailSightLower = /rail[_\s-]*sight[_\s-]*lower|corner[_\s-]*rail[_\s-]*sight|apron[_\s-]*strip/.test(name);
-  const namedSideApron = /side[_\s-]*wood[_\s-]*apron|sidewoodapron|side[_\s-]*apron|apron(?![_\s-]*strip)/.test(name);
   const namedWood = /wood|walnut|rail|apron|leg|base|frame|cabinet|corner|showood|support/i.test(name);
   const metalish = (material?.metalness ?? 0) > 0.16 || (material?.clearcoat ?? 0) > 0.58 || gold;
   const high = s.relY > 0.54;
@@ -13262,7 +13246,7 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   const hardwareCandidate = namedHardware || metalish || ((black || gold || light) && !green && !brown && !namedWood);
   if (namedPocket || (black && anyPocketZone && (s.downFace || s.sideFace || s.relY < 0.79) && !hardwareCandidate)) return 'pocketCup';
   if (hardwareCandidate && (sideMiddlePocketZone || cornerPocketZone) && !green && !brown) return 'railSight';
-  if ((namedSight || namedRailSightLower) && high) return 'railSight';
+  if (namedSight && high) return 'railSight';
   if ((namedCloth || green) && centralCloth) return 'cloth';
   if ((namedCushion || green) && cushionBand) return 'cushion';
   if ((outsideBaseCornerRimZone || outerMostVerticalCorner) && !green && !s.upFace) return 'verticalCornerRim';
@@ -13272,13 +13256,12 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   if ((brown || namedWood || black) && baseCornerZone) return 'baseCornerBlock';
   if (midBody && s.sideFace && !(s.longN > 0.64 && s.shortN > 0.64)) return 'leg';
   if (veryTop && (s.upFace || topRailBand) && !green) return 'topWoodRail';
-  if (namedSideApron && s.sideFace) return 'sideWoodApron';
   if (high && s.sideFace && !green && !anyPocketZone) return 'sideWoodApron';
   return namedCushion ? 'cushion' : 'sideWoodApron';
 }
 
 function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInfo = null) {
-  if (!model || tableModel?.id !== 'snooker-generic' || !finishInfo) return;
+  if (!model || tableModel?.id !== 'showood-seven-foot' || !finishInfo) return;
   model.updateMatrixWorld(true);
   const tableBox = new THREE.Box3().setFromObject(model);
   if (tableBox.isEmpty()) return;
@@ -13299,7 +13282,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'verticalCornerRim' : part;
+      const linkedPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];
@@ -13336,7 +13319,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
 
 function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tableModel = null, child = null) {
   if (!material || !finishInfo) return material;
-  if (tableModel?.id === 'snooker-generic') {
+  if (tableModel?.id === 'showood-seven-foot') {
     return applyShowoodStyleToExternalMaterial(material, role, tableModel, finishInfo);
   }
   const canonicalRole = role === 'pocketCup' ? 'pocket' :
@@ -13512,10 +13495,7 @@ async function loadPoolRoyaleExternalTableTemplate(tableModel, renderer = null) 
   const promise = (async () => {
     const loader = createConfiguredGLTFLoader(renderer);
     let lastError = null;
-    const fallbackUrls = Array.isArray(tableModel.fallbackAssetUrls)
-      ? tableModel.fallbackAssetUrls
-      : [tableModel.fallbackAssetUrl].filter(Boolean);
-    const urls = [tableModel.assetUrl, ...fallbackUrls].filter(Boolean);
+    const urls = [tableModel.assetUrl, tableModel.fallbackAssetUrl].filter(Boolean);
     for (const url of urls) {
       try {
         // eslint-disable-next-line no-await-in-loop
@@ -13645,7 +13625,7 @@ function stretchPoolRoyaleExternalLowerBase(model, tableModel, dims) {
 
 
 function adjustPoolRoyaleExternalShowoodBaseProportions(model, tableModel) {
-  if (!model || tableModel?.id !== 'snooker-generic') return;
+  if (!model || tableModel?.id !== 'showood-seven-foot') return;
   const baseScale = Number(tableModel?.lowerBaseHeightScale);
   const legScale = Number(tableModel?.legLengthScale);
   const shouldScaleBase = Number.isFinite(baseScale) && baseScale > MICRO_EPS && Math.abs(baseScale - 1) > MICRO_EPS;
@@ -13799,12 +13779,10 @@ function mountPoolRoyaleExternalTableModel({
       if (disposed || !template) return;
       const model = clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo);
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
-      if (tableModel?.useLegacyShowoodRemap !== false) {
-        remapPoolRoyaleShowoodExternalParts(model, tableModel, finishInfo);
-      }
+      remapPoolRoyaleShowoodExternalParts(model, tableModel, finishInfo);
       externalRoot.clear();
       externalRoot.add(model);
-      if (tableModel.id === 'snooker-generic') {
+      if (tableModel.id === 'showood-seven-foot') {
         const showOriginalBase = table.userData.showoodUsesOriginalBase !== false;
         model.traverse((child) => {
           if (!child?.isMesh) return;
@@ -14278,10 +14256,10 @@ function mountPoolRoyaleExternalTableModel({
 
   const applyBaseVariant = (variant) => {
     const variantId = resolveBaseVariantId(variant);
-    const isShowoodExternalTable = isSnookerGenericExternalTable;
+    const isShowoodExternalTable =
+      usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'showood-seven-foot';
     const usesShowoodOriginalBase =
-      isShowoodExternalTable &&
-      (variantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID || variantId === DEFAULT_TABLE_BASE_ID);
+      isShowoodExternalTable && variantId === SHOWOOD_ORIGINAL_TABLE_BASE_ID;
 
     table.userData.showoodUsesOriginalBase = usesShowoodOriginalBase;
     setExternalOriginalBaseVisible(usesShowoodOriginalBase || !isShowoodExternalTable);
@@ -14327,7 +14305,7 @@ function mountPoolRoyaleExternalTableModel({
   };
 
   table.userData.applyExternalTableFallbackBase = () => {
-    if (isSnookerGenericExternalTable) {
+    if (usesExternalTableModel && resolvedTableOptions?.tableModel?.id === 'showood-seven-foot') {
       applyBaseVariant(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
     }
   };
@@ -14576,8 +14554,8 @@ function mountPoolRoyaleExternalTableModel({
         !visible &&
         (
           (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
-          (externalTableModelForMount?.id === 'snooker-generic' && !table.userData.showoodUsesOriginalBase && object.userData?.showoodGeneratedPocketSupport) ||
-          (externalTableModelForMount?.id === 'snooker-generic' && !table.userData.showoodUsesOriginalBase && object.userData?.__basePart) ||
+          (externalTableModelForMount?.id === 'showood-seven-foot' && !table.userData.showoodUsesOriginalBase && object.userData?.showoodGeneratedPocketSupport) ||
+          (externalTableModelForMount?.id === 'showood-seven-foot' && !table.userData.showoodUsesOriginalBase && object.userData?.__basePart) ||
           (object.userData?.isChromePlate && forceGeneratedChrome)
         )
       ) {
@@ -15639,18 +15617,15 @@ function PoolRoyaleGame({
       ),
     [poolInventory]
   );
-  const availableTableBases = useMemo(() => {
-    if (activeTableModel?.id === 'snooker-generic') {
-      return SNOOKER_ROYALE_BASE_VARIANTS.filter((variant) =>
-        isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
-      );
-    }
-    return POOL_ROYALE_BASE_VARIANTS.filter(
-      (variant) =>
-        variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID &&
-        isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
-    );
-  }, [activeTableModel?.id, poolInventory]);
+  const availableTableBases = useMemo(
+    () =>
+      POOL_ROYALE_BASE_VARIANTS.filter(
+        (variant) =>
+          variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID &&
+          isPoolOptionUnlocked('tableBase', variant.id, poolInventory)
+      ),
+    [poolInventory]
+  );
   const availableChromeOptions = useMemo(
     () =>
       CHROME_COLOR_OPTIONS.filter((option) =>
@@ -15679,14 +15654,13 @@ function PoolRoyaleGame({
       ),
     [poolInventory]
   );
-  const availableEnvironmentHdris = useMemo(() => {
-    const source = activeTableModel?.id === 'snooker-generic'
-      ? SNOOKER_ROYALE_HDRI_VARIANTS
-      : POOL_ROYALE_HDRI_VARIANTS;
-    return source.filter((variant) =>
-      isPoolOptionUnlocked('environmentHdri', variant.id, poolInventory)
-    );
-  }, [activeTableModel?.id, poolInventory]);
+  const availableEnvironmentHdris = useMemo(
+    () =>
+      POOL_ROYALE_HDRI_VARIANTS.filter((variant) =>
+        isPoolOptionUnlocked('environmentHdri', variant.id, poolInventory)
+      ),
+    [poolInventory]
+  );
   const availablePocketLiners = useMemo(
     () =>
       POCKET_LINER_OPTIONS.filter((option) =>
@@ -15702,38 +15676,20 @@ function PoolRoyaleGame({
     [isCueFinishUnlocked, poolInventory]
   );
   const tablePersonalizationSections = useMemo(
-    () => {
-      const hideBasePart = activeTableModel?.id === 'snooker-generic';
-      return SHOWOOD_CONTROL_PARTS
-        .filter((part) => !(hideBasePart && part === 'baseCornerBlock'))
-        .map((part) => ({
-          key: part,
-          label: SHOWOOD_TABLE_PART_LABELS[part] || part,
-          chromeLinked: SHOWOOD_CHROME_LINKED_PARTS.has(part),
-          options: getShowoodTablePartOptions(part, availableClothOptions, availableTableFinishes)
-        }))
-        .filter((section) => section.options.length > 0);
-    },
-    [activeTableModel?.id, availableClothOptions, availableTableFinishes]
+    () =>
+      SHOWOOD_TABLE_PARTS.map((part) => ({
+        key: part,
+        label: SHOWOOD_TABLE_PART_LABELS[part] || part,
+        chromeLinked: SHOWOOD_CHROME_LINKED_PARTS.has(part),
+        options: getShowoodTablePartOptions(part, availableClothOptions, availableTableFinishes)
+      })).filter((section) => section.options.length > 0),
+    [availableClothOptions, availableTableFinishes]
   );
   useEffect(() => {
     if (!tablePersonalizationSections.some((section) => section.key === activeTablePersonalizationPart)) {
       setActiveTablePersonalizationPart(tablePersonalizationSections[0]?.key ?? 'topWoodRail');
     }
   }, [activeTablePersonalizationPart, tablePersonalizationSections]);
-
-  useEffect(() => {
-    if (activeTableModel?.id !== 'snooker-generic') return;
-    setShowoodTableStyle((prev) => {
-      const normalized = normalizeShowoodTableStyle(prev);
-      if (normalized.baseCornerBlock === normalized.topWoodRail) return prev;
-      return {
-        ...normalized,
-        baseCornerBlock: normalized.topWoodRail
-      };
-    });
-  }, [activeTableModel?.id]);
-
   const activeTablePersonalizationSection = useMemo(
     () =>
       tablePersonalizationSections.find((section) => section.key === activeTablePersonalizationPart) ??
@@ -15763,20 +15719,13 @@ function PoolRoyaleGame({
       CLOTH_COLOR_OPTIONS[0],
     [availableClothOptions, clothColorId]
   );
-  const activeTableBase = useMemo(() => {
-    if (activeTableModel?.id === 'snooker-generic') {
-      return (
-        availableTableBases.find((variant) => variant.id === tableBaseId) ??
-        availableTableBases[0] ??
-        SNOOKER_ROYALE_BASE_VARIANTS[0]
-      );
-    }
-    return (
+  const activeTableBase = useMemo(
+    () =>
       availableTableBases.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
       POOL_ROYALE_BASE_VARIANTS.find((variant) => variant.id === SHOWOOD_ORIGINAL_TABLE_BASE_ID) ??
-      POOL_ROYALE_BASE_VARIANTS[0]
-    );
-  }, [activeTableModel?.id, availableTableBases, tableBaseId]);
+      POOL_ROYALE_BASE_VARIANTS[0],
+    [availableTableBases]
+  );
   const resolvedHdriResolution = useMemo(() => {
     return autoHdriResolutionFromGraphics;
   }, [autoHdriResolutionFromGraphics]);
@@ -15789,16 +15738,12 @@ function PoolRoyaleGame({
       const fromAvailable = availableEnvironmentHdris.find(
         (variant) => variant.id === environmentHdriId
       );
-      const usingSnookerMenu = activeTableModel?.id === 'snooker-generic';
-      const hdriVariantMap = usingSnookerMenu ? SNOOKER_ROYALE_HDRI_VARIANT_MAP : POOL_ROYALE_HDRI_VARIANT_MAP;
-      const hdriDefaultId = usingSnookerMenu ? (SNOOKER_ROYALE_HDRI_VARIANTS[0]?.id ?? POOL_ROYALE_DEFAULT_HDRI_ID) : POOL_ROYALE_DEFAULT_HDRI_ID;
-      const hdriVariants = usingSnookerMenu ? SNOOKER_ROYALE_HDRI_VARIANTS : POOL_ROYALE_HDRI_VARIANTS;
       const variant =
         fromAvailable ??
-        hdriVariantMap[environmentHdriId] ??
-        hdriVariantMap[hdriDefaultId] ??
+        POOL_ROYALE_HDRI_VARIANT_MAP[environmentHdriId] ??
+        POOL_ROYALE_HDRI_VARIANT_MAP[POOL_ROYALE_DEFAULT_HDRI_ID] ??
         availableEnvironmentHdris[0] ??
-        hdriVariants[0];
+        POOL_ROYALE_HDRI_VARIANTS[0];
       if (!variant) return null;
       const resolved = resolvedHdriResolution ?? DEFAULT_HDRI_RESOLUTIONS[0];
       if (!resolved) return variant;
@@ -15809,7 +15754,7 @@ function PoolRoyaleGame({
         fallbackResolution: activeHdriPolicy?.fallbackResolution ?? preferredResolutions[1] ?? resolved
       };
     },
-    [activeHdriPolicy, activeTableModel?.id, availableEnvironmentHdris, environmentHdriId, resolvedHdriResolution]
+    [activeHdriPolicy, availableEnvironmentHdris, environmentHdriId, resolvedHdriResolution]
   );
   const dualTablesEnabled = useMemo(() => false, []);
   const activePocketLinerOption = useMemo(
@@ -15836,11 +15781,7 @@ function PoolRoyaleGame({
     if (!isPoolOptionUnlocked('tableFinish', tableFinishId, poolInventory)) {
       setTableFinishId(DEFAULT_TABLE_FINISH_ID);
     }
-    if (activeTableModel?.id === 'snooker-generic') {
-      if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
-        setTableBaseId(SNOOKER_ROYALE_BASE_VARIANTS[0]?.id || DEFAULT_TABLE_BASE_ID);
-      }
-    } else if (tableBaseId !== SHOWOOD_ORIGINAL_TABLE_BASE_ID) {
+    if (tableBaseId !== SHOWOOD_ORIGINAL_TABLE_BASE_ID) {
       setTableBaseId(SHOWOOD_ORIGINAL_TABLE_BASE_ID);
     } else if (!isPoolOptionUnlocked('tableBase', tableBaseId, poolInventory)) {
       setTableBaseId(DEFAULT_TABLE_BASE_ID);
@@ -15861,7 +15802,7 @@ function PoolRoyaleGame({
       setPocketLinerId(DEFAULT_POCKET_LINER_OPTION_ID);
     }
     if (!isPoolOptionUnlocked('environmentHdri', environmentHdriId, poolInventory)) {
-      setEnvironmentHdriId(activeTableModel?.id === 'snooker-generic' ? (SNOOKER_ROYALE_HDRI_VARIANTS[0]?.id || POOL_ROYALE_DEFAULT_HDRI_ID) : POOL_ROYALE_DEFAULT_HDRI_ID);
+      setEnvironmentHdriId(POOL_ROYALE_DEFAULT_HDRI_ID);
     }
   }, [
     chromeColorId,
@@ -15872,8 +15813,7 @@ function PoolRoyaleGame({
     poolInventory,
     railMarkerColorId,
     tableBaseId,
-    tableFinishId,
-    activeTableModel?.id
+    tableFinishId
   ]);
   const isTraining = playType === 'training';
   const hasCareerTaskId = Boolean(careerStageId);
@@ -17164,7 +17104,7 @@ function PoolRoyaleGame({
     queue.forEach((variant) => {
       void prefetchHdriVariant(variant);
     });
-  }, [activeHdriPolicy, activeTableModel?.id, availableEnvironmentHdris, environmentHdriId, resolvedHdriResolution]);
+  }, [activeHdriPolicy, availableEnvironmentHdris, environmentHdriId, resolvedHdriResolution]);
   useEffect(() => {
     if (typeof updateEnvironmentRef.current === 'function') {
       updateEnvironmentRef.current(activeEnvironmentVariantRef.current);
@@ -17252,7 +17192,7 @@ function PoolRoyaleGame({
           material.needsUpdate = true;
         };
         applyShowoodPartMaterial(materials.rail, 'topWoodRail');
-        applyShowoodPartMaterial(materials.frame, 'topWoodRail');
+        applyShowoodPartMaterial(materials.frame, 'baseCornerBlock');
         applyShowoodPartMaterial(materials.leg, 'leg');
         const liners = createPocketLinerMaterials(linerSelection);
         materials.pocketJaw = liners.jawMaterial;
@@ -17321,12 +17261,12 @@ function PoolRoyaleGame({
   useEffect(() => {
     setShowoodTableStyle((current) => {
       const next = normalizeShowoodTableStyle(current);
-      const desiredSide = next.railSight;
-      const desiredFoot = next.verticalCornerRim;
-      if (next.sideWoodApron === desiredSide && next.baseFoot === desiredFoot) return current;
-      return { ...next, sideWoodApron: desiredSide, baseFoot: desiredFoot };
+      const linkedRailSight = chromeColorId === 'gold' ? 'gold' : 'chrome';
+      return next.railSight === linkedRailSight
+        ? next
+        : { ...next, railSight: linkedRailSight };
     });
-  }, [showoodTableStyle]);
+  }, [chromeColorId]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
       window.localStorage.setItem(FRAME_RATE_STORAGE_KEY, frameRateId);
@@ -27210,8 +27150,7 @@ const shotPowerRef = useRef(0);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      const humanRig =
-        null;
+      const humanRig = null; // Human character/rig disabled: cue stick now stays table-driven only.
       const cueShadow = ENABLE_CUE_CLOTH_SHADOW
         ? (() => {
             const shadowWidth = Math.max(BALL_R * CUE_SHADOW_WIDTH_RATIO, BALL_R * 0.4);
@@ -36168,6 +36107,38 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
+              <div>
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Chrome Plates
+                </h3>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {availableChromeOptions.map((option) => {
+                    const active = option.id === chromeColorId;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => setChromeColorId(option.id)}
+                        aria-pressed={active}
+                        className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                          active
+                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                        }`}
+                      >
+                        <span className="flex items-center justify-center gap-2">
+                          <span
+                            className="h-3.5 w-3.5 rounded-full border border-white/40"
+                            style={{ backgroundColor: toHexColor(option.color) }}
+                            aria-hidden="true"
+                          />
+                          {option.label}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
               <div className="rounded-3xl border border-emerald-300/20 bg-white/[0.04] p-3">
                 <div className="flex items-start justify-between gap-3">
                   <div>
@@ -36175,7 +36146,7 @@ const shotPowerRef = useRef(0);
                       Table Personalisation
                     </h3>
                     <p className="mt-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-white/55">
-                      Same mapping as the new Showood code. Keep cushions and use linked apron + sights and rounded feet.
+                      Select a table part, then choose the unlocked finish for that part.
                     </p>
                   </div>
                   <span className="rounded-full border border-emerald-200/30 px-2 py-1 text-[9px] font-black uppercase tracking-[0.18em] text-emerald-100/70">
@@ -36209,16 +36180,21 @@ const shotPowerRef = useRef(0);
                       </p>
                       {activeTablePersonalizationSection.chromeLinked ? (
                         <span className="text-[9px] uppercase tracking-[0.18em] text-emerald-100/55">
-                          linked mapping
+                          linked to chrome plates
                         </span>
                       ) : null}
                     </div>
                     <div className="grid grid-cols-2 gap-2">
                       {activeTablePersonalizationSection.options.map((option) => {
                         const part = activeTablePersonalizationSection.key;
+                        const chromeLinked = activeTablePersonalizationSection.chromeLinked;
                         const selected = part === 'cloth'
                           ? clothColorId
-                          : normalizeShowoodTableStyle(showoodTableStyle)[part];
+                          : part === 'topWoodRail' || part === 'leg'
+                            ? tableFinishId
+                            : chromeLinked
+                              ? (chromeColorId === 'gold' ? 'gold' : 'chrome')
+                              : normalizeShowoodTableStyle(showoodTableStyle)[part];
                         const active = option.id === selected;
                         return (
                           <button
@@ -36227,6 +36203,13 @@ const shotPowerRef = useRef(0);
                             onClick={() => {
                               if (part === 'cloth') {
                                 setClothColorId(option.id);
+                              } else if (part === 'topWoodRail' || part === 'leg') {
+                                setTableFinishId(option.id);
+                                setShowoodTableStyle((current) =>
+                                  normalizeShowoodTableStyle({ ...current, [part]: option.id })
+                                );
+                              } else if (chromeLinked) {
+                                setChromeColorId(option.id === 'gold' ? 'gold' : 'chrome');
                               } else {
                                 setShowoodTableStyle((current) =>
                                   normalizeShowoodTableStyle({ ...current, [part]: option.id })
@@ -36241,9 +36224,18 @@ const shotPowerRef = useRef(0);
                             }`}
                           >
                             {option.thumbnail ? (
-                              <img src={option.thumbnail} alt={option.label} className="h-12 w-full rounded-xl border border-white/20 object-cover" loading="lazy" />
+                              <img
+                                src={option.thumbnail}
+                                alt={option.label}
+                                className="h-12 w-full rounded-xl border border-white/20 object-cover"
+                                loading="lazy"
+                              />
                             ) : (
-                              <span className="h-12 w-full rounded-xl border border-white/30" style={{ backgroundColor: option.color }} aria-hidden="true" />
+                              <span
+                                className="h-12 w-full rounded-xl border border-white/30"
+                                style={{ backgroundColor: option.color }}
+                                aria-hidden="true"
+                              />
                             )}
                             <span className="line-clamp-2">{option.label}</span>
                           </button>
@@ -36287,6 +36279,94 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
+              {availableClothOptions.length > 0 ? (
+                <div>
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                    Cloth Library
+                  </h3>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {availableClothOptions.map((option) => {
+                      const active = option.id === clothColorId;
+                      const thumb = option.thumbnail;
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => setClothColorId(option.id)}
+                          aria-pressed={active}
+                          className={`flex min-w-[8.5rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            active
+                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                          }`}
+                        >
+                          <span className="flex items-center gap-2">
+                            <span
+                              className="h-3.5 w-3.5 rounded-full border border-white/40"
+                              style={{ backgroundColor: toHexColor(option.color) }}
+                              aria-hidden="true"
+                            />
+                            <span className="truncate">{option.label}</span>
+                          </span>
+                          {thumb ? (
+                            <img
+                              src={thumb}
+                              alt={option.label}
+                              className="h-6 w-10 rounded-lg border border-white/20 object-cover"
+                              loading="lazy"
+                            />
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              {availablePocketLiners.length > 0 ? (
+                <div>
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                    Pocket Jaws
+                  </h3>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {availablePocketLiners.map((option) => {
+                      const active = option.id === pocketLinerId;
+                      const swatchColor =
+                        option.jawColor ?? option.rimColor ?? option.sheenColor ?? option.color;
+                      const thumb = option.thumbnail;
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => setPocketLinerId(option.id)}
+                          aria-pressed={active}
+                          className={`flex min-w-[9rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                            active
+                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                          }`}
+                        >
+                          <span className="flex items-center gap-2">
+                            <span
+                              className="h-3.5 w-3.5 rounded-full border border-white/40"
+                              style={{ backgroundColor: toHexColor(swatchColor) }}
+                              aria-hidden="true"
+                            />
+                            <span className="truncate">{option.label}</span>
+                          </span>
+                          {thumb ? (
+                            <img
+                              src={thumb}
+                              alt={option.label}
+                              className="h-6 w-10 rounded-lg border border-white/20 object-cover"
+                              loading="lazy"
+                            />
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Graphics

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,7 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
@@ -77,27 +76,7 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const [tableModelId, setTableModelId] = useState(() => {
-    try {
-      return window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY) || '';
-    } catch {
-      return '';
-    }
-  });
-  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(tableModelId), [tableModelId]);
-  const lobbyTableModelOptions = useMemo(() => {
-    const base = POOL_ROYALE_TABLE_MODEL_OPTIONS.filter(
-      (model) => model.id !== 'procedural-legacy'
-    );
-    const priority = ['snooker-generic', 'showood-seven-foot'];
-    const ordered = [
-      ...priority
-        .map((id) => base.find((model) => model.id === id))
-        .filter(Boolean),
-      ...base.filter((model) => !priority.includes(model.id))
-    ];
-    return ordered;
-  }, []);
+  const selectedTableModel = useMemo(() => resolvePoolRoyaleTableModel(), []);
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -135,37 +114,8 @@ export default function PoolRoyaleLobby() {
     playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
   const selectedTableModelReady = true;
-  const showTableModelSelector = true;
 
 
-
-
-
-  useEffect(() => {
-    try {
-      if (selectedTableModel?.id) {
-
-        window.localStorage?.setItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY, selectedTableModel.id);
-      }
-    } catch {}
-  }, [selectedTableModel?.id]);
-
-
-  useEffect(() => {
-    const urls = [selectedTableModel?.assetUrl, ...(selectedTableModel?.fallbackAssetUrls || [])]
-      .filter((url) => typeof url === 'string' && url.length);
-    if (!urls.length || typeof window === 'undefined' || typeof window.fetch !== 'function') return;
-    const controller = new AbortController();
-    urls.slice(0, 1).forEach((url) => {
-      window.fetch(url, {
-        method: 'GET',
-        cache: 'force-cache',
-        mode: 'cors',
-        signal: controller.signal
-      }).catch(() => {});
-    });
-    return () => controller.abort();
-  }, [selectedTableModel?.id]);
   useEffect(() => {
     try {
       const saved = loadAvatar();
@@ -282,7 +232,8 @@ export default function PoolRoyaleLobby() {
     setMatchingError('');
     try {
       window.localStorage?.setItem(
-              selectedTableModel.id
+        POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
+        selectedTableModel.id
       );
       if (selectedTableModel.finishId) {
         window.localStorage?.setItem(
@@ -907,43 +858,22 @@ export default function PoolRoyaleLobby() {
           </div>
         )}
 
-
-        {!hasActiveTournament && showTableModelSelector && (
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Pool Table (2 options)</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Models</span>
-            </div>
-            <p className="text-xs text-white/60">Choose either 9ft Snooker Generic GLB or 7ft Showood GLB.</p>
-            <div className="grid grid-cols-1 gap-3">
-              {lobbyTableModelOptions.map((model) => {
-                const active = selectedTableModel?.id === model.id;
-                return (
-                  <button
-                    key={model.id}
-                    type="button"
-                    onClick={() => setTableModelId(model.id)}
-                    className={`lobby-option-card ${active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
-                  >
-                    <div className="text-left">
-                      <p className="lobby-option-label">{model.icon || '🎱'} {model.label}</p>
-                      <p className="lobby-option-subtitle">{model.description}</p>
-                    </div>
-                  </button>
-                );
-              })}
+        {!hasActiveTournament && (
+          <div className="rounded-2xl border border-emerald-300/20 bg-white/[0.04] p-4 text-xs text-white/60">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h3 className="font-semibold text-white">Pool Table</h3>
+                <p className="mt-1">
+                  Showood 7 ft GLB is now the fixed Pool Royale table.
+                </p>
+              </div>
+              <span className="rounded-full border border-emerald-300/35 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100">
+                Default
+              </span>
             </div>
           </div>
         )}
 
-        {!hasActiveTournament && !showTableModelSelector && (
-          <div className="space-y-2">
-            <h3 className="font-semibold text-white">Pool Table</h3>
-            <p className="text-xs text-white/60">
-              Showood 7 ft GLB is now the fixed Pool Royale table.
-            </p>
-          </div>
-        )}
 
         {playType === 'training' && (
           <div className="space-y-3 rounded-2xl border border-emerald-300/30 bg-gradient-to-br from-emerald-500/10 via-black/35 to-cyan-500/10 p-4">

--- a/webapp/src/pages/Games/SnookerChampion.jsx
+++ b/webapp/src/pages/Games/SnookerChampion.jsx
@@ -1,0 +1,7 @@
+import SnookerChampionProvided from './SnookerChampionProvided.jsx';
+
+export default function SnookerChampion() {
+  // Dedicated Snooker Champion implementation that mirrors Snooker Royal table,
+  // mapping, rules, and broadcast package while preserving Champion-specific flow.
+  return <SnookerChampionProvided gameTitle="Snooker Champion" />;
+}

--- a/webapp/src/pages/Games/SnookerChampionLobby.jsx
+++ b/webapp/src/pages/Games/SnookerChampionLobby.jsx
@@ -1,0 +1,693 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramFirstName, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { resolveTableSize } from '../../config/snookerClubTables.js';
+import { socket } from '../../utils/socket.js';
+import { getOnlineUsers } from '../../utils/api.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { runSnookerRoyalOnlineFlow } from './snookerRoyalOnlineFlow.js';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import { getLobbyIcon } from '../../config/gameAssets.js';
+import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import {
+  applySnookerTableModelParam,
+  TABLE_MODEL_OPENSOURCE
+} from './snookerTableModel.js';
+
+const PLAYER_FLAG_STORAGE_KEY = 'snookerChampionPlayerFlag';
+const AI_FLAG_STORAGE_KEY = 'snookerChampionAiFlag';
+const SNOOKER_ROYAL_MENU_THUMBNAIL_SLUG = 'snookerroyale';
+
+export default function SnookerChampionLobby() {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  useTelegramBackButton();
+
+  const searchParams = new URLSearchParams(search);
+  const initialPlayType = (() => {
+    const requestedType = searchParams.get('type');
+    return requestedType === 'tournament' ? 'tournament' : 'regular';
+  })();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('ai');
+  const [avatar, setAvatar] = useState('');
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
+  const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
+  const [aiFlagIndex, setAiFlagIndex] = useState(null);
+  const [playType, setPlayType] = useState(initialPlayType);
+  const [players, setPlayers] = useState(8);
+  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const tableModel = TABLE_MODEL_OPENSOURCE;
+  const [onlinePlayers, setOnlinePlayers] = useState([]);
+  const [matching, setMatching] = useState(false);
+  const [spinningPlayer, setSpinningPlayer] = useState('');
+  const [matchPlayers, setMatchPlayers] = useState([]);
+  const matchPlayersRef = useRef([]);
+  const [readyList, setReadyList] = useState([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [matchingError, setMatchingError] = useState('');
+  const [matchStatus, setMatchStatus] = useState('');
+  const spinIntervalRef = useRef(null);
+  const accountIdRef = useRef(null);
+  const pendingTableRef = useRef('');
+  const cleanupRef = useRef(() => {});
+  const stakeDebitRef = useRef(null);
+  const matchTimeoutRef = useRef(null);
+  const seatTimeoutRef = useRef(null);
+  const forcedVariant = 'snooker';
+
+  const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
+  const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    import('./SnookerChampion.jsx').catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(PLAYER_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setPlayerFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(AI_FLAG_STORAGE_KEY);
+      const idx = FLAG_EMOJIS.indexOf(stored);
+      if (idx >= 0) setAiFlagIndex(idx);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    matchPlayersRef.current = matchPlayers;
+  }, [matchPlayers]);
+
+
+  const navigateToSnookerChampion = ({ tableId: startedId, roster = [], accountId, currentTurn }) => {
+    const selfId = accountId || accountIdRef.current;
+    const selfEntry = roster.find((p) => String(p.id) === String(selfId));
+    const opponentEntry = roster.find((p) => String(p.id) !== String(selfId));
+    const starterId = currentTurn || roster?.[0]?.id || null;
+    const selfIndex = roster.findIndex((p) => String(p.id) === String(selfId));
+    const seat = selfIndex === 1 ? 'B' : 'A';
+    const starterSeat = starterId && String(starterId) === String(selfId) ? seat : seat === 'A' ? 'B' : 'A';
+    const friendlyName =
+      selfEntry?.name ||
+      getTelegramFirstName() ||
+      getTelegramId() ||
+      (selfId ? `TPC ${selfId}` : 'Player');
+    const friendlyAvatar = selfEntry?.avatar || avatar;
+    const opponentName =
+      opponentEntry?.name ||
+      opponentEntry?.username ||
+      opponentEntry?.telegramName ||
+      (opponentEntry?.id ? `TPC ${opponentEntry.id}` : '');
+    const opponentAvatar = opponentEntry?.avatar || '';
+    cleanupRef.current?.({ account: accountId, skipRefReset: true });
+    const params = new URLSearchParams();
+    params.set('variant', forcedVariant);
+    params.set('type', playType);
+    params.set('mode', 'online');
+    params.set('tableId', startedId);
+    if (stake.token) params.set('token', stake.token);
+    if (stake.amount) params.set('amount', stake.amount);
+    if (friendlyAvatar) params.set('avatar', friendlyAvatar);
+    const tgId = getTelegramId();
+    if (tgId) params.set('tgId', tgId);
+    const resolvedAccountId = accountIdRef.current;
+    if (resolvedAccountId) params.set('accountId', resolvedAccountId);
+    if (tableSize) params.set('tableSize', tableSize);
+    applySnookerTableModelParam(params, tableModel);
+    params.set('seat', seat);
+    params.set('starter', starterSeat);
+    const name = (friendlyName || '').trim();
+    if (name) params.set('name', name);
+    if (opponentName) params.set('opponent', opponentName);
+    if (opponentAvatar) params.set('opponentAvatar', opponentAvatar);
+    navigate(`/games/snookerchampion?${params.toString()}`);
+  };
+
+  const startGame = async () => {
+    const isOnlineMatch = mode === 'online' && playType === 'regular';
+    if (matching) return;
+    await cleanupRef.current?.();
+    setMatchStatus('');
+    setMatchingError('');
+
+    if (isOnlineMatch) {
+      await runSnookerRoyalOnlineFlow({
+        stake,
+        variant: forcedVariant,
+        ballSet: null,
+        playType,
+        mode,
+        tableSize,
+        avatar,
+        gameType: 'snookerchampion',
+        transactionGame: 'snookerchampion-online',
+        deps: { ensureAccountId, getAccountBalance, addTransaction, getTelegramId, getTelegramFirstName, socket },
+        state: {
+          setMatchingError,
+          setMatchStatus,
+          setMatching,
+          setIsSearching,
+          setMatchPlayers,
+          setReadyList,
+          setSpinningPlayer
+        },
+        refs: {
+          accountIdRef,
+          matchPlayersRef,
+          pendingTableRef,
+          cleanupRef,
+          spinIntervalRef,
+          stakeDebitRef,
+          matchTimeoutRef,
+          seatTimeoutRef
+        },
+        onGameStart: navigateToSnookerChampion
+      });
+      return;
+    }
+
+    let tgId;
+    let accountId;
+    try {
+      tgId = getTelegramId();
+      accountId = await ensureAccountId();
+    } catch (error) {
+      const message = 'Unable to verify your TPC account. Please retry.';
+      setMatchingError(message);
+      try {
+        window?.Telegram?.WebApp?.showAlert?.(message);
+      } catch {}
+      console.error('[SnookerChampionLobby] ensureAccountId failed (offline)', error);
+      return;
+    }
+
+    accountIdRef.current = accountId;
+
+    const params = new URLSearchParams();
+    params.set('variant', forcedVariant);
+    params.set('tableSize', tableSize);
+    applySnookerTableModelParam(params, tableModel);
+    params.set('type', playType);
+    params.set('mode', mode);
+    if (isOnlineMatch) {
+      if (stake.token) params.set('token', stake.token);
+      if (stake.amount) params.set('amount', stake.amount);
+    }
+    if (playType === 'tournament') params.set('players', players);
+    const initData = window.Telegram?.WebApp?.initData;
+    if (avatar) params.set('avatar', avatar);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    const name = getTelegramFirstName();
+    if (name) params.set('name', name);
+    if (selectedFlag) params.set('flag', selectedFlag);
+    if (selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+    const devAcc = import.meta.env.VITE_DEV_ACCOUNT_ID;
+    const devAcc1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
+    const devAcc2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
+    if (devAcc) params.set('dev', devAcc);
+    if (devAcc1) params.set('dev1', devAcc1);
+    if (devAcc2) params.set('dev2', devAcc2);
+    if (initData) params.set('init', encodeURIComponent(initData));
+
+    if (playType === 'tournament') {
+      window.location.href = `/snooker-champion-bracket.html?${params.toString()}`;
+      return;
+    }
+
+    navigate(`/games/snookerchampion?${params.toString()}`);
+  };
+
+  useEffect(() => {
+    let active = true;
+    const loadOnline = () => {
+      getOnlineUsers()
+        .then((data) => {
+          if (!active) return;
+          const list = Array.isArray(data?.users)
+            ? data.users
+            : Array.isArray(data)
+            ? data
+            : [];
+          setOnlinePlayers(list);
+        })
+        .catch(() => {});
+    };
+    loadOnline();
+    const id = setInterval(loadOnline, 15000);
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  const matchingCandidates = useMemo(() => {
+    const base = (onlinePlayers || []).map((p) => ({
+      id: p.accountId || p.playerId || p.id,
+      name: p.username || p.name || p.telegramName || p.telegramId || p.accountId
+    }));
+    const lobbyEntries = (matchPlayers || []).map((p) => ({ id: p.id, name: p.name || p.id }));
+    const merged = [...base, ...lobbyEntries].filter((p) => p.id);
+    const seen = new Set();
+    return merged.filter((p) => {
+      const key = String(p.id);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [matchPlayers, onlinePlayers]);
+
+  useEffect(() => {
+    if (spinIntervalRef.current) {
+      clearInterval(spinIntervalRef.current);
+      spinIntervalRef.current = null;
+    }
+    if (!matching || matchingCandidates.length === 0) return undefined;
+    setSpinningPlayer(matchingCandidates[0].name || 'Searching…');
+    spinIntervalRef.current = setInterval(() => {
+      const pick = matchingCandidates[Math.floor(Math.random() * matchingCandidates.length)];
+      setSpinningPlayer(pick?.name || 'Searching…');
+    }, 500);
+    return () => {
+      if (spinIntervalRef.current) clearInterval(spinIntervalRef.current);
+    };
+  }, [matching, matchingCandidates]);
+
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  useEffect(() => {
+    if (playType === 'tournament') {
+      setMode('ai');
+    }
+  }, [playType]);
+
+  useEffect(() => {
+    if (mode !== 'online' || playType !== 'regular') {
+      cleanupRef.current?.();
+      setMatching(false);
+      setMatchStatus('');
+      setMatchPlayers([]);
+      setReadyList([]);
+      setIsSearching(false);
+    }
+  }, [mode, playType]);
+
+  useEffect(() => {
+    if (!matching) return;
+    const readyIds = new Set((readyList || []).map((id) => String(id)));
+    const selfId = accountIdRef.current;
+    if (selfId && readyIds.has(String(selfId)) && readyIds.size >= 2) {
+      setMatchStatus('All players ready. Launching match…');
+    }
+  }, [matching, readyList]);
+
+  const readyIds = useMemo(
+    () => new Set((readyList || []).map((id) => String(id))),
+    [readyList]
+  );
+
+  const winnerParam = searchParams.get('winner');
+
+  return (
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-6 p-4 pb-8">
+        {winnerParam && (
+          <div className="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-center text-sm font-semibold text-emerald-200">
+            {winnerParam === '1' ? 'You won!' : 'CPU won!'}
+          </div>
+        )}
+        <GameLobbyHeader
+          slug="snookerchampion"
+          title="Snooker Champion Lobby"
+          badge={`${onlinePlayers.length} online`}
+        />
+
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Player Profile</p>
+          <div className="mt-3 flex items-center gap-3">
+            <div className="h-12 w-12 overflow-hidden rounded-full border border-white/15 bg-white/5">
+              {avatar ? (
+                <img src={avatar} alt="Your avatar" className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-lg">🙂</div>
+              )}
+            </div>
+            <div className="text-sm text-white/80">
+              <p className="font-semibold">{getTelegramFirstName() || 'Player'} ready</p>
+              <p className="text-xs text-white/50">Flag: {selectedFlag || 'Auto'}</p>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2">
+            <button
+              type="button"
+              onClick={() => setShowFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">Flag</div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedFlag || '🌐'}</span>
+                <span>{selectedFlag ? 'Custom flag' : 'Auto-detect & save'}</span>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAiFlagPicker(true)}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+            >
+              <div className="text-[11px] uppercase tracking-wide text-white/50">AI Flag</div>
+              <div className="flex items-center gap-2 text-base font-semibold">
+                <span className="text-lg">{selectedAiFlag || '🌐'}</span>
+                <span>{selectedAiFlag ? 'Custom AI flag' : 'Auto-pick opponent'}</span>
+              </div>
+            </button>
+          </div>
+          <p className="mt-3 text-xs text-white/60">Your lobby choices persist into the match intro.</p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Match Type</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              {
+                id: 'regular',
+                label: 'Regular',
+                desc: 'Quick single match',
+                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
+                icon: '🔴'
+              },
+              {
+                id: 'tournament',
+                label: 'Tournament',
+                desc: 'Bracket challenge',
+                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
+                icon: '🏆'
+              }
+            ].map(({ id, label, desc, accent, icon }) => {
+              const active = playType === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setPlayType(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon(SNOOKER_ROYAL_MENU_THUMBNAIL_SLUG, `type-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60 text-center">
+            Tournament mode locks online matchmaking and uses the bracket flow.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Table</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Royal GLB</span>
+          </div>
+          <div className="lobby-option-card lobby-option-card-active cursor-default">
+            <div className="lobby-option-thumb bg-gradient-to-br from-emerald-400/30 via-emerald-500/10 to-transparent">
+              <div className="lobby-option-thumb-inner">
+                <OptionIcon
+                  src={getLobbyIcon(SNOOKER_ROYAL_MENU_THUMBNAIL_SLUG, 'table-championship')}
+                  alt="Snooker Royal GLB table"
+                  fallback="🎱"
+                  className="lobby-option-icon"
+                />
+              </div>
+            </div>
+            <div className="text-center">
+              <p className="lobby-option-label">Snooker Royal GLB Table</p>
+              <p className="lobby-option-subtitle">Identical Royal table, balls, cushion map, cloth finish, broadcast cameras, power, and spin.</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Queue</span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              {
+                id: 'ai',
+                label: 'Vs AI',
+                desc: 'Instant practice',
+                accent: 'from-emerald-400/30 via-emerald-500/10 to-transparent',
+                icon: '🤖',
+                disabled: false
+              },
+              {
+                id: 'online',
+                label: '1v1 Online',
+                desc: 'Stake & match',
+                accent: 'from-indigo-400/30 via-sky-500/10 to-transparent',
+                icon: '⚔️',
+                disabled: playType === 'tournament'
+              }
+            ].map(({ id, label, desc, accent, icon, disabled }) => {
+              const active = mode === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => !disabled && setMode(id)}
+                  disabled={disabled}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  } ${disabled ? 'lobby-option-card-disabled' : ''}`}
+                >
+                  <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('poolroyale', `mode-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">
+                      {disabled ? 'Tournament bracket only' : desc}
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60 text-center">
+            AI matches stay offline. Online mode uses your TPC stake and pairs you with another player.
+          </p>
+        </div>
+
+        {playType === 'tournament' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-400/40 to-indigo-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  🧩
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Tournament Seats</h3>
+                <p className="text-xs text-white/60">Choose the bracket size before launching.</p>
+              </div>
+            </div>
+            <div className="mt-3 grid grid-cols-3 gap-3">
+              {[8, 16, 24].map((p) => {
+                const active = players === p;
+                return (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => setPlayers(p)}
+                    className={`lobby-option-card ${
+                      active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                    }`}
+                  >
+                    <div className="lobby-option-thumb bg-gradient-to-br from-purple-400/30 via-indigo-500/10 to-transparent">
+                      <div className="lobby-option-thumb-inner">
+                        <span className="text-2xl font-semibold">{p}</span>
+                      </div>
+                    </div>
+                    <div className="text-center">
+                      <p className="lobby-option-label">{p} Players</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-white/60">
+              Winner takes the pot minus a 10% developer fee.
+            </p>
+          </div>
+        )}
+
+        {mode === 'online' && playType === 'regular' && (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center gap-3">
+              <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-yellow-400/40 to-orange-500/40 p-[1px]">
+                <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
+                  💰
+                </div>
+              </div>
+              <div>
+                <h3 className="font-semibold text-white">Select Stake</h3>
+                <p className="text-xs text-white/60">Stake your TPC to lock a table.</p>
+              </div>
+            </div>
+            <div className="mt-3">
+              <RoomSelector selected={stake} onSelect={setStake} tokens={['TPC']} />
+            </div>
+            <p className="text-center text-white/60 text-xs">
+              Online games use your TPC stake as escrow, while AI matches stay free.
+            </p>
+          </div>
+        )}
+
+        {mode === 'online' && playType === 'regular' && (
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold text-white">Online Arena</h3>
+                <p className="text-sm text-white/60">
+                  We match players by TPC account number, stake ({stake.amount} {stake.token}),
+                  and Snooker Champion game type.
+                </p>
+              </div>
+              <div className="text-xs text-white/60">{onlinePlayers.length} online</div>
+            </div>
+            {matchingError && <div className="text-sm text-red-400">{matchingError}</div>}
+            {matching && (
+              <div className="space-y-2">
+                {matchStatus && <div className="text-xs text-white/60">{matchStatus}</div>}
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-white">Spinning wheel</span>
+                  <span className="text-xs text-white/60">Searching for stake match…</span>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white/80">
+                  <div className="flex items-center justify-between">
+                    <span>🎯 {spinningPlayer || 'Searching…'}</span>
+                    <span className="text-xs text-white/60">
+                      Stake {stake.amount} {stake.token}
+                    </span>
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  {matchPlayers.map((p) => (
+                    <div
+                      key={p.id}
+                      className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white/80"
+                    >
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="text-sm font-semibold">{p.name || `TPC ${p.id}`}</p>
+                          <p className="text-xs text-white/60">Account #{p.id}</p>
+                        </div>
+                        <span
+                          className={`text-xs font-semibold ${
+                            readyIds.has(String(p.id)) ? 'text-emerald-400' : 'text-white/50'
+                          }`}
+                        >
+                          {readyIds.has(String(p.id)) ? 'Ready' : 'Waiting'}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                  {matchPlayers.length === 0 && (
+                    <div className="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white/60">
+                      Waiting for another player in this snooker arena…
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+            {!matching && (
+              <div className="text-sm text-white/60">
+                Start to join a 1v1 snooker arena. We keep you at the same table until the match begins.
+              </div>
+            )}
+          </div>
+        )}
+
+        <button
+          onClick={startGame}
+          className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={mode === 'online' && (isSearching || matching)}
+        >
+          {mode === 'online' ? (matching ? 'Waiting for opponent…' : 'Start Online') : 'Start'}
+        </button>
+
+        <FlagPickerModal
+          open={showFlagPicker}
+          count={1}
+          selected={playerFlagIndex != null ? [playerFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setPlayerFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(PLAYER_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowFlagPicker(false)}
+        />
+
+        <FlagPickerModal
+          open={showAiFlagPicker}
+          count={1}
+          selected={aiFlagIndex != null ? [aiFlagIndex] : []}
+          onSave={(indices) => {
+            const idx = indices?.[0] ?? null;
+            setAiFlagIndex(idx);
+            try {
+              if (idx != null) window.localStorage?.setItem(AI_FLAG_STORAGE_KEY, FLAG_EMOJIS[idx]);
+            } catch {}
+          }}
+          onClose={() => setShowAiFlagPicker(false)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SnookerChampionProvided.jsx
+++ b/webapp/src/pages/Games/SnookerChampionProvided.jsx
@@ -133,7 +133,7 @@ const OFFICIAL_SNOOKER_BLACK_FROM_TOP_CUSHION_M = 0.324;
 const OFFICIAL_SNOOKER_POCKET_CORNER_MOUTH_M = 0.086;
 const OFFICIAL_SNOOKER_POCKET_MIDDLE_MOUTH_M = 0.095;
 const SNOOKER_TABLE_VISUAL_LENGTH_TRIM = 1.08; // larger GLB cabinet framing so the imported snooker table wraps the official mapped cushion rectangle
-const SNOOKER_PLAYFIELD_SCALE = (2.62 * WORLD_SCALE) / OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M;
+const SNOOKER_PLAYFIELD_SCALE = (2.55 * WORLD_SCALE) / OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M;
 const SNOOKER_OFFICIAL_PLAYFIELD_W = OFFICIAL_SNOOKER_PLAYFIELD_WIDTH_M * SNOOKER_PLAYFIELD_SCALE;
 const SNOOKER_OFFICIAL_PLAYFIELD_L = OFFICIAL_SNOOKER_PLAYFIELD_LENGTH_M * SNOOKER_PLAYFIELD_SCALE;
 const SNOOKER_OFFICIAL_BALL_R = (OFFICIAL_SNOOKER_BALL_DIAMETER_M * SNOOKER_PLAYFIELD_SCALE) / 2;
@@ -151,7 +151,7 @@ const SNOOKER_SHOT_POWER_RANGE = 0.75;
 const SNOOKER_SHOT_FULL_SPEED = 12 * WORLD_SCALE * SNOOKER_SHOT_POWER_BOOST;
 const SNOOKER_BALL_MASS = 0.17;
 const SNOOKER_SHOT_SPIN_SCALE = 0.25;
-const SNOOKER_SPIN_GLOBAL_SCALE = 0.68; // match Pool Royale's reduced cue-spin input so centre-ball shots do not over-rotate
+const SNOOKER_SPIN_GLOBAL_SCALE = 0.82; // match Pool Royale's reduced cue-spin input so centre-ball shots do not over-rotate
 const SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER = 1.2;
 const SNOOKER_SIDE_SPIN_MULTIPLIER = 1.5 * SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER;
 const SNOOKER_BACKSPIN_MULTIPLIER = 2.6 * SNOOKER_SPIN_GLOBAL_BOOST_MULTIPLIER;
@@ -237,7 +237,7 @@ const CFG = {
   tableTopY: 0.84 * WORLD_SCALE,
   tableW: SNOOKER_OFFICIAL_PLAYFIELD_W,
   tableL: SNOOKER_OFFICIAL_PLAYFIELD_L,
-  tableVisualMultiplier: 1.12 * SNOOKER_TABLE_VISUAL_LENGTH_TRIM,
+  tableVisualMultiplier: 1.08 * SNOOKER_TABLE_VISUAL_LENGTH_TRIM,
   railH: 0.08 * WORLD_SCALE,
   ballR: SNOOKER_OFFICIAL_BALL_R,
   friction: 1.18,
@@ -1211,8 +1211,8 @@ function applyCueShot(cueBall, power, yaw, out, spinInput = { x: 0, y: 0 }) {
   if (launchSpeed > 1e-6 && cueBall.omega) {
     const rollingAxis = new THREE.Vector3(cueBall.vel.z, 0, -cueBall.vel.x).normalize();
     cueBall.omega.addScaledVector(rollingAxis, launchSpeed / CFG.ballR);
-    cueBall.omega.x += -(spin.y ?? 0) * p * 11;
-    cueBall.omega.z += -(spin.x ?? 0) * p * 11;
+    cueBall.omega.x += -(spin.y ?? 0) * p * 18;
+    cueBall.omega.z += -(spin.x ?? 0) * p * 18;
   }
   cueBall.launchDir = cueBall.vel.lengthSq() > 1e-8 ? cueBall.vel.clone().normalize() : null;
   cueBall.impacted = false;
@@ -1850,7 +1850,7 @@ function updateCamera(camera, mode, broadcastMode, cueBallWorld, aimForward, act
   camera.updateProjectionMatrix();
 }
 
-export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provided' } = {}) {
+export default function SnookerChampionProvided({ gameTitle = 'Snooker Champion' } = {}) {
   const hostRef = useRef(null);
   const canvasRef = useRef(null);
   const sliderMountRef = useRef(null);
@@ -2310,10 +2310,7 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
       let gap = CFG.idleGap;
       const spinOffset = mapSpinForPhysics(spinRef.current);
       if (state === 'dragging') gap += pull + practiceStroke;
-      if (state === 'striking') {
-        const strikeMotionNorm = didHit ? 0.88 : strikeNorm;
-        gap = lerp(CFG.idleGap + pull, CFG.contactGap, easeOutCubic(strikeMotionNorm));
-      }
+      if (state === 'striking') gap = lerp(CFG.idleGap + pull, CFG.contactGap, easeOutCubic(strikeNorm));
       const cueTipShoot = cueBallWorld.clone()
         .addScaledVector(aimForward, -(CFG.ballR + gap))
         .addScaledVector(aimSide, (spinOffset.x ?? 0) * CFG.ballR * 0.52)
@@ -2528,6 +2525,44 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
                 <span className={railOverheadSide === 'front' ? 'text-emerald-100' : 'text-white/65'}>▼</span>
               </span>
             </button>
+            <button
+              type="button"
+              disabled={!hasReplay}
+              onClick={() => {
+                if (!hasReplay) return;
+                replayStartedAtRef.current = performance.now();
+                setReplayActive(true);
+              }}
+              className={`flex h-12 w-12 items-center justify-center rounded-full border text-[15px] font-semibold shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
+                replayActive
+                  ? 'border-amber-200 bg-amber-300/25 text-amber-100'
+                  : hasReplay
+                    ? 'border-white/30 bg-black/70 text-white hover:bg-black/60'
+                    : 'border-white/10 bg-black/45 text-white/35'
+              }`}
+              aria-label="Replay last snooker shot"
+            >
+              <span aria-hidden="true">↻</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setReplaySkipAll((prev) => {
+                  const next = !prev;
+                  replaySkipAllRef.current = next;
+                  if (next) setReplayActive(false);
+                  return next;
+                });
+              }}
+              className={`flex h-12 w-12 items-center justify-center rounded-full border text-[10px] font-black uppercase tracking-[0.08em] shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
+                replaySkipAll
+                  ? 'border-rose-300 bg-rose-500/25 text-rose-100'
+                  : 'border-white/30 bg-black/70 text-white hover:bg-black/60'
+              }`}
+              aria-label="Skip all replays"
+            >
+              Skip
+            </button>
           </div>
         </div>
 
@@ -2738,18 +2773,6 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
             />
           </div>
         </div>
-        {replayActive ? (
-          <div className="pointer-events-none absolute inset-y-0 right-0 z-[70] flex items-center pr-2">
-            <button
-              type="button"
-              onClick={() => setReplayActive(false)}
-              className="pointer-events-auto rounded-l-xl border border-white/30 bg-black/70 px-3 py-2 text-[11px] font-black uppercase tracking-[0.12em] text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition hover:bg-black/60"
-              aria-label="Skip current replay"
-            >
-              Skip
-            </button>
-          </div>
-        ) : null}
         {lastQuickMessage ? (
           <div className="pointer-events-none absolute left-1/2 top-24 z-40 -translate-x-1/2 rounded-full border border-white/15 bg-black/70 px-4 py-2 text-sm font-semibold text-white shadow-xl backdrop-blur">
             {lastQuickMessage}

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -102,6 +102,7 @@ import {
   smoothDamp,
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
+import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -1089,7 +1090,7 @@ const TABLE_OUTER_EXPANSION = TABLE.WALL * 0.22;
 const FRAME_RAIL_OUTWARD_SCALE = 1.38; // expand wooden frame rails outward by 38% on all sides
 const RAIL_HEIGHT = TABLE.THICK * 1.9; // match Pool Royale rail/cushion top height
 const POCKET_JAW_CORNER_OUTER_LIMIT_SCALE = 1.024; // push the corner jaws outward a touch so the fascia meets the chrome edge cleanly
-const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.08; // expand jaw collision arcs further to block escape paths around pocket lips
+const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.02; // slightly expand jaw collision arcs so balls cannot slip past the GLB pocket lips
 const POCKET_JAW_SIDE_OUTER_LIMIT_SCALE =
   POCKET_JAW_CORNER_OUTER_LIMIT_SCALE; // keep the middle jaw clamp as wide as the corners so the fascia mass matches
 const POCKET_JAW_CORNER_INNER_SCALE = 1.44; // pull the inner lip farther outward so the jaw profile runs longer and thins slightly while keeping the chrome-facing radius untouched
@@ -1635,7 +1636,7 @@ const CUE_PULL_ALIGNMENT_BOOST = 0.32; // amplify visible pull when the camera l
 const CUE_PULL_CUE_CAMERA_DAMPING = 0.08; // trim the pull depth slightly while keeping more of the stroke visible in cue view
 const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit angles so the stroke feels weightier
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
-const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.42; // ensure every stroke pulls slightly farther back for readability at all angles
+const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 1.24; // ensure every stroke pulls slightly farther back for readability at all angles
 const CUE_STROKE_MIN_MS = 95;
 const CUE_STROKE_MAX_MS = 420;
 const CUE_STROKE_SPEED_MIN = BALL_R * 18;
@@ -1645,8 +1646,8 @@ const CUE_FOLLOW_MAX_MS = 420;
 const CUE_FOLLOW_SPEED_MIN = BALL_R * 12;
 const CUE_FOLLOW_SPEED_MAX = BALL_R * 24;
 const ENABLE_CUE_STROKE_ANIMATION = true;
-const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.34; // ensure the forward push is visible even on short strokes
-const CUE_FOLLOW_THROUGH_MAX = BALL_R * 2.3; // cap the forward travel so the cue never overshoots the ball too far
+const CUE_FOLLOW_THROUGH_MIN = BALL_R * 0.18; // ensure the forward push is visible even on short strokes
+const CUE_FOLLOW_THROUGH_MAX = BALL_R * 1.8; // cap the forward travel so the cue never overshoots the ball too far
 const PLAYER_CUE_FORWARD_MIN_MS = 450;
 const PLAYER_CUE_FORWARD_MAX_MS = 1025;
 const PLAYER_CUE_FORWARD_EASE = 0.65;
@@ -1668,16 +1669,16 @@ const SNOOKER_HUMAN_WORLD_SCALE = BALL_R / 0.0525;
 const SNOOKER_HUMAN_CFG = Object.freeze({
   // Match the larger Snooker Champion character proportions exactly so the
   // Royal avatar reads as a full-sized player beside the GLB snooker table.
-  targetHeight: 1.35 * 1.78 * SNOOKER_HUMAN_WORLD_SCALE,
+  targetHeight: 1.2 * 1.78 * SNOOKER_HUMAN_WORLD_SCALE,
   floorY: FLOOR_Y - TABLE_Y,
-  idleDistance: 0.9 * SNOOKER_HUMAN_WORLD_SCALE,
+  idleDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
   bridgeBackFromBall: 0.27 * SNOOKER_HUMAN_WORLD_SCALE,
-  bridgeSide: -0.115 * SNOOKER_HUMAN_WORLD_SCALE,
-  stanceSide: 0.31 * SNOOKER_HUMAN_WORLD_SCALE,
-  rightFootBack: 0.34 * SNOOKER_HUMAN_WORLD_SCALE,
-  leftFootForward: 0.34 * SNOOKER_HUMAN_WORLD_SCALE,
-  chinCueOffsetY: 0.11 * SNOOKER_HUMAN_WORLD_SCALE,
-  chestCueOffsetY: 0.2 * SNOOKER_HUMAN_WORLD_SCALE,
+  bridgeSide: -0.025 * SNOOKER_HUMAN_WORLD_SCALE,
+  stanceSide: 0.25 * SNOOKER_HUMAN_WORLD_SCALE,
+  rightFootBack: 0.38 * SNOOKER_HUMAN_WORLD_SCALE,
+  leftFootForward: 0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+  chinCueOffsetY: 0.12 * SNOOKER_HUMAN_WORLD_SCALE,
+  chestCueOffsetY: 0.22 * SNOOKER_HUMAN_WORLD_SCALE,
   rootLambda: 7.5,
   poseLambda: 10,
   yawFix: 0
@@ -2113,38 +2114,6 @@ function getSnookerCueEndpoints(cueStick, cueLen) {
   return { tip, butt };
 }
 
-function chooseSnookerHumanPerimeterTarget(cueBall, aimDir) {
-  const desired = cueBall.clone().addScaledVector(aimDir, -SNOOKER_HUMAN_CFG.idleDistance);
-  const xEdge = TABLE_W / 2 + TABLE.THICK * 0.9;
-  const zEdge = TABLE_H / 2 + TABLE.THICK * 0.9;
-  const candidates = [
-    new THREE.Vector3(-xEdge, SNOOKER_HUMAN_CFG.floorY, clamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(xEdge, SNOOKER_HUMAN_CFG.floorY, clamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), SNOOKER_HUMAN_CFG.floorY, -zEdge),
-    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), SNOOKER_HUMAN_CFG.floorY, zEdge)
-  ];
-  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
-}
-
-function constrainSnookerHumanPerimeterStep(current, target) {
-  const xEdge = TABLE_W / 2 + TABLE.THICK * 0.9;
-  const zEdge = TABLE_H / 2 + TABLE.THICK * 0.9;
-  const project = (point) => {
-    const dx = Math.abs(Math.abs(point.x) - xEdge);
-    const dz = Math.abs(Math.abs(point.z) - zEdge);
-    if (dx < dz) return new THREE.Vector3(Math.sign(point.x || target.x || 1) * xEdge, SNOOKER_HUMAN_CFG.floorY, clamp(point.z, -zEdge, zEdge));
-    return new THREE.Vector3(clamp(point.x, -xEdge, xEdge), SNOOKER_HUMAN_CFG.floorY, Math.sign(point.z || target.z || 1) * zEdge);
-  };
-  const cur = current.lengthSq() > 1e-6 ? project(current) : project(target);
-  const goal = project(target);
-  const curOnX = Math.abs(Math.abs(cur.x) - xEdge) < Math.abs(Math.abs(cur.z) - zEdge);
-  const goalOnX = Math.abs(Math.abs(goal.x) - xEdge) < Math.abs(Math.abs(goal.z) - zEdge);
-  if (curOnX === goalOnX && (curOnX ? Math.sign(cur.x) === Math.sign(goal.x) : Math.sign(cur.z) === Math.sign(goal.z))) return goal;
-  return curOnX
-    ? new THREE.Vector3(cur.x, SNOOKER_HUMAN_CFG.floorY, Math.sign(goal.z || cur.z || 1) * zEdge)
-    : new THREE.Vector3(Math.sign(goal.x || cur.x || 1) * xEdge, SNOOKER_HUMAN_CFG.floorY, cur.z);
-}
-
 function updateSnookerRoyalHumanPlayer(human, dt, options) {
   if (!human?.root || human.disabled) return;
   const {
@@ -2174,11 +2143,10 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
   // Orientation is driven from the actual shot line: the root stands behind
   // the cue ball on -dir, then faces +dir back through cue ball/object ball.
   // Keeping local +Z on the shot line prevents mirrored cue/hand placement.
-  const rawRootTarget = cueBall.clone()
+  const rootTarget = cueBall.clone()
     .addScaledVector(dir, -SNOOKER_HUMAN_CFG.idleDistance - pullPose * BALL_R * 1.8)
-    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceSide * 0.3);
-  const perimeterTarget = chooseSnookerHumanPerimeterTarget(cueBall, dir);
-  const rootTarget = constrainSnookerHumanPerimeterStep(human.root.position, perimeterTarget.clone().lerp(rawRootTarget, 0.35));
+    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceSide * 0.32);
+  rootTarget.y = SNOOKER_HUMAN_CFG.floorY;
   const playfieldTarget = new THREE.Vector3(0, cueBall.y, 0);
   const cueFacing = cueBall.clone().sub(rootTarget).setY(0);
   const tableFacing = playfieldTarget.clone().sub(rootTarget).setY(0);
@@ -2205,7 +2173,7 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
     .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
     .setY(CUE_Y + BALL_R * 0.08);
-  const gripBlend = tableCueVisible ? (0.58 + pullPose * 0.06) : 0.62;
+  const gripBlend = tableCueVisible ? (0.37 + pullPose * 0.08) : 0.62;
   const grip = cueEndpoints.butt
     .clone()
     .lerp(cueEndpoints.tip, gripBlend)
@@ -2219,13 +2187,11 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
   const head = toRootLocal(headWorld);
   const neck = chest.clone().lerp(head, 0.68);
   const leftShoulder = chest.clone().add(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, -0.025 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightShoulder = chest.clone().add(new THREE.Vector3(0.2 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, -0.04 * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightShoulder = chest.clone().add(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.055 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
   const leftHand = toRootLocal(bridge);
-  const strokePush = (shooting || cueAnimating) ? Math.sin(Math.min(1, pullPose) * Math.PI) : 0;
-  const forearmStroke = -0.3 * SNOOKER_HUMAN_WORLD_SCALE * pullPose + 0.24 * SNOOKER_HUMAN_WORLD_SCALE * strokePush;
-  const rightHand = toRootLocal(grip.clone().addScaledVector(dir, forearmStroke));
+  const rightHand = toRootLocal(grip);
   const leftElbow = leftShoulder.clone().lerp(leftHand, 0.58).add(new THREE.Vector3(-0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.03 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightElbow = rightShoulder.clone().add(new THREE.Vector3(-0.46 * SNOOKER_HUMAN_WORLD_SCALE, 0.18 * SNOOKER_HUMAN_WORLD_SCALE, -0.78 * SNOOKER_HUMAN_WORLD_SCALE));
+  const rightElbow = rightShoulder.clone().lerp(rightHand, 0.42).add(new THREE.Vector3(0.22 * SNOOKER_HUMAN_WORLD_SCALE, 0.20 * SNOOKER_HUMAN_WORLD_SCALE, -0.20 * SNOOKER_HUMAN_WORLD_SCALE));
   const leftHip = new THREE.Vector3(-0.07 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE);
   const rightHip = new THREE.Vector3(0.08 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.12 * SNOOKER_HUMAN_WORLD_SCALE);
   const walkLift = Math.sin(human.walkPhase) * 0.028 * SNOOKER_HUMAN_WORLD_SCALE * human.walkAmount;
@@ -5674,21 +5640,21 @@ function applySnookerScaling({
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
 const STANDING_VIEW_PHI = 1.04; // lower the standing camera a touch so the table sits slightly lower on screen
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
-const STANDING_VIEW_MARGIN = 0.00005; // pull the standing frame even closer so the table fills more of the portrait screen
+const STANDING_VIEW_MARGIN = 0.001; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
 const CAMERA_ABS_MIN_PHI = 0.08;
 const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.1; // match Pool Royale standing-view lower sweep
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.54);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0102; // move standing/cue camera physically closer for tighter near-rail framing
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0132; // match Pool Royale standing/cue camera distance
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.24; // tighten standing view distance so the playfield appears larger in portrait
+const STANDING_VIEW_DISTANCE_SCALE = 0.28; // pull the standing camera slightly closer to the table for tighter portrait framing
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -5751,7 +5717,7 @@ const DEFAULT_RAIL_LIMIT_X = PLAY_W / 2 - BALL_R - CUSHION_FACE_INSET;
 const DEFAULT_RAIL_LIMIT_Y = PLAY_H / 2 - BALL_R - CUSHION_FACE_INSET;
 let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
-const RAIL_LIMIT_PADDING = BALL_R * 0.2; // increase in-bounds clamp so balls stay inside the mapped playfield edge
+const RAIL_LIMIT_PADDING = BALL_R * 0.12; // mirror Pool Royale rail padding so balls cannot slip outside table limits
 const RAIL_CONTACT_RADIUS = BALL_R;
 const CUSHION_CUT_CONTACT_RADIUS = RAIL_CONTACT_RADIUS * 1.12;
 const CUSHION_CUT_NEAR_POCKET_BUFFER = BALL_R * 0.9;
@@ -5797,7 +5763,7 @@ const RAIL_OVERHEAD_DISTANCE_BIAS = 1; // mirror Pool Royale rail-overhead dista
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
-const CUE_VIEW_RADIUS_RATIO = 0.0152; // bring cue camera closer so cueing view sits tighter to the table
+const CUE_VIEW_RADIUS_RATIO = 0.0175; // pull the cue camera closer to the table for tighter address framing
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.064; // allow a closer minimum cue-camera radius before rail safety clamps apply
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
@@ -5864,9 +5830,9 @@ const REPLAY_BANNER_VARIANTS = {
 };
 const REPLAY_TRAIL_HEIGHT = BALL_CENTER_Y + BALL_R * 0.3;
 const REPLAY_TRAIL_COLOR = 0xffffff;
-const REPLAY_CUE_STROKE_SLOWDOWN = 1.95;
-const REPLAY_CUE_STICK_HOLD_MS = 840;
-const REPLAY_CUE_RETURN_WINDOW_MS = 420;
+const REPLAY_CUE_STROKE_SLOWDOWN = 1.6;
+const REPLAY_CUE_STICK_HOLD_MS = 620;
+const REPLAY_CUE_RETURN_WINDOW_MS = 260;
 const RAIL_NEAR_BUFFER = BALL_R * 3.5;
 const SHORT_SHOT_CAMERA_DISTANCE = BALL_R * 12; // keep camera in standing view for close shots
 const SHORT_RAIL_POCKET_TRIGGER =
@@ -5895,8 +5861,8 @@ const AI_WARMUP_PULL_RATIO = 0.62;
 const PLAYER_CUE_PULL_VISIBILITY_BOOST = 1.32;
 const PLAYER_WARMUP_PULL_RATIO = 0.72;
 const PLAYER_STROKE_TIME_SCALE = 1.28;
-const PLAYER_FORWARD_SLOWDOWN = 1.05;
-const PLAYER_STROKE_PULLBACK_FACTOR = 0.95;
+const PLAYER_FORWARD_SLOWDOWN = 1.2;
+const PLAYER_STROKE_PULLBACK_FACTOR = 0.68;
 const PLAYER_PULLBACK_MIN_SCALE = 1.1;
 const MIN_PULLBACK_GAP = BALL_R * 0.5;
 const CAMERA_SWITCH_MIN_HOLD_MS = 220;
@@ -14506,8 +14472,6 @@ const showRuleToast = useCallback((message) => {
   }, 3000);
 }, []);
 const powerRef = useRef(hud.power);
-const shotPowerRef = useRef(hud.power);
-const draggingSliderRef = useRef(false);
   const applyPower = useCallback((nextPower) => {
     const clampedPower = THREE.MathUtils.clamp(nextPower ?? 0, 0, 1);
     powerRef.current = clampedPower;
@@ -14518,9 +14482,6 @@ const draggingSliderRef = useRef(false);
   }, [inHandPlacementMode]);
   useEffect(() => {
     powerRef.current = hud.power;
-    if (!draggingSliderRef.current) {
-      shotPowerRef.current = hud.power;
-    }
   }, [hud.power]);
   const hudRef = useRef(hud);
   useEffect(() => {
@@ -23260,7 +23221,7 @@ const draggingSliderRef = useRef(false);
             0,
             Math.max(maxPull + CUE_PULL_VISUAL_FUDGE, CUE_PULL_MIN_VISUAL)
           );
-          const visualPull = applyVisualPullCompensation(startPull * 1.12, dir);
+          const visualPull = applyVisualPullCompensation(startPull, dir);
           cuePullCurrentRef.current = startPull;
           cuePullTargetRef.current = startPull;
           const cuePerp = new THREE.Vector3(-dir.z, 0, dir.x);
@@ -23306,21 +23267,21 @@ const draggingSliderRef = useRef(false);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
           const pullbackDuration = 115;
-          const strikeDuration = 130;
+          const strikeDuration = 110;
           const holdDuration = 45;
           const returnDuration = 95;
           // Keep the no-character cue stroke matching the old human-rig shot:
           // drive the tip forward from pullback into cue-ball contact instead
           // of stopping at the original address gap.
           const impactPush = THREE.MathUtils.clamp(
-            CUE_TIP_CLEARANCE * 1.9,
-            BALL_R * 0.2,
-            BALL_R * 0.5
+            CUE_TIP_CLEARANCE,
+            BALL_R * 0.08,
+            BALL_R * 0.3
           );
           const impactPos = buildCuePosition(-impactPush);
           // Stop the visible cue at contact so it reads as a push without
           // chasing the moving cue ball after physics takes over.
-          const followExtra = BALL_R * 0.24;
+          const followExtra = 0;
           TMP_VEC3_FOLLOW_DIR.copy(impactPos).sub(pullPos);
           if (TMP_VEC3_FOLLOW_DIR.lengthSq() > 1e-8) {
             TMP_VEC3_FOLLOW_DIR.normalize();
@@ -23409,23 +23370,27 @@ const draggingSliderRef = useRef(false);
               return;
             }
             const elapsed = Math.max(0, now - startTime);
-            if (elapsed <= pullbackDuration) {
-              const t = THREE.MathUtils.clamp(elapsed / pullbackDuration, 0, 1);
-              cueStick.position.lerpVectors(idlePos, pullPos, easeInOutQuad(t));
-            } else if (elapsed <= pullbackDuration + strikeDuration) {
-              const strikeElapsed = elapsed - pullbackDuration;
-              const t = THREE.MathUtils.clamp(strikeElapsed / strikeDuration, 0, 1);
-              const strikeEase = easeOutCubic(t);
+            const sample = sampleCueStrokeTimeline({
+              elapsed,
+              pullbackDuration,
+              strikeDuration,
+              holdDuration,
+              animationStyle: 'linear',
+              strikeWindowRatio: 0.12,
+              hitArmRatio: 0.88
+            });
+            if (sample.phase === 'pullback') {
+              cueStick.position.lerpVectors(idlePos, pullPos, easeInOutQuad(sample.t));
+            } else if (sample.phase === 'release' || sample.phase === 'strike') {
+              const strikeEase = easeOutCubic(sample.t);
               const dynamicFollow =
-                followExtra * (0.55 + 0.45 * Math.sin(t * Math.PI));
+                followExtra * (0.55 + 0.45 * Math.sin(sample.t * Math.PI));
               cueStick.position.lerpVectors(pullPos, impactPos, strikeEase);
               if (dynamicFollow > 1e-6) {
                 cueStick.position.addScaledVector(TMP_VEC3_FOLLOW_DIR, dynamicFollow);
               }
-            } else if (elapsed <= pullbackDuration + strikeDuration + holdDuration) {
-              const holdElapsed = elapsed - pullbackDuration - strikeDuration;
-              const t = THREE.MathUtils.clamp(holdElapsed / holdDuration, 0, 1);
-              cueStick.position.lerpVectors(impactPos, settlePos, easeInOutQuad(t));
+            } else if (sample.phase === 'hold') {
+              cueStick.position.lerpVectors(impactPos, settlePos, easeInOutQuad(sample.t));
             } else if (now <= returnTime && returnDuration > 0) {
               const t = THREE.MathUtils.clamp((now - holdEndTime) / returnDuration, 0, 1);
               cueStick.position.lerpVectors(settlePos, idlePos, easeInOutQuad(t));
@@ -27615,32 +27580,15 @@ const draggingSliderRef = useRef(false);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
+      onChange: (v) => applyPower(v / 100),
       onStart: () => {
-        draggingSliderRef.current = true;
         captureCueStickAnchor();
       },
-      onChange: (v) => {
-        const normalized = THREE.MathUtils.clamp((v ?? 0) / 100, 0, 1);
-        applyPower(normalized);
-        if (draggingSliderRef.current) {
-          shotPowerRef.current = normalized;
-        }
-      },
       onCommit: () => {
-        const committedPower = THREE.MathUtils.clamp(
-          shotPowerRef.current ?? powerRef.current ?? 0,
-          0,
-          1
-        );
-        shotPowerRef.current = committedPower;
-        powerRef.current = committedPower;
-        draggingSliderRef.current = false;
         fireRef.current?.();
         requestAnimationFrame(() => {
-          slider.animateToMin?.({ duration: 180 });
           slider.set(slider.min, { animate: true });
           applyPower(0);
-          shotPowerRef.current = 0;
         });
       }
     });
@@ -27657,8 +27605,6 @@ const draggingSliderRef = useRef(false);
     if (slider) {
       slider.set(slider.min, { animate: true });
     }
-    draggingSliderRef.current = false;
-    shotPowerRef.current = 0;
     applyPower(0);
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;


### PR DESCRIPTION
### Motivation
- Restore Pool Royal gameplay, lobby, table-model config and related Snooker integration to the oldest available baseline in the branch (commit `1820c3b`, May 20, 2026) because an exact one‑month snapshot was not present locally.
- Ensure Pool Royale table model, UI, and tests remain consistent with the restored baseline to avoid runtime mismatches between config, preview and gameplay.

### Description
- Reverted/updated Pool Royale pages and configuration by restoring `webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/pages/Games/PoolRoyaleLobby.jsx`, `webapp/src/config/poolRoyaleTableModels.js`, and the table-model test `test/poolRoyaleTableModels.test.js` to the May 20 baseline and adjusted defaults to use the Showood 7 ft GLB table.
- Reintroduced Snooker Champion integration files that existed in that snapshot by adding `webapp/src/pages/Games/SnookerChampion.jsx`, `webapp/src/pages/Games/SnookerChampionLobby.jsx`, and `webapp/src/pages/Games/SnookerChampionProvided.jsx` and aligned Snooker/SnookerRoyal provider code with the restored Pool Royale flow.
- Applied numerous gameplay/material/visual tuning changes in `PoolRoyale.jsx` and table model mappings to match the Showood GLB behavior (table finish roles, chrome/trim mappings, geometry/scale constants, physics/shot tuning and runtime texture/profile defaults).
- Kept UI changes consistent: removed selectable table model in the lobby (fixed Showood table), updated personalization controls and chrome/cloth UI elements, and preserved related helper scripts referenced by the tests.

### Testing
- Restoration commands executed successfully: `git checkout 1820c3b -- <files>`, `git status --short`, and `git commit -m "Restore Pool Royal-related game code to May 20 baseline"` (commit created: `0dd3ccf`).
- Verified the staged diff and commit summary showing the restored files were applied (9 files staged: listed in the PR record) with the commit finishing without errors.
- No automated test suite was executed as part of this restore; the repo includes `test/poolRoyaleTableModels.test.js` which was reverted to match the restored config but unit tests were not run in this operation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1285bdb6788329ae948f312f59c725)