### PR TITLE
Optimize Pool Royale mobile texture/HDRI loading

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4679,12 +4679,16 @@ let runtimeTextureProfile = Object.freeze({
   textureSize: resolveGraphicsResolutionTier(90).textureSize,
   anisotropy: CLOTH_QUALITY.anisotropy,
   generateMipmaps: CLOTH_QUALITY.generateMipmaps,
-  polyHavenResolution: '4k',
-  hdriResolution: '4k',
-  polyHavenPreferredResolutions: Object.freeze(['4k', '2k']),
-  polyHavenFallbackResolution: '2k',
-  hdriPreferredResolutions: Object.freeze(['4k']),
-  hdriFallbackResolution: '4k',
+  polyHavenResolution: isLikelyMobileDevice() ? '2k' : '4k',
+  hdriResolution: isLikelyMobileDevice() ? '2k' : '4k',
+  polyHavenPreferredResolutions: isLikelyMobileDevice()
+    ? Object.freeze(['2k', '1k'])
+    : Object.freeze(['4k', '2k']),
+  polyHavenFallbackResolution: isLikelyMobileDevice() ? '1k' : '2k',
+  hdriPreferredResolutions: isLikelyMobileDevice()
+    ? Object.freeze(['2k', '1k'])
+    : Object.freeze(['4k', '2k']),
+  hdriFallbackResolution: isLikelyMobileDevice() ? '1k' : '2k',
   enforceTableFinishTextureSize: 4096,
   cueTextureSize: 4096,
   pocketTextureSize: 2048
@@ -4702,12 +4706,14 @@ const updateRuntimeTextureProfile = ({ fps } = {}) => {
     anisotropy,
     generateMipmaps: CLOTH_QUALITY.generateMipmaps,
     polyHavenResolution: tier.key,
-    hdriResolution: '4k',
+    hdriResolution: isLikelyMobileDevice() ? '2k' : '4k',
     polyHavenPreferredResolutions: tier.preferredResolutions ?? Object.freeze([tier.key]),
     polyHavenFallbackResolution:
       tier.fallbackResolution ?? tier.preferredResolutions?.[tier.preferredResolutions.length - 1] ?? tier.key,
-    hdriPreferredResolutions: Object.freeze(['4k']),
-    hdriFallbackResolution: '4k',
+    hdriPreferredResolutions: isLikelyMobileDevice()
+      ? Object.freeze(['2k', '1k'])
+      : Object.freeze(['4k', '2k']),
+    hdriFallbackResolution: isLikelyMobileDevice() ? '1k' : '2k',
     enforceTableFinishTextureSize: textureSize,
     cueTextureSize: textureSize,
     pocketTextureSize: Math.max(512, Math.min(textureSize, 4096))


### PR DESCRIPTION
### Motivation
- The Pool Royale table scene was loading slowly on phones due to high-resolution HDRI and environment textures, so defaults should favor lower-res assets on likely mobile devices to reduce initial download and decode time.

### Description
- Updated the default `runtimeTextureProfile` in `webapp/src/pages/Games/PoolRoyale.jsx` to use `2k` (with `1k` fallback) for `polyHaven` and `hdri` on `isLikelyMobileDevice()` instead of always using `4k`.
- Applied the same mobile-first `hdri` resolution and preferred/fallback resolution logic inside `updateRuntimeTextureProfile` so runtime FPS-based recomputation respects the mobile preference.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151af6253883299764e4a13d7723e6)