### PR TITLE
Lower bowling field to sit below HDRI ground on portrait screens

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -286,8 +286,8 @@ const RESULT_COMPLIMENTS = {
   open: ['Nice try—adjust and fire again.', 'Good pace, keep rhythm.']
 } as const;
 
-// Visually lower the entire bowling field so it sits on the HDRI ground line.
-const BOWLING_HDRI_GROUND_SNAP_DROP = 0.82;
+// Visually lower the entire bowling field so it sits below the HDRI ground line on portrait screens.
+const BOWLING_HDRI_GROUND_SNAP_DROP = 2.0;
 
 const CFG = {
   laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,


### PR DESCRIPTION
### Motivation
- Ensure the bowling scene visually sits below the HDRI ground line on portrait-oriented screens to avoid clipping and improve composition.

### Description
- Increase `BOWLING_HDRI_GROUND_SNAP_DROP` from `0.82` to `2.0` and update the inline comment so `laneY` (and related positions) are shifted downward accordingly.

### Testing
- Ran TypeScript type-check and project build (`yarn build`), and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1921f1af288329b15d284275154a67)