### PR TITLE
PoolRoyale: tweak power slider & table/shot scaling, slim chrome apron, and fix Showood part mapping

### DIFF
--- a/pool-royale-power-slider.css
+++ b/pool-royale-power-slider.css
@@ -2,7 +2,7 @@
 
 .ps.ps-theme-pool-royale {
   --ps-width: 28px;
-  --ps-height: 702px;
+  --ps-height: 760px;
   --ps-radius: 18px;
 }
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -837,7 +837,8 @@ const CHROME_SIDE_PLATE_CORNER_BIAS_SCALE = 1.24; // lean the added width furthe
 const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.012; // push middle chrome plates slightly outward away from table center while preserving the rounded cut
 const CHROME_SIDE_APRON_COVER_THICKNESS_SCALE = 0.055; // cover the grey middle-pocket side apron with rail-sight chrome/gold
-const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 0.82; // drop the side apron cover down the rail face behind the side-pocket jaw
+const CHROME_SIDE_APRON_COVER_HEIGHT_SCALE = 0.18; // keep only a slim gold/chrome strip on the side apron
+const CHROME_SIDE_APRON_COVER_CENTER_HEIGHT_SCALE = 0.84; // keep the slim strip visually high near the top rail edge
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.022; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.078; // trim the middle-pocket outside chrome a touch more so the outer edge ends flush with the wooden rails
 const CHROME_CORNER_POCKET_CUT_SCALE = 1.045; // open only the corner chrome rounded cut a tiny bit more so the arc reads slightly larger
@@ -1150,7 +1151,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.86; // make the table read just a bit larger in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.84; // shrink the on-screen table a touch in portrait while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1833,7 +1834,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 1; // restore legacy shot scaling used before the May 19 power retune
+const SHOT_POWER_ADJUSTMENT = 1.08; // add a small power boost so full pulls travel a bit stronger
 const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
 const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
 const SHOT_FORCE_BOOST =
@@ -4419,7 +4420,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -11225,7 +11226,7 @@ export function Table3D(
       apron.userData.isSidePocketApronCover = true;
       apron.position.set(
         sx * (outerHalfW + apronThickness * 0.5 - MICRO_EPS),
-        frameTopY + railH * 0.5,
+        frameTopY + railH * CHROME_SIDE_APRON_COVER_CENTER_HEIGHT_SCALE,
         centerZ
       );
       apron.castShadow = false;
@@ -13070,7 +13071,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'railSight',
+    sideWoodApron: 'topWoodRail',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',
@@ -13293,7 +13294,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+      const linkedPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];


### PR DESCRIPTION
### Motivation
- Increase the vertical size of the in-game power slider to improve touch/pull ergonomics on mobile.  
- Adjust overall on-screen table sizing and add a small shot power tweak to restore intended feel after recent retunes.  
- Make the side chrome apron a slim high strip visually instead of a large cover to match design intent.  
- Correct material/part mapping for external Showood table imports so the side wood apron uses the top rail styling instead of the rail-sight preset.

### Description
- Increased power slider height in `pool-royale-power-slider.css` by changing `--ps-height` from `702px` to `760px`.  
- Reduced `TABLE_DISPLAY_SCALE` in `PoolRoyale.jsx` from `0.86` to `0.84` to slightly shrink the on-screen table in portrait.  
- Added `CHROME_SIDE_APRON_COVER_CENTER_HEIGHT_SCALE` and changed `CHROME_SIDE_APRON_COVER_HEIGHT_SCALE` from `0.82` to `0.18`, and updated apron `position.y` to use the new center-height scale so the apron becomes a slim, high strip.  
- Bumped gameplay power a touch by changing `SHOT_POWER_ADJUSTMENT` from `1` to `1.08`, which flows into `SHOT_FORCE_BOOST` / `SHOT_BASE_SPEED` calculations.  
- Updated Showood material/part mapping in `PoolRoyale.jsx` so `sideWoodApron` maps to `topWoodRail` (replacing prior `railSight` mapping) in `getShowoodPartOption`, `applyShowoodStyleToExternalMaterial`, and `remapPoolRoyaleShowoodExternalParts` to ensure consistent styling for external models.

### Testing
- Ran the project lint and unit test suite with `yarn lint` and `yarn test`, and both completed successfully.  
- Performed a development build with `yarn build` and verified the bundle completed without errors.  
- Manually verified the UI in the dev server that the power slider height, table scale, chrome apron placement, and shot feel reflect the changes (no automated visual tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d91d780c8329b04f089c6eff5d34)