### PR TITLE
Slightly enlarge Pool Royale table footprint

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1303,7 +1303,7 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
   const TABLE_SURFACE_REFERENCE = 1.12; // baseline expansion before the wider table adjustment
-  const TABLE_SURFACE_EXPANSION = 1.32; // widen/lengthen the table footprint to better match the actual 7ft Showood table size
+  const TABLE_SURFACE_EXPANSION = 1.36; // widen/lengthen the table footprint a bit more on all four sides while preserving table height
   const TABLE_SURFACE_COMPENSATION = TABLE_SURFACE_EXPANSION / TABLE_SURFACE_REFERENCE;
   const TABLE = {
     W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * OFFICIAL_TABLE_SCALE * TABLE_SURFACE_EXPANSION,


### PR DESCRIPTION
### Motivation
- Make the Pool Royale table visually a bit larger on all four sides while keeping the same table height so the playfield reads slightly bigger on portrait/mobile screens.

### Description
- Adjusted the horizontal footprint multiplier `TABLE_SURFACE_EXPANSION` from `1.32` to `1.36` in `webapp/src/pages/Games/PoolRoyale.jsx`, which widens/lengthens the table footprint on all sides while leaving table height unchanged.

### Testing
- Ran unit tests with `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and all tests passed (4 passed).
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully.
- Installed Playwright browsers with `npx playwright install chromium` successfully, but a headless screenshot attempt failed because the container was missing the system library `libatk-1.0.so.0`, preventing the browser from launching for visual verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bae727b0883299d82f26e5f6fadec)