### PR TITLE
Pool Royale: link side aprons to railSight, match cloth-edge, and lighten cushion shadow

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1615,7 +1615,7 @@ const CLOTH_EDGE_TOP_RADIUS_SCALE = 0.986; // pinch the cloth sleeve opening sli
 const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.04; // flare the lower sleeve so the wrap hugs the pocket throat before meeting the drop
 const CLOTH_EDGE_CURVE_INTENSITY = 0.012; // shallow easing that rounds the cloth sleeve as it transitions from lip to throat
 const CLOTH_EDGE_TEXTURE_HEIGHT_SCALE = 1.2; // boost vertical tiling so the wrapped cloth reads with tighter, more realistic fibres
-const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt tone so they don't glow around the cuts
+const CLOTH_EDGE_TINT = 0; // keep field-edge sleeves identical to the active cloth tone/texture
 const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve walls while keeping reflections muted
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.32; // overlap between cushions and rails to hide seams
@@ -4419,7 +4419,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -5232,7 +5232,8 @@ const createClothTextures = (() => {
     }
 
     const palette = preset.palette || CLOTH_TEXTURE_PRESETS[DEFAULT_CLOTH_TEXTURE_KEY].palette;
-    const shadow = toRgb(palette.shadow);
+    const isCushionPreset = /cushion/i.test(preset?.id || '') || preset?.target === 'cushion';
+    const shadow = isCushionPreset ? toRgb('#c3c7ce') : toRgb(palette.shadow);
     const base = toRgb(palette.base);
     const accent = toRgb(palette.accent);
     const highlight = toRgb(palette.highlight);
@@ -13069,7 +13070,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'baseCornerBlock',
+    sideWoodApron: 'railSight',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',
@@ -13292,7 +13293,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+      const linkedPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];


### PR DESCRIPTION
### Motivation
- Ensure Showood side-apron strips follow the same chrome/gold `railSight` option in the menu so apron trim is controlled together with rail sights. 
- Make field-edge sleeves use the same cloth tone/texture as the main field so the pocket/edge trim no longer appears darker or mismatched. 
- Make cushion shadows light grey and ensure cushion procedural textures read consistently across the full cushion surface.

### Description
- Changed `CLOTH_EDGE_TINT` from `0.18` to `0` so cloth edge sleeves match the active cloth tone/texture (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Mapped `sideWoodApron` to the `railSight` option in both the Showood option resolver and the external remap path so side aprons resolve to the same chrome/gold material family (`getShowoodPartOption`, `roleToPart`, and remap `linkedPart`).
- Added an `isCushionPreset` branch in the procedural cloth generator to use a light-grey shadow (`#c3c7ce`) for cushion-targeted presets so cushion shadows render as light grey in generated textures.
- Changes are scoped to `webapp/src/pages/Games/PoolRoyale.jsx` and preserve existing UI options while re-linking apron material selection and cloth-edge behavior.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and the suite passed (all tests `PASS`).
- No other automated tests were modified or required for these UI/material remapping changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12bd8ebdb0832984f3b93977f6e9c8)