### PR TITLE
Improve seated-human reach and piece pickup visuals in Checkers Battle Royal

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -125,10 +125,15 @@ const SEATED_HUMAN_PICKUP_PHASE_END = 0.34;
 const SEATED_HUMAN_CARRY_PHASE_END = 0.74;
 const SEATED_HUMAN_PICK_LIFT_HEIGHT = 0.16 * CHECKERS_ARENA_SCALE;
 const SEATED_HUMAN_HAND_DROP_CLEARANCE = 0.003 * CHECKERS_ARENA_SCALE;
-const SEATED_HUMAN_HAND_REACH_DOWN_OFFSET = 0.048 * CHECKERS_ARENA_SCALE;
-const SEATED_HUMAN_FORWARD_REACH_MIN = 0.9;
-const SEATED_HUMAN_FORWARD_REACH_MAX = 1.68;
-const SEATED_HUMAN_SIDE_REACH_SCALE = 1.28;
+const SEATED_HUMAN_HAND_REACH_DOWN_OFFSET = 0.064 * CHECKERS_ARENA_SCALE;
+const SEATED_HUMAN_FORWARD_REACH_MIN = 1.04;
+const SEATED_HUMAN_FORWARD_REACH_MAX = 1.92;
+const SEATED_HUMAN_SIDE_REACH_SCALE = 1.36;
+const SEATED_HUMAN_BOARD_LEAN_MIN = 0.28;
+const SEATED_HUMAN_BOARD_LEAN_MAX = 1;
+const SEATED_HUMAN_PICKUP_CONTACT_START_RATIO = 0.56;
+const SEATED_HUMAN_PLACE_CONTACT_END_RATIO = 0.94;
+const SEATED_HUMAN_GRIP_PIECE_Y_OFFSET_MULTIPLIER = 0.082;
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
 const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
 const HDRI_UNITS_PER_METER = 1;
@@ -2532,7 +2537,7 @@ export default function CheckersBattleRoyal() {
           capture ? CAPTURE_JUMP_DURATION_MS : MOVE_JUMP_DURATION_MS,
           SEATED_HUMAN_MOVE_DURATION_MS
         );
