### PR TITLE
Fix Pool Royale side apron finish mapping to rail-sight metal options

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4419,7 +4419,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -13070,7 +13070,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'topWoodRail',
+    sideWoodApron: 'railSight',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',


### PR DESCRIPTION
### Motivation
- Side-apron stripe triangles were receiving the top-rail wood texture instead of the metallic rail-sight finish, causing the apron stripes to look like wood rather than gold/chrome accents.

### Description
- Update `webapp/src/pages/Games/PoolRoyale.jsx` so `sideWoodApron` resolves to the `railSight` option set in both the Showood part-option resolver and the external-material role→part mapping, ensuring the same gold/chrome technique used by rail sights is applied to the side apron.

### Testing
- Verified the change with `rg -n "sideWoodApron: 'railSight'|optionPart = part === 'sideWoodApron'"` and committed the patch with `git add`/`git commit`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13fff0667c83298b016a8d28443b60)