### PR TITLE
Adjust Chess Battle Royal portrait camera framing

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -597,7 +597,7 @@ const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(21); // raise f
 const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 1.18; // keep forced 3D animation wider during capture so the board stays fully readable
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 0; // keep projected avatars pinned to the seated character chest anchors
 const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(82); // tilt 3D view more top-down so the board sits visually lower (toward the bottom) on portrait screens.
-const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.44; // move locked 3D camera closer so the table appears larger/nearer in portrait play.
+const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.34; // move locked 3D camera even closer so the table appears larger/nearer in portrait play.
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.06;
 const PLAYER_FACE_CAMERA_SEAT_ANGLE = Math.PI / 2;
 // Keep Chess Battle Royal bottom-player camera aligned with Checkers Battle Royal
@@ -629,7 +629,7 @@ const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.24; // raise player camera w
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.92;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 1.35;
 const PLAYER_VIEW_LOOK_TARGET_UP_BIAS = 0.6; // increase upward aim so the table/pieces/opponent sit higher in view.
-const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 7.1; // pull arena contents upward so the 2D board lands closer to screen center on portrait phones.
+const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 5.6; // shift arena contents lower on portrait screens so table/chairs/humans sit closer to the bottom.
 const FPV_FACE_FORWARD_OFFSET = 0.012; // keep the camera almost exactly at the eyes for a true first-person perspective.
 const FPV_FACE_UP_OFFSET = 0.0; // slight lift so the board edge does not clip while still feeling eye-level.
 const FPV_LOOK_AHEAD_DISTANCE = BOARD.tile * BOARD_SCALE * 5.8; // prioritize looking down the board journey toward the opponent side.


### PR DESCRIPTION
### Motivation
- Improve portrait-phone framing so the 2D camera appears closer to the chess table and the table/board/chairs/human characters sit visually lower (toward the bottom) on the screen.

### Description
- Tuned two portrait constants in `webapp/src/pages/Games/ChessBattleRoyal.jsx`: `CAMERA_LOCKED_3D_RADIUS_SCALE` was reduced from `0.44` to `0.34` to move the locked 3D camera closer to the table, and `TABLE_BOTTOM_PLAYER_BIAS_Z` was reduced from `BOARD.tile * BOARD_SCALE * 7.1` to `BOARD.tile * BOARD_SCALE * 5.6` to shift the arena contents downward on portrait screens.

### Testing
- No automated tests were run for this tuning-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a140db15950832991ecf650e76ec1fe)