### PR TITLE
Tweak Pool Royale UI/physics and showood material mapping (scale, power, slider height)

### DIFF
--- a/pool-royale-power-slider.css
+++ b/pool-royale-power-slider.css
@@ -2,7 +2,7 @@
 
 .ps.ps-theme-pool-royale {
   --ps-width: 28px;
-  --ps-height: 702px;
+  --ps-height: 760px;
   --ps-radius: 18px;
 }
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1150,7 +1150,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.86; // make the table read just a bit larger in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.84; // shrink the on-screen table a touch in portrait while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1833,7 +1833,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 1; // restore legacy shot scaling used before the May 19 power retune
+const SHOT_POWER_ADJUSTMENT = 1.08; // add a small power boost so full pulls travel a bit stronger
 const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
 const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
 const SHOT_FORCE_BOOST =
@@ -13259,7 +13259,7 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   if (hardwareCandidate && (sideMiddlePocketZone || cornerPocketZone) && !green && !brown) return 'railSight';
   if (namedSight && high) return 'railSight';
   if ((namedCloth || green) && centralCloth) return 'cloth';
-  if ((namedCushion || green) && cushionBand) return 'cushion';
+  if ((namedCushion || namedCloth || green) && cushionBand) return 'cushion';
   if ((outsideBaseCornerRimZone || outerMostVerticalCorner) && !green && !s.upFace) return 'verticalCornerRim';
   if (hardwareCandidate && topRailBand && s.upFace && !brown && !green) return 'railSight';
   if (hardwareCandidate && sideLowerTrimZone && !green) return 'railSight';
@@ -13267,8 +13267,8 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   if ((brown || namedWood || black) && baseCornerZone) return 'baseCornerBlock';
   if (midBody && s.sideFace && !(s.longN > 0.64 && s.shortN > 0.64)) return 'leg';
   if (veryTop && (s.upFace || topRailBand) && !green) return 'topWoodRail';
-  if (high && s.sideFace && !green && !anyPocketZone) return 'sideWoodApron';
-  return namedCushion ? 'cushion' : 'sideWoodApron';
+  if (high && s.sideFace && !green && !anyPocketZone) return 'topWoodRail';
+  return namedCushion ? 'cushion' : 'topWoodRail';
 }
 
 function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInfo = null) {


### PR DESCRIPTION
### Motivation
- Adjust in-game feel and UI layout for Pool Royale by slightly shrinking the on-screen table, increasing maximum shot strength, and making the right-side power slider more prominent. 
- Fix material remapping for the `showood-seven-foot` table so cloth-labelled parts can map to cushion and prefer the `topWoodRail` material in more regions. 

### Description
- Reduced `TABLE_DISPLAY_SCALE` from `0.86` to `0.84` to make the on-screen table a bit smaller in portrait. 
- Increased `SHOT_POWER_ADJUSTMENT` from `1` to `1.08` to give full pulls a modest power boost. 
- Increased the Pool Royale power slider height in `pool-royale-power-slider.css` by changing `--ps-height` from `702px` to `760px`. 
- Updated material selection in `resolvePoolRoyaleShowoodTrianglePart` to include `namedCloth` in the cushion check and replace `sideWoodApron` fallbacks with `topWoodRail` for improved finish mapping. 

### Testing
- Ran the project lint and unit test suite via the repository test commands and they completed successfully. 
- Performed a local build of the webapp to verify there were no compile-time errors and the changes bundled without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d91d780c8329b04f089c6eff5d34)