### PR TITLE
Adjust Murlan Royale top and side opponent card positions

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2333,7 +2333,7 @@ function computeHeldCardsPose({ resolvedSeatIndex = 0 } = {}) {
     // Top opponent cards: push outward so they sit farther from table center.
     return {
       ...basePose,
-      z: basePose.z - 1.65 * MODEL_SCALE
+      z: basePose.z - 2.15 * MODEL_SCALE
     };
   }
 
@@ -2341,8 +2341,8 @@ function computeHeldCardsPose({ resolvedSeatIndex = 0 } = {}) {
     // Side opponent cards: keep same card size/height and move visually upward.
     return {
       ...basePose,
-      y: basePose.y + 0.72 * MODEL_SCALE,
-      z: basePose.z - 0.5 * MODEL_SCALE
+      y: basePose.y + 0.98 * MODEL_SCALE,
+      z: basePose.z + 0.28 * MODEL_SCALE
     };
   }
 


### PR DESCRIPTION
### Motivation
- Tweak held-card placement so the top player's cards appear farther outward from the table center and the left/right players' cards appear closer to the table and slightly higher on-screen while leaving the bottom player's cards unchanged.

### Description
- Updated `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to increase the outward offset for the top seat by changing `z` from `basePose.z - 1.65 * MODEL_SCALE` to `basePose.z - 2.15 * MODEL_SCALE`.
- Adjusted side-seat offsets to raise cards and bring them visually inward by changing `y` from `basePose.y + 0.72 * MODEL_SCALE` to `basePose.y + 0.98 * MODEL_SCALE` and `z` from `basePose.z - 0.5 * MODEL_SCALE` to `basePose.z + 0.28 * MODEL_SCALE`.
- No other files or card behavior for seat index 0 (bottom player) were modified.

### Testing
- Verified the code diff with `git diff -- webapp/src/pages/Games/MurlanRoyaleArena.jsx` which showed the intended changes and succeeded.
- Created a commit with the message `Adjust Murlan Royale top and side opponent card positions` which completed successfully.
- No automated unit tests were run as part of this change; visual verification on the target portrait mobile layout is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d9b90e388329891816e220501633)