### PR TITLE
Separate Shahad/Ukrainian drone attacks, show parked drones, and implement precise no-smoke Ukrainian missile

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -733,6 +733,7 @@ const LUDO_CAPTURE_ATTACK_TUNING_BY_WEAPON = Object.freeze({
   fighter: Object.freeze({ speed: 0.92, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
   helicopter: Object.freeze({ speed: 0.94, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
   drone: Object.freeze({ speed: 0.86, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
+  ukrainianDrone: Object.freeze({ speed: 0.94, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
   // Pawn javelin and support-truck rockets intentionally match drone speed/altitude profile.
   javelin: Object.freeze({ speed: 0.86, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
   supportTruck: Object.freeze({ speed: 0.86, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 })
@@ -754,8 +755,9 @@ const WEAPON_PARKED_ROLL_BY_KIND = Object.freeze({
 const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
   missileJavelin: 'javelin',
   droneAttack: 'drone',
-  ukrainianDroneAttack: 'drone',
-  ukrainiandroneattack: 'drone',
+  ukrainianDroneAttack: 'ukrainianDrone',
+  ukrainiandroneattack: 'ukrainianDrone',
+  ukrainianDrone: 'ukrainianDrone',
   fighterJetAttack: 'fighter',
   helicopterAttack: 'helicopter',
   fpsGunAttack: 'supportTruck',
@@ -868,6 +870,10 @@ function applyFlatTableWeaponParkingPose(object, parkingPose = 'horizontal') {
 
 function normalizeSnakeCaptureWeaponKind(weaponType = 'fighter') {
   return SNAKE_CAPTURE_WEAPON_KIND_MAP[weaponType] || weaponType || 'fighter';
+}
+
+function getSnakeCaptureVehicleModelKind(vehicleKind = 'fighter') {
+  return vehicleKind === 'ukrainianDrone' ? 'drone' : vehicleKind;
 }
 
 function pullPointTowardCenter(point, amount = TILE_EDGE_INSET) {
@@ -6052,7 +6058,7 @@ function createSeatWeaponMesh(weaponType = 'fighter', options = {}) {
   const catalogOption = SNAKE_CAPTURE_WEAPON_OPTION_BY_ID[rawWeaponType] || null;
   const catalogWeaponType = catalogOption ? rawWeaponType : null;
   const normalizedWeaponType = catalogOption?.vehicleKind || normalizeSnakeCaptureWeaponKind(rawWeaponType || weaponType);
-  const isVehicleWeapon = ['supportTruck', 'drone', 'helicopter', 'fighter', 'javelin'].includes(
+  const isVehicleWeapon = ['supportTruck', 'drone', 'ukrainianDrone', 'helicopter', 'fighter', 'javelin'].includes(
     normalizedWeaponType
   );
   const firearmScale = isVehicleWeapon ? 1 : FIREARM_DISPLAY_SIZE_MULTIPLIER;
@@ -6085,13 +6091,13 @@ function createSeatWeaponMesh(weaponType = 'fighter', options = {}) {
     applyFlatTableWeaponParkingPose(polyMesh, parkingPose);
     return polyMesh;
   }
-  const rig = createCaptureVehicleRig(normalizedWeaponType);
+  const rig = createCaptureVehicleRig(getSnakeCaptureVehicleModelKind(normalizedWeaponType));
   const group = rig.root;
   group.visible = true;
   const displayScale =
     normalizedWeaponType === 'supportTruck'
       ? TOKEN_HEIGHT * 0.8
-      : normalizedWeaponType === 'drone'
+      : (normalizedWeaponType === 'drone' || normalizedWeaponType === 'ukrainianDrone')
       ? TOKEN_HEIGHT * 0.75
       : TOKEN_HEIGHT * 0.85;
   group.scale.setScalar(displayScale * 1.5 * WEAPON_DISPLAY_SIZE_MULTIPLIER);
@@ -6575,6 +6581,7 @@ export default function SnakeBoard3D({
       fighter: createCaptureVehicleRig('fighter'),
       helicopter: createCaptureVehicleRig('helicopter'),
       drone: createCaptureVehicleRig('drone'),
+      ukrainianDrone: createCaptureVehicleRig('drone'),
       supportTruck: createCaptureVehicleRig('supportTruck'),
       javelin: createCaptureVehicleRig('javelin')
     };
@@ -7447,7 +7454,7 @@ export default function SnakeBoard3D({
     };
     const vehicleKind = normalizeSnakeCaptureWeaponKind(captureEvent.weaponType || 'fighter');
     const vehicleMap = board.captureFx?.vehicles || {};
-    const primaryVehicle = vehicleMap[vehicleKind] || vehicleMap.fighter || Object.values(vehicleMap)[0];
+    const primaryVehicle = vehicleMap[vehicleKind] || vehicleMap[getSnakeCaptureVehicleModelKind(vehicleKind)] || vehicleMap.fighter || Object.values(vehicleMap)[0];
     const missileProjectile = vehicleMap.javelin || vehicleMap.fighter || Object.values(vehicleMap)[0];
     const explosion = board.captureFx?.explosion;
     if (!primaryVehicle || !missileProjectile || !explosion) {
@@ -7497,14 +7504,19 @@ export default function SnakeBoard3D({
     const bbox = new THREE.Box3().setFromObject(attacker);
     const tokenHeight = Math.max(TOKEN_HEIGHT * 5, bbox.max.y - bbox.min.y);
     primaryVehicle.root.scale.set(tokenHeight, tokenHeight * 0.38, tokenHeight * 0.38);
-    missileProjectile.root.scale.set(tokenHeight * 0.85, tokenHeight * 0.22, tokenHeight * 0.22);
+    const missileScale = vehicleKind === 'ukrainianDrone'
+      ? { length: tokenHeight * 0.52, thickness: tokenHeight * 0.13 }
+      : { length: tokenHeight * 0.85, thickness: tokenHeight * 0.22 };
+    missileProjectile.root.scale.set(missileScale.length, missileScale.thickness, missileScale.thickness);
 
     const startTime = performance.now();
     const stageFlightDuration = CAPTURE_MISSILE_FLIGHT_MS / Math.max(0.58, captureTuning.speed || 1);
     const impactDuration = CAPTURE_EXPLOSION_MS;
     const advanceDuration = CAPTURE_TOKEN_ADVANCE_MS;
-    const isDroneLikeAircraft = vehicleKind === 'drone' || vehicleKind === 'fighter' || vehicleKind === 'helicopter';
-    const isReturningAircraft = vehicleKind === 'fighter' || vehicleKind === 'helicopter';
+    const isShahadDrone = vehicleKind === 'drone';
+    const isUkrainianDrone = vehicleKind === 'ukrainianDrone';
+    const isDroneLikeAircraft = isShahadDrone || isUkrainianDrone || vehicleKind === 'fighter' || vehicleKind === 'helicopter';
+    const isReturningAircraft = isUkrainianDrone || vehicleKind === 'fighter' || vehicleKind === 'helicopter';
     const volleyCount = vehicleKind === 'supportTruck' ? 1 : (isReturningAircraft ? 1 : CAPTURE_MULTI_SHOT_COUNT);
     const perMissileFlight = CAPTURE_MISSILE_FLIGHT_MS;
     const perMissileGap = 120;
@@ -7607,7 +7619,7 @@ export default function SnakeBoard3D({
           return false;
         }
         const attackElapsed = elapsed - stageFlightDuration;
-        if (vehicleKind === 'drone' && attackElapsed <= droneAttackDuration) {
+        if (isShahadDrone && attackElapsed <= droneAttackDuration) {
           const rawU = easeInOut(clamp01(attackElapsed / droneAttackDuration));
           const u = remapTakeoffLandingProgress(rawU, captureTuning.takeoff, captureTuning.landing);
           const nextU = clamp01(u + 0.02);
@@ -7650,12 +7662,22 @@ export default function SnakeBoard3D({
             const rawU = easeInOut(clamp01(missileElapsed / perMissileFlight));
             const u = remapTakeoffLandingProgress(rawU, captureTuning.takeoff, captureTuning.landing);
             const from = aircraftMissileLaunchFrom || centerStage;
-            const pos = missilePathAt(u, from);
-            const next = missilePathAt(clamp01(u + 0.02), from);
+            const pos = isUkrainianDrone
+              ? from.clone().lerp(impact, u).setX(impact.x).setZ(impact.z)
+              : missilePathAt(u, from);
+            const next = isUkrainianDrone
+              ? from.clone().lerp(impact, clamp01(u + 0.02)).setX(impact.x).setZ(impact.z)
+              : missilePathAt(clamp01(u + 0.02), from);
             const dir = next.clone().sub(pos).normalize();
             missileProjectile.root.visible = true;
             missileProjectile.root.position.copy(pos);
             missileProjectile.root.quaternion.setFromUnitVectors(new THREE.Vector3(1, 0, 0), dir);
+            if (isUkrainianDrone) {
+              missileProjectile.trail?.forEach((puff) => {
+                puff.visible = false;
+                if (puff.material) puff.material.opacity = 0;
+              });
+            }
           } else {
             missileProjectile.root.visible = false;
           }
@@ -7712,8 +7734,12 @@ export default function SnakeBoard3D({
             const rawU = easeInOut(clamp01(cycleElapsed / perMissileFlight));
             const u = remapTakeoffLandingProgress(rawU, captureTuning.takeoff, captureTuning.landing);
             const from = vehicleKind === 'supportTruck' ? parkedTop : centerStage;
-            const pos = missilePathAt(u, from);
-            const next = missilePathAt(clamp01(u + 0.02), from);
+            const pos = isUkrainianDrone
+              ? from.clone().lerp(impact, u).setX(impact.x).setZ(impact.z)
+              : missilePathAt(u, from);
+            const next = isUkrainianDrone
+              ? from.clone().lerp(impact, clamp01(u + 0.02)).setX(impact.x).setZ(impact.z)
+              : missilePathAt(clamp01(u + 0.02), from);
             const dir = next.clone().sub(pos).normalize();
             missileProjectile.root.visible = true;
             missileProjectile.root.position.copy(pos);
@@ -7727,7 +7753,7 @@ export default function SnakeBoard3D({
           return false;
         }
         missileProjectile.root.visible = false;
-        const impactElapsed = attackElapsed - (vehicleKind === 'drone' ? droneAttackDuration : volleyDuration);
+        const impactElapsed = attackElapsed - (isShahadDrone ? droneAttackDuration : volleyDuration);
         if (impactElapsed <= impactDuration) {
           explosion.root.position.copy(impact);
           updateCaptureExplosionRig(explosion, impactElapsed / 1000);

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -1,12 +1,12 @@
-import { swatchThumbnail, weaponSilhouetteThumbnail } from './storeThumbnails.js';
+import { swatchThumbnail, weaponSilhouetteThumbnail } from './storeThumbnails.js'
 
-const polyGlb = (uuid) => `https://static.poly.pizza/${uuid}.glb`;
+const polyGlb = (uuid) => `https://static.poly.pizza/${uuid}.glb`
 
 export const UKRAINIAN_DRONE_GLB_URLS = Object.freeze([
   'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
   'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
   'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
-]);
+])
 
 export const SNAKE_KNOWN_WORKING_GLB = Object.freeze({
   awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
@@ -18,7 +18,7 @@ export const SNAKE_KNOWN_WORKING_GLB = Object.freeze({
   pistolHolsterRaw: 'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
   fps: 'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
   fpsRaw: 'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf'
-});
+})
 
 export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   {
@@ -26,42 +26,52 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
     label: 'Ukrainian Drone',
     thumbnail: swatchThumbnail(['#60a5fa', '#facc15', '#1d4ed8']),
     urls: UKRAINIAN_DRONE_GLB_URLS,
+    vehicleKind: 'ukrainianDrone'
+  },
+  {
+    id: 'droneAttack',
+    label: 'Shahad Drone',
+    thumbnail: swatchThumbnail(['#94a3b8', '#475569', '#111827']),
+    urls: UKRAINIAN_DRONE_GLB_URLS,
     vehicleKind: 'drone'
   },
-  { id: 'poly-shotgun-01', label: 'Quaternius Shotgun', thumbnail: weaponSilhouetteThumbnail(['#64748b','#1e293b','#f8fafc']), urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')] },
-  { id: 'poly-assault-rifle-01', label: 'Quaternius Assault Rifle', thumbnail: weaponSilhouetteThumbnail(['#334155','#0f172a','#94a3b8']), urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')] },
-  { id: 'poly-pistol-01', label: 'Quaternius Pistol', thumbnail: weaponSilhouetteThumbnail(['#6b7280','#111827','#e5e7eb']), urls: [polyGlb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc')] },
-  { id: 'poly-revolver-01', label: 'Quaternius Heavy Revolver', thumbnail: weaponSilhouetteThumbnail(['#7c2d12','#1f2937','#fbbf24']), urls: [polyGlb('9e728565-67a3-44db-9567-982320abff09')] },
-  { id: 'poly-sawed-off-01', label: 'Quaternius Sawed-Off', thumbnail: weaponSilhouetteThumbnail(['#78350f','#0f172a','#d6d3d1']), urls: [polyGlb('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e')] },
-  { id: 'poly-revolver-02', label: 'Quaternius Revolver Silver', thumbnail: weaponSilhouetteThumbnail(['#94a3b8','#1f2937','#f8fafc']), urls: [polyGlb('7951b3b9-d3a5-4ec8-81b7-11111f1c8e88')] },
-  { id: 'poly-shotgun-02', label: 'Quaternius Long Shotgun', thumbnail: weaponSilhouetteThumbnail(['#475569','#020617','#cbd5e1']), urls: [polyGlb('f71d6771-f512-4374-bd23-ba00b564db68')] },
-  { id: 'poly-shotgun-03', label: 'Quaternius Pump Shotgun', thumbnail: weaponSilhouetteThumbnail(['#52525b','#111827','#e2e8f0']), urls: [polyGlb('08f27141-8e64-425a-9161-1bbd6956dfca')] },
-  { id: 'poly-smg-01', label: 'Quaternius SMG', thumbnail: weaponSilhouetteThumbnail(['#374151','#030712','#d1d5db']), urls: [polyGlb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710')] },
-  { id: 'slot-10-ak47-gltf', label: 'AK47 GLTF', thumbnail: weaponSilhouetteThumbnail(['#7f1d1d','#111827','#f59e0b']), urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'] },
-  { id: 'slot-11-krsv-gltf', label: 'KRSV GLTF', thumbnail: weaponSilhouetteThumbnail(['#1d4ed8','#0f172a','#bfdbfe']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf', SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkRaw] },
-  { id: 'slot-12-smith-gltf', label: 'Smith GLTF', thumbnail: weaponSilhouetteThumbnail(['#6b7280','#0f172a','#f8fafc']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf', SNAKE_KNOWN_WORKING_GLB.pistolHolster, SNAKE_KNOWN_WORKING_GLB.pistolHolsterRaw] },
-  { id: 'slot-13-mosin-gltf', label: 'Mosin GLTF', thumbnail: weaponSilhouetteThumbnail(['#92400e','#1f2937','#fcd34d']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf', SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
-  { id: 'slot-14-uzi-gltf', label: 'Uzi GLTF', thumbnail: weaponSilhouetteThumbnail(['#0f766e','#111827','#99f6e4']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf', SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkMaster] },
-  { id: 'slot-15-sigsauer-gltf', label: 'SigSauer GLTF', thumbnail: weaponSilhouetteThumbnail(['#334155','#020617','#f1f5f9']), urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf', SNAKE_KNOWN_WORKING_GLB.pistolHolster, SNAKE_KNOWN_WORKING_GLB.pistolHolsterRaw] },
-  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b','#0f172a','#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
-  { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b','#111827','#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
-]);
-
+  { id: 'poly-shotgun-01', label: 'Quaternius Shotgun', thumbnail: weaponSilhouetteThumbnail(['#64748b', '#1e293b', '#f8fafc']), urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')] },
+  { id: 'poly-assault-rifle-01', label: 'Quaternius Assault Rifle', thumbnail: weaponSilhouetteThumbnail(['#334155', '#0f172a', '#94a3b8']), urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')] },
+  { id: 'poly-pistol-01', label: 'Quaternius Pistol', thumbnail: weaponSilhouetteThumbnail(['#6b7280', '#111827', '#e5e7eb']), urls: [polyGlb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc')] },
+  { id: 'poly-revolver-01', label: 'Quaternius Heavy Revolver', thumbnail: weaponSilhouetteThumbnail(['#7c2d12', '#1f2937', '#fbbf24']), urls: [polyGlb('9e728565-67a3-44db-9567-982320abff09')] },
+  { id: 'poly-sawed-off-01', label: 'Quaternius Sawed-Off', thumbnail: weaponSilhouetteThumbnail(['#78350f', '#0f172a', '#d6d3d1']), urls: [polyGlb('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e')] },
+  { id: 'poly-revolver-02', label: 'Quaternius Revolver Silver', thumbnail: weaponSilhouetteThumbnail(['#94a3b8', '#1f2937', '#f8fafc']), urls: [polyGlb('7951b3b9-d3a5-4ec8-81b7-11111f1c8e88')] },
+  { id: 'poly-shotgun-02', label: 'Quaternius Long Shotgun', thumbnail: weaponSilhouetteThumbnail(['#475569', '#020617', '#cbd5e1']), urls: [polyGlb('f71d6771-f512-4374-bd23-ba00b564db68')] },
+  { id: 'poly-shotgun-03', label: 'Quaternius Pump Shotgun', thumbnail: weaponSilhouetteThumbnail(['#52525b', '#111827', '#e2e8f0']), urls: [polyGlb('08f27141-8e64-425a-9161-1bbd6956dfca')] },
+  { id: 'poly-smg-01', label: 'Quaternius SMG', thumbnail: weaponSilhouetteThumbnail(['#374151', '#030712', '#d1d5db']), urls: [polyGlb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710')] },
+  { id: 'slot-10-ak47-gltf', label: 'AK47 GLTF', thumbnail: weaponSilhouetteThumbnail(['#7f1d1d', '#111827', '#f59e0b']), urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'] },
+  { id: 'slot-11-krsv-gltf', label: 'KRSV GLTF', thumbnail: weaponSilhouetteThumbnail(['#1d4ed8', '#0f172a', '#bfdbfe']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf', SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkRaw] },
+  { id: 'slot-12-smith-gltf', label: 'Smith GLTF', thumbnail: weaponSilhouetteThumbnail(['#6b7280', '#0f172a', '#f8fafc']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf', SNAKE_KNOWN_WORKING_GLB.pistolHolster, SNAKE_KNOWN_WORKING_GLB.pistolHolsterRaw] },
+  { id: 'slot-13-mosin-gltf', label: 'Mosin GLTF', thumbnail: weaponSilhouetteThumbnail(['#92400e', '#1f2937', '#fcd34d']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf', SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
+  { id: 'slot-14-uzi-gltf', label: 'Uzi GLTF', thumbnail: weaponSilhouetteThumbnail(['#0f766e', '#111827', '#99f6e4']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf', SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkMaster] },
+  { id: 'slot-15-sigsauer-gltf', label: 'SigSauer GLTF', thumbnail: weaponSilhouetteThumbnail(['#334155', '#020617', '#f1f5f9']), urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf', SNAKE_KNOWN_WORKING_GLB.pistolHolster, SNAKE_KNOWN_WORKING_GLB.pistolHolsterRaw] },
+  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
+  { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b', '#111827', '#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
+])
 
 export const SNAKE_CAPTURE_WEAPON_ALIAS_MAP = Object.freeze({
   fighter: 'poly-assault-rifle-01',
   helicopter: 'poly-shotgun-02',
   supporttruck: 'poly-smg-01',
-  drone: 'ukrainianDroneAttack',
+  drone: 'droneAttack',
+  shahad: 'droneAttack',
+  shahed: 'droneAttack',
+  shahaddrone: 'droneAttack',
+  droneattack: 'droneAttack',
   ukrainiandrone: 'ukrainianDroneAttack',
   ukrainiandroneattack: 'ukrainianDroneAttack'
-});
+})
 
 export const normalizeSnakeWeaponId = (value) =>
-  typeof value === 'string' ? value.trim().toLowerCase() : '';
+  typeof value === 'string' ? value.trim().toLowerCase() : ''
 
 export const resolveSnakeCaptureWeaponId = (weaponId) => {
-  const normalized = normalizeSnakeWeaponId(weaponId);
-  if (!normalized) return '';
-  return SNAKE_CAPTURE_WEAPON_ALIAS_MAP[normalized] || normalized;
-};
+  const normalized = normalizeSnakeWeaponId(weaponId)
+  if (!normalized) return ''
+  return SNAKE_CAPTURE_WEAPON_ALIAS_MAP[normalized] || normalized
+}

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -9077,8 +9077,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         CAPTURE_ANIMATION_OPTIONS[optionIndex]?.id ?? CAPTURE_ANIMATION_OPTIONS[0]?.id ?? 'missileJavelin';
       if (entry?.jet) entry.jet.visible = selectedCaptureAnimationId === 'fighterJetAttack';
       if (entry?.helicopter) entry.helicopter.visible = selectedCaptureAnimationId === 'helicopterAttack';
-      if (entry?.drone) entry.drone.visible = false;
-      if (entry?.droneTruck) entry.droneTruck.visible = (selectedCaptureAnimationId === 'droneAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack');
+      if (entry?.drone) entry.drone.visible = (selectedCaptureAnimationId === 'droneAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack');
+      if (entry?.droneTruck) entry.droneTruck.visible = false;
       if (entry?.missile) entry.missile.visible = selectedCaptureAnimationId === 'missileJavelin';
       if (entry?.weaponRack) {
         const showFirearm = FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId);
@@ -11941,7 +11941,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         };
         const captureTuning = resolveCaptureAttackTuning(resolvedCaptureAnimationId);
         const isHelicopterAttack = resolvedCaptureAnimationId === 'helicopterAttack';
-        const isDroneAttack = (resolvedCaptureAnimationId === 'droneAttack' || resolvedCaptureAnimationId === 'ukrainianDroneAttack');
+        const isShahadDroneAttack = resolvedCaptureAnimationId === 'droneAttack';
+        const isUkrainianDroneAttack = resolvedCaptureAnimationId === 'ukrainianDroneAttack';
+        const isDroneAttack = isShahadDroneAttack || isUkrainianDroneAttack;
         const isFighterJetAttack = resolvedCaptureAnimationId === 'fighterJetAttack';
         const isFirearmAttack = FIREARM_CAPTURE_ANIMATION_IDS.has(resolvedCaptureAnimationId);
         if (isFirearmAttack) {
@@ -12492,7 +12494,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : isHelicopterAttack
             ? parkedEntry?.helicopterPark?.clone?.()
             : isDroneAttack
-            ? parkedEntry?.droneTruckPark?.clone?.() ?? parkedEntry?.dronePark?.clone?.()
+            ? parkedEntry?.dronePark?.clone?.()
             : isMissileTruckAttack
             ? parkedEntry?.missilePark?.clone?.()
             : null;
@@ -12502,23 +12504,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? parkedEntry?.helicopter
             : (resolvedCaptureAnimationId === 'droneAttack' || resolvedCaptureAnimationId === 'ukrainianDroneAttack')
-            ? parkedEntry?.droneTruck ?? parkedEntry?.drone
+            ? parkedEntry?.drone
             : resolvedCaptureAnimationId === 'missileJavelin'
             ? parkedEntry?.missile
             : null;
         parkedReloadMissile = parkedEntry?.reloadMissile ?? null;
         parkedReloadMissileLocalPosition = parkedEntry?.reloadMissileLocalPosition ?? null;
         parkedReloadMissileLocalRotation = parkedEntry?.reloadMissileLocalRotation ?? null;
-        if (isDroneAttack) {
-          const parkedPayloads = Array.isArray(parkedEntry?.droneTruckPayloads) ? parkedEntry.droneTruckPayloads : [];
-          if (parkedPayloads.length > 0) {
-            const nextPayloadIndex = Number.isFinite(parkedEntry?.nextDronePayloadIndex)
-              ? parkedEntry.nextDronePayloadIndex
-              : 0;
-            parkedDronePayload = parkedPayloads[((nextPayloadIndex % parkedPayloads.length) + parkedPayloads.length) % parkedPayloads.length];
-            parkedEntry.nextDronePayloadIndex = (nextPayloadIndex + 1) % parkedPayloads.length;
-          }
-        }
         stopCaptureVehicleSounds();
         if (isHelicopterAttack) {
           stopFighterJetSound();
@@ -12540,6 +12532,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const jetMissiles =
           resolvedCaptureAnimationId === 'fighterJetAttack' || resolvedCaptureAnimationId === 'helicopterAttack'
             ? [createCaptureMissileFx({ withTrail: true }), createCaptureMissileFx({ withTrail: true })]
+            : isUkrainianDroneAttack
+            ? [createCaptureMissileFx({ withTrail: false })]
             : [];
         const explosion = createCaptureExplosionFx();
         scene.add(primaryFx.root);
@@ -12586,7 +12580,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         if (jetMissiles.length) {
           const jetMissileScale =
             missileThicknessScale *
-            (isHelicopterAttack ? 0.68 : 0.78) *
+            (isUkrainianDroneAttack ? 0.46 : isHelicopterAttack ? 0.68 : 0.78) *
             CAPTURE_MISSILE_SIZE_MULTIPLIER;
           jetMissiles.forEach((entry) => {
             entry.root.scale.set(jetMissileScale, jetMissileScale, jetMissileScale);
@@ -12647,20 +12641,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const baseTravelTime =
           resolvedCaptureAnimationId === 'fighterJetAttack'
             ? 2860
-            : resolvedCaptureAnimationId === 'helicopterAttack'
+            : (resolvedCaptureAnimationId === 'helicopterAttack' || resolvedCaptureAnimationId === 'ukrainianDroneAttack')
             ? 3320
-            : (resolvedCaptureAnimationId === 'droneAttack' || resolvedCaptureAnimationId === 'ukrainianDroneAttack')
+            : resolvedCaptureAnimationId === 'droneAttack'
             ? 1780
             : 1780;
         const airAttackSlowFactor =
           resolvedCaptureAnimationId === 'fighterJetAttack' ||
           resolvedCaptureAnimationId === 'helicopterAttack' ||
-          (resolvedCaptureAnimationId === 'droneAttack' || resolvedCaptureAnimationId === 'ukrainianDroneAttack')
+          resolvedCaptureAnimationId === 'droneAttack' ||
+          resolvedCaptureAnimationId === 'ukrainianDroneAttack'
             ? CAPTURE_AIRCRAFT_SLOW_FACTOR
             : 1;
         const travelTime =
           resolvedCaptureAnimationId === 'fighterJetAttack' ||
-          resolvedCaptureAnimationId === 'helicopterAttack'
+          resolvedCaptureAnimationId === 'helicopterAttack' ||
+          resolvedCaptureAnimationId === 'ukrainianDroneAttack'
             ? baseTravelTime * 1.3 * airAttackSlowFactor
             : baseTravelTime * airAttackSlowFactor;
         const tunedTravelTime = travelTime * captureTuning.speed;
@@ -12668,7 +12664,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const flyAwayDuration =
           resolvedCaptureAnimationId === 'fighterJetAttack'
             ? 900
-            : resolvedCaptureAnimationId === 'helicopterAttack'
+            : (resolvedCaptureAnimationId === 'helicopterAttack' || resolvedCaptureAnimationId === 'ukrainianDroneAttack')
             ? 900
             : 0;
         const topStrikeHeight = Math.max(bishopHeight * 1.55, TILE_HALF_HEIGHT * 2.2);
@@ -12763,7 +12759,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const apexHeight =
             selectedCaptureAnimationId === 'fighterJetAttack'
               ? liveTarget.y + topStrikeLift.y * 0.54 * CAPTURE_AIRCRAFT_ALTITUDE_FACTOR
-              : selectedCaptureAnimationId === 'helicopterAttack'
+              : (selectedCaptureAnimationId === 'helicopterAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack')
               ? liveTarget.y + topStrikeLift.y * 0.72 * CAPTURE_AIRCRAFT_ALTITUDE_FACTOR
               : liveTarget.y + topStrikeLift.y;
           const apex = new THREE.Vector3(
@@ -12815,9 +12811,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const phaseSplit =
             selectedCaptureAnimationId === 'fighterJetAttack'
               ? 0.84
-            : selectedCaptureAnimationId === 'helicopterAttack'
+            : (selectedCaptureAnimationId === 'helicopterAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack')
               ? 0.84
-              : (selectedCaptureAnimationId === 'droneAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack')
+              : selectedCaptureAnimationId === 'droneAttack'
               ? 0.78
               : 0.84;
           if (elapsed < tunedTravelTime) {
@@ -12844,14 +12840,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   .add(new THREE.Vector3(0, topStrikeHeight * 0.2, 0));
                 return quadraticBezier(apex, apex.clone().lerp(flyByEnd, 0.5), flyByEnd, d);
               }
-              if (selectedCaptureAnimationId === 'helicopterAttack') {
+              if (selectedCaptureAnimationId === 'helicopterAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack') {
                 const flyByEnd = dynamicTo
                   .clone()
                   .add(dynamicTo.clone().sub(arenaCenter).setY(0).normalize().multiplyScalar(orbitalRadius * 0.85))
                   .add(new THREE.Vector3(0, topStrikeHeight * 0.2, 0));
                 return quadraticBezier(apex, apex.clone().lerp(flyByEnd, 0.5), flyByEnd, d);
               }
-              const isDroneStrike = (selectedCaptureAnimationId === 'droneAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack');
+              const isDroneStrike = selectedCaptureAnimationId === 'droneAttack';
               if (isDroneStrike) {
                 return quadraticBezier(apex, apex.clone().lerp(dynamicTo, 0.46), dynamicTo, d);
               }
@@ -12886,7 +12882,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             }
             const isVerticalImpactVehicle =
               selectedCaptureAnimationId === 'missileJavelin' ||
-              (selectedCaptureAnimationId === 'droneAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack');
+              selectedCaptureAnimationId === 'droneAttack';
             if (isVerticalImpactVehicle && u > phaseSplit) {
               primaryFx.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, new THREE.Vector3(0, -1, 0));
             }
@@ -12951,7 +12947,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             let cameraFollowMissileObject = null;
             let cameraFollowMissilePosition = null;
             if (
-              (selectedCaptureAnimationId === 'fighterJetAttack' || selectedCaptureAnimationId === 'helicopterAttack') &&
+              (selectedCaptureAnimationId === 'fighterJetAttack' || selectedCaptureAnimationId === 'helicopterAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack') &&
               jetMissiles.length
             ) {
               const releaseStart = tunedTravelTime * 0.56;
@@ -12973,20 +12969,26 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   playMissileLaunchSound();
                 }
                 const sideOffset = missileIndex === 0 ? -0.045 : 0.045;
-                const launchPos = pos.clone().add(right.clone().multiplyScalar(sideOffset));
+                const launchPos = selectedCaptureAnimationId === 'ukrainianDroneAttack'
+                  ? new THREE.Vector3(dynamicTo.x, Math.max(pos.y - 0.02, dynamicTo.y + topStrikeHeight * 0.85), dynamicTo.z)
+                  : pos.clone().add(right.clone().multiplyScalar(sideOffset));
                 const missileEntry = launchPos.clone().lerp(hitTop, 0.72);
                 missileEntry.y += topStrikeHeight * 0.12;
                 const missilePos =
-                  missileU < 0.74
+                  selectedCaptureAnimationId === 'ukrainianDroneAttack'
+                    ? launchPos.clone().lerp(dynamicTo, missileU)
+                    : missileU < 0.74
                     ? launchPos.clone().lerp(missileEntry, missileU / 0.74)
                     : missileEntry.clone().lerp(dynamicTo, (missileU - 0.74) / 0.26);
-                const missileNext = quadraticBezier(
-                  missileU < 0.74 ? launchPos : missileEntry,
-                  missileU < 0.74 ? missileEntry : missileEntry,
-                  dynamicTo,
-                  clamp(missileU + 0.03, 0, 1)
-                );
-                if (missileU >= 0.74) {
+                const missileNext = selectedCaptureAnimationId === 'ukrainianDroneAttack'
+                  ? launchPos.clone().lerp(dynamicTo, clamp(missileU + 0.03, 0, 1))
+                  : quadraticBezier(
+                      missileU < 0.74 ? launchPos : missileEntry,
+                      missileU < 0.74 ? missileEntry : missileEntry,
+                      dynamicTo,
+                      clamp(missileU + 0.03, 0, 1)
+                    );
+                if (selectedCaptureAnimationId !== 'ukrainianDroneAttack' && missileU >= 0.74) {
                   missileNext.x = missilePos.x;
                   missileNext.z = missilePos.z;
                 }
@@ -12999,7 +13001,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   cameraFollowMissilePosition = missilePos.clone();
                 }
                 if (
-                  selectedCaptureAnimationId === 'helicopterAttack' &&
+                  (selectedCaptureAnimationId === 'helicopterAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack') &&
                   helicopterMissileImpactAt == null &&
                   missileU >= 0.96
                 ) {
@@ -13010,6 +13012,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   playCapture();
                 }
                 jetMissile.trail.forEach((puff, i) => {
+                  if (selectedCaptureAnimationId === 'ukrainianDroneAttack') {
+                    puff.visible = false;
+                    if (puff.material) puff.material.opacity = 0;
+                    return;
+                  }
+                  puff.visible = true;
                   puff.position.set(-0.5 - i * 0.14, Math.sin(elapsed * 0.024 + i + missileIndex) * 0.02, 0);
                   puff.scale.setScalar(0.85 + i * 0.12 + missileU * 0.5);
                 });
@@ -13018,11 +13026,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             if (cameraFollowMissileObject && cameraFollowMissilePosition) {
               trackAttackCamera(cameraFollowMissilePosition, dynamicTo, u, cameraFollowMissileObject, 10);
             }
-            if ((selectedCaptureAnimationId === 'fighterJetAttack' || selectedCaptureAnimationId === 'helicopterAttack') && u > 0.88) {
+            if ((selectedCaptureAnimationId === 'fighterJetAttack' || selectedCaptureAnimationId === 'helicopterAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack') && u > 0.88) {
               const retreatDir = pos.clone().sub(dynamicTo).setY(0).normalize();
               primaryFx.root.position.addScaledVector(retreatDir, (u - 0.88) * 1.5);
             }
-            if (selectedCaptureAnimationId === 'helicopterAttack' && helicopterMissileImpactAt != null) {
+            if ((selectedCaptureAnimationId === 'helicopterAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack') && helicopterMissileImpactAt != null) {
               const impactElapsed = (elapsed - helicopterMissileImpactAt) / 1000;
               updateExplosionRig(impactElapsed);
             } else {
@@ -13048,7 +13056,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             flyAwayDir.normalize();
             const flyAwayStart = liveExitFrom.clone().add(new THREE.Vector3(0, topStrikeHeight * 0.32, 0));
             const shouldLandAtPark =
-              (selectedCaptureAnimationId === 'fighterJetAttack' || selectedCaptureAnimationId === 'helicopterAttack') &&
+              (selectedCaptureAnimationId === 'fighterJetAttack' || selectedCaptureAnimationId === 'helicopterAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack') &&
               parkedLaunch?.isVector3;
             const parkedReturn =
               shouldLandAtPark
@@ -13093,7 +13101,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             entry.root.visible = false;
           });
           const useHelicopterMissileImpact =
-            selectedCaptureAnimationId === 'helicopterAttack' && helicopterMissileImpactAt != null;
+            (selectedCaptureAnimationId === 'helicopterAttack' || selectedCaptureAnimationId === 'ukrainianDroneAttack') &&
+            helicopterMissileImpactAt != null;
           const explosionElapsed = useHelicopterMissileImpact
             ? (elapsed - helicopterMissileImpactAt) / 1000
             : (elapsed - tunedTravelTime) / 1000;


### PR DESCRIPTION
### Motivation
- Make the two drone options visually and behaviorally distinct so parked weapons show the actual drone model (not the launcher truck) and each drone has its own attack logic. 

### Description
- Show parked drone units instead of the drone-launcher truck by default and hide the truck display when the drone variants are selected, implemented in `webapp/src/pages/Games/LudoBattleRoyal.jsx` (parked visibility changes and selection handling). 
- Split drone kinds into `drone` (Shahad kamikaze) and `ukrainianDrone` (Ukrainian drop) and add mapping/aliases so the catalog resolves each variant, implemented in `webapp/src/config/snakeWeaponCatalog.js` (new `droneAttack`/`ukrainianDroneAttack` entries and alias updates). 
- Add model-kind mapping and rig wiring so `ukrainianDrone` uses the drone model but resolves separately for logic, and register `ukrainianDrone` in the capture vehicle rigs, implemented in `webapp/src/components/SnakeBoard3D.jsx` (`getSnakeCaptureVehicleModelKind`, capture vehicle map, and rig creation). 
- Implement distinct flight/missile behaviors: Shahad (`drone`) follows the kamikaze strike path; Ukrainian (`ukrainianDrone`) follows the aircraft/returning-launch flow and drops a smaller missile straight down with no smoke trail and tighter scaling/precision (missile sizing, path math, and trail suppression were adjusted in `SnakeBoard3D.jsx` and Ludo capture flow). 

### Testing
- Ran lint: `npm --prefix webapp run lint -- src/components/SnakeBoard3D.jsx src/pages/Games/LudoBattleRoyal.jsx src/config/snakeWeaponCatalog.js` and fixed style issues; linter run completed successfully. (✅)
- Built the webapp: `npm --prefix webapp run build` (Vite production build completed successfully; chunks emitted). (✅)
- Dev server started (`npm --prefix webapp run dev`) and served the changed pages for local preview. (✅)
- Attempted an automated Playwright mobile screenshot to validate portrait preview, but Chromium could not launch in the container due to a missing native dependency (`libatk-1.0.so.0`), so the screenshot step failed; code paths were exercised by the build/dev runs. (⚠️)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab5cbc9748329bd38b15e7a9606fe)