### PR TITLE
Align Pool Royale GLTF loading, tighten table scale, and unify cushion UV mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -122,7 +122,7 @@ import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -1386,7 +1386,7 @@ const END_RAIL_INNER_SCALE =
   (2 * TABLE.WALL);
 const END_RAIL_INNER_REDUCTION = 1 - END_RAIL_INNER_SCALE;
 const END_RAIL_INNER_THICKNESS = TABLE.WALL * END_RAIL_INNER_SCALE;
-const PLAYFIELD_SHRINK = 0.85; // shrink the playfield footprint by ~15% on all sides while keeping table height intact
+const PLAYFIELD_SHRINK = 0.83; // shrink the playfield footprint a bit more to better match gameplay mapping while keeping table height intact
 const PLAY_W = (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
 const PLAY_H = (TABLE.H - 2 * END_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
 export const POOL_ROYALE_TABLE_DIMENSIONS = Object.freeze({
@@ -5683,7 +5683,7 @@ function updateClothTexturesForFinish (
     if (finishInfo.cushionMat.userData) {
       // Keep native cushion UVs so side faces keep the same weave/texture family
       // as the cushion top instead of being remapped like wood rails.
-      finishInfo.cushionMat.userData.preserveOriginalUvMapping = true;
+      finishInfo.cushionMat.userData.preserveOriginalUvMapping = false;
     }
   }
   if (finishInfo.clothEdgeMat) {
@@ -9616,7 +9616,7 @@ export function Table3D(
   cushionMat.side = THREE.DoubleSide;
   cushionMat.userData = {
     ...(cushionMat.userData || {}),
-    preserveOriginalUvMapping: true
+    preserveOriginalUvMapping: false
   };
   const clothEdgeMat = clothMat.clone();
   clothEdgeMat.color.copy(clothColor);


### PR DESCRIPTION
### Motivation
- Make Pool Royale use the same GLTF decoding approach as Snooker Royal to improve model loading consistency and avoid decoder mismatches.
- Slightly reduce the playfield footprint so the visual table size better matches gameplay mapping and aiming overlays.
- Ensure side cushions share the same texture/UV projection behavior as short-rail cushions so cloth and cushion textures look consistent.

### Description
- Update `DRACO_DECODER_PATH` in `webapp/src/pages/Games/PoolRoyale.jsx` to the versioned decoder URL `https://www.gstatic.com/draco/versioned/decoders/1.5.7/` to match Snooker Royal loader behavior.
- Reduce the playfield shrink factor by changing `PLAYFIELD_SHRINK` from `0.85` to `0.83` to make the table visually a bit smaller and align the playfield mapping.
- Disable preserved original cushion UV mapping by setting `preserveOriginalUvMapping` to `false` where side/short-rail cushion materials are configured so side cushions use the same cloth projection as short rails.

### Testing
- No automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15322b25948329b3c8ae7bb418844f)