### PR TITLE
Replace procedural cushions/jaws with Showood GLB assets and add Showood material palette + lobby controls

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -8,7 +8,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'royal-original',
     label: 'Royal Original',
     description:
-      'Current TonPlaygram rails, base, and chrome with Showood GLB playfield, cushions, pockets, and jaw layout overlaid.',
+      'Current TonPlaygram rails, base, and chrome with Showood GLB playfield, GLB cushions, pockets, and jaw layout overlaid.',
     tableSizeId: '9ft',
     finishId: 'peelingPaintWeathered',
     baseId: 'classicCylinders',
@@ -24,7 +24,9 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     useOriginalLayoutSurfaces: false,
     usePoolRoyaleFinish: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket'],
-    preserveSourceTextureRoles: ['cushion'],
+    cushionUsesClothFinish: true,
+    hideGeneratedCushionsAndJaws: true,
+    preserveSourceTextureRoles: [],
     preserveOriginalSurfaceRoles: ['trim', 'wood'],
     hideSurfaceRoles: ['trim', 'wood'],
     keepGeneratedShell: true,
@@ -36,8 +38,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     description:
       'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while keeping the original GLB layout for cloth, cushions, pockets, and preserved Showood chrome plates.',
     tableSizeId: '9ft',
-    assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
+    assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
+    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.02,
@@ -49,10 +51,11 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket'],
-    preserveSourceTextureRoles: ['cushion', 'wood'],
-    preserveOriginalSurfaceRoles: ['trim'],
-    tintOriginalTrimGold: true,
+    useReferenceShowoodMapping: true,
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
+    preserveSourceTextureRoles: ['cushion', 'topWoodRail', 'leg', 'baseCornerBlock', 'underside'],
+    preserveOriginalSurfaceRoles: [],
+    tintOriginalTrimGold: false,
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }
@@ -69,3 +72,63 @@ export function resolvePoolRoyaleTableModel(modelId) {
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
   );
 }
