### PR TITLE
Adjust Chess Battle Royal portrait framing and parked weapon visuals

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -226,8 +226,7 @@ const CHESS_CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   },
   assaultRifleAttack: {
     urls: ['https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb', 'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb'],
-    scale: 0.13,
-    textureOverrideUrls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg']
+    scale: 0.13
   },
   uziSprayAttack: {
     urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf'],
@@ -235,12 +234,7 @@ const CHESS_CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   },
   ak47VolleyAttack: {
     urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'],
-    scale: 0.24,
-    textureOverrideUrls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/textures/Material.001_baseColor.png',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/textures/Material.001_baseColor.png',
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg'
-    ]
+    scale: 0.24
   },
   krsvBurstAttack: {
     urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf'],
@@ -629,7 +623,7 @@ const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.42; // lift camera a bit hig
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.98; // mirror the slight upward lift for landscape framing.
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 1.35;
 const PLAYER_VIEW_LOOK_TARGET_UP_BIAS = 0.6; // increase upward aim so the table/pieces/opponent sit higher in view.
-const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 7.05; // shift arena lower so chairs/avatars/table sit farther toward the phone-bottom edge.
+const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 7.55; // shift arena lower so chairs/avatars/table sit farther toward the phone-bottom edge.
 const FPV_FACE_FORWARD_OFFSET = 0.012; // keep the camera almost exactly at the eyes for a true first-person perspective.
 const FPV_FACE_UP_OFFSET = 0.0; // slight lift so the board edge does not clip while still feeling eye-level.
 const FPV_LOOK_AHEAD_DISTANCE = BOARD.tile * BOARD_SCALE * 5.8; // prioritize looking down the board journey toward the opponent side.
@@ -3203,7 +3197,7 @@ const SHORT_PEDESTAL_SCALE_BY_SHAPE = Object.freeze({
   diamondEdge: 0.7
 });
 const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 20.5; // make parked jet/helicopter/drone read large beside the table
-const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -4.2; // push parked vehicles and parked weapons farther to the arena sides
+const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -2.85; // pull parked vehicles and parked weapons closer to the board side edges
 const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.12; // lower parked firearms/vehicles so the side lineup sits visually lower on the board area
 const SIDE_PARKED_AIR_UNITS_LANE_SPREAD = 2.22; // increase spacing between parking slots
 const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.22; // keep truck as prominent as the parked aircraft
@@ -4212,6 +4206,26 @@ function fitObjectToTargetSize(object, targetSize = 0.12) {
 
 function prepareChessCaptureWeaponClone(template, captureAnimationId, { flat = true, targetSize = null } = {}) {
   const clone = cloneSkinned(template);
+  if (captureAnimationId === 'ak47VolleyAttack') {
+    clone.updateMatrixWorld?.(true);
+    const bbox = getRenderableMeshBounds(clone) || new THREE.Box3().setFromObject(clone);
+    const yCutoff = bbox.min.y + (bbox.max.y - bbox.min.y) * 0.36;
+    const nodesToRemove = [];
+    clone.traverse((node) => {
+      if (!node?.isMesh) return;
+      const nodeName = String(node.name || '').toLowerCase();
+      const materials = Array.isArray(node.material) ? node.material : [node.material];
+      const hasWoodLabel =
+        /wood|stock|grip|handle/.test(nodeName) ||
+        materials.some((mat) => /wood|stock|grip|handle/.test(String(mat?.name || '').toLowerCase()));
+      if (!hasWoodLabel) return;
+      const nodeBox = new THREE.Box3().setFromObject(node);
+      if (Number.isFinite(nodeBox.max.y) && nodeBox.max.y <= yCutoff) {
+        nodesToRemove.push(node);
+      }
+    });
+    nodesToRemove.forEach((node) => node.parent?.remove(node));
+  }
   clone.traverse((node) => {
     if (!node?.isMesh) return;
     node.castShadow = true;


### PR DESCRIPTION
### Motivation
- Improve portrait mobile layout so the table, chairs, and seated humans sit closer to the bottom of the screen for better ergonomics and visibility.
- Move parked side weapons/vehicles visually closer to the board so their displays are more readable and less pushed off-screen.
- Restore original GLTF texturing for assault rifle and AK47 assets and re-introduce the previous AK47 appearance (remove the lower wooden stock) to match the configuration from five days ago.

### Description
- Updated `webapp/src/pages/Games/ChessBattleRoyal.jsx` to increase the bottom-screen arena bias by adjusting `TABLE_BOTTOM_PLAYER_BIAS_Z` so the table/chairs/humans render lower on portrait phones.
- Reduced side offset by changing `SIDE_PARKED_AIR_UNITS_INWARD_OFFSET` so parked vehicles and parked weapons are pulled closer to the board edges.
- Removed forced texture overrides from `assaultRifleAttack` and `ak47VolleyAttack` entries in `CHESS_CAPTURE_WEAPON_MODEL_CONFIG` so models use their original GLTF textures.
- Added AK47-specific cleanup in `prepareChessCaptureWeaponClone` to detect and remove lower wood/stock/grip mesh parts (by name/material heuristics and bounds) so the AK47 matches the previous wood-removed look when cloned.

### Testing
- Ran the production build with `npm --prefix webapp run -s build`, which completed successfully (Vite build finished without errors).
- Verified the modified file `webapp/src/pages/Games/ChessBattleRoyal.jsx` is the only source change in this PR and the build assets were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152cc6b1608329abb1d0f8a0dc7d9c)