### PR TITLE
Restore PoolRoyale.jsx to May 20 baseline

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1150,7 +1150,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.84; // shrink the on-screen table a touch in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.86; // make the table read just a bit larger in portrait while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1405,17 +1405,17 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
 const MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION;
-const BALL_SIZE_SCALE = 0.99; // enlarge balls slightly for a fuller on-cloth visual while preserving all BALL_R/BALL_DIAMETER-linked helpers
+const BALL_SIZE_SCALE = 0.96; // trim ball size slightly while keeping every helper tied to BALL_R/BALL_DIAMETER
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
 const RACK_VERTICAL_SCREEN_LIFT = BALL_R * 0.86; // nudge the rack farther upward on screen so object balls sit visibly higher
-const ENABLE_BALL_FLOOR_SHADOWS = true;
+const ENABLE_BALL_FLOOR_SHADOWS = false;
 const ENABLE_CUE_CLOTH_SHADOW = true;
 const ENABLE_TABLE_FLOOR_SHADOW = false;
-const BALL_SHADOW_RADIUS_MULTIPLIER = 0.96;
-const BALL_SHADOW_OPACITY = 0.31;
-const BALL_SHADOW_LIFT = BALL_R * 0.012;
+const BALL_SHADOW_RADIUS_MULTIPLIER = 1;
+const BALL_SHADOW_OPACITY = 0.25;
+const BALL_SHADOW_LIFT = BALL_R * 0.02;
 const CUE_SHADOW_OPACITY = 0.18;
 const CUE_SHADOW_WIDTH_RATIO = 0.62;
 const TABLE_FLOOR_SHADOW_OPACITY = 0.2;
@@ -1615,7 +1615,7 @@ const CLOTH_EDGE_TOP_RADIUS_SCALE = 0.986; // pinch the cloth sleeve opening sli
 const CLOTH_EDGE_BOTTOM_RADIUS_SCALE = 1.04; // flare the lower sleeve so the wrap hugs the pocket throat before meeting the drop
 const CLOTH_EDGE_CURVE_INTENSITY = 0.012; // shallow easing that rounds the cloth sleeve as it transitions from lip to throat
 const CLOTH_EDGE_TEXTURE_HEIGHT_SCALE = 1.2; // boost vertical tiling so the wrapped cloth reads with tighter, more realistic fibres
-const CLOTH_EDGE_TINT = 0; // keep field-edge sleeves identical to the active cloth tone/texture
+const CLOTH_EDGE_TINT = 0.18; // keep the pocket sleeves closer to the base felt tone so they don't glow around the cuts
 const CLOTH_EDGE_EMISSIVE_MULTIPLIER = 0.02; // soften light spill on the sleeve walls while keeping reflections muted
 const CLOTH_EDGE_EMISSIVE_INTENSITY = 0.24; // further dim emissive brightness so the cutouts stay consistent with the cloth plane
 const CUSHION_OVERLAP = SIDE_RAIL_INNER_THICKNESS * 0.32; // overlap between cushions and rails to hide seams
@@ -1833,9 +1833,9 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 1.08; // add a small power boost so full pulls travel a bit stronger
-const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
-const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
+const SHOT_POWER_ADJUSTMENT = 0.62; // reduce overall Pool Royale power by an additional 20%
+const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
+const SHOT_GLOBAL_POWER_SCALE = 0.78; // tone down Pool Royale strike speed so shots match the requested game power pacing
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -2654,8 +2654,8 @@ let CUSHION_CUT_ANGLE = DEFAULT_CUSHION_CUT_ANGLE;
 let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
