### PR TITLE
Adjust chair and character scales and seating offsets for domino avatars

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -983,7 +983,7 @@ const CHAIR_RADIUS =
   TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
 const CHAIR_GLOBAL_PUSHBACK = 0.09 * MODEL_SCALE;
 const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.14 * MODEL_SCALE;
-const CHAIR_VISUAL_SCALE = 0.58;
+const CHAIR_VISUAL_SCALE = 0.46;
 const CHAIR_VERTICAL_DROP = 0.055 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = LEGACY_BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
@@ -7988,15 +7988,14 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.7;
-const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.45;
-const DOMINO_HUMAN_CHARACTER_VISUAL_SHRINK = 0.84;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 3.8;
+const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 1.35;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.
 const DOMINO_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = -0.03;
 // Slide only the AI/upper-seat characters inward so their hands sit closer to their domino racks.
 const DOMINO_CHARACTER_INWARD_DOMINO_REACH_BIAS = 0.14;
-const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0.09;
+const DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS = 0;
 const DOMINO_CHARACTER_EXTRA_LOWER_OFFSET = 1.68;
 const DOMINO_HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = -0.08;
 const ENABLE_DOMINO_CHARACTER_HELD_RACKS = false;
@@ -8517,10 +8516,7 @@ function attachDominoCharacterToChair(template, chair, seatIndex, player) {
   const isHumanSeat = seatIndex === HUMAN_SEAT_INDEX;
   const characterScale = DOMINO_CHARACTER_PROPORTION_SCALE +
     (isHumanSeat ? DOMINO_HUMAN_CHARACTER_SCALE_BOOST : 0);
-  const seatScale =
-    (theme.scale || 1) *
-    characterScale *
-    (isHumanSeat ? DOMINO_HUMAN_CHARACTER_VISUAL_SHRINK : 1);
+  const seatScale = (theme.scale || 1) * characterScale;
   const scaleDelta = Math.max(0, characterScale - 1);
   seatRoot.scale.setScalar(seatScale);
   seatRoot.position.copy(


### PR DESCRIPTION
### Motivation

- Make seated chairs and avatar models visually consistent with the table by updating scale factors and seating offsets.
- Remove the prior human visual shrink so human avatars render at a corrected scale relative to chair footprints.
- Reduce human avatar outward offset so seat alignment and hand placement better match the chair geometry.

### Description

- Reduced chair visual scale by changing `CHAIR_VISUAL_SCALE` from `0.58` to `0.46` to alter chair appearance relative to the table.
- Increased global character sizing by changing `DOMINO_CHARACTER_PROPORTION_SCALE` from `2.7` to `3.8` and raised the human seat boost `DOMINO_HUMAN_CHARACTER_SCALE_BOOST` from `0.45` to `1.35` to enlarge avatars.
- Removed `DOMINO_HUMAN_CHARACTER_VISUAL_SHRINK` and stopped applying a separate shrink to human seats by simplifying `seatScale` calculation in `attachDominoCharacterToChair` to `const seatScale = (theme.scale || 1) * characterScale;`.
- Cleared the human chair outward bias by changing `DOMINO_HUMAN_CHARACTER_CHAIR_SEAT_OUTWARD_BIAS` from `0.09` to `0` so human avatars sit directly on the chair footprint.

### Testing

- Ran linting with `npm run lint` which completed without errors.
- Ran the unit test suite with `npm test` and all tests passed.
- Built the web client with `npm run build` and validated the bundle built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152d3c90b08329a3da57424eb2d1d6)