### PR TITLE
Fix Pool Royal side apron stripes to use metal-accent material

### DIFF
--- a/webapp/src/pages/Games/PoolRoyalGameTable.tsx
+++ b/webapp/src/pages/Games/PoolRoyalGameTable.tsx
@@ -149,6 +149,7 @@ const ALWAYS_SPATIAL_PARTS = new Set<TablePart>([
   "baseCornerBlock",
   "lowerTrim",
   "railSight",
+  "sideWoodApron",
   "underside",
 ]);
 
@@ -559,7 +560,7 @@ function classifyTriangle(
   if (outsideBaseCornerRimZone && (flags.brown || namedWood) && !outerMostVerticalCorner) return "baseCornerBlock";
   if (s.longN > 0.64 && s.shortN > 0.64 && midBody) return "baseCornerBlock";
   if (midBody && s.sideFace && !(s.longN > 0.64 && s.shortN > 0.64)) return "leg";
-  if (veryTop && (s.upFace || topRailBand) && !flags.green) return "topWoodRail";
+  if (veryTop && s.upFace && topRailBand && !flags.green) return "topWoodRail";
   if (high && s.sideFace && !flags.green && !anyPocketZone) return "sideWoodApron";
   return "sideWoodApron";
 }


### PR DESCRIPTION
### Motivation

- Side-apron stripe triangles were being classified with the top-rail wood material and thus inherited the top-rail texture instead of the gold/chrome metal accent; this change restores the intended metal accent styling for those stripes.

### Description

- Tightened the top-rail classification to require visually top-facing triangles by changing the condition to require `s.upFace && topRailBand`, preventing side-facing apron triangles from being pulled into `topWoodRail`.
- Ensured the side apron remains treated as a spatially-split part by adding `"sideWoodApron"` to `ALWAYS_SPATIAL_PARTS` so it keeps its own bucket and inherits the metal-accent flow (gold/chrome). The only modified file is `webapp/src/pages/Games/PoolRoyalGameTable.tsx`.

### Testing

- Ran `npx eslint webapp/src/pages/Games/PoolRoyalGameTable.tsx` which completed with no errors and only repository ignore warnings. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyalGameTable.tsx` which produced the same ignore-warning but no lint errors, indicating the change is syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13ea33622c8329b01201a1057dda1f)