### PR TITLE
Improve Pool Royale cushion visuals and load performance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1515,7 +1515,7 @@ const BALL_SHADOW_GEOMETRY = ENABLE_BALL_FLOOR_SHADOWS
 if (BALL_SHADOW_GEOMETRY) BALL_SHADOW_GEOMETRY.rotateX(-Math.PI / 2);
 const BALL_SHADOW_MATERIAL = ENABLE_BALL_FLOOR_SHADOWS
   ? new THREE.MeshBasicMaterial({
-      color: 0x000000,
+      color: 0x6b6b6b,
       transparent: true,
       opacity: BALL_SHADOW_OPACITY,
       depthWrite: false,
@@ -2997,8 +2997,8 @@ const CLOTH_SOFT_BLEND = 0.34;
 
 const CLOTH_QUALITY = (() => {
   const defaults = {
-    textureSize: 6144,
-    anisotropy: 72,
+    textureSize: 3072,
+    anisotropy: 24,
     generateMipmaps: true,
     bumpScaleMultiplier: 1.16,
     sheen: 0.95,
@@ -3029,8 +3029,8 @@ const CLOTH_QUALITY = (() => {
   if (isMobileUA || isTouch || lowMemory || lowRefresh) {
     const highDensity = dpr >= 3;
     return {
-      textureSize: highDensity ? 3072 : 2048,
-      anisotropy: highDensity ? 28 : 24,
+      textureSize: highDensity ? 2048 : 1536,
+      anisotropy: highDensity ? 16 : 12,
       generateMipmaps: true,
       bumpScaleMultiplier: highDensity ? 1.02 : 0.94,
       sheen: 0.78,
@@ -3040,8 +3040,8 @@ const CLOTH_QUALITY = (() => {
 
   if (hardwareConcurrency <= 6 || dpr < 1.75) {
     return {
-      textureSize: 5120,
-      anisotropy: 48,
+      textureSize: 2560,
+      anisotropy: 20,
       generateMipmaps: true,
       bumpScaleMultiplier: 1.12,
       sheen: 0.9,
@@ -10313,7 +10313,7 @@ export function Table3D(
     const shadowGeo = new THREE.PlaneGeometry(shadowWidth, shadowHeight);
     shadowGeo.rotateX(-Math.PI / 2);
     const shadowMat = new THREE.MeshBasicMaterial({
-      color: 0x000000,
+      color: 0x6b6b6b,
       transparent: true,
       opacity: TABLE_FLOOR_SHADOW_OPACITY,
       depthWrite: false,
@@ -12481,6 +12481,23 @@ export function Table3D(
         }
       }
     }
+
+    // Project a unified top-plane UV across all cushion faces so the visible sides
+    // keep the same cloth grain direction/scale as the cushion top.
+    const uvAttr = geo.attributes.uv;
+    if (uvAttr?.array) {
+      const uv = uvAttr.array;
+      const invLen = 1 / Math.max(len, MICRO_EPS);
+      const invSpan = 1 / Math.max(backY - frontY, MICRO_EPS);
+      for (let i = 0, j = 0; i < arr.length && j < uv.length; i += 3, j += 2) {
+        const px = arr[i];
+        const py = arr[i + 1];
+        uv[j] = (px + halfLen) * invLen;
+        uv[j + 1] = (py - frontY) * invSpan;
+      }
+      uvAttr.needsUpdate = true;
+    }
+
     pos.needsUpdate = true;
     geo.computeVertexNormals();
     return geo;


### PR DESCRIPTION
### Motivation
- Cushion side faces were showing a different cloth direction/scale than the cushion top which produced a visible seam and inconsistent appearance on mobile portrait screens.  
- Table floor/cushion shadows were pure black and the Pool Royale cloth texture system was using very high default resolutions/anisotropy that increases initial load time on devices, especially high-DPR mobile devices.

### Description
- Project a unified top-plane UV across cushion geometry in `cushionProfileAdvanced` so cushion sides reuse the same cloth grain direction/scale as the cushion top by updating UVs on the generated `ExtrudeGeometry`.  
- Change the table floor shadow and ball floor shadow materials from pure black to a neutral grey (`0x6b6b6b`) so on-screen shadows look more natural.  
- Lowered default `CLOTH_QUALITY` values and reduced the adaptive mobile/high-DPR tiers (reduced `textureSize` and `anisotropy`) to cut texture load and memory pressure at startup.  
- Modified file: `webapp/src/pages/Games/PoolRoyale.jsx` (UV projection, shadow material color, and quality constants adjustments).

### Testing
- Ran `npm test -- --runTestsByPath test/poolRoyaleTableModels.test.js --runInBand` and the test suite passed.  
- The targeted Pool Royale table model tests in `test/poolRoyaleTableModels.test.js` completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151f464fcc832993023cb186059cc4)