### PR TITLE
Fix Pool Royale cushion collision mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6863,8 +6863,11 @@ const STANDING_VIEW_COT = (() => {
   const sinPhi = Math.sin(STANDING_VIEW_PHI);
   return sinPhi > 1e-6 ? Math.cos(STANDING_VIEW_PHI) / sinPhi : 0;
 })();
-const DEFAULT_RAIL_LIMIT_X = PLAY_W / 2 - BALL_R - CUSHION_FACE_INSET_LONG;
-const DEFAULT_RAIL_LIMIT_Y = PLAY_H / 2 - BALL_R - CUSHION_FACE_INSET_SHORT;
+const CUSHION_COLLISION_INWARD_OFFSET = BALL_R * 0.34; // keep rail physics on the visible cushion nose so balls bounce before overlapping the rubber
+const DEFAULT_RAIL_LIMIT_X =
+  PLAY_W / 2 - BALL_R - CUSHION_FACE_INSET_LONG - CUSHION_COLLISION_INWARD_OFFSET;
+const DEFAULT_RAIL_LIMIT_Y =
+  PLAY_H / 2 - BALL_R - CUSHION_FACE_INSET_SHORT - CUSHION_COLLISION_INWARD_OFFSET;
 let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
 const RAIL_LIMIT_PADDING = BALL_R * 0.12;
@@ -9071,13 +9074,19 @@ function updateRailLimitsFromTable(table) {
     }
   }
   if (minAbsX !== Infinity) {
-    const computedX = Math.max(0, minAbsX - BALL_R - RAIL_LIMIT_PADDING);
+    const computedX = Math.max(
+      0,
+      minAbsX - BALL_R - RAIL_LIMIT_PADDING - CUSHION_COLLISION_INWARD_OFFSET
+    );
     if (computedX > 0) {
       RAIL_LIMIT_X = Math.min(DEFAULT_RAIL_LIMIT_X, computedX);
     }
   }
   if (minAbsZ !== Infinity) {
-    const computedZ = Math.max(0, minAbsZ - BALL_R - RAIL_LIMIT_PADDING);
+    const computedZ = Math.max(
+      0,
+      minAbsZ - BALL_R - RAIL_LIMIT_PADDING - CUSHION_COLLISION_INWARD_OFFSET
+    );
     if (computedZ > 0) {
       RAIL_LIMIT_Y = Math.min(DEFAULT_RAIL_LIMIT_Y, computedZ);
     }
@@ -9224,6 +9233,11 @@ function updateCushionSegmentsFromTable(table) {
       normal.multiplyScalar(-1);
     }
     segment.normal = normal.clone();
+  });
+  segments.forEach((segment) => {
+    if (!segment?.normal || segment.type === 'jaw') return;
+    segment.start.addScaledVector(segment.normal, CUSHION_COLLISION_INWARD_OFFSET);
+    segment.end.addScaledVector(segment.normal, CUSHION_COLLISION_INWARD_OFFSET);
   });
   const updateRailLimitsFromSegments = (segmentList) => {
     let minAbsX = Infinity;


### PR DESCRIPTION
### Motivation
- Balls were visually overlapping the cushion geometry on impact; collisions should occur at the visible cushion nose so rebounds happen before overlapping the rubber.

### Description
- Added `CUSHION_COLLISION_INWARD_OFFSET` and moved default rail limits inward so physics bounds align with the visible cushion noses in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Subtracted the inward offset when computing fallback `RAIL_LIMIT_X/Y` from live table cushion boxes so runtime rail bounds match the visual cushions.
- Shifted generated cushion rail/cut `segments` inward by the same offset (but skipped `jaw` segments) so cushion collision tests resolve before geometry overlap while preserving pocket jaw capture geometry.
- Kept all changes localized to the Pool Royale table mapping and collision helpers to avoid side effects elsewhere.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Ran `npm --prefix webapp run lint -- src/pages/Games/PoolRoyale.jsx` and lint passed for the modified file.
- Ran `git diff --check` to ensure no whitespace/merge issues and committed the change.
- Attempted a headless mobile Playwright screenshot to validate visual behavior but it timed out / failed due to environment issues (missing system libs and remote resource loading), so automated visual capture did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b034ca68c8329b68ee29a0bff356c)