### PR TITLE
Enlarge Pool Royale table footprint

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1303,7 +1303,7 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
   const TABLE_SURFACE_REFERENCE = 1.12; // baseline expansion before the wider table adjustment
-  const TABLE_SURFACE_EXPANSION = 1.25; // widen/lengthen the table footprint by ~12% while keeping pockets/balls unchanged
+  const TABLE_SURFACE_EXPANSION = 1.3; // widen/lengthen the table footprint by ~16% so the visible table better matches the mapped player field while keeping pockets/balls unchanged
   const TABLE_SURFACE_COMPENSATION = TABLE_SURFACE_EXPANSION / TABLE_SURFACE_REFERENCE;
   const TABLE = {
     W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * OFFICIAL_TABLE_SCALE * TABLE_SURFACE_EXPANSION,


### PR DESCRIPTION
### Motivation
- Make the Pool Royale table render slightly larger on portrait/mobile so the visible table better matches the player-field mapping and UI framing by adjusting the surface expansion used for visual layout.

### Description
- Increased `TABLE_SURFACE_EXPANSION` from `1.25` to `1.3` in `webapp/src/pages/Games/PoolRoyale.jsx` so the table footprint (width/length) is expanded ~16% visually while keeping pocket and ball metrics tied to the existing compensation path.

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully; this verifies the code compiles into the webapp bundle. 
- Ran `npx playwright install chromium` and `npx playwright install-deps chromium` to provision browser and OS deps; both completed successfully. 
- Attempted an automated Playwright mobile screenshot of `/games/poolroyale?mode=practice`, but the headless screenshot step could not produce a stable image in this environment despite installing deps, so visual verification via the CI headless renderer failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af65c1f888329b0538c3ac563ecf0)