### PR TITLE
Lower bowling field to meet HDRI ground

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -287,7 +287,7 @@ const RESULT_COMPLIMENTS = {
 } as const;
 
 // Visually lower the entire bowling field so it sits on the HDRI ground line.
-const BOWLING_HDRI_GROUND_SNAP_DROP = 0.46;
+const BOWLING_HDRI_GROUND_SNAP_DROP = 0.82;
 
 const CFG = {
   laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,


### PR DESCRIPTION
### Motivation
- The bowling lane/floor was visually floating above the HDRI ground, so the entire field needs to be shifted downward to sit on the HDRI ground line.

### Description
- Updated `BOWLING_HDRI_GROUND_SNAP_DROP` from `0.46` to `0.82` in `webapp/src/pages/Games/BowlingRealistic.tsx`, which changes `CFG.laneY` and thus moves lane/approach/gutter/pin/rack geometry downward.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17daba24d083299b07b38a7f83386d)