### PR TITLE
Refactor pool table preview to procedural material mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyalGameTable.tsx
+++ b/webapp/src/pages/Games/PoolRoyalGameTable.tsx
@@ -11,10 +11,9 @@ import { MeshoptDecoder } from "three/examples/jsm/libs/meshopt_decoder.module.j
 
 const TABLE_MODEL_URL =
   "https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb";
-
 const DRACO_DECODER_PATH = "https://www.gstatic.com/draco/versioned/decoders/1.5.7/";
 const BASIS_TRANSCODER_PATH = "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/";
-const CUSHION_SHADOW_GREY = "#2f353f";
+const CUSHION_SHADOW_GREY = "#666a72";
 
 type TablePart =
   | "cloth"
@@ -32,8 +31,9 @@ type TablePart =
   | "railSight"
   | "underside";
 
+type ControlPart = "cloth" | "cushion" | "metalAccent" | "jaws" | "topWoodRail" | "legBase";
 type ChoiceKey = "a" | "b";
-type Palette = Record<TablePart, ChoiceKey>;
+type Palette = Record<ControlPart, ChoiceKey>;
 type WorkingMaterial = THREE.MeshPhysicalMaterial;
 type MaterialBuckets = Record<TablePart, WorkingMaterial[]>;
 
@@ -52,12 +52,6 @@ type ColorOption = {
   envMapIntensity: number;
   clearcoat?: number;
   clearcoatRoughness?: number;
-};
-
-type PartMeta = {
-  label: string;
-  description: string;
-  keepSourceTexture: boolean;
 };
 
 type MaterialSnapshot = {
@@ -87,7 +81,7 @@ type TriangleRecord = {
   c: number;
   sourceMaterialIndex: number;
   sourceSlot: string;
-  spatialPart: TablePart;
+  part: TablePart;
   cushionShadow: boolean;
 };
 
@@ -130,18 +124,69 @@ const TABLE_PARTS: TablePart[] = [
   "underside",
 ];
 
-const CONTROL_PARTS: TablePart[] = [
-  "cloth",
-  "cushion",
-  "topWoodRail",
-  "railSight",
-  "pocketCup",
-  "verticalCornerRim",
-  "baseCornerBlock",
-  "leg",
-];
+const CONTROL_PARTS: ControlPart[] = ["cloth", "cushion", "metalAccent", "jaws", "topWoodRail", "legBase"];
 
-const ALWAYS_SPATIAL_PARTS = new Set<TablePart>([
+const CONTROL_META: Record<ControlPart, { label: string; description: string }> = {
+  cloth: { label: "Field cloth", description: "Only the flat playfield surface." },
+  cushion: {
+    label: "Cushions",
+    description: "All cushion faces use the same cloth-like finish. Underside shadow faces stay grey.",
+  },
+  metalAccent: {
+    label: "Rail sights + side strip + feet",
+    description: "One gold/chrome control for rail sights, side apron strip, vertical rims, trims, plates, and feet.",
+  },
+  jaws: { label: "Jaws", description: "Pocket jaws / cups: black or brown." },
+  topWoodRail: { label: "Top rail frame", description: "Main top wood rail frame." },
+  legBase: { label: "Legs + base", description: "Legs and lower base blocks together, separate from metal accents." },
+};
+
+const CONTROL_OPTIONS: Record<ControlPart, Record<ChoiceKey, ColorOption>> = {
+  cloth: {
+    a: { label: "Green field", color: "#0a7b33", metalness: 0, roughness: 1, envMapIntensity: 0.16 },
+    b: { label: "Blue field", color: "#0d4fb8", metalness: 0, roughness: 1, envMapIntensity: 0.16 },
+  },
+  cushion: {
+    a: { label: "Green cushions", color: "#0a7b33", metalness: 0, roughness: 0.97, envMapIntensity: 0.14 },
+    b: { label: "Blue cushions", color: "#0d4fb8", metalness: 0, roughness: 0.97, envMapIntensity: 0.14 },
+  },
+  metalAccent: {
+    a: { label: "Gold", color: "#d8b23d", metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 },
+    b: { label: "Chrome", color: "#d7dde7", metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 },
+  },
+  jaws: {
+    a: { label: "Black jaws", color: "#020202", metalness: 0, roughness: 0.96, envMapIntensity: 0.14 },
+    b: { label: "Brown jaws", color: "#2a1207", metalness: 0, roughness: 0.88, envMapIntensity: 0.26 },
+  },
+  topWoodRail: {
+    a: { label: "Walnut frame", color: "#5a2608", metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 },
+    b: { label: "Black frame", color: "#070605", metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 },
+  },
+  legBase: {
+    a: { label: "Brown legs/base", color: "#3d1706", metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 },
+    b: { label: "Black legs/base", color: "#070504", metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 },
+  },
+};
+
+const PART_TO_CONTROL: Record<TablePart, ControlPart> = {
+  cloth: "cloth",
+  cushion: "cushion",
+  topWoodRail: "topWoodRail",
+  sideWoodApron: "metalAccent",
+  pocketCup: "jaws",
+  cornerPocketPlate: "metalAccent",
+  middlePocketPlate: "metalAccent",
+  verticalCornerRim: "metalAccent",
+  baseCornerBlock: "legBase",
+  leg: "legBase",
+  baseFoot: "metalAccent",
+  lowerTrim: "metalAccent",
+  railSight: "metalAccent",
+  underside: "legBase",
+};
+
+const KEEP_TEXTURE_PARTS = new Set<TablePart>(["topWoodRail", "leg", "baseCornerBlock", "underside"]);
+const FINE_PARTS = new Set<TablePart>([
   "pocketCup",
   "cornerPocketPlate",
   "middlePocketPlate",
@@ -149,153 +194,17 @@ const ALWAYS_SPATIAL_PARTS = new Set<TablePart>([
   "baseCornerBlock",
   "lowerTrim",
   "railSight",
-  "sideWoodApron",
   "underside",
 ]);
 
-const LINKED_TO_RAIL_SIGHT = new Set<TablePart>(["sideWoodApron", "railSight"]);
-const LINKED_TO_CORNER_RIM = new Set<TablePart>(["baseFoot", "verticalCornerRim"]);
-
-const PART_META: Record<TablePart, PartMeta> = {
-  cloth: {
-    label: "Field cloth",
-    description: "Uses original table slots first, then keeps a geometry split only when the cloth/cushion slot is mixed.",
-    keepSourceTexture: false,
-  },
-  cushion: {
-    label: "Cushions",
-    description: "Raised inner rail bands using cloth texture continuity. Cushion underside shadows use a darker tone.",
-    keepSourceTexture: true,
-  },
-  topWoodRail: {
-    label: "Top rails",
-    description: "Horizontal wood rail tops.",
-    keepSourceTexture: true,
-  },
-  sideWoodApron: {
-    label: "Side apron",
-    description: "Linked to the Side apron + rail sights option.",
-    keepSourceTexture: false,
-  },
-  pocketCup: {
-    label: "Pocket cups",
-    description: "Dark pocket holes and cup interiors.",
-    keepSourceTexture: true,
-  },
-  cornerPocketPlate: {
-    label: "Corner plates",
-    description: "Hidden option, internal default only.",
-    keepSourceTexture: false,
-  },
-  middlePocketPlate: {
-    label: "Side plates",
-    description: "Hidden option, internal default only.",
-    keepSourceTexture: false,
-  },
-  verticalCornerRim: {
-    label: "Corner rims + rounded feet",
-    description: "Controls the original 4 outside vertical base-corner rim strips and the rounded feet below the actual feet.",
-    keepSourceTexture: false,
-  },
-  baseCornerBlock: {
-    label: "Base corners",
-    description: "Corner/base pieces under the apron. Default black and editable.",
-    keepSourceTexture: false,
-  },
-  leg: {
-    label: "Legs",
-    description: "Vertical wooden supports.",
-    keepSourceTexture: true,
-  },
-  baseFoot: {
-    label: "Rounded feet",
-    description: "Hidden row. Controlled by Corner rims + rounded feet.",
-    keepSourceTexture: false,
-  },
-  lowerTrim: {
-    label: "Lower trim",
-    description: "Hidden option, internal default only.",
-    keepSourceTexture: false,
-  },
-  railSight: {
-    label: "Side apron + rail sights",
-    description: "Linked option for the side apron and rail sight dots.",
-    keepSourceTexture: false,
-  },
-  underside: {
-    label: "Underside",
-    description: "Hidden option, internal default only.",
-    keepSourceTexture: true,
-  },
+const DEFAULT_PALETTE: Palette = {
+  cloth: "a",
+  cushion: "a",
+  metalAccent: "a",
+  jaws: "a",
+  topWoodRail: "a",
+  legBase: "b",
 };
-
-const PART_OPTIONS: Record<TablePart, Record<ChoiceKey, ColorOption>> = {
-  cloth: {
-    a: { label: "Clean green field", color: "#0a7b33", metalness: 0, roughness: 1, envMapIntensity: 0.16 },
-    b: { label: "Clean blue field", color: "#0d4fb8", metalness: 0, roughness: 1, envMapIntensity: 0.16 },
-  },
-  cushion: {
-    a: { label: "Green cushions", color: "#064f23", metalness: 0, roughness: 0.94, envMapIntensity: 0.24 },
-    b: { label: "Black cushions", color: "#050505", metalness: 0, roughness: 0.88, envMapIntensity: 0.38 },
-  },
-  topWoodRail: {
-    a: { label: "Walnut rails", color: "#5a2608", metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 },
-    b: { label: "Black rails", color: "#070605", metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 },
-  },
-  sideWoodApron: {
-    a: { label: "Gold side apron", color: "#d8a928", metalness: 0.9, roughness: 0.11, envMapIntensity: 5.9, clearcoat: 1, clearcoatRoughness: 0.045 },
-    b: { label: "Black side apron", color: "#050505", metalness: 0.82, roughness: 0.17, envMapIntensity: 3.15, clearcoat: 1, clearcoatRoughness: 0.07 },
-  },
-  pocketCup: {
-    a: { label: "Black cups", color: "#000000", metalness: 0, roughness: 0.98, envMapIntensity: 0.12 },
-    b: { label: "Dark leather cups", color: "#1b0c04", metalness: 0, roughness: 0.9, envMapIntensity: 0.26 },
-  },
-  cornerPocketPlate: {
-    a: { label: "Gold corners", color: "#f7c943", metalness: 1, roughness: 0.045, envMapIntensity: 8.4, clearcoat: 1, clearcoatRoughness: 0.025 },
-    b: { label: "Black corners", color: "#050505", metalness: 0.9, roughness: 0.11, envMapIntensity: 4.2, clearcoat: 1, clearcoatRoughness: 0.045 },
-  },
-  middlePocketPlate: {
-    a: { label: "Black side plates", color: "#050505", metalness: 0.88, roughness: 0.12, envMapIntensity: 4, clearcoat: 1, clearcoatRoughness: 0.05 },
-    b: { label: "Gold side plates", color: "#f7c943", metalness: 1, roughness: 0.045, envMapIntensity: 8.4, clearcoat: 1, clearcoatRoughness: 0.025 },
-  },
-  verticalCornerRim: {
-    a: { label: "Gold rims + feet", color: "#d8b23d", metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 },
-    b: { label: "Chrome rims + feet", color: "#d7dde7", metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 },
-  },
-  baseCornerBlock: {
-    a: { label: "Walnut corners", color: "#7b2d11", metalness: 0.02, roughness: 0.48, envMapIntensity: 1.1, clearcoat: 0.22, clearcoatRoughness: 0.33 },
-    b: { label: "Black corners", color: "#080605", metalness: 0.03, roughness: 0.38, envMapIntensity: 1.34, clearcoat: 0.34, clearcoatRoughness: 0.22 },
-  },
-  leg: {
-    a: { label: "Walnut legs", color: "#3d1706", metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 },
-    b: { label: "Black legs", color: "#070504", metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 },
-  },
-  baseFoot: {
-    a: { label: "Gold rounded feet", color: "#d8b23d", metalness: 1, roughness: 0.065, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 },
-    b: { label: "Chrome rounded feet", color: "#d7dde7", metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 },
-  },
-  lowerTrim: {
-    a: { label: "Gold trim", color: "#d8b23d", metalness: 0.94, roughness: 0.085, envMapIntensity: 5.8, clearcoat: 1, clearcoatRoughness: 0.04 },
-    b: { label: "Black trim", color: "#070707", metalness: 0.82, roughness: 0.15, envMapIntensity: 3.2, clearcoat: 1, clearcoatRoughness: 0.07 },
-  },
-  railSight: {
-    a: { label: "Gold apron + gold sights", color: "#f5d978", metalness: 1, roughness: 0.065, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 },
-    b: { label: "Black apron + black sights", color: "#050505", metalness: 0.82, roughness: 0.16, envMapIntensity: 3, clearcoat: 1, clearcoatRoughness: 0.07 },
-  },
-  underside: {
-    a: { label: "Dark underside", color: "#1e130b", metalness: 0.01, roughness: 0.72, envMapIntensity: 0.58 },
-    b: { label: "Black underside", color: "#050505", metalness: 0.02, roughness: 0.62, envMapIntensity: 0.82 },
-  },
-};
-
-const DEFAULT_PALETTE: Palette = TABLE_PARTS.reduce((acc, part) => {
-  acc[part] = "a";
-  return acc;
-}, {} as Palette);
-
-DEFAULT_PALETTE.baseCornerBlock = "b";
-DEFAULT_PALETTE.verticalCornerRim = "a";
-DEFAULT_PALETTE.baseFoot = "a";
 
 const EMPTY_COUNTS: Counts = {
   cloth: 0,
@@ -318,30 +227,19 @@ const EMPTY_COUNTS: Counts = {
   triangleGroups: 0,
 };
 
-function createMaterialBuckets(): MaterialBuckets {
-  return TABLE_PARTS.reduce((acc, part) => {
+const createBuckets = (): MaterialBuckets =>
+  TABLE_PARTS.reduce((acc, part) => {
     acc[part] = [];
     return acc;
   }, {} as MaterialBuckets);
-}
 
-function cleanName(value?: string | null) {
-  return (value || "unnamed").replace(/\s+/g, "_").toLowerCase();
-}
+const cleanName = (value?: string | null) => (value || "unnamed").replace(/\s+/g, "_").toLowerCase();
 
-function makeSlotKey(mesh: THREE.Mesh, sourceMaterialIndex: number, material: THREE.Material) {
-  return `${cleanName(mesh.name)}::slot_${sourceMaterialIndex}::${cleanName(material.name)}`;
-}
+const makeSlotKey = (mesh: THREE.Mesh, sourceMaterialIndex: number, material: THREE.Material) =>
+  `${cleanName(mesh.name)}::slot_${sourceMaterialIndex}::${cleanName(material.name)}`;
 
-function choiceForPart(part: TablePart, palette: Palette): ChoiceKey {
-  if (LINKED_TO_RAIL_SIGHT.has(part)) return palette.railSight;
-  if (LINKED_TO_CORNER_RIM.has(part)) return palette.verticalCornerRim;
-  return palette[part];
-}
-
-function optionForPart(part: TablePart, palette: Palette): ColorOption {
-  return PART_OPTIONS[part][choiceForPart(part, palette)];
-}
+const optionForPart = (part: TablePart, palette: Palette) =>
+  CONTROL_OPTIONS[PART_TO_CONTROL[part]][palette[PART_TO_CONTROL[part]]];
 
 function patchTexture(texture?: THREE.Texture | null, isColorTexture = false) {
   if (!texture) return;
@@ -352,87 +250,39 @@ function patchTexture(texture?: THREE.Texture | null, isColorTexture = false) {
 
 function patchMaterial(material: THREE.Material) {
   const mat = material as WorkingMaterial;
-  patchTexture(mat.map, true);
-  patchTexture(mat.emissiveMap, true);
-  patchTexture(mat.lightMap, true);
-  patchTexture(mat.normalMap);
-  patchTexture(mat.roughnessMap);
-  patchTexture(mat.metalnessMap);
-  patchTexture(mat.aoMap);
-  patchTexture(mat.bumpMap);
-  patchTexture(mat.alphaMap);
+  [mat.map, mat.emissiveMap, mat.lightMap].forEach((texture) => patchTexture(texture, true));
+  [mat.normalMap, mat.bumpMap, mat.roughnessMap, mat.metalnessMap, mat.aoMap, mat.alphaMap].forEach((texture) => patchTexture(texture));
   mat.side = THREE.DoubleSide;
   mat.needsUpdate = true;
 }
 
 function snapshotMaterial(material: WorkingMaterial): MaterialSnapshot {
   return {
-    color: material.color.clone(),
-    emissive: material.emissive.clone(),
-    metalness: material.metalness,
-    roughness: material.roughness,
-    envMapIntensity: material.envMapIntensity,
-    clearcoat: material.clearcoat ?? 0,
-    clearcoatRoughness: material.clearcoatRoughness ?? 0,
-    map: material.map ?? null,
-    normalMap: material.normalMap ?? null,
-    bumpMap: material.bumpMap ?? null,
-    roughnessMap: material.roughnessMap ?? null,
-    metalnessMap: material.metalnessMap ?? null,
-    aoMap: material.aoMap ?? null,
-    emissiveMap: material.emissiveMap ?? null,
-    lightMap: material.lightMap ?? null,
-    alphaMap: material.alphaMap ?? null,
-    transparent: material.transparent,
-    opacity: material.opacity,
+    color: material.color.clone(), emissive: material.emissive.clone(), metalness: material.metalness, roughness: material.roughness, envMapIntensity: material.envMapIntensity,
+    clearcoat: material.clearcoat ?? 0, clearcoatRoughness: material.clearcoatRoughness ?? 0,
+    map: material.map ?? null, normalMap: material.normalMap ?? null, bumpMap: material.bumpMap ?? null, roughnessMap: material.roughnessMap ?? null,
+    metalnessMap: material.metalnessMap ?? null, aoMap: material.aoMap ?? null, emissiveMap: material.emissiveMap ?? null, lightMap: material.lightMap ?? null, alphaMap: material.alphaMap ?? null,
+    transparent: material.transparent, opacity: material.opacity,
   };
 }
 
-function restoreOriginalMaterial(material: WorkingMaterial) {
-  const snapshot = material.userData.originalSnapshot as MaterialSnapshot | undefined;
-  if (!snapshot) return;
-  material.color.copy(snapshot.color);
-  material.emissive.copy(snapshot.emissive);
-  material.metalness = snapshot.metalness;
-  material.roughness = snapshot.roughness;
-  material.envMapIntensity = snapshot.envMapIntensity;
-  material.clearcoat = snapshot.clearcoat;
-  material.clearcoatRoughness = snapshot.clearcoatRoughness;
-  material.map = snapshot.map;
-  material.normalMap = snapshot.normalMap;
-  material.bumpMap = snapshot.bumpMap;
-  material.roughnessMap = snapshot.roughnessMap;
-  material.metalnessMap = snapshot.metalnessMap;
-  material.aoMap = snapshot.aoMap;
-  material.emissiveMap = snapshot.emissiveMap;
-  material.lightMap = snapshot.lightMap;
-  material.alphaMap = snapshot.alphaMap;
-  material.transparent = snapshot.transparent;
-  material.opacity = snapshot.opacity;
-  material.depthWrite = true;
+function restoreMaterial(material: WorkingMaterial) {
+  const snap = material.userData.originalSnapshot as MaterialSnapshot | undefined;
+  if (!snap) return;
+  material.color.copy(snap.color); material.emissive.copy(snap.emissive); material.metalness = snap.metalness; material.roughness = snap.roughness;
+  material.envMapIntensity = snap.envMapIntensity; material.clearcoat = snap.clearcoat; material.clearcoatRoughness = snap.clearcoatRoughness;
+  material.map = snap.map; material.normalMap = snap.normalMap; material.bumpMap = snap.bumpMap; material.roughnessMap = snap.roughnessMap;
+  material.metalnessMap = snap.metalnessMap; material.aoMap = snap.aoMap; material.emissiveMap = snap.emissiveMap; material.lightMap = snap.lightMap; material.alphaMap = snap.alphaMap;
+  material.transparent = snap.transparent; material.opacity = snap.opacity; material.depthWrite = true;
 }
 
-function cloneToWorkingMaterial(raw: THREE.Material): WorkingMaterial {
-  const source = raw as Partial<WorkingMaterial>;
-  const material = new THREE.MeshPhysicalMaterial({
-    name: raw.name || "source_material",
-    color: source.color ? source.color.clone() : new THREE.Color("#ffffff"),
-    emissive: source.emissive ? source.emissive.clone() : new THREE.Color("#000000"),
-    map: source.map ?? null,
-    normalMap: source.normalMap ?? null,
-    bumpMap: source.bumpMap ?? null,
-    roughnessMap: source.roughnessMap ?? null,
-    metalnessMap: source.metalnessMap ?? null,
-    aoMap: source.aoMap ?? null,
-    emissiveMap: source.emissiveMap ?? null,
-    lightMap: source.lightMap ?? null,
-    alphaMap: source.alphaMap ?? null,
-    roughness: typeof source.roughness === "number" ? source.roughness : 0.55,
-    metalness: typeof source.metalness === "number" ? source.metalness : 0,
-    transparent: raw.transparent,
-    opacity: raw.opacity,
-  });
+function clearMaps(material: WorkingMaterial) {
+  material.map = null; material.normalMap = null; material.bumpMap = null; material.roughnessMap = null; material.metalnessMap = null; material.aoMap = null; material.emissiveMap = null; material.lightMap = null; material.alphaMap = null;
+}
 
+function cloneWorking(raw: THREE.Material): WorkingMaterial {
+  const source = raw as Partial<WorkingMaterial>;
+  const material = new THREE.MeshPhysicalMaterial({ name: raw.name || "source_material", color: source.color ? source.color.clone() : new THREE.Color("#ffffff"), emissive: source.emissive ? source.emissive.clone() : new THREE.Color("#000000"), map: source.map ?? null, normalMap: source.normalMap ?? null, bumpMap: source.bumpMap ?? null, roughnessMap: source.roughnessMap ?? null, metalnessMap: source.metalnessMap ?? null, aoMap: source.aoMap ?? null, emissiveMap: source.emissiveMap ?? null, lightMap: source.lightMap ?? null, alphaMap: source.alphaMap ?? null, roughness: typeof source.roughness === "number" ? source.roughness : 0.55, metalness: typeof source.metalness === "number" ? source.metalness : 0, transparent: raw.transparent, opacity: raw.opacity });
   material.clearcoat = typeof source.clearcoat === "number" ? source.clearcoat : 0;
   material.clearcoatRoughness = typeof source.clearcoatRoughness === "number" ? source.clearcoatRoughness : 0.18;
   material.userData.originalSnapshot = snapshotMaterial(material);
@@ -440,25 +290,20 @@ function cloneToWorkingMaterial(raw: THREE.Material): WorkingMaterial {
   return material;
 }
 
-function getMaterialColor(material: WorkingMaterial) {
-  return material.color instanceof THREE.Color ? material.color.clone() : new THREE.Color("#ffffff");
-}
-
 function colorFlags(material: WorkingMaterial) {
-  const c = getMaterialColor(material);
+  const color = material.color instanceof THREE.Color ? material.color : new THREE.Color("#ffffff");
   return {
-    green: c.g > c.r * 1.14 && c.g > c.b * 1.08 && c.g > 0.11,
-    black: c.r < 0.11 && c.g < 0.11 && c.b < 0.11,
-    brown: c.r > c.b * 1.12 && c.g > c.b * 0.48 && c.r > 0.07 && c.g < c.r * 0.9,
-    gold: c.r > 0.42 && c.g > 0.29 && c.b < 0.25 && c.r >= c.g * 0.88,
-    light: c.r > 0.72 && c.g > 0.72 && c.b > 0.62,
+    green: color.g > color.r * 1.14 && color.g > color.b * 1.08 && color.g > 0.11,
+    black: color.r < 0.11 && color.g < 0.11 && color.b < 0.11,
+    brown: color.r > color.b * 1.12 && color.g > color.b * 0.48 && color.r > 0.07 && color.g < color.r * 0.9,
+    gold: color.r > 0.42 && color.g > 0.29 && color.b < 0.25 && color.r >= color.g * 0.88,
+    light: color.r > 0.72 && color.g > 0.72 && color.b > 0.62,
   };
 }
 
 function materialIndexAtOffset(geometry: THREE.BufferGeometry, offset: number) {
   if (!geometry.groups.length) return 0;
-  const group = geometry.groups.find((item) => offset >= item.start && offset < item.start + item.count);
-  return group?.materialIndex ?? 0;
+  return geometry.groups.find((item) => offset >= item.start && offset < item.start + item.count)?.materialIndex ?? 0;
 }
 
 function triangleWorld(mesh: THREE.Mesh, geometry: THREE.BufferGeometry, aIndex: number, bIndex: number, cIndex: number) {
@@ -467,10 +312,7 @@ function triangleWorld(mesh: THREE.Mesh, geometry: THREE.BufferGeometry, aIndex:
   const b = new THREE.Vector3().fromBufferAttribute(position, bIndex).applyMatrix4(mesh.matrixWorld);
   const c = new THREE.Vector3().fromBufferAttribute(position, cIndex).applyMatrix4(mesh.matrixWorld);
   const center = new THREE.Vector3().addVectors(a, b).add(c).multiplyScalar(1 / 3);
-  const normal = new THREE.Vector3()
-    .crossVectors(new THREE.Vector3().subVectors(b, a), new THREE.Vector3().subVectors(c, a))
-    .normalize()
-    .transformDirection(mesh.matrixWorld);
+  const normal = new THREE.Vector3().crossVectors(new THREE.Vector3().subVectors(b, a), new THREE.Vector3().subVectors(c, a)).normalize().transformDirection(mesh.matrixWorld);
   return { center, normal };
 }
 
@@ -488,21 +330,10 @@ function spatialContext(mesh: THREE.Mesh, geometry: THREE.BufferGeometry, aIndex
   return { relY, longN, shortN, upFace, sideFace, downFace };
 }
 
-function classifyTriangle(
-  mesh: THREE.Mesh,
-  geometry: THREE.BufferGeometry,
-  material: WorkingMaterial,
-  aIndex: number,
-  bIndex: number,
-  cIndex: number,
-  tableBox: THREE.Box3,
-  tableCenter: THREE.Vector3,
-  tableSize: THREE.Vector3
-): TablePart {
+function classifyTriangle(mesh: THREE.Mesh, geometry: THREE.BufferGeometry, material: WorkingMaterial, aIndex: number, bIndex: number, cIndex: number, tableBox: THREE.Box3, tableCenter: THREE.Vector3, tableSize: THREE.Vector3): TablePart {
   const name = `${mesh.name || ""} ${material.name || ""}`.toLowerCase();
   const s = spatialContext(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize);
   const flags = colorFlags(material);
-
   const namedCloth = /cloth|felt|fabric|surface|bed|slate/i.test(name);
   const namedCushion = /cushion|rubber|bumper|railrubber/i.test(name);
   const namedPocket = /pocket|hole|drop|net|liner|leather|cup/i.test(name);
@@ -510,76 +341,55 @@ function classifyTriangle(
   const namedSight = /sight|diamond|marker|dot|inlay/i.test(name);
   const namedWood = /wood|walnut|rail|apron|leg|base|frame|cabinet|corner|showood|support/i.test(name);
   const metalish = material.metalness > 0.16 || material.clearcoat > 0.58 || flags.gold;
-
   const high = s.relY > 0.54;
   const veryTop = s.relY > 0.65;
-  const midBody = s.relY > 0.16 && s.relY <= 0.62;
   const low = s.relY <= 0.16;
   const sideMiddlePocketZone = high && s.longN < 0.255 && s.shortN > 0.69;
   const cornerPocketZone = high && s.longN > 0.68 && s.shortN > 0.66;
   const anyPocketZone = sideMiddlePocketZone || cornerPocketZone;
-
-  const centralCloth = high && s.upFace && !anyPocketZone && s.longN < 0.74 && s.shortN < 0.59;
-  const cushionBand =
-    high &&
-    !anyPocketZone &&
-    ((s.upFace && s.longN >= 0.70 && s.longN < 0.88 && s.shortN < 0.68) ||
-      (s.upFace && s.shortN >= 0.54 && s.shortN < 0.78 && s.longN < 0.88) ||
-      (s.sideFace && s.relY > 0.58 && (s.longN > 0.66 || s.shortN > 0.50)) ||
-      (s.downFace && s.relY > 0.46 && s.relY < 0.84 && ((s.longN > 0.62 && s.longN < 0.94) || (s.shortN > 0.44 && s.shortN < 0.86))));
-
+  const centralCloth = high && s.upFace && !anyPocketZone && s.longN < 0.69 && s.shortN < 0.54;
+  const cushionBand = high && !anyPocketZone && ((s.upFace && s.longN >= 0.63 && s.longN < 0.92 && s.shortN < 0.75) || (s.upFace && s.shortN >= 0.5 && s.shortN < 0.84 && s.longN < 0.92) || (s.sideFace && s.relY > 0.5 && s.relY < 0.9 && (s.longN > 0.6 || s.shortN > 0.42)) || (s.downFace && s.relY > 0.46 && s.relY < 0.86 && ((s.longN > 0.6 && s.longN < 0.96) || (s.shortN > 0.4 && s.shortN < 0.9))));
   const topRailBand = high && (s.longN > 0.58 || s.shortN > 0.535);
   const topRailNonPocket = topRailBand && !anyPocketZone;
+  const topRailSideVerticalRimZone = s.sideFace && !s.upFace && s.relY > 0.46 && s.relY < 0.96 && s.longN > 0.6 && s.shortN > 0.58;
+  const underRailSightCornerRimZone = s.sideFace && !s.upFace && s.relY > 0.36 && s.relY < 0.76 && s.longN > 0.67 && s.shortN > 0.52;
   const outsideBaseCornerRimZone = s.sideFace && s.relY > 0.08 && s.relY < 0.78 && s.longN > 0.72 && s.shortN > 0.54;
-  const outerMostVerticalCorner = s.sideFace && s.relY > 0.10 && s.relY < 0.80 && s.longN > 0.80 && s.shortN > 0.68;
-  const sideLowerTrimZone = s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54) && !outsideBaseCornerRimZone;
-  const innerBaseCornerZone =
-    s.sideFace &&
-    s.relY > 0.12 &&
-    s.relY < 0.68 &&
-    ((s.longN > 0.10 && s.longN < 0.54 && s.shortN < 0.36) || (s.longN > 0.58 && s.shortN > 0.56));
+  const outerMostVerticalCorner = s.sideFace && s.relY > 0.1 && s.relY < 0.8 && s.longN > 0.8 && s.shortN > 0.68;
+  const baseCornerZone = s.sideFace && s.relY > 0.12 && s.relY < 0.64 && ((s.longN > 0.1 && s.longN < 0.56 && s.shortN < 0.36) || (s.longN > 0.58 && s.shortN > 0.56)) && !(underRailSightCornerRimZone || topRailSideVerticalRimZone);
+  const legZone = s.sideFace && s.relY > 0.14 && s.relY < 0.62 && s.longN < 0.62 && s.shortN < 0.58;
+  const railSightDownBand = s.sideFace && !s.upFace && !anyPocketZone && s.relY > 0.44 && s.relY < 0.72 && (s.longN > 0.54 || s.shortN > 0.48) && !(topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner || baseCornerZone || legZone);
+  const sideLowerTrimZone = s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54);
   const hardwareCandidate = namedHardware || metalish || ((flags.black || flags.gold || flags.light) && !flags.green && !flags.brown && !namedWood);
   const pocketInteriorCandidate = namedPocket || (flags.black && anyPocketZone && (s.downFace || s.sideFace || s.relY < 0.79) && !hardwareCandidate);
-
   if (pocketInteriorCandidate) return "pocketCup";
   if (namedPocket && hardwareCandidate && sideMiddlePocketZone) return "middlePocketPlate";
   if (namedPocket && hardwareCandidate && cornerPocketZone) return "cornerPocketPlate";
   if (hardwareCandidate && sideMiddlePocketZone && !flags.green && !flags.brown) return "middlePocketPlate";
   if (hardwareCandidate && cornerPocketZone && !flags.green && !flags.brown) return "cornerPocketPlate";
+  if ((namedCloth || flags.green || namedCushion) && centralCloth) return "cloth";
+  if ((namedCushion || namedCloth || flags.green) && cushionBand) return "cushion";
+  if (topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner) return "verticalCornerRim";
   if (namedSight && high) return "railSight";
-  if (namedCloth && centralCloth) return "cloth";
-  if ((flags.green || namedCloth) && centralCloth) return "cloth";
-  if (namedCushion && !centralCloth) return "cushion";
-  if ((flags.green || namedCushion) && cushionBand) return "cushion";
-  if ((outsideBaseCornerRimZone || outerMostVerticalCorner) && !flags.green && !s.upFace) return "verticalCornerRim";
   if (hardwareCandidate && topRailNonPocket && s.upFace && !flags.brown && !flags.green) return "railSight";
-  if (hardwareCandidate && sideLowerTrimZone && !flags.green) return "lowerTrim";
   if (low) return "baseFoot";
   if (s.downFace && s.relY < 0.5) return "underside";
-  if ((flags.brown || namedWood) && innerBaseCornerZone) return "baseCornerBlock";
-  if (outsideBaseCornerRimZone && (flags.brown || namedWood) && !outerMostVerticalCorner) return "baseCornerBlock";
-  if (s.longN > 0.64 && s.shortN > 0.64 && midBody) return "baseCornerBlock";
-  if (midBody && s.sideFace && !(s.longN > 0.64 && s.shortN > 0.64)) return "leg";
-  if (veryTop && s.upFace && topRailBand && !flags.green) return "topWoodRail";
+  if ((flags.brown || namedWood) && baseCornerZone) return "baseCornerBlock";
+  if (baseCornerZone) return "baseCornerBlock";
+  if (legZone && (flags.brown || namedWood || !hardwareCandidate)) return "leg";
+  if (hardwareCandidate && sideLowerTrimZone && !flags.green) return "lowerTrim";
+  if (railSightDownBand && !flags.green) return "sideWoodApron";
+  if (veryTop && (s.upFace || topRailBand) && !flags.green) return "topWoodRail";
   if (high && s.sideFace && !flags.green && !anyPocketZone) return "sideWoodApron";
   return "sideWoodApron";
 }
 
 function isCushionShadowTriangle(mesh: THREE.Mesh, geometry: THREE.BufferGeometry, aIndex: number, bIndex: number, cIndex: number, tableBox: THREE.Box3, tableCenter: THREE.Vector3, tableSize: THREE.Vector3) {
   const s = spatialContext(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize);
-  return s.downFace && s.relY > 0.46 && s.relY < 0.84 && ((s.longN > 0.62 && s.longN < 0.94) || (s.shortN > 0.44 && s.shortN < 0.86));
+  return s.downFace && s.relY > 0.46 && s.relY < 0.84 && ((s.longN > 0.6 && s.longN < 0.95) || (s.shortN > 0.42 && s.shortN < 0.88));
 }
 
 function createSlotStat(): SlotStat {
-  return {
-    total: 0,
-    dominantPart: "sideWoodApron",
-    dominantRatio: 1,
-    parts: TABLE_PARTS.reduce((acc, part) => {
-      acc[part] = 0;
-      return acc;
-    }, {} as Partial<Record<TablePart, number>>),
-  };
+  return { total: 0, dominantPart: "sideWoodApron", dominantRatio: 1, parts: TABLE_PARTS.reduce((acc, part) => { acc[part] = 0; return acc; }, {} as Partial<Record<TablePart, number>>) };
 }
 
 function updateSlotStat(stats: Map<string, SlotStat>, sourceSlot: string, part: TablePart) {
@@ -597,79 +407,39 @@ function isMixedClothCushionSlot(stat?: SlotStat | null) {
 
 function resolvePart(triangle: TriangleRecord, slotStats: Map<string, SlotStat>) {
   const stat = slotStats.get(triangle.sourceSlot);
-  if (!stat) return triangle.spatialPart;
-  if (ALWAYS_SPATIAL_PARTS.has(triangle.spatialPart) && triangle.spatialPart !== stat.dominantPart) return triangle.spatialPart;
-  if (isMixedClothCushionSlot(stat) && (triangle.spatialPart === "cloth" || triangle.spatialPart === "cushion")) return triangle.spatialPart;
-  if ((triangle.spatialPart === "cloth" || triangle.spatialPart === "cushion") && stat.dominantRatio >= 0.88) return stat.dominantPart;
-  return stat.dominantRatio >= 0.965 ? stat.dominantPart : triangle.spatialPart;
+  if (!stat) return triangle.part;
+  if (FINE_PARTS.has(triangle.part) && triangle.part !== stat.dominantPart) return triangle.part;
+  if (isMixedClothCushionSlot(stat) && (triangle.part === "cloth" || triangle.part === "cushion")) return triangle.part;
+  if ((triangle.part === "cloth" || triangle.part === "cushion") && stat.dominantRatio >= 0.88) return stat.dominantPart;
+  return stat.dominantRatio >= 0.965 ? stat.dominantPart : triangle.part;
 }
 
-function clearTextureMaps(material: WorkingMaterial) {
-  material.map = null;
-  material.normalMap = null;
-  material.bumpMap = null;
-  material.roughnessMap = null;
-  material.metalnessMap = null;
-  material.aoMap = null;
-  material.emissiveMap = null;
-  material.lightMap = null;
-  material.alphaMap = null;
-}
-
-function applyCustomMaterial(material: WorkingMaterial, part: TablePart, option: ColorOption, cushionShadow = false) {
-  restoreOriginalMaterial(material);
+function applyMaterial(material: WorkingMaterial, part: TablePart, option: ColorOption, cushionShadow = false) {
+  restoreMaterial(material);
   if (part === "cushion" && cushionShadow) {
-    material.color.set(CUSHION_SHADOW_GREY);
-    material.metalness = 0;
-    material.roughness = 0.96;
-    material.envMapIntensity = 0.22;
-    material.clearcoat = 0;
-    material.clearcoatRoughness = 0;
-    clearTextureMaps(material);
+    material.color.set(CUSHION_SHADOW_GREY); material.metalness = 0; material.roughness = 0.96; material.envMapIntensity = 0.22; material.clearcoat = 0; material.clearcoatRoughness = 0; clearMaps(material);
   } else {
-    material.color.set(option.color);
-    material.metalness = option.metalness;
-    material.roughness = option.roughness;
-    material.envMapIntensity = option.envMapIntensity;
-    material.clearcoat = option.clearcoat ?? 0;
-    material.clearcoatRoughness = option.clearcoatRoughness ?? 0;
-    if (!PART_META[part].keepSourceTexture) clearTextureMaps(material);
+    material.color.set(option.color); material.metalness = option.metalness; material.roughness = option.roughness; material.envMapIntensity = option.envMapIntensity; material.clearcoat = option.clearcoat ?? 0; material.clearcoatRoughness = option.clearcoatRoughness ?? 0;
+    if (!KEEP_TEXTURE_PARTS.has(part)) clearMaps(material);
   }
-  material.transparent = false;
-  material.opacity = 1;
-  material.depthWrite = true;
-  material.userData.part = part;
-  material.userData.cushionShadow = cushionShadow;
-  patchMaterial(material);
+  material.transparent = false; material.opacity = 1; material.depthWrite = true; material.userData.part = part; material.userData.cushionShadow = cushionShadow; patchMaterial(material);
 }
 
 function makePartMaterial(source: WorkingMaterial, part: TablePart, palette: Palette, buckets: MaterialBuckets, sourceSlot: string, meshName: string, materialName: string, cushionShadow = false) {
   const material = source.clone() as WorkingMaterial;
   material.name = `${source.name || "source"}__${part}${cushionShadow ? "__shadow" : ""}`;
   material.userData.originalSnapshot = snapshotMaterial(source);
-  material.userData.part = part;
-  material.userData.sourceSlot = sourceSlot;
-  material.userData.meshName = meshName;
-  material.userData.materialName = materialName;
-  material.userData.cushionShadow = cushionShadow;
-  applyCustomMaterial(material, part, optionForPart(part, palette), cushionShadow);
+  material.userData.part = part; material.userData.sourceSlot = sourceSlot; material.userData.meshName = meshName; material.userData.materialName = materialName; material.userData.cushionShadow = cushionShadow;
+  applyMaterial(material, part, optionForPart(part, palette), cushionShadow);
   buckets[part].push(material);
   return material;
 }
 
-function applyPaletteToBuckets(buckets: MaterialBuckets, palette: Palette) {
-  TABLE_PARTS.forEach((part) => {
-    buckets[part].forEach((material) => applyCustomMaterial(material, part, optionForPart(part, palette), Boolean(material.userData.cushionShadow)));
-  });
-}
+function applyPaletteToBuckets(buckets: MaterialBuckets, palette: Palette) { TABLE_PARTS.forEach((part) => buckets[part].forEach((material) => applyMaterial(material, part, optionForPart(part, palette), Boolean(material.userData.cushionShadow)))); }
 
 function countTextures(materials: WorkingMaterial[]) {
   const textures = new Set<THREE.Texture>();
-  materials.forEach((material) => {
-    [material.map, material.normalMap, material.bumpMap, material.roughnessMap, material.metalnessMap, material.aoMap, material.emissiveMap, material.lightMap, material.alphaMap].forEach((texture) => {
-      if (texture) textures.add(texture);
-    });
-  });
+  materials.forEach((material) => [material.map, material.normalMap, material.bumpMap, material.roughnessMap, material.metalnessMap, material.aoMap, material.emissiveMap, material.lightMap, material.alphaMap].forEach((texture) => texture && textures.add(texture)));
   return textures.size;
 }
 
@@ -687,14 +457,10 @@ function splitTableIntoMappedParts(root: THREE.Object3D, palette: Palette, bucke
     const mesh = child as THREE.Mesh;
     if (!mesh.isMesh) return;
     const sourceGeometry = mesh.geometry.clone();
-    const sourceMaterials = (Array.isArray(mesh.material) ? mesh.material : [mesh.material]).map((material) => cloneToWorkingMaterial(material));
+    const sourceMaterials = (Array.isArray(mesh.material) ? mesh.material : [mesh.material]).map((material) => cloneWorking(material));
     const position = sourceGeometry.attributes.position as THREE.BufferAttribute | undefined;
     if (!position) return;
-    mesh.castShadow = true;
-    mesh.receiveShadow = true;
-    mesh.frustumCulled = false;
-    counts.sourceMeshes += 1;
-    textureMaterials.push(...sourceMaterials);
+    mesh.castShadow = true; mesh.receiveShadow = true; mesh.frustumCulled = false; counts.sourceMeshes += 1; textureMaterials.push(...sourceMaterials);
     const oldIndex = sourceGeometry.index;
     const totalIndices = oldIndex ? oldIndex.count : position.count;
     const triangles: TriangleRecord[] = [];
@@ -706,11 +472,12 @@ function splitTableIntoMappedParts(root: THREE.Object3D, palette: Palette, bucke
       const sourceMaterialIndex = Math.min(materialIndexAtOffset(sourceGeometry, i), sourceMaterials.length - 1);
       const sourceMaterial = sourceMaterials[Math.max(0, sourceMaterialIndex)];
       const sourceSlot = makeSlotKey(mesh, sourceMaterialIndex, sourceMaterial);
-      const spatialPart = classifyTriangle(mesh, sourceGeometry, sourceMaterial, a, b, c, tableBox, tableCenter, tableSize);
-      const cushionShadow = spatialPart === "cushion" && isCushionShadowTriangle(mesh, sourceGeometry, a, b, c, tableBox, tableCenter, tableSize);
-      triangles.push({ a, b, c, sourceMaterialIndex, sourceSlot, spatialPart, cushionShadow });
-      updateSlotStat(slotStats, sourceSlot, spatialPart);
+      const part = classifyTriangle(mesh, sourceGeometry, sourceMaterial, a, b, c, tableBox, tableCenter, tableSize);
+      const cushionShadow = part === "cushion" && isCushionShadowTriangle(mesh, sourceGeometry, a, b, c, tableBox, tableCenter, tableSize);
+      triangles.push({ a, b, c, sourceMaterialIndex, sourceSlot, part, cushionShadow });
+      updateSlotStat(slotStats, sourceSlot, part);
     }
+
     buildData.push({ mesh, sourceGeometry, sourceMaterials, triangles });
   });
 
@@ -724,7 +491,7 @@ function splitTableIntoMappedParts(root: THREE.Object3D, palette: Palette, bucke
     const finalIndex: number[] = [];
     finalGeometry.clearGroups();
 
-    const getFinalMaterialIndex = (sourceMaterialIndex: number, sourceSlot: string, part: TablePart, cushionShadow = false) => {
+    const getMaterialIndex = (sourceMaterialIndex: number, sourceSlot: string, part: TablePart, cushionShadow = false) => {
       const key = `${sourceSlot}::${part}::${cushionShadow ? "shadow" : "main"}`;
       const existing = materialLookup.get(key);
       if (existing !== undefined) return existing;
@@ -739,7 +506,7 @@ function splitTableIntoMappedParts(root: THREE.Object3D, palette: Palette, bucke
     triangles.forEach((triangle) => {
       const part = resolvePart(triangle, slotStats);
       const cushionShadow = part === "cushion" && triangle.cushionShadow;
-      const materialIndex = getFinalMaterialIndex(triangle.sourceMaterialIndex, triangle.sourceSlot, part, cushionShadow);
+      const materialIndex = getMaterialIndex(triangle.sourceMaterialIndex, triangle.sourceSlot, part, cushionShadow);
       const start = finalIndex.length;
       finalIndex.push(triangle.a, triangle.b, triangle.c);
       finalGeometry.addGroup(start, 3, materialIndex);
@@ -754,27 +521,20 @@ function splitTableIntoMappedParts(root: THREE.Object3D, palette: Palette, bucke
     mesh.geometry = finalGeometry;
     mesh.material = finalMaterials.length > 1 ? finalMaterials : finalMaterials[0];
   });
+
   return counts;
 }
 
 function createStandalonePartMaterial(part: TablePart, palette: Palette, buckets: MaterialBuckets, name: string) {
   const material = new THREE.MeshPhysicalMaterial({ name, color: "#ffffff", roughness: 0.5, metalness: 0 });
   material.userData.originalSnapshot = snapshotMaterial(material);
-  material.userData.part = part;
-  material.userData.sourceSlot = name;
-  material.userData.meshName = name;
-  material.userData.materialName = name;
-  applyCustomMaterial(material, part, optionForPart(part, palette));
+  material.userData.part = part; material.userData.sourceSlot = name; material.userData.meshName = name; material.userData.materialName = name;
+  applyMaterial(material, part, optionForPart(part, palette));
   buckets[part].push(material);
   return material;
 }
 
-function averagePoints(points: THREE.Vector3[]) {
-  const out = new THREE.Vector3();
-  if (!points.length) return out;
-  points.forEach((point) => out.add(point));
-  return out.multiplyScalar(1 / points.length);
-}
+function averagePoints(points: THREE.Vector3[]) { const out = new THREE.Vector3(); if (!points.length) return out; points.forEach((point) => out.add(point)); return out.multiplyScalar(1 / points.length); }
 
 function collectBaseFootAnchorsFromMappedTable(table: THREE.Object3D) {
   table.updateMatrixWorld(true);
@@ -789,12 +549,14 @@ function collectBaseFootAnchorsFromMappedTable(table: THREE.Object3D) {
     const position = geometry.attributes.position as THREE.BufferAttribute | undefined;
     const index = geometry.index;
     if (!position) return;
+
     const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
     const groups = geometry.groups.length ? geometry.groups : [{ start: 0, count: index ? index.count : position.count, materialIndex: 0 }];
 
     groups.forEach((group) => {
-      const material = materials[Math.max(0, Math.min(group.materialIndex, materials.length - 1))] as WorkingMaterial;
-      if ((material?.userData?.part as TablePart | undefined) !== "baseFoot") return;
+      const material = materials[Math.max(0, Math.min(group.materialIndex ?? 0, materials.length - 1))] as WorkingMaterial;
+      if ((material.userData.part as TablePart | undefined) !== "baseFoot") return;
+
       for (let i = group.start; i + 2 < group.start + group.count; i += 3) {
         const ai = index ? index.getX(i) : i;
         const bi = index ? index.getX(i + 1) : i + 1;
@@ -814,10 +576,9 @@ function collectBaseFootAnchorsFromMappedTable(table: THREE.Object3D) {
   });
 
   const anchors = [quadrants.lt, quadrants.rt, quadrants.lb, quadrants.rb].map((points) => (points.length ? averagePoints(points) : null)).filter(Boolean) as THREE.Vector3[];
+
   if (anchors.length === 4) {
-    anchors.forEach((anchor) => {
-      anchor.y = tableBox.min.y;
-    });
+    anchors.forEach((anchor) => (anchor.y = tableBox.min.y));
     return anchors;
   }
 
@@ -825,6 +586,7 @@ function collectBaseFootAnchorsFromMappedTable(table: THREE.Object3D) {
   const x = size.x * 0.24;
   const z = size.z * 0.2;
   const y = tableBox.min.y;
+
   return [new THREE.Vector3(tableCenter.x - x, y, tableCenter.z - z), new THREE.Vector3(tableCenter.x + x, y, tableCenter.z - z), new THREE.Vector3(tableCenter.x - x, y, tableCenter.z + z), new THREE.Vector3(tableCenter.x + x, y, tableCenter.z + z)];
 }
 
@@ -835,15 +597,17 @@ function createRoundedFootCaps(table: THREE.Object3D, palette: Palette, buckets:
   const anchors = collectBaseFootAnchorsFromMappedTable(table);
   const material = createStandalonePartMaterial("baseFoot", palette, buckets, "rounded_metal_feet_material");
   const geometry = new THREE.CylinderGeometry(0.13, 0.18, 0.055, 48, 1, false);
+
   anchors.forEach((anchor, index) => {
     const cap = new THREE.Mesh(geometry.clone(), material);
     cap.name = `rounded_metal_foot_${index + 1}`;
     cap.position.set(anchor.x, anchor.y + 0.028, anchor.z);
-    cap.scale.set(1.34, 1, 1.34);
+    cap.scale.set(1.1, 1, 1.1);
     cap.castShadow = true;
     cap.receiveShadow = true;
     group.add(cap);
   });
+
   return group;
 }
 
@@ -853,6 +617,7 @@ function fitTable(table: THREE.Object3D) {
   const size = box.getSize(new THREE.Vector3());
   table.scale.setScalar(8.4 / Math.max(size.x, size.z, 0.001));
   table.updateMatrixWorld(true);
+
   const fitBox = new THREE.Box3().setFromObject(table);
   const center = fitBox.getCenter(new THREE.Vector3());
   table.position.x -= center.x;
@@ -875,54 +640,30 @@ function Pill({ children }: { children: React.ReactNode }) {
 }
 
 function ColorButton({ active, option, onClick }: { active: boolean; option: ColorOption; onClick: () => void }) {
-  return (
-    <button onClick={onClick} style={{ display: "flex", alignItems: "center", gap: 6, border: active ? "1px solid rgba(255,255,255,0.78)" : "1px solid rgba(255,255,255,0.18)", background: active ? "rgba(255,255,255,0.16)" : "rgba(255,255,255,0.06)", color: "white", borderRadius: 999, padding: "6px 8px", fontSize: 10.5, fontWeight: 850, cursor: "pointer", whiteSpace: "nowrap" }}>
-      <span style={{ width: 13, height: 13, borderRadius: 999, background: option.color, border: "1px solid rgba(255,255,255,0.38)", display: "inline-block", flex: "0 0 auto" }} />
-      {option.label}
-    </button>
-  );
+  return <button onClick={onClick} style={{ display: "flex", alignItems: "center", gap: 6, border: active ? "1px solid rgba(255,255,255,0.78)" : "1px solid rgba(255,255,255,0.18)", background: active ? "rgba(255,255,255,0.16)" : "rgba(255,255,255,0.06)", color: "white", borderRadius: 999, padding: "6px 8px", fontSize: 10.5, fontWeight: 850, cursor: "pointer", whiteSpace: "nowrap" }}><span style={{ width: 13, height: 13, borderRadius: 999, background: option.color, border: "1px solid rgba(255,255,255,0.38)", display: "inline-block", flex: "0 0 auto" }} />{option.label}</button>;
 }
 
 export default function PoolTableCustomOptionsPreview() {
   const hostRef = useRef<HTMLDivElement>(null);
-  const bucketsRef = useRef<MaterialBuckets>(createMaterialBuckets());
+  const bucketsRef = useRef<MaterialBuckets>(createBuckets());
   const paletteRef = useRef<Palette>(DEFAULT_PALETTE);
   const [palette, setPalette] = useState<Palette>(DEFAULT_PALETTE);
   const [status, setStatus] = useState("loading table...");
   const [counts, setCounts] = useState<Counts>({ ...EMPTY_COUNTS });
   const [pickInfo, setPickInfo] = useState<PickInfo | null>(null);
 
-  useEffect(() => {
-    paletteRef.current = palette;
-    applyPaletteToBuckets(bucketsRef.current, palette);
-  }, [palette]);
+  useEffect(() => { paletteRef.current = palette; applyPaletteToBuckets(bucketsRef.current, palette); }, [palette]);
 
-  const optionRows = useMemo(
-    () =>
-      CONTROL_PARTS.map((part) => {
-        const count = part === "railSight" ? counts.sideWoodApron + counts.railSight : part === "verticalCornerRim" ? counts.verticalCornerRim + 4 : counts[part];
-        return { part, label: PART_META[part].label, description: PART_META[part].description, count, selected: choiceForPart(part, palette), options: PART_OPTIONS[part] };
-      }),
-    [counts, palette]
-  );
-
-  const setPartChoice = (part: TablePart, choice: ChoiceKey) => {
-    setPalette((current) => {
-      const next = { ...current, [part]: choice };
-      if (part === "railSight") next.sideWoodApron = choice;
-      if (part === "sideWoodApron") next.railSight = choice;
-      if (part === "verticalCornerRim") next.baseFoot = choice;
-      if (part === "baseFoot") next.verticalCornerRim = choice;
-      return next;
-    });
-  };
+  const rows = useMemo(() => CONTROL_PARTS.map((control) => { const mappedParts = TABLE_PARTS.filter((part) => PART_TO_CONTROL[part] === control); const count = mappedParts.reduce((sum, part) => sum + counts[part], 0); return { control, ...CONTROL_META[control], count, selected: palette[control], options: CONTROL_OPTIONS[control] }; }), [counts, palette]);
 
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
+
     const scene = new THREE.Scene();
     scene.background = new THREE.Color("#050505");
     scene.fog = new THREE.Fog(0x050505, 24, 70);
+
     const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: "high-performance" });
     renderer.setSize(window.innerWidth, window.innerHeight);
     renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
@@ -932,69 +673,83 @@ export default function PoolTableCustomOptionsPreview() {
     renderer.shadowMap.enabled = true;
     renderer.shadowMap.type = THREE.PCFSoftShadowMap;
     host.appendChild(renderer.domElement);
+
     const pmrem = new THREE.PMREMGenerator(renderer);
     const envTexture = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
     scene.environment = envTexture;
+
     const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 120);
     camera.position.set(6.2, 4.2, 7.0);
+
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.enableDamping = true;
     controls.enablePan = true;
     controls.minDistance = 3;
     controls.maxDistance = 24;
     controls.target.set(0, 1.05, 0);
+
     scene.add(new THREE.AmbientLight(0xffffff, 1.08));
+
     const key = new THREE.DirectionalLight(0xffffff, 3.25);
     key.position.set(6, 10, 7);
     key.castShadow = true;
     key.shadow.mapSize.set(2048, 2048);
     scene.add(key);
+
     scene.add(new THREE.HemisphereLight(0xdbeafe, 0x241307, 1.18));
+
     const warm = new THREE.PointLight(0xffd08a, 2.0, 28);
     warm.position.set(0, 4, 0);
     scene.add(warm);
+
     const floor = new THREE.Mesh(new THREE.PlaneGeometry(40, 40), new THREE.MeshStandardMaterial({ color: "#101010", roughness: 0.86, metalness: 0.02 }));
     floor.rotation.x = -Math.PI / 2;
     floor.receiveShadow = true;
     scene.add(floor);
+
     const manager = new THREE.LoadingManager();
     manager.onStart = () => setStatus("loading original table...");
     manager.onProgress = (url, loaded, total) => setStatus(`loading ${loaded}/${total}: ${url.split("/").pop() || "asset"}`);
     manager.onError = (url) => setStatus(`asset failed: ${url.split("/").pop() || url}`);
+
     const draco = new DRACOLoader(manager);
     draco.setDecoderPath(DRACO_DECODER_PATH);
     draco.setDecoderConfig({ type: "js" });
     draco.preload();
+
     const ktx2 = new KTX2Loader(manager);
     ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
     ktx2.detectSupport(renderer);
+
     const loader = new GLTFLoader(manager);
     loader.setDRACOLoader(draco);
     loader.setKTX2Loader(ktx2);
     loader.setMeshoptDecoder(MeshoptDecoder);
     loader.setCrossOrigin("anonymous");
+
     const raycaster = new THREE.Raycaster();
     const pointer = new THREE.Vector2();
     let frame = 0;
     let tableObject: THREE.Object3D | null = null;
     let mounted = true;
     let pointerDown: { x: number; y: number; t: number } | null = null;
+
     loader.load(
       TABLE_MODEL_URL,
       (gltf) => {
         if (!mounted) return;
         const table = gltf.scene;
         fitTable(table);
-        bucketsRef.current = createMaterialBuckets();
+        bucketsRef.current = createBuckets();
         const resultCounts = splitTableIntoMappedParts(table, paletteRef.current, bucketsRef.current);
         const displayGroup = new THREE.Group();
-        displayGroup.name = "mapped_pool_table_with_precise_rounded_feet";
+        displayGroup.name = "mapped_pool_table_simplified_options";
         displayGroup.add(table);
         displayGroup.add(createRoundedFootCaps(table, paletteRef.current, bucketsRef.current));
         tableObject = displayGroup;
         scene.add(displayGroup);
         setCounts(resultCounts);
-        setStatus("ready: cushions use cloth texture continuity, darker cushion shadow tone, and wider linked metal feet");
+        setStatus("ready: leg/base separated, cushions use green/blue cloth-style options");
       },
       (event) => {
         if (!event.total) return;
@@ -1005,6 +760,7 @@ export default function PoolTableCustomOptionsPreview() {
         setStatus("failed to load the table model");
       }
     );
+
     const pick = (clientX: number, clientY: number) => {
       if (!tableObject) return;
       const rect = renderer.domElement.getBoundingClientRect();
@@ -1016,32 +772,27 @@ export default function PoolTableCustomOptionsPreview() {
       const mesh = hit.object as THREE.Mesh;
       const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
       const material = materials[Math.max(0, Math.min(hit.face.materialIndex ?? 0, materials.length - 1))] as WorkingMaterial;
-      setPickInfo({
-        part: (material.userData.part as TablePart) || "sideWoodApron",
-        meshName: String(material.userData.meshName || mesh.name || "unknown mesh"),
-        materialName: String(material.userData.materialName || material.name || "unknown material"),
-        sourceSlot: String(material.userData.sourceSlot || "unknown slot"),
-        point: `${hit.point.x.toFixed(2)}, ${hit.point.y.toFixed(2)}, ${hit.point.z.toFixed(2)}`,
-      });
+      setPickInfo({ part: (material.userData.part as TablePart) || "sideWoodApron", meshName: String(material.userData.meshName || mesh.name || "unknown mesh"), materialName: String(material.userData.materialName || material.name || "unknown material"), sourceSlot: String(material.userData.sourceSlot || "unknown slot"), point: `${hit.point.x.toFixed(2)}, ${hit.point.y.toFixed(2)}, ${hit.point.z.toFixed(2)}` });
     };
-    const onPointerDown = (event: PointerEvent) => {
-      pointerDown = { x: event.clientX, y: event.clientY, t: performance.now() };
-    };
+
+    const onPointerDown = (event: PointerEvent) => { pointerDown = { x: event.clientX, y: event.clientY, t: performance.now() }; };
+
     const onPointerUp = (event: PointerEvent) => {
       if (!pointerDown) return;
-      const dist = Math.hypot(event.clientX - pointerDown.x, event.clientY - pointerDown.y);
-      const age = performance.now() - pointerDown.t;
-      if (dist < 8 && age < 380) pick(event.clientX, event.clientY);
+      if (Math.hypot(event.clientX - pointerDown.x, event.clientY - pointerDown.y) < 8 && performance.now() - pointerDown.t < 380) pick(event.clientX, event.clientY);
       pointerDown = null;
     };
+
     renderer.domElement.addEventListener("pointerdown", onPointerDown);
     renderer.domElement.addEventListener("pointerup", onPointerUp);
+
     const animate = () => {
       frame = requestAnimationFrame(animate);
       controls.update();
       renderer.render(scene, camera);
     };
     animate();
+
     const resize = () => {
       camera.aspect = window.innerWidth / window.innerHeight;
       camera.updateProjectionMatrix();
@@ -1049,6 +800,7 @@ export default function PoolTableCustomOptionsPreview() {
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
     };
     window.addEventListener("resize", resize);
+
     return () => {
       mounted = false;
       window.removeEventListener("resize", resize);
@@ -1068,52 +820,5 @@ export default function PoolTableCustomOptionsPreview() {
     };
   }, []);
 
-  return (
-    <div ref={hostRef} style={{ position: "fixed", inset: 0, background: "#050505", overflow: "hidden", touchAction: "none" }}>
-      <div style={{ position: "fixed", left: 10, top: 10, right: 10, color: "white", fontFamily: "system-ui, sans-serif", pointerEvents: "none" }}>
-        <div style={{ maxWidth: 920, border: "1px solid rgba(255,255,255,0.14)", background: "rgba(0,0,0,0.62)", backdropFilter: "blur(10px)", borderRadius: 16, padding: "9px 10px", boxShadow: "0 18px 40px rgba(0,0,0,0.35)" }}>
-          <div style={{ fontSize: 13.5, fontWeight: 950 }}>Seven Foot Pool Table — Custom Options</div>
-          <div style={{ marginTop: 5, fontSize: 11.5, color: "#cbd5e1", lineHeight: 1.35 }}>{status}</div>
-          <div style={{ marginTop: 7, display: "flex", flexWrap: "wrap", gap: 5 }}>
-            <Pill>slots {counts.sourceSlots}</Pill>
-            <Pill>cloth {counts.cloth}</Pill>
-            <Pill>cushions {counts.cushion}</Pill>
-            <Pill>gold rims {counts.verticalCornerRim}</Pill>
-            <Pill>rounded feet 4</Pill>
-            <Pill>base corners {counts.baseCornerBlock}</Pill>
-          </div>
-          {pickInfo && (
-            <div style={{ marginTop: 7, padding: "7px 8px", borderRadius: 12, background: "rgba(15,23,42,0.78)", border: "1px solid rgba(255,255,255,0.1)" }}>
-              <div style={{ fontSize: 11.5, fontWeight: 950, color: "#f8fafc" }}>Tapped: {PART_META[pickInfo.part].label}</div>
-              <div style={{ marginTop: 3, fontSize: 10.2, color: "#cbd5e1", lineHeight: 1.25 }}>mesh: {pickInfo.meshName} · material: {pickInfo.materialName}</div>
-            </div>
-          )}
-        </div>
-      </div>
-      <div style={{ position: "fixed", left: 10, right: 10, bottom: 10, maxHeight: "54vh", overflow: "auto", color: "white", fontFamily: "system-ui, sans-serif", pointerEvents: "auto" }}>
-        <div style={{ maxWidth: 1040, border: "1px solid rgba(255,255,255,0.14)", background: "rgba(0,0,0,0.72)", backdropFilter: "blur(10px)", borderRadius: 18, padding: 11, boxShadow: "0 18px 40px rgba(0,0,0,0.35)" }}>
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, marginBottom: 10 }}>
-            <div>
-              <div style={{ fontSize: 12.5, fontWeight: 950 }}>Custom material options</div>
-              <div style={{ marginTop: 2, fontSize: 10.5, color: "#94a3b8" }}>Cushions keep cloth texture continuity, cushion shadows are darker, and feet stay linked with Corner rims + rounded feet.</div>
-            </div>
-            <button onClick={() => setPalette(DEFAULT_PALETTE)} style={{ border: "1px solid rgba(255,255,255,0.25)", background: "rgba(255,255,255,0.08)", color: "white", borderRadius: 999, padding: "7px 10px", fontSize: 11, fontWeight: 900, cursor: "pointer", flex: "0 0 auto" }}>Reset</button>
-          </div>
-          <div style={{ display: "grid", gap: 10 }}>
-            {optionRows.map((row) => (
-              <div key={row.part} style={{ display: "grid", gridTemplateColumns: "minmax(116px, 172px) 1fr", gap: 8, alignItems: "center" }}>
-                <div>
-                  <div style={{ fontSize: 11.3, fontWeight: 950, color: "#e5e7eb" }}>{row.label} <span style={{ color: "#94a3b8" }}>({row.count})</span></div>
-                  <div style={{ fontSize: 9.4, color: "#94a3b8", lineHeight: 1.2 }}>{row.description}</div>
-                </div>
-                <div style={{ display: "flex", flexWrap: "wrap", gap: 7 }}>
-                  {(["a", "b"] as ChoiceKey[]).map((choice) => <ColorButton key={`${row.part}-${choice}`} active={row.selected === choice} option={row.options[choice]} onClick={() => setPartChoice(row.part, choice)} />)}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  return <div ref={hostRef} style={{ position: "fixed", inset: 0, background: "#050505", overflow: "hidden", touchAction: "none" }}><div style={{ position: "fixed", left: 10, top: 10, right: 10, color: "white", fontFamily: "system-ui, sans-serif", pointerEvents: "none" }}><div style={{ maxWidth: 920, border: "1px solid rgba(255,255,255,0.14)", background: "rgba(0,0,0,0.62)", backdropFilter: "blur(10px)", borderRadius: 16, padding: "9px 10px", boxShadow: "0 18px 40px rgba(0,0,0,0.35)" }}><div style={{ fontSize: 13.5, fontWeight: 950 }}>Seven Foot Pool Table — Simplified Options</div><div style={{ marginTop: 5, fontSize: 11.5, color: "#cbd5e1", lineHeight: 1.35 }}>{status}</div><div style={{ marginTop: 7, display: "flex", flexWrap: "wrap", gap: 5 }}><Pill>slots {counts.sourceSlots}</Pill><Pill>cloth {counts.cloth}</Pill><Pill>cushions {counts.cushion}</Pill><Pill>accents {counts.railSight + counts.sideWoodApron + counts.verticalCornerRim + counts.baseFoot + counts.lowerTrim}</Pill><Pill>jaws {counts.pocketCup}</Pill><Pill>legs/base {counts.leg + counts.baseCornerBlock}</Pill></div>{pickInfo && <div style={{ marginTop: 7, padding: "7px 8px", borderRadius: 12, background: "rgba(15,23,42,0.78)", border: "1px solid rgba(255,255,255,0.1)" }}><div style={{ fontSize: 11.5, fontWeight: 950, color: "#f8fafc" }}>Tapped: {CONTROL_META[PART_TO_CONTROL[pickInfo.part]].label}</div><div style={{ marginTop: 3, fontSize: 10.2, color: "#cbd5e1", lineHeight: 1.25 }}>mesh: {pickInfo.meshName} · material: {pickInfo.materialName}</div></div>}</div></div><div style={{ position: "fixed", left: 10, right: 10, bottom: 10, maxHeight: "54vh", overflow: "auto", color: "white", fontFamily: "system-ui, sans-serif", pointerEvents: "auto" }}><div style={{ maxWidth: 1040, border: "1px solid rgba(255,255,255,0.14)", background: "rgba(0,0,0,0.72)", backdropFilter: "blur(10px)", borderRadius: 18, padding: 11, boxShadow: "0 18px 40px rgba(0,0,0,0.35)" }}><div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, marginBottom: 10 }}><div><div style={{ fontSize: 12.5, fontWeight: 950 }}>Easy material options</div><div style={{ marginTop: 2, fontSize: 10.5, color: "#94a3b8" }}>Cloth and cushions now both use green/blue choices. Legs/base stay separate from the metal accents.</div></div><button onClick={() => setPalette(DEFAULT_PALETTE)} style={{ border: "1px solid rgba(255,255,255,0.25)", background: "rgba(255,255,255,0.08)", color: "white", borderRadius: 999, padding: "7px 10px", fontSize: 11, fontWeight: 900, cursor: "pointer", flex: "0 0 auto" }}>Reset</button></div><div style={{ display: "grid", gap: 10 }}>{rows.map((row) => <div key={row.control} style={{ display: "grid", gridTemplateColumns: "minmax(116px, 172px) 1fr", gap: 8, alignItems: "center" }}><div><div style={{ fontSize: 11.3, fontWeight: 950, color: "#e5e7eb" }}>{row.label} <span style={{ color: "#94a3b8" }}>({row.count})</span></div><div style={{ fontSize: 9.4, color: "#94a3b8", lineHeight: 1.2 }}>{row.description}</div></div><div style={{ display: "flex", flexWrap: "wrap", gap: 7 }}>{(["a", "b"] as ChoiceKey[]).map((choice) => <ColorButton key={`${row.control}-${choice}`} active={row.selected === choice} option={row.options[choice]} onClick={() => setPalette((current) => ({ ...current, [row.control]: choice }))} />)}</div></div>)}</div></div></div></div>;
 }


### PR DESCRIPTION
### Motivation
- Fix incorrect textures on the pool table by removing the legacy texture-driven mapping and using only procedural material assignments per table part.
- Reduce load time and complexity by removing old table setup code and unnecessary material/rig paths while keeping a lightweight GLTF loader for geometry.

### Description
- Replaced the table preview implementation at `webapp/src/pages/Games/PoolRoyalGameTable.tsx` with the provided procedural-material mapping implementation that classifies triangles and remaps materials (`classifyTriangle`, `splitTableIntoMappedParts`, `resolvePart`).
- Introduced grouped controls (`cloth`, `cushion`, `metalAccent`, `jaws`, `topWoodRail`, `legBase`) and a palette system to apply procedural `MeshPhysicalMaterial` options and to clear legacy texture maps for non-kept parts (`KEEP_TEXTURE_PARTS`, `clearMaps`, `applyMaterial`).
- Added cushion-shadow handling and programmatic rounded foot caps generation, plus a simplified preview UI (`Seven Foot Pool Table — Simplified Options`) and pick inspection support via raycasting.
- Removed old part metadata/linked-control branches and consolidated material cloning/patching utilities to focus on procedural coloring and texture clearing.

### Testing
- Ran lint for the webapp project with `npm --prefix webapp run -s lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a166be241288329956ffb1650ec0e74)