### PR TITLE
Fix GLTF weapon textures fallback mapping

### DIFF
--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -27,10 +27,16 @@ namespace Aiming.Gameplay.Rendering
         private static readonly int MainTexStId = Shader.PropertyToID("_MainTex_ST");
         private static readonly int GltfBaseColorTextureId = Shader.PropertyToID("_BaseColorTexture");
         private static readonly int GltfBaseColorMapId = Shader.PropertyToID("baseColorTexture");
+        private static readonly int GltfBaseColorMapAltId = Shader.PropertyToID("_BaseColorTex");
+        private static readonly int GltfMainTexAltId = Shader.PropertyToID("_BaseColorMap");
         private static readonly int GltfNormalTextureId = Shader.PropertyToID("_NormalTexture");
+        private static readonly int GltfNormalMapAltId = Shader.PropertyToID("normalTexture");
         private static readonly int GltfMetallicRoughnessTextureId = Shader.PropertyToID("_MetallicRoughnessTexture");
+        private static readonly int GltfMetallicRoughnessAltId = Shader.PropertyToID("metallicRoughnessTexture");
         private static readonly int GltfOcclusionTextureId = Shader.PropertyToID("_OcclusionTexture");
+        private static readonly int GltfOcclusionAltId = Shader.PropertyToID("occlusionTexture");
         private static readonly int GltfEmissiveTextureId = Shader.PropertyToID("_EmissiveTexture");
+        private static readonly int GltfEmissiveAltId = Shader.PropertyToID("emissiveTexture");
         private static readonly int GltfBaseColorFactorId = Shader.PropertyToID("_BaseColorFactor");
 
         void Awake()
