### PR TITLE
Domino Royal: increase chair size, shrink & push human seated avatar outward

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -983,7 +983,7 @@ const CHAIR_RADIUS =
   TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
 const CHAIR_GLOBAL_PUSHBACK = 0.09 * MODEL_SCALE;
 const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.14 * MODEL_SCALE;
-const CHAIR_VISUAL_SCALE = 0.46;
+const CHAIR_VISUAL_SCALE = 0.52;
 const CHAIR_VERTICAL_DROP = 0.055 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = LEGACY_BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
@@ -7989,13 +7989,14 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
   }
 ]);
 const DOMINO_CHARACTER_PROPORTION_SCALE = 2.95;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.2;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.6;
+const DOMINO_HUMAN_CHARACTER_VISUAL_SHRINK = 0.84;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = -0.03;
 // Slide only the AI/upper-seat characters inward so their hands sit closer to their domino racks.
 const DOMINO_CHARACTER_INWARD_DOMINO_REACH_BIAS = 0.14;
-const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0;
+const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.09;
 const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 1.68;
 const DOMINO_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = -0.08;
 const ENABLE_DOMINO_CHARACTER_HELD_RACKS = false;
@@ -8516,7 +8517,10 @@ function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   const isHumanSeat = seatIndex === HUMAN_SEAT_INDEX;
   const characterScale = DOMINO_CHARACTER_PROPORTION_SCALE +
     (isHumanSeat ? DOMINO_HUMAN_CHARACTER_SCALE_BOOST : 0);
-  const seatScale = (theme.scale || 1) * characterScale;
+  const seatScale =
+    (theme.scale || 1) *
+    characterScale *
+    (isHumanSeat ? DOMINO_HUMAN_CHARACTER_VISUAL_SHRINK : 1);
   const scaleDelta = Math.max(0, characterScale - 1);
   seatRoot.scale.setScalar(seatScale);
   seatRoot.position.copy(


### PR DESCRIPTION
### Motivation
- Improve on-screen composition for the Domino Battle Royal arena so the human seated avatar appears slightly smaller and visually pushed away from the table while chairs read as larger around the table.
- Keep seated human readability constraints intact while adjusting scale/positioning for portrait/mobile presentation.

### Description
- Updated `webapp/public/domino-royal-game.js` to raise `CHAIR_VISUAL_SCALE` from `0.46` to `0.52` so chairs render larger around the table.
- Added `DOMINO_HUMAN_CHARACTER_VISUAL_SHRINK = 0.84` and applied it when computing `seatScale` so the bottom (human) seated character appears smaller on screen.
- Increased `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` to `0.6` to preserve internal rig/readability math while applying the visual shrink separately.
- Nudged the human seat outward by changing `DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS` from `0` to `0.09` so the player sits slightly farther from the table.

### Testing
- Ran `npm test -- --runInBand test/dominoRoyalCharacterScale.test.js`; the first run failed due to a missing constant, the code was updated, and the final run passed.
- Final automated test result: `test/dominoRoyalCharacterScale.test.js` — PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152467a274832984ebb915556ad1be)