### PR TITLE
Preserve exact Ukrainian drone visual & align Chess Battle inventory

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -268,9 +268,6 @@ export const CHESS_HUMAN_CHARACTER_OPTIONS = Object.freeze([
 ]);
 
 const CHESS_STORE_HUMAN_CHARACTER_IDS = Object.freeze([
-  'rpm-67d411-domino',
-  'rpm-67f433-domino',
-  'rpm-67e1b5-domino',
   'webgl-vietnam-human',
   'webgl-human-body-a',
   'webgl-human-body-b',
@@ -420,10 +417,28 @@ const POOL_ROYALE_LT_TABLE_FINISH_IDS = new Set([
   'carbonFiberAlligatorNight'
 ]);
 
-const CHESS_LT_TABLE_FINISHES = Object.freeze(
-  POOL_ROYALE_STORE_ITEMS.filter(
+const CHESS_LT_TABLE_FINISH_FALLBACKS = Object.freeze([
+  {
+    optionId: 'carbonFiberSnakeChalk',
+    name: 'Carbon Fiber Snake Chalk Finish',
+    description: 'Snake-scale carbon fiber LT finish adapted for the chess battle table.',
+    price: 1630,
+    swatches: ['#050816', '#14532d', '#94a3b8'],
+    thumbnail: swatchThumbnail(['#050816', '#14532d', '#94a3b8'])
+  }
+]);
+
+const CHESS_LT_TABLE_FINISH_SOURCE_ITEMS = Object.freeze([
+  ...POOL_ROYALE_STORE_ITEMS.filter(
     (item) => item.type === 'tableFinish' && POOL_ROYALE_LT_TABLE_FINISH_IDS.has(item.optionId)
-  ).map((item) => ({
+  ),
+  ...CHESS_LT_TABLE_FINISH_FALLBACKS.filter(
+    (fallback) => !POOL_ROYALE_STORE_ITEMS.some((item) => item.type === 'tableFinish' && item.optionId === fallback.optionId)
+  )
+]);
+
+const CHESS_LT_TABLE_FINISHES = Object.freeze(
+  CHESS_LT_TABLE_FINISH_SOURCE_ITEMS.map((item) => ({
     id: item.optionId,
     label: item.name.replace(/\s*Finish$/i, ''),
     description: item.description,

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -12564,20 +12564,23 @@ function Chess3D({
           captureFxGroup.add(droneFx.root);
         }
         const launchBase = parkedDrone?.root?.position?.clone?.() || parkedDrone?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'drone', 0);
-        const sideSkin = resolveSideVehicleSkin(isWhiteSide);
-        if (sideSkin) {
-          applyVehicleSkinToModel(droneFx.root, sideSkin, (node) =>
-            /rotor|propell|blade|fan|window|cockpit|glass|canopy/.test(`${node.name || ''}`.toLowerCase())
+        const exactUkrainianDroneVisual = isExactUkrainianDroneObject(droneFx.root);
+        if (!exactUkrainianDroneVisual) {
+          const sideSkin = resolveSideVehicleSkin(isWhiteSide);
+          if (sideSkin) {
+            applyVehicleSkinToModel(droneFx.root, sideSkin, (node) =>
+              /rotor|propell|blade|fan|window|cockpit|glass|canopy/.test(`${node.name || ''}`.toLowerCase())
+            );
+          }
+          setUkrainianDroneAccentsVisible(droneFx.root, true);
+          attachVehicleAvatarBadge(
+            droneFx.root,
+            isWhiteSide
+              ? avatar || username || playerFlag || '🙂'
+              : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
+            isWhiteSide ? 1 : -1
           );
         }
-        setUkrainianDroneAccentsVisible(droneFx.root, true);
-        attachVehicleAvatarBadge(
-          droneFx.root,
-          isWhiteSide
-            ? avatar || username || playerFlag || '🙂'
-            : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
-          isWhiteSide ? 1 : -1
-        );
         droneFx.root.position.copy(launchBase.clone());
         const missileFx = createFxNoSmokeDropMissile();
         missileFx.root.scale.setScalar(CAPTURE_UKRAINIAN_DRONE_MISSILE_SCALE);


### PR DESCRIPTION
### Motivation
- Keep the exact GLB visual for the Ukrainian drone during Chess Battle Royal capture sequences so external/model-authored appearance is not overwritten by team skins, accent panels or avatar badges. 
- Ensure the Chess Battle Royal inventory/store configuration matches requested purchasables (limit sold humans to the WebGL set and include an LT table-finish fallback) so tests and UX are consistent.

### Description
- Add a runtime check `isExactUkrainianDroneObject(droneFx.root)` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` and only apply side skin, blue/yellow accents, and avatar badges when the loaded drone is not the exact Ukrainian GLB. 
- Remove non-WebGL RPM IDs from `CHESS_STORE_HUMAN_CHARACTER_IDS` in `webapp/src/config/chessBattleInventoryConfig.js` so only the requested WebGL human characters are sold. 
- Add `CHESS_LT_TABLE_FINISH_FALLBACKS` and `CHESS_LT_TABLE_FINISH_SOURCE_ITEMS` and rebuild `CHESS_LT_TABLE_FINISHES` from `POOL_ROYALE_STORE_ITEMS` plus fallback items so `carbonFiberSnakeChalk` is available when Pool Royale does not expose it directly. 
- Commit message: "Add exact Ukrainian drone inventory handling" and updated the two files above.

### Testing
- Ran unit tests with `npm test -- --runInBand test/chessBattleInventoryConfig.test.js`, which passed after the changes. 
- Built the frontend with `npm --prefix webapp run build`, which completed successfully. 
- Installed Playwright and platform deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully. 
- Performed an automated Playwright mobile screenshot smoke-check (narrow portrait viewport) for `/games/chessbattleroyal`; a screenshot was produced but the run logged remote asset fetch failures so the full 3D scene could not be visually validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1baf00d5c88329adf5f77af10e0b35)