### PR TITLE
Adjust Pool Royale default cushions and rail/apron accents

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4322,9 +4322,9 @@ const SHOWOOD_TABLE_CONTROL_PARTS = Object.freeze({
   legBase: ['leg', 'baseCornerBlock', 'underside']
 });
 const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
-  cloth: 'green',
-  cushion: 'green',
-  metalAccent: 'gold',
+  cloth: 'blue',
+  cushion: 'blue',
+  metalAccent: 'chrome',
   jaws: 'black',
   topWoodRail: 'brown',
   legBase: 'black'


### PR DESCRIPTION
### Motivation
- Bring the default Showood Pool Royale table appearance closer to the provided screenshot by changing the visible table finishes. 
- Specifically adjust cushions, rail sights and the side apron so the in-game look matches the requested visual target. 

### Description
- Updated `DEFAULT_SHOWOOD_TABLE_STYLE` in `webapp/src/pages/Games/PoolRoyale.jsx` to set `cloth` to `blue`, `cushion` to `blue`, and `metalAccent` to `chrome`. 
- These defaults affect the linked `metalAccent` control group which includes `railSight` and `sideWoodApron`, so rail sights and side apron now default to chrome. 
- Committed the single-file change and preserved existing palette/options entries for the Showood table. 

### Testing
- Ran `npm test -- test/poolRoyaleTableModels.test.js` and the suite passed. 
- The specific test run reported 6 tests passed (all matching tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16607bc4c88329b23fc7695e427f43)