### PR TITLE
Preserve original Ukrainian drone GLB visuals (Ludo/Chess/Snake)

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -5727,7 +5727,7 @@ async function resolveExternalImageToDataUri(imageUri, kind, sourceUrl, modelUrl
   if (isDataUri(imageUri)) return imageUri;
   const placeholderColors = {
     drone: ['#7c8791', '#4f5861'],
-    ukrainianDrone: ['#2f80ed', '#f2c94c'],
+    ukrainianDrone: ['#7c8791', '#4f5861'],
     helicopter: ['#6f7763', '#4f5648'],
     fighter: ['#98a1a9', '#646d76'],
     supportTruck: ['#6b7280', '#4b5563'],
@@ -5856,7 +5856,9 @@ function createCaptureVehicleRig(kind = 'fighter') {
     loadCaptureVehicleModel(kind)
       .then((model) => {
         if (!model) return;
-        applyCaptureVehicleLook(model, visualKind);
+        if (kind !== 'ukrainianDrone') {
+          applyCaptureVehicleLook(model, visualKind);
+        }
         while (root.children.length > 0) {
           const child = root.children[0];
           if (child?.userData?.trailPuff) break;

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -11090,7 +11090,7 @@ function Chess3D({
       root.userData.ukrainianDroneAccentGroup.visible = Boolean(visible);
       return root.userData.ukrainianDroneAccentGroup;
     };
-    const createFxDrone = ({ forceProcedural = false } = {}) => {
+    const createFxDrone = ({ forceProcedural = false, exactOriginal = false } = {}) => {
       const model = forceProcedural ? null : cloneCaptureUnitTemplate('drone');
       if (model) {
         const root = new THREE.Group();
@@ -11100,7 +11100,9 @@ function Chess3D({
           model.getObjectByName('Propeller') ||
           model.getObjectByName('Rotor') ||
           model;
-        applyMilitaryDroneLook(model, propeller, getCaptureToneSeed('drone'));
+        if (!exactOriginal) {
+          applyMilitaryDroneLook(model, propeller, getCaptureToneSeed('drone'));
+        }
         return { root, propeller, exhaustClouds: [] };
       }
       const root = new THREE.Group();
@@ -12538,26 +12540,14 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_HELICOPTER_TOTAL * 1000;
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedDrone = acquireParkedAirUnit(isWhiteSide, 'drone');
-        const droneFx = parkedDrone || createFxDrone({ forceProcedural: !parkedDrone });
+        const droneFx = parkedDrone || createFxDrone({ forceProcedural: !parkedDrone, exactOriginal: true });
         if (!parkedDrone) {
           droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
           captureFxGroup.add(droneFx.root);
         }
         const launchBase = parkedDrone?.root?.position?.clone?.() || parkedDrone?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'drone', 0);
-        const sideSkin = resolveSideVehicleSkin(isWhiteSide);
-        if (sideSkin) {
-          applyVehicleSkinToModel(droneFx.root, sideSkin, (node) =>
-            /rotor|propell|blade|fan|window|cockpit|glass|canopy/.test(`${node.name || ''}`.toLowerCase())
-          );
-        }
-        setUkrainianDroneAccentsVisible(droneFx.root, true);
-        attachVehicleAvatarBadge(
-          droneFx.root,
-          isWhiteSide
-            ? avatar || username || playerFlag || '🙂'
-            : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
-          isWhiteSide ? 1 : -1
-        );
+        // Keep the Ukrainian drone visually identical to the source drone.glb asset.
+        setUkrainianDroneAccentsVisible(droneFx.root, false);
         droneFx.root.position.copy(launchBase.clone());
         const missileFx = createFxNoSmokeDropMissile();
         missileFx.root.scale.setScalar(CAPTURE_UKRAINIAN_DRONE_MISSILE_SCALE);
@@ -13333,10 +13323,9 @@ function Chess3D({
             parkedIsWhite: isWhite
           };
         }
-        const sideDrone = createFxDrone();
+        const sideDrone = createFxDrone({ exactOriginal: true });
         sideDrone.root.scale.setScalar(CAPTURE_DRONE_SCALE * 1.15 * SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER);
-        if (skin) applyVehicleSkinToModel(sideDrone.root, skin);
-        attachVehicleAvatarBadge(sideDrone.root, badge, isWhite ? 1 : -1);
+        // Do not reskin/badge the parked drone; it must match the original drone.glb asset.
         const dronePad = getAirPadAnchor(isWhite, 'drone', 0);
         sideDrone.root.position.copy(dronePad);
         sideDrone.root.rotation.y = isWhite ? -Math.PI * 0.13 : Math.PI * 1.13;

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2854,7 +2854,7 @@ async function createCaptureDroneLauncherTruckFx() {
   };
 }
 
-async function createCaptureDroneFx() {
+async function createCaptureDroneFx({ preserveOriginalDrone = false } = {}) {
   const root = new THREE.Group();
   root.userData.lockCaptureTexture = true;
   const loadedDrone = await loadCaptureVehicleModel('drone');
@@ -2862,22 +2862,24 @@ async function createCaptureDroneFx() {
     const model = loadedDrone.clone(true);
     fitObjectToTargetSize(model, 3.85 * CAPTURE_DRONE_SIZE_MULTIPLIER);
     model.rotation.y = Math.PI;
-    const propeller = applyMilitaryDroneLook(model);
+    const propeller = preserveOriginalDrone ? findDroneMotorMesh(model) : applyMilitaryDroneLook(model);
     root.add(model);
     const trail = [];
-    for (let i = 0; i < 5; i += 1) {
-      trail.push(
-        addFxSphere(
-          root,
-          0.12 + i * 0.03,
-          [-0.84 - i * 0.19, 0, 0],
-          i < 2 ? '#f6af4b' : '#8f989d',
-          i < 2 ? 0.2 : 1,
-          0,
-          true,
-          i < 2 ? 0.8 - i * 0.15 : 0.26 - (i - 2) * 0.04
-        )
-      );
+    if (!preserveOriginalDrone) {
+      for (let i = 0; i < 5; i += 1) {
+        trail.push(
+          addFxSphere(
+            root,
+            0.12 + i * 0.03,
+            [-0.84 - i * 0.19, 0, 0],
+            i < 2 ? '#f6af4b' : '#8f989d',
+            i < 2 ? 0.2 : 1,
+            0,
+            true,
+            i < 2 ? 0.8 - i * 0.15 : 0.26 - (i - 2) * 0.04
+          )
+        );
+      }
     }
     root.visible = false;
     return { root, propeller, trail };
@@ -9149,7 +9151,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       // eslint-disable-next-line no-await-in-loop
       const helicopterFx = await createCaptureHelicopterFx();
       // eslint-disable-next-line no-await-in-loop
-      const droneFx = await createCaptureDroneFx();
+      const droneFx = await createCaptureDroneFx({ preserveOriginalDrone: true });
       // eslint-disable-next-line no-await-in-loop
       const missileFx = await createCaptureMissileTruckFx();
       // eslint-disable-next-line no-await-in-loop
@@ -12542,7 +12544,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         if (isFighterJetAttack) playFighterJetSound();
         const primaryFx =
           (resolvedCaptureAnimationId === 'droneAttack' || resolvedCaptureAnimationId === 'ukrainianDroneAttack')
-            ? await createCaptureDroneFx()
+            ? await createCaptureDroneFx({ preserveOriginalDrone: resolvedCaptureAnimationId === 'ukrainianDroneAttack' })
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? await createCaptureHelicopterFx()
             : resolvedCaptureAnimationId === 'fighterJetAttack'


### PR DESCRIPTION
### Motivation
- Ensure the Ukrainian drone attack uses the exact same `drone.glb` visuals (no reskin/badging/trail repaint) so the in‑game Ukrainian drone matches the source asset across Ludo, Chess and Snake views.

### Description
- Ludo: updated `createCaptureDroneFx` to accept `preserveOriginalDrone` and, when true, avoid the military re-material pass and procedural smoke trail, and use the drone model's original propeller node; parked drone generation and Ukrainian attack calls now request the preserved-original path (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Chess: extended `createFxDrone` with `exactOriginal` so cloned drones can skip `applyMilitaryDroneLook`; Ukrainian drone attack and parked drone displays use `exactOriginal` and skip reskin/badge/accents so they match the GLB asset (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Snake & Ladder: aligned Ukrainian drone fallback palette to the standard drone palette and prevented the capture-vehicle repaint for `ukrainianDrone` so the GLB materials are kept intact (`webapp/src/components/SnakeBoard3D.jsx`).
- Small helper updates: calls that construct parked/drone FX or choose drone variant pass the new flags so parked units and in-flight Ukrainian drops consistently use the original model.

### Testing
- Ran lint: `npm run lint -- --quiet src/pages/Games/LudoBattleRoyal.jsx src/pages/Games/ChessBattleRoyal.jsx src/pages/Games/SnakeAndLadder.jsx src/components/SnakeBoard3D.jsx` — succeeded.
- Ran full production build: `npm run build` — succeeded (Vite build completed without runtime errors reported during build).
- Dev verification: started Vite dev server and attempted an automated portrait screenshot via Playwright, but headless Chromium failed to launch in the container due to a missing system library (`libatk-1.0.so.0`) so the screenshot step could not complete; the dev server itself started normally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b03e8d5b483299234d530156f5d7c)