-        activeAnimationsRef.current.push({
+        const moveAnimation = {
           type: 'move',
           object: moving,
           startedAt,
@@ -2540,13 +2545,23 @@ export default function CheckersBattleRoyal() {
           from: fromPos,
           to: toPos,
           arcHeight: tile * (capture ? 0.72 : 0.52),
-          handCarried: false
-        });
+          handCarried: false,
+          humanPickupT: null,
+          humanReleaseT: null
+        };
+        activeAnimationsRef.current.push(moveAnimation);
         const moverSeatIndex = side === 'light' ? 1 : 0;
         const moverActor = seatedHumanActorsRef.current.find(
           (entry) => entry?.playerIndex === moverSeatIndex
         );
         if (moverActor?.rig) {
+          moveAnimation.humanPickupT =
+            SEATED_HUMAN_PICKUP_PHASE_END * SEATED_HUMAN_PICKUP_CONTACT_START_RATIO;
+          moveAnimation.humanReleaseT = Math.min(
+            0.985,
+            SEATED_HUMAN_CARRY_PHASE_END +
+              (1 - SEATED_HUMAN_CARRY_PHASE_END) * SEATED_HUMAN_PLACE_CONTACT_END_RATIO
+          );
           seatedHumanMoveActionsRef.current.set(moverSeatIndex, {
             startedAt,
             duration,
@@ -2591,6 +2606,12 @@ export default function CheckersBattleRoyal() {
         -1,
         1
       );
+      const boardLean = clamp(
+        SEATED_HUMAN_BOARD_LEAN_MIN +
+          reachDistanceRatio * (SEATED_HUMAN_BOARD_LEAN_MAX - SEATED_HUMAN_BOARD_LEAN_MIN),
+        SEATED_HUMAN_BOARD_LEAN_MIN,
+        SEATED_HUMAN_BOARD_LEAN_MAX
+      );
       let mode = 'reachPiece';
       let intensity = 1;
       let grip = 0;
@@ -2609,19 +2630,28 @@ export default function CheckersBattleRoyal() {
         intensity = 1;
         grip = 1 - smoothEase(phase);
       }
-      applySeatedHumanPose(entry.rig, mode, intensity, grip, { forwardReach, sideReach });
+      applySeatedHumanPose(entry.rig, mode, intensity, grip, {
+        forwardReach,
+        sideReach,
+        boardLean
+      });
       applySeatedHumanRightArmIK(entry.rig, target, 0.98);
       entry.actor.updateMatrixWorld(true);
       const gripWorld = getSeatedHumanGripWorldPosition(entry.rig);
-      const pickupContactStart = SEATED_HUMAN_PICKUP_PHASE_END * 0.56;
-      const placeContactEnd = Math.min(0.985, SEATED_HUMAN_CARRY_PHASE_END + (1 - SEATED_HUMAN_CARRY_PHASE_END) * 0.94);
+      const pickupContactStart =
+        SEATED_HUMAN_PICKUP_PHASE_END * SEATED_HUMAN_PICKUP_CONTACT_START_RATIO;
+      const placeContactEnd = Math.min(
+        0.985,
+        SEATED_HUMAN_CARRY_PHASE_END +
+          (1 - SEATED_HUMAN_CARRY_PHASE_END) * SEATED_HUMAN_PLACE_CONTACT_END_RATIO
+      );
       const isHandCarrying = rawT >= pickupContactStart && rawT <= placeContactEnd;
       const linkedAnim = activeAnimationsRef.current.find((anim) => anim.object === action.object);
       if (linkedAnim) linkedAnim.handCarried = isHandCarrying;
       if (action.object) action.object.userData.handCarried = isHandCarrying;
       if (action.object && isHandCarrying) {
         action.object.position.copy(gripWorld || target);
-        action.object.position.y -= action.tile * 0.06;
+        action.object.position.y -= action.tile * SEATED_HUMAN_GRIP_PIECE_Y_OFFSET_MULTIPLIER;
         action.object.rotation.z = Math.sin(rawT * Math.PI * 2) * 0.05;
       }
       if (rawT >= 1) {
@@ -3297,9 +3327,27 @@ export default function CheckersBattleRoyal() {
           const t = Math.max(0, Math.min(1, elapsed / anim.duration));
           if (anim.type === 'move') {
             if (!anim.handCarried) {
-              anim.object.position.lerpVectors(anim.from, anim.to, t);
-              anim.object.position.y += Math.sin(Math.PI * t) * anim.arcHeight;
-              anim.object.rotation.z = Math.sin(t * Math.PI * 2.1) * 0.1;
+              const hasHumanCarryTiming =
+                Number.isFinite(anim.humanPickupT) && Number.isFinite(anim.humanReleaseT);
+              if (hasHumanCarryTiming && t < anim.humanPickupT) {
+                const pickupSettleT = smoothEase(t / Math.max(anim.humanPickupT, 0.001));
+                anim.object.position.copy(anim.from);
+                anim.object.position.y +=
+                  Math.sin(Math.PI * pickupSettleT) * anim.arcHeight * 0.08;
+                anim.object.rotation.z = Math.sin(pickupSettleT * Math.PI) * 0.035;
+              } else if (hasHumanCarryTiming && t > anim.humanReleaseT) {
+                const releaseT = smoothEase(
+                  (t - anim.humanReleaseT) / Math.max(1 - anim.humanReleaseT, 0.001)
+                );
+                anim.object.position.copy(anim.to);
+                anim.object.position.y +=
+                  Math.sin(Math.PI * releaseT) * anim.arcHeight * 0.05;
+                anim.object.rotation.z = Math.sin(releaseT * Math.PI * 1.5) * 0.025;
+              } else if (!hasHumanCarryTiming) {
+                anim.object.position.lerpVectors(anim.from, anim.to, t);
+                anim.object.position.y += Math.sin(Math.PI * t) * anim.arcHeight;
+                anim.object.rotation.z = Math.sin(t * Math.PI * 2.1) * 0.1;
+              }
             }
             if (t >= 1) {
               animateSmokePuff(

--- a/webapp/src/pages/Games/shared/seatedHumanActors.js
+++ b/webapp/src/pages/Games/shared/seatedHumanActors.js
@@ -17,6 +17,8 @@ const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.35;
 const SEATED_HUMAN_REACH_FORWARD_GAIN = 0.5;
 const SEATED_HUMAN_REACH_SIDE_GAIN = 0.3;
+const SEATED_HUMAN_BOARD_LEAN_GAIN = 0.38;
+const SEATED_HUMAN_BOARD_LEAN_HEAD_GAIN = 0.16;
 
 const seatedHumanTemplatePromiseById = new Map();
 const chessDominoCharacterTextureCache = new Map();
@@ -234,6 +236,7 @@ export function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip
   let headX = -0.03;
   const forwardReach = clamp01(motionProfile?.forwardReach, 0);
   const sideReach = THREE.MathUtils.clamp(motionProfile?.sideReach ?? 0, -1, 1);
+  const boardLean = clamp01(motionProfile?.boardLean, 0);
 
   if (mode === 'reachPiece') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -1.22, t);
@@ -287,6 +290,7 @@ export function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip
 
   const reachForwardDelta = forwardReach * SEATED_HUMAN_REACH_FORWARD_GAIN;
   const reachSideDelta = sideReach * SEATED_HUMAN_REACH_SIDE_GAIN;
+  const boardLeanDelta = boardLean * SEATED_HUMAN_BOARD_LEAN_GAIN;
   shoulderX = THREE.MathUtils.lerp(shoulderX, shoulderX - reachForwardDelta, t);
   shoulderY = THREE.MathUtils.lerp(shoulderY, shoulderY + reachSideDelta * 0.32, t);
   shoulderZ = THREE.MathUtils.lerp(shoulderZ, shoulderZ - reachSideDelta * 0.5, t);
@@ -295,9 +299,14 @@ export function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip
   forearmZ = THREE.MathUtils.lerp(forearmZ, forearmZ - reachSideDelta * 0.36, t);
   wristY = THREE.MathUtils.lerp(wristY, wristY + reachSideDelta * 0.2, t);
   wristZ = THREE.MathUtils.lerp(wristZ, wristZ - reachSideDelta * 0.16, t);
-  chestX = THREE.MathUtils.lerp(chestX, chestX + reachForwardDelta * 0.5, t);
-  headX = THREE.MathUtils.lerp(headX, headX + reachForwardDelta * 0.22, t);
+  chestX = THREE.MathUtils.lerp(chestX, chestX + reachForwardDelta * 0.5 + boardLeanDelta, t);
+  headX = THREE.MathUtils.lerp(
+    headX,
+    headX + reachForwardDelta * 0.22 + boardLean * SEATED_HUMAN_BOARD_LEAN_HEAD_GAIN,
+    t
+  );
 
+  addBoneRot(rig, rig.spine, 0.18 + breathe + boardLeanDelta * 0.42 * t, 0, 0);
   addBoneRot(rig, rig.chest, chestX, 0, 0);
   addBoneRot(rig, rig.head, headX, 0, 0);
   addBoneRot(rig, rig.rightUpperArm, shoulderX, shoulderY, shoulderZ);


### PR DESCRIPTION
### Motivation
- Players need the seated human upper body to lean more toward the board and visibly pick up/place checkers so the hand makes clear physical contact with pieces during move animations.

### Description
- Tightened reach tuning and increased forward/side reach limits by adjusting `SEATED_HUMAN_HAND_REACH_DOWN_OFFSET`, `SEATED_HUMAN_FORWARD_REACH_MIN/ MAX`, and `SEATED_HUMAN_SIDE_REACH_SCALE` in `CheckersBattleRoyal.jsx`.
- Added board-lean support and timing constants (`SEATED_HUMAN_BOARD_LEAN_MIN/MAX`, `SEATED_HUMAN_PICKUP_CONTACT_START_RATIO`, `SEATED_HUMAN_PLACE_CONTACT_END_RATIO`, `SEATED_HUMAN_GRIP_PIECE_Y_OFFSET_MULTIPLIER`) and wired a `boardLean` motionProfile through move handling so spine/chest/head bend toward the board during reaches.
- Track human pickup/release timing on move animations by introducing `humanPickupT`/`humanReleaseT` on move animation objects and updated the animation loop so a piece stays on the source square until the hand reaches it, follows the grip while carried, and settles cleanly on place.
- Small tuning: lower carried checker under the grip while hand-carried and add spine tilt in `applySeatedHumanPose` inside `shared/seatedHumanActors.js` to visually reinforce contact.

### Testing
- Ran `npm run lint` and it completed without errors.
- Built the web app via `npm run build` and the production build finished successfully.
- Installed Playwright browsers with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully.
- Captured a mobile portrait preview of `/games/checkersbattleroyal` using a Chromium screenshot flow (CDP `Page.captureScreenshot`) after Playwright screenshot attempts timed out, and the CDP capture succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b18d315b883299e460a4964274dfb)