### PR TITLE
Reduce Domino Royal seated human character size

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7988,8 +7988,8 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 3.4;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.45;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 2.95;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.2;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = -0.03;


### PR DESCRIPTION
### Motivation
- Make seated human characters visually smaller in the Domino Battle Royal arena so they are better balanced with the table and chairs on portrait (mobile) screens.

### Description
- Lowered the global seated character proportion by changing `DOMINO_CHARACTER_PROPORTION_SCALE` from `3.4` to `2.95` in `webapp/public/domino-royal-game.js`.
- Reduced the extra player-seat size boost by changing `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` from `0.45` to `0.2` in `webapp/public/domino-royal-game.js`.

### Testing
- Verified the edit with `git diff -- webapp/public/domino-royal-game.js`, which showed the two constants updated, and the diff succeeded.
- Committed the change with `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151e5c69088329a829c11c55651b33)