### PR TITLE
Restore Ludo weapons inventory and GLTF/GLB texture fallback

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -61,69 +61,7 @@ const HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS = new Set([
 ]);
 
 
-const PREFERRED_CAPTURE_ANIMATION_BY_FAMILY = Object.freeze({
-  pistol: 'sigsauerTacticalAttack',
-  smg: 'polySmg01Attack',
-  assaultRifle: 'ak47VolleyAttack',
-  marksman: 'sniperShotAttack',
-  shotgun: 'shotgunBlastAttack',
-  revolver: 'polyRevolver02Attack',
-  explosive: 'grenadeBlastAttack',
-  bazooka: 'polyBazooka01Attack',
-  grenadeLauncher: 'polyGrenadeLauncher01Attack',
-  dynamite: 'polyDynamiteBomb01Attack',
-  gasTank: 'polyGasTank01Attack',
-  handGrenade: 'polyHandGrenade01Attack',
-  incendiary: 'polyMolotov01Attack',
-  armor: 'polyTank01Attack',
-  robotLargeGun: 'polyRobotLargeGunAttack',
-  robotFlyingGun: 'polyRobotFlyingGunAttack'
-});
-
-const CAPTURE_ANIMATION_FAMILY_BY_ID = Object.freeze({
-  glockSidearmAttack: 'pistol',
-  pistolSidearmAttack: 'pistol',
-  pistolHolsterAttack: 'pistol',
-  smithSidearmAttack: 'pistol',
-  sigsauerTacticalAttack: 'pistol',
-  polyPistol01Attack: 'pistol',
-  uziSprayAttack: 'smg',
-  smgBurstAttack: 'smg',
-  polySmg01Attack: 'smg',
-  fpsGunAttack: 'assaultRifle',
-  assaultRifleAttack: 'assaultRifle',
-  ak47VolleyAttack: 'assaultRifle',
-  krsvBurstAttack: 'assaultRifle',
-  compactCarbineAttack: 'assaultRifle',
-  polyAssaultRifle01Attack: 'assaultRifle',
-  mosinMarksmanAttack: 'marksman',
-  marksmanDmrAttack: 'marksman',
-  sniperShotAttack: 'marksman',
-  shotgunBlastAttack: 'shotgun',
-  polyShotgun01Attack: 'shotgun',
-  polyShotgun02Attack: 'shotgun',
-  polyShotgun03Attack: 'shotgun',
-  polySawedOff01Attack: 'shotgun',
-  polyRevolver01Attack: 'revolver',
-  polyRevolver02Attack: 'revolver',
-  grenadeBlastAttack: 'explosive',
-  polyHandGrenade01Attack: 'handGrenade',
-  polyGrenadeLauncher01Attack: 'grenadeLauncher',
-  polyBazooka01Attack: 'bazooka',
-  polyDynamiteBomb01Attack: 'dynamite',
-  polyGasTank01Attack: 'gasTank',
-  polyMolotov01Attack: 'incendiary',
-  polyTank01Attack: 'armor',
-  polyRobotLargeGunAttack: 'robotLargeGun',
-  polyRobotFlyingGunAttack: 'robotFlyingGun'
-});
-
-const shouldShowCaptureAnimationInStore = (optionId) => {
-  if (HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS.has(optionId)) return false;
-  const family = CAPTURE_ANIMATION_FAMILY_BY_ID[optionId];
-  if (!family) return true;
-  return PREFERRED_CAPTURE_ANIMATION_BY_FAMILY[family] === optionId;
-};
+const shouldShowCaptureAnimationInStore = (optionId) => !HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS.has(optionId);
 
 const uniqueStoreItemsByName = (items) => {
   const seen = new Set();

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1444,22 +1444,15 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     for (let i = 0; i < candidateUrls.length; i += 1) {
       const candidateUrl = candidateUrls[i];
       try {
-        // Always ask GLTFLoader to load firearm weapons directly first. That keeps the
-        // source GLB/GLTF texture slots, UV transforms, sampler wrapping, and relative
-        // image paths exactly as authored instead of repacking maps into a patched GLB.
-        // eslint-disable-next-line no-await-in-loop
-        loadedRoot = assignLoadedGltf(await withLoadTimeout(loader.loadAsync(candidateUrl)));
-      } catch (error) {
-        if (i === candidateUrls.length - 1) {
-          console.warn('Capture weapon source model load failed', normalizedCaptureAnimationId, candidateUrl, error);
+        if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl)) {
+          // Poly Pizza GLBs and external GLTF weapon folders ship with their own
+          // material data. Load them directly first so GLTFLoader keeps their
+          // embedded PBR bindings and relative texture paths when the host allows it.
+          // eslint-disable-next-line no-await-in-loop
+          loadedRoot = assignLoadedGltf(await withLoadTimeout(loader.loadAsync(candidateUrl)));
+          if (loadedRoot) break;
+          if (isGltfAssetUrl(candidateUrl)) continue;
         }
-      }
-      if (loadedRoot) break;
-      if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl)) continue;
-      try {
-        // The patched path is only a GLB fallback for older hosts whose external image
-        // references cannot be resolved by GLTFLoader. Placeholders stay disabled so
-        // firearm source textures are never replaced by synthetic vehicle-style maps.
         // eslint-disable-next-line no-await-in-loop
         const rawBuffer = await withLoadTimeout(fetchBuffer(candidateUrl));
         if (!rawBuffer) continue;
@@ -1469,13 +1462,22 @@ async function loadCaptureWeaponModel(captureAnimationId) {
           'firearm',
           candidateUrl,
           candidateUrls,
-          imageCache,
-          { allowPlaceholder: false }
+          imageCache
         );
         // eslint-disable-next-line no-await-in-loop
         loadedRoot = await parseObjectFromBuffer(loader, patchedBuffer);
       } catch (error) {
-        // ignore patched fallback and try the next source URL
+        // Ignore patched path and try direct loader fallback below.
+      }
+      if (loadedRoot) break;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const gltf = await withLoadTimeout(loader.loadAsync(candidateUrl));
+        loadedRoot = assignLoadedGltf(gltf);
+      } catch (error) {
+        if (i === candidateUrls.length - 1) {
+          console.warn('Capture weapon model load failed', normalizedCaptureAnimationId, candidateUrl, error);
+        }
       }
       if (loadedRoot) break;
     }