+
+export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
+  'cloth',
+  'cushion',
+  'metalAccent',
+  'jaws',
+  'topWoodRail',
+  'legBase'
+]);
+
+export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
+  cloth: 'a',
+  cushion: 'a',
+  metalAccent: 'a',
+  jaws: 'a',
+  topWoodRail: 'a',
+  legBase: 'b'
+});
+
+export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
+  cloth: { label: 'Field cloth', description: 'Only the flat playfield surface.' },
+  cushion: {
+    label: 'Cushions',
+    description: 'Matched green or Black rubber; source cushion texture is preserved like the reference preview.'
+  },
+  metalAccent: {
+    label: 'Rail sights + side strip + feet',
+    description: 'One gold/chrome control for rail sights, side apron strip, rims, trims, plates, and feet.'
+  },
+  jaws: { label: 'Jaws', description: 'Pocket jaws / cups: black or brown.' },
+  topWoodRail: { label: 'Top rail frame', description: 'Main top wood rail frame.' },
+  legBase: { label: 'Legs + base', description: 'Legs and lower base blocks together, separate from metal accents.' }
+});
+
+export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
+  cloth: Object.freeze({
+    a: Object.freeze({ label: 'Green field', color: '#0a7b33', metalness: 0, roughness: 1, envMapIntensity: 0.16 }),
+    b: Object.freeze({ label: 'Blue field', color: '#0d4fb8', metalness: 0, roughness: 1, envMapIntensity: 0.16 })
+  }),
+  cushion: Object.freeze({
+    a: Object.freeze({ label: 'Matched green', color: '#064f22', metalness: 0, roughness: 0.88, envMapIntensity: 0.55 }),
+    b: Object.freeze({ label: 'Black rubber', color: '#050505', metalness: 0, roughness: 0.86, envMapIntensity: 0.55 })
+  }),
+  metalAccent: Object.freeze({
+    a: Object.freeze({ label: 'Gold', color: '#d8b23d', metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 }),
+    b: Object.freeze({ label: 'Chrome', color: '#d7dde7', metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 })
+  }),
+  jaws: Object.freeze({
+    a: Object.freeze({ label: 'Black jaws', color: '#020202', metalness: 0, roughness: 0.96, envMapIntensity: 0.14 }),
+    b: Object.freeze({ label: 'Brown jaws', color: '#2a1207', metalness: 0, roughness: 0.88, envMapIntensity: 0.26 })
+  }),
+  topWoodRail: Object.freeze({
+    a: Object.freeze({ label: 'Walnut frame', color: '#5a2608', metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 }),
+    b: Object.freeze({ label: 'Black frame', color: '#070605', metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 })
+  }),
+  legBase: Object.freeze({
+    a: Object.freeze({ label: 'Brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }),
+    b: Object.freeze({ label: 'Black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 })
+  })
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -35,6 +35,8 @@ import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
+  POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS,
+  POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
 import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
@@ -12137,6 +12139,113 @@ export function Table3D(
 const poolRoyaleExternalTableTemplates = new Map();
 const poolRoyaleExternalTablePromises = new Map();
 
+
+const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
+  cloth: 'cloth',
+  cushion: 'cushion',
+  topWoodRail: 'topWoodRail',
+  sideWoodApron: 'metalAccent',
+  pocketCup: 'jaws',
+  cornerPocketPlate: 'metalAccent',
+  middlePocketPlate: 'metalAccent',
+  verticalCornerRim: 'metalAccent',
+  baseCornerBlock: 'legBase',
+  leg: 'legBase',
+  baseFoot: 'metalAccent',
+  lowerTrim: 'metalAccent',
+  railSight: 'metalAccent',
+  underside: 'legBase',
+  trim: 'metalAccent',
+  wood: 'topWoodRail',
+  pocket: 'jaws'
+});
+const POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS = new Set([
+  'cushion',
+  'topWoodRail',
+  'leg',
+  'baseCornerBlock',
+  'underside'
+]);
+
+function resolvePoolRoyaleShowoodPalette(tableModel = null) {
+  return {
+    ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
+    ...(tableModel?.showoodPalette && typeof tableModel.showoodPalette === 'object'
+      ? tableModel.showoodPalette
+      : {})
+  };
+}
+
+function clearPoolRoyaleMaterialTextureMaps(material) {
+  if (!material) return;
+  material.map = null;
+  material.normalMap = null;
+  material.bumpMap = null;
+  material.roughnessMap = null;
+  material.metalnessMap = null;
+  material.aoMap = null;
+  material.emissiveMap = null;
+  material.lightMap = null;
+  material.alphaMap = null;
+}
+
+function classifyPoolRoyaleShowoodReferencePart(child, material) {
+  const childName = `${child?.name || ''}`.toLowerCase();
+  const materialName = `${material?.name || ''}`.toLowerCase();
+  const label = `${childName} ${materialName}`;
+  const color = material?.color instanceof THREE.Color ? material.color : new THREE.Color('#ffffff');
+  const green = color.g > color.r * 1.14 && color.g > color.b * 1.08 && color.g > 0.11;
+  const black = color.r < 0.11 && color.g < 0.11 && color.b < 0.11;
+  const brown = color.r > color.b * 1.12 && color.g > color.b * 0.48 && color.r > 0.07 && color.g < color.r * 0.9;
+  const gold = color.r > 0.42 && color.g > 0.29 && color.b < 0.25 && color.r >= color.g * 0.88;
+  const metalish = (material?.metalness ?? 0) > 0.16 || (material?.clearcoat ?? 0) > 0.58 || gold;
+
+  if (/cloth|felt|fabric|surface|bed|slate|playfield|baize/.test(label) && !/cushion|rubber|bumper/.test(childName)) return 'cloth';
+  if (/cushion|rubber|bumper|railrubber|rail[_\s-]*nose/.test(childName)) return 'cushion';
+  if (/sight|diamond|marker|dot|inlay/.test(label)) return 'railSight';
+  if (/pocket|hole|drop|net|liner|leather|cup|basket|holder/.test(label)) {
+    return metalish && !black && !brown ? 'cornerPocketPlate' : 'pocketCup';
+  }
+  if (/trim|bezel|ring|metal|chrome|brass|gold|plate|cap|rim|guard|insert|hardware|bolt|screw/.test(label) || metalish) {
+    return /foot|feet/.test(label) ? 'baseFoot' : 'lowerTrim';
+  }
+  if (/leg/.test(label)) return 'leg';
+  if (/base|block|support|underside/.test(label)) return 'baseCornerBlock';
+  if (/rail|frame|top|wood|walnut|showood|apron|cabinet|corner/.test(label)) return 'topWoodRail';
+  if (green) return 'cloth';
+  return 'sideWoodApron';
+}
+
+function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null) {
+  if (!material) return material;
+  const mat = material.clone ? material.clone() : material;
+  const control = POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[part] || POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[classifyPoolRoyaleExternalTableSurface(null, mat)] || 'topWoodRail';
+  const palette = resolvePoolRoyaleShowoodPalette(tableModel);
+  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] || 'a';
+  const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice] || POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.a;
+  if (!option) return mat;
+  mat.color?.set?.(option.color);
+  if ('metalness' in mat) mat.metalness = option.metalness;
+  if ('roughness' in mat) mat.roughness = option.roughness;
+  if ('envMapIntensity' in mat) mat.envMapIntensity = option.envMapIntensity;
+  if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? 0;
+  if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? 0;
+  if (!POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS.has(part)) {
+    clearPoolRoyaleMaterialTextureMaps(mat);
+  }
+  mat.transparent = false;
+  mat.opacity = 1;
+  mat.depthWrite = true;
+  mat.side = THREE.DoubleSide;
+  mat.userData = {
+    ...(mat.userData || {}),
+    poolRoyaleShowoodReferencePart: part,
+    poolRoyaleShowoodReferenceControl: control,
+    poolRoyaleShowoodReferenceChoice: choice
+  };
+  return mat;
+}
+
 function classifyPoolRoyaleExternalTableSurface(child, material) {
   const childName = `${child?.name || ''}`.toLowerCase();
   const materialName = `${material?.name || ''}`.toLowerCase();
@@ -12305,6 +12414,11 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
   };
 
   if (role === 'cloth' || role === 'cushion') {
+    const finishSource = role === 'cushion' && tableModel?.cushionUsesClothFinish
+      ? finishInfo.clothMat
+      : role === 'cushion'
+        ? finishInfo.cushionMat
+        : finishInfo.clothMat;
     const preserveSourceTexture = Array.isArray(tableModel?.preserveSourceTextureRoles) &&
       tableModel.preserveSourceTextureRoles.includes(role);
     const sourceSnapshot = preserveSourceTexture
@@ -12317,7 +12431,7 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
           aoMap: mat.aoMap
         }
       : null;
