### PR TITLE
Restore Ludo battle royal weapons inventory and GLTF texture handling

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -4,13 +4,13 @@ import {
   TOKEN_PIECE_OPTIONS,
   TOKEN_STYLE_OPTIONS,
   HUMAN_CHARACTER_OPTIONS
-} from './ludoBattleOptions.js';
-import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
-import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
-import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
-import { CHESS_BATTLE_OPTION_LABELS, CHESS_BATTLE_STORE_ITEMS } from './chessBattleInventoryConfig.js';
-import { swatchThumbnail } from './storeThumbnails.js';
-import { TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
+} from './ludoBattleOptions.js'
+import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js'
+import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js'
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js'
+import { CHESS_BATTLE_OPTION_LABELS, CHESS_BATTLE_STORE_ITEMS } from './chessBattleInventoryConfig.js'
+import { swatchThumbnail } from './storeThumbnails.js'
+import { TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js'
 
 export const LUDO_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   tables: [MURLAN_TABLE_THEMES[0]?.id],
@@ -21,15 +21,15 @@ export const LUDO_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   tokenPalette: [TOKEN_PALETTE_OPTIONS[0]?.id],
   tokenStyle: [TOKEN_STYLE_OPTIONS[0]?.id],
   tokenPiece: [TOKEN_PIECE_OPTIONS[0]?.id],
-  captureAnimation: [CAPTURE_ANIMATION_OPTIONS[0]?.id],
+  captureAnimation: CAPTURE_ANIMATION_OPTIONS.map((option) => option.id),
   humanCharacter: [HUMAN_CHARACTER_OPTIONS[0]?.id]
-});
+})
 
 const reduceLabels = (options) =>
   options.reduce((acc, option) => {
-    acc[option.id] = option.label;
-    return acc;
-  }, {});
+    acc[option.id] = option.label
+    return acc
+  }, {})
 
 export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
   tables: Object.freeze(reduceLabels(MURLAN_TABLE_THEMES)),
@@ -51,89 +51,19 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
   humanCharacter: Object.freeze(reduceLabels(HUMAN_CHARACTER_OPTIONS)),
   sideColor: Object.freeze(CHESS_BATTLE_OPTION_LABELS.sideColor),
   headStyle: Object.freeze(CHESS_BATTLE_OPTION_LABELS.headStyle)
-});
+})
 
