### PR TITLE
Restore Ludo firearm GLTF texture handling

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1458,10 +1458,11 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         // eslint-disable-next-line no-await-in-loop
         const patchedBuffer = await patchGlbImagesToDataUris(
           rawBuffer,
-          'fighter',
+          'firearm',
           candidateUrl,
           candidateUrls,
-          imageCache
+          imageCache,
+          { allowPlaceholder: false }
         );
         // eslint-disable-next-line no-await-in-loop
         loadedRoot = await parseObjectFromBuffer(loader, patchedBuffer);
@@ -2169,12 +2170,20 @@ function makePlaceholderTextureDataUri(primary, secondary) {
   return canvas.toDataURL('image/png');
 }
 
-async function resolveExternalImageToDataUri(imageUri, kind, sourceUrl, modelUrls, cache) {
+async function resolveExternalImageToDataUri(
+  imageUri,
+  kind,
+  sourceUrl,
+  modelUrls,
+  cache,
+  { allowPlaceholder = true } = {}
+) {
   if (isDataUri(imageUri)) return imageUri;
   const placeholderColors = {
     drone: ['#7c8791', '#4f5861'],
     helicopter: ['#6f7763', '#4f5648'],
-    fighter: ['#98a1a9', '#646d76']
+    fighter: ['#98a1a9', '#646d76'],
+    firearm: ['#2d3340', '#111827']
   };
   const [primary, secondary] = placeholderColors[kind] ?? ['#6e7681', '#4f5861'];
   const placeholderDataUri = makePlaceholderTextureDataUri(primary, secondary);
@@ -2196,10 +2205,17 @@ async function resolveExternalImageToDataUri(imageUri, kind, sourceUrl, modelUrl
       // ignore candidate
     }
   }
-  return placeholderDataUri;
+  return allowPlaceholder ? placeholderDataUri : null;
 }
 
-async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cache) {
+async function patchGlbImagesToDataUris(
+  buffer,
+  kind,
+  sourceUrl,
+  modelUrls,
+  cache,
+  { allowPlaceholder = true } = {}
+) {
   const { json, binChunk } = decodeGlb(buffer);
   const cloned = JSON.parse(JSON.stringify(json));
   const images = Array.isArray(cloned.images) ? cloned.images : [];
@@ -2208,8 +2224,14 @@ async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cach
   for (let i = 0; i < images.length; i += 1) {
     const image = images[i];
     if (typeof image.uri === 'string') {
+      const originalImageUri = image.uri;
       // eslint-disable-next-line no-await-in-loop
-      image.uri = await resolveExternalImageToDataUri(image.uri, kind, sourceUrl, modelUrls, cache);
+      image.uri = await resolveExternalImageToDataUri(originalImageUri, kind, sourceUrl, modelUrls, cache, {
+        allowPlaceholder
+      });
+      if (!image.uri) {
+        throw new Error(`Unable to resolve external GLB texture: ${sourceUrl} -> ${originalImageUri}`);
+      }
       delete image.bufferView;
       image.mimeType = image.mimeType ?? 'image/png';
       continue;


### PR DESCRIPTION
### Motivation
- Firearm GLB assets in Ludo Battle Royal were fallbacking to vehicle/placeholder textures when external image URIs could not be resolved, breaking the original GLB/GLTF texture bindings used previously.

### Description
- Adjust GLB image-patching to use the `firearm` kind when preparing capture weapon GLBs so firearm-specific logic is applied at load time (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Add an `allowPlaceholder` option to `resolveExternalImageToDataUri` and `patchGlbImagesToDataUris` so callers can disable placeholder substitution for critical assets; firearm loads are now called with `{ allowPlaceholder: false }` to force a clean fallback path.
- Introduce a `firearm` placeholder color palette and change the logic to throw when a firearm GLB image cannot be resolved without placeholders, ensuring the loader falls back to the GLTF/GLB embedded textures instead of silently substituting vehicle placeholders.

### Testing
- Ran `npm --prefix webapp run lint -- src/pages/Games/LudoBattleRoyal.jsx` and the linter completed without errors (success).
- Ran `npm --prefix webapp run build` and the production build completed (success).
- Ran `npx playwright install chromium` and `npx playwright install-deps chromium` to prepare the test browser (success).
- Launched a dev server and attempted a Playwright mobile screenshot of `/games/ludobattleroyal`; the screenshot was produced at `/tmp/tonplaygram-screenshots/ludo-battle-royal.png` but the browser console reported external asset fetch and certificate/network errors (resource fetch failures) while the route still rendered (partial/expected environmental failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190dd02d5c83299b06800afcee2057)