### PR TITLE
Tweak Pool Royale UI/physics and refine showood part classification

### DIFF
--- a/pool-royale-power-slider.css
+++ b/pool-royale-power-slider.css
@@ -2,7 +2,7 @@
 
 .ps.ps-theme-pool-royale {
   --ps-width: 28px;
-  --ps-height: 702px;
+  --ps-height: 760px;
   --ps-radius: 18px;
 }
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1150,7 +1150,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.86; // make the table read just a bit larger in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.84; // shrink the on-screen table a touch in portrait while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1833,7 +1833,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 1; // restore legacy shot scaling used before the May 19 power retune
+const SHOT_POWER_ADJUSTMENT = 1.08; // add a small power boost so full pulls travel a bit stronger
 const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
 const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
 const SHOT_FORCE_BOOST =
@@ -13238,34 +13238,61 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   const sideMiddlePocketZone = high && s.longN < 0.255 && s.shortN > 0.69;
   const cornerPocketZone = high && s.longN > 0.68 && s.shortN > 0.66;
   const anyPocketZone = sideMiddlePocketZone || cornerPocketZone;
-  const centralCloth = high && s.upFace && !anyPocketZone && s.longN < 0.74 && s.shortN < 0.59;
+  const centralCloth = high && s.upFace && !anyPocketZone && s.longN < 0.69 && s.shortN < 0.54;
   const cushionBand = high && !anyPocketZone && (
-    (s.upFace && s.longN >= 0.70 && s.longN < 0.88 && s.shortN < 0.68) ||
-    (s.upFace && s.shortN >= 0.54 && s.shortN < 0.78 && s.longN < 0.88) ||
-    (s.sideFace && s.relY > 0.58 && (s.longN > 0.66 || s.shortN > 0.50)) ||
-    (s.downFace && s.relY > 0.46 && s.relY < 0.84 && ((s.longN > 0.62 && s.longN < 0.94) || (s.shortN > 0.44 && s.shortN < 0.86)))
+    (s.upFace && s.longN >= 0.63 && s.longN < 0.92 && s.shortN < 0.75) ||
+    (s.upFace && s.shortN >= 0.5 && s.shortN < 0.84 && s.longN < 0.92) ||
+    (s.sideFace && s.relY > 0.5 && s.relY < 0.9 && (s.longN > 0.6 || s.shortN > 0.42)) ||
+    (s.downFace && s.relY > 0.46 && s.relY < 0.86 && ((s.longN > 0.6 && s.longN < 0.96) || (s.shortN > 0.4 && s.shortN < 0.9)))
   );
   const topRailBand = high && (s.longN > 0.58 || s.shortN > 0.535);
-  const outsideBaseCornerRimZone = s.sideFace && s.relY > 0.08 && s.relY < 0.82 && s.longN > 0.70 && s.shortN > 0.50;
-  const outerMostVerticalCorner = s.sideFace && s.relY > 0.10 && s.relY < 0.84 && s.longN > 0.78 && s.shortN > 0.64;
-  const sideLowerTrimZone = s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54) && !outsideBaseCornerRimZone;
-  const baseCornerZone = s.sideFace && midBody && (
-    (s.longN > 0.08 && s.longN < 0.58 && s.shortN < 0.42) ||
-    (s.longN > 0.50 && s.shortN > 0.48) ||
-    (s.longN > 0.64 && s.shortN > 0.64)
-  );
+  const topRailNonPocket = topRailBand && !anyPocketZone;
+  const topRailSideVerticalRimZone =
+    s.sideFace && !s.upFace && s.relY > 0.46 && s.relY < 0.96 && s.longN > 0.6 && s.shortN > 0.58;
+  const underRailSightCornerRimZone =
+    s.sideFace && !s.upFace && s.relY > 0.36 && s.relY < 0.76 && s.longN > 0.67 && s.shortN > 0.52;
+  const outsideBaseCornerRimZone =
+    s.sideFace && s.relY > 0.08 && s.relY < 0.78 && s.longN > 0.72 && s.shortN > 0.54;
+  const outerMostVerticalCorner =
+    s.sideFace && s.relY > 0.1 && s.relY < 0.8 && s.longN > 0.8 && s.shortN > 0.68;
+  const baseCornerZone =
+    s.sideFace &&
+    s.relY > 0.12 &&
+    s.relY < 0.64 &&
+    ((s.longN > 0.1 && s.longN < 0.56 && s.shortN < 0.36) || (s.longN > 0.58 && s.shortN > 0.56)) &&
+    !(underRailSightCornerRimZone || topRailSideVerticalRimZone);
+  const legZone =
+    s.sideFace && s.relY > 0.14 && s.relY < 0.62 && s.longN < 0.62 && s.shortN < 0.58;
+  const railSightDownBand =
+    s.sideFace &&
+    !s.upFace &&
+    !anyPocketZone &&
+    s.relY > 0.44 &&
+    s.relY < 0.72 &&
+    (s.longN > 0.54 || s.shortN > 0.48) &&
+    !(topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner || baseCornerZone || legZone);
+  const sideLowerTrimZone =
+    s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54);
   const hardwareCandidate = namedHardware || metalish || ((black || gold || light) && !green && !brown && !namedWood);
