### PR TITLE
Fix Murlan Royale human character loading and add procedural fallback

### DIFF
--- a/webapp/src/config/murlanCharacterThemes.js
+++ b/webapp/src/config/murlanCharacterThemes.js
@@ -1,4 +1,4 @@
-import { khronosThumb } from './storeThumbnails.js';
+import { khronosThumb } from './storeThumbnails.js'
 
 export const MURLAN_CHARACTER_THEMES = Object.freeze([
   {
@@ -177,7 +177,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     source: 'hmthanh/3d-human-model GitHub',
     license: 'Check repository license',
     price: 560,
-    description: 'Distinct full-body WebGL humanoid model used as a non-Soldier Pool Royale shooter option.',
+    description: 'Distinct full-body WebGL humanoid model adapted for Murlan Royale seating.',
     url: 'https://raw.githubusercontent.com/hmthanh/3d-human-model/main/Thanh.glb',
     thumbnail: khronosThumb('ThanhHuman'),
     scale: 1.0,
@@ -337,27 +337,5 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     hairColor: 0x21150f,
     eyeColor: 0x4a5d6a,
     skinTone: 0xc98f68
-  },
-  {
-    id: 'threejs-xbot-human',
-    label: 'Xbot Human',
-    source: 'three.js examples',
-    license: 'MIT',
-    price: 580,
-    description: 'Full-body Xbot humanoid from the three.js examples, used as a second new non-Soldier Pool Royale character.',
-    url: 'https://threejs.org/examples/models/gltf/Xbot.glb',
-    thumbnail: khronosThumb('XbotHuman'),
-    scale: 1.0,
-    seatOffsetY: -0.84,
-    seatOffsetZ: -0.22,
-    normalizedSeatOffsetY: -0.4,
-    normalizedSeatOffsetZ: 0.52,
-    seatPitch: 0,
-    seatYaw: 0,
-    handLift: 1.04,
-    clothCombo: 'casinoCheck',
-    hairColor: 0x111111,
-    eyeColor: 0x2f4b5f,
-    skinTone: 0xc9906e
   }
-]);
+])

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1879,6 +1879,7 @@ function cloneModelWithLocalMaterials(source) {
   const clonedRoot = source.clone(true);
   const textureCache = new Map();
   const materialCache = new Map();
+  const geometryCache = new Map();
 
   const cloneTexture = (texture) => {
     if (!texture?.isTexture) return texture ?? null;
@@ -1902,6 +1903,10 @@ function cloneModelWithLocalMaterials(source) {
 
   clonedRoot.traverse((node) => {
     if (!node?.isMesh) return;
+    if (node.geometry) {
+      if (!geometryCache.has(node.geometry)) geometryCache.set(node.geometry, node.geometry.clone());
+      node.geometry = geometryCache.get(node.geometry);
+    }
     if (Array.isArray(node.material)) {
       node.material = node.material.map((mat) => cloneMaterial(mat));
     } else {
@@ -1910,6 +1915,32 @@ function cloneModelWithLocalMaterials(source) {
   });
 
   return clonedRoot;
+}
+
+function localizeCharacterInstanceResources(root) {
+  const geometryCache = new Map();
+  const materialCache = new Map();
+  root?.traverse((node) => {
+    if (!node?.isMesh) return;
+    if (node.geometry) {
+      if (!geometryCache.has(node.geometry)) geometryCache.set(node.geometry, node.geometry.clone());
+      node.geometry = geometryCache.get(node.geometry);
+    }
+    const cloneMaterial = (material) => {
+      if (!material) return material;
+      if (!materialCache.has(material)) materialCache.set(material, material.clone());
+      return materialCache.get(material);
+    };
+    node.material = Array.isArray(node.material)
+      ? node.material.map((material) => cloneMaterial(material))
+      : cloneMaterial(node.material);
+  });
+  return root;
+}
+
+function cloneCharacterTemplateInstance(template) {
+  if (!template) return null;
+  return localizeCharacterInstanceResources(cloneSkeleton(template));
 }
 
 function liftModelToGround(model, targetMinY = 0) {
@@ -2160,13 +2191,115 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0, renderer = 
 
 const CHARACTER_MODEL_CACHE = new Map();
 
+const CHARACTER_FALLBACK_TEMPLATE_CACHE = new Map();
+
+function createFallbackCharacterMaterial(color, roughness = 0.8) {
+  return new THREE.MeshStandardMaterial({
+    color: new THREE.Color(color),
+    roughness,
+    metalness: 0.02
+  });
+}
+
+function addNamedCharacterPart(root, name, mesh, position, rotation = null) {
+  mesh.name = name;
+  mesh.position.copy(position);
+  if (rotation) mesh.rotation.set(rotation.x, rotation.y, rotation.z);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  root.add(mesh);
+  return mesh;
+}
+
+function createProceduralMurlanHumanTemplate(theme = {}) {
+  const root = new THREE.Group();
+  root.name = `murlan-procedural-human-${theme?.id || 'fallback'}`;
+  root.userData.isMurlanProceduralFallback = true;
+
+  const skin = createFallbackCharacterMaterial(theme?.skinTone ?? 0xd19a76, 0.72);
+  const hair = createFallbackCharacterMaterial(theme?.hairColor ?? 0x24160f, 0.86);
+  const jacket = createFallbackCharacterMaterial(theme?.clothColor ?? 0x24324f, 0.82);
+  const shirt = createFallbackCharacterMaterial(0xf6f1e8, 0.74);
+  const pants = createFallbackCharacterMaterial(0x20283a, 0.84);
+  const shoe = createFallbackCharacterMaterial(0x111827, 0.78);
+
+  addNamedCharacterPart(
+    root,
+    'fallback-hips',
+    new THREE.Mesh(new THREE.CapsuleGeometry(0.27, 0.24, 8, 16), pants),
+    new THREE.Vector3(0, 0.74, 0.02),
+    new THREE.Euler(0, 0, Math.PI / 2)
+  );
+  addNamedCharacterPart(
+    root,
+    'fallback-torso',
+    new THREE.Mesh(new THREE.CapsuleGeometry(0.3, 0.56, 10, 18), jacket),
+    new THREE.Vector3(0, 1.22, 0),
+    new THREE.Euler(0.08, 0, 0)
+  );
+  addNamedCharacterPart(
+    root,
+    'fallback-shirt-panel',
+    new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.5, 0.035), shirt),
+    new THREE.Vector3(0, 1.24, -0.27)
+  );
+  addNamedCharacterPart(
+    root,
+    'fallback-head',
+    new THREE.Mesh(new THREE.SphereGeometry(0.22, 22, 18), skin),
+    new THREE.Vector3(0, 1.68, -0.01)
+  );
+  addNamedCharacterPart(
+    root,
+    'fallback-hair',
+    new THREE.Mesh(new THREE.SphereGeometry(0.225, 22, 10, 0, Math.PI * 2, 0, Math.PI * 0.52), hair),
+    new THREE.Vector3(0, 1.74, -0.01)
+  );
+
+  const limbSpecs = [
+    ['fallback-left-upper-arm', -0.36, 1.28, -0.02, 0.13, 0.5, jacket, 0.18],
+    ['fallback-right-upper-arm', 0.36, 1.28, -0.02, 0.13, 0.5, jacket, -0.18],
+    ['fallback-left-forearm', -0.42, 0.95, -0.18, 0.105, 0.42, skin, 0.28],
+    ['fallback-right-forearm', 0.42, 0.95, -0.18, 0.105, 0.42, skin, -0.28],
+    ['fallback-left-thigh', -0.17, 0.48, -0.22, 0.15, 0.52, pants, 0.34],
+    ['fallback-right-thigh', 0.17, 0.48, -0.22, 0.15, 0.52, pants, -0.34],
+    ['fallback-left-calf', -0.2, 0.22, -0.52, 0.12, 0.5, pants, 0.16],
+    ['fallback-right-calf', 0.2, 0.22, -0.52, 0.12, 0.5, pants, -0.16]
+  ];
+
+  limbSpecs.forEach(([name, x, y, z, radius, length, material, zRot]) => {
+    addNamedCharacterPart(
+      root,
+      name,
+      new THREE.Mesh(new THREE.CapsuleGeometry(radius, length, 8, 14), material),
+      new THREE.Vector3(x, y, z),
+      new THREE.Euler(Math.PI / 2.8, 0, zRot)
+    );
+  });
+
+  addNamedCharacterPart(root, 'fallback-left-hand', new THREE.Mesh(new THREE.SphereGeometry(0.095, 16, 12), skin), new THREE.Vector3(-0.47, 0.76, -0.38));
+  addNamedCharacterPart(root, 'fallback-right-hand', new THREE.Mesh(new THREE.SphereGeometry(0.095, 16, 12), skin), new THREE.Vector3(0.47, 0.76, -0.38));
+  addNamedCharacterPart(root, 'fallback-left-shoe', new THREE.Mesh(new THREE.BoxGeometry(0.21, 0.11, 0.32), shoe), new THREE.Vector3(-0.22, 0.02, -0.78));
+  addNamedCharacterPart(root, 'fallback-right-shoe', new THREE.Mesh(new THREE.BoxGeometry(0.21, 0.11, 0.32), shoe), new THREE.Vector3(0.22, 0.02, -0.78));
+
+  return root;
+}
+
+function getProceduralMurlanHumanTemplate(theme = {}) {
+  const cacheKey = theme?.id || 'fallback';
+  if (!CHARACTER_FALLBACK_TEMPLATE_CACHE.has(cacheKey)) {
+    CHARACTER_FALLBACK_TEMPLATE_CACHE.set(cacheKey, createProceduralMurlanHumanTemplate(theme));
+  }
+  return CHARACTER_FALLBACK_TEMPLATE_CACHE.get(cacheKey);
+}
+
 async function loadCharacterModel(theme, renderer = null) {
   const urls = Array.isArray(theme?.modelUrls) && theme.modelUrls.length
     ? theme.modelUrls
     : theme?.url
       ? [theme.url]
       : [];
-  if (!urls.length) throw new Error('Missing character model URL');
+  if (!urls.length) return getProceduralMurlanHumanTemplate(theme);
   const cacheKey = `${theme.id || urls[0]}::${urls.join('|')}`;
   if (CHARACTER_MODEL_CACHE.has(cacheKey)) {
     return CHARACTER_MODEL_CACHE.get(cacheKey);
@@ -2186,10 +2319,21 @@ async function loadCharacterModel(theme, renderer = null) {
       }
     }
     if (!gltf) {
-      throw lastError || new Error(`Character load failed for ${theme.id || 'unknown'}`);
+      console.warn('Using procedural Murlan human fallback because character model failed to load', {
+        characterId: theme?.id,
+        urls,
+        error: lastError
+      });
+      return getProceduralMurlanHumanTemplate(theme);
     }
     const root = gltf.scene || gltf.scenes?.[0];
-    if (!root) throw new Error(`Character scene missing for ${theme.id || 'unknown'}`);
+    if (!root) {
+      console.warn('Using procedural Murlan human fallback because character scene is missing', {
+        characterId: theme?.id,
+        urls
+      });
+      return getProceduralMurlanHumanTemplate(theme);
+    }
     prepareLoadedModel(root, { preserveGltfTextureMapping: true, maxAnisotropy: 8 }); // keep original glTF UV/texture mapping intact
     return root;
   })();
@@ -2592,7 +2736,7 @@ function createThrownCardMesh(color = '#f8fafc') {
 
 function attachSeatedCharacter({ template, seatConfig, characterTheme, store, player = null, playerIndex = 0, cardTheme, cardTextureSize = null }) {
   if (!template || !seatConfig?.chair) return;
-  const instance = cloneSkeleton(template);
+  const instance = cloneCharacterTemplateInstance(template);
   instance.traverse((obj) => {
     if (!obj?.isMesh) return;
     obj.castShadow = true;


### PR DESCRIPTION
### Motivation
- Prevent empty/failed seats when Sketchfab glTF assets are missing or fail to load by providing a robust fallback and avoiding shared template disposal issues.
- Remove the skeleton/Xbot/Soldier-like hosted option from the Murlan roster so human characters are realistic and consistent for portrait mobile framing.

### Description
- Add a procedural seated human template generator and a cached `getProceduralMurlanHumanTemplate(theme)` fallback used when a theme has no model URL or when GLTF loading fails. (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`) 
- Make character cloning localize geometry and materials by cloning meshes' geometry/materials into instance-local caches and expose `cloneCharacterTemplateInstance()` so attached instances don't share disposable resources. (`cloneModelWithLocalMaterials`, `localizeCharacterInstanceResources`, `cloneCharacterTemplateInstance` in `MurlanRoyaleArena.jsx`)
- Update `loadCharacterModel()` to return the procedural fallback when `theme` has no URLs or when remote/local glTF load or scene extraction fails, with console warnings to aid debugging. (`MurlanRoyaleArena.jsx`)
- Remove the Xbot/skeleton-like human option from the Murlan character catalog and update wording that referenced Soldier-style models in the character themes config. (`webapp/src/config/murlanCharacterThemes.js`)

### Testing
- Ran lint: `npm run lint -- src/pages/Games/MurlanRoyaleArena.jsx src/config/murlanCharacterThemes.js` and it completed successfully.
- Built production bundle: `npm run build` and the Vite build finished successfully with assets produced.
- Started preview and attempted an automated mobile screenshot via Playwright (launched `vite preview` and ran a headless Chromium script); the preview server started but screenshot capture timed out in the headless environment after retries, so visual verification in this CI environment was not completed (Playwright browser binaries were installed and system libs added during attempts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab6a13f388329899820fe2583a9e7)