### PR TITLE
Lower bowling field floor

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -286,8 +286,8 @@ const RESULT_COMPLIMENTS = {
   open: ['Nice try—adjust and fire again.', 'Good pace, keep rhythm.']
 } as const;
 
-// Visually lower the entire bowling field so it sits on the HDRI ground line.
-const BOWLING_HDRI_GROUND_SNAP_DROP = 0.82;
+// Visually lower the entire bowling field so it sits below the HDRI ground line on portrait screens.
+const BOWLING_HDRI_GROUND_SNAP_DROP = 1.22;
 
 const CFG = {
   laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,


### PR DESCRIPTION
### Motivation
- Improve portrait-screen framing by moving the entire bowling field visually lower so the lane, pins, ball, and related props sit further below the HDRI ground line.

### Description
- Increased `BOWLING_HDRI_GROUND_SNAP_DROP` from `0.82` to `1.22` and updated the inline comment in `webapp/src/pages/Games/BowlingRealistic.tsx` so the shared `CFG.laneY` moves all lane objects together.

### Testing
- Ran `npm run build` successfully; attempted automated mobile screenshot with Playwright but the Chromium browser binary is not available in the environment so the headless screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1921f1af288329b15d284275154a67)