### PR TITLE
Optimize Pool Royale loading profile and graphics presets

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2997,7 +2997,7 @@ const CLOTH_SOFT_BLEND = 0.34;
 
 const CLOTH_QUALITY = (() => {
   const defaults = {
-    textureSize: 6144,
+    textureSize: 4096,
     anisotropy: 72,
     generateMipmaps: true,
     bumpScaleMultiplier: 1.16,
@@ -3008,7 +3008,7 @@ const CLOTH_QUALITY = (() => {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
     return {
       ...defaults,
-      textureSize: 2560,
+      textureSize: 2048,
       anisotropy: 20,
       bumpScaleMultiplier: 1,
       sheen: 0.9,
@@ -3029,8 +3029,8 @@ const CLOTH_QUALITY = (() => {
   if (isMobileUA || isTouch || lowMemory || lowRefresh) {
     const highDensity = dpr >= 3;
     return {
-      textureSize: highDensity ? 3072 : 2048,
-      anisotropy: highDensity ? 28 : 24,
+      textureSize: highDensity ? 2048 : 1024,
+      anisotropy: highDensity ? 22 : 18,
       generateMipmaps: true,
       bumpScaleMultiplier: highDensity ? 1.02 : 0.94,
       sheen: 0.78,
@@ -3040,7 +3040,7 @@ const CLOTH_QUALITY = (() => {
 
   if (hardwareConcurrency <= 6 || dpr < 1.75) {
     return {
-      textureSize: 5120,
+      textureSize: 4096,
       anisotropy: 48,
       generateMipmaps: true,
       bumpScaleMultiplier: 1.12,
@@ -4598,34 +4598,52 @@ const FRAME_RATE_STORAGE_KEY = 'snookerFrameRate';
 const AUTO_REPLAY_STORAGE_KEY = 'poolRoyaleAutoReplay';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
-    id: 'fhd60',
-    label: 'Performance (60 Hz)',
-    fps: 60,
+    id: 'hd50',
+    label: 'HD Performance (50 Hz)',
+    fps: 50,
     renderScale: 1,
-    pixelRatioCap: 1.4,
-    resolution: '2K texture pack • 60 FPS',
-    description: 'Balanced battery profile using Poly Haven 2K assets.'
+    pixelRatioCap: 1.35,
+    resolution: 'HD render • DPR 1.35 cap',
+    description: 'Low-power 50 Hz profile for battery saver and thermal relief.'
   },
   {
-    id: 'qhd90',
-    label: 'Smooth (90 Hz)',
+    id: 'fhd60',
+    label: 'Full HD (60 Hz)',
+    fps: 60,
+    renderScale: 1.1,
+    pixelRatioCap: 1.5,
+    resolution: 'Full HD render • DPR 1.5 cap',
+    description: '1080p-focused profile that mirrors the Snooker frame pacing.'
+  },
+  {
+    id: 'fhd90',
+    label: 'Full HD (90 Hz)',
     fps: 90,
     renderScale: 1.12,
     pixelRatioCap: 1.55,
-    resolution: '4K texture pack • 90 FPS',
-    description: 'Sharper Poly Haven 4K assets at a 90 FPS target.'
+    resolution: 'Full HD render • DPR 1.55 cap',
+    description: '1080p-focused profile tuned for 90 Hz full-motion play.'
+  },
+  {
+    id: 'qhd90',
+    label: 'Quad HD (105 Hz)',
+    fps: 105,
+    renderScale: 1.22,
+    pixelRatioCap: 1.72,
+    resolution: 'QHD render • DPR 1.72 cap',
+    description: 'Sharper 1440p render for capable 105 Hz mobile and desktop GPUs.'
   },
   {
     id: 'uhd120',
-    label: 'Ultra (120 Hz)',
+    label: 'Ultra HD (120 Hz cap)',
     fps: 120,
-    renderScale: 1.3,
+    renderScale: 1.28,
     pixelRatioCap: 1.85,
-    resolution: 'Desktop: 8K / Mobile: 4K • 120 FPS',
-    description: 'Desktop uses Poly Haven 8K (4K fallback); mobile uses 4K (2K fallback) at 120 FPS target.'
+    resolution: 'Ultra HD render • DPR 1.85 cap',
+    description: '4K-oriented profile tuned for smooth play up to 120 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'qhd90';
+const DEFAULT_FRAME_RATE_ID = 'fhd60';
 const GRAPHICS_RESOLUTION_BY_FPS = Object.freeze([
   {
     minFps: 120,
@@ -4672,24 +4690,24 @@ const resolveGraphicsUiScaleFactor = (fps) => {
   return 1;
 };
 let runtimeTextureProfile = Object.freeze({
-  textureSize: resolveGraphicsResolutionTier(90).textureSize,
+  textureSize: resolveGraphicsResolutionTier(60).textureSize,
   anisotropy: CLOTH_QUALITY.anisotropy,
   generateMipmaps: CLOTH_QUALITY.generateMipmaps,
-  polyHavenResolution: '4k',
+  polyHavenResolution: '2k',
   hdriResolution: '4k',
-  polyHavenPreferredResolutions: Object.freeze(['4k', '2k']),
-  polyHavenFallbackResolution: '2k',
+  polyHavenPreferredResolutions: Object.freeze(['2k', '1k']),
+  polyHavenFallbackResolution: '1k',
   hdriPreferredResolutions: Object.freeze(['4k']),
   hdriFallbackResolution: '4k',
-  enforceTableFinishTextureSize: 4096,
-  cueTextureSize: 4096,
-  pocketTextureSize: 2048
+  enforceTableFinishTextureSize: 2048,
+  cueTextureSize: 2048,
+  pocketTextureSize: 1024
 });
 
 const updateRuntimeTextureProfile = ({ fps } = {}) => {
   const tier = resolveGraphicsResolutionTier(fps);
   const textureSize = tier.textureSize;
-  const anisotropyRatio = textureSize / 6144;
+  const anisotropyRatio = textureSize / 4096;
   const anisotropy = Math.max(16, Math.round(CLOTH_QUALITY.anisotropy * anisotropyRatio));
   const ballAnisotropy = Math.max(6, Math.min(12, Math.round(12 * (textureSize / 8192))));
   setBallMaterialAnisotropy(ballAnisotropy);
@@ -20328,7 +20346,7 @@ const shotPowerRef = useRef(0);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       renderer.sortObjects = true;
-      renderer.shadowMap.enabled = true;
+      renderer.shadowMap.enabled = false;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       rendererRef.current = renderer;
       updateRendererAnisotropyCap(renderer);
@@ -20352,12 +20370,9 @@ const shotPowerRef = useRef(0);
       const world = new THREE.Group();
       scene.add(world);
       worldRef.current = world;
-      const applyHdriEnvironment = async (variantConfig = activeEnvironmentVariantRef.current) => {
+      const applyLoadedHdriEnvironment = (envResult, activeVariant) => {
         const sceneInstance = sceneRef.current;
-        if (!renderer || !sceneInstance) return;
-        const activeVariant = variantConfig || activeEnvironmentVariantRef.current;
-        const envResult = await loadPolyHavenHdriEnvironment(renderer, activeVariant);
-        if (!envResult) return;
+        if (!renderer || !sceneInstance || !envResult) return;
         const { envMap, skyboxMap } = envResult;
         if (!envMap) return;
         if (disposed) {
@@ -20497,12 +20512,33 @@ const shotPowerRef = useRef(0);
           prevDispose();
         }
       };
-      updateEnvironmentRef.current = applyHdriEnvironment;
-      void applyHdriEnvironment(activeEnvironmentVariantRef.current).finally(() => {
-        if (!disposed) {
-          markBreakRollLoadReady('hdri', true);
+      const applyHdriEnvironment = async (variantConfig = activeEnvironmentVariantRef.current) => {
+        const sceneInstance = sceneRef.current;
+        if (!renderer || !sceneInstance) return;
+        const activeVariant = variantConfig || activeEnvironmentVariantRef.current;
+        try {
+          if (!envTextureRef.current && !disposed) {
+            const fallbackEnv = await createFallbackHdriEnvironment(renderer);
+            if (fallbackEnv?.envMap && !disposed) {
+              applyLoadedHdriEnvironment(fallbackEnv, activeVariant);
+            }
+            if (!disposed) {
+              markBreakRollLoadReady('hdri', true);
+            }
+          }
+          const envResult = await loadPolyHavenHdriEnvironment(renderer, activeVariant);
+          if (!envResult) return;
+          applyLoadedHdriEnvironment(envResult, activeVariant);
+        } catch (error) {
+          console.warn('Pool Royale HDRI environment load failed; keeping fallback.', error);
+        } finally {
+          if (!disposed) {
+            markBreakRollLoadReady('hdri', true);
+          }
         }
-      });
+      };
+      updateEnvironmentRef.current = applyHdriEnvironment;
+      void applyHdriEnvironment(activeEnvironmentVariantRef.current);
       let worldScaleFactor = WORLD_SCALE * (tableSizeRef.current?.scale ?? 1);
       let cue;
       let clothMat;


### PR DESCRIPTION
### Motivation
- Reduce Pool Royale cold-start time and memory/texture pressure on mobile by reusing the same lighter graphics/profile approach used for Snooker Royal. 
- Ensure a faster perceived readiness by applying a fallback HDRI immediately and loading the full HDRI asynchronously so the scene becomes usable sooner.
- Align runtime texture & frame-rate defaults with the Snooker setup to provide consistent mobile-first behaviour and faster onboarding.

### Description
- Lowered cloth/texture quality defaults for Pool Royale and mobile fallbacks so initial loads use smaller textures (2k/1k fallbacks) and reduced anisotropy for lighter runtime footprint (`CLOTH_QUALITY` and `runtimeTextureProfile` updates in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Aligned frame-rate presets with Snooker-style profiles and changed the default from QHD/90-ish to Full HD 60 Hz for faster mobile startup (`FRAME_RATE_OPTIONS`, `DEFAULT_FRAME_RATE_ID`).
- Switched runtime anisotropy scaling to a 4k baseline ratio and adjusted `updateRuntimeTextureProfile` accordingly (anisotropyRatio uses 4096 divisor).
- Disabled renderer shadow maps for Pool Royale to match Snooker Royal’s lighter renderer setup (`renderer.shadowMap.enabled = false`).
- Reworked HDRI startup flow: added `applyLoadedHdriEnvironment` helper to apply an environment immediately when available and changed `applyHdriEnvironment` to first apply a fallback HDRI synchronously (when present) then load the full PolyHaven HDRI async, and ensure `markBreakRollLoadReady('hdri', true)` runs when appropriate so the UI can mark readiness earlier.

### Testing
- Ran lint on the modified file with `npm --prefix webapp run lint -- src/pages/Games/PoolRoyale.jsx`, which completed without failures.
- Built the webapp with `npm --prefix webapp run build`, which completed successfully (Vite production build output produced; chunk-size warnings are informational only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187b7a2d00832985bea5b746f53f39)