### PR TITLE
Align Pool Royale graphics loading, table scale, and cushion UV mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -122,7 +122,7 @@ import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -1150,7 +1150,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.86; // make the table read just a bit larger in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.8; // shrink the rendered table in portrait so gameplay mapping has more breathing room
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -5681,9 +5681,8 @@ function updateClothTexturesForFinish (
       finishInfo.cushionMat.bumpScale = finishInfo.clothBase.baseBumpScale;
     }
     if (finishInfo.cushionMat.userData) {
-      // Keep native cushion UVs so side faces keep the same weave/texture family
-      // as the cushion top instead of being remapped like wood rails.
-      finishInfo.cushionMat.userData.preserveOriginalUvMapping = true;
+      // Align side-cushion mapping with short-rail cushion mapping so the same cloth texture reads consistently on all rails.
+      finishInfo.cushionMat.userData.preserveOriginalUvMapping = false;
     }
   }
   if (finishInfo.clothEdgeMat) {


### PR DESCRIPTION
### Motivation
- Align Pool Royale's graphics and geometry decoding with Snooker Royal by using the same versioned Draco decoder to reduce loading differences and inconsistencies.
- Reduce the on-screen table footprint so portrait gameplay mapping and aiming align better with the visual table.
- Make side-cushion textures read identically to short-rail cushions so the cloth appearance is consistent across rails.

### Description
- Updated `DRACO_DECODER_PATH` in `webapp/src/pages/Games/PoolRoyale.jsx` to `https://www.gstatic.com/draco/versioned/decoders/1.5.7/` to match the Snooker Royal loading pattern.
- Reduced `TABLE_DISPLAY_SCALE` from `0.86` to `0.8` to shrink the rendered table footprint for portrait gameplay.
- Set `finishInfo.cushionMat.userData.preserveOriginalUvMapping = false` (and updated the inline comment) so side cushions use the same cloth mapping as short rails for consistent textures.

### Testing
- Ran the production build with `npm -C webapp run -s build`, which completed successfully and produced the expected build artifacts.
- No unit/integration tests were changed and build-only validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15322b25948329b3c8ae7bb418844f)