### PR TITLE
perf(pool-royale): reduce mobile renderer and texture load cost

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3029,12 +3029,13 @@ const CLOTH_QUALITY = (() => {
   if (isMobileUA || isTouch || lowMemory || lowRefresh) {
     const highDensity = dpr >= 3;
     return {
-      textureSize: highDensity ? 3072 : 2048,
-      anisotropy: highDensity ? 28 : 24,
+      // Mobile-first profile: keep GPU upload + shader sampling lighter for faster table boot.
+      textureSize: highDensity ? 2048 : 1536,
+      anisotropy: highDensity ? 16 : 12,
       generateMipmaps: true,
-      bumpScaleMultiplier: highDensity ? 1.02 : 0.94,
-      sheen: 0.78,
-      sheenRoughness: 0.82
+      bumpScaleMultiplier: highDensity ? 0.96 : 0.88,
+      sheen: 0.72,
+      sheenRoughness: 0.86
     };
   }
 
@@ -20235,8 +20236,14 @@ const shotPowerRef = useRef(0);
       updatePocketCameraState(false);
       screen.orientation?.lock?.('portrait').catch(() => {});
       // Renderer
+      const mobileTouchDevice =
+        typeof navigator !== 'undefined' &&
+        ((navigator.maxTouchPoints ?? 0) > 1 ||
+          /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+            navigator.userAgent ?? ''
+          ));
       const renderer = new THREE.WebGLRenderer({
-        antialias: true,
+        antialias: !mobileTouchDevice,
         alpha: false,
         powerPreference: 'high-performance'
       });
@@ -20246,7 +20253,9 @@ const shotPowerRef = useRef(0);
       renderer.toneMappingExposure = 1.2;
       renderer.sortObjects = true;
       renderer.shadowMap.enabled = true;
-      renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+      renderer.shadowMap.type = mobileTouchDevice
+        ? THREE.PCFShadowMap
+        : THREE.PCFSoftShadowMap;
       rendererRef.current = renderer;
       updateRendererAnisotropyCap(renderer);
       applyRendererQuality();


### PR DESCRIPTION
### Motivation
- Pool Royale was doing expensive GPU/texture work and high-quality renderer setup on mobile which increases startup time and memory pressure. 
- Aim to improve phone-first loading speed by cutting unnecessary GPU uploads and runtime render cost for touch/mobile devices.

### Description
- Tune mobile cloth quality profile in `CLOTH_QUALITY` to use smaller `textureSize`, lower `anisotropy`, and slightly reduced `bumpScaleMultiplier`/`sheen` parameters to reduce GPU upload and sampling cost on mobile devices.
- Add `mobileTouchDevice` detection and set `antialias` to `false` for touch/mobile devices when creating `THREE.WebGLRenderer` to avoid the extra render cost from antialiasing.
- Use lighter shadow filtering on mobile by switching `renderer.shadowMap.type` to `THREE.PCFShadowMap` for touch/mobile devices and keep `THREE.PCFSoftShadowMap` for desktop.
- Changes are implemented in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Built the production webapp bundle successfully with `npm -C webapp run build` (build completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a129dc4960c8329aa04aeaa23752dc6)