### PR TITLE
PoolRoyale: Refactor Showood table styles, part mapping, and cushion shadow handling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4317,11 +4317,11 @@ const SHOWOOD_TABLE_PARTS = Object.freeze([
 const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
   cloth: 'green',
   cushion: 'green',
-  topWoodRail: DEFAULT_TABLE_FINISH_ID,
+  topWoodRail: 'walnut',
   railSight: 'gold',
   pocketCup: 'black',
-  baseCornerBlock: DEFAULT_TABLE_FINISH_ID,
-  leg: DEFAULT_TABLE_FINISH_ID,
+  baseCornerBlock: 'black',
+  leg: 'black',
   baseFoot: 'gold'
 });
 const SHOWOOD_TABLE_PART_OPTIONS = Object.freeze({
@@ -4330,8 +4330,8 @@ const SHOWOOD_TABLE_PART_OPTIONS = Object.freeze({
     { id: 'blue', label: 'Clean Blue Field', color: '#0d4fb8', material: { color: 0x0d4fb8, roughness: 1, metalness: 0, envMapIntensity: 0.16 } }
   ]),
   cushion: Object.freeze([
-    { id: 'green', label: 'Green Cushions', color: '#064f23', material: { color: 0x064f23, roughness: 0.94, metalness: 0, envMapIntensity: 0.24 } },
-    { id: 'black', label: 'Black Cushions', color: '#050505', material: { color: 0x050505, roughness: 0.88, metalness: 0, envMapIntensity: 0.38 } }
+    { id: 'green', label: 'Matched Green Cushions', color: '#064f22', keepSourceTexture: true, material: { color: 0x064f22, roughness: 0.88, metalness: 0, envMapIntensity: 0.55 } },
+    { id: 'black', label: 'Black Rubber Cushions', color: '#050505', keepSourceTexture: true, material: { color: 0x050505, roughness: 0.86, metalness: 0, envMapIntensity: 0.55 } }
   ]),
   topWoodRail: Object.freeze([]),
   railSight: Object.freeze([
@@ -4363,6 +4363,7 @@ const SHOWOOD_TABLE_PART_LABELS = Object.freeze({
   baseFoot: 'Feet'
 });
 const SHOWOOD_CHROME_LINKED_PARTS = new Set(['railSight', 'baseFoot']);
+const CUSHION_SHADOW_GREY = '#666a72';
 const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOptions = null) => {
   if (part === 'cloth' || part === 'cushion') {
     const sourceOptions = Array.isArray(clothOptions) && clothOptions.length
@@ -4375,21 +4376,17 @@ const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOption
       material: { color: option.color, roughness: 1, metalness: 0, envMapIntensity: 0.16 }
     }));
   }
-  if (part === 'topWoodRail' || part === 'baseCornerBlock' || part === 'leg') {
-    const sourceOptions = Array.isArray(tableFinishOptions) && tableFinishOptions.length
-      ? tableFinishOptions
-      : TABLE_FINISH_OPTIONS;
-    return sourceOptions.map((option) => {
-      const finish = TABLE_FINISHES[option.id] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
-      const swatch = option.swatches?.[0] ?? finish?.colors?.rail ?? finish?.colors?.base ?? 0x5a2608;
-      return {
-        id: option.id,
-        label: `${option.label || finish?.label || option.id} ${part === 'topWoodRail' ? 'Rails' : part === 'baseCornerBlock' ? 'Base' : 'Legs'}`,
-        color: toHexColor(swatch),
-        thumbnail: option.thumbnail,
-        useTableFinishTexture: true
-      };
-    });
+  if (part === 'topWoodRail') {
+    return [
+      { id: 'walnut', label: 'Walnut Frame', color: '#5a2608', material: { color: 0x5a2608, roughness: 0.38, metalness: 0.02, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 }, keepSourceTexture: true },
+      { id: 'black', label: 'Black Frame', color: '#070605', material: { color: 0x070605, roughness: 0.28, metalness: 0.04, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 }, keepSourceTexture: true }
+    ];
+  }
+  if (part === 'baseCornerBlock' || part === 'leg') {
+    return [
+      { id: 'brown', label: part === 'leg' ? 'Brown Legs' : 'Brown Base', color: '#3d1706', material: { color: 0x3d1706, roughness: 0.52, metalness: 0.02, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }, keepSourceTexture: true },
+      { id: 'black', label: part === 'leg' ? 'Black Legs' : 'Black Base', color: '#070504', material: { color: 0x070504, roughness: 0.4, metalness: 0.04, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 }, keepSourceTexture: true }
+    ];
   }
   return SHOWOOD_TABLE_PART_OPTIONS[part] || [];
 };
@@ -13209,10 +13206,11 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   const s = resolvePoolRoyaleShowoodSpatialContext(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize);
   const color = material?.color?.isColor ? material.color : null;
   const green = color ? color.g > color.r * 1.14 && color.g > color.b * 1.08 && color.g > 0.11 : false;
-  const brown = color ? color.r > color.b * 1.12 && color.g > color.b * 0.48 && color.r > 0.07 && color.g < color.r * 0.9 : false;
   const black = color ? color.r < 0.11 && color.g < 0.11 && color.b < 0.11 : false;
+  const brown = color ? color.r > color.b * 1.12 && color.g > color.b * 0.48 && color.r > 0.07 && color.g < color.r * 0.9 : false;
   const gold = color ? color.r > 0.42 && color.g > 0.29 && color.b < 0.25 && color.r >= color.g * 0.88 : false;
   const light = color ? color.r > 0.72 && color.g > 0.72 && color.b > 0.62 : false;
+
   const namedCloth = /cloth|felt|fabric|surface|bed|slate/i.test(name);
   const namedCushion = /cushion|rubber|bumper|railrubber/i.test(name);
   const namedPocket = /pocket|hole|drop|net|liner|leather|cup/i.test(name);
@@ -13220,44 +13218,103 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   const namedSight = /sight|diamond|marker|dot|inlay/i.test(name);
   const namedWood = /wood|walnut|rail|apron|leg|base|frame|cabinet|corner|showood|support/i.test(name);
   const metalish = (material?.metalness ?? 0) > 0.16 || (material?.clearcoat ?? 0) > 0.58 || gold;
+
   const high = s.relY > 0.54;
   const veryTop = s.relY > 0.65;
-  const midBody = s.relY > 0.16 && s.relY <= 0.62;
   const low = s.relY <= 0.16;
+
   const sideMiddlePocketZone = high && s.longN < 0.255 && s.shortN > 0.69;
   const cornerPocketZone = high && s.longN > 0.68 && s.shortN > 0.66;
   const anyPocketZone = sideMiddlePocketZone || cornerPocketZone;
-  const centralCloth = high && s.upFace && !anyPocketZone && s.longN < 0.74 && s.shortN < 0.59;
-  const cushionBand = high && !anyPocketZone && (
-    (s.upFace && s.longN >= 0.70 && s.longN < 0.88 && s.shortN < 0.68) ||
-    (s.upFace && s.shortN >= 0.54 && s.shortN < 0.78 && s.longN < 0.88) ||
-    (s.sideFace && s.relY > 0.58 && (s.longN > 0.66 || s.shortN > 0.50)) ||
-    (s.downFace && s.relY > 0.46 && s.relY < 0.84 && ((s.longN > 0.62 && s.longN < 0.94) || (s.shortN > 0.44 && s.shortN < 0.86)))
-  );
+
+  const centralCloth = high && s.upFace && s.longN < 0.61 && s.shortN < 0.53;
+  const cushionBand = high && (s.longN > 0.52 || s.shortN > 0.49) && (s.longN < 0.9 || s.shortN < 0.9);
   const topRailBand = high && (s.longN > 0.58 || s.shortN > 0.535);
-  const outsideBaseCornerRimZone = s.sideFace && s.relY > 0.08 && s.relY < 0.82 && s.longN > 0.70 && s.shortN > 0.50;
-  const outerMostVerticalCorner = s.sideFace && s.relY > 0.10 && s.relY < 0.84 && s.longN > 0.78 && s.shortN > 0.64;
-  const sideLowerTrimZone = s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54) && !outsideBaseCornerRimZone;
-  const baseCornerZone = s.sideFace && midBody && (
-    (s.longN > 0.08 && s.longN < 0.58 && s.shortN < 0.42) ||
-    (s.longN > 0.50 && s.shortN > 0.48) ||
-    (s.longN > 0.64 && s.shortN > 0.64)
-  );
-  const hardwareCandidate = namedHardware || metalish || ((black || gold || light) && !green && !brown && !namedWood);
-  if (namedPocket || (black && anyPocketZone && (s.downFace || s.sideFace || s.relY < 0.79) && !hardwareCandidate)) return 'pocketCup';
-  if (hardwareCandidate && (sideMiddlePocketZone || cornerPocketZone) && !green && !brown) return 'railSight';
+  const topRailNonPocket = topRailBand && !anyPocketZone;
+
+  const topRailSideVerticalRimZone =
+    s.sideFace && !s.upFace && s.relY > 0.46 && s.relY < 0.96 && s.longN > 0.6 && s.shortN > 0.58;
+
+  const underRailSightCornerRimZone =
+    s.sideFace && !s.upFace && s.relY > 0.36 && s.relY < 0.76 && s.longN > 0.67 && s.shortN > 0.52;
+
+  const outsideBaseCornerRimZone =
+    s.sideFace && s.relY > 0.08 && s.relY < 0.78 && s.longN > 0.72 && s.shortN > 0.54;
+
+  const outerMostVerticalCorner =
+    s.sideFace && s.relY > 0.1 && s.relY < 0.8 && s.longN > 0.8 && s.shortN > 0.68;
+
+  const baseCornerZone =
+    s.sideFace &&
+    s.relY > 0.12 &&
+    s.relY < 0.64 &&
+    ((s.longN > 0.1 && s.longN < 0.56 && s.shortN < 0.36) ||
+      (s.longN > 0.58 && s.shortN > 0.56)) &&
+    !(underRailSightCornerRimZone || topRailSideVerticalRimZone);
+
+  const legZone = s.sideFace && s.relY > 0.14 && s.relY < 0.62 && s.longN < 0.62 && s.shortN < 0.58;
+
+  const railSightDownBand =
+    s.sideFace &&
+    !s.upFace &&
+    !anyPocketZone &&
+    s.relY > 0.44 &&
+    s.relY < 0.72 &&
+    (s.longN > 0.54 || s.shortN > 0.48) &&
+    !(topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner || baseCornerZone || legZone);
+
+  const sideLowerTrimZone =
+    s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54);
+
+  const hardwareCandidate =
+    namedHardware ||
+    metalish ||
+    ((black || gold || light) && !green && !brown && !namedWood);
+
+  const pocketInteriorCandidate =
+    namedPocket ||
+    (black && anyPocketZone && (s.downFace || s.sideFace || s.relY < 0.79) && !hardwareCandidate);
+
+  if (namedCloth) return 'cloth';
+  if (namedCushion) return 'cushion';
   if (namedSight && high) return 'railSight';
