### PR TITLE
Improve Showood external table fit, chrome mapping and live material refresh

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -17,7 +17,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
-    fitFootprintScale: 1,
+    fitFootprintScale: 1.08,
     fitHeightScale: 1,
     lowerBaseHeightScale: 1.38,
     legLengthScale: 2.05,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -4323,7 +4323,7 @@ const SHOWOOD_TABLE_PARTS = Object.freeze([
   'cushion',
   'topWoodRail',
   'railSight',
-    'baseCornerBlock',
+  'baseCornerBlock',
   'leg',
   'baseFoot'
 ]);
@@ -4419,7 +4419,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -12916,8 +12916,10 @@ export function Table3D(
   const createConfiguredGLTFLoader = (renderer = null, manager = null) => {
     const loader = new GLTFLoader(manager ?? undefined);
     loader.setCrossOrigin('anonymous');
-    const draco = new DRACOLoader();
+    const draco = new DRACOLoader(manager ?? undefined);
     draco.setDecoderPath(DRACO_DECODER_PATH);
+    draco.setDecoderConfig({ type: 'js' });
+    draco.preload();
     loader.setDRACOLoader(draco);
     const ktx2 = ensurePolyhavenKtx2Loader(renderer);
     loader.setKTX2Loader(ktx2);
@@ -13091,7 +13093,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'baseCornerBlock',
+    sideWoodApron: 'railSight',
     railSight: 'railSight',
     trim: 'railSight',
     pocket: 'pocketCup',
@@ -13373,7 +13375,7 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalMaterials = [];
     const materialLookup = new Map();
     const getMaterialIndex = (sourceMaterialIndex, part, cushionShadow = false) => {
-      const linkedPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+      const linkedPart = part === 'sideWoodApron' ? 'railSight' : part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}:${cushionShadow ? 'shadow' : 'main'}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];
@@ -13397,6 +13399,11 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
         next.alphaMap = null;
       }
       next.name = `${source?.name || 'showood'}__${linkedPart}${cushionShadow ? '__shadow' : ''}`;
+      next.userData = {
+        ...(next.userData || {}),
+        poolRoyaleShowoodPart: linkedPart,
+        poolRoyaleShowoodCushionShadow: cushionShadow
+      };
       const index = finalMaterials.length;
       finalMaterials.push(next);
       materialLookup.set(key, index);
