### PR TITLE
Match Showood GLB to Pool footprint, sync ball roll to Snooker, and narrow side-apron chrome strips

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -35,7 +35,7 @@ describe('Pool Royale table models', () => {
     );
     assert.equal(showood.fitScale, 1);
     assert.equal(showood.fitFootprintScale, 1);
-    assert.equal(showood.preserveOriginalFootprintAspect, true);
+    assert.equal(showood.preserveOriginalFootprintAspect, false);
     assert.equal(showood.lowerBaseHeightScale, 1.38);
     assert.equal(showood.legLengthScale, 2.05);
     assert.equal(showood.clothRepeatScale, 7.5);

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -11,7 +11,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Fixed Pooltool Showood 7 ft GLB table mapped exactly to the 78" × 39" Pool Royale playfield. Install the GLB at the local URL outside git; CDN/raw URLs remain runtime fallbacks only.',
+      'Fixed Pooltool Showood 7 ft GLB table scaled on both footprint axes so the original Showood tabletop mapping matches the Pool Royale playfield. Install the GLB at the local URL outside git; CDN/raw URLs remain runtime fallbacks only.',
     tableSizeId: '7ft',
     baseId: 'showoodOriginal',
     assetUrl: SHOWOOD_LOCAL_ASSET_URL,
@@ -32,7 +32,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitReference: 'upperTabletop',
     matchNativeHeight: true,
     matchNativeUpperComponentHeight: true,
-    preserveOriginalFootprintAspect: true,
+    preserveOriginalFootprintAspect: false,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1543,14 +1543,14 @@ if (BALL_SHADOW_MATERIAL) {
 // Match the snooker build so pace and rebound energy stay consistent between modes.
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
-  restitution: 0.96,
+  restitution: 1.08,
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
   maxTipOffsetRatio: 0.9
 });
 const PHYSICS_BASE_STEP = 1 / 60;
-const FRICTION = 0.9951;
+const FRICTION = 0.995;
 const DEFAULT_CUSHION_RESTITUTION = PHYSICS_PROFILE.restitution;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const BALL_MASS = 0.17;
@@ -1561,13 +1561,13 @@ const SPIN_KINETIC_FRICTION = 0.22;
 const SPIN_ROLL_DAMPING = 0.085;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const ROLLING_RESISTANCE = 0.0092;
+const ROLLING_RESISTANCE = 0; // Snooker Royal pace: use frame-based rolling friction instead of extra linear drag.
 const BALL_BALL_FRICTION = 0.105;
 const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
 const BALL_COLLISION_SLOP = BALL_R * 0.001; // tighter tolerance so visible ball overlap is corrected faster
 const BALL_COLLISION_BAUMGARTE = 0.92; // stronger overlap correction so touching balls settle at true physical spacing
 const RAIL_FRICTION = 0.16;
-const STOP_EPS = 0.0074;
+const STOP_EPS = 0.012;
 const STOP_SOFTENING = 0.96; // ease balls into a stop instead of hard-braking at the speed threshold
 const STOP_FINAL_EPS = STOP_EPS * 0.35;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3; // allow up to 3 frames of catch-up when recovering from slow frames
@@ -13351,14 +13351,17 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
     (s.longN > 0.54 || s.shortN > 0.48) &&
     !(topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner || baseCornerZone || legZone);
 
+  // Keep the metal side-apron accent limited to the two small strips that sit
+  // immediately beside the middle-pocket jaws. Wider side faces stay wood/base
+  // so a finish change cannot turn the full table side gold/chrome.
   const pocketApronStripZone =
     s.sideFace &&
     !s.upFace &&
-    high &&
-    anyPocketZone &&
-    s.relY > 0.44 &&
-    s.relY < 0.78 &&
-    (s.longN > 0.5 || s.shortN > 0.5);
+    sideMiddlePocketZone &&
+    s.relY > 0.5 &&
+    s.relY < 0.72 &&
+    s.shortN > 0.72 &&
+    s.longN < 0.255;
 
   const sideLowerTrimZone =
     s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54);
@@ -33708,6 +33711,7 @@ const shotPowerRef = useRef(0);
               }
             }
             b.pos.addScaledVector(b.vel, stepScale);
+            b.vel.multiplyScalar(Math.pow(FRICTION, stepScale));
             let speed = b.vel.length();
             let scaledSpeed = speed * stepScale;
             if (scaledSpeed < STOP_EPS) {


### PR DESCRIPTION
### Motivation
- Ensure the external Showood 7ft GLB is fitted so its original surface layout maps correctly to the Pool Royale playfield footprint. 
- Make Pool Royale ball rolling pace consistent with Snooker Royal so ball travel, rebounds and feel match across modes. 
- Limit the gold/chrome accent to the small pocket-apron strips next to middle pockets instead of tinting the whole table side.

### Description
- External table model configuration: updated `webapp/src/config/poolRoyaleTableModels.js` to clarify that the Showood GLB is scaled on both footprint axes and set `preserveOriginalFootprintAspect` to `false` so the GLB mapping can be fit to the Pool Royale playfield. 
- Physics adjustments in `webapp/src/pages/Games/PoolRoyale.jsx`: increased restitution to `1.08`, adjusted global `FRICTION` (0.995), set `ROLLING_RESISTANCE` to `0` (switch to frame-based rolling damping), raised `STOP_EPS` to `0.012`, and apply per-step friction multiplication (`b.vel.multiplyScalar(Math.pow(FRICTION, stepScale))`) during ball integration to match Snooker Royal pacing. 
- Table material mapping: constrained the pocket-apron strip detection so `sideWoodApron`/metal accent is only applied to the narrow strips immediately beside middle-pocket jaws (replaced the previous broader `pocketApronStripZone` test with a tighter condition). 
- Tests and descriptions: adjusted `test/poolRoyaleTableModels.test.js` and the Showood table description to reflect the footprint-scaling behavior. 
- Small cleanup/comment additions explaining the intent of the side-apron restriction and the rolling friction change.

### Testing
- Ran the unit test suite for the table model contract: `npm test -- --runTestsByPath test/poolRoyaleTableModels.test.js --runInBand`, all tests passed (4/4). 
- Ran ESLint on the modified files via `npx eslint ...`; lint produced warnings only (no errors) due to ignore patterns in the repo. 
- Manual quick smoke: adjusted physics integration to apply friction per-step and limited apron mapping logic; no runtime errors surfaced in the unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aaef7a39083299031dde6c87f0928)