@@ -121,7 +127,7 @@ namespace Aiming.Gameplay.Rendering
         private static void CopyPbrMaps(Material material, MaterialTextureSnapshot textureSnapshot)
         {
             int sourceUvPropertyId;
-            Texture baseTexture = FirstTexture(material, out sourceUvPropertyId, BaseMapId, MainTexId, GltfBaseColorTextureId, GltfBaseColorMapId);
+            Texture baseTexture = FirstTexture(material, out sourceUvPropertyId, BaseMapId, MainTexId, GltfBaseColorTextureId, GltfBaseColorMapId, GltfBaseColorMapAltId, GltfMainTexAltId);
             if (baseTexture == null)
             {
                 baseTexture = textureSnapshot.BaseTexture;
@@ -154,7 +160,7 @@ namespace Aiming.Gameplay.Rendering
                 material.SetColor(ColorId, resolvedBaseColor);
             }
 
-            Texture normal = FirstTexture(material, BumpMapId, GltfNormalTextureId);
+            Texture normal = FirstTexture(material, BumpMapId, GltfNormalTextureId, GltfNormalMapAltId);
             if (normal == null)
             {
                 normal = textureSnapshot.NormalTexture;
@@ -165,7 +171,7 @@ namespace Aiming.Gameplay.Rendering
                 material.EnableKeyword("_NORMALMAP");
             }
 
-            Texture metallic = FirstTexture(material, MetallicGlossMapId, GltfMetallicRoughnessTextureId);
+            Texture metallic = FirstTexture(material, MetallicGlossMapId, GltfMetallicRoughnessTextureId, GltfMetallicRoughnessAltId);
             if (metallic == null)
             {
                 metallic = textureSnapshot.MetallicTexture;
@@ -175,7 +181,7 @@ namespace Aiming.Gameplay.Rendering
                 TrySetTexture(material, MetallicGlossMapId, metallic);
             }
 
-            Texture occlusion = FirstTexture(material, OcclusionMapId, GltfOcclusionTextureId);
+            Texture occlusion = FirstTexture(material, OcclusionMapId, GltfOcclusionTextureId, GltfOcclusionAltId);
             if (occlusion == null)
             {
                 occlusion = textureSnapshot.OcclusionTexture;
@@ -185,7 +191,7 @@ namespace Aiming.Gameplay.Rendering
                 TrySetTexture(material, OcclusionMapId, occlusion);
             }
 
-            Texture emission = FirstTexture(material, EmissionMapId, GltfEmissiveTextureId);
+            Texture emission = FirstTexture(material, EmissionMapId, GltfEmissiveTextureId, GltfEmissiveAltId);
             if (emission == null)
             {
                 emission = textureSnapshot.EmissionTexture;
@@ -212,12 +218,12 @@ namespace Aiming.Gameplay.Rendering
             public static MaterialTextureSnapshot Capture(Material material)
             {
                 MaterialTextureSnapshot snapshot = new MaterialTextureSnapshot();
-                snapshot.BaseTexture = FirstTexture(material, out snapshot.BaseTexturePropertyId, BaseMapId, MainTexId, GltfBaseColorTextureId, GltfBaseColorMapId);
+                snapshot.BaseTexture = FirstTexture(material, out snapshot.BaseTexturePropertyId, BaseMapId, MainTexId, GltfBaseColorTextureId, GltfBaseColorMapId, GltfBaseColorMapAltId, GltfMainTexAltId);
                 snapshot.HasGltfOnlyBaseTexture = snapshot.BaseTexture != null && snapshot.BaseTexturePropertyId != BaseMapId && snapshot.BaseTexturePropertyId != MainTexId;
-                snapshot.NormalTexture = FirstTexture(material, BumpMapId, GltfNormalTextureId);
-                snapshot.MetallicTexture = FirstTexture(material, MetallicGlossMapId, GltfMetallicRoughnessTextureId);
-                snapshot.OcclusionTexture = FirstTexture(material, OcclusionMapId, GltfOcclusionTextureId);
-                snapshot.EmissionTexture = FirstTexture(material, EmissionMapId, GltfEmissiveTextureId);
+                snapshot.NormalTexture = FirstTexture(material, BumpMapId, GltfNormalTextureId, GltfNormalMapAltId);
+                snapshot.MetallicTexture = FirstTexture(material, MetallicGlossMapId, GltfMetallicRoughnessTextureId, GltfMetallicRoughnessAltId);
+                snapshot.OcclusionTexture = FirstTexture(material, OcclusionMapId, GltfOcclusionTextureId, GltfOcclusionAltId);
+                snapshot.EmissionTexture = FirstTexture(material, EmissionMapId, GltfEmissiveTextureId, GltfEmissiveAltId);
 
                 if (material.HasProperty(BaseColorId))
                 {

--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -147,8 +147,8 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private float maxLookDownDegrees = 26f;
 
         [Header("Material import behavior")]
-        [Tooltip("Keeps imported GLTF/GLB weapon materials untouched so original weapon textures stay exactly as authored.")]
-        [SerializeField] private bool preserveOriginalWeaponMaterials = true;
+        [Tooltip("Run a compatibility pass for imported GLTF/GLB weapon materials so base-color textures remain visible on all supported shaders.")]
+        [SerializeField] private bool preserveOriginalWeaponMaterials = false;
 
 
         private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();


### PR DESCRIPTION
### Motivation
- Some imported GLTF/GLB firearm assets used alternate texture property names, causing base-color and other PBR textures to appear missing on weapons at runtime.
- The compatibility adapter previously only checked a subset of GLTF property names and therefore did not always surface textures when the import shader used different property aliases.
- The compatibility pass was effectively disabled by default for battle-royale weapons, preventing the adapter from running in the common runtime path.

### Description
- Extended `GltfMaterialCompatibilityAdapter` to recognize additional GLTF texture property aliases by adding new property IDs (e.g. `_BaseColorTex`, `_BaseColorMap`, `normalTexture`, `metallicRoughnessTexture`, `occlusionTexture`, `emissiveTexture`).
- Included these aliases in both the snapshot capture and the live copy path so `FirstTexture(...)` checks the new property IDs when resolving base, normal, metallic-roughness, occlusion, and emissive textures.
- Changed `BattleRoyaleWeaponDirector` default to run the compatibility pass at runtime by setting `preserveOriginalWeaponMaterials` to `false` and updated the tooltip to reflect the behavior.
- Modified files: `Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs` and `Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs`.

### Testing
- Verified code changes with `git diff` and `git status --short` and committed the update (`Fix GLTF weapon textures fallback mapping`), all commands succeeded.
- Confirmed the alias properties are used in both snapshot and copy code paths by inspecting the updated `GltfMaterialCompatibilityAdapter` source.
- No automated Unity Editor/runtime rendering tests were executed in this CLI environment, so visual verification in the Unity Editor is still recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17b4a94f7c8329af4e0e26841570b4)