-    copyMaterialLook(role === 'cushion' ? finishInfo.cushionMat : finishInfo.clothMat);
+    copyMaterialLook(finishSource);
     if (sourceSnapshot) {
       Object.assign(mat, sourceSnapshot);
     }
@@ -12374,8 +12488,16 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const prepareMaterial = (material) => {
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
+      const referencePart = tableModel?.useReferenceShowoodMapping
+        ? classifyPoolRoyaleShowoodReferencePart(child, material)
+        : null;
       if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
         child.visible = false;
+      }
+      if (tableModel?.useReferenceShowoodMapping) {
+        const nextMaterial = applyPoolRoyaleShowoodReferenceMaterial(material, referencePart || role, tableModel);
+        normalizePoolRoyaleExternalClothTextureScale(child, nextMaterial, role);
+        return nextMaterial;
       }
       if (tableModel?.usePoolRoyaleFinish && finishInfo) {
         const nextMaterial = applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tableModel);
@@ -13327,9 +13449,9 @@ function mountPoolRoyaleExternalTableModel({
     : generatedVisualBounds.getSize(new THREE.Vector3());
   const generatedUpperComponentObjects = [
     ...finishParts.railMeshes,
+    ...(Array.isArray(table.userData.cushions) ? table.userData.cushions : []),
     ...finishParts.pocketJawMeshes,
-    ...finishParts.pocketRimMeshes,
-    ...(Array.isArray(table.userData.cushions) ? table.userData.cushions : [])
+    ...finishParts.pocketRimMeshes
   ].filter(Boolean);
   const generatedUpperComponentBounds = expandPoolRoyaleBoundsByObjects(
     generatedUpperComponentObjects.length ? generatedUpperComponentObjects : generatedStructuralObjects
@@ -13351,11 +13473,28 @@ function mountPoolRoyaleExternalTableModel({
     ...finishParts.pocketRimMeshes,
     ...pocketMeshes
   ].forEach(markReplaceableGeneratedSurface);
+  const markGeneratedCushionsAndJawsHiddenByExternalTable = (object) => {
+    if (!object) return;
+    object.userData = {
+      ...(object.userData || {}),
+      externalTableHideWhenMounted: true
+    };
+  };
+  if (resolvedTableOptions?.tableModel?.hideGeneratedCushionsAndJaws) {
+    [
+      ...(Array.isArray(table.userData.cushions) ? table.userData.cushions : []),
+      ...finishParts.pocketJawMeshes,
+      ...finishParts.pocketRimMeshes,
+      ...pocketMeshes
+    ].forEach(markGeneratedCushionsAndJawsHiddenByExternalTable);
+  }
   const setGeneratedVisualsVisible = (visible) => {
     generatedVisualObjects.forEach((object) => {
       const forceGeneratedChrome = Boolean(externalTableModelForMount?.forceGeneratedChromePlates);
       if (!visible && externalTableModelForMount?.keepGeneratedShell) {
-        object.visible = !object.userData?.externalTableReplaceableSurface;
+        object.visible = object.userData?.externalTableHideWhenMounted
+          ? false
+          : !object.userData?.externalTableReplaceableSurface;
         if (object.userData?.isChromePlate && forceGeneratedChrome) object.visible = true;
         return;
       }
@@ -13376,12 +13515,14 @@ function mountPoolRoyaleExternalTableModel({
     resolvedTableOptions?.tableModel?.kind === 'gltf'
       ? {
           ...resolvedTableOptions.tableModel,
-          preserveOriginalSurfaceRoles: resolvedTableOptions.tableModel.useOriginalLayoutSurfaces
-            ? Array.from(new Set([
-                ...(resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles || []),
-                'trim'
-              ]))
-            : chromePlateStyle.preserveExternalTrim
+          preserveOriginalSurfaceRoles: resolvedTableOptions.tableModel.useReferenceShowoodMapping
+            ? (resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles || [])
+            : resolvedTableOptions.tableModel.useOriginalLayoutSurfaces
+              ? Array.from(new Set([
+                  ...(resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles || []),
+                  'trim'
+                ]))
+              : chromePlateStyle.preserveExternalTrim
               ? resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles
               : resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles?.filter(
                   (role) => role !== 'trim'
@@ -13985,10 +14126,20 @@ function PoolRoyaleGame({
     () => resolveTableSize(tableSizeKey),
     [tableSizeKey]
   );
-  const activeTableModel = useMemo(
-    () => resolvePoolRoyaleTableModel(tableModelKey),
-    [tableModelKey]
-  );
+  const activeTableModel = useMemo(() => {
+    const model = resolvePoolRoyaleTableModel(tableModelKey);
+    if (!model?.useReferenceShowoodMapping) return model;
+    let showoodPalette = null;
+    try {
+      const params = new URLSearchParams(location.search);
+      const raw = params.get('showoodPalette') || window.localStorage?.getItem('poolRoyaleShowoodMaterialPalette');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') showoodPalette = parsed;
+      }
+    } catch {}
+    return showoodPalette ? { ...model, showoodPalette } : model;
+  }, [location.search, tableModelKey]);
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
   const resolvedAccountId = useMemo(
     () => poolRoyalAccountId(accountId),

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,6 +13,10 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
+  POOL_ROYALE_SHOWOOD_CONTROL_META,
+  POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS,
+  POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
+  POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS,
   POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
@@ -39,6 +43,7 @@ const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
 const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
+const POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY = 'poolRoyaleShowoodMaterialPalette';
 
 function resolveTpcAccountNumber(player) {
   if (!player || typeof player !== 'object') return '';
@@ -86,8 +91,24 @@ export default function PoolRoyaleLobby() {
     } catch {}
     return resolvePoolRoyaleTableModel().id;
   });
+  const [showoodPalette, setShowoodPalette] = useState(() => {
+    try {
+      const stored = JSON.parse(
+        window.localStorage?.getItem(POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY) || 'null'
+      );
+      if (stored && typeof stored === 'object') {
+        return { ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE, ...stored };
+      }
+    } catch {}
+    return { ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE };
+  });
   const [players, setPlayers] = useState(8);
-  const selectedTableModel = resolvePoolRoyaleTableModel(tableModelId);
+  const selectedTableModel = useMemo(() => {
+    const model = resolvePoolRoyaleTableModel(tableModelId);
+    return model?.useReferenceShowoodMapping
+      ? { ...model, showoodPalette }
+      : model;
+  }, [showoodPalette, tableModelId]);
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -206,6 +227,9 @@ export default function PoolRoyaleLobby() {
       params.set('ballSet', 'american');
     }
     params.set('tableModel', selectedTableModel.id);
+    if (selectedTableModel.useReferenceShowoodMapping) {
+      params.set('showoodPalette', JSON.stringify(showoodPalette));
+    }
     params.set('type', playType);
     params.set('mode', 'online');
     params.set('tableId', startedId);
@@ -255,6 +279,12 @@ export default function PoolRoyaleLobby() {
         window.localStorage?.setItem(
           TABLE_BASE_STORAGE_KEY,
           selectedTableModel.baseId
+        );
+      }
+      if (selectedTableModel.useReferenceShowoodMapping) {
+        window.localStorage?.setItem(
+          POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY,
+          JSON.stringify(showoodPalette)
         );
       }
     } catch {}
@@ -328,6 +358,9 @@ export default function PoolRoyaleLobby() {
     }
     params.set('tableSize', tableSize);
     params.set('tableModel', selectedTableModel.id);
+    if (selectedTableModel.useReferenceShowoodMapping) {
+      params.set('showoodPalette', JSON.stringify(showoodPalette));
+    }
     params.set(
       'type',
       effectivePlayType === 'friendly' ? 'regular' : effectivePlayType
@@ -666,8 +699,64 @@ export default function PoolRoyaleLobby() {
             })}
           </div>
           <p className="text-xs text-white/60">
-            New GLB tables replace the in-game table visually while Pool Royale keeps the matched playfield, pockets, cushions, and ball physics.
+            Royal Original now keeps TonPlaygram shell/chrome but uses GLB cushions and pocket jaws; Showood uses the reference texture mapping and option set.
           </p>
+          {selectedTableModel.useReferenceShowoodMapping ? (
+            <div className="rounded-2xl border border-amber-300/20 bg-black/25 p-3">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div>
+                  <h4 className="text-sm font-semibold text-white">Showood table setup</h4>
+                  <p className="text-[11px] text-white/55">Same material options as the supplied reference preview.</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setShowoodPalette({ ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE })}
+                  className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-white/80"
+                >
+                  Reset
+                </button>
+              </div>
+              <div className="space-y-3">
+                {POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS.map((control) => {
+                  const meta = POOL_ROYALE_SHOWOOD_CONTROL_META[control];
+                  const options = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control];
+                  return (
+                    <div key={control} className="rounded-xl border border-white/10 bg-white/5 p-2">
+                      <div className="mb-2">
+                        <p className="text-[11px] font-black uppercase tracking-[0.22em] text-emerald-100">{meta.label}</p>
+                        <p className="text-[10px] leading-snug text-white/50">{meta.description}</p>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {['a', 'b'].map((choice) => {
+                          const option = options[choice];
+                          const active = showoodPalette[control] === choice;
+                          return (
+                            <button
+                              key={`${control}-${choice}`}
+                              type="button"
+                              onClick={() => setShowoodPalette((current) => ({ ...current, [control]: choice }))}
+                              className={`flex flex-1 items-center justify-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-extrabold transition ${
+                                active
+                                  ? 'border-white/80 bg-white/20 text-white shadow-[0_0_14px_rgba(255,255,255,0.22)]'
+                                  : 'border-white/15 bg-white/5 text-white/70'
+                              }`}
+                            >
+                              <span
+                                className="h-3.5 w-3.5 rounded-full border border-white/40"
+                                style={{ backgroundColor: option.color }}
+                                aria-hidden="true"
+                              />
+                              <span>{option.label}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
         </div>
 
         <div className="space-y-3">


### PR DESCRIPTION
### Motivation
- Replace the procedural cushion/jaw geometry and mapping on the Royal table with the Showood GLB cushions/jaws and make cushions optionally match the playfield cloth so visuals match the reference GLB.
- Expose the Showood reference material choices (cloth, cushions, metal accents, jaws, top rail, legs/base) in the lobby so the Showood GLB can be configured with the same palette and persisted into matches.

### Description
- Add new table model flags and Showood palette constants in `webapp/src/config/poolRoyaleTableModels.js` and swap the Showood GLB variant order and options to enable reference mapping, control which GLB surfaces preserve textures, and hide generated procedural cushions/jaws when the GLB is used. 
- Implement Showood reference mapping and material application in `webapp/src/pages/Games/PoolRoyale.jsx` including material classification, a palette resolver, functions that recolor GLB parts while preserving texture-bearing parts (cushions/wood/legs), and marking generated cushions/jaws to be hidden when an external GLB is mounted. 
- Make the cushions use the cloth finish when requested by introducing `cushionUsesClothFinish` handling so GLB cushions can inherit the playfield cloth color/texture. 
- Add a Showood setup UI in `webapp/src/pages/Games/PoolRoyaleLobby.jsx` that lets players pick the Showood palette (two choices per control), persists the palette to localStorage, and forwards the palette in match URLs so the same mapping is applied at match load. 
- Wire visibility rules so generated visuals (cushions/jaws) are hidden or kept depending on table model flags and chrome-plate preferences during external GLB mounting.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully. 
- Ran `git diff --check` on the modified files and no index/diff errors were reported. 
- Attempted a headless browser smoke test (Playwright) to capture the lobby with the Showood table, but Chromium failed to launch in this environment due to a missing native library (`libatk-1.0.so.0`), so the screenshot step was aborted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0b44e44c83298d2fd9524983952d)