### PR TITLE
Refactor GLTF material adapter; simplify weapon camera look and FPS hand presentation

### DIFF
--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -11,7 +11,6 @@ namespace Aiming.Gameplay.Rendering
         [SerializeField] private Renderer[] targetRenderers;
         [SerializeField] private bool runOnAwake = true;
         [SerializeField] private bool forceUrpLitShader = true;
-        [SerializeField] private bool upgradeGltfImportShaders = true;
         [SerializeField] private Shader urpLitShader;
         [SerializeField] private Shader standardShader;
 
@@ -25,13 +24,6 @@ namespace Aiming.Gameplay.Rendering
         private static readonly int EmissionMapId = Shader.PropertyToID("_EmissionMap");
         private static readonly int BaseMapStId = Shader.PropertyToID("_BaseMap_ST");
         private static readonly int MainTexStId = Shader.PropertyToID("_MainTex_ST");
-        private static readonly int GltfBaseColorTextureId = Shader.PropertyToID("_BaseColorTexture");
-        private static readonly int GltfBaseColorMapId = Shader.PropertyToID("baseColorTexture");
-        private static readonly int GltfNormalTextureId = Shader.PropertyToID("_NormalTexture");
-        private static readonly int GltfMetallicRoughnessTextureId = Shader.PropertyToID("_MetallicRoughnessTexture");
-        private static readonly int GltfOcclusionTextureId = Shader.PropertyToID("_OcclusionTexture");
-        private static readonly int GltfEmissiveTextureId = Shader.PropertyToID("_EmissiveTexture");
-        private static readonly int GltfBaseColorFactorId = Shader.PropertyToID("_BaseColorFactor");
 
         void Awake()
         {
@@ -62,9 +54,8 @@ namespace Aiming.Gameplay.Rendering
                         continue;
                     }
 
-                    MaterialTextureSnapshot textureSnapshot = MaterialTextureSnapshot.Capture(mat);
-                    EnsureSupportedShader(mat, textureSnapshot);
-                    CopyPbrMaps(mat, textureSnapshot);
+                    EnsureSupportedShader(mat);
+                    CopyPbrMaps(mat);
                 }
             }
         }
@@ -79,11 +70,9 @@ namespace Aiming.Gameplay.Rendering
             return GetComponentsInChildren<Renderer>(true);
         }
 
-        private void EnsureSupportedShader(Material material, MaterialTextureSnapshot textureSnapshot)
+        private void EnsureSupportedShader(Material material)
         {
-            bool needsFallbackShader = material.shader == null || !material.shader.isSupported;
-            bool shouldUpgradeGltfShader = upgradeGltfImportShaders && textureSnapshot.HasGltfOnlyBaseTexture && ResolveFallbackShader() != null;
-            if (!needsFallbackShader && !shouldUpgradeGltfShader)
+            if (material.shader != null && material.shader.isSupported)
             {
                 return;
             }
@@ -118,15 +107,10 @@ namespace Aiming.Gameplay.Rendering
             return standardShader;
         }
 
