### PR TITLE
Restore Pool Royale page to week-old baseline

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -122,7 +122,7 @@ import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -1386,7 +1386,7 @@ const END_RAIL_INNER_SCALE =
   (2 * TABLE.WALL);
 const END_RAIL_INNER_REDUCTION = 1 - END_RAIL_INNER_SCALE;
 const END_RAIL_INNER_THICKNESS = TABLE.WALL * END_RAIL_INNER_SCALE;
-const PLAYFIELD_SHRINK = 0.83; // shrink the playfield footprint a bit more to better match gameplay mapping while keeping table height intact
+const PLAYFIELD_SHRINK = 0.85; // shrink the playfield footprint by ~15% on all sides while keeping table height intact
 const PLAY_W = (TABLE.W - 2 * SIDE_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
 const PLAY_H = (TABLE.H - 2 * END_RAIL_INNER_THICKNESS) * PLAYFIELD_SHRINK;
 export const POOL_ROYALE_TABLE_DIMENSIONS = Object.freeze({
@@ -1412,14 +1412,13 @@ const BALL_R = BALL_DIAMETER / 2;
 const RACK_VERTICAL_SCREEN_LIFT = BALL_R * 0.86; // nudge the rack farther upward on screen so object balls sit visibly higher
 const ENABLE_BALL_FLOOR_SHADOWS = false;
 const ENABLE_CUE_CLOTH_SHADOW = true;
-const ENABLE_TABLE_FLOOR_SHADOW = true;
+const ENABLE_TABLE_FLOOR_SHADOW = false;
 const BALL_SHADOW_RADIUS_MULTIPLIER = 1;
 const BALL_SHADOW_OPACITY = 0.25;
 const BALL_SHADOW_LIFT = BALL_R * 0.02;
 const CUE_SHADOW_OPACITY = 0.18;
 const CUE_SHADOW_WIDTH_RATIO = 0.62;
-const TABLE_FLOOR_SHADOW_OPACITY = 0.22;
-const TABLE_FLOOR_SHADOW_COLOR = 0x626262; // natural neutral-grey cushion under-shadow
+const TABLE_FLOOR_SHADOW_OPACITY = 0.2;
 const TABLE_FLOOR_SHADOW_MARGIN = TABLE.WALL * 1.1;
 const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.17; // push middle pocket centres a bit farther outside from table center
 const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.34; // keep chrome plate, wood cut, nets and holder alignment with the farther-out middle pockets
@@ -2998,8 +2997,8 @@ const CLOTH_SOFT_BLEND = 0.34;
 
 const CLOTH_QUALITY = (() => {
   const defaults = {
-    textureSize: 4096,
-    anisotropy: 24,
+    textureSize: 6144,
+    anisotropy: 72,
     generateMipmaps: true,
     bumpScaleMultiplier: 1.16,
     sheen: 0.95,
@@ -3030,8 +3029,8 @@ const CLOTH_QUALITY = (() => {
   if (isMobileUA || isTouch || lowMemory || lowRefresh) {
     const highDensity = dpr >= 3;
     return {
-      textureSize: highDensity ? 2048 : 1536,
-      anisotropy: highDensity ? 14 : 10,
+      textureSize: highDensity ? 3072 : 2048,
+      anisotropy: highDensity ? 28 : 24,
       generateMipmaps: true,
       bumpScaleMultiplier: highDensity ? 1.02 : 0.94,
       sheen: 0.78,
@@ -3041,8 +3040,8 @@ const CLOTH_QUALITY = (() => {
 
   if (hardwareConcurrency <= 6 || dpr < 1.75) {
     return {
-      textureSize: 3072,
-      anisotropy: 16,
+      textureSize: 5120,
+      anisotropy: 48,
       generateMipmaps: true,
       bumpScaleMultiplier: 1.12,
       sheen: 0.9,
@@ -4308,63 +4307,92 @@ const SHOWOOD_TABLE_STYLE_STORAGE_KEY = 'poolRoyaleShowoodTableStyle';
 const SHOWOOD_TABLE_PARTS = Object.freeze([
   'cloth',
   'cushion',
-  'metalAccent',
-  'jaws',
   'topWoodRail',
-  'legBase'
+  'railSight',
+  'pocketCup',
+  'baseCornerBlock',
+  'leg',
+  'baseFoot'
 ]);
-const SHOWOOD_TABLE_CONTROL_PARTS = Object.freeze({
-  cloth: ['cloth'],
-  cushion: ['cushion'],
-  metalAccent: ['railSight', 'sideWoodApron', 'verticalCornerRim', 'baseFoot', 'lowerTrim', 'cornerPocketPlate', 'middlePocketPlate'],
-  jaws: ['pocketCup'],
-  topWoodRail: ['topWoodRail'],
-  legBase: ['leg', 'baseCornerBlock', 'underside']
-});
 const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
-  cloth: 'blue',
-  cushion: 'blue',
-  metalAccent: 'chrome',
-  jaws: 'black',
-  topWoodRail: 'brown',
-  legBase: 'black'
+  cloth: 'green',
+  cushion: 'green',
+  topWoodRail: DEFAULT_TABLE_FINISH_ID,
+  railSight: 'gold',
+  pocketCup: 'black',
+  baseCornerBlock: DEFAULT_TABLE_FINISH_ID,
+  leg: DEFAULT_TABLE_FINISH_ID,
+  baseFoot: 'gold'
 });
 const SHOWOOD_TABLE_PART_OPTIONS = Object.freeze({
   cloth: Object.freeze([
-    { id: 'green', label: 'Green field', color: '#0a7b33', material: { color: 0x0a7b33, roughness: 1, metalness: 0, envMapIntensity: 0.16 } },
-    { id: 'blue', label: 'Blue field', color: '#0d4fb8', material: { color: 0x0d4fb8, roughness: 1, metalness: 0, envMapIntensity: 0.16 } }
+    { id: 'green', label: 'Clean Green Field', color: '#0a7b33', material: { color: 0x0a7b33, roughness: 1, metalness: 0, envMapIntensity: 0.16 } },
+    { id: 'blue', label: 'Clean Blue Field', color: '#0d4fb8', material: { color: 0x0d4fb8, roughness: 1, metalness: 0, envMapIntensity: 0.16 } }
   ]),
   cushion: Object.freeze([
-    { id: 'green', label: 'Green cushions', color: '#0a7b33', material: { color: 0x0a7b33, roughness: 0.97, metalness: 0, envMapIntensity: 0.14 } },
-    { id: 'blue', label: 'Blue cushions', color: '#0d4fb8', material: { color: 0x0d4fb8, roughness: 0.97, metalness: 0, envMapIntensity: 0.14 } }
+    { id: 'green', label: 'Green Cushions', color: '#064f23', material: { color: 0x064f23, roughness: 0.94, metalness: 0, envMapIntensity: 0.24 } },
+    { id: 'black', label: 'Black Cushions', color: '#050505', material: { color: 0x050505, roughness: 0.88, metalness: 0, envMapIntensity: 0.38 } }
   ]),
-  metalAccent: Object.freeze([
-    { id: 'gold', label: 'Gold', color: '#d8b23d', material: { color: 0xd8b23d, roughness: 0.06, metalness: 0.98, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 } },
-    { id: 'chrome', label: 'Chrome', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } }
+  topWoodRail: Object.freeze([]),
+  railSight: Object.freeze([
+    { id: 'chrome', label: 'Chrome Apron + Sights', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
+    { id: 'gold', label: 'Gold Apron + Sights', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } }
   ]),
-  jaws: Object.freeze([
-    { id: 'black', label: 'Black jaws', color: '#020202', material: { color: 0x020202, roughness: 0.96, metalness: 0, envMapIntensity: 0.14 } },
-    { id: 'brown', label: 'Brown jaws', color: '#2a1207', material: { color: 0x2a1207, roughness: 0.88, metalness: 0, envMapIntensity: 0.26 } }
+  pocketCup: Object.freeze([
+    { id: 'black', label: 'Black Cups', color: '#000000', keepSourceTexture: true, material: { color: 0x000000, roughness: 0.98, metalness: 0, envMapIntensity: 0.12 } },
+    { id: 'leather', label: 'Dark Leather Cups', color: '#1b0c04', keepSourceTexture: true, material: { color: 0x1b0c04, roughness: 0.9, metalness: 0, envMapIntensity: 0.26 } }
   ]),
-  topWoodRail: Object.freeze([
-    { id: 'brown', label: 'Walnut frame', color: '#5a2608', material: { color: 0x5a2608, roughness: 0.38, metalness: 0.02, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 } },
-    { id: 'black', label: 'Black frame', color: '#070605', material: { color: 0x070605, roughness: 0.28, metalness: 0.04, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 } }
+  baseCornerBlock: Object.freeze([
+    { id: 'brown', label: 'Brown Base', color: '#7b2d11', material: { color: 0x7b2d11, roughness: 0.48, metalness: 0.02, envMapIntensity: 1.1, clearcoat: 0.22, clearcoatRoughness: 0.33 } },
+    { id: 'black', label: 'Black Base', color: '#080605', material: { color: 0x080605, roughness: 0.38, metalness: 0.03, envMapIntensity: 1.34, clearcoat: 0.34, clearcoatRoughness: 0.22 } }
   ]),
-  legBase: Object.freeze([
-    { id: 'brown', label: 'Brown legs/base', color: '#3d1706', material: { color: 0x3d1706, roughness: 0.52, metalness: 0.02, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 } },
-    { id: 'black', label: 'Black legs/base', color: '#070504', material: { color: 0x070504, roughness: 0.4, metalness: 0.04, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 } }
+  leg: Object.freeze([]),
+  baseFoot: Object.freeze([
+    { id: 'chrome', label: 'Chrome Feet', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
+    { id: 'gold', label: 'Gold Feet', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } }
   ])
 });
 const SHOWOOD_TABLE_PART_LABELS = Object.freeze({
-  cloth: 'Field cloth',
+  cloth: 'Field Cloth',
   cushion: 'Cushions',
-  metalAccent: 'Rail sights + side strip + feet',
-  jaws: 'Jaws',
-  topWoodRail: 'Top rail frame',
-  legBase: 'Legs + base'
+  topWoodRail: 'Top Rails',
+  railSight: 'Side Apron + Rail Sights',
+  pocketCup: 'Pocket Cups',
+  baseCornerBlock: 'Table Base',
+  leg: 'Legs',
+  baseFoot: 'Feet'
 });
-const SHOWOOD_CHROME_LINKED_PARTS = new Set(['metalAccent']);
-const getShowoodTablePartOptions = (part) => SHOWOOD_TABLE_PART_OPTIONS[part] || [];
+const SHOWOOD_CHROME_LINKED_PARTS = new Set(['railSight', 'baseFoot']);
+const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOptions = null) => {
+  if (part === 'cloth' || part === 'cushion') {
+    const sourceOptions = Array.isArray(clothOptions) && clothOptions.length
+      ? clothOptions
+      : CLOTH_COLOR_OPTIONS;
+    return sourceOptions.map((option) => ({
+      id: option.id,
+      label: option.label,
+      color: toHexColor(option.color),
+      material: { color: option.color, roughness: 1, metalness: 0, envMapIntensity: 0.16 }
+    }));
+  }
+  if (part === 'topWoodRail' || part === 'baseCornerBlock' || part === 'leg') {
+    const sourceOptions = Array.isArray(tableFinishOptions) && tableFinishOptions.length
+      ? tableFinishOptions
+      : TABLE_FINISH_OPTIONS;
+    return sourceOptions.map((option) => {
+      const finish = TABLE_FINISHES[option.id] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
+      const swatch = option.swatches?.[0] ?? finish?.colors?.rail ?? finish?.colors?.base ?? 0x5a2608;
+      return {
+        id: option.id,
+        label: `${option.label || finish?.label || option.id} ${part === 'topWoodRail' ? 'Rails' : part === 'baseCornerBlock' ? 'Base' : 'Legs'}`,
+        color: toHexColor(swatch),
+        thumbnail: option.thumbnail,
+        useTableFinishTexture: true
+      };
+    });
+  }
+  return SHOWOOD_TABLE_PART_OPTIONS[part] || [];
+};
 const normalizeShowoodTableStyle = (value = {}) => {
   const source = value && typeof value === 'object' ? value : {};
   return SHOWOOD_TABLE_PARTS.reduce((acc, part) => {
@@ -4381,7 +4409,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = Object.entries(SHOWOOD_TABLE_CONTROL_PARTS).find(([, parts]) => parts.includes(part))?.[0] || part;
+  const optionPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -4651,16 +4679,12 @@ let runtimeTextureProfile = Object.freeze({
   textureSize: resolveGraphicsResolutionTier(90).textureSize,
   anisotropy: CLOTH_QUALITY.anisotropy,
   generateMipmaps: CLOTH_QUALITY.generateMipmaps,
-  polyHavenResolution: isLikelyMobileDevice() ? '2k' : '4k',
-  hdriResolution: isLikelyMobileDevice() ? '2k' : '4k',
-  polyHavenPreferredResolutions: isLikelyMobileDevice()
-    ? Object.freeze(['2k', '1k'])
-    : Object.freeze(['4k', '2k']),
-  polyHavenFallbackResolution: isLikelyMobileDevice() ? '1k' : '2k',
-  hdriPreferredResolutions: isLikelyMobileDevice()
-    ? Object.freeze(['2k', '1k'])
-    : Object.freeze(['4k', '2k']),
-  hdriFallbackResolution: isLikelyMobileDevice() ? '1k' : '2k',
+  polyHavenResolution: '4k',
+  hdriResolution: '4k',
+  polyHavenPreferredResolutions: Object.freeze(['4k', '2k']),
+  polyHavenFallbackResolution: '2k',
+  hdriPreferredResolutions: Object.freeze(['4k']),
+  hdriFallbackResolution: '4k',
   enforceTableFinishTextureSize: 4096,
   cueTextureSize: 4096,
   pocketTextureSize: 2048
@@ -4678,14 +4702,12 @@ const updateRuntimeTextureProfile = ({ fps } = {}) => {
     anisotropy,
     generateMipmaps: CLOTH_QUALITY.generateMipmaps,
     polyHavenResolution: tier.key,
-    hdriResolution: isLikelyMobileDevice() ? '2k' : '4k',
+    hdriResolution: '4k',
     polyHavenPreferredResolutions: tier.preferredResolutions ?? Object.freeze([tier.key]),
     polyHavenFallbackResolution:
       tier.fallbackResolution ?? tier.preferredResolutions?.[tier.preferredResolutions.length - 1] ?? tier.key,
-    hdriPreferredResolutions: isLikelyMobileDevice()
-      ? Object.freeze(['2k', '1k'])
-      : Object.freeze(['4k', '2k']),
-    hdriFallbackResolution: isLikelyMobileDevice() ? '1k' : '2k',
+    hdriPreferredResolutions: Object.freeze(['4k']),
+    hdriFallbackResolution: '4k',
     enforceTableFinishTextureSize: textureSize,
     cueTextureSize: textureSize,
     pocketTextureSize: Math.max(512, Math.min(textureSize, 4096))
@@ -5650,11 +5672,6 @@ function updateClothTexturesForFinish (
     }
     if (Number.isFinite(finishInfo.clothBase?.baseBumpScale)) {
       finishInfo.cushionMat.bumpScale = finishInfo.clothBase.baseBumpScale;
-    }
-    if (finishInfo.cushionMat.userData) {
-      // Keep native cushion UVs so side faces keep the same weave/texture family
-      // as the cushion top instead of being remapped like wood rails.
-      finishInfo.cushionMat.userData.preserveOriginalUvMapping = false;
     }
   }
   if (finishInfo.clothEdgeMat) {
@@ -9585,10 +9602,6 @@ export function Table3D(
   cushionMat.color.copy(cushionColor);
   cushionMat.emissive.copy(cushionColor.clone().multiplyScalar(0.045));
   cushionMat.side = THREE.DoubleSide;
-  cushionMat.userData = {
-    ...(cushionMat.userData || {}),
-    preserveOriginalUvMapping: false
-  };
   const clothEdgeMat = clothMat.clone();
   clothEdgeMat.color.copy(clothColor);
   clothEdgeMat.emissive.set(0x000000);
@@ -10294,7 +10307,7 @@ export function Table3D(
     const shadowGeo = new THREE.PlaneGeometry(shadowWidth, shadowHeight);
     shadowGeo.rotateX(-Math.PI / 2);
     const shadowMat = new THREE.MeshBasicMaterial({
-      color: TABLE_FLOOR_SHADOW_COLOR,
+      color: 0x000000,
       transparent: true,
       opacity: TABLE_FLOOR_SHADOW_OPACITY,
       depthWrite: false,
@@ -13038,62 +13051,25 @@ function normalizePoolRoyaleExternalClothTextureScale(mesh, material, role) {
   material.needsUpdate = true;
 }
 
-
-const SHOWOOD_FAST_WOOD_TEXTURE_CACHE = new Map();
-function getShowoodFastWoodTexture(hexColor = '#5a2608') {
-  const key = String(hexColor || '#5a2608').toLowerCase();
-  const cached = SHOWOOD_FAST_WOOD_TEXTURE_CACHE.get(key);
-  if (cached) return cached.clone();
-  const canvas = document.createElement('canvas');
-  canvas.width = 256; canvas.height = 128;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return null;
-  const grad = ctx.createLinearGradient(0, 0, canvas.width, 0);
-  grad.addColorStop(0, '#2b180d');
-  grad.addColorStop(0.35, key);
-  grad.addColorStop(0.7, '#6f3f21');
-  grad.addColorStop(1, '#2b180d');
-  ctx.fillStyle = grad;
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-  for (let x = 0; x < canvas.width; x += 8) {
-    ctx.fillStyle = `rgba(255,255,255,${x % 16 === 0 ? 0.07 : 0.035})`;
-    ctx.fillRect(x, 0, 2, canvas.height);
-  }
-  const tex = new THREE.CanvasTexture(canvas);
-  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-  tex.repeat.set(2, 1);
-  tex.colorSpace = THREE.SRGBColorSpace;
-  tex.anisotropy = resolveTextureAnisotropy(8);
-  tex.needsUpdate = true;
-  SHOWOOD_FAST_WOOD_TEXTURE_CACHE.set(key, tex);
-  return tex.clone();
-}
-
 function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, finishInfo = null) {
   if (!material) return material;
   const style = normalizeShowoodTableStyle(tableModel?.showoodStyle);
-  const roleName = String(role || '').toLowerCase();
-  const forceMetalAccentRole = /railsight|rail[_\s-]*sight|side[_\s-]*wood[_\s-]*apron|sidewoodapron|apron|trim|plate|diamond|marker|inlay|vertical[_\s-]*corner[_\s-]*rim|basefoot|foot/.test(roleName);
   const roleToPart = {
     cloth: 'cloth',
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'metalAccent',
-    railSight: 'metalAccent',
-    trim: 'metalAccent',
-    lowerTrim: 'metalAccent',
-    cornerPocketPlate: 'metalAccent',
-    middlePocketPlate: 'metalAccent',
-    pocket: 'jaws',
-    pocketCup: 'jaws',
-    verticalCornerRim: 'metalAccent',
-    baseFoot: 'metalAccent',
-    baseCornerBlock: 'legBase',
-    leg: 'legBase',
-    underside: 'legBase'
+    sideWoodApron: 'baseCornerBlock',
+    railSight: 'railSight',
+    trim: 'railSight',
+    pocket: 'pocketCup',
+    pocketCup: 'pocketCup',
+    verticalCornerRim: 'baseFoot',
+    baseFoot: 'baseFoot',
+    baseCornerBlock: 'baseCornerBlock',
+    leg: 'leg'
   };
-  const part = forceMetalAccentRole ? 'metalAccent' : (roleToPart[role] || 'topWoodRail');
+  const part = roleToPart[role] || 'topWoodRail';
   const option = getShowoodPartOption(style, part);
   if (!option) return material;
   const mat = material.clone ? material.clone() : material;
@@ -13132,7 +13108,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     });
   };
 
-  if (part === 'metalAccent') {
+  if (part === 'railSight' || part === 'baseFoot') {
     copyMaterialLook(materials.trim);
     if (mat.color && Number.isFinite(materialProps.color)) mat.color.set(materialProps.color);
     ['roughness', 'metalness', 'clearcoat', 'clearcoatRoughness', 'envMapIntensity'].forEach((key) => {
@@ -13147,9 +13123,10 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     mat.bumpMap = null;
     enhanceChromeMaterial(mat);
   } else if (part === 'cloth' || part === 'cushion') {
-    // keep cushion faces on the exact same cloth texture set as the field
-    copyMaterialLook(finishInfo?.clothMat);
-    if (part === 'cushion') applyShowoodTint();
+    copyMaterialLook(part === 'cushion' ? finishInfo?.cushionMat : finishInfo?.clothMat);
+    if (part === 'cushion') {
+      applyShowoodTint();
+    }
     scalePoolRoyaleExternalClothTextureRepeats(mat, tableModel?.clothRepeatScale ?? 1);
     mat.userData = {
       ...(mat.userData || {}),
@@ -13158,20 +13135,19 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
   } else if (part === 'pocketCup') {
     copyMaterialLook(materials.pocketJaw ?? materials.pocketRim);
     applyShowoodTint();
-  } else if (part === 'topWoodRail' || part === 'legBase' || part === 'baseCornerBlock' || part === 'leg') {
-    const baseHex = option?.color || '#5a2608';
-    const woodTex = getShowoodFastWoodTexture(baseHex);
-    if (woodTex) {
-      mat.map = woodTex;
-      mat.normalMap = null;
-      mat.roughnessMap = null;
-      mat.aoMap = null;
-      mat.metalnessMap = null;
-      mat.bumpMap = null;
+  } else if (part === 'topWoodRail' || part === 'baseCornerBlock' || part === 'leg') {
+    const surface = part === 'topWoodRail'
+      ? finishInfo?.parts?.woodSurfaces?.rail
+      : finishInfo?.parts?.woodSurfaces?.frame || finishInfo?.parts?.woodSurfaces?.rail;
+    if (materials.rail?.color && mat.color) mat.color.copy(materials.rail.color);
+    applyWoodTextureToMaterial(mat, surface || { woodRepeatScale: finishInfo?.woodRepeatScale });
+    applyTableFinishDulling(mat);
+    applyTableWoodVisibilityTuning(mat);
+    if (finish?.surfaceStyle === 'matte') {
+      if (finish?.preserveFinishTintOnWood) applyMatteSurfacePropsOnly(mat);
+      else applyMonoMattePlasticSurface(mat);
     }
     applyShowoodTint();
-    if ('clearcoat' in mat) mat.clearcoat = Math.max(mat.clearcoat ?? 0, 0.2);
-    if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = Math.max(mat.clearcoatRoughness ?? 0, 0.2);
   } else {
     applyShowoodTint();
   }
@@ -13306,7 +13282,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part) => {
-      const linkedPart = part;
+      const linkedPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];
@@ -13347,8 +13323,8 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
     return applyShowoodStyleToExternalMaterial(material, role, tableModel, finishInfo);
   }
   const canonicalRole = role === 'pocketCup' ? 'pocket' :
-    (role === 'topWoodRail' || role === 'leg' || role === 'baseCornerBlock' ? 'wood' :
-      ((role === 'railSight' || role === 'sideWoodApron' || role === 'verticalCornerRim' || role === 'baseFoot' || role === 'lowerTrim' || role === 'cornerPocketPlate' || role === 'middlePocketPlate') ? 'trim' : role));
+    (role === 'topWoodRail' || role === 'sideWoodApron' || role === 'leg' || role === 'baseCornerBlock' || role === 'verticalCornerRim' ? 'wood' :
+      (role === 'railSight' ? 'trim' : role));
   role = canonicalRole;
   const finishRoles = Array.isArray(tableModel?.usePoolRoyaleFinishRoles)
     ? tableModel.usePoolRoyaleFinishRoles
@@ -13856,8 +13832,7 @@ function mountPoolRoyaleExternalTableModel({
 
   const ensurePolyhavenBaseTemplate = (assetId, renderer = null) => {
     if (!assetId) {
-      console.warn('Pool Royale base asset missing; falling back to default base.');
-      return Promise.resolve(null);
+      return Promise.reject(new Error('Missing Poly Haven asset id'));
     }
     if (polyhavenBaseTemplates.has(assetId)) {
       return Promise.resolve(polyhavenBaseTemplates.get(assetId));
@@ -13881,12 +13856,10 @@ function mountPoolRoyaleExternalTableModel({
           lastError = error;
         }
       }
-      console.warn('Failed to load Poly Haven base; using fallback.', lastError);
-      polyhavenBaseTemplates.set(assetId, null);
-      return null;
+      throw lastError || new Error(`Failed to load Poly Haven model: ${assetId}`);
     })();
     polyhavenBasePromises.set(assetId, promise);
-    promise.finally(() => polyhavenBasePromises.delete(assetId));
+    promise.catch(() => polyhavenBasePromises.delete(assetId));
     return promise;
   };
 
@@ -17288,10 +17261,10 @@ function PoolRoyaleGame({
   useEffect(() => {
     setShowoodTableStyle((current) => {
       const next = normalizeShowoodTableStyle(current);
-      const linkedMetalAccent = chromeColorId === 'gold' ? 'gold' : 'chrome';
-      return next.metalAccent === linkedMetalAccent
+      const linkedRailSight = chromeColorId === 'gold' ? 'gold' : 'chrome';
+      return next.railSight === linkedRailSight
         ? next
-        : { ...next, metalAccent: linkedMetalAccent };
+        : { ...next, railSight: linkedRailSight };
     });
   }, [chromeColorId]);
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale game page back to the exact week-old baseline to undo recent gameplay, rendering, and material-mapping adjustments that changed runtime behavior and visual framing.

### Description
- Replaced the runtime implementation of `webapp/src/pages/Games/PoolRoyale.jsx` with the prior week-old baseline version, returning constants, texture/profile tuning, and Showood/table mapping logic to the earlier state.
- Restored older graphics/configuration constants and defaults including decoder path, `PLAYFIELD_SHRINK`, table floor shadow flags/opacities, cloth quality defaults, and runtime texture profile choices for polyhaven/HDri resolution handling.
- Reinstated the prior Showood table parts/options and remapping behavior by reintroducing the earlier part list, option lookup, and the revised `applyShowoodStyleToExternalMaterial`/remapping logic used by external table models.
- Adjusted external model loading behavior and error handling for PolyHaven templates and cleaned up related resource/promise handling and material texture normalization logic.

### Testing
- Checked out the historical baseline file into the working tree and inspected the modified ranges using `nl -ba webapp/src/pages/Games/PoolRoyale.jsx | sed -n '120,170p;1380,1435p;2990,3040p'`, which displayed the restored sections successfully (succeeded).
- Verified the staged diff for the restored file with `git diff --cached -- webapp/src/pages/Games/PoolRoyale.jsx | head -n 40` to confirm the intended changes (succeeded).
- Committed the restored file into a working branch and generated PR metadata using `make_pr` to prepare the PR entry (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16abd805dc8329816777215b6cd51c)