### PR TITLE
Move Showood material controls into in-game menu, live-apply GLB palette, and adjust GLB fit scales

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,7 +1,7 @@
-export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
 const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
@@ -16,7 +16,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     icon: '🎱',
     kind: 'gltf',
-    fitScale: 1.02,
+    fitScale: 1.055,
     clothRepeatScale: 5.25,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
@@ -42,7 +42,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     icon: '🟫',
     kind: 'gltf',
-    fitScale: 1.02,
+    fitScale: 1.06,
     lowerBaseHeightScale: 1.16,
     clothRepeatScale: 5.25,
     fitStrategy: 'exact',
@@ -59,18 +59,18 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }
-]);
+])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === 'royal-original')?.id ||
-  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
-export function resolvePoolRoyaleTableModel(modelId) {
-  const key = typeof modelId === 'string' ? modelId.trim() : '';
+export function resolvePoolRoyaleTableModel (modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : ''
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  )
 }
 
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
@@ -80,7 +80,7 @@ export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'jaws',
   'topWoodRail',
   'legBase'
-]);
+])
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   cloth: 'a',
@@ -89,7 +89,7 @@ export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   jaws: 'a',
   topWoodRail: 'a',
   legBase: 'b'
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   cloth: { label: 'Field cloth', description: 'Only the flat playfield surface.' },
@@ -104,7 +104,7 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   jaws: { label: 'Jaws', description: 'Pocket jaws / cups: black or brown.' },
   topWoodRail: { label: 'Top rail frame', description: 'Main top wood rail frame.' },
   legBase: { label: 'Legs + base', description: 'Legs and lower base blocks together, separate from metal accents.' }
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   cloth: Object.freeze({
@@ -131,4 +131,4 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
     a: Object.freeze({ label: 'Brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }),
     b: Object.freeze({ label: 'Black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 })
   })
-});
+})

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -35,8 +35,10 @@ import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
+  POOL_ROYALE_SHOWOOD_CONTROL_META,
   POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS,
   POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
+  POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
 import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
@@ -128,6 +130,7 @@ import { createMurlanStyleTable } from '../../utils/murlanTable.js';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+const POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY = 'poolRoyaleShowoodMaterialPalette';
 
 
 const TRAINING_MISS_ATTEMPT_COST = 1;
