### PR TITLE
Slightly enlarge Pool Royale table footprint

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -34,7 +34,7 @@ describe('Pool Royale table models', () => {
       )
     );
     assert.equal(showood.fitScale, 1);
-    assert.equal(showood.fitFootprintScale, 1);
+    assert.equal(showood.fitFootprintScale, 1.04);
     assert.equal(showood.preserveOriginalFootprintAspect, true);
     assert.equal(showood.lowerBaseHeightScale, 1.38);
     assert.equal(showood.legLengthScale, 2.05);

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -23,7 +23,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
-    fitFootprintScale: 1,
+    fitFootprintScale: 1.04,
     fitHeightScale: 1,
     lowerBaseHeightScale: 1.38,
     legLengthScale: 2.05,


### PR DESCRIPTION
### Motivation
- Increase the visible Pool Royale table footprint slightly on all four sides while preserving the current height so the table looks a bit bigger on mobile portrait screens.

### Description
- Change `fitFootprintScale` for the Showood Pool Royale model from `1` to `1.04` in `webapp/src/config/poolRoyaleTableModels.js` to enlarge the playfield footprint without altering `fitHeightScale`.
- Update the table model unit test expectation in `test/poolRoyaleTableModels.test.js` to assert the new `fitFootprintScale` value `1.04`.

### Testing
- Ran the targeted unit tests with `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and all tests in that file passed.
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bae727b0883299d82f26e5f6fadec)