### PR TITLE
Domino Royal: nudge top/side opponent domino racks higher and inward

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6723,22 +6723,23 @@ const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
 const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.0025; // keep chain tiles touching without visible overlap
 const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
-// Keep player-hand dominoes compact while nudging opponent hands slightly
-// higher and farther outward; the bottom player's hand anchor stays fixed.
+// Keep player-hand dominoes compact while nudging opponent hands
+// slightly higher and slightly inward (closer to the table center);
+// the bottom player's hand anchor stays fixed.
 const PLAYER_HAND_TILE_SCALE = 0.9;
 const HUMAN_PLAYER_HAND_TILE_SCALE = 0.74;
 const PLAYER_HAND_GAP_SCALE = 0.5;
 const PLAYER_HAND_MIN_GAP_SCALE = 0.76;
 const PLAYER_HAND_OPPONENT_MIN_GAP_SCALE = 0.8;
-const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 4.28;
+const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 4.16;
 const PLAYER_HAND_OPPONENT_OUTWARD_EXTRA = DOMINO_WIDTH * -0.04;
-const PLAYER_HAND_SIDE_OUTWARD_EXTRA = DOMINO_WIDTH * -0.02;
+const PLAYER_HAND_SIDE_OUTWARD_EXTRA = DOMINO_WIDTH * -0.05;
 // Only non-bottom racks move outward: keep the bottom player's dominoes untouched.
-const PLAYER_HAND_TOP_OUTWARD_EXTRA = DOMINO_WIDTH * -0.02;
+const PLAYER_HAND_TOP_OUTWARD_EXTRA = DOMINO_WIDTH * -0.06;
 const PLAYER_HAND_SIDE_EDGE_OUTWARD_EXTRA = DOMINO_WIDTH * -0.01;
 const HUMAN_PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 4.34;
 const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 3.84;
-const PLAYER_HAND_OPPONENT_VERTICAL_EXTRA = DOMINO_WIDTH * 0.28;
+const PLAYER_HAND_OPPONENT_VERTICAL_EXTRA = DOMINO_WIDTH * 0.4;
 const PLAYER_HAND_CENTER_VERTICAL_DROP = DOMINO_WIDTH * 2.7;
 const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 4.42;
 const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.0;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-26-domino-opponents-higher-closer-v59';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-27-domino-opponents-higher-closer-v60';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',


### PR DESCRIPTION
### Motivation
- Small portrait-focused visual tweak to bring opponent players' domino tiles (top/left/right) slightly higher and closer to the table center so they read better on phone in portrait; the bottom player's dominoes remain unchanged.

### Description
- Tuned layout constants in `webapp/public/domino-royal-game.js` by adjusting `PLAYER_HAND_OUTWARD_OFFSET`, `PLAYER_HAND_SIDE_OUTWARD_EXTRA`, `PLAYER_HAND_TOP_OUTWARD_EXTRA`, and `PLAYER_HAND_OPPONENT_VERTICAL_EXTRA` to make opponent racks appear a bit higher and more inward.
- Bumped the Domino Royal script cache/version key in `webapp/src/pages/Games/DominoRoyalArena.jsx` so the updated runtime is loaded immediately.

### Testing
- No automated tests were run for this small visual layout change; the update is intended for visual QA on a portrait mobile device.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1667f9b45c8329a0f6906dd3ae0660)