### PR TITLE
Adjust Murlan Royale opponent card seat offsets

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2333,7 +2333,7 @@ function computeHeldCardsPose({ resolvedSeatIndex = 0 } = {}) {
     // Top opponent cards: push outward so they sit farther from table center.
     return {
       ...basePose,
-      z: basePose.z - 1.65 * MODEL_SCALE
+      z: basePose.z - 2.15 * MODEL_SCALE
     };
   }
 
@@ -2341,8 +2341,8 @@ function computeHeldCardsPose({ resolvedSeatIndex = 0 } = {}) {
     // Side opponent cards: keep same card size/height and move visually upward.
     return {
       ...basePose,
-      y: basePose.y + 0.72 * MODEL_SCALE,
-      z: basePose.z - 0.5 * MODEL_SCALE
+      y: basePose.y + 0.9 * MODEL_SCALE,
+      z: basePose.z + 0.45 * MODEL_SCALE
     };
   }
 


### PR DESCRIPTION
### Motivation
- Tweak opponent held-card poses for portrait mobile framing so the top player’s cards sit farther outward from the table and the left/right players’ cards move inward and slightly higher on the screen while preserving the bottom (human) player pose.

### Description
- Updated `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to increase the top-seat outward offset by changing `z: basePose.z - 1.65 * MODEL_SCALE` to `z: basePose.z - 2.15 * MODEL_SCALE` for seat 3.
- Adjusted side-seat offsets for seats 1 and 2 by changing `y: basePose.y + 0.72 * MODEL_SCALE` to `y: basePose.y + 0.9 * MODEL_SCALE` and `z: basePose.z - 0.5 * MODEL_SCALE` to `z: basePose.z + 0.45 * MODEL_SCALE` to move them visually upward and inward toward the table.
- Left the bottom (seat 0) pose intact and only modified pose offsets (no card geometry/scale changes).

### Testing
- No automated tests were executed for this change since it is position-tuning only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d9b90e388329891816e220501633)