### PR TITLE
Use Showood GLB cushions/jaws and add Showood reference mapping with lobby controls

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -24,7 +24,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     useOriginalLayoutSurfaces: false,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket'],
-    preserveSourceTextureRoles: ['cushion'],
+    preserveSourceTextureRoles: [],
+    matchCushionsToCloth: true,
     preserveOriginalSurfaceRoles: ['trim', 'wood'],
     hideSurfaceRoles: ['trim', 'wood'],
     keepGeneratedShell: true,
@@ -49,10 +50,11 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
+    useReferenceShowoodMapping: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
     preserveSourceTextureRoles: ['cushion', 'wood'],
-    preserveOriginalSurfaceRoles: ['trim'],
-    tintOriginalTrimGold: true,
+    preserveOriginalSurfaceRoles: [],
+    tintOriginalTrimGold: false,
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -37,6 +37,14 @@ import {
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
+import {
+  POOL_ROYALE_SHOWOOD_CONTROL_META,
+  POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS,
+  POOL_ROYALE_SHOWOOD_CONTROL_PARTS,
+  POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
+  applyPoolRoyaleShowoodReferenceMapping,
+  normalizePoolRoyaleShowoodPalette
+} from '../../utils/poolRoyaleShowoodMapping.js';
 import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { chatBeep } from '../../assets/coreSoundData.js';
@@ -1158,6 +1166,7 @@ const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
+const SHOWOOD_PALETTE_STORAGE_KEY = 'poolRoyaleShowoodPalette';
 const POOL_ROYALE_REPLAY_ENABLED = true;
 const POOL_ROYALE_VOICE_COMMENTARY_ENABLED = false;
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
@@ -12307,6 +12316,7 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
   if (role === 'cloth' || role === 'cushion') {
     const preserveSourceTexture = Array.isArray(tableModel?.preserveSourceTextureRoles) &&
       tableModel.preserveSourceTextureRoles.includes(role);
+    const matchCushionToCloth = role === 'cushion' && tableModel?.matchCushionsToCloth;
     const sourceSnapshot = preserveSourceTexture
       ? {
           map: mat.map,
@@ -12317,7 +12327,7 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
           aoMap: mat.aoMap
         }
       : null;
-    copyMaterialLook(role === 'cushion' ? finishInfo.cushionMat : finishInfo.clothMat);
+    copyMaterialLook(matchCushionToCloth ? finishInfo.clothMat : (role === 'cushion' ? finishInfo.cushionMat : finishInfo.clothMat));
     if (sourceSnapshot) {
       Object.assign(mat, sourceSnapshot);
     }
@@ -12365,6 +12375,10 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
 }
 
 function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finishInfo = null) {
+  if (tableModel?.useReferenceShowoodMapping) {
+    applyPoolRoyaleShowoodReferenceMapping(root, tableModel.showoodPalette);
+    return;
+  }
   root?.traverse?.((child) => {
     if (!child?.isMesh) return;
     child.castShadow = true;
@@ -13989,6 +14003,23 @@ function PoolRoyaleGame({
     () => resolvePoolRoyaleTableModel(tableModelKey),
     [tableModelKey]
   );
+  const [showoodPalette, setShowoodPalette] = useState(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = window.localStorage.getItem(SHOWOOD_PALETTE_STORAGE_KEY);
+        if (stored) return normalizePoolRoyaleShowoodPalette(JSON.parse(stored));
+      } catch {}
+    }
+    return normalizePoolRoyaleShowoodPalette(POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE);
+  });
+  const activeTableModelWithPalette = useMemo(
+    () =>
+      activeTableModel?.useReferenceShowoodMapping
+        ? { ...activeTableModel, showoodPalette }
+        : activeTableModel,
+    [activeTableModel, showoodPalette]
+  );
+  const showoodTableSetupActive = activeTableModel?.useReferenceShowoodMapping === true;
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
   const resolvedAccountId = useMemo(
     () => poolRoyalAccountId(accountId),
@@ -14535,6 +14566,24 @@ function PoolRoyaleGame({
       POCKET_LINER_OPTIONS[0],
     [availablePocketLiners, pocketLinerId]
   );
+  const showoodOptionRows = useMemo(
+    () =>
+      POOL_ROYALE_SHOWOOD_CONTROL_PARTS.map((control) => ({
+        control,
+        ...POOL_ROYALE_SHOWOOD_CONTROL_META[control],
+        selected: showoodPalette[control],
+        options: POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]
+      })),
+    [showoodPalette]
+  );
+  const setShowoodControlChoice = useCallback((control, choice) => {
+    setShowoodPalette((current) =>
+      normalizePoolRoyaleShowoodPalette({
+        ...current,
+        [control]: choice === 'b' ? 'b' : 'a'
+      })
+    );
+  }, []);
   useEffect(() => {
     if (!POOL_ROYALE_VOICE_COMMENTARY_ENABLED) {
       setCommentarySupported(false);
@@ -15971,6 +16020,11 @@ function PoolRoyaleGame({
   useEffect(() => {
     activeVariantRef.current = activeVariant;
   }, [activeVariant]);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(SHOWOOD_PALETTE_STORAGE_KEY, JSON.stringify(showoodPalette));
+    }
+  }, [showoodPalette]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
       window.localStorage.setItem(TABLE_FINISH_STORAGE_KEY, tableFinishId);
@@ -24735,7 +24789,7 @@ const shotPowerRef = useRef(0);
         railMarkerStyleRef.current,
         activeTableBase,
         rendererRef.current,
-        { tableModel: activeTableModel, chromePlateStyle: activeChromePlateStyle }
+        { tableModel: activeTableModelWithPalette, chromePlateStyle: activeChromePlateStyle }
       );
       const SPOTS = spotPositions(baulkZ);
 
@@ -24790,7 +24844,7 @@ const shotPowerRef = useRef(0);
         railMarkerStyleRef.current,
         activeTableBase,
         rendererRef.current,
-        { tableModel: activeTableModel, chromePlateStyle: activeChromePlateStyle }
+        { tableModel: activeTableModelWithPalette, chromePlateStyle: activeChromePlateStyle }
       );
       secondaryTableRef.current = secondaryTableEntry?.group ?? null;
       secondaryBaseSetterRef.current = secondaryTableEntry?.setBaseVariant ?? null;
@@ -35560,10 +35614,68 @@ const shotPowerRef = useRef(0);
                   </button>
                 </div>
               ) : null}
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Finish
-                </h3>
+              {showoodTableSetupActive ? (
+                <div className="rounded-3xl border border-emerald-300/25 bg-black/20 p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                        Showood Table Setup
+                      </h3>
+                      <p className="mt-1 text-[0.68rem] text-white/60">
+                        Uses the pasted Showood GLB texture mapping and identical two-choice controls.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setShowoodPalette(normalizePoolRoyaleShowoodPalette(POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE))}
+                      className="rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.2em] text-white/80"
+                    >
+                      Reset
+                    </button>
+                  </div>
+                  <div className="mt-3 grid gap-3">
+                    {showoodOptionRows.map((row) => (
+                      <div key={row.control} className="grid gap-2 rounded-2xl bg-white/5 p-2">
+                        <div>
+                          <p className="text-[11px] font-black uppercase tracking-[0.2em] text-white">{row.label}</p>
+                          <p className="mt-0.5 text-[0.65rem] leading-snug text-white/55">{row.description}</p>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          {(['a', 'b']).map((choice) => {
+                            const option = row.options[choice];
+                            const active = row.selected === choice;
+                            return (
+                              <button
+                                key={`${row.control}-${choice}`}
+                                type="button"
+                                onClick={() => setShowoodControlChoice(row.control, choice)}
+                                aria-pressed={active}
+                                className={`flex min-w-[8.5rem] flex-1 items-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                                  active
+                                    ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                                    : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                                }`}
+                              >
+                                <span
+                                  className="h-3.5 w-3.5 rounded-full border border-white/40"
+                                  style={{ backgroundColor: option.color }}
+                                  aria-hidden="true"
+                                />
+                                <span className="truncate">{option.label}</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {!showoodTableSetupActive ? (
+                <div>
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                    Table Finish
+                  </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {availableTableFinishes.map((option) => {
                     const active = option.id === tableFinishId;
@@ -35592,11 +35704,13 @@ const shotPowerRef = useRef(0);
                       </button>
                     );
                   })}
+                  </div>
                 </div>
-              </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Base
+              ) : null}
+              {!showoodTableSetupActive ? (
+                <div>
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                    Table Base
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {availableTableBases.map((option) => {
@@ -35636,8 +35750,9 @@ const shotPowerRef = useRef(0);
                       </button>
                     );
                   })}
+                  </div>
                 </div>
-              </div>
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   HDR Environment

--- a/webapp/src/utils/poolRoyaleShowoodMapping.js
+++ b/webapp/src/utils/poolRoyaleShowoodMapping.js
@@ -1,0 +1,481 @@
+import * as THREE from 'three';
+
+const CUSHION_SHADOW_GREY = '#666a72';
+
+const TABLE_PARTS = [
+  'cloth',
+  'cushion',
+  'topWoodRail',
+  'sideWoodApron',
+  'pocketCup',
+  'cornerPocketPlate',
+  'middlePocketPlate',
+  'verticalCornerRim',
+  'baseCornerBlock',
+  'leg',
+  'baseFoot',
+  'lowerTrim',
+  'railSight',
+  'underside'
+];
+
+const PART_TO_CONTROL = {
+  cloth: 'cloth',
+  cushion: 'cushion',
+  topWoodRail: 'topWoodRail',
+  sideWoodApron: 'metalAccent',
+  pocketCup: 'jaws',
+  cornerPocketPlate: 'metalAccent',
+  middlePocketPlate: 'metalAccent',
+  verticalCornerRim: 'metalAccent',
+  baseCornerBlock: 'legBase',
+  leg: 'legBase',
+  baseFoot: 'metalAccent',
+  lowerTrim: 'metalAccent',
+  railSight: 'metalAccent',
+  underside: 'legBase'
+};
+
+export const POOL_ROYALE_SHOWOOD_CONTROL_PARTS = [
+  'cloth',
+  'cushion',
+  'metalAccent',
+  'jaws',
+  'topWoodRail',
+  'legBase'
+];
+
+export const POOL_ROYALE_SHOWOOD_CONTROL_META = {
+  cloth: { label: 'Field cloth', description: 'Only the flat playfield surface.' },
+  cushion: {
+    label: 'Cushions',
+    description:
+      'Reference Showood mapping: matched green or black rubber while preserving the GLB cushion texture.'
+  },
+  metalAccent: {
+    label: 'Rail sights + side strip + feet',
+    description: 'One gold/chrome control for sights, side apron strip, vertical rims, trims, plates, and feet.'
+  },
+  jaws: { label: 'Jaws', description: 'Pocket jaws / cups: black or brown.' },
+  topWoodRail: { label: 'Top rail frame', description: 'Main top wood rail frame.' },
+  legBase: { label: 'Legs + base', description: 'Legs and lower base blocks together, separate from metal accents.' }
+};
+
+export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = {
+  cloth: {
+    a: { label: 'Green field', color: '#0a7b33', metalness: 0, roughness: 1, envMapIntensity: 0.16 },
+    b: { label: 'Blue field', color: '#0d4fb8', metalness: 0, roughness: 1, envMapIntensity: 0.16 }
+  },
+  cushion: {
+    a: { label: 'Matched green', color: '#064f22', metalness: 0, roughness: 0.88, envMapIntensity: 0.55 },
+    b: { label: 'Black rubber', color: '#050505', metalness: 0, roughness: 0.86, envMapIntensity: 0.55 }
+  },
+  metalAccent: {
+    a: { label: 'Gold', color: '#d8b23d', metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 },
+    b: { label: 'Chrome', color: '#d7dde7', metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 }
+  },
+  jaws: {
+    a: { label: 'Black jaws', color: '#020202', metalness: 0, roughness: 0.96, envMapIntensity: 0.14 },
+    b: { label: 'Brown jaws', color: '#2a1207', metalness: 0, roughness: 0.88, envMapIntensity: 0.26 }
+  },
+  topWoodRail: {
+    a: { label: 'Walnut frame', color: '#5a2608', metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 },
+    b: { label: 'Black frame', color: '#070605', metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 }
+  },
+  legBase: {
+    a: { label: 'Brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 },
+    b: { label: 'Black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 }
+  }
+};
+
+export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
+  cloth: 'a',
+  cushion: 'a',
+  metalAccent: 'a',
+  jaws: 'a',
+  topWoodRail: 'a',
+  legBase: 'b'
+});
+
+const KEEP_TEXTURE_PARTS = new Set(['cushion', 'topWoodRail', 'leg', 'baseCornerBlock', 'underside']);
+const FINE_PARTS = new Set([
+  'pocketCup',
+  'cornerPocketPlate',
+  'middlePocketPlate',
+  'verticalCornerRim',
+  'baseCornerBlock',
+  'lowerTrim',
+  'railSight',
+  'underside'
+]);
+
+export function normalizePoolRoyaleShowoodPalette(palette = {}) {
+  return POOL_ROYALE_SHOWOOD_CONTROL_PARTS.reduce((acc, control) => {
+    acc[control] = palette?.[control] === 'b' ? 'b' : POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control];
+    return acc;
+  }, {});
+}
+
+function optionForPart(part, palette) {
+  return POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[PART_TO_CONTROL[part]][palette[PART_TO_CONTROL[part]]];
+}
+
+function patchTexture(texture, isColorTexture = false) {
+  if (!texture) return;
+  if (isColorTexture) texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = 16;
+  texture.needsUpdate = true;
+}
+
+function patchMaterial(material) {
+  [material.map, material.emissiveMap, material.lightMap].forEach((texture) => patchTexture(texture, true));
+  [material.normalMap, material.bumpMap, material.roughnessMap, material.metalnessMap, material.aoMap, material.alphaMap].forEach((texture) => patchTexture(texture));
+  material.side = THREE.DoubleSide;
+  material.needsUpdate = true;
+}
+
+function snapshotMaterial(material) {
+  return {
+    color: material.color?.clone?.() ?? new THREE.Color('#ffffff'),
+    emissive: material.emissive?.clone?.() ?? new THREE.Color('#000000'),
+    metalness: material.metalness ?? 0,
+    roughness: material.roughness ?? 0.55,
+    envMapIntensity: material.envMapIntensity ?? 1,
+    clearcoat: material.clearcoat ?? 0,
+    clearcoatRoughness: material.clearcoatRoughness ?? 0,
+    map: material.map ?? null,
+    normalMap: material.normalMap ?? null,
+    bumpMap: material.bumpMap ?? null,
+    roughnessMap: material.roughnessMap ?? null,
+    metalnessMap: material.metalnessMap ?? null,
+    aoMap: material.aoMap ?? null,
+    emissiveMap: material.emissiveMap ?? null,
+    lightMap: material.lightMap ?? null,
+    alphaMap: material.alphaMap ?? null,
+    transparent: material.transparent,
+    opacity: material.opacity
+  };
+}
+
+function restoreMaterial(material) {
+  const snap = material.userData?.originalSnapshot;
+  if (!snap) return;
+  material.color.copy(snap.color);
+  material.emissive?.copy?.(snap.emissive);
+  material.metalness = snap.metalness;
+  material.roughness = snap.roughness;
+  material.envMapIntensity = snap.envMapIntensity;
+  material.clearcoat = snap.clearcoat;
+  material.clearcoatRoughness = snap.clearcoatRoughness;
+  material.map = snap.map;
+  material.normalMap = snap.normalMap;
+  material.bumpMap = snap.bumpMap;
+  material.roughnessMap = snap.roughnessMap;
+  material.metalnessMap = snap.metalnessMap;
+  material.aoMap = snap.aoMap;
+  material.emissiveMap = snap.emissiveMap;
+  material.lightMap = snap.lightMap;
+  material.alphaMap = snap.alphaMap;
+  material.transparent = snap.transparent;
+  material.opacity = snap.opacity;
+  material.depthWrite = true;
+}
+
+function clearMaps(material) {
+  material.map = null;
+  material.normalMap = null;
+  material.bumpMap = null;
+  material.roughnessMap = null;
+  material.metalnessMap = null;
+  material.aoMap = null;
+  material.emissiveMap = null;
+  material.lightMap = null;
+  material.alphaMap = null;
+}
+
+function cloneWorking(raw) {
+  const source = raw || new THREE.MeshPhysicalMaterial();
+  const material = new THREE.MeshPhysicalMaterial({
+    name: source.name || 'source_material',
+    color: source.color ? source.color.clone() : new THREE.Color('#ffffff'),
+    emissive: source.emissive ? source.emissive.clone() : new THREE.Color('#000000'),
+    map: source.map ?? null,
+    normalMap: source.normalMap ?? null,
+    bumpMap: source.bumpMap ?? null,
+    roughnessMap: source.roughnessMap ?? null,
+    metalnessMap: source.metalnessMap ?? null,
+    aoMap: source.aoMap ?? null,
+    emissiveMap: source.emissiveMap ?? null,
+    lightMap: source.lightMap ?? null,
+    alphaMap: source.alphaMap ?? null,
+    roughness: typeof source.roughness === 'number' ? source.roughness : 0.55,
+    metalness: typeof source.metalness === 'number' ? source.metalness : 0,
+    transparent: source.transparent,
+    opacity: source.opacity
+  });
+  material.clearcoat = typeof source.clearcoat === 'number' ? source.clearcoat : 0;
+  material.clearcoatRoughness = typeof source.clearcoatRoughness === 'number' ? source.clearcoatRoughness : 0.18;
+  material.userData.originalSnapshot = snapshotMaterial(material);
+  patchMaterial(material);
+  return material;
+}
+
+function colorFlags(material) {
+  const color = material.color instanceof THREE.Color ? material.color : new THREE.Color('#ffffff');
+  return {
+    green: color.g > color.r * 1.14 && color.g > color.b * 1.08 && color.g > 0.11,
+    black: color.r < 0.11 && color.g < 0.11 && color.b < 0.11,
+    brown: color.r > color.b * 1.12 && color.g > color.b * 0.48 && color.r > 0.07 && color.g < color.r * 0.9,
+    gold: color.r > 0.42 && color.g > 0.29 && color.b < 0.25 && color.r >= color.g * 0.88,
+    light: color.r > 0.72 && color.g > 0.72 && color.b > 0.62
+  };
+}
+
+function cleanName(value) {
+  return (value || 'unnamed').replace(/\s+/g, '_').toLowerCase();
+}
+
+function makeSlotKey(mesh, sourceMaterialIndex, material) {
+  return `${cleanName(mesh.name)}::slot_${sourceMaterialIndex}::${cleanName(material.name)}`;
+}
+
+function materialIndexAtOffset(geometry, offset) {
+  if (!geometry.groups.length) return 0;
+  return geometry.groups.find((item) => offset >= item.start && offset < item.start + item.count)?.materialIndex ?? 0;
+}
+
+function triangleWorld(mesh, geometry, aIndex, bIndex, cIndex) {
+  const position = geometry.attributes.position;
+  const a = new THREE.Vector3().fromBufferAttribute(position, aIndex).applyMatrix4(mesh.matrixWorld);
+  const b = new THREE.Vector3().fromBufferAttribute(position, bIndex).applyMatrix4(mesh.matrixWorld);
+  const c = new THREE.Vector3().fromBufferAttribute(position, cIndex).applyMatrix4(mesh.matrixWorld);
+  const center = new THREE.Vector3().addVectors(a, b).add(c).multiplyScalar(1 / 3);
+  const normal = new THREE.Vector3()
+    .crossVectors(new THREE.Vector3().subVectors(b, a), new THREE.Vector3().subVectors(c, a))
+    .normalize()
+    .transformDirection(mesh.matrixWorld);
+  return { center, normal };
+}
+
+function spatialContext(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize) {
+  const { center, normal } = triangleWorld(mesh, geometry, aIndex, bIndex, cIndex);
+  const relX = Math.abs(center.x - tableCenter.x) / Math.max(tableSize.x * 0.5, 0.001);
+  const relZ = Math.abs(center.z - tableCenter.z) / Math.max(tableSize.z * 0.5, 0.001);
+  const relY = (center.y - tableBox.min.y) / Math.max(tableSize.y, 0.001);
+  const xIsLongAxis = tableSize.x >= tableSize.z;
+  const longN = xIsLongAxis ? relX : relZ;
+  const shortN = xIsLongAxis ? relZ : relX;
+  const upFace = normal.y > 0.33;
+  const sideFace = Math.abs(normal.x) > 0.25 || Math.abs(normal.z) > 0.25;
+  const downFace = normal.y < -0.33;
+  return { relY, longN, shortN, upFace, sideFace, downFace };
+}
+
+function classifyTriangle(mesh, geometry, material, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize) {
+  const name = `${mesh.name || ''} ${material.name || ''}`.toLowerCase();
+  const s = spatialContext(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize);
+  const flags = colorFlags(material);
+
+  const namedCloth = /cloth|felt|fabric|surface|bed|slate/i.test(name);
+  const namedCushion = /cushion|rubber|bumper|railrubber/i.test(name);
+  const namedPocket = /pocket|hole|drop|net|liner|leather|cup/i.test(name);
+  const namedHardware = /trim|bezel|ring|metal|chrome|brass|gold|plate|cap|rim|guard|insert|hardware|bolt|screw/i.test(name);
+  const namedSight = /sight|diamond|marker|dot|inlay/i.test(name);
+  const namedWood = /wood|walnut|rail|apron|leg|base|frame|cabinet|corner|showood|support/i.test(name);
+  const metalish = material.metalness > 0.16 || material.clearcoat > 0.58 || flags.gold;
+
+  const high = s.relY > 0.54;
+  const veryTop = s.relY > 0.65;
+  const low = s.relY <= 0.16;
+  const sideMiddlePocketZone = high && s.longN < 0.255 && s.shortN > 0.69;
+  const cornerPocketZone = high && s.longN > 0.68 && s.shortN > 0.66;
+  const anyPocketZone = sideMiddlePocketZone || cornerPocketZone;
+  const centralCloth = high && s.upFace && s.longN < 0.61 && s.shortN < 0.53;
+  const cushionBand = high && (s.longN > 0.52 || s.shortN > 0.49) && (s.longN < 0.9 || s.shortN < 0.9);
+  const topRailBand = high && (s.longN > 0.58 || s.shortN > 0.535);
+  const topRailNonPocket = topRailBand && !anyPocketZone;
+  const topRailSideVerticalRimZone = s.sideFace && !s.upFace && s.relY > 0.46 && s.relY < 0.96 && s.longN > 0.6 && s.shortN > 0.58;
+  const underRailSightCornerRimZone = s.sideFace && !s.upFace && s.relY > 0.36 && s.relY < 0.76 && s.longN > 0.67 && s.shortN > 0.52;
+  const outsideBaseCornerRimZone = s.sideFace && s.relY > 0.08 && s.relY < 0.78 && s.longN > 0.72 && s.shortN > 0.54;
+  const outerMostVerticalCorner = s.sideFace && s.relY > 0.1 && s.relY < 0.8 && s.longN > 0.8 && s.shortN > 0.68;
+  const baseCornerZone = s.sideFace && s.relY > 0.12 && s.relY < 0.64 && ((s.longN > 0.1 && s.longN < 0.56 && s.shortN < 0.36) || (s.longN > 0.58 && s.shortN > 0.56)) && !(underRailSightCornerRimZone || topRailSideVerticalRimZone);
+  const legZone = s.sideFace && s.relY > 0.14 && s.relY < 0.62 && s.longN < 0.62 && s.shortN < 0.58;
+  const railSightDownBand = s.sideFace && !s.upFace && !anyPocketZone && s.relY > 0.44 && s.relY < 0.72 && (s.longN > 0.54 || s.shortN > 0.48) && !(topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner || baseCornerZone || legZone);
+  const sideLowerTrimZone = s.sideFace && s.relY > 0.18 && s.relY < 0.44 && (s.longN > 0.54 || s.shortN > 0.54);
+  const hardwareCandidate = namedHardware || metalish || ((flags.black || flags.gold || flags.light) && !flags.green && !flags.brown && !namedWood);
+  const pocketInteriorCandidate = namedPocket || (flags.black && anyPocketZone && (s.downFace || s.sideFace || s.relY < 0.79) && !hardwareCandidate);
+
+  if (namedCloth) return 'cloth';
+  if (namedCushion) return 'cushion';
+  if (namedSight && high) return 'railSight';
+  if (pocketInteriorCandidate) return 'pocketCup';
+  if (namedPocket && hardwareCandidate && sideMiddlePocketZone) return 'middlePocketPlate';
+  if (namedPocket && hardwareCandidate && cornerPocketZone) return 'cornerPocketPlate';
+  if (hardwareCandidate && sideMiddlePocketZone && !flags.green && !flags.brown) return 'middlePocketPlate';
+  if (hardwareCandidate && cornerPocketZone && !flags.green && !flags.brown) return 'cornerPocketPlate';
+  if (flags.green && centralCloth) return 'cloth';
+  if (flags.green && cushionBand) return 'cushion';
+  if (topRailSideVerticalRimZone || underRailSightCornerRimZone || outsideBaseCornerRimZone || outerMostVerticalCorner) return 'verticalCornerRim';
+  if (hardwareCandidate && topRailNonPocket && s.upFace && !flags.brown && !flags.green) return 'railSight';
+  if (low) return 'baseFoot';
+  if (s.downFace && s.relY < 0.5) return 'underside';
+  if ((flags.brown || namedWood) && baseCornerZone) return 'baseCornerBlock';
+  if (baseCornerZone) return 'baseCornerBlock';
+  if (legZone && (flags.brown || namedWood || !hardwareCandidate)) return 'leg';
+  if (hardwareCandidate && sideLowerTrimZone && !flags.green) return 'lowerTrim';
+  if (railSightDownBand && !flags.green) return 'sideWoodApron';
+  if (veryTop && (s.upFace || topRailBand) && !flags.green) return 'topWoodRail';
+  if (high && s.sideFace && !flags.green && !anyPocketZone) return 'sideWoodApron';
+  return 'sideWoodApron';
+}
+
+function isCushionShadowTriangle(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize) {
+  const s = spatialContext(mesh, geometry, aIndex, bIndex, cIndex, tableBox, tableCenter, tableSize);
+  return s.downFace && s.relY > 0.46 && s.relY < 0.84 && ((s.longN > 0.6 && s.longN < 0.95) || (s.shortN > 0.42 && s.shortN < 0.88));
+}
+
+function createSlotStat() {
+  return { total: 0, dominantPart: 'sideWoodApron', dominantRatio: 1, parts: Object.fromEntries(TABLE_PARTS.map((part) => [part, 0])) };
+}
+
+function updateSlotStat(stats, sourceSlot, part) {
+  const stat = stats.get(sourceSlot) ?? createSlotStat();
+  stat.total += 1;
+  stat.parts[part] = (stat.parts[part] || 0) + 1;
+  stat.dominantPart = TABLE_PARTS.reduce((best, item) => ((stat.parts[item] || 0) > (stat.parts[best] || 0) ? item : best), stat.dominantPart);
+  stat.dominantRatio = stat.total > 0 ? (stat.parts[stat.dominantPart] || 0) / stat.total : 1;
+  stats.set(sourceSlot, stat);
+}
+
+function resolvePart(triangle, slotStats) {
+  const stat = slotStats.get(triangle.sourceSlot);
+  if (!stat) return triangle.part;
+  if (FINE_PARTS.has(triangle.part) && triangle.part !== stat.dominantPart) return triangle.part;
+  const mixedClothCushion = (stat.parts.cloth || 0) > 0 && (stat.parts.cushion || 0) > 0;
+  if (mixedClothCushion && (triangle.part === 'cloth' || triangle.part === 'cushion')) return triangle.part;
+  if ((triangle.part === 'cloth' || triangle.part === 'cushion') && stat.dominantRatio >= 0.88) return stat.dominantPart;
+  return stat.dominantRatio >= 0.965 ? stat.dominantPart : triangle.part;
+}
+
+function applyMaterial(material, part, option, cushionShadow = false) {
+  restoreMaterial(material);
+  if (part === 'cushion' && cushionShadow) {
+    material.color.set(CUSHION_SHADOW_GREY);
+    material.metalness = 0;
+    material.roughness = 0.96;
+    material.envMapIntensity = 0.22;
+    material.clearcoat = 0;
+    material.clearcoatRoughness = 0;
+    clearMaps(material);
+  } else {
+    material.color.set(option.color);
+    material.metalness = option.metalness;
+    material.roughness = option.roughness;
+    material.envMapIntensity = option.envMapIntensity;
+    material.clearcoat = option.clearcoat ?? 0;
+    material.clearcoatRoughness = option.clearcoatRoughness ?? 0;
+    if (!KEEP_TEXTURE_PARTS.has(part)) clearMaps(material);
+  }
+  material.transparent = false;
+  material.opacity = 1;
+  material.depthWrite = true;
+  material.userData.part = part;
+  material.userData.cushionShadow = cushionShadow;
+  patchMaterial(material);
+}
+
+function makePartMaterial(source, part, palette, sourceSlot, meshName, materialName, cushionShadow = false) {
+  const material = source.clone();
+  material.name = `${source.name || 'source'}__${part}${cushionShadow ? '__shadow' : ''}`;
+  material.userData.originalSnapshot = snapshotMaterial(source);
+  material.userData.part = part;
+  material.userData.sourceSlot = sourceSlot;
+  material.userData.meshName = meshName;
+  material.userData.materialName = materialName;
+  material.userData.cushionShadow = cushionShadow;
+  applyMaterial(material, part, optionForPart(part, palette), cushionShadow);
+  return material;
+}
+
+export function applyPoolRoyaleShowoodReferenceMapping(root, paletteInput = {}) {
+  if (!root) return { counts: {} };
+  const palette = normalizePoolRoyaleShowoodPalette(paletteInput);
+  root.updateMatrixWorld(true);
+  const tableBox = new THREE.Box3().setFromObject(root);
+  const tableCenter = tableBox.getCenter(new THREE.Vector3());
+  const tableSize = tableBox.getSize(new THREE.Vector3());
+  const slotStats = new Map();
+  const buildData = [];
+  const counts = Object.fromEntries(TABLE_PARTS.map((part) => [part, 0]));
+
+  root.traverse((child) => {
+    if (!child?.isMesh) return;
+    const mesh = child;
+    const sourceGeometry = mesh.geometry?.clone?.();
+    const position = sourceGeometry?.attributes?.position;
+    if (!sourceGeometry || !position) return;
+    const sourceMaterials = (Array.isArray(mesh.material) ? mesh.material : [mesh.material]).map((material) => cloneWorking(material));
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    mesh.frustumCulled = false;
+    const oldIndex = sourceGeometry.index;
+    const totalIndices = oldIndex ? oldIndex.count : position.count;
+    const triangles = [];
+    for (let i = 0; i + 2 < totalIndices; i += 3) {
+      const a = oldIndex ? oldIndex.getX(i) : i;
+      const b = oldIndex ? oldIndex.getX(i + 1) : i + 1;
+      const c = oldIndex ? oldIndex.getX(i + 2) : i + 2;
+      const sourceMaterialIndex = Math.min(materialIndexAtOffset(sourceGeometry, i), sourceMaterials.length - 1);
+      const sourceMaterial = sourceMaterials[Math.max(0, sourceMaterialIndex)];
+      const sourceSlot = makeSlotKey(mesh, sourceMaterialIndex, sourceMaterial);
+      const part = classifyTriangle(mesh, sourceGeometry, sourceMaterial, a, b, c, tableBox, tableCenter, tableSize);
+      const cushionShadow = part === 'cushion' && isCushionShadowTriangle(mesh, sourceGeometry, a, b, c, tableBox, tableCenter, tableSize);
+      triangles.push({ a, b, c, sourceMaterialIndex, sourceSlot, part, cushionShadow });
+      updateSlotStat(slotStats, sourceSlot, part);
+    }
+    buildData.push({ mesh, sourceGeometry, sourceMaterials, triangles });
+  });
+
+  buildData.forEach(({ mesh, sourceGeometry, sourceMaterials, triangles }) => {
+    const finalGeometry = sourceGeometry.clone();
+    const finalMaterials = [];
+    const materialLookup = new Map();
+    const finalIndex = [];
+    finalGeometry.clearGroups();
+    const getMaterialIndex = (sourceMaterialIndex, sourceSlot, part, cushionShadow = false) => {
+      const key = `${sourceSlot}::${part}::${cushionShadow ? 'shadow' : 'main'}`;
+      if (materialLookup.has(key)) return materialLookup.get(key);
+      const source = sourceMaterials[Math.max(0, Math.min(sourceMaterialIndex, sourceMaterials.length - 1))];
+      const material = makePartMaterial(source, part, palette, sourceSlot, mesh.name || 'unnamed mesh', source.name || 'unnamed material', cushionShadow);
+      const index = finalMaterials.length;
+      finalMaterials.push(material);
+      materialLookup.set(key, index);
+      return index;
+    };
+
+    triangles.forEach((triangle) => {
+      const part = resolvePart(triangle, slotStats);
+      const cushionShadow = part === 'cushion' && triangle.cushionShadow;
+      const materialIndex = getMaterialIndex(triangle.sourceMaterialIndex, triangle.sourceSlot, part, cushionShadow);
+      const start = finalIndex.length;
+      finalIndex.push(triangle.a, triangle.b, triangle.c);
+      finalGeometry.addGroup(start, 3, materialIndex);
+      counts[part] = (counts[part] || 0) + 1;
+    });
+
+    finalGeometry.setIndex(finalIndex);
+    finalGeometry.computeBoundingBox();
+    finalGeometry.computeBoundingSphere();
+    mesh.geometry?.dispose?.();
+    mesh.geometry = finalGeometry;
+    mesh.material = finalMaterials.length > 1 ? finalMaterials : finalMaterials[0];
+  });
+
+  root.userData = {
+    ...(root.userData || {}),
+    poolRoyaleShowoodReferenceMapping: true,
+    poolRoyaleShowoodPalette: palette,
+    poolRoyaleShowoodCounts: counts
+  };
+  return { counts, palette };
+}


### PR DESCRIPTION
### Motivation
- Replace the procedural cushion/jaw generation on the Royal original table with the cushions and pocket jaws from the Showood GLB and make cushions adopt the same cloth look/color as the playfield.
- Provide a drop-in path that uses the full Showood GLB mapping and the identical two-choice material options (cloth, cushion, metal accents, jaws, top rail, legs/base) so the GLB table can render with the exact texture mapping and options as the reference code.
- Make the mapping selectable from the lobby/setup UI and persist the chosen two-option palette across sessions so designers/players can pick the Showood-style finish without changing physics.

### Description
- Config: updated `webapp/src/config/poolRoyaleTableModels.js` to (a) make `royal-original` stop preserving GLB cushion textures and enable `matchCushionsToCloth`, and (b) add `useReferenceShowoodMapping` and related flags for the Showood GLB option. (file: `poolRoyaleTableModels.js`)
- New utility: added `webapp/src/utils/poolRoyaleShowoodMapping.js` which implements triangle-level GLB remapping, material cloning, material buckets, cushion shadow handling, and an API `applyPoolRoyaleShowoodReferenceMapping(root, palette)` to replace generated cushions/jaws with GLB assets while applying the two-choice palette. (file: `poolRoyaleShowoodMapping.js`)
- Integration: wired the new mapping into the Pool Royale pipeline in `webapp/src/pages/Games/PoolRoyale.jsx` so that when a table model requests `useReferenceShowoodMapping` the external template path calls `applyPoolRoyaleShowoodReferenceMapping(root, tableModel.showoodPalette)` and returns early instead of running the per-material finish application logic.
- Cushion-to-cloth: enabled `matchCushionsToCloth` support and updated `applyPoolRoyaleFinishToExternalMaterial` so cushions can copy the cloth material look when requested by the tableModel config.
- UI: added persistent Showood palette state, a small Showood setup panel in the in-game Table Setup dialog with the same six two-choice controls and a Reset button, and persist the palette to `localStorage` under `poolRoyaleShowoodPalette`. (modifications: `PoolRoyale.jsx`)
- Table mounting: pass the augmented `activeTableModelWithPalette` into `Table3D` for both primary and secondary table mounts so the Showood mapping and palette are used when the GLB option is selected.

### Testing
- Built the web app: ran `npm --prefix webapp run build` and the Vite production build completed successfully (built assets listed and process finished without error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0b44e44c83298d2fd9524983952d)