### PR TITLE
Ground Real Bowling arena on HDRI floor

### DIFF
--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -286,8 +286,8 @@ const RESULT_COMPLIMENTS = {
   open: ['Nice try—adjust and fire again.', 'Good pace, keep rhythm.']
 } as const;
 
-// Raise the full bowling field above the HDRI ground plane in portrait view.
-const BOWLING_HDRI_GROUND_SNAP_DROP = -0.62;
+// Keep the full bowling field grounded on the HDRI floor in portrait view.
+const BOWLING_HDRI_GROUND_SNAP_DROP = 0;
 
 const CFG = {
   laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,


### PR DESCRIPTION
### Motivation
- Ensure the bowling lane, lounge floor, tables, chairs and players sit flush with the HDRI ground rather than being raised above it in portrait/mobile view.

### Description
- Updated the portrait-grounding constant by changing `BOWLING_HDRI_GROUND_SNAP_DROP` from `-0.62` to `0` in `webapp/src/pages/Games/BowlingRealistic.tsx` so `CFG.laneY` and related scene objects are computed at the HDRI floor level.

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully.
- Installed Playwright browsers with `npx playwright install chromium` and system deps with `npx playwright install-deps chromium`, both succeeded.
- Launched the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1` and confirmed it served the app.
- Performed a Playwright mobile smoke screenshot of `/games/bowling` which completed and produced a saved screenshot, validating the scene grounding visually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bafc407a0832993f326d2336292d3)