### PR TITLE
Align Chess Battle Royal camera behavior with Checkers camera logic

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -10562,59 +10562,28 @@ function Chess3D({
         controls.enabled = true;
         controls.enableRotate = false;
         controls.enablePan = false;
-        controls.enableZoom = true;
-        controls.minPolarAngle = CAMERA_TOPDOWN_LOCK;
-        controls.maxPolarAngle = CAMERA_TOPDOWN_LOCK;
-        controls.minDistance = CAMERA_2D_MIN_RADIUS;
-        controls.maxDistance = CAMERA_2D_MAX_RADIUS;
-        const targetRadius = clamp(CAMERA_2D_MAX_RADIUS, CAMERA_2D_MIN_RADIUS, CAMERA_2D_MAX_RADIUS);
-        if (!initial2dViewRef.current) {
-          initial2dViewRef.current = new THREE.Spherical(targetRadius, CAMERA_TOPDOWN_LOCK, 0);
-        }
-        const target = initial2dViewRef.current;
+        controls.enableZoom = false;
+        controls.minPolarAngle = 0;
+        controls.maxPolarAngle = 0;
         locked3dViewRef.current.activeLook = false;
-        animateCameraTo(target, 360);
+        camera.position.set(
+          0,
+          TABLE_HEIGHT + 9.2 * CHECKERS_ARENA_SCALE * CHECKERS_CAMERA_FRAME_COMPENSATION,
+          0.001
+        );
+        controls.update();
       } else {
         camera.near = CAM.near;
         camera.updateProjectionMatrix();
         controls.enabled = true;
-        controls.enableRotate = true;
+        controls.enableRotate = false;
         controls.enablePan = false;
-        controls.enableZoom = true;
-        controls.minPolarAngle = CAMERA_PULL_FORWARD_MIN;
+        controls.enableZoom = false;
+        controls.minPolarAngle = THREE.MathUtils.degToRad(28);
         controls.maxPolarAngle = CAM.phiMax;
-        controls.minAzimuthAngle = -Infinity;
-        controls.maxAzimuthAngle = Infinity;
-        controls.minDistance = CAMERA_3D_MIN_RADIUS;
-        controls.maxDistance = CAMERA_3D_MAX_RADIUS;
-        const restore = cameraMemory.last3d || default3d;
-        const targetPhi = clamp(
-          restore.phi - (isForcedCapture3dView ? CAMERA_CAPTURE_VIEW_UPWARD_BIAS : 0),
-          CAMERA_PULL_FORWARD_MIN,
-          CAM.phiMax
-        );
-        const targetRadius = clamp(
-          restore.radius * (isForcedCapture3dView ? CAMERA_CAPTURE_VIEW_RADIUS_SCALE : 1),
-          CAMERA_3D_MIN_RADIUS,
-          CAMERA_3D_MAX_RADIUS
-        );
-        const lockedRadius = clamp(CAMERA_2D_MAX_RADIUS * CAMERA_LOCKED_3D_RADIUS_SCALE, CAMERA_3D_MIN_RADIUS, CAMERA_3D_MAX_RADIUS);
-        const target = new THREE.Spherical(
-          isForcedCapture3dView ? targetRadius : lockedRadius,
-          isForcedCapture3dView ? targetPhi : CAMERA_LOCKED_3D_PHI,
-          Number.isFinite(restore.theta) ? restore.theta : default3d.theta
-        );
-        const lookDir = boardLookTarget.clone().sub(camera.position).normalize();
-        const yaw = Math.atan2(lookDir.x, lookDir.z);
-        const pitch = Math.asin(clamp(lookDir.y, -1, 1));
-        locked3dViewRef.current.yaw = yaw;
-        locked3dViewRef.current.pitch = pitch;
-        locked3dViewRef.current.targetYaw = yaw;
-        locked3dViewRef.current.targetPitch = pitch;
-        // Let OrbitControls drive the normal 3D camera again so players can
-        // move forward/back with pinch or wheel and look left/right by dragging.
         locked3dViewRef.current.activeLook = false;
-        animateCameraTo(target, 420);
+        applyBottomPlayerFaceCamera(camera, playerFaceLookRef.current);
+        controls.update();
       }
     };
 


### PR DESCRIPTION
### Motivation
- Make Chess Battle Royal camera follow the same visual position, interaction limits, and locking behavior used by Checkers Battle Royal so portrait/mobile views match across both games.

### Description
- Updated `webapp/src/pages/Games/ChessBattleRoyal.jsx` to snap the 2D camera to the same top-down coordinates and disable rotate/zoom so it matches Checkers' top-down behavior. 
- In 3D mode the code now reuses `applyBottomPlayerFaceCamera(camera, playerFaceLookRef.current)`, disables rotate/pan/zoom, and enforces the same polar-angle constraints (min polar ≈ 28°) used by Checkers. 
- Removed the animated spherical transition path for the modes in favor of explicit camera positioning and `controls.update()` to preserve the same fixed-look limits as Checkers. 
- Changes are limited to camera/control logic in `ChessBattleRoyal.jsx` and do not alter game rules or assets.

### Testing
- Ran a full production build with `npm -C webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e9c2350c83298a0a8d054841a452)