### PR TITLE
Fix Murlan Royale human character loading

### DIFF
--- a/webapp/src/config/murlanCharacterThemes.js
+++ b/webapp/src/config/murlanCharacterThemes.js
@@ -177,7 +177,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     source: 'hmthanh/3d-human-model GitHub',
     license: 'Check repository license',
     price: 560,
-    description: 'Distinct full-body WebGL humanoid model used as a non-Soldier Pool Royale shooter option.',
+    description: 'Distinct full-body WebGL humanoid model prepared as a clean Murlan Royale human character option.',
     url: 'https://raw.githubusercontent.com/hmthanh/3d-human-model/main/Thanh.glb',
     thumbnail: khronosThumb('ThanhHuman'),
     scale: 1.0,
@@ -344,7 +344,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     source: 'three.js examples',
     license: 'MIT',
     price: 580,
-    description: 'Full-body Xbot humanoid from the three.js examples, used as a second new non-Soldier Pool Royale character.',
+    description: 'Legacy Xbot humanoid kept as a loader fallback only; hidden from Murlan Royale human character selection.',
     url: 'https://threejs.org/examples/models/gltf/Xbot.glb',
     thumbnail: khronosThumb('XbotHuman'),
     scale: 1.0,
@@ -358,6 +358,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     clothCombo: 'casinoCheck',
     hairColor: 0x111111,
     eyeColor: 0x2f4b5f,
-    skinTone: 0xc9906e
+    skinTone: 0xc9906e,
+    retiredFromMurlanRoster: true,
+    retiredReason: 'Removed from Murlan Royale character selection so skeleton-style placeholders do not appear as playable humans.'
   }
 ]);

--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -26,8 +26,11 @@ const DEFAULT_MURLAN_SHARED_IDS = Object.freeze({
 });
 
 
+const selectableMurlanCharacterThemes = (themes = MURLAN_CHARACTER_THEMES) =>
+  themes.filter((theme) => !theme?.retiredFromMurlanRoster);
+
 const DEFAULT_UNLOCKED_CHARACTER_IDS = Object.freeze(
-  MURLAN_CHARACTER_THEMES.filter((theme, index) => index === 0 || theme?.sourceUrl?.includes('sketchfab.com/3d-models/'))
+  selectableMurlanCharacterThemes().filter((theme, index) => index === 0 || theme?.sourceUrl?.includes('sketchfab.com/3d-models/'))
     .map((theme) => theme.id)
     .filter(Boolean)
 );
@@ -50,7 +53,7 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   tables: mapLabels(MURLAN_TABLE_THEMES),
   tableCloth: mapLabels(MURLAN_TABLE_CLOTH_OPTIONS),
   tableFinish: mapLabels(MURLAN_TABLE_FINISH_OPTIONS),
