### PR TITLE
Fix Pool Royale cushion collision mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6863,8 +6863,11 @@ const STANDING_VIEW_COT = (() => {
   const sinPhi = Math.sin(STANDING_VIEW_PHI);
   return sinPhi > 1e-6 ? Math.cos(STANDING_VIEW_PHI) / sinPhi : 0;
 })();
-const DEFAULT_RAIL_LIMIT_X = PLAY_W / 2 - BALL_R - CUSHION_FACE_INSET_LONG;
-const DEFAULT_RAIL_LIMIT_Y = PLAY_H / 2 - BALL_R - CUSHION_FACE_INSET_SHORT;
+const CUSHION_GAMEPLAY_CONTACT_INSET = BALL_R * 0.36; // keep the physics contact line visually inside the cushion nose so balls rebound before overlapping the rubber.
+const DEFAULT_RAIL_LIMIT_X =
+  PLAY_W / 2 - BALL_R - CUSHION_FACE_INSET_LONG - CUSHION_GAMEPLAY_CONTACT_INSET;
+const DEFAULT_RAIL_LIMIT_Y =
+  PLAY_H / 2 - BALL_R - CUSHION_FACE_INSET_SHORT - CUSHION_GAMEPLAY_CONTACT_INSET;
 let RAIL_LIMIT_X = DEFAULT_RAIL_LIMIT_X;
 let RAIL_LIMIT_Y = DEFAULT_RAIL_LIMIT_Y;
 const RAIL_LIMIT_PADDING = BALL_R * 0.12;
@@ -8255,8 +8258,6 @@ function reflectRails(ball) {
       if (segment.type === 'jaw' && segment.center && segment.captureRadius != null) {
         if (ball.pos.distanceTo(segment.center) <= segment.captureRadius) continue;
       }
-      const velocityToward = ball.vel.dot(segment.normal);
-      if (velocityToward >= 0) continue;
       TMP_VEC2_A.copy(segment.end).sub(segment.start);
       const lenSq = TMP_VEC2_A.lengthSq();
       if (lenSq < 1e-8) continue;
@@ -9071,13 +9072,19 @@ function updateRailLimitsFromTable(table) {
     }
   }
   if (minAbsX !== Infinity) {
-    const computedX = Math.max(0, minAbsX - BALL_R - RAIL_LIMIT_PADDING);
+    const computedX = Math.max(
+      0,
+      minAbsX - BALL_R - RAIL_LIMIT_PADDING - CUSHION_GAMEPLAY_CONTACT_INSET
+    );
     if (computedX > 0) {
       RAIL_LIMIT_X = Math.min(DEFAULT_RAIL_LIMIT_X, computedX);
     }
   }
   if (minAbsZ !== Infinity) {
-    const computedZ = Math.max(0, minAbsZ - BALL_R - RAIL_LIMIT_PADDING);
+    const computedZ = Math.max(
+      0,
+      minAbsZ - BALL_R - RAIL_LIMIT_PADDING - CUSHION_GAMEPLAY_CONTACT_INSET
+    );
     if (computedZ > 0) {
       RAIL_LIMIT_Y = Math.min(DEFAULT_RAIL_LIMIT_Y, computedZ);
     }
@@ -9224,6 +9231,10 @@ function updateCushionSegmentsFromTable(table) {
       normal.multiplyScalar(-1);
     }
     segment.normal = normal.clone();
+    if (segment.type === 'rail' || segment.type === 'cut') {
+      segment.start.addScaledVector(segment.normal, CUSHION_GAMEPLAY_CONTACT_INSET);
+      segment.end.addScaledVector(segment.normal, CUSHION_GAMEPLAY_CONTACT_INSET);
+    }
   });
   const updateRailLimitsFromSegments = (segmentList) => {
     let minAbsX = Infinity;


### PR DESCRIPTION
### Motivation
- Balls were visually entering/overlapping cushion geometry because the physics contact boundary sat on or beyond the visible cushion nose, causing seams and incorrect rebounds.
- Make the gameplay collision line sit visually inside the cushion nose so rebounds occur before any overlap, and ensure segment-based collision correction still resolves overlaps even when a ball is separating.

### Description
- Added `CUSHION_GAMEPLAY_CONTACT_INSET` and used it to move the gameplay rail/contact limits inward by `BALL_R * 0.36` so the physics contact line is visually inside the cushion nose (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Apply the inset when computing `DEFAULT_RAIL_LIMIT_X` / `DEFAULT_RAIL_LIMIT_Y` and in `updateRailLimitsFromTable` so computed rail limits follow the visual cushion placement.
- When building cushion collision segments in `updateCushionSegmentsFromTable`, shift `segment.start`/`segment.end` inward by the inset for `rail`/`cut` segments so collision arcs map inside the visible cushion geometry.
- Keep the penetration/overlap correction active for segments (removed the strict early `velocityToward` skip) so balls that are touching or slightly separating are pushed out instead of remaining overlapped at cushion edges.

### Testing
- Ran `git diff --check` to validate whitespace/patch checks and it passed.
- Ran `npm --prefix webapp run lint -- src/pages/Games/PoolRoyale.jsx` and the lint check passed.
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Attempted an automated Playwright screenshot of `/games/poolroyale` after installing browser deps; the page loaded and the scene rendered but headless screenshot capture timed out on the heavy WebGL scene (diagnostic only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b034ca68c8329b68ee29a0bff356c)