### PR TITLE
Increase Domino chair and seated character scale slightly

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -983,7 +983,7 @@ const CHAIR_RADIUS =
   TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
 const CHAIR_GLOBAL_PUSHBACK = 0.28 * MODEL_SCALE;
 const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.36 * MODEL_SCALE;
-const CHAIR_VISUAL_SCALE = 1.06;
+const CHAIR_VISUAL_SCALE = 1.12;
 const CHAIR_VERTICAL_DROP = 0.035 * MODEL_SCALE;
 const CHAIR_BASE_HEIGHT = LEGACY_BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
@@ -7988,7 +7988,7 @@ const DOMINO_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xe3b08b
   }
 ]);
-const DOMINO_CHARACTER_PROPORTION_SCALE = 2.4;
+const DOMINO_CHARACTER_PROPORTION_SCALE = 2.5;
 const DOMINO_HUMAN_CHARACTER_SCALE_BOOST = 0.63;
 // Seat avatars from the chair footprint instead of adding a table-facing Z offset.
 // This keeps every human visually aligned with the chair that owns the seat.

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-26-human-smaller-chair-bigger-v48';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-26-chair-human-slightly-bigger-v49';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Improve visual readability on portrait mobile by making Domino table chairs and seated human characters slightly larger so they appear closer and more prominent on screen.

### Description
- Raise `CHAIR_VISUAL_SCALE` from `1.06` to `1.12` in `webapp/public/domino-royal-game.js` to scale up rendered chairs. 
- Increase `DOMINO_CHARACTER_PROPORTION_SCALE` from `2.4` to `2.5` in `webapp/public/domino-royal-game.js` so seated human avatars appear a bit larger.
- Bump the Domino Royal script cache/version string to `'2026-05-26-chair-human-slightly-bigger-v49'` in `webapp/src/pages/Games/DominoRoyalArena.jsx` so clients fetch the updated bundle immediately.

### Testing
- Verified the changes by searching for the updated constants with `rg -n "DOMINO_ROYAL_SCRIPT_VERSION|CHAIR_VISUAL_SCALE|DOMINO_CHARACTER_PROPORTION_SCALE"` which returned the modified locations successfully. 
- Confirmed the working tree and committed the changes with `git commit`, which completed successfully. 
- No full unit/integration test suite was executed as part of this change; manual verification via the grep/commit checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1564ab511483298e45966a93408250)