@@ -1485,13 +1487,8 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     try {
       const root = loadedRoot;
       if (!root) return null;
-      const preserveSourceTextures = config?.preserveSourceTextures !== false;
-      const textureOverrideUrls = preserveSourceTextures
-        ? []
-        : Array.isArray(config?.textureOverrideUrls)
-        ? config.textureOverrideUrls.filter(Boolean)
-        : [];
-      const forceTextureOverride = !preserveSourceTextures && config?.forceTextureOverride === true;
+      const textureOverrideUrls = Array.isArray(config?.textureOverrideUrls) ? config.textureOverrideUrls.filter(Boolean) : [];
+      const forceTextureOverride = config?.forceTextureOverride === true;
       let textureOverride = null;
       if (textureOverrideUrls.length) {
         const textureLoader = new THREE.TextureLoader();


### PR DESCRIPTION
### Motivation
- Fix missing capture weapons (including the helicopter) and restore correct GLB/GLTF texture handling so the Ludo Battle Royal experience matches the state from ~4 weeks ago.
- Ensure weapon model textures and configured overrides are preserved or fall back cleanly when external image references cannot be resolved.

### Description
- Re-enabled all non-hidden capture animation entries in the Ludo store by changing the capture visibility predicate so items are no longer collapsed to a single preferred item per family. (updates in `webapp/src/config/ludoBattleInventoryConfig.js`).
- Restored the robust model loading path in `loadCaptureWeaponModel` so GLTF/PolyPizza assets are attempted via `GLTFLoader` first and GLB fallbacks are generated by patching external images into the GLB when direct loading cannot resolve them (changes in `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Re-enabled and preserved configured `textureOverrideUrls` behavior so weapon-specific override maps are applied again instead of being disabled by default.
- Tightened error/log handling and ordering so patched GLB fallback, direct GLTF load, and texture override application occur in the expected sequence.

### Testing
- Ran the inventory smoke check with: `node --input-type=module -e "import('./webapp/src/config/ludoBattleInventoryConfig.js').then(m=>{const items=m.LUDO_BATTLE_STORE_ITEMS.filter(i=>i.type==='captureAnimation'); console.log(items.length); console.log(items.map(i=>i.optionId).join('\n')); if(!items.some(i=>i.optionId==='helicopterAttack')) process.exit(1); if(items.length < 25) process.exit(2);})"`, which completed successfully and showed `helicopterAttack` present.
- Built the webapp with: `npm --prefix webapp run build`, which completed successfully.
- Ran linting with: `npm --prefix webapp run lint`, which completed successfully.
- Verified no diff-check issues using `git diff --check` on the modified files, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a90ea0fd48329bd509bb397099f85)