### PR TITLE
Showood: add side-apron customization, improve material mapping and GLTF loading

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,14 +1,14 @@
-export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
 const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint. If the CDN GLB cannot load, Pool Royale retries the raw Showood GLB and keeps the Showood original base and legs.',
+      'Open-source Pooltool Showood showroom table enlarged to match Pool Royale mapping. If the CDN GLB cannot load, Pool Royale retries the raw Showood GLB and keeps the Showood original base and legs.',
     tableSizeId: '7ft',
     baseId: 'showoodOriginal',
     assetUrl:
@@ -16,8 +16,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
-    fitScale: 1,
-    fitFootprintScale: 1,
+    fitScale: 1.12,
+    fitFootprintScale: 1.12,
     fitHeightScale: 1,
     lowerBaseHeightScale: 1.38,
     legLengthScale: 2.05,
@@ -37,20 +37,20 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }
-]);
+])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
     (option) => option.id === 'showood-seven-foot'
-  )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+  )?.id || POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
-export function resolvePoolRoyaleTableModel(modelId) {
-  const key = typeof modelId === 'string' ? modelId.trim() : '';
+export function resolvePoolRoyaleTableModel (modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : ''
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
       (option) => option.id === DEFAULT_POOL_ROYALE_TABLE_MODEL_ID
     ) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  )
 }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -124,7 +124,7 @@ import { computeCueDriveBoost } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
-  'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+  'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/';
 
 
 const TRAINING_MISS_ATTEMPT_COST = 1;
@@ -4322,18 +4322,20 @@ const SHOWOOD_TABLE_PARTS = Object.freeze([
   'cloth',
   'cushion',
   'topWoodRail',
+  'sideWoodApron',
   'railSight',
-    'baseCornerBlock',
+  'baseCornerBlock',
   'leg',
   'baseFoot'
 ]);
-const SHOWOOD_TABLE_SETUP_HIDDEN_PARTS = new Set(['cloth', 'cushion', 'railSight', 'baseFoot']);
+const SHOWOOD_TABLE_SETUP_HIDDEN_PARTS = new Set(['cloth', 'cushion']);
 const DEFAULT_SHOWOOD_TABLE_STYLE = Object.freeze({
   cloth: 'green',
   cushion: 'green',
   topWoodRail: 'walnut',
+  sideWoodApron: 'gold',
   railSight: 'gold',
-  baseCornerBlock: 'black',
+  baseCornerBlock: DEFAULT_CUE_STYLE_ID,
   leg: 'black',
   baseFoot: 'gold'
 });
@@ -4347,9 +4349,13 @@ const SHOWOOD_TABLE_PART_OPTIONS = Object.freeze({
     { id: 'black', label: 'Black Rubber Cushions', color: '#050505', keepSourceTexture: true, material: { color: 0x050505, roughness: 0.86, metalness: 0, envMapIntensity: 0.55 } }
   ]),
   topWoodRail: Object.freeze([]),
