### PR TITLE
Add exact Ukrainian drone inventory preview

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -800,9 +800,21 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     type: 'captureAnimation',
     optionId: option.id,
     name: option.label,
-    price: 900 + idx * 110,
-    description: option.description || 'Ludo Battle Royal weapon animation pack adapted for Chess Battle Royal.',
-    thumbnail: option.thumbnail
+    price: option.id === 'ukrainianDroneAttack' ? 0 : 900 + idx * 110,
+    description:
+      option.id === 'ukrainianDroneAttack'
+        ? 'Exact srcejon Ukrainian drone.glb inventory weapon with original texture preflight, direct-loader fallbacks, and a straight-down no-smoke missile drop.'
+        : option.description || 'Ludo Battle Royal weapon animation pack adapted for Chess Battle Royal.',
+    thumbnail: option.thumbnail,
+    swatches: option.id === 'ukrainianDroneAttack' ? ['#020617', '#2563eb', '#facc15'] : undefined,
+    previewShape: option.id === 'ukrainianDroneAttack' ? 'ukrainian-drone' : undefined,
+    modelUrls: option.id === 'ukrainianDroneAttack'
+      ? [
+          'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
+          'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
+          'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
+        ]
+      : undefined
   })),
   ...CHESS_HUMAN_CHARACTER_OPTIONS.filter((option) =>
     CHESS_STORE_HUMAN_CHARACTER_IDS.includes(option.id)

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import * as THREE from 'three';
+import { loadExactUkrainianDroneModel } from '../utils/ukrainianDroneModel.js';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import {
   POOL_ROYALE_DEFAULT_LOADOUT,
@@ -169,6 +170,216 @@ import {
 import { DEV_INFO } from '../utils/constants.js';
 import { swatchThumbnail } from '../config/storeThumbnails.js';
 import { getCustomHdriCatalog, saveCustomHdriEntry } from '../utils/customHdriCatalog.js';
+
+const UKRAINIAN_DRONE_PREVIEW_STATUS = Object.freeze({
+  loading: 'LOADING',
+  ready: 'READY',
+  fallback: 'FALLBACK'
+});
+
+function fitUkrainianDronePreviewObject(model, targetLength = 4.2) {
+  model.updateMatrixWorld?.(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const maxLength = Math.max(size.x, size.y, size.z);
+  if (!Number.isFinite(maxLength) || maxLength <= 0) return;
+  model.scale.setScalar(targetLength / maxLength);
+  model.updateMatrixWorld?.(true);
+  const fittedBox = new THREE.Box3().setFromObject(model);
+  const center = fittedBox.getCenter(new THREE.Vector3());
+  model.position.x -= center.x;
+  model.position.z -= center.z;
+  model.position.y += -fittedBox.min.y + 1.4;
+  model.updateMatrixWorld?.(true);
+}
+
+function createUkrainianDronePreviewFallback() {
+  const group = new THREE.Group();
+  const bodyMat = new THREE.MeshStandardMaterial({ color: '#7b8792', roughness: 0.65, metalness: 0.2 });
+  const darkMat = new THREE.MeshStandardMaterial({ color: '#374151', roughness: 0.7, metalness: 0.12 });
+
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.2, 2.4, 24), bodyMat);
+  body.rotation.z = Math.PI / 2;
+  body.position.y = 1.8;
+  group.add(body);
+
+  const wing = new THREE.Mesh(new THREE.BoxGeometry(1.0, 0.06, 3.0), bodyMat);
+  wing.position.set(-0.1, 1.76, 0);
+  group.add(wing);
+
+  const nose = new THREE.Mesh(new THREE.ConeGeometry(0.18, 0.55, 24), bodyMat);
+  nose.rotation.z = -Math.PI / 2;
+  nose.position.set(1.45, 1.8, 0);
+  group.add(nose);
+
+  const prop = new THREE.Mesh(new THREE.BoxGeometry(0.04, 1.1, 0.08), darkMat);
+  prop.name = 'propeller';
+  prop.position.set(-1.45, 1.8, 0);
+  group.add(prop);
+
+  group.traverse((obj) => {
+    if (obj.isMesh) {
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+    }
+  });
+
+  return group;
+}
+
+function disposeUkrainianDronePreviewObject(object) {
+  object?.traverse?.((child) => {
+    if (!child?.isMesh && !child?.isSkinnedMesh) return;
+    child.geometry?.dispose?.();
+    const materials = Array.isArray(child.material) ? child.material : child.material ? [child.material] : [];
+    materials.forEach((material) => {
+      ['map', 'emissiveMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'alphaMap'].forEach((key) => material?.[key]?.dispose?.());
+      material?.dispose?.();
+    });
+  });
+}
+
+function UkrainianDroneExactPreview({ showCaption = true, size = 'sm', containerClassName = '' }) {
+  const mountRef = useRef(null);
+  const runtimeRef = useRef(null);
+  const [status, setStatus] = useState(UKRAINIAN_DRONE_PREVIEW_STATUS.loading);
+  const sizeClasses = {
+    sm: 'h-16 w-24',
+    md: 'h-24 w-40',
+    lg: 'h-32 w-full'
+  };
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return undefined;
+
+    let disposed = false;
+    let frame = 0;
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#020617');
+    scene.fog = new THREE.Fog('#020617', 18, 48);
+
+    const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 120);
+    camera.position.set(5.2, 4.2, 7.5);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.6;
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    mount.innerHTML = '';
+    mount.appendChild(renderer.domElement);
+
+    scene.add(new THREE.AmbientLight(0xffffff, 1.5));
+    scene.add(new THREE.HemisphereLight(0xdbeafe, 0x0f172a, 2.1));
+
+    const key = new THREE.DirectionalLight(0xffffff, 4.4);
+    key.position.set(5, 7, 6);
+    key.castShadow = true;
+    key.shadow.mapSize.set(2048, 2048);
+    scene.add(key);
+
+    const fill = new THREE.PointLight(0x9cc8ff, 11, 28, 1.4);
+    fill.position.set(-3, 3.8, 5.5);
+    scene.add(fill);
+
+    const floor = new THREE.Mesh(
+      new THREE.CircleGeometry(3.4, 72),
+      new THREE.MeshStandardMaterial({ color: '#111827', roughness: 0.88, metalness: 0.12 })
+    );
+    floor.rotation.x = -Math.PI / 2;
+    floor.receiveShadow = true;
+    scene.add(floor);
+
+    const resize = () => {
+      const width = mount.clientWidth || 160;
+      const height = mount.clientHeight || 100;
+      camera.aspect = width / Math.max(1, height);
+      camera.updateProjectionMatrix();
+      renderer.setSize(width, height, false);
+    };
+
+    const start = async () => {
+      try {
+        setStatus(UKRAINIAN_DRONE_PREVIEW_STATUS.loading);
+        const drone = await loadExactUkrainianDroneModel(renderer);
+        if (disposed) {
+          disposeUkrainianDronePreviewObject(drone);
+          return;
+        }
+        fitUkrainianDronePreviewObject(drone, 4.2);
+        drone.rotation.y = 0.45;
+        scene.add(drone);
+        runtimeRef.current = { root: drone, baseY: drone.position.y };
+        setStatus(UKRAINIAN_DRONE_PREVIEW_STATUS.ready);
+      } catch (error) {
+        console.warn('Store Ukrainian drone exact preview failed, using fallback drone', error);
+        if (disposed) return;
+        const fallback = createUkrainianDronePreviewFallback();
+        scene.add(fallback);
+        runtimeRef.current = { root: fallback, baseY: fallback.position.y };
+        setStatus(UKRAINIAN_DRONE_PREVIEW_STATUS.fallback);
+      }
+    };
+
+    resize();
+    void start();
+    const clock = new THREE.Clock();
+    const animate = () => {
+      if (disposed) return;
+      frame = requestAnimationFrame(animate);
+      const time = clock.elapsedTime;
+      const runtime = runtimeRef.current;
+      if (runtime?.root) {
+        runtime.root.position.y = runtime.baseY + Math.sin(time * 1.5) * 0.08;
+        runtime.root.rotation.y += 0.004;
+        runtime.root.traverse((obj) => {
+          if (obj.name?.toLowerCase?.().includes('propeller') || obj.name?.toLowerCase?.().includes('rotor')) {
+            obj.rotation.x = time * 24;
+          }
+        });
+      }
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    const observer = new ResizeObserver(resize);
+    observer.observe(mount);
+    window.addEventListener('resize', resize);
+
+    return () => {
+      disposed = true;
+      observer.disconnect();
+      window.removeEventListener('resize', resize);
+      cancelAnimationFrame(frame);
+      if (runtimeRef.current?.root) disposeUkrainianDronePreviewObject(runtimeRef.current.root);
+      floor.geometry.dispose();
+      floor.material.dispose();
+      renderer.dispose();
+      if (renderer.domElement.parentElement === mount) mount.removeChild(renderer.domElement);
+      runtimeRef.current = null;
+    };
+  }, []);
+
+  return (
+    <div className={`flex items-center gap-3 ${containerClassName}`}>
+      <div className={`relative overflow-hidden rounded-xl border border-white/10 bg-[#020617] shadow-[0_18px_45px_-26px_rgba(0,0,0,0.9)] ${sizeClasses[size] || sizeClasses.sm}`}>
+        <div ref={mountRef} className="absolute inset-0" />
+        <div className="pointer-events-none absolute left-1 top-1 rounded-full border border-white/10 bg-slate-950/70 px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-[0.18em] text-white/80">
+          {status}
+        </div>
+      </div>
+      {showCaption ? (
+        <div className="grid gap-0.5 text-xs text-white/70">
+          <span className="font-semibold text-white">Exact GLB Drone</span>
+          <span className="text-white/60">Original textures + fallbacks</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 const TYPE_LABELS = {
   tableFinish: 'Table Finishes',
@@ -3560,6 +3771,16 @@ export default function Store() {
       md: 'h-24 w-40',
       lg: 'h-32 w-full'
     };
+
+    if (previewShape === 'ukrainian-drone') {
+      return (
+        <UkrainianDroneExactPreview
+          showCaption={showCaption}
+          size={size}
+          containerClassName={containerClassName}
+        />
+      );
+    }
 
     const shapeLayer = (shape) => {
       switch (shape) {

--- a/webapp/src/utils/ukrainianDroneModel.js
+++ b/webapp/src/utils/ukrainianDroneModel.js
@@ -91,6 +91,34 @@ function resourceCandidates(resourceUri, sourceUrl) {
   return urlAlternates(resolved);
 }
 
+function installUkrainianDroneImageFallback() {
+  const originalLoad = THREE.ImageLoader.prototype.load;
+  THREE.ImageLoader.prototype.load = function patchedUkrainianDroneImageLoad(url, onLoad, onProgress, onError) {
+    const candidates = urlAlternates(String(url));
+    let index = 0;
+    const tryLoad = () => {
+      const candidate = candidates[index] ?? FALLBACK_PIXEL;
+      return originalLoad.call(this, candidate, onLoad, onProgress, (event) => {
+        index += 1;
+        if (index < candidates.length) {
+          window.setTimeout(tryLoad, 250);
+          return;
+        }
+        console.warn('Ukrainian drone ImageLoader failed all original candidates, using fallback pixel:', candidates, event);
+        const img = document.createElement('img');
+        img.crossOrigin = 'anonymous';
+        img.onload = () => onLoad?.(img);
+        img.onerror = () => onError?.(event);
+        img.src = FALLBACK_PIXEL;
+      });
+    };
+    return tryLoad();
+  };
+  return () => {
+    THREE.ImageLoader.prototype.load = originalLoad;
+  };
+}
+
 async function fetchWithTimeout(input, init = {}, timeoutMs = TEXTURE_FETCH_TIMEOUT_MS) {
   const controller = new AbortController();
   const timer = window.setTimeout(() => controller.abort(), timeoutMs);
@@ -310,26 +338,31 @@ async function loadSharedUkrainianDrone(renderer = null) {
   if (!sharedDronePromise) {
     sharedDronePromise = (async () => {
       let lastError = null;
-      for (const source of UKRAINIAN_DRONE_SOURCES) {
-        try {
-          const patched = await inlineExternalGlbTextures(source.url);
-          const loader = createTextureAwareLoader(source.url, renderer);
-          const gltf = await parseGlbBuffer(loader, patched);
-          return configureUkrainianDroneModel(gltf.scene, renderer);
-        } catch (error) {
-          lastError = error;
-          console.warn('Ukrainian drone preflight parse failed:', source, error);
+      const restoreImageLoader = installUkrainianDroneImageFallback();
+      try {
+        for (const source of UKRAINIAN_DRONE_SOURCES) {
+          try {
+            const patched = await inlineExternalGlbTextures(source.url);
+            const loader = createTextureAwareLoader(source.url, renderer);
+            const gltf = await parseGlbBuffer(loader, patched);
+            return configureUkrainianDroneModel(gltf.scene, renderer);
+          } catch (error) {
+            lastError = error;
+            console.warn('Ukrainian drone preflight parse failed:', source, error);
+          }
+          try {
+            const loader = createTextureAwareLoader(source.url, renderer);
+            const gltf = await loadUrlDirect(loader, source.url);
+            return configureUkrainianDroneModel(gltf.scene, renderer);
+          } catch (error) {
+            lastError = error;
+            console.warn('Ukrainian drone direct load failed:', source, error);
+          }
         }
-        try {
-          const loader = createTextureAwareLoader(source.url, renderer);
-          const gltf = await loadUrlDirect(loader, source.url);
-          return configureUkrainianDroneModel(gltf.scene, renderer);
-        } catch (error) {
-          lastError = error;
-          console.warn('Ukrainian drone direct load failed:', source, error);
-        }
+        throw lastError ?? new Error('Ukrainian drone failed from all sources');
+      } finally {
+        restoreImageLoader();
       }
-      throw lastError ?? new Error('Ukrainian drone failed from all sources');
     })();
   }
   return sharedDronePromise;


### PR DESCRIPTION
### Motivation
- Provide an exact Ukrainian drone capture-animation item in the Chess Battle Royal store with the same visual fidelity as the supplied Three.js GLB loader and fallback behaviour.
- Surface a live 3D preview in the Store UI so the drone appears exactly as authored (original textures, rotor animation, hover/rotation, and fallback model when the GLB fails).
- Make texture loading more robust by retrying alternate CDN/raw URLs before falling back to a tiny placeholder.

### Description
- Add metadata for the Ukrainian drone store item in `webapp/src/config/chessBattleInventoryConfig.js`, including `previewShape: 'ukrainian-drone'`, blue/yellow `swatches`, free/default `price` for `ukrainianDroneAttack`, and the three GLB fallback `modelUrls` (jsDelivr/raw/Statically).
- Add a Three.js-powered preview component `UkrainianDroneExactPreview` into `webapp/src/pages/Store.jsx` that matches the provided scene (camera, fog, ACES tone mapping, lights, floor), fits/normalizes the model, animates hover/rotation and propeller spin, and falls back to a procedural drone when exact model load fails.
- Hook the preview into `renderPreview3d` so items with `previewShape === 'ukrainian-drone'` show the new exact preview component.
- Extend `webapp/src/utils/ukrainianDroneModel.js` with an `installUkrainianDroneImageFallback()` wrapper that patches `THREE.ImageLoader.prototype.load` to try url alternates (jsDelivr/raw) before using the fallback pixel, and ensure the patched loader is installed/removed around the shared drone preflight load path.
- Add helper functions in the Store page for fitting/disposing the preview model and a small fallback drone mesh (procedural) used when the exact GLB fails.

### Testing
- Built the webapp production bundle with `npm run build` and the build completed successfully (Vite build completed and assets emitted).
- Ran ESLint for the modified files via `npx eslint` and observed repository ignore warnings for these files (no fatal blocking errors for the targeted checks in the final run); running `npm run lint -- --no-ignore` surfaced many project-wide style errors when forced (these are style/config-induced and not regressions from the functional changes).
- Attempted an automated visual smoke test with Playwright: `npx playwright install` completed and browsers were downloaded, but running headless Chromium in-container failed to start due to a missing system library (`libatk-1.0.so.0`), so the screenshot step could not be captured in this environment.
- Verified the Store UI now returns early to the exact preview path when an item declares `previewShape: 'ukrainian-drone'` and the preview component uses the shared `loadExactUkrainianDroneModel` loader with fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1baf00d5c88329adf5f77af10e0b35)