### PR TITLE
Add support for exact Ukrainian drone GLB and prefer it in capture visuals/UI

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -10,6 +10,10 @@ import { EXRLoader } from 'three/addons/loaders/EXRLoader.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js';
+import {
+  isExactUkrainianDroneObject,
+  loadExactUkrainianDroneModel
+} from '../utils/ukrainianDroneModel.js';
 
 import {
   createMurlanStyleTable,
@@ -5786,6 +5790,14 @@ async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cach
 }
 
 async function loadCaptureVehicleModel(kind = 'fighter') {
+  if (kind === 'drone' || kind === 'ukrainianDrone') {
+    const cacheKey = `${kind}:exactUkrainianDrone`;
+    if (!SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.has(cacheKey)) {
+      SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.set(cacheKey, loadExactUkrainianDroneModel().then((model) => normalizeCaptureVehicleModel(model)));
+    }
+    const model = await SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.get(cacheKey);
+    return model?.clone?.(true) ?? null;
+  }
   const files = SNAKE_CAPTURE_VEHICLE_MODEL_FILES[kind] || SNAKE_CAPTURE_VEHICLE_MODEL_FILES.fighter;
   const fileList = Array.isArray(files) ? files : [files];
   const cacheKey = `${kind}:${fileList.join('|')}`;
@@ -5856,7 +5868,7 @@ function createCaptureVehicleRig(kind = 'fighter') {
     loadCaptureVehicleModel(kind)
       .then((model) => {
         if (!model) return;
-        applyCaptureVehicleLook(model, visualKind);
+        if (!isExactUkrainianDroneObject(model)) applyCaptureVehicleLook(model, visualKind);
         while (root.children.length > 0) {
           const child = root.children[0];
           if (child?.userData?.trailPuff) break;

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -67,6 +67,11 @@ import GiftPopup from '../../components/GiftPopup.jsx';
 import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import { socket } from '../../utils/socket.js';
+import {
+  findExactUkrainianDroneRotor,
+  isExactUkrainianDroneObject,
+  loadExactUkrainianDroneModel
+} from '../../utils/ukrainianDroneModel.js';
 import { giftSounds } from '../../utils/giftSounds.js';
 import { CAPTURE_ANIMATION_OPTIONS } from '../../config/ludoBattleOptions.js';
 import { LUDO_WEAPON_DIRECTOR_BRIDGE } from '../../config/ludoWeaponDirectorBridge.js';
@@ -8485,6 +8490,8 @@ function Chess3D({
   const QUICK_SWAP_WEAPON_IDS = useMemo(
     () =>
       [
+        'ukrainianDroneAttack',
+        'droneAttack',
         'polyShotgun01Attack',
         'polyAssaultRifle01Attack',
         'polyPistol01Attack',
@@ -8563,13 +8570,15 @@ function Chess3D({
     if (!weaponSwapTargetKind) return pool;
 
     // Parked pads (jet / drone / helicopter / truck) can now be swapped with any owned firearm.
-    // Keep full firearm inventory visible when player taps one of those parked vehicles.
+    // On portrait phones, keep the matching vehicle options first so Ukrainian Drone is visible
+    // immediately at the top of the drone quick-swap sheet instead of below the firearm list.
     if (['jet', 'drone', 'helicopter', 'truck'].includes(weaponSwapTargetKind)) {
-      const firearmAndOriginalVehicle = pool.filter((option) => {
-        if (FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)) return true;
-        return isCaptureAnimationVisibleOnParkedKind(option.id, weaponSwapTargetKind);
-      });
-      if (firearmAndOriginalVehicle.length) return firearmAndOriginalVehicle;
+      const matchingVehicles = pool.filter(
+        (option) => !FIREARM_CAPTURE_ANIMATION_IDS.has(option.id) && isCaptureAnimationVisibleOnParkedKind(option.id, weaponSwapTargetKind)
+      );
+      const firearms = pool.filter((option) => FIREARM_CAPTURE_ANIMATION_IDS.has(option.id));
+      const ordered = [...matchingVehicles, ...firearms];
+      if (ordered.length) return ordered;
     }
 
     const filtered = pool.filter((option) => {
@@ -10716,6 +10725,16 @@ function Chess3D({
 
     const loadCaptureUnitTemplate = async (key, targetSize) => {
       if (captureUnitTemplates[key]) return captureUnitTemplates[key];
+      if (key === 'drone') {
+        if (!captureUnitLoads.exactUkrainianDrone) {
+          captureUnitLoads.exactUkrainianDrone = loadExactUkrainianDroneModel(renderer).then((model) => {
+            normalizeModel(model, targetSize);
+            captureUnitTemplates[key] = model;
+            return model;
+          });
+        }
+        return captureUnitLoads.exactUkrainianDrone;
+      }
       if (captureUnitLoads[key]) return captureUnitLoads[key];
       const urls = CAPTURE_MODEL_URLS[key] || [];
       const loader = createConfiguredGLTFLoader(renderer);
@@ -11047,7 +11066,7 @@ function Chess3D({
       return badge;
     };
     const setUkrainianDroneAccentsVisible = (root, visible = true) => {
-      if (!root) return null;
+      if (!root || isExactUkrainianDroneObject(root)) return null;
       if (!root.userData.ukrainianDroneAccentGroup) {
         const accentGroup = new THREE.Group();
         accentGroup.name = 'ukrainian-drone-blue-yellow-accents';
@@ -11100,8 +11119,9 @@ function Chess3D({
           model.getObjectByName('Propeller') ||
           model.getObjectByName('Rotor') ||
           model;
-        applyMilitaryDroneLook(model, propeller, getCaptureToneSeed('drone'));
-        return { root, propeller, exhaustClouds: [] };
+        const exactDronePropeller = isExactUkrainianDroneObject(model) ? findExactUkrainianDroneRotor(model) : null;
+        if (!isExactUkrainianDroneObject(model)) applyMilitaryDroneLook(model, propeller, getCaptureToneSeed('drone'));
+        return { root, propeller: exactDronePropeller || propeller, exhaustClouds: [] };
       }
       const root = new THREE.Group();
       root.scale.setScalar(0.3);

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -63,6 +63,10 @@ import {
 import { giftSounds } from '../../utils/giftSounds.js';
 import { playLudoDiceRollSfx, playLudoTokenStepSfx } from '../../utils/ludoSfx.js';
 import { socket } from '../../utils/socket.js';
+import {
+  findExactUkrainianDroneRotor,
+  loadExactUkrainianDroneModel
+} from '../../utils/ukrainianDroneModel.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
@@ -2854,6 +2858,23 @@ async function createCaptureDroneLauncherTruckFx() {
   };
 }
 
+
+function upgradeCaptureDroneRootToExactModel(root, currentModel, targetSize) {
+  if (!root?.isObject3D) return;
+  void loadExactUkrainianDroneModel()
+    .then((exactModel) => {
+      if (!root?.isObject3D || !exactModel) return;
+      fitObjectToTargetSize(exactModel, targetSize);
+      exactModel.rotation.y = Math.PI;
+      if (currentModel?.parent === root) root.remove(currentModel);
+      root.add(exactModel);
+      root.userData.exactUkrainianDroneVisual = exactModel;
+      root.userData.exactUkrainianDronePropeller = findExactUkrainianDroneRotor(exactModel) || exactModel;
+    })
+    .catch((error) => {
+      console.warn('Exact Ukrainian drone visual failed; keeping existing Ludo drone visible.', error);
+    });
+}
 async function createCaptureDroneFx() {
   const root = new THREE.Group();
   root.userData.lockCaptureTexture = true;
@@ -2864,6 +2885,7 @@ async function createCaptureDroneFx() {
     model.rotation.y = Math.PI;
     const propeller = applyMilitaryDroneLook(model);
     root.add(model);
+    upgradeCaptureDroneRootToExactModel(root, model, 3.85 * CAPTURE_DRONE_SIZE_MULTIPLIER);
     const trail = [];
     for (let i = 0; i < 5; i += 1) {
       trail.push(

--- a/webapp/src/utils/ukrainianDroneModel.js
+++ b/webapp/src/utils/ukrainianDroneModel.js
@@ -1,0 +1,362 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js';
+
+THREE.Cache.enabled = true;
+
+export const UKRAINIAN_DRONE_SOURCES = Object.freeze([
+  {
+    label: 'jsDelivr',
+    url: 'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb'
+  },
+  {
+    label: 'raw GitHub',
+    url: 'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb'
+  },
+  {
+    label: 'Statically',
+    url: 'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
+  }
+]);
+
+const MODEL_LOAD_TIMEOUT_MS = 150000;
+const TEXTURE_FETCH_TIMEOUT_MS = 90000;
+const GLB_MAGIC = 0x46546c67;
+const GLB_VERSION = 2;
+const GLB_JSON_CHUNK = 0x4e4f534a;
+const GLB_BIN_CHUNK = 0x004e4942;
+const FALLBACK_PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+let sharedDronePromise = null;
+let sharedKtx2Loader = null;
+
+function isAbsoluteOrDataUrl(url) {
+  return /^(https?:)?\/\//i.test(url) || url.startsWith('data:') || url.startsWith('blob:');
+}
+
+function parentFolder(url) {
+  return url.slice(0, url.lastIndexOf('/') + 1);
+}
+
+function normalizeResourcePath(resourceUrl) {
+  try {
+    return decodeURIComponent(resourceUrl).replace(/\\/g, '/').replace(/^\.\//, '');
+  } catch {
+    return resourceUrl.replace(/\\/g, '/').replace(/^\.\//, '');
+  }
+}
+
+function resolveRelativeUrl(url, baseFolder) {
+  if (isAbsoluteOrDataUrl(url)) return url;
+  return new URL(normalizeResourcePath(url), baseFolder).toString();
+}
+
+function mimeFromUri(uri) {
+  const clean = uri.split('?')[0].split('#')[0].toLowerCase();
+  if (clean.endsWith('.jpg') || clean.endsWith('.jpeg')) return 'image/jpeg';
+  if (clean.endsWith('.webp')) return 'image/webp';
+  if (clean.endsWith('.ktx2') || clean.endsWith('.basis')) return 'image/ktx2';
+  if (clean.endsWith('.bin')) return 'application/octet-stream';
+  return 'image/png';
+}
+
+function toJsDelivrFromRawUrl(url) {
+  const match = url.match(/^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/i);
+  if (!match) return null;
+  return `https://cdn.jsdelivr.net/gh/${match[1]}/${match[2]}@${match[3]}/${match[4]}`;
+}
+
+function toRawFromJsDelivrUrl(url) {
+  const match = url.match(/^https:\/\/cdn\.jsdelivr\.net\/gh\/([^/]+)\/([^@/]+)@([^/]+)\/(.+)$/i);
+  if (!match) return null;
+  return `https://raw.githubusercontent.com/${match[1]}/${match[2]}/${match[3]}/${match[4]}`;
+}
+
+function urlAlternates(url) {
+  const values = [url];
+  const rawFromJsDelivr = toRawFromJsDelivrUrl(url);
+  const jsFromRaw = toJsDelivrFromRawUrl(url);
+  if (rawFromJsDelivr) values.push(rawFromJsDelivr);
+  if (jsFromRaw) values.push(jsFromRaw);
+  return Array.from(new Set(values));
+}
+
+function resourceCandidates(resourceUri, sourceUrl) {
+  if (isAbsoluteOrDataUrl(resourceUri)) return urlAlternates(resourceUri);
+  const resolved = resolveRelativeUrl(resourceUri, parentFolder(sourceUrl));
+  return urlAlternates(resolved);
+}
+
+async function fetchWithTimeout(input, init = {}, timeoutMs = TEXTURE_FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
+
+async function blobToDataUri(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(new Error('Failed converting blob to data URI'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+async function fetchAsDataUri(url, fallbackMime) {
+  const response = await fetchWithTimeout(url, { mode: 'cors' }, TEXTURE_FETCH_TIMEOUT_MS);
+  if (!response.ok) throw new Error(`Fetch failed ${response.status}: ${url}`);
+  const blob = await response.blob();
+  if (/text\/html|text\/plain/i.test(blob.type || '')) {
+    throw new Error(`Rejected non-asset response ${blob.type || 'unknown'}: ${url}`);
+  }
+  if (blob.type || !fallbackMime) return blobToDataUri(blob);
+  return blobToDataUri(new Blob([await blob.arrayBuffer()], { type: fallbackMime }));
+}
+
+async function fetchFirstDataUri(candidates, fallbackMime) {
+  let lastError = null;
+  for (const candidate of candidates) {
+    try {
+      return await fetchAsDataUri(candidate, fallbackMime || mimeFromUri(candidate));
+    } catch (error) {
+      lastError = error;
+      console.warn('Ukrainian drone texture candidate failed:', candidate, error);
+    }
+  }
+  throw lastError ?? new Error('No Ukrainian drone texture candidate loaded');
+}
+
+async function fetchArrayBufferWithTimeout(url) {
+  const response = await fetchWithTimeout(url, { mode: 'cors' }, MODEL_LOAD_TIMEOUT_MS);
+  if (!response.ok) throw new Error(`Fetch failed ${response.status}: ${url}`);
+  return response.arrayBuffer();
+}
+
+function decodeGlb(buffer) {
+  const view = new DataView(buffer);
+  if (view.byteLength < 20) throw new Error('GLB too small');
+  if (view.getUint32(0, true) !== GLB_MAGIC) throw new Error('Not a GLB asset');
+  if (view.getUint32(4, true) !== GLB_VERSION) throw new Error('Unsupported GLB version');
+  const totalLength = view.getUint32(8, true);
+  const bytes = new Uint8Array(buffer, 0, totalLength);
+  const decoder = new TextDecoder();
+  let offset = 12;
+  let json = null;
+  let binChunk = null;
+  while (offset + 8 <= totalLength) {
+    const chunkLength = view.getUint32(offset, true);
+    const chunkType = view.getUint32(offset + 4, true);
+    offset += 8;
+    const chunkBytes = bytes.slice(offset, offset + chunkLength);
+    offset += chunkLength;
+    if (chunkType === GLB_JSON_CHUNK) json = JSON.parse(decoder.decode(chunkBytes).trim());
+    if (chunkType === GLB_BIN_CHUNK) binChunk = chunkBytes;
+  }
+  if (!json) throw new Error('GLB missing JSON chunk');
+  return { json, binChunk };
+}
+
+function encodeGlb(json, binChunk) {
+  const encoder = new TextEncoder();
+  const rawJson = encoder.encode(JSON.stringify(json));
+  const jsonPadding = (4 - (rawJson.length % 4)) % 4;
+  const paddedJson = new Uint8Array(rawJson.length + jsonPadding);
+  paddedJson.set(rawJson);
+  paddedJson.fill(0x20, rawJson.length);
+  let paddedBin = null;
+  if (binChunk) {
+    const binPadding = (4 - (binChunk.length % 4)) % 4;
+    paddedBin = new Uint8Array(binChunk.length + binPadding);
+    paddedBin.set(binChunk);
+  }
+  const totalLength = 12 + 8 + paddedJson.length + (paddedBin ? 8 + paddedBin.length : 0);
+  const buffer = new ArrayBuffer(totalLength);
+  const view = new DataView(buffer);
+  const bytes = new Uint8Array(buffer);
+  view.setUint32(0, GLB_MAGIC, true);
+  view.setUint32(4, GLB_VERSION, true);
+  view.setUint32(8, totalLength, true);
+  let offset = 12;
+  view.setUint32(offset, paddedJson.length, true);
+  view.setUint32(offset + 4, GLB_JSON_CHUNK, true);
+  offset += 8;
+  bytes.set(paddedJson, offset);
+  offset += paddedJson.length;
+  if (paddedBin) {
+    view.setUint32(offset, paddedBin.length, true);
+    view.setUint32(offset + 4, GLB_BIN_CHUNK, true);
+    offset += 8;
+    bytes.set(paddedBin, offset);
+  }
+  return buffer;
+}
+
+async function inlineExternalGlbTextures(sourceUrl) {
+  const rawBuffer = await fetchArrayBufferWithTimeout(sourceUrl);
+  const decoded = decodeGlb(rawBuffer);
+  const images = Array.isArray(decoded.json.images) ? decoded.json.images : [];
+  let changed = false;
+  for (const image of images) {
+    if (typeof image.uri !== 'string' || image.uri.startsWith('data:')) continue;
+    const candidates = resourceCandidates(image.uri, sourceUrl);
+    try {
+      image.uri = await fetchFirstDataUri(candidates, image.mimeType || mimeFromUri(candidates[0]));
+      image.mimeType = image.mimeType || mimeFromUri(candidates[0]);
+    } catch (error) {
+      console.warn('Ukrainian drone external texture failed, using fallback pixel:', image.uri, error);
+      image.uri = FALLBACK_PIXEL;
+      image.mimeType = 'image/png';
+    }
+    changed = true;
+  }
+  return changed ? encodeGlb(decoded.json, decoded.binChunk) : rawBuffer;
+}
+
+function getSharedKtx2Loader(renderer) {
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath('https://threejs.org/examples/jsm/libs/basis/');
+  }
+  if (renderer) {
+    try {
+      sharedKtx2Loader.detectSupport(renderer);
+    } catch (error) {
+      console.warn('Ukrainian drone KTX2 support detection failed', error);
+    }
+  }
+  return sharedKtx2Loader;
+}
+
+function createTextureAwareLoader(modelUrl, renderer = null) {
+  const baseFolder = parentFolder(modelUrl);
+  const manager = new THREE.LoadingManager();
+  manager.setURLModifier((resourceUrl) => {
+    if (!resourceUrl || resourceUrl.startsWith('data:') || resourceUrl.startsWith('blob:') || resourceUrl.startsWith('#')) return resourceUrl;
+    if (isAbsoluteOrDataUrl(resourceUrl)) return resourceUrl;
+    return resolveRelativeUrl(resourceUrl, baseFolder);
+  });
+  manager.onError = (url) => console.warn('Ukrainian drone texture/bin resource failed:', url, 'for model', modelUrl);
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin('anonymous');
+  loader.setResourcePath(baseFolder);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+  const draco = new DRACOLoader();
+  draco.setDecoderPath('https://www.gstatic.com/draco/versioned/decoders/1.5.7/');
+  loader.setDRACOLoader(draco);
+  loader.setKTX2Loader(getSharedKtx2Loader(renderer));
+  return loader;
+}
+
+function parseGlbBuffer(loader, buffer) {
+  return new Promise((resolve, reject) => loader.parse(buffer, '', resolve, reject));
+}
+
+function loadUrlDirect(loader, url) {
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(() => reject(new Error('Timeout loading Ukrainian drone')), MODEL_LOAD_TIMEOUT_MS);
+    loader.load(
+      url,
+      (loaded) => {
+        window.clearTimeout(timer);
+        resolve(loaded);
+      },
+      undefined,
+      (error) => {
+        window.clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
+function configureTexture(texture, key, renderer = null) {
+  if (key === 'map' || key === 'emissiveMap' || key === 'baseColorTexture') texture.colorSpace = THREE.SRGBColorSpace;
+  const maxAnisotropy = renderer?.capabilities?.getMaxAnisotropy?.() || 8;
+  texture.anisotropy = Math.max(texture.anisotropy || 1, maxAnisotropy);
+  texture.needsUpdate = true;
+}
+
+function configureUkrainianDroneModel(model, renderer = null) {
+  model.userData = { ...(model.userData || {}), exactUkrainianDroneModel: true };
+  model.traverse((obj) => {
+    obj.userData = { ...(obj.userData || {}), exactUkrainianDroneModel: true };
+    if (!obj.isMesh && !obj.isSkinnedMesh) return;
+    obj.castShadow = true;
+    obj.receiveShadow = true;
+    obj.frustumCulled = false;
+    const materials = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+    materials.forEach((material) => {
+      ['map', 'emissiveMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'alphaMap', 'bumpMap', 'clearcoatMap', 'clearcoatNormalMap', 'clearcoatRoughnessMap'].forEach((key) => {
+        if (material?.[key]?.isTexture) configureTexture(material[key], key, renderer);
+      });
+      if (material && 'envMapIntensity' in material && typeof material.envMapIntensity === 'number') {
+        material.envMapIntensity = Math.max(material.envMapIntensity, 1.2);
+      }
+      if (material) material.needsUpdate = true;
+    });
+  });
+  return model;
+}
+
+async function loadSharedUkrainianDrone(renderer = null) {
+  if (!sharedDronePromise) {
+    sharedDronePromise = (async () => {
+      let lastError = null;
+      for (const source of UKRAINIAN_DRONE_SOURCES) {
+        try {
+          const patched = await inlineExternalGlbTextures(source.url);
+          const loader = createTextureAwareLoader(source.url, renderer);
+          const gltf = await parseGlbBuffer(loader, patched);
+          return configureUkrainianDroneModel(gltf.scene, renderer);
+        } catch (error) {
+          lastError = error;
+          console.warn('Ukrainian drone preflight parse failed:', source, error);
+        }
+        try {
+          const loader = createTextureAwareLoader(source.url, renderer);
+          const gltf = await loadUrlDirect(loader, source.url);
+          return configureUkrainianDroneModel(gltf.scene, renderer);
+        } catch (error) {
+          lastError = error;
+          console.warn('Ukrainian drone direct load failed:', source, error);
+        }
+      }
+      throw lastError ?? new Error('Ukrainian drone failed from all sources');
+    })();
+  }
+  return sharedDronePromise;
+}
+
+export function isExactUkrainianDroneObject(root) {
+  if (!root) return false;
+  if (root.userData?.exactUkrainianDroneModel) return true;
+  let found = false;
+  root.traverse?.((node) => {
+    if (node.userData?.exactUkrainianDroneModel) found = true;
+  });
+  return found;
+}
+
+export async function loadExactUkrainianDroneModel(renderer = null) {
+  const template = await loadSharedUkrainianDrone(renderer);
+  const model = cloneSkeleton(template);
+  configureUkrainianDroneModel(model, renderer);
+  return model;
+}
+
+export function findExactUkrainianDroneRotor(root) {
+  let fallback = null;
+  root?.traverse?.((node) => {
+    const name = `${node.name || ''}`.toLowerCase();
+    if (!fallback && /propell|rotor|blade|fan|motor/.test(name)) fallback = node;
+  });
+  return fallback;
+}


### PR DESCRIPTION
### Motivation
- Add the ability to load and use an exact external Ukrainian drone GLB instead of procedural drone visuals for captures and FX, and ensure UI quick-swap shows the drone option more prominently on portrait phones.

### Description
- Add `webapp/src/utils/ukrainianDroneModel.js` which implements robust GLB loading, external-texture inlining, KTX2 handling, caching, and exported helpers `loadExactUkrainianDroneModel`, `isExactUkrainianDroneObject`, and `findExactUkrainianDroneRotor`.
- Update capture model loading to return the exact drone model for `drone`/`ukrainianDrone` kinds and to cache the result in `loadCaptureVehicleModel`.
- Ensure procedural look/accents are not applied to exact models by checking `isExactUkrainianDroneObject` before calling `applyCaptureVehicleLook`/`applyMilitaryDroneLook` and by returning early from `setUkrainianDroneAccentsVisible` when an exact model is present.
- Wire exact model loading into game pages: import and use the new utilities in `ChessBattleRoyal.jsx` and `LudoBattleRoyal.jsx`, add an upgrader (`upgradeCaptureDroneRootToExactModel`) to swap procedural visuals with the exact model when available, and use `findExactUkrainianDroneRotor` when picking a propeller node.
- Adjust quick-swap ordering in `ChessBattleRoyal.jsx` to surface matching vehicle options first on portrait phones and add `ukrainianDroneAttack` to `QUICK_SWAP_WEAPON_IDS`.

### Testing
- Ran the project build via `npm run build` which completed successfully.
- Executed the repository's automated test suite via `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b03e8d5b483299234d530156f5d7c)