### PR TITLE
Aim-guide & collision: clamp guide to table edge and add locked-aim collision handling

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -6183,6 +6183,22 @@ function distanceToTableEdge(pos, dir) {
   return minT;
 }
 
+function guideEndAtTableEdge(start, dir, fallbackDistance = BALL_R * 2) {
+  const guideDir = dir.clone();
+  if (guideDir.lengthSq() < 1e-8) return start.clone();
+  guideDir.normalize();
+  const dir2 = new THREE.Vector2(guideDir.x, guideDir.z);
+  const start2 = new THREE.Vector2(start.x, start.z);
+  const edgeDistance = distanceToTableEdge(start2, dir2);
+  const travel = Number.isFinite(edgeDistance)
+    ? edgeDistance
+    : Math.max(fallbackDistance, 0);
+  const end = start.clone().add(guideDir.multiplyScalar(Math.max(travel, 0)));
+  end.x = THREE.MathUtils.clamp(end.x, -RAIL_LIMIT_X, RAIL_LIMIT_X);
+  end.z = THREE.MathUtils.clamp(end.z, -RAIL_LIMIT_Y, RAIL_LIMIT_Y);
+  return end;
+}
+
 function applyAxisClearance(
   limits,
   key,
@@ -7240,9 +7256,9 @@ function calcTarget(cue, dir, balls) {
     if (contactNormal.lengthSq() > 1e-8) contactNormal.normalize();
     else contactNormal.copy(dirNorm);
     targetDir = contactNormal.clone();
-    const projected = dirNorm.dot(targetDir);
+    const projected = Math.max(0, dirNorm.dot(targetDir));
     cueDir = dirNorm.clone().sub(targetDir.clone().multiplyScalar(projected));
-    if (cueDir.lengthSq() > 1e-8) cueDir.normalize();
+    if (cueDir.lengthSq() > 1e-6) cueDir.normalize();
     else cueDir = null;
   } else if (railNormal) {
     const n = railNormal.clone().normalize();
@@ -23013,6 +23029,7 @@ const powerRef = useRef(hud.power);
         shotPrediction = {
           ballId: prediction.targetBall?.id ?? null,
           dir: prediction.targetDir ? prediction.targetDir.clone() : null,
+          cueDir: prediction.cueDir ? prediction.cueDir.clone() : null,
           impact: prediction.impact
             ? new THREE.Vector2(prediction.impact.x, prediction.impact.y)
             : null,
@@ -26117,9 +26134,10 @@ const powerRef = useRef(hud.power);
           } else {
             aimFocusRef.current = null;
           }
+          const hasSpinDrivenCueFollow = Math.abs(physicsSpin.y || 0) > 1e-4;
           const cueFollowDir = cueDir
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
-            : dir.clone();
+            : (hasSpinDrivenCueFollow && (physicsSpin.y || 0) < 0 ? dir.clone().negate() : dir.clone());
           const cueFollowDirSpinAdjusted = cueFollowDir.clone();
           const spinVerticalInfluence = (physicsSpin.y || 0) * 0.68;
           const backSpinWeight = Math.max(0, -(physicsSpin.y || 0));
@@ -26133,11 +26151,9 @@ const powerRef = useRef(hud.power);
           }
           const cueFollowLength =
             BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
-          const followEnd = end
-            .clone()
-            .add(cueFollowDirSpinAdjusted.clone().multiplyScalar(cueFollowLength));
+          const followEnd = guideEndAtTableEdge(end, cueFollowDirSpinAdjusted, cueFollowLength);
           cueAfterGeom.setFromPoints([end, followEnd]);
-          cueAfter.visible = true;
+          cueAfter.visible = Boolean(cueDir || hasSpinDrivenCueFollow);
           const cueBackwards = cueFollowDirSpinAdjusted.dot(dir) < 0;
           cueAfter.material.color.setHex(cueBackwards ? 0xff3b3b : 0x7ce7ff);
           cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
@@ -26297,10 +26313,7 @@ const powerRef = useRef(hud.power);
               BALL_CENTER_Y,
               targetBall.pos.y
             );
-            const distanceScale = travelScale;
-            const tEnd = targetStart
-              .clone()
-              .add(tDir.clone().multiplyScalar(distanceScale));
+            const tEnd = guideEndAtTableEdge(targetStart, tDir, travelScale);
             targetGeom.setFromPoints([targetStart, tEnd]);
             target.material.color.setHex(0xffd166);
             target.material.opacity = 0.65 + 0.3 * powerStrength;
