### PR TITLE
Lower bowling field to align with HDRI ground

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -286,8 +286,11 @@ const RESULT_COMPLIMENTS = {
   open: ['Nice try—adjust and fire again.', 'Good pace, keep rhythm.']
 } as const;
 
+// Visually lower the entire bowling field so it sits on the HDRI ground line.
+const BOWLING_HDRI_GROUND_SNAP_DROP = 0.46;
+
 const CFG = {
-  laneY: -1.5,
+  laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,
   laneHalfW: 1.36,
   gutterHalfW: 1.72,
   laneCenterOffset: 1.82,


### PR DESCRIPTION
### Motivation
- The bowling playfield appeared visually too high relative to HDRI environments and needed to sit lower so the lane/floor reads as touching the HDRI ground on mobile portrait view.
- Provide a single, tunable offset constant so the vertical snap can be adjusted without touching many placement sites.

### Description
- Added `BOWLING_HDRI_GROUND_SNAP_DROP = 0.46` and applied it to the baseline by changing `CFG.laneY` from `-1.5` to `-1.5 - BOWLING_HDRI_GROUND_SNAP_DROP` in `webapp/src/pages/Games/BowlingRealistic.tsx`.
- The change is localized to the configuration constants and is intentionally non-invasive so existing placement math continues to reference `CFG.laneY` as before.

### Testing
- No automated unit or integration tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c0a1c7c48329834fb55bf25898f0)