### PR TITLE
Tighten Pool Royale cushion collision mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -8157,7 +8157,7 @@ function makeWoodTexture({
   texture.needsUpdate = true;
   return texture;
 }
-function reflectRails(ball) {
+function reflectRails(ball, previousPos = null) {
   const limX = RAIL_LIMIT_X;
   const limY = RAIL_LIMIT_Y;
   const railRadius = RAIL_CONTACT_RADIUS;
@@ -8303,6 +8303,63 @@ function reflectRails(ball) {
       ball.lastRailHitAt = stamp;
       ball.lastRailHitType = bestImpact.type;
       return { ...bestImpact, preImpactVel };
+    }
+    if (previousPos instanceof THREE.Vector2) {
+      let sweptImpact = null;
+      let sweptTravel = Infinity;
+      for (const segment of CUSHION_SEGMENTS) {
+        if (!segment?.normal || !segment?.start || !segment?.end) continue;
+        if (segment.type === 'jaw' && segment.center && segment.captureRadius != null) {
+          if (ball.pos.distanceTo(segment.center) <= segment.captureRadius) continue;
+        }
+        const contactRadius = segment.type === 'cut' ? cutRadius : railRadius;
+        TMP_VEC2_A.copy(segment.end).sub(segment.start);
+        const lenSq = TMP_VEC2_A.lengthSq();
+        if (lenSq < 1e-8) continue;
+        TMP_VEC2_B.copy(previousPos).sub(segment.start);
+        TMP_VEC2_C.copy(ball.pos).sub(segment.start);
+        const prevSigned = TMP_VEC2_B.dot(segment.normal);
+        const currSigned = TMP_VEC2_C.dot(segment.normal);
+        if (prevSigned < contactRadius || currSigned >= contactRadius) continue;
+        const denom = prevSigned - currSigned;
+        if (denom <= 1e-8) continue;
+        const travel = THREE.MathUtils.clamp((prevSigned - contactRadius) / denom, 0, 1);
+        TMP_VEC2_D.copy(previousPos).lerp(ball.pos, travel).sub(segment.start);
+        const projection = TMP_VEC2_D.dot(TMP_VEC2_A) / lenSq;
+        const endpointPadding = contactRadius / Math.sqrt(lenSq);
+        if (projection < -endpointPadding || projection > 1 + endpointPadding) continue;
+        if (travel < sweptTravel) {
+          sweptTravel = travel;
+          const normal = segment.normal.clone().normalize();
+          sweptImpact = {
+            type:
+              segment.type === 'cut'
+                ? 'cut'
+                : segment.type === 'jaw'
+                  ? 'jaw'
+                  : 'rail',
+            normal,
+            tangent: new THREE.Vector2(-normal.y, normal.x),
+            push: contactRadius - currSigned
+          };
+        }
+      }
+      if (sweptImpact) {
+        ball.pos.addScaledVector(sweptImpact.normal, Math.max(0, sweptImpact.push));
+        preImpactVel = ball.vel.clone();
+        const stamp =
+          typeof performance !== 'undefined' && performance.now
+            ? performance.now()
+            : Date.now();
+        ball.lastRailHitAt = stamp;
+        ball.lastRailHitType = sweptImpact.type;
+        return {
+          type: sweptImpact.type,
+          normal: sweptImpact.normal,
+          tangent: sweptImpact.tangent,
+          preImpactVel
+        };
+      }
     }
     for (let i = 0; i < centers.length; i++) {
       const center = centers[i];
@@ -33707,6 +33764,7 @@ const shotPowerRef = useRef(0);
                 }
               }
             }
+            const previousRailPos = b.pos.clone();
             b.pos.addScaledVector(b.vel, stepScale);
             let speed = b.vel.length();
             let scaledSpeed = speed * stepScale;
@@ -33729,7 +33787,7 @@ const shotPowerRef = useRef(0);
               }
               b.launchDir = null;
             }
-            const railImpact = reflectRails(b);
+            const railImpact = reflectRails(b, previousRailPos);
             if (railImpact && b.id === 'cue') b.impacted = true;
             if (railImpact && shotContextRef.current.contactMade) {
               shotContextRef.current.cushionAfterContact = true;


### PR DESCRIPTION
### Motivation
- Fast-moving balls could skip past mapped cushions/jaws on the Showood table and appear to enter the cushions instead of rebounding, so physics must check swept motion against the precise cushion/jaw mapping. 

### Description
- Added an optional `previousPos` parameter to `reflectRails` and implemented swept collision checks against `CUSHION_SEGMENTS` so the function can detect impacts that occur between physics substeps. 
- When a swept impact is found the code now nudges `ball.pos` back out along the computed normal and returns the same impact object shape (including `preImpactVel`) used by existing rail response handling. 
- Captured the ball pre-move position inside the physics loop (`previousRailPos = b.pos.clone()`) and pass it to `reflectRails(b, previousRailPos)` so the per-step sweep is evaluated. 
- Change is localized to `webapp/src/pages/Games/PoolRoyale.jsx` (cushion mapping / physics update). 

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully. 
- Ran `npm --prefix webapp run lint` and the lint task completed (no blocking errors). 
- Attempted `node --check webapp/src/pages/Games/PoolRoyale.jsx` but Node cannot syntax-check `.jsx` files directly in this ESM project, so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ababe4380832992a29963e3011a21)