### PR TITLE
Align bowling field with HDRI ground on portrait screens

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -286,8 +286,8 @@ const RESULT_COMPLIMENTS = {
   open: ['Nice try—adjust and fire again.', 'Good pace, keep rhythm.']
 } as const;
 
-// Visually lower the entire bowling field so it sits on the HDRI ground line.
-const BOWLING_HDRI_GROUND_SNAP_DROP = 0.82;
+// Keep the bowling field aligned with the base HDRI ground height on portrait screens.
+const BOWLING_HDRI_GROUND_SNAP_DROP = 0.0;
 
 const CFG = {
   laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,


### PR DESCRIPTION
### Motivation
- Prevent the bowling field from being visually lowered on portrait screens by keeping it aligned to the base HDRI ground height (`BOWLING_HDRI_GROUND_SNAP_DROP`).

### Description
- Change `BOWLING_HDRI_GROUND_SNAP_DROP` from `0.82` to `0.0` and update the comment to indicate the field now stays aligned with the HDRI ground on portrait screens.

### Testing
- Ran the project's automated test suite (`yarn test`) and a TypeScript build (`yarn build` / `tsc`) locally and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1921f1af288329b15d284275154a67)