### PR TITLE
Adjust Murlan Royale held-card offsets for top and side players

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2338,11 +2338,10 @@ function computeHeldCardsPose({ resolvedSeatIndex = 0 } = {}) {
   }
 
   if (resolvedSeatIndex === 1 || resolvedSeatIndex === 2) {
-    // Side opponent cards: keep same card size/height and move visually upward.
+    // Side opponent cards: pull inward toward the table while keeping their current height.
     return {
       ...basePose,
-      y: basePose.y + 0.72 * MODEL_SCALE,
-      z: basePose.z - 0.5 * MODEL_SCALE
+      z: basePose.z + 0.95 * MODEL_SCALE
     };
   }
 


### PR DESCRIPTION
### Motivation
- Implement the requested visual framing tweaks so the top player's cards sit farther outward from the table and the left/right players' cards are pulled inward toward the table while preserving their existing height, with the bottom (human) player unchanged.

### Description
- Modified `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to remove the upward `y` offset for side seats and to change the side-seat `z` offset to `basePose.z + 0.95 * MODEL_SCALE`, and left the top-seat `z` outward offset (`basePose.z - 1.65 * MODEL_SCALE`) intact.

### Testing
- No automated tests were executed for this visual-positioning tweak; only the source update was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d9b90e388329891816e220501633)