### PR TITLE
Align Chess Battle Royal player camera framing with Checkers

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -600,9 +600,11 @@ const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(82); // tilt 3D view more 
 const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.44; // move locked 3D camera closer so the table appears larger/nearer in portrait play.
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.06;
 const PLAYER_FACE_CAMERA_SEAT_ANGLE = Math.PI / 2;
-const PLAYER_FACE_CAMERA_RADIUS = TABLE_RADIUS * 0.9 * CHECKERS_CAMERA_FRAME_COMPENSATION;
-const PLAYER_FACE_CAMERA_EYE_HEIGHT = 2.05 * MODEL_SCALE;
-const PLAYER_FACE_CAMERA_TARGET_HEIGHT = 0.18 * MODEL_SCALE;
+// Keep Chess Battle Royal bottom-player camera aligned with Checkers Battle Royal
+// so portrait framing and left/right/up/down look limits match exactly.
+const PLAYER_FACE_CAMERA_RADIUS = TABLE_RADIUS * 0.98 * CHECKERS_CAMERA_FRAME_COMPENSATION;
+const PLAYER_FACE_CAMERA_EYE_HEIGHT = 2.05 * LAYOUT_SCALE_FACTOR;
+const PLAYER_FACE_CAMERA_TARGET_HEIGHT = 0.18 * LAYOUT_SCALE_FACTOR;
 const PLAYER_FACE_CAMERA_YAW_LIMIT = THREE.MathUtils.degToRad(18);
 const PLAYER_FACE_CAMERA_PITCH_LIMIT = THREE.MathUtils.degToRad(12);
 const SAND_TIMER_RADIUS_FACTOR = 0.68;


### PR DESCRIPTION
### Motivation
- Ensure the Chess Battle Royal bottom-player camera uses the same visual framing, coordinate scaling, and left/right/up/down look limits as Checkers Battle Royal so portrait mobile view and camera interactions feel identical.

### Description
- Updated camera constants in `webapp/src/pages/Games/ChessBattleRoyal.jsx`: changed `PLAYER_FACE_CAMERA_RADIUS` to use `TABLE_RADIUS * 0.98 * CHECKERS_CAMERA_FRAME_COMPENSATION`, and switched `PLAYER_FACE_CAMERA_EYE_HEIGHT` and `PLAYER_FACE_CAMERA_TARGET_HEIGHT` to scale with `LAYOUT_SCALE_FACTOR` instead of `MODEL_SCALE`, and added an inline comment explaining the alignment.

### Testing
- Ran automated repository validation (file-diff and repo state checks) which confirmed only the intended constant updates in `webapp/src/pages/Games/ChessBattleRoyal.jsx` and that the change applied cleanly with no test-suite changes required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e9c2350c83298a0a8d054841a452)