-  if ((namedCloth || green) && centralCloth) return 'cloth';
-  if ((namedCushion || green) && cushionBand) return 'cushion';
-  if ((outsideBaseCornerRimZone || outerMostVerticalCorner) && !green && !s.upFace) return 'verticalCornerRim';
-  if (hardwareCandidate && topRailBand && s.upFace && !brown && !green) return 'railSight';
-  if (hardwareCandidate && sideLowerTrimZone && !green) return 'railSight';
+
+  if (pocketInteriorCandidate) return 'pocketCup';
+  if (namedPocket && hardwareCandidate && sideMiddlePocketZone) return 'middlePocketPlate';
+  if (namedPocket && hardwareCandidate && cornerPocketZone) return 'cornerPocketPlate';
+  if (hardwareCandidate && sideMiddlePocketZone && !green && !brown) return 'middlePocketPlate';
+  if (hardwareCandidate && cornerPocketZone && !green && !brown) return 'cornerPocketPlate';
+
+  if (green && centralCloth) return 'cloth';
+  if (green && cushionBand) return 'cushion';
+
+  if (topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner) {
+    return 'verticalCornerRim';
+  }
+
+  if (hardwareCandidate && topRailNonPocket && s.upFace && !brown && !green) return 'railSight';
+
   if (low) return 'baseFoot';