+  sideWoodApron: Object.freeze([
+    { id: 'chrome', label: 'Chrome Side Apron', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
+    { id: 'gold', label: 'Gold Side Apron', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } }
+  ]),
   railSight: Object.freeze([
-    { id: 'chrome', label: 'Chrome Apron + Sights', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
-    { id: 'gold', label: 'Gold Apron + Sights', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } }
+    { id: 'chrome', label: 'Chrome Rail Sights + Markings', color: '#d7dde7', material: { color: 0xd7dde7, roughness: 0.055, metalness: 1, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 } },
+    { id: 'gold', label: 'Gold Rail Sights + Markings', color: '#f5d978', material: { color: 0xf5d978, roughness: 0.065, metalness: 1, envMapIntensity: 6.7, clearcoat: 1, clearcoatRoughness: 0.035 } }
   ]),
   baseCornerBlock: Object.freeze([
     { id: 'brown', label: 'Brown Base', color: '#7b2d11', material: { color: 0x7b2d11, roughness: 0.48, metalness: 0.02, envMapIntensity: 1.1, clearcoat: 0.22, clearcoatRoughness: 0.33 } },
@@ -4365,14 +4371,15 @@ const SHOWOOD_TABLE_PART_LABELS = Object.freeze({
   cloth: 'Field Cloth',
   cushion: 'Cushions',
   topWoodRail: 'Top Rails',
-  railSight: 'Side Apron + Rail Sights',
+  sideWoodApron: 'Pocket Apron Strip',
+  railSight: 'Rail Sights + Markings',
   baseCornerBlock: 'Table Base',
   leg: 'Legs',
   baseFoot: 'Feet'
 });
-const SHOWOOD_CHROME_LINKED_PARTS = new Set(['railSight', 'baseFoot']);
+const SHOWOOD_CHROME_LINKED_PARTS = new Set(['sideWoodApron', 'railSight', 'baseFoot']);
 const CUSHION_SHADOW_GREY = '#666a72';
-const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOptions = null) => {
+const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOptions = null, cueFinishOptions = null) => {
   if (part === 'cloth' || part === 'cushion') {
     const sourceOptions = Array.isArray(clothOptions) && clothOptions.length
       ? clothOptions
@@ -4396,10 +4403,15 @@ const getShowoodTablePartOptions = (part, clothOptions = null, tableFinishOption
     }));
   }
   if (part === 'baseCornerBlock') {
-    return [
-      { id: 'brown', label: part === 'leg' ? 'Brown Legs' : 'Brown Base', color: '#3d1706', material: { color: 0x3d1706, roughness: 0.52, metalness: 0.02, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }, keepSourceTexture: true },
-      { id: 'black', label: part === 'leg' ? 'Black Legs' : 'Black Base', color: '#070504', material: { color: 0x070504, roughness: 0.4, metalness: 0.04, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 }, keepSourceTexture: true }
-    ];
+    const source = Array.isArray(cueFinishOptions) && cueFinishOptions.length
+      ? cueFinishOptions
+      : CUE_FINISH_OPTIONS;
+    return source.map((option) => ({
+      id: option.id,
+      label: `${option.label} Base`,
+      color: option.swatches?.[0] ?? toHexColor(option.colors?.base ?? option.colors?.rail ?? '#3d1706'),
+      keepSourceTexture: true
+    }));
   }
   return SHOWOOD_TABLE_PART_OPTIONS[part] || [];
 };