-        private static void CopyPbrMaps(Material material, MaterialTextureSnapshot textureSnapshot)
+        private static void CopyPbrMaps(Material material)
         {
             int sourceUvPropertyId;
-            Texture baseTexture = FirstTexture(material, out sourceUvPropertyId, BaseMapId, MainTexId, GltfBaseColorTextureId, GltfBaseColorMapId);
-            if (baseTexture == null)
-            {
-                baseTexture = textureSnapshot.BaseTexture;
-                sourceUvPropertyId = textureSnapshot.BaseTexturePropertyId;
-            }
+            Texture baseTexture = FirstTexture(material, out sourceUvPropertyId, BaseMapId, MainTexId);
             if (baseTexture != null)
             {
                 TrySetTexture(material, BaseMapId, baseTexture);
@@ -134,108 +118,41 @@ namespace Aiming.Gameplay.Rendering
                 SyncTextureTransform(material, sourceUvPropertyId);
             }
 
-            Color resolvedBaseColor = textureSnapshot.HasBaseColor ? textureSnapshot.BaseColor : Color.white;
-            if (!textureSnapshot.HasBaseColor && material.HasProperty(BaseColorId))
+            if (material.HasProperty(BaseColorId) && material.HasProperty(ColorId))
             {
-                resolvedBaseColor = material.GetColor(BaseColorId);
+                Color baseColor = material.GetColor(BaseColorId);
+                material.SetColor(ColorId, baseColor);
             }
-            else if (!textureSnapshot.HasBaseColor && material.HasProperty(ColorId))
+            else if (material.HasProperty(ColorId) && material.HasProperty(BaseColorId))
             {
-                resolvedBaseColor = material.GetColor(ColorId);
-            }
-
-            if (material.HasProperty(BaseColorId))
-            {
-                material.SetColor(BaseColorId, resolvedBaseColor);
+                Color mainColor = material.GetColor(ColorId);
+                material.SetColor(BaseColorId, mainColor);
             }
 
-            if (material.HasProperty(ColorId))
-            {
-                material.SetColor(ColorId, resolvedBaseColor);
-            }
-
-            Texture normal = FirstTexture(material, BumpMapId, GltfNormalTextureId);
-            if (normal == null)
-            {
-                normal = textureSnapshot.NormalTexture;
-            }
+            Texture normal = FirstTexture(material, BumpMapId);
             if (normal != null)
             {
                 TrySetTexture(material, BumpMapId, normal);
                 material.EnableKeyword("_NORMALMAP");
             }
 
-            Texture metallic = FirstTexture(material, MetallicGlossMapId, GltfMetallicRoughnessTextureId);
-            if (metallic == null)
-            {
-                metallic = textureSnapshot.MetallicTexture;
-            }
+            Texture metallic = FirstTexture(material, MetallicGlossMapId);
             if (metallic != null)
             {
                 TrySetTexture(material, MetallicGlossMapId, metallic);
             }
 
-            Texture occlusion = FirstTexture(material, OcclusionMapId, GltfOcclusionTextureId);
-            if (occlusion == null)
-            {
-                occlusion = textureSnapshot.OcclusionTexture;
-            }
+            Texture occlusion = FirstTexture(material, OcclusionMapId);
             if (occlusion != null)
             {
                 TrySetTexture(material, OcclusionMapId, occlusion);
             }
 
-            Texture emission = FirstTexture(material, EmissionMapId, GltfEmissiveTextureId);
-            if (emission == null)
-            {
-                emission = textureSnapshot.EmissionTexture;
-            }
+            Texture emission = FirstTexture(material, EmissionMapId);
             if (emission != null)
             {
                 TrySetTexture(material, EmissionMapId, emission);
                 material.EnableKeyword("_EMISSION");
-            }
-        }
-
-        private sealed class MaterialTextureSnapshot
-        {
-            public Texture BaseTexture;
-            public int BaseTexturePropertyId = -1;
-            public Texture NormalTexture;
-            public Texture MetallicTexture;
-            public Texture OcclusionTexture;
-            public Texture EmissionTexture;
-            public Color BaseColor = Color.white;
-            public bool HasBaseColor;
-            public bool HasGltfOnlyBaseTexture;
-
-            public static MaterialTextureSnapshot Capture(Material material)
-            {
-                MaterialTextureSnapshot snapshot = new MaterialTextureSnapshot();
-                snapshot.BaseTexture = FirstTexture(material, out snapshot.BaseTexturePropertyId, BaseMapId, MainTexId, GltfBaseColorTextureId, GltfBaseColorMapId);
-                snapshot.HasGltfOnlyBaseTexture = snapshot.BaseTexture != null && snapshot.BaseTexturePropertyId != BaseMapId && snapshot.BaseTexturePropertyId != MainTexId;
-                snapshot.NormalTexture = FirstTexture(material, BumpMapId, GltfNormalTextureId);
-                snapshot.MetallicTexture = FirstTexture(material, MetallicGlossMapId, GltfMetallicRoughnessTextureId);
-                snapshot.OcclusionTexture = FirstTexture(material, OcclusionMapId, GltfOcclusionTextureId);
-                snapshot.EmissionTexture = FirstTexture(material, EmissionMapId, GltfEmissiveTextureId);
-
-                if (material.HasProperty(BaseColorId))
-                {
-                    snapshot.BaseColor = material.GetColor(BaseColorId);
-                    snapshot.HasBaseColor = true;
-                }
-                else if (material.HasProperty(ColorId))
-                {
-                    snapshot.BaseColor = material.GetColor(ColorId);
-                    snapshot.HasBaseColor = true;
-                }
-                else if (material.HasProperty(GltfBaseColorFactorId))
-                {
-                    snapshot.BaseColor = material.GetColor(GltfBaseColorFactorId);
-                    snapshot.HasBaseColor = true;
-                }
-
-                return snapshot;
             }
         }
 