-  if (namedPocket || (black && anyPocketZone && (s.downFace || s.sideFace || s.relY < 0.79) && !hardwareCandidate)) return 'pocketCup';
-  if (hardwareCandidate && (sideMiddlePocketZone || cornerPocketZone) && !green && !brown) return 'railSight';
-  if (namedSight && high) return 'railSight';
+  const pocketInteriorCandidate =
+    namedPocket || (black && anyPocketZone && (s.downFace || s.sideFace || s.relY < 0.79) && !hardwareCandidate);
+  if (pocketInteriorCandidate) return 'pocketCup';
+  if (namedPocket && hardwareCandidate && sideMiddlePocketZone) return 'middlePocketPlate';
+  if (namedPocket && hardwareCandidate && cornerPocketZone) return 'cornerPocketPlate';
+  if (hardwareCandidate && sideMiddlePocketZone && !green && !brown) return 'middlePocketPlate';
+  if (hardwareCandidate && cornerPocketZone && !green && !brown) return 'cornerPocketPlate';
   if ((namedCloth || green) && centralCloth) return 'cloth';
   if ((namedCushion || green) && cushionBand) return 'cushion';
-  if ((outsideBaseCornerRimZone || outerMostVerticalCorner) && !green && !s.upFace) return 'verticalCornerRim';
-  if (hardwareCandidate && topRailBand && s.upFace && !brown && !green) return 'railSight';
-  if (hardwareCandidate && sideLowerTrimZone && !green) return 'railSight';
+  if (topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner) return 'verticalCornerRim';
+  if (namedSight && high) return 'railSight';
+  if (hardwareCandidate && topRailNonPocket && s.upFace && !brown && !green) return 'railSight';
   if (low) return 'baseFoot';
-  if ((brown || namedWood || black) && baseCornerZone) return 'baseCornerBlock';
-  if (midBody && s.sideFace && !(s.longN > 0.64 && s.shortN > 0.64)) return 'leg';
+  if (s.downFace && s.relY < 0.5) return 'underside';
+  if ((brown || namedWood) && baseCornerZone) return 'baseCornerBlock';
+  if (baseCornerZone) return 'baseCornerBlock';
+  if (legZone && (brown || namedWood || !hardwareCandidate)) return 'leg';
+  if (hardwareCandidate && sideLowerTrimZone && !green) return 'railSight';
+  if (railSightDownBand && !green) return 'sideWoodApron';
   if (veryTop && (s.upFace || topRailBand) && !green) return 'topWoodRail';
   if (high && s.sideFace && !green && !anyPocketZone) return 'sideWoodApron';
   return namedCushion ? 'cushion' : 'sideWoodApron';


### PR DESCRIPTION
### Motivation
- Increase vertical space for the Pool Royale power slider and slightly adjust on-screen table sizing to improve mobile presentation and control ergonomics.
- Nudge overall shot strength so full "pull" strokes feel slightly stronger while keeping legacy tuning behavior.
- Improve mesh-part detection heuristics for the seven-foot showood table so wood/rail/pocket parts are classified more robustly across varied geometry.

### Description
- Increase power slider theme height from `702px` to `760px` in `pool-royale-power-slider.css` to make the pull-style slider larger on screen.
- Reduce the portrait table display scale by changing `TABLE_DISPLAY_SCALE` from `0.86` to `0.84` in `PoolRoyale.jsx` to slightly shrink on-screen table footprint.
- Raise shot power by changing `SHOT_POWER_ADJUSTMENT` from `1` to `1.08` to give a small boost to full pulls while keeping other shot-scaling constants intact.
- Substantially refactor `resolvePoolRoyaleShowoodTrianglePart` spatial logic in `PoolRoyale.jsx` by tightening/adjusting numeric thresholds and introducing new zone predicates (for example `topRailSideVerticalRimZone`, `underRailSightCornerRimZone`, `legZone`, `railSightDownBand`, and `pocketInteriorCandidate`) to better detect pockets, pocket plates, rail sights, vertical corner rims, base/leg parts, and undersides.
- Add new return cases for `middlePocketPlate` and `cornerPocketPlate`, and rearrange ordering of detection so pocket-related hardware and interior cases are handled with higher fidelity.

### Testing
- Ran the repository lint and the existing unit test suite via the project CI commands (`npm run lint`, `npm test`); both completed successfully with no failures.
- Manually inspected affected UI elements and table model mappings in local dev run to confirm the larger slider height and adjusted table/rail part classifications render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d91d780c8329b04f089c6eff5d34)