### PR TITLE
Show Ukrainian drone in Chess Battle Royal inventory

### DIFF
--- a/test/chessBattleInventoryConfig.test.js
+++ b/test/chessBattleInventoryConfig.test.js
@@ -41,6 +41,8 @@ describe('chess battle inventory config', () => {
     expect(labelsById.droneAttack).toBe('Shahad Drone');
     expect(labelsById.ukrainianDroneAttack).toBe('Ukrainian Drone');
     expect(CHESS_BATTLE_OPTION_LABELS.captureAnimation.ukrainianDroneAttack).toBe('Ukrainian Drone');
+    expect(CHESS_BATTLE_DEFAULT_UNLOCKS.captureAnimation).toContain('ukrainianDroneAttack');
+    expect(CHESS_BATTLE_ROYAL_DEFAULT_UNLOCKS.captureAnimation).toContain('ukrainianDroneAttack');
 
     const storeDroneIds = new Set(
       CHESS_BATTLE_ROYAL_STORE_ITEMS.filter((item) => item.type === 'captureAnimation').map((item) => item.optionId)

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -453,7 +453,7 @@ export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   headStyle: ['current'],
   humanCharacter: [CHESS_HUMAN_CHARACTER_OPTIONS[0]?.id],
   environmentHdri: [DEFAULT_HDRI_ID],
-  captureAnimation: [CAPTURE_ANIMATION_OPTIONS[0]?.id]
+  captureAnimation: [CAPTURE_ANIMATION_OPTIONS[0]?.id, 'ukrainianDroneAttack']
 });
 
 export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -207,6 +207,15 @@ const GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID = Object.freeze({
   fighterJetAttack: 'jet',
   helicopterAttack: 'helicopter'
 });
+const PARKED_WEAPON_KIND_BY_CAPTURE_KIND = Object.freeze({
+  ukrainianDrone: 'drone'
+});
+const getParkedWeaponKindForAnimationId = (animationId) => {
+  const captureKind = GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[animationId] || 'truck';
+  return PARKED_WEAPON_KIND_BY_CAPTURE_KIND[captureKind] || captureKind;
+};
+const isCaptureAnimationVisibleOnParkedKind = (animationId, parkedKind) =>
+  getParkedWeaponKindForAnimationId(animationId) === parkedKind;
 const FIREARM_CAPTURE_ANIMATION_IDS = new Set(
   CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter((id) => !GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[id])
 );
@@ -8431,7 +8440,7 @@ function Chess3D({
     return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[selectedCaptureAnimationId] || 'truck';
   }, [selectedCaptureAnimationId]);
   const selectedParkedWeaponKind = useMemo(
-    () => GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[selectedCaptureAnimationId] || 'truck',
+    () => getParkedWeaponKindForAnimationId(selectedCaptureAnimationId),
     [selectedCaptureAnimationId]
   );
   const selectedParkedWeaponKindRef = useRef(selectedParkedWeaponKind);
@@ -8530,14 +8539,14 @@ function Chess3D({
     if (['jet', 'drone', 'helicopter', 'truck'].includes(weaponSwapTargetKind)) {
       const firearmAndOriginalVehicle = pool.filter((option) => {
         if (FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)) return true;
-        return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[option.id] === weaponSwapTargetKind;
+        return isCaptureAnimationVisibleOnParkedKind(option.id, weaponSwapTargetKind);
       });
       if (firearmAndOriginalVehicle.length) return firearmAndOriginalVehicle;
     }
 
     const filtered = pool.filter((option) => {
       if (FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)) return true;
-      return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[option.id] === weaponSwapTargetKind;
+      return isCaptureAnimationVisibleOnParkedKind(option.id, weaponSwapTargetKind);
     });
     if (filtered.length) return filtered;
     return pool;
@@ -11009,6 +11018,50 @@ function Chess3D({
       root.add(badge);
       return badge;
     };
+    const setUkrainianDroneAccentsVisible = (root, visible = true) => {
+      if (!root) return null;
+      if (!root.userData.ukrainianDroneAccentGroup) {
+        const accentGroup = new THREE.Group();
+        accentGroup.name = 'ukrainian-drone-blue-yellow-accents';
+        const blueMaterial = new THREE.MeshStandardMaterial({
+          color: '#2563eb',
+          emissive: '#0f3aa8',
+          emissiveIntensity: 0.22,
+          roughness: 0.36,
+          metalness: 0.18
+        });
+        const yellowMaterial = new THREE.MeshStandardMaterial({
+          color: '#facc15',
+          emissive: '#854d0e',
+          emissiveIntensity: 0.2,
+          roughness: 0.38,
+          metalness: 0.12
+        });
+        const addPanel = (size, position, material) => {
+          const panel = new THREE.Mesh(new THREE.BoxGeometry(...size), material.clone());
+          panel.position.set(...position);
+          panel.castShadow = true;
+          panel.receiveShadow = true;
+          accentGroup.add(panel);
+          return panel;
+        };
+        addPanel([0.9, 0.045, 0.16], [0.03, 0.25, -0.18], blueMaterial);
+        addPanel([0.9, 0.045, 0.16], [0.03, 0.25, 0.18], yellowMaterial);
+        addPanel([0.34, 0.05, 1.18], [-0.38, 0.12, 0], blueMaterial);
+        addPanel([0.2, 0.06, 1.28], [0.22, 0.13, 0], yellowMaterial);
+        const marker = new THREE.Mesh(
+          new THREE.CircleGeometry(0.18, 24),
+          new THREE.MeshBasicMaterial({ color: '#f8fafc', side: THREE.DoubleSide })
+        );
+        marker.position.set(0.58, 0.17, 0);
+        marker.rotation.y = Math.PI / 2;
+        accentGroup.add(marker);
+        root.userData.ukrainianDroneAccentGroup = accentGroup;
+        root.add(accentGroup);
+      }
+      root.userData.ukrainianDroneAccentGroup.visible = Boolean(visible);
+      return root.userData.ukrainianDroneAccentGroup;
+    };
     const createFxDrone = ({ forceProcedural = false } = {}) => {
       const model = forceProcedural ? null : cloneCaptureUnitTemplate('drone');
       if (model) {
@@ -12469,6 +12522,7 @@ function Chess3D({
             /rotor|propell|blade|fan|window|cockpit|glass|canopy/.test(`${node.name || ''}`.toLowerCase())
           );
         }
+        setUkrainianDroneAccentsVisible(droneFx.root, true);
         attachVehicleAvatarBadge(
           droneFx.root,
           isWhiteSide
@@ -13133,11 +13187,16 @@ function Chess3D({
           unit.parkedFirearmDisplay = null;
           unit.parkedFirearmAnimationId = null;
         }
+        setUkrainianDroneAccentsVisible(
+          unit.root,
+          unit.kind === 'drone' && animationId === 'ukrainianDroneAttack'
+        );
         unit.root.position.y = unit.homePosition.y;
         unit.root.rotation.copy(unit.homeRotation);
         unit.root.quaternion.setFromEuler(unit.root.rotation);
         return;
       }
+      setUkrainianDroneAccentsVisible(unit.root, false);
       unit.root.position.y = unit.tableSurfacePosition?.y ?? unit.homePosition.y;
       unit.root.rotation.copy(unit.homeRotation);
       unit.root.rotateX(Math.PI * 0.5);


### PR DESCRIPTION
### Motivation
- Ensure the Ukrainian drone is available and visible to players by default in Chess Battle Royal inventory and UI so the parked drone and its strike animation are discoverable and selectable.
- Map the Ukrainian drone capture kind to the existing parked drone pad and add visual accents so the variant is identifiable on portrait mobile screens during park and flight.

### Description
- Add `ukrainianDroneAttack` to the Chess Battle default unlocks so it appears in `CHESS_BATTLE_DEFAULT_UNLOCKS.captureAnimation` by default (`webapp/src/config/chessBattleInventoryConfig.js`).
- Introduce `PARKED_WEAPON_KIND_BY_CAPTURE_KIND`, `getParkedWeaponKindForAnimationId`, and `isCaptureAnimationVisibleOnParkedKind` and switch parked-weapon selection/filtering to those helpers so Ukrainian drone captures map to the drone pad (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Add `setUkrainianDroneAccentsVisible` to procedurally add blue/yellow accent panels and toggle them when the Ukrainian drone is used or shown as a parked variant, and enable the accent on both flight FX and parked visuals (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Update unit test expectations to assert the Ukrainian drone label and that it is unlocked by default (`test/chessBattleInventoryConfig.test.js`).

### Testing
- Ran the focused unit test: `npm test -- --runInBand test/chessBattleInventoryConfig.test.js -t "adds Ukrainian drone"`, and it passed.
- Built the webapp with `npm --prefix webapp run build`, which completed successfully producing the production assets.
- Linted the updated webapp files with `cd webapp && npx eslint --no-warn-ignored src/pages/Games/ChessBattleRoyal.jsx src/config/chessBattleInventoryConfig.js`, which ran against the targeted files without reported errors.
- Attempted a Playwright smoke screenshot of the Chess Battle Royal page on a mobile viewport; installing Playwright browsers and system deps was required and performed, and a screenshot run was exercised (note: initial headless launch failed until `playwright install` and system deps were installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aa159fd208329a5b800f01cb1b834)