### PR TITLE
Use metallic gold/chrome material for side apron strips (Pool Royale)

### DIFF
--- a/frontend/src/pool-royale/SevenFootShowoodPreview.tsx
+++ b/frontend/src/pool-royale/SevenFootShowoodPreview.tsx
@@ -38,9 +38,9 @@ export const TABLES: Record<TableKey, { title: string; subtitle: string; mapping
 };
 
 const CLOTH_PRESETS: Record<ClothKey, { label: string; color: string }> = { tournamentGreen: { label: 'Procedural Cloth · Tournament Green', color: '#0f6f34' }, royalBlue: { label: 'Procedural Cloth · Royal Blue', color: '#0f4cb3' } };
-const FINISH_PRESETS: Record<FinishKey, { label: string; color: string; metalness: number; roughness: number; railSightColor: string }> = {
-  goldRail: { label: 'RailSight + Apron · Gold', color: '#553118', metalness: 0.08, roughness: 0.43, railSightColor: '#d4af37' },
-  chromeRail: { label: 'RailSight + Apron · Chrome', color: '#141414', metalness: 0.28, roughness: 0.22, railSightColor: '#cfd6dd' },
+const FINISH_PRESETS: Record<FinishKey, { label: string; color: string; metalness: number; roughness: number; railSightColor: string; railSightMetalness: number; railSightRoughness: number; railSightEnvMapIntensity: number; railSightClearcoat: number; railSightClearcoatRoughness: number }> = {
+  goldRail: { label: 'RailSight + Apron · Gold', color: '#553118', metalness: 0.08, roughness: 0.43, railSightColor: '#d8b23d', railSightMetalness: 0.98, railSightRoughness: 0.06, railSightEnvMapIntensity: 2.2, railSightClearcoat: 1, railSightClearcoatRoughness: 0.03 },
+  chromeRail: { label: 'RailSight + Apron · Chrome', color: '#141414', metalness: 0.28, roughness: 0.22, railSightColor: '#d7dde7', railSightMetalness: 1, railSightRoughness: 0.055, railSightEnvMapIntensity: 2.4, railSightClearcoat: 1, railSightClearcoatRoughness: 0.025 },
 };
 
 function proceduralClothTexture(renderer: THREE.WebGLRenderer, tint: string) { const canvas = document.createElement('canvas'); canvas.width = 256; canvas.height = 256; const ctx = canvas.getContext('2d'); if (!ctx) return null; ctx.fillStyle = tint; ctx.fillRect(0, 0, 256, 256); for (let y = 0; y < 256; y += 4) { const a = 0.03 + ((y / 256) % 1) * 0.02; ctx.fillStyle = `rgba(255,255,255,${a.toFixed(3)})`; ctx.fillRect(0, y, 256, 2); } const t = new THREE.CanvasTexture(canvas); t.wrapS = THREE.RepeatWrapping; t.wrapT = THREE.RepeatWrapping; t.repeat.set(4, 2); t.anisotropy = renderer.capabilities.getMaxAnisotropy(); return t; }
@@ -65,7 +65,14 @@ export default function SevenFootShowoodPreview({ selectedTable, onBack }: { sel
     const woodTexture = cueWoodTexture(renderer, FINISH_PRESETS[finish].color);
     const woodMat = new THREE.MeshStandardMaterial({ color: '#ffffff', map: woodTexture, metalness: FINISH_PRESETS[finish].metalness, roughness: FINISH_PRESETS[finish].roughness });
     const railMat = new THREE.MeshStandardMaterial({ color: '#5e2f15', map: woodTexture, metalness: 0.1, roughness: 0.35 });
-    const railSightMat = new THREE.MeshStandardMaterial({ color: FINISH_PRESETS[finish].railSightColor, metalness: 1, roughness: finish === 'goldRail' ? 0.22 : 0.16 });
+    const railSightMat = new THREE.MeshPhysicalMaterial({
+      color: FINISH_PRESETS[finish].railSightColor,
+      metalness: FINISH_PRESETS[finish].railSightMetalness,
+      roughness: FINISH_PRESETS[finish].railSightRoughness,
+      envMapIntensity: FINISH_PRESETS[finish].railSightEnvMapIntensity,
+      clearcoat: FINISH_PRESETS[finish].railSightClearcoat,
+      clearcoatRoughness: FINISH_PRESETS[finish].railSightClearcoatRoughness,
+    });
 
     const tableBody = new THREE.Mesh(new THREE.BoxGeometry(currentMapping.playfield.width * scale * 1.08, 0.24, currentMapping.playfield.length * scale * 1.12), woodMat); tableBody.position.y = -0.13; tableGroup.add(tableBody);
     const railFrame = new THREE.Mesh(new THREE.BoxGeometry(currentMapping.playfield.width * scale * 1.16, 0.13, currentMapping.playfield.length * scale * 1.2), railMat); railFrame.position.y = 0.03; tableGroup.add(railFrame);


### PR DESCRIPTION
### Motivation
- Side apron stripes were inheriting the top rail / wood texture and needed to render as metallic gold or chrome accents using the same physical-metal technique used elsewhere. 
- The change applies the dedicated metallic parameters (metalness/roughness/envMapIntensity/clearcoat) to the rail-sight/apron elements so they visually read as gold or chrome.

### Description
- Expanded `FINISH_PRESETS` in `frontend/src/pool-royale/SevenFootShowoodPreview.tsx` to include explicit railSight metallic parameters (`railSightMetalness`, `railSightRoughness`, `railSightEnvMapIntensity`, `railSightClearcoat`, `railSightClearcoatRoughness`).
- Replaced the apron/rail-sight material from `MeshStandardMaterial` to `MeshPhysicalMaterial` and applied the new preset values so apron strips and rail-sight accents render as gold/chrome.
- Kept the top rail wood material (`railMat`) and wood texture unchanged so only the accent parts get the metallic finish.
- Modified file: `frontend/src/pool-royale/SevenFootShowoodPreview.tsx`.

### Testing
- Ran `npm -s run -q test -- test/poolRoyaleTableModels.test.js` and the suite passed (all tests in that file succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13ea33622c8329b01201a1057dda1f)