### PR TITLE
Adjust Domino Royal seated character scale to appear smaller

### DIFF
--- a/test/dominoRoyalCharacterScale.test.js
+++ b/test/dominoRoyalCharacterScale.test.js
@@ -11,11 +11,11 @@ function readNumericConstant(source, name) {
   return Number(match[1]);
 }
 
-test('Domino Royal seated human characters stay large and readable', () => {
+test('Domino Royal seated human characters stay readable while appearing smaller on screen', () => {
   const source = fs.readFileSync(DOMINO_PUBLIC_SCRIPT, 'utf8');
   const baseScale = readNumericConstant(source, 'DOMINO_CHARACTER_PROPORTION_SCALE');
   const humanBoost = readNumericConstant(source, 'DOMINO_HUMAN_CHARACTER_SCALE_BOOST');
 
   expect(baseScale).toBeGreaterThanOrEqual(2.9);
-  expect(baseScale + humanBoost).toBeGreaterThanOrEqual(3.7);
+  expect(baseScale + humanBoost).toBeGreaterThanOrEqual(3.5);
 });

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7988,8 +7988,8 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 3.8;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 1.35;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 3.4;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.45;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = -0.03;


### PR DESCRIPTION
### Motivation
- Reduce the on-screen visual size of seated human characters in Domino Royal so they appear smaller on mobile/portrait while remaining readable.

### Description
- Lowered `DOMINO_CHARACTER_PROPORTION_SCALE` from `3.8` to `3.4` in `webapp/public/domino-royal-game.js` to reduce base character proportions.
- Reduced `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` from `1.35` to `0.45` so the human (bottom) seat no longer scales up as much.
- Updated the related test description and threshold in `test/dominoRoyalCharacterScale.test.js` to reflect the new visual target and combined-scale expectation.

### Testing
- Ran `npm test -- test/dominoRoyalCharacterScale.test.js` and the test passed (1 test, 1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151b2107d08329a07886031953e7b0)