### PR TITLE
Fix Showood side apron finish mapping to use metal accents

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4419,7 +4419,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -13293,7 +13293,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+      const linkedPart = part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];


### PR DESCRIPTION
### Motivation
- The side apron stripes were inheriting the top-rail wood texture instead of using the metal-accent (gold/chrome) flow, so the visual finish needed to follow the metal accent control.

### Description
- Removed the `sideWoodApron -> topWoodRail` remap in `getShowoodPartOption` and the triangle material remap in `remapPoolRoyaleShowoodExternalParts` in `webapp/src/pages/Games/PoolRoyale.jsx` so the side apron now uses its own finish option while keeping the `verticalCornerRim -> baseFoot` linkage unchanged.

### Testing
- Verified the remap expression was removed via `rg` (search) and confirmed the updated logic in `webapp/src/pages/Games/PoolRoyale.jsx` (no remaining `sideWoodApron ? 'topWoodRail'` mapping); the search succeeded.
- Committed the change and created the PR metadata (commit `926f68a`); `git status`/`git commit` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13fff0667c83298b016a8d28443b60)