-  characters: mapLabels(MURLAN_CHARACTER_THEMES),
+  characters: mapLabels(selectableMurlanCharacterThemes()),
   environmentHdri: mapLabels(
     MURLAN_HDRI_OPTIONS.map((variant) => ({
       id: variant.id,
@@ -110,7 +113,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: theme.description || `Premium ${theme.label} seating with original finish.`,
     thumbnail: theme.thumbnail
   })),
-  MURLAN_CHARACTER_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+  selectableMurlanCharacterThemes().filter((theme, idx) => idx > 0).map((theme, idx) => ({
     id: `character-${theme.id}`,
     type: 'characters',
     optionId: theme.id,

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -176,7 +176,11 @@ function hashMurlanCharacterRosterSeed(input) {
 }
 
 function hasMurlanCharacterModelSource(theme) {
-  return Boolean(theme && (theme.url || (Array.isArray(theme.modelUrls) && theme.modelUrls.length)));
+  return Boolean(
+    theme &&
+      !theme.retiredFromMurlanRoster &&
+      (theme.url || (Array.isArray(theme.modelUrls) && theme.modelUrls.length))
+  );
 }
 
 function buildSeatCharacterThemeRoster(baseTheme, players = [], humanSeatIndex = 0, rosterSeed = 0) {
@@ -1737,6 +1741,8 @@ const COMMENTARY_PRIMARY_SPEAKERS = Object.freeze({
   english: MURLAN_ROYALE_SPEAKERS.analyst,
   'latin-pulse': MURLAN_ROYALE_SPEAKERS.analyst
 });
+const MURLAN_SELECTABLE_CHARACTER_THEMES = MURLAN_CHARACTER_THEMES.filter((theme) => !theme?.retiredFromMurlanRoster);
+
 const CUSTOMIZATION_SECTIONS = [
   { key: 'tables', label: 'Table Model', options: TABLE_THEMES },
   { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
@@ -1746,7 +1752,7 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'cards', label: 'Cards', options: CARD_THEMES },
   { key: 'stools', label: 'Stools', options: STOOL_THEMES },
   ...(ENABLE_3D_HUMAN_CHARACTERS
-    ? [{ key: 'characters', label: '3D Players', options: MURLAN_CHARACTER_THEMES }]
+    ? [{ key: 'characters', label: '3D Players', options: MURLAN_SELECTABLE_CHARACTER_THEMES }]
     : [])
 ];
 
@@ -1780,7 +1786,7 @@ function normalizeAppearance(value = {}) {
     const raw = Number(value?.[key]);
     if (Number.isFinite(raw)) {
       const clamped = Math.min(Math.max(0, Math.round(raw)), max - 1);
-      normalized[key] = clamped;
+      normalized[key] = key === 'characters' && MURLAN_CHARACTER_THEMES[clamped]?.retiredFromMurlanRoster ? 0 : clamped;
     }
   });
   return normalized;
@@ -2158,14 +2164,55 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0, renderer = 
   };
 }
 
-const CHARACTER_MODEL_CACHE = new Map();
 
-async function loadCharacterModel(theme, renderer = null) {
-  const urls = Array.isArray(theme?.modelUrls) && theme.modelUrls.length
+const MURLAN_CHARACTER_EXCLUDED_ATTACHMENT_PATTERN = /(^|[\s_.:-])(skeleton|skel|soldier|solder)([\s_.:-]|$)/i;
+const MURLAN_SKETCHFAB_CHARACTER_FALLBACK_MODEL_URLS = Object.freeze([
+  'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
+  'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+  'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+]);
+
+function uniqueCharacterModelUrls(urls = []) {
+  return [...new Set(urls.filter((url) => typeof url === 'string' && url.trim()).map((url) => url.trim()))];
+}
+
+function resolveCharacterModelUrls(theme) {
+  const primaryUrls = Array.isArray(theme?.modelUrls) && theme.modelUrls.length
     ? theme.modelUrls
     : theme?.url
       ? [theme.url]
       : [];
+  const fallbackUrls = theme?.sourceFormat === 'sketchfab-converted-gltf'
+    ? MURLAN_SKETCHFAB_CHARACTER_FALLBACK_MODEL_URLS
+    : [];
+  return uniqueCharacterModelUrls([...primaryUrls, ...fallbackUrls]);
+}
+
+function shouldRemoveCharacterAttachment(obj) {
+  if (!obj || obj.isBone) return false;
+  if (!(obj.isMesh || obj.isLine || obj.isLineSegments || obj.isSprite || obj.isPoints)) return false;
+  const names = [obj.name, obj.userData?.name, obj.material?.name, obj.geometry?.name]
+    .filter(Boolean)
+    .join(' ');
+  return MURLAN_CHARACTER_EXCLUDED_ATTACHMENT_PATTERN.test(names);
+}
+
+function removeExcludedCharacterAttachments(root) {
+  if (!root) return;
+  const removable = [];
+  root.traverse((obj) => {
+    if (shouldRemoveCharacterAttachment(obj)) removable.push(obj);
+  });
+  removable.forEach((obj) => {
+    obj.visible = false;
+    obj.parent?.remove(obj);
+  });
+}
+
+const CHARACTER_MODEL_CACHE = new Map();
+
+async function loadCharacterModel(theme, renderer = null) {
+  const urls = resolveCharacterModelUrls(theme);
   if (!urls.length) throw new Error('Missing character model URL');
   const cacheKey = `${theme.id || urls[0]}::${urls.join('|')}`;
   if (CHARACTER_MODEL_CACHE.has(cacheKey)) {
@@ -2190,6 +2237,7 @@ async function loadCharacterModel(theme, renderer = null) {
     }
     const root = gltf.scene || gltf.scenes?.[0];
     if (!root) throw new Error(`Character scene missing for ${theme.id || 'unknown'}`);
+    removeExcludedCharacterAttachments(root);
     prepareLoadedModel(root, { preserveGltfTextureMapping: true, maxAnisotropy: 8 }); // keep original glTF UV/texture mapping intact
     return root;
   })();


### PR DESCRIPTION
### Motivation
- Prevent empty/placeholder visuals when runtime-only Sketchfab glTF folders are missing and stop skeleton-style fallback models from appearing as playable humans.
- Remove unwanted skeleton/soldier attachments from imported glTFs while preserving animation bones so seated humans render correctly on mobile portrait screens.

### Description
- Retire the legacy Xbot placeholder from selectable Murlan character themes by adding `retiredFromMurlanRoster` metadata and a short `retiredReason` note in `webapp/src/config/murlanCharacterThemes.js`.
- Hide retired characters from UI/rosters and store logic by introducing `selectableMurlanCharacterThemes()` and `MURLAN_SELECTABLE_CHARACTER_THEMES`, and by filtering default unlocks and store items in `webapp/src/config/murlanInventoryConfig.js`.
- Add robust character model resolution and cleanup in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`: implement `resolveCharacterModelUrls()` to include readyplayer.me fallbacks for Sketchfab-backed themes, and add `removeExcludedCharacterAttachments()` that strips visible meshes/attachments whose names match `skeleton|skel|soldier|solder` while leaving bones intact.
- Wire the cleanup and fallback URLs into the load flow by calling `removeExcludedCharacterAttachments(root)` before `prepareLoadedModel(...)` in `loadCharacterModel`, and ensure `hasMurlanCharacterModelSource()` and `normalizeAppearance()` ignore retired themes.

### Testing
- Ran the inventory cross-game unit tests with `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` and all tests passed (9 tests, suite passed).
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.
- Ran `git diff --check` to verify no whitespace/diff-check issues; none reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab6a13f388329899820fe2583a9e7)