### PR TITLE
Raise bowling field above HDRI ground plane in portrait view

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -286,8 +286,8 @@ const RESULT_COMPLIMENTS = {
   open: ['Nice try—adjust and fire again.', 'Good pace, keep rhythm.']
 } as const;
 
-// Keep the bowling field aligned with the base HDRI ground height on portrait screens.
-const BOWLING_HDRI_GROUND_SNAP_DROP = 0.0;
+// Raise the full bowling field above the HDRI ground plane in portrait view.
+const BOWLING_HDRI_GROUND_SNAP_DROP = -0.62;
 
 const CFG = {
   laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,


### PR DESCRIPTION
### Motivation
- Ensure the full bowling field sits visually above the HDRI ground plane on portrait screens to avoid clipping/ground intersection. 

### Description
- Update `BOWLING_HDRI_GROUND_SNAP_DROP` from `0.0` to `-0.62` and adjust the inline comment to indicate the field is raised, which implicitly shifts `CFG.laneY` and related layout values that derive from this constant. 

### Testing
- Ran the project test suite with `yarn test` and a development build with `yarn build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19509cdd00832993a74792bb7fdd0f)