### PR TITLE
Pool Royale: restore cushion/cloth mapping, narrow side-apron accent, slightly shrink table, boost power, and lengthen slider

### DIFF
--- a/pool-royale-power-slider.css
+++ b/pool-royale-power-slider.css
@@ -2,7 +2,7 @@
 
 .ps.ps-theme-pool-royale {
   --ps-width: 28px;
-  --ps-height: 702px;
+  --ps-height: 760px;
   --ps-radius: 18px;
 }
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -836,8 +836,8 @@ const CHROME_SIDE_PLATE_WIDTH_REDUCTION_SCALE = 0.9; // tighten the middle fasci
 const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.24; // lean the added width further toward the corner pockets while keeping the curved pocket cut unchanged
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.012; // push middle chrome plates slightly outward away from table center while preserving the rounded cut
-const CHROME_SIDE_APRON_COVER_THICKNESS_SCALE = 0.055; // cover the grey middle-pocket side apron with rail-sight chrome/gold
-const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 0.82; // drop the side apron cover down the rail face behind the side-pocket jaw
+const CHROME_SIDE_APRON_COVER_THICKNESS_SCALE = 0.038; // keep the side apron strip narrow so only the trim goes gold/chrome and cushions stay cloth
+const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 0.62; // reduce vertical reach so the side-panel cover does not spill onto cushion faces
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.022; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.078; // trim the middle-pocket outside chrome a touch more so the outer edge ends flush with the wooden rails
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.045; // open only the corner chrome rounded cut a tiny bit more so the arc reads slightly larger
@@ -1150,7 +1150,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.86; // make the table read just a bit larger in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.84; // shrink the full table a touch in portrait while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1834,7 +1834,7 @@ const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 1; // restore legacy shot scaling used before the May 19 power retune
-const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
+const SHOT_POWER_BOOST = 0.52; // add a bit more launch power while keeping the same control curve
 const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
 const SHOT_FORCE_BOOST =
   1.5 *
@@ -2654,8 +2654,8 @@ let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.605; // tighten long-rail cushion mapping so gameplay rebounds align closer to the visual nose
-const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.462; // tighten short-rail cushion mapping to better match the rendered table shape
+const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.56; // restore the long-rail cushion mapping closer to the earlier baseline
+const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.43; // restore the short-rail cushion mapping so cloth/cushion alignment matches the earlier layout
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 


### PR DESCRIPTION
### Motivation
- Restore the original cushion-to-cloth mapping so cushions render with the cloth texture while the side-apron strip alone receives the gold/chrome finish. 
- Prevent the side apron accent from spilling onto cushion faces after a prior change to apron/strip mapping. 
- Make the table visually a touch smaller in portrait and give shots a bit more feel by modestly increasing launch power. 
- Improve ergonomics of the new pull-style power control by lengthening the slider drag range for finer power control.

### Description
- Narrowed the side-apron accent by reducing `CHROME_SIDE_APRON_COVER_THICKNESS_SCALE` and `CHROME_SIDE_APRON_COVER_HEIGHT_SCALE` in `webapp/src/pages/Games/PoolRoyale.jsx` so only the intended strip is gold/chrome and cushions remain cloth-textured. 
- Restored long/short cushion mapping toward the earlier baseline by adjusting `CUSHION_FACE_INSET_LONG` and `CUSHION_FACE_INSET_SHORT` in `webapp/src/pages/Games/PoolRoyale.jsx` to better align cloth and cushion UV/visual mapping. 
- Slightly reduced on-screen table size by lowering `TABLE_DISPLAY_SCALE` in `webapp/src/pages/Games/PoolRoyale.jsx` to make the table “just a bit” smaller in portrait. 
- Increased shot strength by bumping `SHOT_POWER_BOOST` in `webapp/src/pages/Games/PoolRoyale.jsx` for a modest power increase while keeping the existing control curve. 
- Extended the Pool Royale power slider length by increasing `--ps-height` in `pool-royale-power-slider.css` so the pull gesture has a longer travel range.

### Testing
- No automated test suite was executed against these changes. 
- Changes were limited to numeric tuning/constants and theme CSS so they can be validated quickly in a local visual/dev build and by playing Pool Royale in portrait to confirm cushion mapping, apron strip, table size, shot feel, and slider length.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d91d780c8329b04f089c6eff5d34)