@@ -13592,6 +13599,40 @@ function clonePoolRoyaleExternalTableTemplate(template, tableModel = null, finis
   const clone = template.clone(true);
   preparePoolRoyaleExternalTableMaterials(clone, tableModel, finishInfo);
   return clone;
+}
+
+function refreshPoolRoyaleShowoodExternalMaterials(root, tableModel = null, finishInfo = null) {
+  if (!root || tableModel?.id !== 'showood-seven-foot' || !finishInfo) return;
+  root.traverse?.((mesh) => {
+    if (!mesh?.isMesh || !mesh.material) return;
+    const refreshMaterial = (material) => {
+      const part = material?.userData?.poolRoyaleShowoodPart;
+      if (!part) return material;
+      const next = applyShowoodStyleToExternalMaterial(material, part, tableModel, finishInfo);
+      const cushionShadow = Boolean(material.userData?.poolRoyaleShowoodCushionShadow);
+      if (cushionShadow && part === 'cushion') {
+        if (next.color) next.color.set(CUSHION_SHADOW_GREY);
+        if ('metalness' in next) next.metalness = 0;
+        if ('roughness' in next) next.roughness = 0.96;
+        if ('envMapIntensity' in next) next.envMapIntensity = 0.22;
+        if ('clearcoat' in next) next.clearcoat = 0;
+        if ('clearcoatRoughness' in next) next.clearcoatRoughness = 0;
+        ['map', 'normalMap', 'bumpMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'emissiveMap', 'lightMap', 'alphaMap'].forEach((key) => {
+          next[key] = null;
+        });
+      }
+      next.userData = {
+        ...(next.userData || {}),
+        poolRoyaleShowoodPart: part,
+        poolRoyaleShowoodCushionShadow: cushionShadow
+      };
+      next.needsUpdate = true;
+      return next;
+    };
+    mesh.material = Array.isArray(mesh.material)
+      ? mesh.material.map(refreshMaterial)
+      : refreshMaterial(mesh.material);
+  });
 }
 
 async function loadPoolRoyaleExternalTableTemplate(tableModel, renderer = null) {
@@ -14695,6 +14736,14 @@ function mountPoolRoyaleExternalTableModel({
                 )
         }
       : null;
+  table.userData.externalTableModel = externalTableModelForMount;
+  table.userData.refreshExternalShowoodMaterials = (nextTableModel = table.userData.externalTableModel, nextFinishInfo = table.userData.finish) => {
+    refreshPoolRoyaleShowoodExternalMaterials(
+      table.userData?.externalTable?.group,
+      nextTableModel,
+      nextFinishInfo
+    );
+  };
   const externalTable =
     externalTableModelForMount?.kind === 'gltf'
       ? mountPoolRoyaleExternalTableModel({
@@ -15151,6 +15200,16 @@ function applyTableFinishToTable(table, finish) {
     pocketRim: pocketRimMat,
     accent: accentConfig
   };
+  const externalTableModel = table.userData?.externalTableModel
+    ? {
+        ...table.userData.externalTableModel,
+        showoodStyle: resolvedFinish?.showoodStyle ?? table.userData.externalTableModel.showoodStyle
+      }
+    : null;
+  if (externalTableModel?.id === 'showood-seven-foot') {
+    table.userData.externalTableModel = externalTableModel;
+    table.userData.refreshExternalShowoodMaterials?.(externalTableModel, finishInfo);
+  }
   finishInfo.clothDetail = resolvedFinish?.clothDetail ?? null;
 }
 
@@ -17336,6 +17395,7 @@ function PoolRoyaleGame({
       woodTexture: baseFinish?.woodTexture ?? null,
       woodTextureEnabled: baseFinish?.woodTextureEnabled ?? WOOD_TEXTURES_ENABLED,
       woodTextureId: baseFinish?.woodTextureId ?? null,
+      showoodStyle: normalizeShowoodTableStyle(showoodTableStyle),
       woodRepeatScale: baseFinish?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE,
       createMaterials: () => {
         const baseMaterials = baseCreateMaterials();
@@ -17428,6 +17488,10 @@ function PoolRoyaleGame({
     }
   }, [chromeColorId]);
   useEffect(() => {
+    const linkedRailMarker = chromeColorId === 'gold' ? 'gold' : 'chrome';
+    setRailMarkerColorId((current) => (current === linkedRailMarker ? current : linkedRailMarker));
+  }, [chromeColorId]);
+  useEffect(() => {
     if (typeof window !== 'undefined') {
       window.localStorage.setItem('poolChromePlateStyle', chromePlateStyleId);
     }
@@ -17446,9 +17510,9 @@ function PoolRoyaleGame({
     setShowoodTableStyle((current) => {
       const next = normalizeShowoodTableStyle(current);
       const linkedRailSight = chromeColorId === 'gold' ? 'gold' : 'chrome';
-      return next.railSight === linkedRailSight
+      return next.railSight === linkedRailSight && next.baseFoot === linkedRailSight
         ? next
-        : { ...next, railSight: linkedRailSight };
+        : { ...next, railSight: linkedRailSight, baseFoot: linkedRailSight };
     });
   }, [chromeColorId]);
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Make the Showood 7ft GLB visually match Pool Royale footprint and ensure chrome/gold options control all metal accents (side apron, rail sights, feet, rail markers) consistently. 
- Allow applied finish changes to propagate to an already-loaded external GLTF (Showood) so chrome/gold and cushion/cloth treatments update live.

### Description
- Increase Showood external model footprint scaling by changing `fitFootprintScale` to `1.08` in `webapp/src/config/poolRoyaleTableModels.js` so the GLB loads slightly larger to match mapping. 
- Route Showood `sideWoodApron` parts to be treated as `railSight`/chrome parts by updating mapping logic and linked-part resolution in `webapp/src/pages/Games/PoolRoyale.jsx` so chrome/gold selections cover side apron, rail sights, vertical rims and feet. 
- Use a configured `DRACOLoader` in the GLTF loader (`createConfiguredGLTFLoader`) with `manager` passed, `setDecoderConfig({ type: 'js' })` and `preload()` to match the referenced client loading technique while keeping KTX2 and Meshopt support. 
- Mark remapped Showood materials with `userData.poolRoyaleShowoodPart` and `userData.poolRoyaleShowoodCushionShadow`, and add `refreshPoolRoyaleShowoodExternalMaterials` plus a `table.userData.refreshExternalShowoodMaterials` wrapper to reapply Showood finish/materials on an already-mounted external table. 
- Wire `showoodStyle` through the finish/template creation and synchronize rail marker color with chrome color so rail markings follow chrome/gold selections. 

### Testing
- Ran `git diff --check` with no errors (success). 
- Ran a production build with `npm run build` which completed successfully (Vite build finished and artifacts produced). 
- Attempted an automated mobile preview with Playwright; Playwright and browser deps were installed and Chromium launched, but headless screenshot capture timed out in this environment while the WebGL scene kept rendering (environment/network fetch warnings observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190f5fa2308329a766685f9116d192)