### PR TITLE
Load exact Ukrainian drone GLB for Ludo capture FX and add loader self-tests

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2859,17 +2859,23 @@ async function createCaptureDroneLauncherTruckFx() {
 }
 
 
+function installExactUkrainianDroneVisual(root, exactModel, targetSize, currentModel = null) {
+  if (!root?.isObject3D || !exactModel?.isObject3D) return null;
+  fitObjectToTargetSize(exactModel, targetSize);
+  exactModel.rotation.y = Math.PI;
+  if (currentModel?.parent === root) root.remove(currentModel);
+  root.add(exactModel);
+  const propeller = findExactUkrainianDroneRotor(exactModel) || exactModel;
+  root.userData.exactUkrainianDroneVisual = exactModel;
+  root.userData.exactUkrainianDronePropeller = propeller;
+  return propeller;
+}
+
 function upgradeCaptureDroneRootToExactModel(root, currentModel, targetSize) {
   if (!root?.isObject3D) return;
   void loadExactUkrainianDroneModel()
     .then((exactModel) => {
-      if (!root?.isObject3D || !exactModel) return;
-      fitObjectToTargetSize(exactModel, targetSize);
-      exactModel.rotation.y = Math.PI;
-      if (currentModel?.parent === root) root.remove(currentModel);
-      root.add(exactModel);
-      root.userData.exactUkrainianDroneVisual = exactModel;
-      root.userData.exactUkrainianDronePropeller = findExactUkrainianDroneRotor(exactModel) || exactModel;
+      installExactUkrainianDroneVisual(root, exactModel, targetSize, currentModel);
     })
     .catch((error) => {
       console.warn('Exact Ukrainian drone visual failed; keeping existing Ludo drone visible.', error);
@@ -2878,14 +2884,23 @@ function upgradeCaptureDroneRootToExactModel(root, currentModel, targetSize) {
 async function createCaptureDroneFx() {
   const root = new THREE.Group();
   root.userData.lockCaptureTexture = true;
+  const exactDroneTargetSize = 4.2 * CAPTURE_DRONE_SIZE_MULTIPLIER;
+  try {
+    const exactModel = await loadExactUkrainianDroneModel();
+    const propeller = installExactUkrainianDroneVisual(root, exactModel, exactDroneTargetSize);
+    root.visible = false;
+    return { root, propeller, trail: [] };
+  } catch (error) {
+    console.warn('Exact Ukrainian drone visual failed; falling back to the legacy Ludo drone.', error);
+  }
   const loadedDrone = await loadCaptureVehicleModel('drone');
   if (loadedDrone) {
     const model = loadedDrone.clone(true);
-    fitObjectToTargetSize(model, 3.85 * CAPTURE_DRONE_SIZE_MULTIPLIER);
+    fitObjectToTargetSize(model, exactDroneTargetSize);
     model.rotation.y = Math.PI;
     const propeller = applyMilitaryDroneLook(model);
     root.add(model);
-    upgradeCaptureDroneRootToExactModel(root, model, 3.85 * CAPTURE_DRONE_SIZE_MULTIPLIER);
+    upgradeCaptureDroneRootToExactModel(root, model, exactDroneTargetSize);
     const trail = [];
     for (let i = 0; i < 5; i += 1) {
       trail.push(

--- a/webapp/src/utils/ukrainianDroneModel.js
+++ b/webapp/src/utils/ukrainianDroneModel.js
@@ -34,6 +34,10 @@ const FALLBACK_PIXEL =
 let sharedDronePromise = null;
 let sharedKtx2Loader = null;
 
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
 function isAbsoluteOrDataUrl(url) {
   return /^(https?:)?\/\//i.test(url) || url.startsWith('data:') || url.startsWith('blob:');
 }
@@ -90,6 +94,25 @@ function resourceCandidates(resourceUri, sourceUrl) {
   const resolved = resolveRelativeUrl(resourceUri, parentFolder(sourceUrl));
   return urlAlternates(resolved);
 }
+
+
+function runSelfTests() {
+  assert(UKRAINIAN_DRONE_SOURCES.length === 3, 'Ukrainian drone must have 3 source fallbacks');
+  assert(
+    UKRAINIAN_DRONE_SOURCES.every((source) => /drone\.glb(\?|#|$)/i.test(source.url)),
+    'Every Ukrainian drone source must point to drone.glb'
+  );
+  assert(
+    urlAlternates('https://cdn.jsdelivr.net/gh/a/b@main/c.png').some((url) => url.includes('raw.githubusercontent.com/a/b/main/c.png')),
+    'jsDelivr alternate must include raw GitHub URL'
+  );
+  assert(
+    resourceCandidates('textures/a.png', UKRAINIAN_DRONE_SOURCES[0].url).some((url) => url.includes('textures/a.png')),
+    'Relative texture candidate must preserve original texture path'
+  );
+}
+
+runSelfTests();
 
 async function fetchWithTimeout(input, init = {}, timeoutMs = TEXTURE_FETCH_TIMEOUT_MS) {
   const controller = new AbortController();


### PR DESCRIPTION
### Motivation
- Ensure the Ukrainian drone used in Ludo/Chess capture visuals is the exact GLB model when available so capture/parked drone visuals match the reference asset rather than always showing the legacy procedural drone.
- Centralize the code that installs the exact GLB into the capture FX root so rotor tracking and upgrades use the same logic.
- Add lightweight self-tests for the Ukrainian drone loader to catch common CDN/texture resolution regressions early.

### Description
- Add `installExactUkrainianDroneVisual(root, exactModel, targetSize, currentModel)` to centralize fitting/attaching the exact GLB and tracking its propeller/rotor. (edited: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Update `createCaptureDroneFx()` to attempt `loadExactUkrainianDroneModel()` first and use the exact model (sized to `4.2 * CAPTURE_DRONE_SIZE_MULTIPLIER`) before falling back to the legacy Ludo drone visual. (edited: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Route the existing async upgrade path through the new installer so both direct-load and late-upgrade flows behave identically. (edited: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Add `assert` and `runSelfTests()` to the Ukrainian drone loader to validate source fallbacks, `drone.glb` URLs, jsDelivr/raw alternates, and relative texture candidate resolution. (edited: `webapp/src/utils/ukrainianDroneModel.js`)
- Small refactor to reuse a single target size variable across exact/fallback flows so sizing is consistent.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully. (passed)
- Ran lint with `npm run lint -- --quiet` and no errors were reported. (passed)
- Installed Playwright browsers with `npx playwright install chromium` and system deps with `npx playwright install-deps chromium` (both completed). (passed)
- Launched the dev server and captured a mobile portrait screenshot of `/games/ludobattleroyal` via Playwright to verify the in-page drone preview (screenshot saved). (passed)

Files changed: `webapp/src/pages/Games/LudoBattleRoyal.jsx`, `webapp/src/utils/ukrainianDroneModel.js`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1baf2eb99c8329a371f1b2e6bd0d1c)