-const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.605; // tighten long-rail cushion mapping so gameplay rebounds align closer to the visual nose
-const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.462; // tighten short-rail cushion mapping to better match the rendered table shape
+const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.58; // pull long-rail cushions farther inward toward the table center
+const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.44; // move short-rail cushions a touch outward while keeping pocket cuts stable
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
@@ -3029,10 +3029,10 @@ const CLOTH_QUALITY = (() => {
   if (isMobileUA || isTouch || lowMemory || lowRefresh) {
     const highDensity = dpr >= 3;
     return {
-      textureSize: highDensity ? 2048 : 1536,
-      anisotropy: highDensity ? 16 : 12,
+      textureSize: highDensity ? 3072 : 2048,
+      anisotropy: highDensity ? 28 : 24,
       generateMipmaps: true,
-      bumpScaleMultiplier: highDensity ? 0.98 : 0.9,
+      bumpScaleMultiplier: highDensity ? 1.02 : 0.94,
       sheen: 0.78,
       sheenRoughness: 0.82
     };
@@ -3051,16 +3051,6 @@ const CLOTH_QUALITY = (() => {
 
   return defaults;
 })();
-
-function isMobilePerformanceTier() {
-  if (typeof window === 'undefined' || typeof navigator === 'undefined') return false;
-  const dpr = window.devicePixelRatio ?? 1;
-  const ua = navigator.userAgent ?? '';
-  const isMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-  const deviceMemory = typeof navigator.deviceMemory === 'number' ? navigator.deviceMemory : null;
-  const lowMemory = deviceMemory !== null && deviceMemory <= 4;
-  return isMobileUA || lowMemory || dpr >= 2.5;
-}
 
 const makeColorPalette = ({ cloth, rail, base, markings = 0xffffff, cushion }) => ({
   cloth,
@@ -4321,7 +4311,8 @@ const SHOWOOD_TABLE_PARTS = Object.freeze([
   'railSight',
   'pocketCup',
   'baseCornerBlock',
-  'leg'
+  'leg',
+  'baseFoot'
 ]);
 const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
   cloth: 'green',
@@ -4369,10 +4360,9 @@ const SHOWOOD_TABLE_PART_LABELS = Object.freeze({
   pocketCup: 'Pocket Cups',
   baseCornerBlock: 'Table Base',
   leg: 'Legs',
-  baseFoot: 'Feet (linked to Side Apron + Rail Sights)'
+  baseFoot: 'Feet'
 });
 const SHOWOOD_CHROME_LINKED_PARTS = new Set(['railSight', 'baseFoot']);
-const SHOWOOD_VISIBLE_PARTS = Object.freeze(SHOWOOD_TABLE_PARTS.filter((part) => part !== 'baseFoot'));
 const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOptions = null) => {
   if (part === 'cloth' || part === 'cushion') {
     const sourceOptions = Array.isArray(clothOptions) && clothOptions.length
@@ -4419,7 +4409,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -5232,8 +5222,7 @@ const createClothTextures = (() => {
     }
 
     const palette = preset.palette || CLOTH_TEXTURE_PRESETS[DEFAULT_CLOTH_TEXTURE_KEY].palette;
-    const isCushionPreset = /cushion/i.test(preset?.id || '') || preset?.target === 'cushion';
-    const shadow = isCushionPreset ? toRgb('#c3c7ce') : toRgb(palette.shadow);
+    const shadow = toRgb(palette.shadow);
     const base = toRgb(palette.base);
     const accent = toRgb(palette.accent);
     const highlight = toRgb(palette.highlight);
@@ -11955,7 +11944,7 @@ export function Table3D(
   const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.92;
+  const brandPlateOutwardShift = endRailW * 0.62;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -13070,7 +13059,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'topWoodRail',
+    sideWoodApron: 'baseCornerBlock',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',
@@ -13246,9 +13235,6 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
     (s.downFace && s.relY > 0.46 && s.relY < 0.84 && ((s.longN > 0.62 && s.longN < 0.94) || (s.shortN > 0.44 && s.shortN < 0.86)))
   );
   const topRailBand = high && (s.longN > 0.58 || s.shortN > 0.535);
-  const topRailNonPocket = topRailBand && !anyPocketZone;
-  const topRailSideVerticalRimZone = s.sideFace && !s.upFace && s.relY > 0.46 && s.relY < 0.96 && s.longN > 0.6 && s.shortN > 0.58;
-  const underRailSightCornerRimZone = s.sideFace && !s.upFace && s.relY > 0.36 && s.relY < 0.76 && s.longN > 0.67 && s.shortN > 0.52;
   const outsideBaseCornerRimZone = s.sideFace && s.relY > 0.08 && s.relY < 0.82 && s.longN > 0.70 && s.shortN > 0.50;
   const outerMostVerticalCorner = s.sideFace && s.relY > 0.10 && s.relY < 0.84 && s.longN > 0.78 && s.shortN > 0.64;
   const sideLowerTrimZone = s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54) && !outsideBaseCornerRimZone;
@@ -13256,26 +13242,19 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
     (s.longN > 0.08 && s.longN < 0.58 && s.shortN < 0.42) ||
     (s.longN > 0.50 && s.shortN > 0.48) ||
     (s.longN > 0.64 && s.shortN > 0.64)
-  ) && !(underRailSightCornerRimZone || topRailSideVerticalRimZone);
-  const legZone = s.sideFace && s.relY > 0.14 && s.relY < 0.62 && s.longN < 0.62 && s.shortN < 0.58;
-  const railSightDownBand =
-    s.sideFace && !s.upFace && !anyPocketZone && s.relY > 0.44 && s.relY < 0.72 &&
-    (s.longN > 0.54 || s.shortN > 0.48) &&
-    !(topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner || baseCornerZone || legZone);
+  );
   const hardwareCandidate = namedHardware || metalish || ((black || gold || light) && !green && !brown && !namedWood);
   if (namedPocket || (black && anyPocketZone && (s.downFace || s.sideFace || s.relY < 0.79) && !hardwareCandidate)) return 'pocketCup';
   if (hardwareCandidate && (sideMiddlePocketZone || cornerPocketZone) && !green && !brown) return 'railSight';
   if (namedSight && high) return 'railSight';
   if ((namedCloth || green) && centralCloth) return 'cloth';
   if ((namedCushion || green) && cushionBand) return 'cushion';
-  if ((topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner) && !green && !s.upFace) return 'verticalCornerRim';
-  if (hardwareCandidate && topRailNonPocket && s.upFace && !brown && !green) return 'railSight';
+  if ((outsideBaseCornerRimZone || outerMostVerticalCorner) && !green && !s.upFace) return 'verticalCornerRim';
+  if (hardwareCandidate && topRailBand && s.upFace && !brown && !green) return 'railSight';
+  if (hardwareCandidate && sideLowerTrimZone && !green) return 'railSight';
   if (low) return 'baseFoot';
   if ((brown || namedWood || black) && baseCornerZone) return 'baseCornerBlock';
-  if (baseCornerZone) return 'baseCornerBlock';
-  if (legZone && (brown || namedWood || !hardwareCandidate)) return 'leg';
-  if (hardwareCandidate && sideLowerTrimZone && !green) return 'railSight';
-  if (railSightDownBand && !green) return 'sideWoodApron';
+  if (midBody && s.sideFace && !(s.longN > 0.64 && s.shortN > 0.64)) return 'leg';
   if (veryTop && (s.upFace || topRailBand) && !green) return 'topWoodRail';
   if (high && s.sideFace && !green && !anyPocketZone) return 'sideWoodApron';
   return namedCushion ? 'cushion' : 'sideWoodApron';
@@ -13303,7 +13282,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part === 'sideWoodApron' ? 'topWoodRail' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+      const linkedPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];
@@ -15698,7 +15677,7 @@ function PoolRoyaleGame({
   );
   const tablePersonalizationSections = useMemo(
     () =>
-      SHOWOOD_VISIBLE_PARTS.map((part) => ({
+      SHOWOOD_TABLE_PARTS.map((part) => ({
         key: part,
         label: SHOWOOD_TABLE_PART_LABELS[part] || part,
         chromeLinked: SHOWOOD_CHROME_LINKED_PARTS.has(part),
@@ -20255,10 +20234,9 @@ const shotPowerRef = useRef(0);
       };
       updatePocketCameraState(false);
       screen.orientation?.lock?.('portrait').catch(() => {});
-      const mobilePerformanceTier = isMobilePerformanceTier();
       // Renderer
       const renderer = new THREE.WebGLRenderer({
-        antialias: !mobilePerformanceTier,
+        antialias: true,
         alpha: false,
         powerPreference: 'high-performance'
       });
@@ -20267,7 +20245,7 @@ const shotPowerRef = useRef(0);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       renderer.sortObjects = true;
-      renderer.shadowMap.enabled = !mobilePerformanceTier;
+      renderer.shadowMap.enabled = true;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       rendererRef.current = renderer;
       updateRendererAnisotropyCap(renderer);


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale game JSX to the exact May 20 baseline to undo recent tuning/material/visual changes and re-establish the known-good game behavior.
- Ensure gameplay constants, Showood material mappings, and renderer settings match the prior stable presentation used on mobile portrait builds.

### Description
- Replaced `webapp/src/pages/Games/PoolRoyale.jsx` with the historical baseline version from May 20, reverting recent visual and tuning adjustments in that file.
- Key parameter changes restored include display and world scale constants (`TABLE_DISPLAY_SCALE`, ball sizing via `BALL_SIZE_SCALE`), shadow toggles and shadow parameters, cloth/pocket sleeve tint (`CLOTH_EDGE_TINT`), and shot power scaling (`SHOT_POWER_ADJUSTMENT`, `SHOT_POWER_BOOST`, `SHOT_GLOBAL_POWER_SCALE`).
- Restored Showood part handling and mapping (added `baseFoot` part, remapped `sideWoodApron` to `baseCornerBlock` for external material application) and re-enabled full Showood personalization UI sections.
- Reinstated cloth texture/quality profile defaults for mobile and renderer defaults that enable antialiasing and shadowing, and removed the mobile-tier helper used in prior conditional rendering decisions.

### Testing
- Restored the file from repository history and validated the staged diff of `webapp/src/pages/Games/PoolRoyale.jsx` to confirm the contents match the baseline, and the validation succeeded.
- Inspected specific source regions with line listings to confirm key constants and mappings were reverted to baseline values, and the inspection succeeded.
- Created the PR record describing the restoration, and PR creation succeeded.
- No automated runtime or unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1491fcdac883299f36c89f58086695)