### PR TITLE
Tighten Pool Royale Showood cushion mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6868,6 +6868,7 @@ const DEFAULT_RAIL_LIMIT_Y = PLAY_H / 2 - BALL_R - CUSHION_FACE_INSET_SHORT;
 let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
 const RAIL_LIMIT_PADDING = BALL_R * 0.12;
+const SHOWOOD_CUSHION_MAPPING_INWARD_SYNC = BALL_R * 0.42; // shrink gameplay mapping to the visible Showood cushion nose so balls rebound before visually entering the rubber
 const RAIL_CONTACT_RADIUS = BALL_R;
 const CUSHION_CUT_CONTACT_RADIUS = RAIL_CONTACT_RADIUS * 1.12;
 const CUSHION_CUT_NEAR_POCKET_BUFFER = BALL_R * 0.9;
@@ -9225,6 +9226,17 @@ function updateCushionSegmentsFromTable(table) {
     }
     segment.normal = normal.clone();
   });
+  const syncSegmentsToVisibleShowoodCushionNose = (segmentList) => {
+    const inwardSync = Math.max(0, SHOWOOD_CUSHION_MAPPING_INWARD_SYNC);
+    if (!(inwardSync > MICRO_EPS)) return;
+    segmentList.forEach((segment) => {
+      if (!segment?.normal || segment.type === 'jaw') return;
+      segment.start.addScaledVector(segment.normal, inwardSync);
+      segment.end.addScaledVector(segment.normal, inwardSync);
+      segment.showoodMappingInwardSync = inwardSync;
+    });
+  };
+  syncSegmentsToVisibleShowoodCushionNose(segments);
   const updateRailLimitsFromSegments = (segmentList) => {
     let minAbsX = Infinity;
     let minAbsY = Infinity;


### PR DESCRIPTION
### Motivation
- Prevent balls from visually entering Showood cushions by aligning collision geometry with the visible cushion nose so rebounds happen where players expect them on-screen.

### Description
- Added `SHOWOOD_CUSHION_MAPPING_INWARD_SYNC` (scaled from `BALL_R`) to control an inward mapping inset for Showood cushions.
- Implemented `syncSegmentsToVisibleShowoodCushionNose` inside `updateCushionSegmentsFromTable` which shifts rail/cut segment start/end points along their normals by the inset and tags segments with `showoodMappingInwardSync`.
- The inward sync is applied after cushion normals are resolved and before rail limits are derived so `RAIL_LIMIT_X`/`RAIL_LIMIT_Y` are recalculated from the tightened segments.
- Jaw (pocket) arc segments are intentionally left unchanged so pocket capture geometry remains authoritative.

### Testing
- Ran the Pool Royale unit tests: `npm test -- --runInBand test/poolRoyaleTableModels.test.js test/poolRoyalePocketAim.test.js` and both suites passed (2 test suites, 7 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ababe4380832992a29963e3011a21)