### PR TITLE
Fix missing Chess Battle Royal firearm GLTF texture fallbacks

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -231,23 +231,28 @@ const CHESS_CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   },
   uziSprayAttack: {
     urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf'],
-    scale: 0.2
+    scale: 0.2,
+    textureOverrideUrls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/SigSauer.jpg']
   },
   ak47VolleyAttack: {
     urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'],
-    scale: 0.24
+    scale: 0.24,
+    textureOverrideUrls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg']
   },
   krsvBurstAttack: {
     urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf'],
-    scale: 0.24
+    scale: 0.24,
+    textureOverrideUrls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg']
   },
   smithSidearmAttack: {
     urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf'],
-    scale: 0.13
+    scale: 0.13,
+    textureOverrideUrls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Smith.jpeg']
   },
   mosinMarksmanAttack: {
     urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'],
-    scale: 0.5125
+    scale: 0.5125,
+    textureOverrideUrls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Mosin.png']
   },
   sigsauerTacticalAttack: {
     urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf'],


### PR DESCRIPTION
### Motivation
- Several remote Gunify `.gltf` weapon models can load in-browser without resolving their referenced texture files, leaving firearms untextured in the Chess Battle Royal capture visuals.
- Provide explicit per-weapon texture fallbacks so the existing GLTF loader can assign visible maps when model-internal references fail.

### Description
- Added `textureOverrideUrls` to `CHESS_CAPTURE_WEAPON_MODEL_CONFIG` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` for `uziSprayAttack`, `ak47VolleyAttack`, `krsvBurstAttack`, `smithSidearmAttack`, and `mosinMarksmanAttack`.
- The new entries point to hosted image fallbacks (e.g. `https://raw.githubusercontent.com/.../images/AK47.jpeg`) which are consumed by the existing `loadChessCaptureWeaponModel` texture-loading path when a model lacks `material.map`.
- No change to loading logic or runtime shader/material handling was made because the loader already applies the override, flips/sets `flipY`, calls `applySRGBColorSpace`, and marks textures `needsUpdate`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17b4a94f7c8329af4e0e26841570b4)