--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using Aiming.Gameplay.Rendering;
 using UnityEngine;
 
 namespace TonPlaygram.Gameplay.Weapons
@@ -131,7 +130,7 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private int minorPiecesPerNonFinalShot = 3;
 
         [Header("Camera anchors")]
-        [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, 0.08f, 0.28f);
+        [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, -0.04f, 0.18f);
         [SerializeField] private float aimPositionLerp = 20f;
         [SerializeField] private bool followAllBullets = true;
         [SerializeField] private bool forceAttackerAimAnchor = true;
@@ -142,13 +141,6 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Vector3 swapIconWorldOffset = new Vector3(0f, 0.11f, 0f);
         [SerializeField] private bool allowDynamicCameraOnlyDuringAnimation = true;
         [SerializeField] private float turnFocusDuration = 0.22f;
-        [SerializeField] private float aimPitchDownDegrees = 8f;
-        [SerializeField] private float maxLookUpDegrees = 8f;
-        [SerializeField] private float maxLookDownDegrees = 26f;
-
-        [Header("Material import behavior")]
-        [Tooltip("Keeps imported GLTF/GLB weapon materials untouched so original weapon textures stay exactly as authored.")]
-        [SerializeField] private bool preserveOriginalWeaponMaterials = true;
 
 
         private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();
@@ -197,10 +189,6 @@ namespace TonPlaygram.Gameplay.Weapons
             BuildProfileMap();
             CacheTokenPieces();
             CacheStaticAnchors();
-            if (!preserveOriginalWeaponMaterials)
-            {
-                ApplyWeaponMaterialCompatibility();
-            }
             _eventListeners = GetComponentsInParent<ILudoWeaponEvents>(true);
             _projectileListeners = GetComponentsInParent<ILudoProjectileBroadcastEvents>(true);
             Equip(startingWeapon);
@@ -593,7 +581,7 @@ namespace TonPlaygram.Gameplay.Weapons
 
                 playerCamera.fieldOfView = Mathf.Lerp(startFov, weapon.aimFov, t);
                 playerCamera.transform.localPosition = Vector3.Lerp(startPos, targetLocalPos, Mathf.Clamp01(Time.deltaTime * aimPositionLerp));
-                Quaternion toTarget = ResolveLimitedLookRotation(targetWorld - playerCamera.transform.position);
+                Quaternion toTarget = Quaternion.LookRotation((targetWorld - playerCamera.transform.position).normalized, Vector3.up);
                 playerCamera.transform.rotation = Quaternion.Slerp(playerCamera.transform.rotation, toTarget, Mathf.Clamp01(Time.deltaTime * cameraLookLerp));
                 yield return null;
             }
@@ -625,7 +613,7 @@ namespace TonPlaygram.Gameplay.Weapons
                 t += Time.deltaTime;
                 Vector3 targetPos = bulletTransform.position - (bulletTransform.forward * bulletFollowDistance) + (Vector3.up * bulletFollowHeight);
                 playerCamera.transform.position = Vector3.Lerp(playerCamera.transform.position, targetPos, Mathf.Clamp01(Time.deltaTime * cameraTrackLerp));
-                Quaternion toBullet = ResolveLimitedLookRotation(bulletTransform.position - playerCamera.transform.position, 0f);
+                Quaternion toBullet = Quaternion.LookRotation((bulletTransform.position - playerCamera.transform.position).normalized, Vector3.up);
                 playerCamera.transform.rotation = Quaternion.Slerp(playerCamera.transform.rotation, toBullet, Mathf.Clamp01(Time.deltaTime * cameraLookLerp));
                 yield return null;
             }
@@ -654,7 +642,7 @@ namespace TonPlaygram.Gameplay.Weapons
             {
                 t += Time.deltaTime;
                 Vector3 towardImpact = (impactPoint - playerCamera.transform.position).normalized;
-                Quaternion impactRot = ResolveLimitedLookRotation(towardImpact, 0f);
+                Quaternion impactRot = Quaternion.LookRotation(towardImpact, Vector3.up);
                 playerCamera.transform.rotation = Quaternion.Slerp(startRot, impactRot, Mathf.Clamp01(t / seconds));
                 yield return null;
             }
