### PR TITLE
Pool Royale: UI/physics tweaks and showood side-wood mapping fix

### DIFF
--- a/pool-royale-power-slider.css
+++ b/pool-royale-power-slider.css
@@ -2,7 +2,7 @@
 
 .ps.ps-theme-pool-royale {
   --ps-width: 28px;
-  --ps-height: 702px;
+  --ps-height: 760px;
   --ps-radius: 18px;
 }
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1150,7 +1150,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.86; // make the table read just a bit larger in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.84; // shrink the on-screen table a touch in portrait while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1833,7 +1833,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 1; // restore legacy shot scaling used before the May 19 power retune
+const SHOT_POWER_ADJUSTMENT = 1.08; // add a small power boost so full pulls travel a bit stronger
 const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
 const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
 const SHOT_FORCE_BOOST =
@@ -4419,7 +4419,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -13070,7 +13070,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'railSight',
+    sideWoodApron: 'topWoodRail',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',
@@ -13293,7 +13293,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+      const linkedPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];


### PR DESCRIPTION
### Motivation
- Tweak UI sizing and stroke feel to improve mobile presentation and restore a slightly stronger full pull. 
- Ensure showood table materials are mapped consistently so the side apron uses the intended top-wood rail appearance instead of the rail sight material.

### Description
- Increase the Pool Royale power slider height by changing `--ps-height` from `702px` to `760px` in `pool-royale-power-slider.css` to improve touch ergonomics. 
- Adjust on-screen table sizing by changing `TABLE_DISPLAY_SCALE` from `0.86` to `0.84`, which affects `WORLD_SCALE` and related layout. 
- Slightly boost shot strength by changing `SHOT_POWER_ADJUSTMENT` from `1` to `1.08` so full pulls travel a bit stronger. 
- Fix showood material mapping by remapping `sideWoodApron` to `topWoodRail` (was `railSight`) in `getShowoodPartOption`, `applyShowoodStyleToExternalMaterial` role mappings, and the `remapPoolRoyaleShowoodExternalParts` material-link logic so apron geometry picks the correct style option.

### Testing
- Built the webapp using `yarn build` and the build completed successfully. 
- Ran the test suite with `yarn test` and all automated tests passed. 
- Ran linting with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d91d780c8329b04f089c6eff5d34)