### PR TITLE
Tune Pool Royal cushion, rail sight, and side apron material response

### DIFF
--- a/frontend/src/pool-royale/SevenFootShowoodPreview.tsx
+++ b/frontend/src/pool-royale/SevenFootShowoodPreview.tsx
@@ -419,7 +419,34 @@ function applyMaterial(material: WorkingMaterial, part: TablePart, option: Color
   if (part === "cushion" && cushionShadow) {
     material.color.set(CUSHION_SHADOW_GREY); material.metalness = 0; material.roughness = 0.96; material.envMapIntensity = 0.22; material.clearcoat = 0; material.clearcoatRoughness = 0; clearMaps(material);
   } else {
-    material.color.set(option.color); material.metalness = option.metalness; material.roughness = option.roughness; material.envMapIntensity = option.envMapIntensity; material.clearcoat = option.clearcoat ?? 0; material.clearcoatRoughness = option.clearcoatRoughness ?? 0;
+    const tunedColor = new THREE.Color(option.color);
+    let tunedMetalness = option.metalness;
+    let tunedRoughness = option.roughness;
+    let tunedEnv = option.envMapIntensity;
+    let tunedClearcoat = option.clearcoat ?? 0;
+    let tunedClearcoatRoughness = option.clearcoatRoughness ?? 0;
+
+    if (part === "cushion") {
+      tunedColor.multiplyScalar(1.06);
+      tunedRoughness = Math.min(1, tunedRoughness + 0.02);
+      tunedEnv *= 0.86;
+    } else if (part === "railSight") {
+      tunedColor.offsetHSL(0, -0.02, 0.03);
+      tunedMetalness = Math.max(tunedMetalness, 0.98);
+      tunedRoughness = Math.max(0.035, tunedRoughness - 0.015);
+      tunedEnv *= 1.16;
+      tunedClearcoat = Math.max(tunedClearcoat, 1);
+      tunedClearcoatRoughness = Math.max(0.02, tunedClearcoatRoughness - 0.01);
+    } else if (part === "sideWoodApron") {
+      tunedColor.offsetHSL(0, -0.08, -0.06);
+      tunedMetalness = Math.max(0.78, tunedMetalness - 0.2);
+      tunedRoughness = Math.min(0.22, tunedRoughness + 0.06);
+      tunedEnv *= 0.74;
+      tunedClearcoat = Math.min(tunedClearcoat, 0.55);
+      tunedClearcoatRoughness = Math.max(0.08, tunedClearcoatRoughness);
+    }
+
+    material.color.copy(tunedColor); material.metalness = tunedMetalness; material.roughness = tunedRoughness; material.envMapIntensity = tunedEnv; material.clearcoat = tunedClearcoat; material.clearcoatRoughness = tunedClearcoatRoughness;
     if (!KEEP_TEXTURE_PARTS.has(part)) clearMaps(material);
   }
   material.transparent = false; material.opacity = 1; material.depthWrite = true; material.userData.part = part; material.userData.cushionShadow = cushionShadow; patchMaterial(material);


### PR DESCRIPTION
### Motivation
- The table preview visuals for Pool Royal needed per-part material tuning so cushions, rail sights, and the side apron match the photographed/reference look. 
- The change should refine final appearance without altering the existing palette controls or geometry classification logic.

### Description
- Updated `applyMaterial` in `frontend/src/pool-royale/SevenFootShowoodPreview.tsx` to compute a tuned color and tuned material parameters before applying them. 
- Added special-case adjustments for `part === "cushion"` (brighter, slightly rougher, lower env intensity), `part === "railSight"` (more metallic, lower roughness, higher env/clearcoat), and `part === "sideWoodApron"` (darker, less mirror-like, adjusted clearcoat). 
- Preserved existing texture-keeping logic (`KEEP_TEXTURE_PARTS`) and the overall palette system while applying the tuned material values using `THREE.Color` and working material properties.

### Testing
- Built the frontend bundle with `cd frontend && npm run -s build`, and the build completed successfully. 
- The build emitted non-blocking Vite warnings about bundle size and externalized Node shims but produced a valid distribution output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16607bc4c88329b23fc7695e427f43)