### PR TITLE
Fix missing textures on Chess Battle Royal GLTF firearms

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -4268,8 +4268,15 @@ async function loadChessCaptureWeaponModel(captureAnimationId) {
     for (let i = 0; i < candidateUrls.length; i += 1) {
       const candidateUrl = candidateUrls[i];
       try {
+        const resolvedUrl = new URL(
+          candidateUrl,
+          typeof window !== 'undefined' ? window.location?.href : candidateUrl
+        ).href;
+        const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
+        loader.setResourcePath?.(resourcePath);
+        loader.setPath?.('');
         // eslint-disable-next-line no-await-in-loop
-        loadedRoot = assignLoadedGltf(await withLoadTimeout(loader.loadAsync(candidateUrl)));
+        loadedRoot = assignLoadedGltf(await withLoadTimeout(loader.loadAsync(resolvedUrl)));
       } catch (error) {
         if (i === candidateUrls.length - 1) {
           console.warn('Chess capture weapon model load failed', captureAnimationId, candidateUrl, error);


### PR DESCRIPTION
### Motivation
- External firearm `.gltf`/`.glb` assets reference textures with relative paths, which produced untextured weapons when the loader did not set the model's resource directory before loading.

### Description
- Resolve each candidate firearm model URL to an absolute URL and compute its directory, set `GLTFLoader.setResourcePath` and `loader.setPath('')` for that URL, then load the resolved URL so relative texture references resolve correctly.

### Testing
- No automated tests were run for this runtime asset-loading fix; the change was validated by inspecting the updated loader logic and performing a local smoke check of the modified code block.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17b4a94f7c8329af4e0e26841570b4)