### PR TITLE
Ground bowling arena to HDRI floor

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -286,11 +286,11 @@ const RESULT_COMPLIMENTS = {
   open: ['Nice try—adjust and fire again.', 'Good pace, keep rhythm.']
 } as const;
 
-// Raise the full bowling field above the HDRI ground plane in portrait view.
-const BOWLING_HDRI_GROUND_SNAP_DROP = -0.62;
+// Keep the full bowling field snapped down onto the visible HDRI ground plane in portrait view.
+const BOWLING_HDRI_GROUND_Y = -1.5;
 
 const CFG = {
-  laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,
+  laneY: BOWLING_HDRI_GROUND_Y,
   laneHalfW: 1.36,
   gutterHalfW: 1.72,
   laneCenterOffset: 1.82,
@@ -2284,7 +2284,8 @@ function createEnvironment(
     resetMachine: new THREE.Group()
   };
   scene.add(group);
-  group.position.y = -0.32;
+  // Do not add a secondary lift/drop here: CFG.laneY is the single ground datum for lane, players, tables, and chairs.
+  group.position.y = 0;
   let laneMat: THREE.Material;
   let woodMat: THREE.Material;
   try {


### PR DESCRIPTION
### Motivation
- Make the bowling lane, player seating, tables and chairs share the same visible HDRI ground plane so the field and furniture are visually grounded instead of appearing lifted above the HDRI.

### Description
- Replace the previous portrait lift constant with a single ground datum by introducing `BOWLING_HDRI_GROUND_Y` and using it for `CFG.laneY` in `webapp/src/pages/Games/BowlingRealistic.tsx`.
- Remove the separate environment group vertical offset by setting the decor group `position.y` to `0` and adding a comment that `CFG.laneY` is the single ground datum.
- Commit contains only the changes to `webapp/src/pages/Games/BowlingRealistic.tsx` and a brief commit message `Ground bowling arena to HDRI floor`.

### Testing
- Ran `npm run build` in `webapp` and the production build completed successfully.
- Started the dev server with `npm run dev -- --host 127.0.0.1` to verify the scene loads locally.
- Installed Playwright browsers with `npx playwright install chromium` and platform deps with `npx playwright install-deps chromium` to enable headless screenshot checks.
- Attempted a portrait smoke check via Playwright against `/games/bowling?players=2`; the run initially failed due to missing browser binaries, the browsers and OS deps were installed, and a headless screenshot attempt was made but page-screenshot timing was flaky in CI (environment GPU / headless dependencies caused timeouts on one run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bafc407a0832993f326d2336292d3)