@@ -711,69 +699,9 @@ namespace TonPlaygram.Gameplay.Weapons
                 elapsed += Time.deltaTime;
                 Vector3 toTarget = (turnAnchor.position - playerCamera.transform.position).normalized;
                 Vector3 lerped = Vector3.Slerp(fromForward, toTarget, Mathf.Clamp01(elapsed / duration));
-                playerCamera.transform.rotation = ResolveLimitedLookRotation(lerped, 0f);
+                playerCamera.transform.rotation = Quaternion.LookRotation(lerped, Vector3.up);
                 yield return null;
             }
-        }
-
-        private Quaternion ResolveLimitedLookRotation(Vector3 worldDirection)
-        {
-            return ResolveLimitedLookRotation(worldDirection, aimPitchDownDegrees);
-        }
-
-        private Quaternion ResolveLimitedLookRotation(Vector3 worldDirection, float extraPitchDownDegrees)
-        {
-            if (worldDirection.sqrMagnitude <= 0.000001f)
-            {
-                return playerCamera != null ? playerCamera.transform.rotation : Quaternion.identity;
-            }
-
-            Vector3 direction = worldDirection.normalized;
-            Vector3 flatDirection = Vector3.ProjectOnPlane(direction, Vector3.up);
-            if (flatDirection.sqrMagnitude <= 0.000001f)
-            {
-                flatDirection = playerCamera != null ? Vector3.ProjectOnPlane(playerCamera.transform.forward, Vector3.up) : Vector3.forward;
-                if (flatDirection.sqrMagnitude <= 0.000001f)
-                {
-                    flatDirection = Vector3.forward;
-                }
-            }
-
-            flatDirection.Normalize();
-            float signedPitch = Mathf.Atan2(direction.y, flatDirection.magnitude) * Mathf.Rad2Deg - extraPitchDownDegrees;
-            signedPitch = Mathf.Clamp(signedPitch, -Mathf.Abs(maxLookDownDegrees), Mathf.Abs(maxLookUpDegrees));
-
-            Quaternion yaw = Quaternion.LookRotation(flatDirection, Vector3.up);
-            return yaw * Quaternion.AngleAxis(-signedPitch, Vector3.right);
-        }
-
-        private void ApplyWeaponMaterialCompatibility()
-        {
-            ApplyMaterialCompatibility(weaponRoot);
-
-            for (int i = 0; i < weaponProfiles.Count; i++)
-            {
-                WeaponBallisticsProfile profile = weaponProfiles[i];
-                Animator animator = profile != null && profile.gripPose != null ? profile.gripPose.animator : null;
-                if (animator != null)
-                {
-                    ApplyMaterialCompatibility(animator.transform);
-                }
-            }
-        }
-
-        private static void ApplyMaterialCompatibility(Transform root)
-        {
-            if (root == null)
-                return;
-
-            GltfMaterialCompatibilityAdapter adapter = root.GetComponent<GltfMaterialCompatibilityAdapter>();
-            if (adapter == null)
-            {
-                adapter = root.gameObject.AddComponent<GltfMaterialCompatibilityAdapter>();
-            }
-
-            adapter.ApplyCompatibilityPass();
         }
 
         private Vector3 ResolveLiveTargetPosition()

--- a/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
+++ b/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
@@ -87,18 +87,8 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Vector3 weaponGripPositionOffset;
         [SerializeField] private Vector3 weaponGripEulerOffset;
 
-        [Header("FPS screen presentation")]
-        [SerializeField] private Camera presentationCamera;
-        [SerializeField] private Transform fpsPresentationRoot;
-        [SerializeField] private bool keepWeaponVisibleInFpsView = true;
-        [SerializeField] private Vector3 cameraSpaceWeaponOffset = new Vector3(0.18f, -0.2f, 0.55f);
-        [SerializeField] private Vector3 cameraSpaceWeaponEuler = new Vector3(-4f, 2f, 0f);
-        [SerializeField] private Vector2 minWeaponViewport = new Vector2(0.12f, 0.06f);
-        [SerializeField] private Vector2 maxWeaponViewport = new Vector2(0.88f, 0.42f);
-
         private readonly List<Renderer> _hiddenOriginalHandRenderers = new List<Renderer>();
         private Quaternion _weaponGripRotationOffset;
-        private Quaternion _cameraSpaceWeaponRotationOffset;
         private Quaternion _originalGripToWeaponRotation = Quaternion.identity;
         private Vector3 _originalGripToWeaponPosition;
         private bool _hasOriginalGripToWeapon;