-const HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS = new Set([
-  'mrtkGunAttack',
-  'pistolHolsterAttack',
-  'pistolSidearmAttack',
-  'assaultRifleAttack'
-]);
-
-
-const PREFERRED_CAPTURE_ANIMATION_BY_FAMILY = Object.freeze({
-  pistol: 'sigsauerTacticalAttack',
-  smg: 'polySmg01Attack',
-  assaultRifle: 'ak47VolleyAttack',
-  marksman: 'sniperShotAttack',
-  shotgun: 'shotgunBlastAttack',
-  revolver: 'polyRevolver02Attack',
-  explosive: 'grenadeBlastAttack',
-  bazooka: 'polyBazooka01Attack',
-  grenadeLauncher: 'polyGrenadeLauncher01Attack',
-  dynamite: 'polyDynamiteBomb01Attack',
-  gasTank: 'polyGasTank01Attack',
-  handGrenade: 'polyHandGrenade01Attack',
-  incendiary: 'polyMolotov01Attack',
-  armor: 'polyTank01Attack',
-  robotLargeGun: 'polyRobotLargeGunAttack',
-  robotFlyingGun: 'polyRobotFlyingGunAttack'
-});
-
-const CAPTURE_ANIMATION_FAMILY_BY_ID = Object.freeze({
-  glockSidearmAttack: 'pistol',
-  pistolSidearmAttack: 'pistol',
-  pistolHolsterAttack: 'pistol',
-  smithSidearmAttack: 'pistol',
-  sigsauerTacticalAttack: 'pistol',
-  polyPistol01Attack: 'pistol',
-  uziSprayAttack: 'smg',
-  smgBurstAttack: 'smg',
-  polySmg01Attack: 'smg',
-  fpsGunAttack: 'assaultRifle',
-  assaultRifleAttack: 'assaultRifle',
-  ak47VolleyAttack: 'assaultRifle',
-  krsvBurstAttack: 'assaultRifle',
-  compactCarbineAttack: 'assaultRifle',
-  polyAssaultRifle01Attack: 'assaultRifle',
-  mosinMarksmanAttack: 'marksman',
-  marksmanDmrAttack: 'marksman',
-  sniperShotAttack: 'marksman',
-  shotgunBlastAttack: 'shotgun',
-  polyShotgun01Attack: 'shotgun',
-  polyShotgun02Attack: 'shotgun',
-  polyShotgun03Attack: 'shotgun',
-  polySawedOff01Attack: 'shotgun',
-  polyRevolver01Attack: 'revolver',
-  polyRevolver02Attack: 'revolver',
-  grenadeBlastAttack: 'explosive',
-  polyHandGrenade01Attack: 'handGrenade',
-  polyGrenadeLauncher01Attack: 'grenadeLauncher',
-  polyBazooka01Attack: 'bazooka',
-  polyDynamiteBomb01Attack: 'dynamite',
-  polyGasTank01Attack: 'gasTank',
-  polyMolotov01Attack: 'incendiary',
-  polyTank01Attack: 'armor',
-  polyRobotLargeGunAttack: 'robotLargeGun',
-  polyRobotFlyingGunAttack: 'robotFlyingGun'
-});
-
-const shouldShowCaptureAnimationInStore = (optionId) => {
-  if (HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS.has(optionId)) return false;
-  const family = CAPTURE_ANIMATION_FAMILY_BY_ID[optionId];
-  if (!family) return true;
-  return PREFERRED_CAPTURE_ANIMATION_BY_FAMILY[family] === optionId;
-};
+const shouldShowCaptureAnimationInStore = (optionId) => Boolean(optionId)
 
 const uniqueStoreItemsByName = (items) => {
-  const seen = new Set();
+  const seen = new Set()
   return items.filter((item) => {
-    const key = `${item?.type || ''}:${String(item?.name || '').trim().toLowerCase()}`;
-    if (!key || seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-};
+    const key = `${item?.type || ''}:${String(item?.name || '').trim().toLowerCase()}`
+    if (!key || seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
 
 export const LUDO_BATTLE_STORE_ITEMS = uniqueStoreItemsByName([
   ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
@@ -234,7 +164,7 @@ export const LUDO_BATTLE_STORE_ITEMS = uniqueStoreItemsByName([
     thumbnail: swatchThumbnail(['#334155', '#64748b', '#f59e0b'])
   })),
   ...CHESS_BATTLE_STORE_ITEMS.filter((item) => ['sideColor', 'headStyle'].includes(item.type))
-]);
+])
 
 export const LUDO_BATTLE_DEFAULT_LOADOUT = [
   { type: 'tables', optionId: MURLAN_TABLE_THEMES[0]?.id, label: MURLAN_TABLE_THEMES[0]?.label },
@@ -267,4 +197,4 @@ export const LUDO_BATTLE_DEFAULT_LOADOUT = [
     optionId: HUMAN_CHARACTER_OPTIONS[0]?.id,
     label: HUMAN_CHARACTER_OPTIONS[0]?.label
   }
-];
+]

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1444,38 +1444,39 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     for (let i = 0; i < candidateUrls.length; i += 1) {
       const candidateUrl = candidateUrls[i];
       try {
-        // Always ask GLTFLoader to load firearm weapons directly first. That keeps the
-        // source GLB/GLTF texture slots, UV transforms, sampler wrapping, and relative
-        // image paths exactly as authored instead of repacking maps into a patched GLB.
-        // eslint-disable-next-line no-await-in-loop
-        loadedRoot = assignLoadedGltf(await withLoadTimeout(loader.loadAsync(candidateUrl)));
-      } catch (error) {
-        if (i === candidateUrls.length - 1) {
-          console.warn('Capture weapon source model load failed', normalizedCaptureAnimationId, candidateUrl, error);
+        if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl)) {
+          // Poly Pizza GLBs already ship with their own material/texture data. Load them
+          // directly first so GLTFLoader can keep the exact embedded PBR texture bindings.
+          // eslint-disable-next-line no-await-in-loop
+          loadedRoot = assignLoadedGltf(await withLoadTimeout(loader.loadAsync(candidateUrl)));
+          if (loadedRoot) break;
+          if (isGltfAssetUrl(candidateUrl)) continue;
         }
-      }
-      if (loadedRoot) break;
-      if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl)) continue;
-      try {
-        // The patched path is only a GLB fallback for older hosts whose external image
-        // references cannot be resolved by GLTFLoader. Placeholders stay disabled so
-        // firearm source textures are never replaced by synthetic vehicle-style maps.
         // eslint-disable-next-line no-await-in-loop
         const rawBuffer = await withLoadTimeout(fetchBuffer(candidateUrl));
         if (!rawBuffer) continue;
         // eslint-disable-next-line no-await-in-loop
         const patchedBuffer = await patchGlbImagesToDataUris(
           rawBuffer,
-          'firearm',
+          'fighter',
           candidateUrl,
           candidateUrls,
-          imageCache,
-          { allowPlaceholder: false }
+          imageCache
         );
         // eslint-disable-next-line no-await-in-loop
         loadedRoot = await parseObjectFromBuffer(loader, patchedBuffer);
       } catch (error) {
-        // ignore patched fallback and try the next source URL
+        // ignore patched path and try direct loader fallback below
+      }
+      if (loadedRoot) break;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const gltf = await withLoadTimeout(loader.loadAsync(candidateUrl));
+        loadedRoot = assignLoadedGltf(gltf);
+      } catch (error) {
+        if (i === candidateUrls.length - 1) {
+          console.warn('Capture weapon model load failed', normalizedCaptureAnimationId, candidateUrl, error);
+        }
       }
       if (loadedRoot) break;
     }
