### PR TITLE
Fix Showood side apron stripe material mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4419,7 +4419,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -13070,7 +13070,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'topWoodRail',
+    sideWoodApron: 'sideWoodApron',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',
@@ -13293,7 +13293,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+      const linkedPart = part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];


### PR DESCRIPTION
### Motivation
- Side apron stripes were inheriting the top wood rail texture and therefore could not render as metallic gold/chrome, so the mapping needs to route apron triangles through the metal-accent pipeline.

### Description
- Stopped remapping `sideWoodApron` to `topWoodRail` in `getShowoodPartOption` so apron parts select their own options (`const optionPart = ...`).
- Updated the external role mapping so `roleToPart.sideWoodApron` now maps to `sideWoodApron` instead of `topWoodRail`, enabling the metal-accent material path for aprons.
- Adjusted the spatial remap `getMaterialIndex` logic in `remapPoolRoyaleShowoodExternalParts` to avoid forcing `sideWoodApron` → `topWoodRail`, so detected side-apron triangles keep the correct linked part.

### Testing
- Ran pattern searches with `rg -n "optionPart =|sideWoodApron: '|linkedPart ="` to confirm the three linkage points were updated and the expected strings are present, which succeeded.
- Inspected the modified file snippets with `nl`/`sed` to verify the new mappings (`sideWoodApron` → `sideWoodApron` and the `verticalCornerRim` branch) and found the changes as intended.
- Generated the PR diff metadata and reviewed the patch to ensure the three target areas were updated; no automated unit tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13ea33622c8329b01201a1057dda1f)