### PR TITLE
Enlarge Pool Royal table preview

### DIFF
--- a/webapp/src/pages/Games/PoolRoyal.jsx
+++ b/webapp/src/pages/Games/PoolRoyal.jsx
@@ -14,6 +14,7 @@ const TABLE_MODEL_URL =
 const DRACO_DECODER_PATH = "https://www.gstatic.com/draco/versioned/decoders/1.5.7/";
 const BASIS_TRANSCODER_PATH = "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/";
 const CUSHION_SHADOW_GREY = "#666a72";
+const TABLE_PREVIEW_TARGET_LONG_SIDE = 8.8;
 
 type TablePart =
   | "cloth"
@@ -895,7 +896,7 @@ function fitTable(table: THREE.Object3D) {
   table.rotation.y = Math.PI;
   const box = new THREE.Box3().setFromObject(table);
   const size = box.getSize(new THREE.Vector3());
-  table.scale.setScalar(8.4 / Math.max(size.x, size.z, 0.001));
+  table.scale.setScalar(TABLE_PREVIEW_TARGET_LONG_SIDE / Math.max(size.x, size.z, 0.001));
   table.updateMatrixWorld(true);
 
   const fitBox = new THREE.Box3().setFromObject(table);


### PR DESCRIPTION
### Motivation
- Make the Pool Royal table preview slightly larger so the loaded Showood GLB better matches the playfield/player mapping and avoid a hard-coded magic scale.

### Description
- Introduce `TABLE_PREVIEW_TARGET_LONG_SIDE = 8.8` and use it in `fitTable()` instead of the previous inline `8.4`, updating `webapp/src/pages/Games/PoolRoyal.jsx` so previewed tables render a bit bigger.

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully and produced the dist artifacts.
- Ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af65c1f888329b0538c3ac563ecf0)