@@ -26309,9 +26322,7 @@ const powerRef = useRef(hud.power);
           } else if (railNormal && cueDir) {
             const bounceDir = new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize();
             const bounceLength = BALL_R * (12 + powerStrength * 18);
-            const bounceEnd = end
-              .clone()
-              .add(bounceDir.clone().multiplyScalar(bounceLength));
+            const bounceEnd = guideEndAtTableEdge(end, bounceDir, bounceLength);
             targetGeom.setFromPoints([end, bounceEnd]);
             target.material.color.setHex(0x7ce7ff);
             target.material.opacity = 0.35 + 0.25 * powerStrength;
@@ -26374,9 +26385,10 @@ const powerRef = useRef(hud.power);
             end.clone().add(perp.clone().multiplyScalar(-AIM_TICK_HALF_LENGTH))
           ]);
           tick.visible = true;
+          const hasSpinDrivenCueFollow = Math.abs(remotePhysicsSpin.y || 0) > 1e-4;
           const cueFollowDir = cueDir
             ? new THREE.Vector3(cueDir.x, 0, cueDir.y).normalize()
-            : baseDir.clone();
+            : (hasSpinDrivenCueFollow && (remotePhysicsSpin.y || 0) < 0 ? baseDir.clone().negate() : baseDir.clone());
           const cueFollowDirSpinAdjusted = cueFollowDir.clone();
           const spinVerticalInfluence = (remotePhysicsSpin.y || 0) * 0.68;
           const backSpinWeight = Math.max(0, -(remotePhysicsSpin.y || 0));
@@ -26390,11 +26402,9 @@ const powerRef = useRef(hud.power);
           }
           const cueFollowLength =
             BALL_R * (12 + powerStrength * 18) * (1 + spinVerticalInfluence * 0.4);
-          const followEnd = end
-            .clone()
-            .add(cueFollowDirSpinAdjusted.clone().multiplyScalar(cueFollowLength));
+          const followEnd = guideEndAtTableEdge(end, cueFollowDirSpinAdjusted, cueFollowLength);
           cueAfterGeom.setFromPoints([end, followEnd]);
-          cueAfter.visible = true;
+          cueAfter.visible = Boolean(cueDir || hasSpinDrivenCueFollow);
           const cueBackwards = cueFollowDirSpinAdjusted.dot(baseDir) < 0;
           cueAfter.material.color.setHex(cueBackwards ? 0xff3b3b : 0x7ce7ff);
           cueAfter.material.opacity = 0.35 + 0.35 * powerStrength;
@@ -26731,21 +26741,64 @@ const powerRef = useRef(hud.power);
                 newCollisions.add(pairKey);
                 const wasColliding = prevCollisions.has(pairKey);
                 const isNewImpact = firstPairCollision && !wasColliding;
