### PR TITLE
Tune Pool Royale visuals: cushions, ball shadows/size, and linked feet/menu

### DIFF
--- a/webapp/src/pages/Games/PoolRoyalGameTable.tsx
+++ b/webapp/src/pages/Games/PoolRoyalGameTable.tsx
@@ -14,7 +14,7 @@ const TABLE_MODEL_URL =
 
 const DRACO_DECODER_PATH = "https://www.gstatic.com/draco/versioned/decoders/1.5.7/";
 const BASIS_TRANSCODER_PATH = "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/";
-const CUSHION_SHADOW_GREY = "#666a72";
+const CUSHION_SHADOW_GREY = "#2f353f";
 
 type TablePart =
   | "cloth"
@@ -163,8 +163,8 @@ const PART_META: Record<TablePart, PartMeta> = {
   },
   cushion: {
     label: "Cushions",
-    description: "Raised inner rail bands separated from the flat field cloth. Cushion underside shadows stay grey.",
-    keepSourceTexture: false,
+    description: "Raised inner rail bands using cloth texture continuity. Cushion underside shadows use a darker tone.",
+    keepSourceTexture: true,
   },
   topWoodRail: {
     label: "Top rails",
@@ -838,7 +838,7 @@ function createRoundedFootCaps(table: THREE.Object3D, palette: Palette, buckets:
     const cap = new THREE.Mesh(geometry.clone(), material);
     cap.name = `rounded_metal_foot_${index + 1}`;
     cap.position.set(anchor.x, anchor.y + 0.028, anchor.z);
-    cap.scale.set(1.1, 1, 1.1);
+    cap.scale.set(1.34, 1, 1.34);
     cap.castShadow = true;
     cap.receiveShadow = true;
     group.add(cap);
@@ -993,7 +993,7 @@ export default function PoolTableCustomOptionsPreview() {
         tableObject = displayGroup;
         scene.add(displayGroup);
         setCounts(resultCounts);
-        setStatus("ready: cushion shadows fixed grey; four side-panel vertical corner rims default gold");
+        setStatus("ready: cushions use cloth texture continuity, darker cushion shadow tone, and wider linked metal feet");
       },
       (event) => {
         if (!event.total) return;
@@ -1094,7 +1094,7 @@ export default function PoolTableCustomOptionsPreview() {
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, marginBottom: 10 }}>
             <div>
               <div style={{ fontSize: 12.5, fontWeight: 950 }}>Custom material options</div>
-              <div style={{ marginTop: 2, fontSize: 10.5, color: "#94a3b8" }}>Only cushion shadows and cushion colors were adjusted. Vertical rims on the four side-panel corners default to gold.</div>
+              <div style={{ marginTop: 2, fontSize: 10.5, color: "#94a3b8" }}>Cushions keep cloth texture continuity, cushion shadows are darker, and feet stay linked with Corner rims + rounded feet.</div>
             </div>
             <button onClick={() => setPalette(DEFAULT_PALETTE)} style={{ border: "1px solid rgba(255,255,255,0.25)", background: "rgba(255,255,255,0.08)", color: "white", borderRadius: 999, padding: "7px 10px", fontSize: 11, fontWeight: 900, cursor: "pointer", flex: "0 0 auto" }}>Reset</button>
           </div>

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1405,17 +1405,17 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
 const MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION;
-const BALL_SIZE_SCALE = 0.96; // trim ball size slightly while keeping every helper tied to BALL_R/BALL_DIAMETER
+const BALL_SIZE_SCALE = 0.99; // enlarge balls slightly for a fuller on-cloth visual while preserving all BALL_R/BALL_DIAMETER-linked helpers
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
 const RACK_VERTICAL_SCREEN_LIFT = BALL_R * 0.86; // nudge the rack farther upward on screen so object balls sit visibly higher
-const ENABLE_BALL_FLOOR_SHADOWS = false;
+const ENABLE_BALL_FLOOR_SHADOWS = true;
 const ENABLE_CUE_CLOTH_SHADOW = true;
 const ENABLE_TABLE_FLOOR_SHADOW = false;
-const BALL_SHADOW_RADIUS_MULTIPLIER = 1;
-const BALL_SHADOW_OPACITY = 0.25;
-const BALL_SHADOW_LIFT = BALL_R * 0.02;
+const BALL_SHADOW_RADIUS_MULTIPLIER = 0.96;
+const BALL_SHADOW_OPACITY = 0.31;
+const BALL_SHADOW_LIFT = BALL_R * 0.012;
 const CUE_SHADOW_OPACITY = 0.18;
 const CUE_SHADOW_WIDTH_RATIO = 0.62;
 const TABLE_FLOOR_SHADOW_OPACITY = 0.2;
@@ -2654,8 +2654,8 @@ let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.58; // pull long-rail cushions farther inward toward the table center
-const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.44; // move short-rail cushions a touch outward while keeping pocket cuts stable
+const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.605; // tighten long-rail cushion mapping so gameplay rebounds align closer to the visual nose
+const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.462; // tighten short-rail cushion mapping to better match the rendered table shape
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
@@ -4311,8 +4311,7 @@ const SHOWOOD_TABLE_PARTS = Object.freeze([
   'railSight',
   'pocketCup',
   'baseCornerBlock',
-  'leg',
-  'baseFoot'
+  'leg'
 ]);
 const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
   cloth: 'green',
@@ -4360,9 +4359,10 @@ const SHOWOOD_TABLE_PART_LABELS = Object.freeze({
   pocketCup: 'Pocket Cups',
   baseCornerBlock: 'Table Base',
   leg: 'Legs',
-  baseFoot: 'Feet'
+  baseFoot: 'Feet (linked to Side Apron + Rail Sights)'
 });
 const SHOWOOD_CHROME_LINKED_PARTS = new Set(['railSight', 'baseFoot']);
+const SHOWOOD_VISIBLE_PARTS = Object.freeze(SHOWOOD_TABLE_PARTS.filter((part) => part !== 'baseFoot'));
 const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOptions = null) => {
   if (part === 'cloth' || part === 'cushion') {
     const sourceOptions = Array.isArray(clothOptions) && clothOptions.length
@@ -15677,7 +15677,7 @@ function PoolRoyaleGame({
   );
   const tablePersonalizationSections = useMemo(
     () =>
-      SHOWOOD_TABLE_PARTS.map((part) => ({
+      SHOWOOD_VISIBLE_PARTS.map((part) => ({
         key: part,
         label: SHOWOOD_TABLE_PART_LABELS[part] || part,
         chromeLinked: SHOWOOD_CHROME_LINKED_PARTS.has(part),


### PR DESCRIPTION
### Motivation
- Improve table visuals and gameplay alignment by making cushion shadows darker and cushions preserve the cloth texture, making balls slightly larger with natural floor shadows lit by HDRI, and consolidating feet finishes under the rail/apron control so rail sights, side apron stripes and feet can be gold or chrome together.

### Description
- Adjusted preview materials in `PoolRoyalGameTable.tsx` to use a darker cushion shadow (`CUSHION_SHADOW_GREY = "#2f353f"`), preserve cloth texture continuity for cushions (`keepSourceTexture: true`), and updated cushion description and status/help copy.
- Increased the rounded metal foot cap visual scale in `createRoundedFootCaps` (`cap.scale.set(1.34, 1, 1.34)`) so feet render wider, and kept rounded foot caps generation intact for the preview group name `mapped_pool_table_with_precise_rounded_feet`.
- Changed ball and shadow constants in `PoolRoyale.jsx` to enlarge balls slightly (`BALL_SIZE_SCALE = 0.99`), enable cloth-contact floor shadows (`ENABLE_BALL_FLOOR_SHADOWS = true`) and tune shadow sizing/opacity/lift (`BALL_SHADOW_RADIUS_MULTIPLIER = 0.96`, `BALL_SHADOW_OPACITY = 0.31`, `BALL_SHADOW_LIFT = BALL_R * 0.012`).
- Tightened cushion mapping for gameplay to better match rendered cushion noses by updating `CUSHION_FACE_INSET_LONG` and `CUSHION_FACE_INSET_SHORT` to `SIDE_RAIL_INNER_THICKNESS * 0.605` and `* 0.462` respectively.
- Collapsed the separate feet menu entry by hiding `baseFoot` from the visible personalization list and keeping feet controlled/linked under the `railSight`/side-apron flow via a new `SHOWOOD_VISIBLE_PARTS` filter and label update (`baseFoot: 'Feet (linked to Side Apron + Rail Sights)'`).

### Testing
- No automated runtime or unit test suite was executed for this visual/material tuning pass; changes were validated by static code edits and a successful commit (`git status --short` showed the two modified files were staged and committed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1297567c808329927194ee395a654b)