### PR TITLE
Raise tennis avatar vertically for better on-screen framing

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -1381,6 +1381,7 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
       rig.rest = captureRestPose(rig.bones);
       captureTennisLocomotionDefaultPose(model);
       rig.fallback.visible = false;
+      model.position.y += 0.08 * CFG.worldScale;
       rig.modelRoot.add(model);
       rig.modelRoot.updateMatrixWorld(true);
       rig.rightArmChain = makeArmChain(rig.bones.rightShoulder, rig.bones.rightUpperArm, rig.bones.rightForeArm, rig.bones.rightHand);


### PR DESCRIPTION
### Motivation
- Improve on-screen framing so vampire and other tennis avatars appear visually higher in portrait view by applying a small upward offset.

### Description
- Add `model.position.y += 0.08 * CFG.worldScale` inside the `addHuman` loader flow in `webapp/src/pages/Games/Tennis.tsx` after `captureTennisLocomotionDefaultPose(model)` and before the model is added to `modelRoot`.

### Testing
- Performed automated source inspection and file-diff verification to confirm the new line is present in `webapp/src/pages/Games/Tennis.tsx`, and the change was applied successfully (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1524cea698832992c89c5d2d9466a3)