@@ -171,11 +161,6 @@ namespace TonPlaygram.Gameplay.Weapons
         private void CacheRuntimeOffsets()
         {
             _weaponGripRotationOffset = Quaternion.Euler(weaponGripEulerOffset);
-            _cameraSpaceWeaponRotationOffset = Quaternion.Euler(cameraSpaceWeaponEuler);
-            if (presentationCamera == null)
-            {
-                presentationCamera = Camera.main;
-            }
             if (weaponRoot != null && originalFpsRightGrip != null)
             {
                 _originalGripToWeaponRotation = Quaternion.Inverse(originalFpsRightGrip.rotation) * weaponRoot.rotation;
@@ -202,30 +187,11 @@ namespace TonPlaygram.Gameplay.Weapons
             {
                 weaponRoot.rotation = humanRightGrip.rotation * _originalGripToWeaponRotation * _weaponGripRotationOffset;
                 weaponRoot.position = humanRightGrip.position + (humanRightGrip.rotation * (_originalGripToWeaponPosition + weaponGripPositionOffset));
-                KeepWeaponVisibleInFpsView();
                 return;
             }
 
             weaponRoot.position = humanRightGrip.TransformPoint(weaponGripPositionOffset);
             weaponRoot.rotation = humanRightGrip.rotation * _weaponGripRotationOffset;
-            KeepWeaponVisibleInFpsView();
-        }
-
-        private void KeepWeaponVisibleInFpsView()
-        {
-            Transform presentationRoot = fpsPresentationRoot != null ? fpsPresentationRoot : weaponRoot;
-            if (!keepWeaponVisibleInFpsView || presentationCamera == null || presentationRoot == null)
-                return;
-
-            Vector3 viewportPoint = presentationCamera.WorldToViewportPoint(presentationRoot.position);
-            bool behindCamera = viewportPoint.z <= presentationCamera.nearClipPlane;
-            bool outsideSafeBottomFrame = viewportPoint.x < minWeaponViewport.x || viewportPoint.x > maxWeaponViewport.x || viewportPoint.y < minWeaponViewport.y || viewportPoint.y > maxWeaponViewport.y;
-            if (!behindCamera && !outsideSafeBottomFrame)
-                return;
-
-            Transform cameraTransform = presentationCamera.transform;
-            presentationRoot.position = cameraTransform.TransformPoint(cameraSpaceWeaponOffset);
-            presentationRoot.rotation = cameraTransform.rotation * _cameraSpaceWeaponRotationOffset;
         }
 
         private void AddExtraOriginalHandRenderers()


### PR DESCRIPTION
### Motivation
- Remove brittle GLTF-specific texture snapshot/upgrade logic to simplify material compatibility and fallback behavior.  
- Replace custom pitch-limited camera look logic with direct look rotations for weapon aiming and bullet-follow cameras to reduce complexity.  
- Remove FPS presentation-specific features for human hand retargeting to streamline the grip/weapon positioning logic.

### Description
- Simplified `GltfMaterialCompatibilityAdapter` by removing `MaterialTextureSnapshot`, GLTF-only property IDs, and upgrade logic, and updated `EnsureSupportedShader` and `CopyPbrMaps` to only handle supported shader fallback and direct texture copying.  
- Updated `BattleRoyaleWeaponDirector` to adjust `firstPersonAimOffset`, remove `aimPitchDownDegrees`, `maxLookUpDegrees`, `maxLookDownDegrees`, and replaced all `ResolveLimitedLookRotation` calls with `Quaternion.LookRotation` to use direct world-facing rotations, while removing GLTF material application code and references to `GltfMaterialCompatibilityAdapter`.  
- Cleaned up `FpsGunHumanHandRetargeter` by removing FPS presentation camera fields and logic (`presentationCamera`, `fpsPresentationRoot`, viewport constraints, and `KeepWeaponVisibleInFpsView`), and removed related runtime camera-space rotation/offset handling used when snapping the weapon to the human grip.  
- Removed an unused `using` import and several serialized fields across the modified classes to reduce surface area and complexity.

### Testing
- Performed a Unity Editor script compilation (`Assets` compile) which completed successfully.  
- Executed the existing automated test suite and editor play-mode smoke tests, and all tests passed.  
- Verified no compilation errors remained after the refactor on the targeted Unity project assemblies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bed7a7f148329a240743b04d40fcf)