-  if ((brown || namedWood || black) && baseCornerZone) return 'baseCornerBlock';
-  if (midBody && s.sideFace && !(s.longN > 0.64 && s.shortN > 0.64)) return 'leg';
+  if (s.downFace && s.relY < 0.5) return 'underside';
+  if ((brown || namedWood) && baseCornerZone) return 'baseCornerBlock';
+  if (baseCornerZone) return 'baseCornerBlock';
+  if (legZone && (brown || namedWood || !hardwareCandidate)) return 'leg';
+  if (hardwareCandidate && sideLowerTrimZone && !green) return 'lowerTrim';
+  if (railSightDownBand && !green) return 'sideWoodApron';
   if (veryTop && (s.upFace || topRailBand) && !green) return 'topWoodRail';
   if (high && s.sideFace && !green && !anyPocketZone) return 'sideWoodApron';
-  return namedCushion ? 'cushion' : 'sideWoodApron';
+
+  return 'sideWoodApron';
+}
+
+function isPoolRoyaleShowoodCushionShadowTriangle(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize) {
+  const s = resolvePoolRoyaleShowoodSpatialContext(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize);
+  return (
+    s.downFace &&
+    s.relY > 0.46 &&
+    s.relY < 0.84 &&
+    ((s.longN > 0.6 && s.longN < 0.95) || (s.shortN > 0.42 && s.shortN < 0.88))
+  );
 }
 
 function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInfo = null) {
@@ -13281,13 +13338,31 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalIndex = [];
     const finalMaterials = [];
     const materialLookup = new Map();
-    const getMaterialIndex = (sourceMaterialIndex, part) => {
+    const getMaterialIndex = (sourceMaterialIndex, part, cushionShadow = false) => {
       const linkedPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
-      const key = `${sourceMaterialIndex}:${linkedPart}`;
+      const key = `${sourceMaterialIndex}:${linkedPart}:${cushionShadow ? 'shadow' : 'main'}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];
       const next = applyShowoodStyleToExternalMaterial(source, linkedPart, tableModel, finishInfo);
-      next.name = `${source?.name || 'showood'}__${linkedPart}`;
+
+      if (cushionShadow && linkedPart === 'cushion') {
+        if (next.color) next.color.set(CUSHION_SHADOW_GREY);
+        if ('metalness' in next) next.metalness = 0;
+        if ('roughness' in next) next.roughness = 0.96;
+        if ('envMapIntensity' in next) next.envMapIntensity = 0.22;
+        if ('clearcoat' in next) next.clearcoat = 0;
+        if ('clearcoatRoughness' in next) next.clearcoatRoughness = 0;
+        next.map = null;
+        next.normalMap = null;
+        next.bumpMap = null;
+        next.roughnessMap = null;
+        next.metalnessMap = null;
+        next.aoMap = null;
+        next.emissiveMap = null;
+        next.lightMap = null;
+        next.alphaMap = null;
+      }
+      next.name = `${source?.name || 'showood'}__${linkedPart}${cushionShadow ? '__shadow' : ''}`;
       const index = finalMaterials.length;
       finalMaterials.push(next);
       materialLookup.set(key, index);
@@ -13300,7 +13375,8 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
       const sourceMaterialIndex = Math.max(0, Math.min(getPoolRoyaleGeometryMaterialIndexAt(sourceGeometry, i), sourceMaterials.length - 1));
       const sourceMaterial = sourceMaterials[sourceMaterialIndex];
       const part = resolvePoolRoyaleShowoodTrianglePart(mesh, sourceGeometry, sourceMaterial, a, b, c, tableBox, tableCenter, tableSize);
-      const materialIndex = getMaterialIndex(sourceMaterialIndex, part);
+      const cushionShadow = part === 'cushion' && isPoolRoyaleShowoodCushionShadowTriangle(mesh, sourceGeometry, a, b, c, tableBox, tableCenter, tableSize);
+      const materialIndex = getMaterialIndex(sourceMaterialIndex, part, cushionShadow);
       const start = finalIndex.length;
       finalIndex.push(a, b, c);
       finalGeometry.addGroup(start, 3, materialIndex);


### PR DESCRIPTION
### Motivation
- Make Showood table styling more explicit and consistent by replacing indirect finish lookups with concrete part options and sane defaults. 
- Improve geometry-to-part detection for the Showood seven-foot model so materials are mapped more accurately to rails, cushions, pockets, legs, and base elements. 
- Add support for rendering a darker cushion shadow material on interior cushion triangles to reduce lighting artifacts.

### Description
- Replace the previous table-finish lookup for `topWoodRail`, `baseCornerBlock`, and `leg` with explicit option arrays and tuned material properties, and change defaults (`topWoodRail` -> `walnut`, `baseCornerBlock`/`leg` -> `black`).
- Update cloth and cushion option entries (labels, colors, `keepSourceTexture`, and material params) and add a `CUSHION_SHADOW_GREY` constant for shadow material tinting.
- Rework `resolvePoolRoyaleShowoodTrianglePart` with refined spatial zone calculations and ordering to return more granular roles (e.g., `middlePocketPlate`, `cornerPocketPlate`, `lowerTrim`, `sideWoodApron`, `underside`) and better handle cloth/cushion/hardware detection.
- Add `isPoolRoyaleShowoodCushionShadowTriangle` to detect interior cushion triangles that should use a desaturated shadow material and extend `remapPoolRoyaleShowoodExternalParts` to create shadow variants by passing a `cushionShadow` flag into the material lookup and mutating material properties and names for shadow variants.

### Testing
- Ran unit tests with `yarn test` and all tests passed.
- Ran the linter with `yarn lint` and no issues were reported.
- Performed a production build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17bb71eb988329b0b70a3492121bed)