### PR TITLE
Tune Showood table mapping, roll pace, and pocket-strip mapping

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -25,6 +25,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fitScale: 1,
     fitFootprintScale: 1,
     fitHeightScale: 1,
+    fitToPoolRoyalePlayfieldMapping: true,
+    playfieldMappingRailPaddingScale: 2.2,
     lowerBaseHeightScale: 1.38,
     legLengthScale: 2.05,
     clothRepeatScale: 7.5,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1561,7 +1561,9 @@ const SPIN_KINETIC_FRICTION = 0.22;
 const SPIN_ROLL_DAMPING = 0.085;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const ROLLING_RESISTANCE = 0.0092;
+// Keep Pool Royale ball roll pace locked to Snooker Royal so both games feel identical.
+const SNOOKER_ROYAL_MATCHED_ROLLING_RESISTANCE = 0.0092;
+const ROLLING_RESISTANCE = SNOOKER_ROYAL_MATCHED_ROLLING_RESISTANCE;
 const BALL_BALL_FRICTION = 0.105;
 const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
 const BALL_COLLISION_SLOP = BALL_R * 0.001; // tighter tolerance so visible ball overlap is corrected faster
@@ -13351,14 +13353,16 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
     (s.longN > 0.54 || s.shortN > 0.48) &&
     !(topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner || baseCornerZone || legZone);
 
-  const pocketApronStripZone =
+  // Tiny Showood metal strips beside the middle-pocket jaws: keep this
+  // pocket-local so the whole side apron cannot turn gold/chrome.
+  const sidePocketJawStripZone =
     s.sideFace &&
     !s.upFace &&
-    high &&
-    anyPocketZone &&
+    sideMiddlePocketZone &&
     s.relY > 0.44 &&
     s.relY < 0.78 &&
-    (s.longN > 0.5 || s.shortN > 0.5);
+    s.longN < 0.32 &&
+    s.shortN > 0.69;
 
   const sideLowerTrimZone =
     s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54);
@@ -13381,7 +13385,7 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   if (namedPocket && hardwareCandidate && cornerPocketZone) return 'cornerPocketPlate';
   if (hardwareCandidate && sideMiddlePocketZone && !green && !brown) return 'middlePocketPlate';
   if (hardwareCandidate && cornerPocketZone && !green && !brown) return 'cornerPocketPlate';
-  if (pocketApronStripZone && !green) return 'sideWoodApron';
+  if (sidePocketJawStripZone && !green) return 'sideWoodApron';
 
   if (green && centralCloth) return 'cloth';
   if (green && cushionBand) return 'cushion';
@@ -13398,7 +13402,7 @@ function resolvePoolRoyaleShowoodTrianglePart(mesh, geometry, material, aIndex, 
   if (baseCornerZone) return 'baseCornerBlock';
   if (legZone && (brown || namedWood || !hardwareCandidate)) return 'leg';
   if (hardwareCandidate && sideLowerTrimZone && !green) return 'lowerTrim';
-  if (railSightDownBand && !green) return 'baseCornerBlock';
+  if (railSightDownBand && !green) return 'sideWoodApron';
   if (veryTop && (s.upFace || topRailBand) && !green) return 'topWoodRail';
   if (high && s.sideFace && !green && !anyPocketZone) return 'baseCornerBlock';
 
@@ -13923,8 +13927,25 @@ function adjustPoolRoyaleExternalShowoodBaseProportions(model, tableModel) {
   model.updateMatrixWorld(true);
 }
 
+function resolvePoolRoyaleExternalTableFitDims(tableModel, dims) {
+  if (!dims || tableModel?.id !== 'showood-seven-foot' || !tableModel?.fitToPoolRoyalePlayfieldMapping) {
+    return dims;
+  }
+  const railPaddingScale = Number.isFinite(tableModel.playfieldMappingRailPaddingScale)
+    ? Math.max(0, tableModel.playfieldMappingRailPaddingScale)
+    : 2;
+  const mappingWidth = PLAY_W + Math.abs(SIDE_RAIL_INNER_THICKNESS) * railPaddingScale;
+  const mappingLength = PLAY_H + Math.abs(END_RAIL_INNER_THICKNESS) * railPaddingScale;
+  return {
+    ...dims,
+    targetWidth: Math.max(dims.targetWidth ?? 0, mappingWidth),
+    targetLength: Math.max(dims.targetLength ?? 0, mappingLength)
+  };
+}
+
 function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   if (!model || !dims) return;
+  dims = resolvePoolRoyaleExternalTableFitDims(tableModel, dims);
   model.position.set(0, 0, 0);
   model.rotation.set(0, 0, 0);
   model.scale.setScalar(1);


### PR DESCRIPTION
### Motivation
- Make the imported Showood 7ft GLB fit the actual Pool Royale playfield footprint so visual table and physics mapping match exactly. 
- Keep ball rolling pace identical to Snooker Royal so ball travel/feel are consistent across modes. 
- Prevent full side aprons from turning gold/chrome by restricting the small metal strip accent to the tiny strip beside middle-pocket jaws only.

### Description
- Added `fitToPoolRoyalePlayfieldMapping` and `playfieldMappingRailPaddingScale` to the Showood table model config in `webapp/src/config/poolRoyaleTableModels.js` so the GLB fit target can be expanded to the in-game playfield mapping. 
- Implemented `resolvePoolRoyaleExternalTableFitDims()` and call-site integration in `fitPoolRoyaleExternalTableModel` (in `webapp/src/pages/Games/PoolRoyale.jsx`) to expand the external GLB fit `targetWidth/targetLength` using `PLAY_W`/`PLAY_H` plus a rail padding scale before applying the existing fit logic. 
- Locked `ROLLING_RESISTANCE` to an explicit Snooker-aligned constant by introducing `SNOOKER_ROYAL_MATCHED_ROLLING_RESISTANCE` and assigning `ROLLING_RESISTANCE = SNOOKER_ROYAL_MATCHED_ROLLING_RESISTANCE` to keep roll pace matched. 
- Narrowed the Showood pocket-apron classifier: replaced the broader pocket strip zone with a `sidePocketJawStripZone` that is pocket-local and only selects the small strip beside middle-pocket jaws; adjusted the rail/side-part routing so `railSightDownBand` maps to `sideWoodApron` (metal accent) only where appropriate. 
- Minor robustness: use `Math.abs(...)` for rail padding composition when computing mapping dims.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully. 
- Installed Playwright browsers with `npx playwright install chromium` and platform deps with `npx playwright install-deps chromium`, both completed successfully. 
- Launched the dev server and exercised a headless Playwright mobile run that produced a screenshot saved to `/tmp/pool-royale-showood.png`. 
- Observed runtime network fetch warnings for external GLB/asset prefetches, but the dev render pipeline completed and the screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aaef7a39083299031dde6c87f0928)