### PR TITLE
Pool Royale: hide cloth/cushions/apron/feet from setup UI and sync cushions to cloth

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4314,6 +4314,7 @@ const SHOWOOD_TABLE_PARTS = Object.freeze([
   'leg',
   'baseFoot'
 ]);
+const SHOWOOD_TABLE_SETUP_HIDDEN_PARTS = new Set(['cloth', 'cushion', 'railSight', 'baseFoot']);
 const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
   cloth: 'green',
   cushion: 'green',
@@ -15758,7 +15759,7 @@ function PoolRoyaleGame({
         label: SHOWOOD_TABLE_PART_LABELS[part] || part,
         chromeLinked: SHOWOOD_CHROME_LINKED_PARTS.has(part),
         options: getShowoodTablePartOptions(part, availableClothOptions, availableTableFinishes)
-      })).filter((section) => section.options.length > 0),
+      })).filter((section) => !SHOWOOD_TABLE_SETUP_HIDDEN_PARTS.has(section.key) && section.options.length > 0),
     [availableClothOptions, availableTableFinishes]
   );
   useEffect(() => {
@@ -15802,6 +15803,15 @@ function PoolRoyaleGame({
       POOL_ROYALE_BASE_VARIANTS[0],
     [availableTableBases]
   );
+
+  useEffect(() => {
+    setShowoodTableStyle((current) => {
+      const normalized = normalizeShowoodTableStyle(current);
+      return normalized.cushion === clothColorId
+        ? normalized
+        : normalizeShowoodTableStyle({ ...normalized, cushion: clothColorId });
+    });
+  }, [clothColorId]);
   const resolvedHdriResolution = useMemo(() => {
     return autoHdriResolutionFromGraphics;
   }, [autoHdriResolutionFromGraphics]);
@@ -36279,6 +36289,9 @@ const shotPowerRef = useRef(0);
                             onClick={() => {
                               if (part === 'cloth') {
                                 setClothColorId(option.id);
+                                setShowoodTableStyle((current) =>
+                                  normalizeShowoodTableStyle({ ...current, cushion: option.id })
+                                );
                               } else if (part === 'topWoodRail' || part === 'leg') {
                                 setTableFinishId(option.id);
                                 setShowoodTableStyle((current) =>


### PR DESCRIPTION
### Motivation
- Remove redundant table-setup controls so `railSight` (side apron) and `baseFoot` (feet) are driven by the existing chrome-plates flow and are not selectable in the Showood table setup menu. 
- Remove the Field Cloth and Cushions controls from the table setup menu and make cushions use the same cloth selection from the cloth library. 
- Ensure user cloth selections immediately propagate to cushions so finishes remain consistent and non-conflicting in the UI.

### Description
- Added `SHOWOOD_TABLE_SETUP_HIDDEN_PARTS` (a `Set`) and filtered `tablePersonalizationSections` to hide `cloth`, `cushion`, `railSight`, and `baseFoot` from the Table Personalisation UI. 
- Kept chrome-linked behavior intact by relying on the existing `SHOWOOD_CHROME_LINKED_PARTS` mapping so rails/apron and feet remain controlled by the chrome plate/color flow. 
- Added a `useEffect` that enforces `showoodTableStyle.cushion === clothColorId` whenever `clothColorId` changes so cushions always match the cloth library selection. 
- Added an immediate sync in the cloth selection handler so selecting a cloth updates the cushion style at click time for defensive consistency.

### Testing
- No automated tests were run for this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17f0b2a2d88329a8a077e899f56bcc)