### PR TITLE
Fix side apron mapping so apron stripes use metal-accent (gold/chrome) options

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4419,7 +4419,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -13070,7 +13070,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'topWoodRail',
+    sideWoodApron: 'sideWoodApron',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',


### PR DESCRIPTION
### Motivation
- Side-apron stripes were inheriting top-rail wood textures/finishes, preventing the apron from using the intended gold/chrome metal-accent options.

### Description
- Changed the Showood option resolver and external role→part mapping so `sideWoodApron` no longer falls back to `topWoodRail` and instead resolves to `sideWoodApron`, ensuring apron stripes follow the metal-accent option set.

### Testing
- Performed a code search to locate mappings, inspected the resulting diff for `webapp/src/pages/Games/PoolRoyale.jsx`, and verified the two-line mapping change was applied and present in the diff; no automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13fff0667c83298b016a8d28443b60)