### PR TITLE
Pool Royale: loading UI, WebGL resiliency, asset prefetch & graphics profile updates

### DIFF
--- a/webapp/public/pwa/gltf-assets.json
+++ b/webapp/public/pwa/gltf-assets.json
@@ -23,5 +23,7 @@
   "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb",
   "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Binary/Lantern.glb",
   "https://raw.githubusercontent.com/cx20/gltf-test/master/sampleModels/Chess/glTF-Binary/Chess.glb",
-  "https://raw.githubusercontent.com/quaterniusdev/ChessSet/master/Source/GLTF/ChessSet.glb"
+  "https://raw.githubusercontent.com/quaterniusdev/ChessSet/master/Source/GLTF/ChessSet.glb",
+  "https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb",
+  "https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb"
 ]

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -122,7 +122,7 @@ import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -379,14 +379,29 @@ const wait = (ms = 0) =>
     window.setTimeout(resolve, ms);
   });
 
+const WEBGL_CONTEXT_IDS = ['webgl2', 'webgl', 'experimental-webgl'];
+
+const tryGetWebGLContext = (canvas, contextId) => {
+  try {
+    return canvas.getContext(contextId);
+  } catch (err) {
+    return null;
+  }
+};
+
+const resolveWebGLContext = (canvas) => {
+  for (const contextId of WEBGL_CONTEXT_IDS) {
+    const gl = tryGetWebGLContext(canvas, contextId);
+    if (gl) return gl;
+  }
+  return null;
+};
+
 function isWebGLAvailable() {
   if (typeof document === 'undefined') return false;
   try {
     const canvas = document.createElement('canvas');
-    const gl =
-      canvas.getContext('webgl2') ||
-      canvas.getContext('webgl') ||
-      canvas.getContext('experimental-webgl');
+    const gl = resolveWebGLContext(canvas);
     return Boolean(gl);
   } catch (err) {
     console.warn('WebGL availability check failed', err);
@@ -512,10 +527,7 @@ function readGraphicsRendererString() {
   }
   try {
     const canvas = document.createElement('canvas');
-    const gl =
-      canvas.getContext('webgl') ||
-      canvas.getContext('experimental-webgl') ||
-      canvas.getContext('webgl2');
+    const gl = resolveWebGLContext(canvas);
     if (!gl) {
       return null;
     }
@@ -584,12 +596,12 @@ function detectPreferredFrameRateId() {
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
 
   if (lowRefresh) {
-    return 'fhd60';
+    return 'hd50';
   }
 
   if (isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') {
     if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
-      return 'fhd60';
+      return 'hd50';
     }
     if (
       (refreshBucket >= 120 || highRefresh) &&
@@ -611,7 +623,9 @@ function detectPreferredFrameRateId() {
   if (refreshBucket >= 120 && (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8)) {
     return 'uhd120';
   }
-  if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) return 'uhd120';
+  if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) {
+    return 'uhd120';
+  }
 
   if (rendererTier === 'desktopMid') {
     return 'qhd90';
@@ -2131,7 +2145,7 @@ function createPoolHumanGLTFLoader(renderer = null) {
     }
   }
   loader.setKTX2Loader(ktx2);
-  loader.setMeshoptDecoder?.(MeshoptDecoder);
+  loader.setMeshoptDecoder(MeshoptDecoder);
   loader.userData = { draco, ktx2 };
   return loader;
 }
@@ -4594,38 +4608,57 @@ const LIGHTING_PRESET_MAP = Object.freeze(
   }, {})
 );
 
-const FRAME_RATE_STORAGE_KEY = 'snookerFrameRate';
+const FRAME_RATE_STORAGE_KEY = 'poolRoyaleFrameRate';
+const LEGACY_FRAME_RATE_STORAGE_KEY = 'snookerFrameRate';
 const AUTO_REPLAY_STORAGE_KEY = 'poolRoyaleAutoReplay';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
-    id: 'fhd60',
-    label: 'Performance (60 Hz)',
-    fps: 60,
+    id: 'hd50',
+    label: 'HD Performance (50 Hz)',
+    fps: 50,
     renderScale: 1,
-    pixelRatioCap: 1.4,
-    resolution: '2K texture pack • 60 FPS',
-    description: 'Balanced battery profile using Poly Haven 2K assets.'
+    pixelRatioCap: 1.35,
+    resolution: 'HD render • DPR 1.35 cap',
+    description: 'Low-power profile for faster Pool Royal loading, battery saver, and thermal relief.'
   },
   {
-    id: 'qhd90',
-    label: 'Smooth (90 Hz)',
+    id: 'fhd60',
+    label: 'Full HD (60 Hz)',
+    fps: 60,
+    renderScale: 1.1,
+    pixelRatioCap: 1.5,
+    resolution: 'Full HD render • DPR 1.5 cap',
+    description: 'Fast default profile matching the Snooker Royal frame pacing.'
+  },
+  {
+    id: 'fhd90',
+    label: 'Full HD (90 Hz)',
     fps: 90,
     renderScale: 1.12,
     pixelRatioCap: 1.55,
-    resolution: '4K texture pack • 90 FPS',
-    description: 'Sharper Poly Haven 4K assets at a 90 FPS target.'
+    resolution: 'Full HD render • DPR 1.55 cap',
+    description: '1080p-focused profile tuned for 90 Hz full-motion play.'
+  },
+  {
+    id: 'qhd90',
+    label: 'Quad HD (105 Hz)',
+    fps: 105,
+    renderScale: 1.22,
+    pixelRatioCap: 1.72,
+    resolution: 'QHD render • DPR 1.72 cap',
+    description: 'Sharper 1440p render for capable 105 Hz mobile and desktop GPUs.'
   },
   {
     id: 'uhd120',
-    label: 'Ultra (120 Hz)',
+    label: 'Ultra HD (120 Hz cap)',
     fps: 120,
-    renderScale: 1.3,
+    renderScale: 1.28,
     pixelRatioCap: 1.85,
-    resolution: 'Desktop: 8K / Mobile: 4K • 120 FPS',
-    description: 'Desktop uses Poly Haven 8K (4K fallback); mobile uses 4K (2K fallback) at 120 FPS target.'
+    resolution: 'Ultra HD render • DPR 1.85 cap',
+    description: '4K-oriented profile tuned for smooth play up to 120 Hz.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'qhd90';
+const DEFAULT_FRAME_RATE_ID = 'fhd60';
 const GRAPHICS_RESOLUTION_BY_FPS = Object.freeze([
   {
     minFps: 120,
@@ -4671,19 +4704,20 @@ const resolveGraphicsUiScaleFactor = (fps) => {
   if (safeFps >= 90) return 1.04;
   return 1;
 };
+const INITIAL_GRAPHICS_RESOLUTION_TIER = resolveGraphicsResolutionTier(60);
 let runtimeTextureProfile = Object.freeze({
-  textureSize: resolveGraphicsResolutionTier(90).textureSize,
+  textureSize: INITIAL_GRAPHICS_RESOLUTION_TIER.textureSize,
   anisotropy: CLOTH_QUALITY.anisotropy,
   generateMipmaps: CLOTH_QUALITY.generateMipmaps,
-  polyHavenResolution: '4k',
-  hdriResolution: '4k',
-  polyHavenPreferredResolutions: Object.freeze(['4k', '2k']),
-  polyHavenFallbackResolution: '2k',
-  hdriPreferredResolutions: Object.freeze(['4k']),
-  hdriFallbackResolution: '4k',
-  enforceTableFinishTextureSize: 4096,
-  cueTextureSize: 4096,
-  pocketTextureSize: 2048
+  polyHavenResolution: INITIAL_GRAPHICS_RESOLUTION_TIER.key,
+  hdriResolution: INITIAL_GRAPHICS_RESOLUTION_TIER.key,
+  polyHavenPreferredResolutions: INITIAL_GRAPHICS_RESOLUTION_TIER.preferredResolutions,
+  polyHavenFallbackResolution: INITIAL_GRAPHICS_RESOLUTION_TIER.fallbackResolution,
+  hdriPreferredResolutions: Object.freeze([INITIAL_GRAPHICS_RESOLUTION_TIER.key]),
+  hdriFallbackResolution: INITIAL_GRAPHICS_RESOLUTION_TIER.fallbackResolution,
+  enforceTableFinishTextureSize: INITIAL_GRAPHICS_RESOLUTION_TIER.textureSize,
+  cueTextureSize: INITIAL_GRAPHICS_RESOLUTION_TIER.textureSize,
+  pocketTextureSize: Math.min(2048, INITIAL_GRAPHICS_RESOLUTION_TIER.textureSize)
 });
 
 const updateRuntimeTextureProfile = ({ fps } = {}) => {
@@ -12859,6 +12893,7 @@ export function Table3D(
   };
 
   let polyhavenKtx2Loader = null;
+  let hasDetectedPolyhavenKtx2Support = false;
   const polyhavenBaseTemplates = new Map();
   const polyhavenBasePromises = new Map();
 
@@ -12867,9 +12902,10 @@ export function Table3D(
       polyhavenKtx2Loader = new KTX2Loader();
       polyhavenKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
     }
-    if (renderer) {
+    if (renderer && !hasDetectedPolyhavenKtx2Support) {
       try {
         polyhavenKtx2Loader.detectSupport(renderer);
+        hasDetectedPolyhavenKtx2Support = true;
       } catch (error) {
         console.warn('Pool Royale KTX2 support detection failed', error);
       }
@@ -12877,15 +12913,15 @@ export function Table3D(
     return polyhavenKtx2Loader;
   };
 
-  const createConfiguredGLTFLoader = (renderer = null) => {
-    const loader = new GLTFLoader();
+  const createConfiguredGLTFLoader = (renderer = null, manager = null) => {
+    const loader = new GLTFLoader(manager ?? undefined);
     loader.setCrossOrigin('anonymous');
     const draco = new DRACOLoader();
     draco.setDecoderPath(DRACO_DECODER_PATH);
     loader.setDRACOLoader(draco);
     const ktx2 = ensurePolyhavenKtx2Loader(renderer);
     loader.setKTX2Loader(ktx2);
-    loader.setMeshoptDecoder?.(MeshoptDecoder);
+    loader.setMeshoptDecoder(MeshoptDecoder);
     return loader;
   };
 
@@ -15139,6 +15175,8 @@ function PoolRoyaleGame({
   const navigate = useNavigate();
   const location = useLocation();
   const mountRef = useRef(null);
+  const [loadingProgress, setLoadingProgress] = useState(0);
+  const [loadingActive, setLoadingActive] = useState(true);
   const rafRef = useRef(null);
   const worldRef = useRef(null);
   const rules = useMemo(() => new PoolRoyaleRules(variantKey), [variantKey]);
@@ -15280,6 +15318,67 @@ function PoolRoyaleGame({
   const rematchIncomingTimerRef = useRef(null);
   const [rematchCountdown, setRematchCountdown] = useState(0);
   const [incomingCountdown, setIncomingCountdown] = useState(0);
+  useEffect(() => {
+    const manager = THREE.DefaultLoadingManager;
+    let cancelled = false;
+    const prev = {
+      onStart: manager.onStart,
+      onLoad: manager.onLoad,
+      onProgress: manager.onProgress,
+      onError: manager.onError
+    };
+    const updateProgress = (loaded, total) => {
+      const safeTotal = Number.isFinite(total) && total > 0 ? total : Math.max(1, loaded || 1);
+      const ratio = Number.isFinite(loaded) ? loaded / safeTotal : 0;
+      setLoadingProgress(Math.max(0, Math.min(1, ratio)));
+    };
+    const syncManagerState = () => {
+      const loaded = Number(manager.itemsLoaded || 0);
+      const total = Number(manager.itemsTotal || 0);
+      if (total > 0) {
+        updateProgress(loaded, total);
+        if (loaded >= total) {
+          setLoadingProgress(1);
+          setLoadingActive(false);
+        }
+      } else {
+        setLoadingProgress(0);
+        setLoadingActive(false);
+      }
+    };
+    manager.onStart = (url, loaded, total) => {
+      prev.onStart?.(url, loaded, total);
+      if (cancelled) return;
+      setLoadingActive(true);
+      updateProgress(loaded, total);
+    };
+    manager.onProgress = (url, loaded, total) => {
+      prev.onProgress?.(url, loaded, total);
+      if (cancelled) return;
+      updateProgress(loaded, total);
+    };
+    manager.onLoad = () => {
+      prev.onLoad?.();
+      if (cancelled) return;
+      setLoadingProgress(1);
+      window.setTimeout(() => {
+        if (!cancelled) setLoadingActive(false);
+      }, 200);
+    };
+    manager.onError = (url) => {
+      prev.onError?.(url);
+      if (cancelled) return;
+      setLoadingProgress((prevValue) => Math.max(prevValue, 0.9));
+    };
+    syncManagerState();
+    return () => {
+      cancelled = true;
+      manager.onStart = prev.onStart;
+      manager.onLoad = prev.onLoad;
+      manager.onProgress = prev.onProgress;
+      manager.onError = prev.onError;
+    };
+  }, []);
   const coinStyleInjectedRef = useRef(false);
   const ensureCoinBurstStyles = useCallback(() => {
     if (coinStyleInjectedRef.current || typeof document === 'undefined') return;
@@ -15596,7 +15695,9 @@ function PoolRoyaleGame({
   const [activeTablePersonalizationPart, setActiveTablePersonalizationPart] = useState('topWoodRail');
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(FRAME_RATE_STORAGE_KEY);
+      const stored =
+        window.localStorage.getItem(FRAME_RATE_STORAGE_KEY) ||
+        window.localStorage.getItem(LEGACY_FRAME_RATE_STORAGE_KEY);
       if (stored && FRAME_RATE_OPTIONS.some((opt) => opt.id === stored)) {
         return stored;
       }
@@ -18211,6 +18312,12 @@ const shotPowerRef = useRef(0);
     const renderer = rendererRef.current;
     const host = mountRef.current;
     if (!renderer || !host) return;
+    const fallbackWidth =
+      typeof window !== 'undefined' ? window.innerWidth || document.documentElement?.clientWidth || 0 : 0;
+    const fallbackHeight =
+      typeof window !== 'undefined' ? window.innerHeight || document.documentElement?.clientHeight || 0 : 0;
+    const hostWidth = host.clientWidth || fallbackWidth;
+    const hostHeight = host.clientHeight || fallbackHeight;
     const quality = frameQualityRef.current;
     const timing = frameTimingRef.current;
     const targetMs =
@@ -18239,7 +18346,7 @@ const shotPowerRef = useRef(0);
       highFpsBias < 1 ? cappedDpr * (0.92 + highFpsBias * 0.08) : cappedDpr;
     const resolvedPixelRatio = Math.max(1, performanceDpr);
     renderer.setPixelRatio(resolvedPixelRatio);
-    renderer.setSize(host.clientWidth * renderScale, host.clientHeight * renderScale, false);
+    renderer.setSize(hostWidth * renderScale, hostHeight * renderScale, false);
     renderer.domElement.style.width = '100%';
     renderer.domElement.style.height = '100%';
   }, []);
@@ -20328,7 +20435,7 @@ const shotPowerRef = useRef(0);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.2;
       renderer.sortObjects = true;
-      renderer.shadowMap.enabled = true;
+      renderer.shadowMap.enabled = false;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       rendererRef.current = renderer;
       updateRendererAnisotropyCap(renderer);
@@ -37336,6 +37443,47 @@ const shotPowerRef = useRef(0);
             }
           }}
           />
+        </div>
+      )}
+
+      {loadingActive && !err && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/90 px-6 text-white">
+          <div className="flex w-full max-w-sm flex-col items-center gap-4 text-center">
+            <div className="w-full rounded-3xl border border-cyan-300/40 bg-slate-950/70 p-5 shadow-[0_24px_48px_rgba(0,0,0,0.6)]">
+              <svg
+                viewBox="0 0 320 200"
+                className="h-36 w-full"
+                role="img"
+                aria-label="Pool Royal loading"
+              >
+                <rect x="8" y="24" width="304" height="152" rx="18" fill="#0f766e" stroke="#67e8f9" strokeWidth="6" />
+                <rect x="34" y="50" width="252" height="100" rx="12" fill="#155e75" />
+                <circle cx="34" cy="50" r="10" fill="#020617" />
+                <circle cx="286" cy="50" r="10" fill="#020617" />
+                <circle cx="34" cy="150" r="10" fill="#020617" />
+                <circle cx="286" cy="150" r="10" fill="#020617" />
+                <circle cx="160" cy="50" r="10" fill="#020617" />
+                <circle cx="160" cy="150" r="10" fill="#020617" />
+                <circle cx="126" cy="100" r="9" fill="#f8fafc" />
+                <circle cx="166" cy="100" r="9" fill="#facc15" />
+                <circle cx="206" cy="100" r="9" fill="#ef4444" />
+              </svg>
+            </div>
+            <div className="w-full">
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-100">
+                Loading Pool Royal
+              </p>
+              <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-white/10">
+                <div
+                  className="h-full rounded-full bg-cyan-300 transition-[width] duration-200"
+                  style={{ width: `${Math.round(loadingProgress * 100)}%` }}
+                />
+              </div>
+              <p className="mt-2 text-sm text-white/80">
+                {Math.round(loadingProgress * 100)}%
+              </p>
+            </div>
+          </div>
         </div>
       )}
 

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -50,6 +50,53 @@ function resolveTpcAccountNumber(player) {
   ).trim();
 }
 
+
+const runPoolRoyaleIdleTask = (callback) => {
+  if (typeof window === 'undefined') return undefined;
+  if (typeof window.requestIdleCallback === 'function') {
+    const id = window.requestIdleCallback(callback, { timeout: 1200 });
+    return () => window.cancelIdleCallback?.(id);
+  }
+  const id = window.setTimeout(callback, 350);
+  return () => window.clearTimeout(id);
+};
+
+const prewarmPoolRoyaleShowoodModel = (tableModel) => {
+  if (typeof window === 'undefined' || !tableModel?.assetUrl) return undefined;
+  const urls = [tableModel.assetUrl, tableModel.fallbackAssetUrl].filter(Boolean);
+  if (!urls.length) return undefined;
+
+  const links = urls.map((url) => {
+    const link = document.createElement('link');
+    link.rel = 'prefetch';
+    link.as = 'fetch';
+    link.href = url;
+    link.crossOrigin = 'anonymous';
+    document.head?.appendChild(link);
+    return link;
+  });
+
+  let cancelled = false;
+  const cancelIdle = runPoolRoyaleIdleTask(async () => {
+    for (const url of urls) {
+      if (cancelled) return;
+      try {
+        const request = new Request(url, { mode: 'cors', cache: 'force-cache' });
+        const response = await fetch(request);
+        if (response?.ok) return;
+      } catch (err) {
+        // Keep the lobby responsive; the game loader will retry with its normal fallback path.
+      }
+    }
+  });
+
+  return () => {
+    cancelled = true;
+    cancelIdle?.();
+    links.forEach((link) => link.parentNode?.removeChild(link));
+  };
+};
+
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
   const { search } = useLocation();
@@ -115,6 +162,7 @@ export default function PoolRoyaleLobby() {
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
   const selectedTableModelReady = true;
 
+  useEffect(() => prewarmPoolRoyaleShowoodModel(selectedTableModel), [selectedTableModel]);
 
   useEffect(() => {
     try {
@@ -864,7 +912,7 @@ export default function PoolRoyaleLobby() {
               <div>
                 <h3 className="font-semibold text-white">Pool Table</h3>
                 <p className="mt-1">
-                  Showood 7 ft GLB is now the fixed Pool Royale table.
+                  Showood 7 ft GLB is the fixed Pool Royale table and is preloaded from the lobby for faster starts.
                 </p>
               </div>
               <span className="rounded-full border border-emerald-300/35 bg-emerald-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100">


### PR DESCRIPTION
### Motivation
- Improve the Pool Royale startup experience by showing loader progress and prefetching the fixed Showood table to reduce perceived load times.
- Harden WebGL detection and renderer initialization to avoid failures across varied browsers and devices.
- Rework frame-rate profiles, default graphics settings, and runtime texture profile selection to better match Pool Royale performance targets.
- Add a small set of external table assets to the PWA asset list so the lobby/loader can prefetch and resolve fallbacks.

### Description
- Added new assets to `webapp/public/pwa/gltf-assets.json` including Showood 7ft GLB CDN and raw URLs.
- Introduced robust WebGL helpers (`WEBGL_CONTEXT_IDS`, `tryGetWebGLContext`, `resolveWebGLContext`) and replaced ad-hoc `getContext` usage in `isWebGLAvailable` and `readGraphicsRendererString` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Updated DRACO decoder path to `https://www.gstatic.com/draco/versioned/decoders/1.5.7/` and removed optional chaining when setting `MeshoptDecoder` via `loader.setMeshoptDecoder(MeshoptDecoder)`.
- Reworked frame-rate/profile system: added `hd50`, renamed/adjusted labels and parameters for `fhd60`, `fhd90`, `qhd90`, `uhd120`, changed `DEFAULT_FRAME_RATE_ID` to `fhd60`, and added legacy storage support (`LEGACY_FRAME_RATE_STORAGE_KEY`).
- Initialize `runtimeTextureProfile` from a computed `INITIAL_GRAPHICS_RESOLUTION_TIER` and update `updateRuntimeTextureProfile` to derive sizes from resolution tiers.
- Added KTX2 support detection flag `hasDetectedPolyhavenKtx2Support` and adjusted `ensurePolyhavenKtx2Loader` and `createConfiguredGLTFLoader` (now accepts optional `manager`) to avoid repeated detection calls.
- Add loading state management using `THREE.DefaultLoadingManager` in `PoolRoyaleGame`, with `loadingProgress` and `loadingActive` state and a new loading overlay UI block rendered while the game loads.
- Added UI and rendering adjustments: avoid enabling `renderer.shadowMap.enabled` at init (`false`), and make `applyRendererQuality` use fallback window sizes when `host.clientWidth/height` are unavailable.
- Added a lobby prewarm/prefetch utility `prewarmPoolRoyaleShowoodModel` with idle callback helper `runPoolRoyaleIdleTask` and hooked it into `PoolRoyaleLobby` to prefetch the selected table model and update lobby text accordingly.

### Testing
- Ran unit tests via `yarn test` and all tests passed.
- Ran linting via `yarn lint` and no new lint errors were reported.
- Performed a production build via `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187b7a2d00832985bea5b746f53f39)