@@ -1485,13 +1486,8 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     try {
       const root = loadedRoot;
       if (!root) return null;
-      const preserveSourceTextures = config?.preserveSourceTextures !== false;
-      const textureOverrideUrls = preserveSourceTextures
-        ? []
-        : Array.isArray(config?.textureOverrideUrls)
-        ? config.textureOverrideUrls.filter(Boolean)
-        : [];
-      const forceTextureOverride = !preserveSourceTextures && config?.forceTextureOverride === true;
+      const textureOverrideUrls = Array.isArray(config?.textureOverrideUrls) ? config.textureOverrideUrls.filter(Boolean) : [];
+      const forceTextureOverride = config?.forceTextureOverride === true;
       let textureOverride = null;
       if (textureOverrideUrls.length) {
         const textureLoader = new THREE.TextureLoader();
@@ -2173,20 +2169,12 @@ function makePlaceholderTextureDataUri(primary, secondary) {
   return canvas.toDataURL('image/png');
 }
 
-async function resolveExternalImageToDataUri(
-  imageUri,
-  kind,
-  sourceUrl,
-  modelUrls,
-  cache,
-  { allowPlaceholder = true } = {}
-) {
+async function resolveExternalImageToDataUri(imageUri, kind, sourceUrl, modelUrls, cache) {
   if (isDataUri(imageUri)) return imageUri;
   const placeholderColors = {
     drone: ['#7c8791', '#4f5861'],
     helicopter: ['#6f7763', '#4f5648'],
-    fighter: ['#98a1a9', '#646d76'],
-    firearm: ['#2d3340', '#111827']
+    fighter: ['#98a1a9', '#646d76']
   };
   const [primary, secondary] = placeholderColors[kind] ?? ['#6e7681', '#4f5861'];
   const placeholderDataUri = makePlaceholderTextureDataUri(primary, secondary);
@@ -2208,17 +2196,10 @@ async function resolveExternalImageToDataUri(
       // ignore candidate
     }
   }
-  return allowPlaceholder ? placeholderDataUri : null;
+  return placeholderDataUri;
 }
 
-async function patchGlbImagesToDataUris(
-  buffer,
-  kind,
-  sourceUrl,
-  modelUrls,
-  cache,
-  { allowPlaceholder = true } = {}
-) {
+async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cache) {
   const { json, binChunk } = decodeGlb(buffer);
   const cloned = JSON.parse(JSON.stringify(json));
   const images = Array.isArray(cloned.images) ? cloned.images : [];
@@ -2227,14 +2208,8 @@ async function patchGlbImagesToDataUris(
   for (let i = 0; i < images.length; i += 1) {
     const image = images[i];
     if (typeof image.uri === 'string') {
-      const originalImageUri = image.uri;
       // eslint-disable-next-line no-await-in-loop
-      image.uri = await resolveExternalImageToDataUri(originalImageUri, kind, sourceUrl, modelUrls, cache, {
-        allowPlaceholder
-      });
-      if (!image.uri) {
-        throw new Error(`Unable to resolve external GLB texture: ${sourceUrl} -> ${originalImageUri}`);
-      }
+      image.uri = await resolveExternalImageToDataUri(image.uri, kind, sourceUrl, modelUrls, cache);
       delete image.bufferView;
       image.mimeType = image.mimeType ?? 'image/png';
       continue;


### PR DESCRIPTION
### Motivation
- Fix missing Ludo capture weapons (including the helicopter) and restore correct GLB/GLTF texture behavior after recent loader changes.
- Ensure the Ludo quick-swap/store inventory shows the same capture animations and weapons set that was present previously.

### Description
- Reinstated the prior capture-weapon loading flow in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so GLTF/embedded GLB assets are attempted directly first, then a patched-GLB fallback is attempted, and finally a direct loader retry is used if needed to preserve original texture bindings and UVs.
- Restored and simplified external-image/GLB image patching by adjusting `resolveExternalImageToDataUri` / `patchGlbImagesToDataUris` behavior to reliably resolve external image URIs and generate placeholders only when appropriate (removed the conditional `allowPlaceholder` branching and related code paths that caused texture regressions).
- Made all capture animations unlocked by default by changing `captureAnimation` in `webapp/src/config/ludoBattleInventoryConfig.js` to `CAPTURE_ANIMATION_OPTIONS.map((option) => option.id)`, and removed the family-based filter by replacing `shouldShowCaptureAnimationInStore` with a permissive predicate so every non-default capture animation appears in the store/inventory data.
- Minor formatting / lint fixes in `webapp/src/config/ludoBattleInventoryConfig.js` to match project style.

### Testing
- Ran lint with `npm --prefix webapp run lint -- src/config/ludoBattleInventoryConfig.js src/pages/Games/LudoBattleRoyal.jsx` and it completed successfully.
- Executed a Node verification script that confirmed `CAPTURE_ANIMATION_OPTIONS` contains 37 options, the default unlock list contains 37 entries, the store contains 36 capture entries, and the `helicopterAttack` entry is present in both unlocked and store sets, with no missing IDs.
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a90ea0fd48329bd509bb397099f85)