-                a.pos.x -= nx * overlap;
-                a.pos.y -= ny * overlap;
-                b.pos.x += nx * overlap;
-                b.pos.y += ny * overlap;
-                const avn = a.vel.x * nx + a.vel.y * ny;
-                const bvn = b.vel.x * nx + b.vel.y * ny;
-                const impulse = Math.abs(bvn - avn);
-                const at = a.vel
-                  .clone()
-                  .sub(new THREE.Vector2(nx, ny).multiplyScalar(avn));
-                const bt = b.vel
-                  .clone()
-                  .sub(new THREE.Vector2(nx, ny).multiplyScalar(bvn));
-                a.vel.copy(at.add(new THREE.Vector2(nx, ny).multiplyScalar(bvn)));
-                b.vel.copy(bt.add(new THREE.Vector2(nx, ny).multiplyScalar(avn)));
+                const cueBallForPair = a.id === 'cue' ? a : b.id === 'cue' ? b : null;
+                const objectBallForPair = cueBallForPair
+                  ? (cueBallForPair === a ? b : a)
+                  : null;
+                const predictedObjectDir = shotPrediction?.dir?.clone?.() ?? null;
+                const predictedCueDir = shotPrediction?.cueDir?.clone?.() ?? null;
+                const lockedAimCollision = Boolean(
+                  isNewImpact &&
+                  cueBallForPair &&
+                  objectBallForPair &&
+                  shotPrediction?.ballId &&
+                  String(objectBallForPair.id) === String(shotPrediction.ballId) &&
+                  predictedObjectDir &&
+                  predictedObjectDir.lengthSq() > 1e-8
+                );
+                let impulse = Math.abs(
+                  (b.vel.x * nx + b.vel.y * ny) -
+                  (a.vel.x * nx + a.vel.y * ny)
+                );
+                if (lockedAimCollision) {
+                  predictedObjectDir.normalize();
+                  const pairMid = a.pos.clone().add(b.pos).multiplyScalar(0.5);
+                  cueBallForPair.pos.copy(
+                    pairMid.clone().addScaledVector(predictedObjectDir, -BALL_R)
+                  );
+                  objectBallForPair.pos.copy(
+                    pairMid.clone().addScaledVector(predictedObjectDir, BALL_R)
+                  );
+                  const incomingCueVel = cueBallForPair.vel.clone();
+                  const normalSpeed = Math.max(0, incomingCueVel.dot(predictedObjectDir));
+                  const cueResidual = incomingCueVel.clone().addScaledVector(
+                    predictedObjectDir,
+                    -normalSpeed
+                  );
+                  const cueResidualSpeed = cueResidual.length();
+                  objectBallForPair.vel.copy(predictedObjectDir.clone().multiplyScalar(normalSpeed));
+                  if (predictedCueDir && predictedCueDir.lengthSq() > 1e-8 && cueResidualSpeed > 1e-8) {
+                    cueBallForPair.vel.copy(predictedCueDir.normalize().multiplyScalar(cueResidualSpeed));
+                  } else {
+                    cueBallForPair.vel.set(0, 0);
+                  }
+                  impulse = normalSpeed;
+                } else {
+                  a.pos.x -= nx * overlap;
+                  a.pos.y -= ny * overlap;
+                  b.pos.x += nx * overlap;
+                  b.pos.y += ny * overlap;
+                  const avn = a.vel.x * nx + a.vel.y * ny;
+                  const bvn = b.vel.x * nx + b.vel.y * ny;
+                  const at = a.vel
+                    .clone()
+                    .sub(new THREE.Vector2(nx, ny).multiplyScalar(avn));
+                  const bt = b.vel
+                    .clone()
+                    .sub(new THREE.Vector2(nx, ny).multiplyScalar(bvn));
+                  a.vel.copy(at.add(new THREE.Vector2(nx, ny).multiplyScalar(bvn)));
+                  b.vel.copy(bt.add(new THREE.Vector2(nx, ny).multiplyScalar(avn)));
+                }
                 if (isNewImpact) {
                   const shotScale = 0.4 + 0.6 * lastShotPower;
                   const volume = clamp(
@@ -26806,7 +26859,7 @@ const powerRef = useRef(hud.power);
                     cueBall.liftVel ?? 0,
                     launchCeiling
                   );
-                  if (spinEnergy > 1e-6) {
+                  if (spinEnergy > 1e-6 && !lockedAimCollision) {
                     const spinThrow = Math.min(
                       spinEnergy * MAX_POWER_SPIN_LATERAL_THROW,
                       MAX_POWER_BOUNCE_IMPULSE * 0.4

--- a/webapp/src/pages/Games/SnookerRoyalProvided.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalProvided.jsx
@@ -1417,13 +1417,29 @@ function clampSnookerAimImpactToPerimeter(point) {
   );
 }
 
-function snookerGuideEndFrom(start, dir, distance, y) {
-  const bounded = clampSnookerAimImpactToPerimeter(new THREE.Vector2(
-    start.x + dir.x * distance,
-    start.z + dir.z * distance
-  ));
+function calcSnookerGuideRayEnd(start, dir, y, pocketPositions = [], maxDistance = Infinity) {
+  const start2 = new THREE.Vector2(start.x, start.z);
+  const rayDir = new THREE.Vector2(dir.x, dir.z);
+  if (rayDir.lengthSq() < 1e-8) return start.clone().setY(y);
+  rayDir.normalize();
+  const railX = getSnookerCushionCenterLimit('x');
+  const railZ = getSnookerCushionCenterLimit('z');
+  let tHit = Number.isFinite(maxDistance) ? Math.max(maxDistance, 0) : Infinity;
+  const checkRail = (t, axis, sign) => {
+    if (t < 0 || t >= tHit) return;
+    const impact = start2.clone().add(rayDir.clone().multiplyScalar(t));
+    const probe = { pos: new THREE.Vector3(impact.x, CFG.ballR, impact.y) };
+    if (!isInsideSnookerPocketThroat(probe, axis, sign, pocketPositions)) tHit = t;
+  };
+  if (rayDir.x < -1e-8) checkRail((-railX - start2.x) / rayDir.x, 'x', -1);
+  if (rayDir.x > 1e-8) checkRail((railX - start2.x) / rayDir.x, 'x', 1);
+  if (rayDir.y < -1e-8) checkRail((-railZ - start2.y) / rayDir.y, 'z', -1);
+  if (rayDir.y > 1e-8) checkRail((railZ - start2.y) / rayDir.y, 'z', 1);
+  const travel = Number.isFinite(tHit) ? tHit : Math.sqrt(CFG.tableW * CFG.tableW + CFG.tableL * CFG.tableL);
+  const bounded = clampSnookerAimImpactToPerimeter(start2.add(rayDir.multiplyScalar(Math.max(0, travel))));
   return new THREE.Vector3(bounded.x, y, bounded.y);
 }
+
 
 function decaySnookerSpin(ball, stepScale) {
   if (!ball?.spin || ball.spin.lengthSq() < 1e-6) return false;
@@ -1599,43 +1615,71 @@ function updateBalls(balls, dt, tmpA, tmpB, pocketPositions = [], rulesState = n
       const overlap = minDist - dist;
       a.pos.addScaledVector(n, -overlap * 0.5);
       b.pos.addScaledVector(n, overlap * 0.5);
-      const normal = SNOOKER_TMP_VEC3_A.copy(n).setY(0).normalize();
-      const ra = SNOOKER_TMP_VEC3_B.copy(normal).multiplyScalar(CFG.ballR);
-      const rb = SNOOKER_TMP_VEC3_C.copy(normal).multiplyScalar(-CFG.ballR);
-      const va = SNOOKER_TMP_VEC3_D.set(a.vel.x, 0, a.vel.z);
-      const vb = SNOOKER_TMP_VEC3_E.set(b.vel.x, 0, b.vel.z);
-      const omegaA = a.omega ?? new THREE.Vector3();
-      const omegaB = b.omega ?? new THREE.Vector3();
-      const contactA = omegaA.clone().cross(ra).add(va);
-      const contactB = omegaB.clone().cross(rb).add(vb);
-      const relative = contactB.sub(contactA);
-      const relNormal = relative.dot(normal);
-      if (relNormal < 0) {
-        const normalImpulseMag = (-(1 + CFG.restitution) * relNormal * SNOOKER_BALL_MASS) / 2;
-        const impulse = normal.clone().multiplyScalar(normalImpulseMag);
-        va.addScaledVector(impulse, -1 / SNOOKER_BALL_MASS);
-        vb.addScaledVector(impulse, 1 / SNOOKER_BALL_MASS);
-        const tangentVel = relative.addScaledVector(normal, -relNormal);
-        const tangentSpeed = tangentVel.length();
-        if (tangentSpeed > 1e-8) {
-          tangentVel.multiplyScalar(1 / tangentSpeed);
-          const raCrossT = ra.clone().cross(tangentVel).lengthSq();
-          const rbCrossT = rb.clone().cross(tangentVel).lengthSq();
-          const denom = 2 / SNOOKER_BALL_MASS + (raCrossT + rbCrossT) / SNOOKER_BALL_INERTIA;
-          const jt = -tangentSpeed / Math.max(denom, 1e-6);
-          const tangentImpulse = tangentVel.multiplyScalar(clamp(jt, -SNOOKER_BALL_BALL_FRICTION * Math.abs(normalImpulseMag), SNOOKER_BALL_BALL_FRICTION * Math.abs(normalImpulseMag)));
-          va.addScaledVector(tangentImpulse, -1 / SNOOKER_BALL_MASS);
-          vb.addScaledVector(tangentImpulse, 1 / SNOOKER_BALL_MASS);
-          a.omega?.addScaledVector(ra.clone().cross(tangentImpulse), -1 / SNOOKER_BALL_INERTIA);
-          b.omega?.addScaledVector(rb.clone().cross(tangentImpulse), 1 / SNOOKER_BALL_INERTIA);
+      const cueBallForPair = a.isCue ? a : b.isCue ? b : null;
+      const objectBallForPair = cueBallForPair ? (cueBallForPair === a ? b : a) : null;
+      const guidePrediction = cueBallForPair?.aimGuidePrediction;
+      const lockedObjectDir = guidePrediction?.targetBall === objectBallForPair
+        ? guidePrediction.targetDir?.clone?.() ?? null
+        : null;
+      if (lockedObjectDir && lockedObjectDir.lengthSq() > 1e-8) {
+        lockedObjectDir.normalize();
+        const pairMid = a.pos.clone().add(b.pos).multiplyScalar(0.5);
+        cueBallForPair.pos.copy(pairMid.clone().addScaledVector(new THREE.Vector3(lockedObjectDir.x, 0, lockedObjectDir.y), -CFG.ballR));
+        objectBallForPair.pos.copy(pairMid.clone().addScaledVector(new THREE.Vector3(lockedObjectDir.x, 0, lockedObjectDir.y), CFG.ballR));
+        const objectDir3 = new THREE.Vector3(lockedObjectDir.x, 0, lockedObjectDir.y).normalize();
+        const incomingCueVel = new THREE.Vector3(cueBallForPair.vel.x, 0, cueBallForPair.vel.z);
+        const normalSpeed = Math.max(0, incomingCueVel.dot(objectDir3));
+        const cueResidual = incomingCueVel.clone().addScaledVector(objectDir3, -normalSpeed);
+        const cueResidualSpeed = cueResidual.length();
+        objectBallForPair.vel.copy(objectDir3.multiplyScalar(normalSpeed));
+        const lockedCueDir = guidePrediction.cueDir?.clone?.() ?? null;
+        if (lockedCueDir && lockedCueDir.lengthSq() > 1e-8 && cueResidualSpeed > 1e-8) {
+          lockedCueDir.normalize();
+          cueBallForPair.vel.set(lockedCueDir.x * cueResidualSpeed, 0, lockedCueDir.y * cueResidualSpeed);
+        } else {
+          cueBallForPair.vel.set(0, 0, 0);
         }
-        a.vel.set(va.x, 0, va.z);
-        b.vel.set(vb.x, 0, vb.z);
-        if (a.isCue || b.isCue) {
-          const objectBall = a.isCue ? b : a;
-          recordSnookerFirstContact(objectBall, rulesState);
-          a.impacted = a.impacted || a.isCue;
-          b.impacted = b.impacted || b.isCue;
+        recordSnookerFirstContact(objectBallForPair, rulesState);
+        cueBallForPair.impacted = true;
+      } else {
+        const normal = SNOOKER_TMP_VEC3_A.copy(n).setY(0).normalize();
+        const ra = SNOOKER_TMP_VEC3_B.copy(normal).multiplyScalar(CFG.ballR);
+        const rb = SNOOKER_TMP_VEC3_C.copy(normal).multiplyScalar(-CFG.ballR);
+        const va = SNOOKER_TMP_VEC3_D.set(a.vel.x, 0, a.vel.z);
+        const vb = SNOOKER_TMP_VEC3_E.set(b.vel.x, 0, b.vel.z);
+        const omegaA = a.omega ?? new THREE.Vector3();
+        const omegaB = b.omega ?? new THREE.Vector3();
+        const contactA = omegaA.clone().cross(ra).add(va);
+        const contactB = omegaB.clone().cross(rb).add(vb);
+        const relative = contactB.sub(contactA);
+        const relNormal = relative.dot(normal);
+        if (relNormal < 0) {
+          const normalImpulseMag = (-(1 + CFG.restitution) * relNormal * SNOOKER_BALL_MASS) / 2;
+          const impulse = normal.clone().multiplyScalar(normalImpulseMag);
+          va.addScaledVector(impulse, -1 / SNOOKER_BALL_MASS);
+          vb.addScaledVector(impulse, 1 / SNOOKER_BALL_MASS);
+          const tangentVel = relative.addScaledVector(normal, -relNormal);
+          const tangentSpeed = tangentVel.length();
+          if (tangentSpeed > 1e-8) {
+            tangentVel.multiplyScalar(1 / tangentSpeed);
+            const raCrossT = ra.clone().cross(tangentVel).lengthSq();
+            const rbCrossT = rb.clone().cross(tangentVel).lengthSq();
+            const denom = 2 / SNOOKER_BALL_MASS + (raCrossT + rbCrossT) / SNOOKER_BALL_INERTIA;
+            const jt = -tangentSpeed / Math.max(denom, 1e-6);
+            const tangentImpulse = tangentVel.multiplyScalar(clamp(jt, -SNOOKER_BALL_BALL_FRICTION * Math.abs(normalImpulseMag), SNOOKER_BALL_BALL_FRICTION * Math.abs(normalImpulseMag)));
+            va.addScaledVector(tangentImpulse, -1 / SNOOKER_BALL_MASS);
+            vb.addScaledVector(tangentImpulse, 1 / SNOOKER_BALL_MASS);
+            a.omega?.addScaledVector(ra.clone().cross(tangentImpulse), -1 / SNOOKER_BALL_INERTIA);
+            b.omega?.addScaledVector(rb.clone().cross(tangentImpulse), 1 / SNOOKER_BALL_INERTIA);
+          }
+          a.vel.set(va.x, 0, va.z);
+          b.vel.set(vb.x, 0, vb.z);
+          if (a.isCue || b.isCue) {
+            const objectBall = a.isCue ? b : a;
+            recordSnookerFirstContact(objectBall, rulesState);
+            a.impacted = a.impacted || a.isCue;
+            b.impacted = b.impacted || b.isCue;
+          }
         }
       }
     }
@@ -1667,8 +1711,8 @@ function calcSnookerAimTarget(cueBall, aimDir, balls, pocketPositions = []) {
       targetBall = null;
     }
   };
-  const railX = CFG.tableW / 2 - CFG.ballR;
-  const railZ = CFG.tableL / 2 - CFG.ballR;
+  const railX = getSnookerCushionCenterLimit('x');
+  const railZ = getSnookerCushionCenterLimit('z');
   const mouthClear = (axis, sign, impact) => {
     const probe = { pos: new THREE.Vector3(impact.x, CFG.ballR, impact.y) };
     return isInsideSnookerPocketThroat(probe, axis, sign, pocketPositions);
@@ -1718,9 +1762,9 @@ function calcSnookerAimTarget(cueBall, aimDir, balls, pocketPositions = []) {
     targetDir = new THREE.Vector2(targetBall.pos.x - impact.x, targetBall.pos.z - impact.y);
     if (targetDir.lengthSq() > 1e-8) targetDir.normalize();
     else targetDir.copy(dir);
-    const projected = dir.dot(targetDir);
+    const projected = Math.max(0, dir.dot(targetDir));
     cueDir = dir.clone().sub(targetDir.clone().multiplyScalar(projected));
-    if (cueDir.lengthSq() > 1e-8) cueDir.normalize();
+    if (cueDir.lengthSq() > 1e-6) cueDir.normalize();
     else cueDir = null;
   } else if (railNormal) {
     cueDir = dir.clone().sub(railNormal.clone().multiplyScalar(2 * dir.dot(railNormal))).normalize();
@@ -2395,6 +2439,13 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
       updateHumanPose(human, dt, visualState, humanRootTarget, aimForward, bridgeHandTarget, idleRightHandTarget, idleLeftHandTarget, activeCueBack, activeCueTip, activePower);
       setGuideLine(cueLine, activeCueBack, cueBallWorld, true);
       const prediction = calcSnookerAimTarget(cueBall, aimForward, balls, pocketPositions);
+      cueBall.aimGuidePrediction = prediction?.targetBall
+        ? {
+            targetBall: prediction.targetBall,
+            targetDir: prediction.targetDir?.clone?.() ?? null,
+            cueDir: prediction.cueDir?.clone?.() ?? null
+          }
+        : null;
       const aimY = cueBallWorld.y;
       const aimStart = cueBallWorld.clone().setY(aimY);
       const boundedImpact = clampSnookerAimImpactToPerimeter(prediction.impact);
@@ -2403,19 +2454,23 @@ export default function SnookerRoyalProvided({ gameTitle = 'Snooker Royal Provid
       const guideDir = aimEnd.clone().sub(aimStart).setY(0).normalize();
       const tickPerp = new THREE.Vector3(-guideDir.z, 0, guideDir.x).normalize();
       setGuideLine(impactTick, aimEnd.clone().addScaledVector(tickPerp, SNOOKER_AIM_TICK_HALF_LENGTH), aimEnd.clone().addScaledVector(tickPerp, -SNOOKER_AIM_TICK_HALF_LENGTH), true);
-      const followDir2 = prediction.cueDir ?? new THREE.Vector2(aimForward.x, aimForward.z);
-      const followDir3 = new THREE.Vector3(followDir2.x, 0, followDir2.y).normalize();
-      setGuideLine(cueAfterLine, aimEnd, snookerGuideEndFrom(aimEnd, followDir3, CFG.ballR * (7 + activePower * 12), aimY), true);
+      if (prediction.cueDir) {
+        const followDir3 = new THREE.Vector3(prediction.cueDir.x, 0, prediction.cueDir.y).normalize();
+        setGuideLine(cueAfterLine, aimEnd, calcSnookerGuideRayEnd(aimEnd, followDir3, aimY, pocketPositions), true);
+      } else {
+        cueAfterLine.visible = false;
+      }
       if (prediction.targetBall && prediction.targetDir) {
         const targetStart = prediction.targetBall.mesh.getWorldPosition(new THREE.Vector3()).setY(aimY);
         const targetDir3 = new THREE.Vector3(prediction.targetDir.x, 0, prediction.targetDir.y).normalize();
-        setGuideLine(targetLine, targetStart, snookerGuideEndFrom(targetStart, targetDir3, CFG.ballR * 2, aimY), true);
+        setGuideLine(targetLine, targetStart, calcSnookerGuideRayEnd(targetStart, targetDir3, aimY, pocketPositions), true);
         targetLine.material.color.setHex(0xffd166);
       } else if (prediction.railNormal && prediction.cueDir) {
-        setGuideLine(targetLine, aimEnd, snookerGuideEndFrom(aimEnd, followDir3, CFG.ballR * 2, aimY), true);
+        const followDir3 = new THREE.Vector3(prediction.cueDir.x, 0, prediction.cueDir.y).normalize();
+        setGuideLine(targetLine, aimEnd, calcSnookerGuideRayEnd(aimEnd, followDir3, aimY, pocketPositions), true);
         targetLine.material.color.setHex(0x7ce7ff);
       } else {
-        setGuideLine(targetLine, aimEnd, snookerGuideEndFrom(aimEnd, guideDir, CFG.ballR * 2, aimY), true);
+        setGuideLine(targetLine, aimEnd, calcSnookerGuideRayEnd(aimEnd, guideDir, aimY, pocketPositions), true);
         targetLine.material.color.setHex(0x9fd8ff);
       }
       const liveCameraMode = ballsMoving && cameraModeRef.current === 'rail-overhead' ? 'tv-broadcast' : cameraModeRef.current;


### PR DESCRIPTION
### Motivation
- Improve aim/guide visuals so end-points stop at table cushions and respect snooker pocket throats instead of overshooting into world space.
- Make aim prediction more robust by preventing negative projection contributions and stabilizing tiny vectors before normalization.
- Support a locked-aim behavior that enforces predicted cue→object geometry during the first impact to avoid tiny simulation divergence from the visual guide.
- Ensure cue-follow preview visibility and direction respond sensibly to vertical spin (draw/backspin) when no explicit cueDir is available.

### Description
- Added `guideEndAtTableEdge` in `SnookerRoyal.jsx` and `calcSnookerGuideRayEnd` in `SnookerRoyalProvided.jsx` to compute guide line end points clamped to table/rail limits and pocket throat checks respectively, replacing previous ad-hoc end calculations. 
- Store and propagate predicted `cueDir` in `shotPrediction` and attach `aimGuidePrediction` to the cue ball so guide predictions are available to collision logic and rendering. 
- Prevent negative projection by using `Math.max(0, dir.dot(targetDir))` and raise tiny-vector normalization thresholds from `1e-8` to `1e-6` to avoid unstable normalized vectors. 
- Adjust cue-follow preview: account for spin-driven cue-follow flips for negative vertical spin and only show preview when a `cueDir` or sufficient spin-driven influence exists. 
- Implement locked-aim collision handling in both pool and snooker loops: when a new collision involves the cue ball and the predicted target ball, snap their positions to the predicted contact line and set velocities to match the predicted normal and optionally the predicted residual cue direction, while avoiding spin lateral throw and other post-impact spin effects in this locked case. 
- Replace various old end-point usages to call the new guide ray functions for consistent aim and target line rendering. 

### Testing
- Built the webapp (`yarn build`) and verified the dev bundle compiles successfully without type/runtime errors. (succeeded)
- Ran the project's unit and integration test suites (`yarn test`) and confirmed all automated tests passed. (succeeded)
- Performed smoke rendering checks in development to verify guide lines, cue follow previews, and locked-aim collisions trigger and render as expected. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be6135b6c8329be0490fbd9bd017b)