@@ -4419,7 +4431,7 @@ const normalizeShowoodTableStyle = (value = {}) => {
 };
 const getShowoodPartOption = (style, part) => {
   const normalized = normalizeShowoodTableStyle(style);
-  const optionPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+  const optionPart = part === 'verticalCornerRim' ? 'baseFoot' : part;
   const optionId = normalized[optionPart];
   const options = getShowoodTablePartOptions(optionPart);
   return options.find((option) => option.id === optionId) || options[0] || null;
@@ -12916,8 +12928,10 @@ export function Table3D(
   const createConfiguredGLTFLoader = (renderer = null, manager = null) => {
     const loader = new GLTFLoader(manager ?? undefined);
     loader.setCrossOrigin('anonymous');
-    const draco = new DRACOLoader();
+    const draco = new DRACOLoader(manager ?? undefined);
     draco.setDecoderPath(DRACO_DECODER_PATH);
+    draco.setDecoderConfig({ type: 'js' });
+    draco.preload();
     loader.setDRACOLoader(draco);
     const ktx2 = ensurePolyhavenKtx2Loader(renderer);
     loader.setKTX2Loader(ktx2);
@@ -13083,6 +13097,35 @@ function normalizePoolRoyaleExternalClothTextureScale(mesh, material, role) {
   material.needsUpdate = true;
 }
 
+function resolveCueStyleWoodSurfaceForFinish(finish) {
+  const defaultWoodOption =
+    WOOD_GRAIN_OPTIONS_BY_ID[DEFAULT_WOOD_GRAIN_ID] ?? WOOD_GRAIN_OPTIONS[0];
+  const resolvedWoodOption =
+    finish?.woodTexture ||
+    (finish?.woodTextureId && WOOD_GRAIN_OPTIONS_BY_ID[finish.woodTextureId]) ||
+    defaultWoodOption;
+  const cueSurface = resolveWoodSurfaceConfig(
+    resolvedWoodOption?.rail,
+    resolvedWoodOption?.frame ?? { repeat: { x: 1, y: 1 }, rotation: 0 }
+  );
+  const cueRepeatScale = finish?.id === 'peelingPaintWeathered' ? 1 : CUE_WOOD_REPEAT_SCALE;
+  const woodRepeatScale = clampWoodRepeatScaleValue(
+    (finish?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE) * cueRepeatScale
+  );
+  const preferredResolution =
+    getRuntimeTextureProfile().polyHavenPreferredResolutions?.[0] ??
+    getRuntimeTextureProfile().polyHavenResolution;
+  return {
+    repeat: cueSurface.repeat,
+    rotation: cueSurface.rotation,
+    textureSize: Math.max(cueSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE, getRuntimeCueTextureSize()),
+    mapUrl: remapPolyHavenTextureUrlResolution(cueSurface.mapUrl, preferredResolution),
+    roughnessMapUrl: remapPolyHavenTextureUrlResolution(cueSurface.roughnessMapUrl, preferredResolution),
+    normalMapUrl: remapPolyHavenTextureUrlResolution(cueSurface.normalMapUrl, preferredResolution),
+    woodRepeatScale
+  };
+}
+
 function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, finishInfo = null) {
   if (!material) return material;
   const style = normalizeShowoodTableStyle(tableModel?.showoodStyle);
@@ -13091,9 +13134,12 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     cushion: 'cushion',
     topWoodRail: 'topWoodRail',
     wood: 'topWoodRail',
-    sideWoodApron: 'baseCornerBlock',
+    sideWoodApron: 'sideWoodApron',
     railSight: 'railSight',
     trim: 'railSight',
+    cornerPocketPlate: 'railSight',
+    middlePocketPlate: 'railSight',
+    lowerTrim: 'railSight',
     pocket: 'pocketCup',
     verticalCornerRim: 'baseFoot',
     baseFoot: 'baseFoot',
@@ -13102,9 +13148,9 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
   };
   const part = roleToPart[role] || 'topWoodRail';
   const option = getShowoodPartOption(style, part);
-  if (!option) return material;
+  if (!option && part !== 'pocketCup') return material;
   const mat = material.clone ? material.clone() : material;
-  const materialProps = option.material || {};
+  const materialProps = option?.material || {};
   const materials = finishInfo?.materials || {};
   const finish = TABLE_FINISHES[finishInfo?.id] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
 
@@ -13139,7 +13185,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     });
   };
 
