### PR TITLE
Restore Pool Royale legacy shot power

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1840,16 +1840,15 @@ const RAIL_SPIN_THROW_SCALE = 0.09; // re-enable a mild rail throw so cue-ball s
 const RAIL_SPIN_THROW_REF_SPEED = BALL_R * 18;
 const RAIL_SPIN_NORMAL_FLIP = 0.65; // align spin inversion with Snooker Royal rebound behavior
 const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin deflection so lines match the true impact geometry
-// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power softer than before.
-// Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
-// Pool Royale pace now mirrors Snooker Royale to keep ball travel identical between modes.
-// Apply an extra 15% reduction to keep Pool Royale strokes slightly softer than Snooker Royal.
+// Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) and the
+// pre-May-19 Pool Royale shot-force multipliers so ball travel, cue launch,
+// and spin transfer follow the older gameplay feel.
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 0.62; // reduce overall Pool Royale power by an additional 20%
-const SHOT_POWER_BOOST = 1.32; // add stronger cue drive while preserving slider feel
-const SHOT_GLOBAL_POWER_SCALE = 0.78; // tone down Pool Royale strike speed so shots match the requested game power pacing
+const SHOT_POWER_ADJUSTMENT = 1; // restore the legacy shot scaling used before the May 19 power retune
+const SHOT_POWER_BOOST = 0.455; // restore the pre-May-19 cue launch boost
+const SHOT_GLOBAL_POWER_SCALE = 1; // keep global strike scaling neutral to match the legacy feel
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *


### PR DESCRIPTION
### Motivation
- Players reported that current Pool Royale shots felt softer/slower than the gameplay from four weeks ago, so the goal was to restore the older shot strength and cue launch behavior while keeping existing ball/spin logic intact.

### Description
- Restored pre-May-19 shot-force multipliers and documentation by updating the shot-force comment block to reference the legacy multipliers and intent.
- Reverted the Pool Royale tuning constants to legacy values by setting `SHOT_POWER_ADJUSTMENT = 1`, `SHOT_POWER_BOOST = 0.455`, and `SHOT_GLOBAL_POWER_SCALE = 1` in `webapp/src/pages/Games/PoolRoyale.jsx` so the final `SHOT_FORCE_BOOST` and `SHOT_BASE_SPEED` match the older feel.
- Left the spin pipeline, physics profile, and downstream ball/rail logic untouched so spin transfer and collisions continue to use the same code path.

### Testing
- Ran `npm --prefix webapp run build` to produce production bundles for the webapp and confirmed the build completed successfully and emitted `dist` assets.
- Ran `git diff --check HEAD~1..HEAD -- webapp/src/pages/Games/PoolRoyale.jsx` to validate the modified file has no diff-check issues and found no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a927cdab88329b05d7807b83c7c51)