### PR TITLE
Restore Ludo GLTF loader configuration

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1870,8 +1870,7 @@ async function loadCaptureVehicleModel(kind) {
   if (CAPTURE_VEHICLE_MODEL_CACHE.has(kind)) return CAPTURE_VEHICLE_MODEL_CACHE.get(kind);
   const promise = (async () => {
     const urls = CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${file}`);
-    const loader = new GLTFLoader();
-    loader.setCrossOrigin('anonymous');
+    const loader = createConfiguredGLTFLoader();
     const imageCache = new Map();
     for (const url of urls) {
       try {
@@ -4445,11 +4444,7 @@ let abgAssetPromise = null;
 async function getAbgAssets() {
   if (abgAssetPromise) return abgAssetPromise;
   abgAssetPromise = (async () => {
-    const loader = new GLTFLoader();
-    loader.setCrossOrigin('anonymous');
-    const draco = new DRACOLoader();
-    draco.setDecoderPath(DRACO_DECODER_PATH);
-    loader.setDRACOLoader(draco);
+    const loader = createConfiguredGLTFLoader();
 
     let root = null;
     for (const url of ABG_MODEL_URLS) {
@@ -5097,10 +5092,7 @@ function applyChairThemeMaterials(three, theme) {
 }
 
 async function loadGltfChair() {
-  const loader = new GLTFLoader();
-  const draco = new DRACOLoader();
-  draco.setDecoderPath(DRACO_DECODER_PATH);
-  loader.setDRACOLoader(draco);
+  const loader = createConfiguredGLTFLoader();
 
   let gltf = null;
   let lastError = null;


### PR DESCRIPTION
### Motivation
- Restore the shared GLTF/GLB WebGL loader configuration so Ludo capture models, ABG tokens and chair GLTFs load textures and compressed assets (DRACO/KTX2/Meshopt) with the same color-space and cross-origin handling as the May 11 snapshot.

### Description
- Replaced ad-hoc `new GLTFLoader()` + `DRACOLoader` usage with the shared `createConfiguredGLTFLoader()` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` for `loadCaptureVehicleModel`, `getAbgAssets`, and `loadGltfChair`. 
- This change reuses the project-wide DRACO, Meshopt, KTX2/Basis transcoder, cross-origin and KTX2 support-detection setup so GLB/GLTF textures keep consistent sRGB/flipY/anisotropy handling. 
- Calls that prepare or patch GLB buffers such as `patchGlbImagesToDataUris` and `prepareLoadedModel(..., { preserveGltfTextureMapping: true })` remain unchanged and continue to be used. 
- The only source file modified is `webapp/src/pages/Games/LudoBattleRoyal.jsx` and no API or runtime surface behavior was intentionally altered beyond unifying loader configuration. 

### Testing
- Ran `npm run build` in `webapp/` and the Vite production build completed successfully. 
- The build produced the normal bundles (some chunk-size warnings were emitted) and exited without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bed7a7f148329a240743b04d40fcf)