### PR TITLE
Align Pool Royale base asset loading with Snooker fallback caching

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13848,7 +13848,8 @@ function mountPoolRoyaleExternalTableModel({
 
   const ensurePolyhavenBaseTemplate = (assetId, renderer = null) => {
     if (!assetId) {
-      return Promise.reject(new Error('Missing Poly Haven asset id'));
+      console.warn('Pool Royale base asset missing; falling back to default base.');
+      return Promise.resolve(null);
     }
     if (polyhavenBaseTemplates.has(assetId)) {
       return Promise.resolve(polyhavenBaseTemplates.get(assetId));
@@ -13872,10 +13873,12 @@ function mountPoolRoyaleExternalTableModel({
           lastError = error;
         }
       }
-      throw lastError || new Error(`Failed to load Poly Haven model: ${assetId}`);
+      console.warn('Failed to load Poly Haven base; using fallback.', lastError);
+      polyhavenBaseTemplates.set(assetId, null);
+      return null;
     })();
     polyhavenBasePromises.set(assetId, promise);
-    promise.catch(() => polyhavenBasePromises.delete(assetId));
+    promise.finally(() => polyhavenBasePromises.delete(assetId));
     return promise;
   };
 


### PR DESCRIPTION
### Motivation
- Make Pool Royale's Poly Haven model loading resilient to missing or failing remote assets by matching Snooker Royal's fallback and caching behavior to avoid stalls and repeated expensive retries.

### Description
- Update `ensurePolyhavenBaseTemplate` in `PoolRoyale.jsx` so a missing `assetId` returns `null` (with a warning) instead of rejecting, cache `null` on failed loads to prevent retried fetch storms, and always clear the in-flight promise cache with `finally`.

### Testing
- No automated tests were executed for this change; the patch was applied and committed successfully and the modified lines were inspected to verify the new fallback/caching logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152bff75448329b8b5b1e740276c14)