-  if (part === 'railSight' || part === 'baseFoot') {
+  if (part === 'sideWoodApron' || part === 'railSight' || part === 'baseFoot') {
     copyMaterialLook(materials.trim);
     if (mat.color && Number.isFinite(materialProps.color)) mat.color.set(materialProps.color);
     ['roughness', 'metalness', 'clearcoat', 'clearcoatRoughness', 'envMapIntensity'].forEach((key) => {
@@ -13167,15 +13213,27 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
     copyMaterialLook(materials.pocketJaw ?? materials.pocketRim);
     applyShowoodTint();
   } else if (part === 'topWoodRail' || part === 'baseCornerBlock' || part === 'leg') {
-    const surface = part === 'topWoodRail'
-      ? finishInfo?.parts?.woodSurfaces?.rail
-      : finishInfo?.parts?.woodSurfaces?.frame || finishInfo?.parts?.woodSurfaces?.rail;
-    if (materials.rail?.color && mat.color) mat.color.copy(materials.rail.color);
+    const cueStyleFinish = TABLE_FINISHES[option?.id];
+    const surface = part === 'baseCornerBlock' && cueStyleFinish
+      ? resolveCueStyleWoodSurfaceForFinish(cueStyleFinish)
+      : part === 'topWoodRail'
+        ? finishInfo?.parts?.woodSurfaces?.rail
+        : finishInfo?.parts?.woodSurfaces?.frame || finishInfo?.parts?.woodSurfaces?.rail;
+    const tintColor = part === 'baseCornerBlock' && cueStyleFinish
+      ? cueStyleFinish.colors?.base ?? cueStyleFinish.colors?.rail
+      : null;
+    const tintSource = part === 'baseCornerBlock'
+      ? materials.frame ?? materials.rail
+      : materials.rail;
+    if (Number.isFinite(tintColor) && mat.color) mat.color.setHex(tintColor);
+    else if (tintSource?.color && mat.color) mat.color.copy(tintSource.color);
     applyWoodTextureToMaterial(mat, surface || { woodRepeatScale: finishInfo?.woodRepeatScale });
+    applySharedWoodSurfaceProps(mat);
     applyTableFinishDulling(mat);
     applyTableWoodVisibilityTuning(mat);
-    if (finish?.surfaceStyle === 'matte') {
-      if (finish?.preserveFinishTintOnWood) applyMatteSurfacePropsOnly(mat);
+    const activeFinish = part === 'baseCornerBlock' && cueStyleFinish ? cueStyleFinish : finish;
+    if (activeFinish?.surfaceStyle === 'matte') {
+      if (activeFinish?.preserveFinishTintOnWood) applyMatteSurfacePropsOnly(mat);
       else applyMonoMattePlasticSurface(mat);
     }
     applyShowoodTint();
@@ -13197,7 +13255,7 @@ function applyShowoodStyleToExternalMaterial(material, role, tableModel = null, 
   mat.userData = {
     ...(mat.userData || {}),
     poolRoyaleShowoodPart: part,
-    poolRoyaleShowoodOption: option.id,
+    poolRoyaleShowoodOption: option?.id ?? part,
     poolRoyaleUsesOwnTextureSet: true
   };
   mat.needsUpdate = true;
@@ -13297,6 +13355,15 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
     (s.longN > 0.54 || s.shortN > 0.48) &&
     !(topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner || baseCornerZone || legZone);
 
+  const pocketApronStripZone =
+    s.sideFace &&
+    !s.upFace &&
+    high &&
+    anyPocketZone &&
+    s.relY > 0.44 &&
+    s.relY < 0.78 &&
+    (s.longN > 0.5 || s.shortN > 0.5);
+
   const sideLowerTrimZone =
     s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54);
 
@@ -13318,6 +13385,7 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   if (namedPocket && hardwareCandidate && cornerPocketZone) return 'cornerPocketPlate';
   if (hardwareCandidate && sideMiddlePocketZone && !green && !brown) return 'middlePocketPlate';
   if (hardwareCandidate && cornerPocketZone && !green && !brown) return 'cornerPocketPlate';
+  if (pocketApronStripZone && !green) return 'sideWoodApron';
 
   if (green && centralCloth) return 'cloth';
   if (green && cushionBand) return 'cushion';
@@ -13334,11 +13402,11 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   if (baseCornerZone) return 'baseCornerBlock';
   if (legZone && (brown || namedWood || !hardwareCandidate)) return 'leg';
   if (hardwareCandidate && sideLowerTrimZone && !green) return 'lowerTrim';
-  if (railSightDownBand && !green) return 'sideWoodApron';
+  if (railSightDownBand && !green) return 'baseCornerBlock';
   if (veryTop && (s.upFace || topRailBand) && !green) return 'topWoodRail';
-  if (high && s.sideFace && !green && !anyPocketZone) return 'sideWoodApron';
+  if (high && s.sideFace && !green && !anyPocketZone) return 'baseCornerBlock';
 
-  return 'sideWoodApron';
+  return 'baseCornerBlock';
 }
 
 function isPoolRoyaleShowoodCushionShadowTriangle(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize) {
@@ -13349,6 +13417,76 @@ function isPoolRoyaleShowoodCushionShadowTriangle(mesh, geometry, aIndex, bIndex
     s.relY < 0.84 &&
     ((s.longN > 0.6 && s.longN < 0.95) || (s.shortN > 0.42 && s.shortN < 0.88))
   );
+}
+
+
+const SHOWOOD_FINE_PARTS = new Set([
+  'pocketCup',
+  'sideWoodApron',
+  'cornerPocketPlate',
+  'middlePocketPlate',
+  'verticalCornerRim',
+  'baseCornerBlock',
+  'lowerTrim',
+  'railSight',
+  'underside'
+]);
+const SHOWOOD_TABLE_TRIANGLE_PARTS = Object.freeze([
+  'cloth',
+  'cushion',
+  'topWoodRail',
+  'sideWoodApron',
+  'pocketCup',
+  'cornerPocketPlate',
+  'middlePocketPlate',
+  'verticalCornerRim',
+  'baseCornerBlock',
+  'leg',
+  'baseFoot',
+  'lowerTrim',
+  'railSight',
+  'underside'
+]);
+
+function createPoolRoyaleShowoodSlotStat() {
+  return {
+    total: 0,
+    dominantPart: 'sideWoodApron',
+    dominantRatio: 1,
+    parts: SHOWOOD_TABLE_TRIANGLE_PARTS.reduce((acc, part) => {
+      acc[part] = 0;
+      return acc;
+    }, {})
+  };
+}
+
+function updatePoolRoyaleShowoodSlotStat(stats, sourceSlot, part) {
+  const stat = stats.get(sourceSlot) ?? createPoolRoyaleShowoodSlotStat();
+  stat.total += 1;
+  stat.parts[part] = (stat.parts[part] || 0) + 1;
+  stat.dominantPart = SHOWOOD_TABLE_TRIANGLE_PARTS.reduce(
+    (best, item) => ((stat.parts[item] || 0) > (stat.parts[best] || 0) ? item : best),
+    stat.dominantPart
+  );
+  stat.dominantRatio = stat.total > 0 ? (stat.parts[stat.dominantPart] || 0) / stat.total : 1;
+  stats.set(sourceSlot, stat);
+}
+
+function isPoolRoyaleShowoodMixedClothCushionSlot(stat) {
+  return Boolean(stat && (stat.parts.cloth || 0) > 0 && (stat.parts.cushion || 0) > 0);
+}
+
+function resolvePoolRoyaleShowoodMappedPart(triangle, slotStats) {
+  const stat = slotStats.get(triangle.sourceSlot);
+  if (!stat) return triangle.part;
+  if (SHOWOOD_FINE_PARTS.has(triangle.part) && triangle.part !== stat.dominantPart) return triangle.part;
+  if (isPoolRoyaleShowoodMixedClothCushionSlot(stat) && (triangle.part === 'cloth' || triangle.part === 'cushion')) {
+    return triangle.part;
+  }
+  if ((triangle.part === 'cloth' || triangle.part === 'cushion') && stat.dominantRatio >= 0.88) {
+    return stat.dominantPart;
+  }
+  return stat.dominantRatio >= 0.965 ? stat.dominantPart : triangle.part;
 }
 
 function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInfo = null) {
@@ -13372,8 +13510,26 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
     const finalIndex = [];
     const finalMaterials = [];
     const materialLookup = new Map();
+    const slotStats = new Map();
+    const triangles = [];
+    const makeSourceSlot = (sourceMaterialIndex, sourceMaterial) =>
+      `${mesh.name || 'showood_mesh'}::slot_${sourceMaterialIndex}::${sourceMaterial?.name || 'showood_material'}`;
+
+    for (let i = 0; i + 2 < totalIndices; i += 3) {
+      const a = oldIndex ? oldIndex.getX(i) : i;
+      const b = oldIndex ? oldIndex.getX(i + 1) : i + 1;
+      const c = oldIndex ? oldIndex.getX(i + 2) : i + 2;
+      const sourceMaterialIndex = Math.max(0, Math.min(getPoolRoyaleGeometryMaterialIndexAt(sourceGeometry, i), sourceMaterials.length - 1));
+      const sourceMaterial = sourceMaterials[sourceMaterialIndex];
+      const sourceSlot = makeSourceSlot(sourceMaterialIndex, sourceMaterial);
+      const part = resolvePoolRoyaleShowoodTrianglePart(mesh, sourceGeometry, sourceMaterial, a, b, c, tableBox, tableCenter, tableSize);
+      const cushionShadow = part === 'cushion' && isPoolRoyaleShowoodCushionShadowTriangle(mesh, sourceGeometry, a, b, c, tableBox, tableCenter, tableSize);
+      triangles.push({ a, b, c, sourceMaterialIndex, sourceSlot, part, cushionShadow });
+      updatePoolRoyaleShowoodSlotStat(slotStats, sourceSlot, part);
+    }
+
     const getMaterialIndex = (sourceMaterialIndex, part, cushionShadow = false) => {
-      const linkedPart = part === 'sideWoodApron' ? 'baseCornerBlock' : part === 'verticalCornerRim' ? 'baseFoot' : part;
+      const linkedPart = part === 'verticalCornerRim' ? 'baseFoot' : part;
       const key = `${sourceMaterialIndex}:${linkedPart}:${cushionShadow ? 'shadow' : 'main'}`;
       if (materialLookup.has(key)) return materialLookup.get(key);
       const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];
@@ -13402,19 +13558,15 @@ function remapPoolRoyaleShowoodExternalParts(model, tableModel = null, finishInf
       materialLookup.set(key, index);
       return index;
     };
-    for (let i = 0; i + 2 < totalIndices; i += 3) {
-      const a = oldIndex ? oldIndex.getX(i) : i;
-      const b = oldIndex ? oldIndex.getX(i + 1) : i + 1;
-      const c = oldIndex ? oldIndex.getX(i + 2) : i + 2;
-      const sourceMaterialIndex = Math.max(0, Math.min(getPoolRoyaleGeometryMaterialIndexAt(sourceGeometry, i), sourceMaterials.length - 1));
-      const sourceMaterial = sourceMaterials[sourceMaterialIndex];
-      const part = resolvePoolRoyaleShowoodTrianglePart(mesh, sourceGeometry, sourceMaterial, a, b, c, tableBox, tableCenter, tableSize);
-      const cushionShadow = part === 'cushion' && isPoolRoyaleShowoodCushionShadowTriangle(mesh, sourceGeometry, a, b, c, tableBox, tableCenter, tableSize);
-      const materialIndex = getMaterialIndex(sourceMaterialIndex, part, cushionShadow);
+
+    triangles.forEach((triangle) => {
+      const part = resolvePoolRoyaleShowoodMappedPart(triangle, slotStats);
+      const cushionShadow = part === 'cushion' && triangle.cushionShadow;
+      const materialIndex = getMaterialIndex(triangle.sourceMaterialIndex, part, cushionShadow);
       const start = finalIndex.length;
-      finalIndex.push(a, b, c);
+      finalIndex.push(triangle.a, triangle.b, triangle.c);
       finalGeometry.addGroup(start, 3, materialIndex);
-    }
+    });
     finalGeometry.setIndex(finalIndex);
     finalGeometry.computeBoundingBox();
     finalGeometry.computeBoundingSphere();
@@ -13603,7 +13755,8 @@ async function loadPoolRoyaleExternalTableTemplate(tableModel, renderer = null) 
     return poolRoyaleExternalTablePromises.get(tableModel.id);
   }
   const promise = (async () => {
-    const loader = createConfiguredGLTFLoader(renderer);
+    const manager = new THREE.LoadingManager();
+    const loader = createConfiguredGLTFLoader(renderer, manager);
     let lastError = null;
     const urls = [tableModel.assetUrl, tableModel.fallbackAssetUrl].filter(Boolean);
     for (const url of urls) {
@@ -15645,7 +15798,7 @@ function PoolRoyaleGame({
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem('poolRailMarkerShape');
       if (stored && RAIL_MARKER_SHAPE_OPTIONS.some((opt) => opt.id === stored)) {
-        return stored === 'diamond' ? DEFAULT_RAIL_MARKER_SHAPE : stored;
+        return stored;
       }
     }
     return DEFAULT_RAIL_MARKER_SHAPE;
@@ -15654,7 +15807,7 @@ function PoolRoyaleGame({
     return resolveStoredSelection(
       'railMarkerColor',
       'poolRailMarkerColor',
-      (id) => RAIL_MARKER_COLOR_OPTIONS.some((opt) => opt.id === id),
+      (id) => (id === 'gold' || id === 'chrome') && RAIL_MARKER_COLOR_OPTIONS.some((opt) => opt.id === id),
       DEFAULT_RAIL_MARKER_COLOR_ID
     );
   });
@@ -15818,6 +15971,7 @@ function PoolRoyaleGame({
   const availableRailMarkerColors = useMemo(
     () =>
       RAIL_MARKER_COLOR_OPTIONS.filter((option) =>
+        (option.id === 'gold' || option.id === 'chrome') &&
         isPoolOptionUnlocked('railMarkerColor', option.id, poolInventory)
       ),
     [poolInventory]
@@ -15850,15 +16004,19 @@ function PoolRoyaleGame({
       ),
     [isCueFinishUnlocked, poolInventory]
   );
+  const availableCueFinishOptions = useMemo(
+    () => availableCueStyles.map(({ preset }) => preset).filter(Boolean),
+    [availableCueStyles]
+  );
   const tablePersonalizationSections = useMemo(
     () =>
       SHOWOOD_TABLE_PARTS.map((part) => ({
         key: part,
         label: SHOWOOD_TABLE_PART_LABELS[part] || part,
         chromeLinked: SHOWOOD_CHROME_LINKED_PARTS.has(part),
-        options: getShowoodTablePartOptions(part, availableClothOptions, availableTableFinishes)
+        options: getShowoodTablePartOptions(part, availableClothOptions, availableTableFinishes, availableCueFinishOptions)
       })).filter((section) => !SHOWOOD_TABLE_SETUP_HIDDEN_PARTS.has(section.key) && section.options.length > 0),
-    [availableClothOptions, availableTableFinishes]
+    [availableClothOptions, availableCueFinishOptions, availableTableFinishes]
   );
   useEffect(() => {
     if (!tablePersonalizationSections.some((section) => section.key === activeTablePersonalizationPart)) {
@@ -15979,7 +16137,10 @@ function PoolRoyaleGame({
     if (!isPoolOptionUnlocked('chromePlateStyle', chromePlateStyleId, poolInventory)) {
       setChromePlateStyleId(DEFAULT_CHROME_PLATE_STYLE_ID);
     }
-    if (!isPoolOptionUnlocked('railMarkerColor', railMarkerColorId, poolInventory)) {
+    if (
+      (railMarkerColorId !== 'gold' && railMarkerColorId !== 'chrome') ||
+      !isPoolOptionUnlocked('railMarkerColor', railMarkerColorId, poolInventory)
+    ) {
       setRailMarkerColorId(DEFAULT_RAIL_MARKER_COLOR_ID);
     }
     if (!isPoolOptionUnlocked('pocketLiner', pocketLinerId, poolInventory)) {
@@ -17445,10 +17606,17 @@ function PoolRoyaleGame({
   useEffect(() => {
     setShowoodTableStyle((current) => {
       const next = normalizeShowoodTableStyle(current);
-      const linkedRailSight = chromeColorId === 'gold' ? 'gold' : 'chrome';
-      return next.railSight === linkedRailSight
+      const linkedAccent = chromeColorId === 'gold' ? 'gold' : 'chrome';
+      return next.sideWoodApron === linkedAccent &&
+        next.railSight === linkedAccent &&
+        next.baseFoot === linkedAccent
         ? next
-        : { ...next, railSight: linkedRailSight };
+        : {
+            ...next,
+            sideWoodApron: linkedAccent,
+            railSight: linkedAccent,
+            baseFoot: linkedAccent
+          };
     });
   }, [chromeColorId]);
   useEffect(() => {
@@ -36276,6 +36444,58 @@ const shotPowerRef = useRef(0);
                         key={option.id}
                         type="button"
                         onClick={() => setChromeColorId(option.id)}
+                        aria-pressed={active}
+                        className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                          active
+                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                        }`}
+                      >
+                        <span className="flex items-center justify-center gap-2">
+                          <span
+                            className="h-3.5 w-3.5 rounded-full border border-white/40"
+                            style={{ backgroundColor: toHexColor(option.color) }}
+                            aria-hidden="true"
+                          />
+                          {option.label}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div>
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Rail Markings
+                </h3>
+                <div className="mt-2 grid grid-cols-3 gap-2">
+                  {RAIL_MARKER_SHAPE_OPTIONS.map((option) => {
+                    const active = option.id === railMarkerShapeId;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => setRailMarkerShapeId(option.id)}
+                        aria-pressed={active}
+                        className={`rounded-full border px-2 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                          active
+                            ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_14px_rgba(16,185,129,0.45)]'
+                            : 'border-white/20 bg-white/10 text-white/75 hover:bg-white/20'
+                        }`}
+                      >
+                        {option.label}
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {availableRailMarkerColors.map((option) => {
+                    const active = option.id === railMarkerColorId;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => setRailMarkerColorId(option.id)}
                         aria-pressed={active}
                         className={`flex-1 min-w-[8.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
                           active


### PR DESCRIPTION
### Motivation
- Introduce a dedicated side apron / pocket apron strip part for the Showood table so cue finishes and trim can be mapped more accurately. 
- Avoid incorrect mixed cloth/cushion mappings and improve dominant-part heuristics when remapping external Showood model geometry. 
- Harden GLTF loading and texture transcode behavior for external table assets and enable cue-finish-driven wood surfaces. 
- Expose rail marker shape/color controls in the UI and adjust default table model scale to better fit Pool Royale mapping.

### Description
- Added a new `sideWoodApron` Showood part and wired it into UI labels, defaults, options, chrome linking, and personalization sections. 
- Reworked `getShowoodTablePartOptions` to accept cue finish options and derived `baseCornerBlock` options from cue finishes, and introduced `resolveCueStyleWoodSurfaceForFinish` to map cue finishes into wood surface data. 
- Rewrote the Showood geometry remapping flow to collect per-slot triangle stats, compute dominant parts with thresholds, and map triangles using `resolvePoolRoyaleShowoodMappedPart`, replacing the prior one-pass mapping logic. 
- Updated `applyShowoodStyleToExternalMaterial` to handle `sideWoodApron`, cue-driven tinting and wood textures, and to apply shared wood/finish tuning for base parts. 
- Improved GLTF loader setup by making `createConfiguredGLTFLoader` accept a `LoadingManager`, constructing `DRACOLoader` with the manager, calling `setDecoderConfig({ type: 'js' })` and `preload()`, and using a `THREE.LoadingManager` when loading external table templates. 
- Adjusted `BASIS_TRANSCODER_PATH` version and changed the default `showood-seven-foot` `fitScale`/`fitFootprintScale` to `1.12`, plus small description and storage-key formatting tweaks. 
- UI changes: added rail markers controls (shape and color), filtered available rail marker colors, exposed `availableCueFinishOptions` for table personalization, and synchronized chrome accent choices across related parts.

### Testing
- Ran unit tests with `yarn test` and verified the test suite passed. 
- Built the app with `yarn build` to validate bundling and GLTF loader integration and the build completed successfully. 
- Executed linting/type checks with `yarn lint` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190f5fa2308329a766685f9116d192)