@@ -12495,6 +12498,11 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
         child.visible = false;
       }
       if (tableModel?.useReferenceShowoodMapping) {
+        child.userData = {
+          ...(child.userData || {}),
+          poolRoyaleExternalRole: role,
+          poolRoyaleShowoodReferencePart: referencePart || role
+        };
         const nextMaterial = applyPoolRoyaleShowoodReferenceMaterial(material, referencePart || role, tableModel);
         normalizePoolRoyaleExternalClothTextureScale(child, nextMaterial, role);
         return nextMaterial;
@@ -14126,20 +14134,48 @@ function PoolRoyaleGame({
     () => resolveTableSize(tableSizeKey),
     [tableSizeKey]
   );
-  const activeTableModel = useMemo(() => {
-    const model = resolvePoolRoyaleTableModel(tableModelKey);
-    if (!model?.useReferenceShowoodMapping) return model;
-    let showoodPalette = null;
+  const [showoodPalette, setShowoodPalette] = useState(() => {
     try {
       const params = new URLSearchParams(location.search);
-      const raw = params.get('showoodPalette') || window.localStorage?.getItem('poolRoyaleShowoodMaterialPalette');
+      const raw =
+        params.get('showoodPalette') ||
+        window.localStorage?.getItem(POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY);
       if (raw) {
         const parsed = JSON.parse(raw);
-        if (parsed && typeof parsed === 'object') showoodPalette = parsed;
+        if (parsed && typeof parsed === 'object') {
+          return { ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE, ...parsed };
+        }
       }
     } catch {}
-    return showoodPalette ? { ...model, showoodPalette } : model;
-  }, [location.search, tableModelKey]);
+    return { ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE };
+  });
+  const activeTableModel = useMemo(() => {
+    const model = resolvePoolRoyaleTableModel(tableModelKey);
+    return model?.useReferenceShowoodMapping ? { ...model, showoodPalette } : model;
+  }, [showoodPalette, tableModelKey]);
+  useEffect(() => {
+    try {
+      window.localStorage?.setItem(
+        POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY,
+        JSON.stringify(showoodPalette)
+      );
+    } catch {}
+    if (!activeTableModel?.useReferenceShowoodMapping) return;
+    const liveTableModel = { ...activeTableModel, showoodPalette };
+    worldRef.current?.traverse?.((child) => {
+      if (!child?.isMesh || !child.userData?.poolRoyaleShowoodReferencePart) return;
+      const role = child.userData.poolRoyaleExternalRole || 'cloth';
+      const part = child.userData.poolRoyaleShowoodReferencePart || role;
+      const updateMaterial = (material) => {
+        const nextMaterial = applyPoolRoyaleShowoodReferenceMaterial(material, part, liveTableModel);
+        normalizePoolRoyaleExternalClothTextureScale(child, nextMaterial, role);
+        return nextMaterial;
+      };
+      child.material = Array.isArray(child.material)
+        ? child.material.map(updateMaterial)
+        : updateMaterial(child.material);
+    });
+  }, [activeTableModel, showoodPalette]);
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
   const resolvedAccountId = useMemo(
     () => poolRoyalAccountId(accountId),
@@ -35789,6 +35825,76 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
+              {activeTableModel?.useReferenceShowoodMapping ? (
+                <div className="rounded-2xl border border-amber-300/20 bg-black/25 p-3">
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <div>
+                      <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                        Showood Table Setup
+                      </h3>
+                      <p className="mt-1 text-[0.7rem] text-white/60">
+                        Visible only for the Showood GLB table. Changes apply live to the loaded GLB materials.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setShowoodPalette({ ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE })}
+                      className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.2em] text-white/80 transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+                    >
+                      Reset
+                    </button>
+                  </div>
+                  <div className="space-y-3">
+                    {POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS.map((control) => {
+                      const meta = POOL_ROYALE_SHOWOOD_CONTROL_META[control];
+                      const options = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control];
+                      return (
+                        <div key={control} className="rounded-xl border border-white/10 bg-white/5 p-2">
+                          <div className="mb-2">
+                            <p className="text-[10px] font-black uppercase tracking-[0.22em] text-emerald-100">
+                              {meta.label}
+                            </p>
+                            <p className="text-[10px] leading-snug text-white/50">
+                              {meta.description}
+                            </p>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            {['a', 'b'].map((choice) => {
+                              const option = options[choice];
+                              const active = showoodPalette[control] === choice;
+                              return (
+                                <button
+                                  key={`${control}-${choice}`}
+                                  type="button"
+                                  onClick={() =>
+                                    setShowoodPalette((current) => ({
+                                      ...current,
+                                      [control]: choice
+                                    }))
+                                  }
+                                  aria-pressed={active}
+                                  className={`flex flex-1 items-center justify-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-extrabold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                                    active
+                                      ? 'border-white/80 bg-white/20 text-white shadow-[0_0_14px_rgba(255,255,255,0.22)]'
+                                      : 'border-white/15 bg-white/5 text-white/70 hover:bg-white/10'
+                                  }`}
+                                >
+                                  <span
+                                    className="h-3.5 w-3.5 rounded-full border border-white/40"
+                                    style={{ backgroundColor: option.color }}
+                                    aria-hidden="true"
+                                  />
+                                  <span>{option.label}</span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   HDR Environment

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,10 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_SHOWOOD_CONTROL_META,
-  POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS,
-  POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
-  POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS,
   POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
@@ -43,7 +39,6 @@ const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
 const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
-const POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY = 'poolRoyaleShowoodMaterialPalette';
 
 function resolveTpcAccountNumber(player) {
   if (!player || typeof player !== 'object') return '';
@@ -91,24 +86,11 @@ export default function PoolRoyaleLobby() {
     } catch {}
     return resolvePoolRoyaleTableModel().id;
   });
-  const [showoodPalette, setShowoodPalette] = useState(() => {
-    try {
-      const stored = JSON.parse(
-        window.localStorage?.getItem(POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY) || 'null'
-      );
-      if (stored && typeof stored === 'object') {
-        return { ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE, ...stored };
-      }
-    } catch {}
-    return { ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE };
-  });
+  const selectedTableModel = useMemo(
+    () => resolvePoolRoyaleTableModel(tableModelId),
+    [tableModelId]
+  );
   const [players, setPlayers] = useState(8);
-  const selectedTableModel = useMemo(() => {
-    const model = resolvePoolRoyaleTableModel(tableModelId);
-    return model?.useReferenceShowoodMapping
-      ? { ...model, showoodPalette }
-      : model;
-  }, [showoodPalette, tableModelId]);
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -227,9 +209,6 @@ export default function PoolRoyaleLobby() {
       params.set('ballSet', 'american');
     }
     params.set('tableModel', selectedTableModel.id);
-    if (selectedTableModel.useReferenceShowoodMapping) {
-      params.set('showoodPalette', JSON.stringify(showoodPalette));
-    }
     params.set('type', playType);
     params.set('mode', 'online');
     params.set('tableId', startedId);
@@ -279,12 +258,6 @@ export default function PoolRoyaleLobby() {
         window.localStorage?.setItem(
           TABLE_BASE_STORAGE_KEY,
           selectedTableModel.baseId
-        );
-      }
-      if (selectedTableModel.useReferenceShowoodMapping) {
-        window.localStorage?.setItem(
-          POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY,
-          JSON.stringify(showoodPalette)
         );
       }
     } catch {}
@@ -358,9 +331,6 @@ export default function PoolRoyaleLobby() {
     }
     params.set('tableSize', tableSize);
     params.set('tableModel', selectedTableModel.id);
-    if (selectedTableModel.useReferenceShowoodMapping) {
-      params.set('showoodPalette', JSON.stringify(showoodPalette));
-    }
     params.set(
       'type',
       effectivePlayType === 'friendly' ? 'regular' : effectivePlayType
@@ -701,62 +671,6 @@ export default function PoolRoyaleLobby() {
           <p className="text-xs text-white/60">
             Royal Original now keeps TonPlaygram shell/chrome but uses GLB cushions and pocket jaws; Showood uses the reference texture mapping and option set.
           </p>
-          {selectedTableModel.useReferenceShowoodMapping ? (
-            <div className="rounded-2xl border border-amber-300/20 bg-black/25 p-3">
-              <div className="mb-2 flex items-center justify-between gap-2">
-                <div>
-                  <h4 className="text-sm font-semibold text-white">Showood table setup</h4>
-                  <p className="text-[11px] text-white/55">Same material options as the supplied reference preview.</p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setShowoodPalette({ ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE })}
-                  className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-white/80"
-                >
-                  Reset
-                </button>
-              </div>
-              <div className="space-y-3">
-                {POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS.map((control) => {
-                  const meta = POOL_ROYALE_SHOWOOD_CONTROL_META[control];
-                  const options = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control];
-                  return (
-                    <div key={control} className="rounded-xl border border-white/10 bg-white/5 p-2">
-                      <div className="mb-2">
-                        <p className="text-[11px] font-black uppercase tracking-[0.22em] text-emerald-100">{meta.label}</p>
-                        <p className="text-[10px] leading-snug text-white/50">{meta.description}</p>
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        {['a', 'b'].map((choice) => {
-                          const option = options[choice];
-                          const active = showoodPalette[control] === choice;
-                          return (
-                            <button
-                              key={`${control}-${choice}`}
-                              type="button"
-                              onClick={() => setShowoodPalette((current) => ({ ...current, [control]: choice }))}
-                              className={`flex flex-1 items-center justify-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-extrabold transition ${
-                                active
-                                  ? 'border-white/80 bg-white/20 text-white shadow-[0_0_14px_rgba(255,255,255,0.22)]'
-                                  : 'border-white/15 bg-white/5 text-white/70'
-                              }`}
-                            >
-                              <span
-                                className="h-3.5 w-3.5 rounded-full border border-white/40"
-                                style={{ backgroundColor: option.color }}
-                                aria-hidden="true"
-                              />
-                              <span>{option.label}</span>
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          ) : null}
         </div>
 
         <div className="space-y-3">


### PR DESCRIPTION
### Motivation
- Keep the lobby focused on match setup while exposing Showood GLB material controls only where they are relevant (in-game) and apply visual edits live to the loaded GLB table model.
- Ensure the Showood GLB playfield/cushions/jaws visually match the Royal table footprint by adjusting GLB fit scaling and preferring GLB cushions/jaws over procedural geometry.

### Description
- Move Showood material UI from the lobby into the Pool Royale in-game `Table Setup` panel and show it only when the selected table model uses the Showood GLB (`activeTableModel.useReferenceShowoodMapping`), adding a Reset control and per-part choices (cloth, cushion, metalAccent, jaws, topWoodRail, legBase) in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Add runtime palette state and persistence via `POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY` and `showoodPalette` in `PoolRoyale.jsx`, and apply palette changes live by traversing `worldRef.current` and re-materializing external table meshes using `applyPoolRoyaleShowoodReferenceMaterial` and `normalizePoolRoyaleExternalClothTextureScale`.
- Mark imported GLB meshes with `child.userData.poolRoyaleExternalRole` / `poolRoyaleShowoodReferencePart` inside `preparePoolRoyaleExternalTableMaterials` so the runtime can identify which part to remap when the palette changes (in `PoolRoyale.jsx`).
- Remove the Showood palette state/UI from the lobby (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`) to simplify selection flow and move the controls into the running game UI.
- Bump `fitScale` for `royal-original` and `showood-seven-foot` in `webapp/src/config/poolRoyaleTableModels.js` so the Showood GLB playfield/cushions/jaws appear slightly larger and better match the Royal table visuals, and keep `hideGeneratedCushionsAndJaws` behavior for the Royal overlay so GLB cushions/jaws replace procedural cushions where intended.

### Testing
- Ran lint with `npm --prefix webapp run lint -- src/pages/Games/PoolRoyale.jsx src/pages/Games/PoolRoyaleLobby.jsx src/config/poolRoyaleTableModels.js` and fixed issues; lint passed after fixes.
- Built the webapp with `npm --prefix webapp run build` and the Vite production build completed successfully.
- Started the dev server with `npm --prefix webapp run dev -- --host 127.0.0.1` and exercised the Pool Royale lobby and in-game menu in a local mobile viewport.
- Captured a local mobile viewport screenshot of the Pool Royale lobby (dev server) to verify UI placement and that the Showood controls are no longer present in the lobby, and verified the in-game Showood panel appears when the Showood GLB model is active.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c17f3528883299b55e84bd5c1d98e)