### PR TITLE
Add Ukrainian drone capture option and harden GLB texture loading

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -754,6 +754,8 @@ const WEAPON_PARKED_ROLL_BY_KIND = Object.freeze({
 const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
   missileJavelin: 'javelin',
   droneAttack: 'drone',
+  ukrainianDroneAttack: 'drone',
+  ukrainiandroneattack: 'drone',
   fighterJetAttack: 'fighter',
   helicopterAttack: 'helicopter',
   fpsGunAttack: 'supportTruck',
@@ -5524,23 +5526,47 @@ const GLB_JSON_CHUNK = 0x4e4f534a;
 const GLB_BIN_CHUNK = 0x004e4942;
 
 function isAbsoluteUrl(uri) {
-  return /^https?:\/\//i.test(uri) || uri.startsWith('blob:');
+  return /^(https?:)?\/\//i.test(uri) || uri.startsWith('blob:');
 }
 
 function isDataUri(uri) {
   return typeof uri === 'string' && uri.startsWith('data:');
 }
 
+function normalizeResourcePath(resourceUrl) {
+  try {
+    return decodeURIComponent(resourceUrl).replace(/\\/g, '/').replace(/^\.\//, '');
+  } catch {
+    return resourceUrl.replace(/\\/g, '/').replace(/^\.\//, '');
+  }
+}
+
+function toJsDelivrFromRawUrl(url) {
+  const match = String(url).match(/^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/i);
+  if (!match) return null;
+  return `https://cdn.jsdelivr.net/gh/${match[1]}/${match[2]}@${match[3]}/${match[4]}`;
+}
+
+function toRawFromJsDelivrUrl(url) {
+  const match = String(url).match(/^https:\/\/cdn\.jsdelivr\.net\/gh\/([^/]+)\/([^@/]+)@([^/]+)\/(.+)$/i);
+  if (!match) return null;
+  return `https://raw.githubusercontent.com/${match[1]}/${match[2]}/${match[3]}/${match[4]}`;
+}
+
 function uniqueStrings(values) {
-  return Array.from(new Set(values));
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function urlAlternates(url) {
+  return uniqueStrings([url, toRawFromJsDelivrUrl(url), toJsDelivrFromRawUrl(url)]);
 }
 
 function buildImageCandidates(imageUri, sourceUrl, modelUrls) {
-  if (isAbsoluteUrl(imageUri)) return uniqueStrings([imageUri]);
+  const normalizedUri = normalizeResourcePath(String(imageUri || ''));
+  if (isAbsoluteUrl(normalizedUri) || isDataUri(normalizedUri)) return urlAlternates(normalizedUri);
   return uniqueStrings([
-    imageUri,
-    new URL(imageUri, sourceUrl).href,
-    ...modelUrls.map((modelUrl) => new URL(imageUri, modelUrl).href)
+    ...urlAlternates(new URL(normalizedUri, sourceUrl).href),
+    ...modelUrls.flatMap((modelUrl) => urlAlternates(new URL(normalizedUri, modelUrl).href))
   ]);
 }
 
@@ -5650,7 +5676,11 @@ async function fetchBuffer(url) {
 async function fetchBlob(url) {
   const response = await fetch(url, { mode: 'cors' });
   if (!response.ok) throw new Error(`Fetch blob failed: ${response.status}`);
-  return response.blob();
+  const blob = await response.blob();
+  if (/text\/html|text\/plain/i.test(blob.type || '')) {
+    throw new Error(`Rejected non-asset response ${blob.type}: ${url}`);
+  }
+  return blob;
 }
 
 function parseObjectFromBuffer(loader, buffer) {
@@ -6019,14 +6049,15 @@ function createPolySeatWeaponMesh(weaponType) {
 function createSeatWeaponMesh(weaponType = 'fighter', options = {}) {
   const parkingPose = options?.parkingPose === 'vertical' ? 'vertical' : 'horizontal';
   const rawWeaponType = typeof weaponType === 'string' ? weaponType.trim() : '';
-  const catalogWeaponType = SNAKE_CAPTURE_WEAPON_OPTION_BY_ID[rawWeaponType] ? rawWeaponType : null;
-  const normalizedWeaponType = normalizeSnakeCaptureWeaponKind(rawWeaponType || weaponType);
+  const catalogOption = SNAKE_CAPTURE_WEAPON_OPTION_BY_ID[rawWeaponType] || null;
+  const catalogWeaponType = catalogOption ? rawWeaponType : null;
+  const normalizedWeaponType = catalogOption?.vehicleKind || normalizeSnakeCaptureWeaponKind(rawWeaponType || weaponType);
   const isVehicleWeapon = ['supportTruck', 'drone', 'helicopter', 'fighter', 'javelin'].includes(
     normalizedWeaponType
   );
   const firearmScale = isVehicleWeapon ? 1 : FIREARM_DISPLAY_SIZE_MULTIPLIER;
   const firearmModelScaleById = catalogWeaponType ? FIREARM_MODEL_SCALE_BY_ID[catalogWeaponType] ?? 1 : 1;
-  if (catalogWeaponType) {
+  if (catalogWeaponType && !catalogOption?.vehicleKind) {
     const holder = new THREE.Group();
     const fallback = createPolySeatWeaponMesh(normalizedWeaponType);
     fallback.scale.multiplyScalar(firearmScale);

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -2,6 +2,12 @@ import { swatchThumbnail, weaponSilhouetteThumbnail } from './storeThumbnails.js
 
 const polyGlb = (uuid) => `https://static.poly.pizza/${uuid}.glb`;
 
+export const UKRAINIAN_DRONE_GLB_URLS = Object.freeze([
+  'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
+  'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
+  'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
+]);
+
 export const SNAKE_KNOWN_WORKING_GLB = Object.freeze({
   awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
   awpRaw: 'https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb',
@@ -15,6 +21,13 @@ export const SNAKE_KNOWN_WORKING_GLB = Object.freeze({
 });
 
 export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
+  {
+    id: 'ukrainianDroneAttack',
+    label: 'Ukrainian Drone',
+    thumbnail: swatchThumbnail(['#60a5fa', '#facc15', '#1d4ed8']),
+    urls: UKRAINIAN_DRONE_GLB_URLS,
+    vehicleKind: 'drone'
+  },
   { id: 'poly-shotgun-01', label: 'Quaternius Shotgun', thumbnail: weaponSilhouetteThumbnail(['#64748b','#1e293b','#f8fafc']), urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')] },
   { id: 'poly-assault-rifle-01', label: 'Quaternius Assault Rifle', thumbnail: weaponSilhouetteThumbnail(['#334155','#0f172a','#94a3b8']), urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')] },
   { id: 'poly-pistol-01', label: 'Quaternius Pistol', thumbnail: weaponSilhouetteThumbnail(['#6b7280','#111827','#e5e7eb']), urls: [polyGlb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc')] },
@@ -39,7 +52,9 @@ export const SNAKE_CAPTURE_WEAPON_ALIAS_MAP = Object.freeze({
   fighter: 'poly-assault-rifle-01',
   helicopter: 'poly-shotgun-02',
   supporttruck: 'poly-smg-01',
-  drone: 'poly-shotgun-01'
+  drone: 'ukrainianDroneAttack',
+  ukrainiandrone: 'ukrainianDroneAttack',
+  ukrainiandroneattack: 'ukrainianDroneAttack'
 });
 
 export const normalizeSnakeWeaponId = (value) =>

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -4683,19 +4683,43 @@ function isDataUri(uri) {
 }
 
 function isAbsoluteUrl(uri) {
-  return /^https?:\/\//i.test(uri) || uri.startsWith('blob:');
+  return /^(https?:)?\/\//i.test(uri) || uri.startsWith('blob:');
+}
+
+function normalizeResourcePath(resourceUrl) {
+  try {
+    return decodeURIComponent(resourceUrl).replace(/\\/g, '/').replace(/^\.\//, '');
+  } catch {
+    return resourceUrl.replace(/\\/g, '/').replace(/^\.\//, '');
+  }
+}
+
+function toJsDelivrFromRawUrl(url) {
+  const match = String(url).match(/^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/i);
+  if (!match) return null;
+  return `https://cdn.jsdelivr.net/gh/${match[1]}/${match[2]}@${match[3]}/${match[4]}`;
+}
+
+function toRawFromJsDelivrUrl(url) {
+  const match = String(url).match(/^https:\/\/cdn\.jsdelivr\.net\/gh\/([^/]+)\/([^@/]+)@([^/]+)\/(.+)$/i);
+  if (!match) return null;
+  return `https://raw.githubusercontent.com/${match[1]}/${match[2]}/${match[3]}/${match[4]}`;
 }
 
 function uniqueStrings(values) {
-  return Array.from(new Set(values));
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function urlAlternates(url) {
+  return uniqueStrings([url, toRawFromJsDelivrUrl(url), toJsDelivrFromRawUrl(url)]);
 }
 
 function buildImageCandidates(imageUri, sourceUrl, modelUrls) {
-  if (isAbsoluteUrl(imageUri)) return uniqueStrings([imageUri]);
+  const normalizedUri = normalizeResourcePath(String(imageUri || ''));
+  if (isAbsoluteUrl(normalizedUri) || isDataUri(normalizedUri)) return urlAlternates(normalizedUri);
   return uniqueStrings([
-    imageUri,
-    new URL(imageUri, sourceUrl).href,
-    ...modelUrls.map((modelUrl) => new URL(imageUri, modelUrl).href)
+    ...urlAlternates(new URL(normalizedUri, sourceUrl).href),
+    ...modelUrls.flatMap((modelUrl) => urlAlternates(new URL(normalizedUri, modelUrl).href))
   ]);
 }
 
@@ -4805,7 +4829,11 @@ async function fetchBuffer(url) {
 async function fetchBlob(url) {
   const response = await fetch(url, { mode: 'cors' });
   if (!response.ok) throw new Error(`Fetch blob failed: ${response.status}`);
-  return response.blob();
+  const blob = await response.blob();
+  if (/text\/html|text\/plain/i.test(blob.type || '')) {
+    throw new Error(`Rejected non-asset response ${blob.type}: ${url}`);
+  }
+  return blob;
 }
 
 function parseObjectFromBuffer(loader, buffer) {

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2031,19 +2031,43 @@ function isDataUri(uri) {
 }
 
 function isAbsoluteUrl(uri) {
-  return /^https?:\/\//i.test(uri) || uri.startsWith('blob:');
+  return /^(https?:)?\/\//i.test(uri) || uri.startsWith('blob:');
+}
+
+function normalizeResourcePath(resourceUrl) {
+  try {
+    return decodeURIComponent(resourceUrl).replace(/\\/g, '/').replace(/^\.\//, '');
+  } catch {
+    return resourceUrl.replace(/\\/g, '/').replace(/^\.\//, '');
+  }
+}
+
+function toJsDelivrFromRawUrl(url) {
+  const match = String(url).match(/^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/i);
+  if (!match) return null;
+  return `https://cdn.jsdelivr.net/gh/${match[1]}/${match[2]}@${match[3]}/${match[4]}`;
+}
+
+function toRawFromJsDelivrUrl(url) {
+  const match = String(url).match(/^https:\/\/cdn\.jsdelivr\.net\/gh\/([^/]+)\/([^@/]+)@([^/]+)\/(.+)$/i);
+  if (!match) return null;
+  return `https://raw.githubusercontent.com/${match[1]}/${match[2]}/${match[3]}/${match[4]}`;
 }
 
 function uniqueStrings(values) {
-  return Array.from(new Set(values));
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function urlAlternates(url) {
+  return uniqueStrings([url, toRawFromJsDelivrUrl(url), toJsDelivrFromRawUrl(url)]);
 }
 
 function buildImageCandidates(imageUri, sourceUrl, modelUrls) {
-  if (isAbsoluteUrl(imageUri)) return uniqueStrings([imageUri]);
+  const normalizedUri = normalizeResourcePath(String(imageUri || ''));
+  if (isAbsoluteUrl(normalizedUri) || isDataUri(normalizedUri)) return urlAlternates(normalizedUri);
   return uniqueStrings([
-    imageUri,
-    new URL(imageUri, sourceUrl).href,
-    ...modelUrls.map((modelUrl) => new URL(imageUri, modelUrl).href)
+    ...urlAlternates(new URL(normalizedUri, sourceUrl).href),
+    ...modelUrls.flatMap((modelUrl) => urlAlternates(new URL(normalizedUri, modelUrl).href))
   ]);
 }
 
@@ -2153,7 +2177,11 @@ async function fetchBuffer(url) {
 async function fetchBlob(url) {
   const response = await fetch(url, { mode: 'cors' });
   if (!response.ok) throw new Error(`Fetch blob failed: ${response.status}`);
-  return response.blob();
+  const blob = await response.blob();
+  if (/text\/html|text\/plain/i.test(blob.type || '')) {
+    throw new Error(`Rejected non-asset response ${blob.type}: ${url}`);
+  }
+  return blob;
 }
 
 function parseObjectFromBuffer(loader, buffer) {


### PR DESCRIPTION
### Motivation
- Provide a dedicated Ukrainian drone capture model for Snake & Ladder using the existing drone.glb fallback chain so the requested asset can be used in-game. 
- Ensure GLB texture loading is more resilient across Ludo, Chess and Snake by normalizing resource paths and adding CDN/raw alternates to avoid broken external texture references. 
- Reject non-asset fetch responses early to avoid silently loading HTML/error pages as textures.

### Description
- Add `UKRAINIAN_DRONE_GLB_URLS` and a new `ukrainianDroneAttack` entry in `SNAKE_CAPTURE_WEAPON_OPTIONS`, plus alias mappings so `drone` resolves to the Ukrainian Drone option; file: `webapp/src/config/snakeWeaponCatalog.js`.
- Route catalog options that declare `vehicleKind` into the vehicle rig path so the Ukrainian Drone uses the drone vehicle model instead of a firearm placeholder; file: `webapp/src/components/SnakeBoard3D.jsx`.
- Harden GLB texture resolution by adding `normalizeResourcePath`, `toJsDelivrFromRawUrl`, `toRawFromJsDelivrUrl`, `urlAlternates`, and updating `buildImageCandidates` to produce normalized absolute/model CDN alternates for Ludo, Chess and Snake loaders; files: `webapp/src/pages/Games/LudoBattleRoyal.jsx`, `webapp/src/pages/Games/ChessBattleRoyal.jsx`, and `webapp/src/components/SnakeBoard3D.jsx`.
- Make `fetchBlob` validate responses and throw on likely HTML/plain text responses to avoid non-asset blobs being used as textures; applied across the three GLB-loading modules.

### Testing
- Ran a production build via `npm run build` in the webapp which completed successfully and produced the `dist/` output without build errors. 
- Ran `git diff --check` (style/sanity checks) which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aaac7a10c8329926a562bd98d9d2c)