### PR TITLE
Adjust chair layout and avatar scaling; bump Domino Royal script version

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -977,13 +977,13 @@ const COLUMN_RADIUS_BOTTOM = 0.26 * MODEL_SCALE;
 const BASE_RADIUS = 0.72 * MODEL_SCALE;
 const FOOT_RING_RADIUS = 0.52 * MODEL_SCALE;
 const FOOT_RING_TUBE = 0.04 * MODEL_SCALE;
-const CHAIR_GAP = -0.12 * MODEL_SCALE; // pull all chairs inward so they sit closer to the table edge
+const CHAIR_GAP = 0.03 * MODEL_SCALE; // keep top/bottom seats at their original table distance
 const CHAIR_OUTWARD_OFFSET = 0;
 const CHAIR_RADIUS =
   TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
-const CHAIR_GLOBAL_PUSHBACK = 0.09 * MODEL_SCALE;
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.14 * MODEL_SCALE;
-const CHAIR_VISUAL_SCALE = 0.58;
+const CHAIR_GLOBAL_PUSHBACK = 0.28 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.36 * MODEL_SCALE;
+const CHAIR_VISUAL_SCALE = 0.72;
 const CHAIR_VERTICAL_DROP = 0.055 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = LEGACY_BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
@@ -7988,15 +7988,14 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.7;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.45;
-const DOMINO_HUMAN_CHARACTER_VISUAL_SHRINK = 0.84;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 3.22;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 1.1;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = -0.03;
 // Slide only the AI/upper-seat characters inward so their hands sit closer to their domino racks.
 const DOMINO_CHARACTER_INWARD_DOMINO_REACH_BIAS = 0.14;
-const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.09;
+const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0;
 const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 1.68;
 const DOMINO_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = -0.08;
 const ENABLE_DOMINO_CHARACTER_HELD_RACKS = false;
@@ -8517,10 +8516,7 @@ function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   const isHumanSeat = seatIndex === HUMAN_SEAT_INDEX;
   const characterScale = DOMINO_CHARACTER_PROPORTION_SCALE +
     (isHumanSeat ? DOMINO_HUMAN_CHARACTER_SCALE_BOOST : 0);
-  const seatScale =
-    (theme.scale || 1) *
-    characterScale *
-    (isHumanSeat ? DOMINO_HUMAN_CHARACTER_VISUAL_SHRINK : 1);
+  const seatScale = (theme.scale || 1) * characterScale;
   const scaleDelta = Math.max(0, characterScale - 1);
   seatRoot.scale.setScalar(seatScale);
   seatRoot.position.copy(

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-18-pass-pick-hand-polish-v45';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-21-layout-size-baseline-v46';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation

- Improve seating layout and visual alignment of seated humans and AI characters so avatars sit correctly relative to chairs and domino racks.
- Increase character proportions and remove a visual shrink applied to human avatars to achieve better scale and presence at the table.
- Update the in-page game script version to reflect the new layout and sizing baseline.

### Description

- Modified chair geometry and positioning constants in `webapp/public/domino-royal-game.js`, including `CHAIR_GAP`, `CHAIR_GLOBAL_PUSHBACK`, `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK`, and `CHAIR_VISUAL_SCALE` to change seat distance and visual scale around the table. 
- Increased character sizing values by changing `DOMINO_CHARACTER_PROPORTION_SCALE` and `DOMINO_HUMAN_CHARACTER_SCALE_BOOST`, removed the previous human visual shrink factor, and set `DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS` to `0` to align humans to their chair footprints. 
- Adjusted how seat scale is computed by removing the conditional visual shrink for humans so `seatScale` uses `(theme.scale || 1) * characterScale` for all seats. 
- Bumped the script version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-05-21-layout-size-baseline-v46`.

### Testing

- Ran the repository test suite with `yarn test`, which completed successfully. 
- Built the web application with `yarn build`, which succeeded and produced the updated bundle. 
- Verified automated linting with `yarn lint`, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152d3c90b08329a3da57424eb2d1d6)