### PR TITLE
Restore Chess Battle Royal jet & missile audio (use jet sound for missile launches)

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -2226,9 +2226,11 @@ const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const LAUGH_SOUND_URL = '/assets/sounds/Haha.mp3';
 const DRONE_FLY_SOUND_URL = '/assets/sounds/kimsa-kimsa-big-motorcycle-sound-394700.mp3';
+const JET_FLY_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
 const HELICOPTER_FLY_SOUND_URL = '/assets/sounds/dragon-studio-helicopter-sound-8d-372463.mp3';
-const BAZOOKA_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
+const MISSILE_LAUNCH_SOUND_URL = JET_FLY_SOUND_URL;
 const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
+const CHESS_MISSILE_JET_SOUND_MAX_MS = 1200;
 const LUDO_FIREARM_BROADCAST_PROFILE = LUDO_WEAPON_DIRECTOR_BRIDGE.firearmBroadcastProfile || {};
 const LUDO_WEAPON_TYPE_BY_ANIMATION_ID = LUDO_WEAPON_DIRECTOR_BRIDGE.weaponTypeByCaptureAnimationId || {};
 const CHESS_FIREARM_FATAL_BULLET_TRAVEL_MS = 1250; // match Ludo Battle Royal service-pistol final bullet travel.
@@ -8336,6 +8338,7 @@ function Chess3D({
   const laughSoundRef = useRef(null);
   const swordSoundRef = useRef(null);
   const droneSoundRef = useRef(null);
+  const jetSoundRef = useRef(null);
   const helicopterSoundRef = useRef(null);
   const missileLaunchSoundRef = useRef(null);
   const missileImpactSoundRef = useRef(null);
@@ -9490,7 +9493,7 @@ function Chess3D({
         } catch {}
       }
     }
-    [swordSoundRef, droneSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
+    [swordSoundRef, droneSoundRef, jetSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
       if (!ref.current) return;
       ref.current.volume = effectiveSoundEnabled ? volume : 0;
       if (!effectiveSoundEnabled) {
@@ -9527,7 +9530,7 @@ function Chess3D({
       if (laughSoundRef.current) {
         laughSoundRef.current.volume = settingsRef.current.soundEnabled ? volume : 0;
       }
-      [swordSoundRef, droneSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
+      [swordSoundRef, droneSoundRef, jetSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
         if (!ref.current) return;
         ref.current.volume = settingsRef.current.soundEnabled ? volume : 0;
       });
@@ -9955,9 +9958,12 @@ function Chess3D({
     swordSoundRef.current.volume = baseVolume;
     droneSoundRef.current = new Audio(DRONE_FLY_SOUND_URL);
     droneSoundRef.current.volume = baseVolume;
+    jetSoundRef.current = new Audio(JET_FLY_SOUND_URL);
+    jetSoundRef.current.loop = true;
+    jetSoundRef.current.volume = baseVolume;
     helicopterSoundRef.current = new Audio(HELICOPTER_FLY_SOUND_URL);
     helicopterSoundRef.current.volume = baseVolume;
-    missileLaunchSoundRef.current = new Audio(BAZOOKA_FIRE_SOUND_URL);
+    missileLaunchSoundRef.current = new Audio(MISSILE_LAUNCH_SOUND_URL);
     missileLaunchSoundRef.current.volume = baseVolume;
     missileImpactSoundRef.current = new Audio(MISSILE_IMPACT_SOUND_URL);
     missileImpactSoundRef.current.volume = baseVolume;
@@ -10052,6 +10058,8 @@ function Chess3D({
       const playCheckSound = () => playAudio(checkSoundRef);
       const playMateSound = () => playAudio(mateSoundRef);
       const playLaughSound = () => playAudio(laughSoundRef, { maxDurationMs: 6000 });
+      const playMissileLaunchSound = () =>
+        playAudio(missileLaunchSoundRef, { maxDurationMs: CHESS_MISSILE_JET_SOUND_MAX_MS });
       const chairTheme = mapChairOptionToTheme(chairOption);
       const chairBuild = await buildChessChairTemplate(chairTheme);
       if (cancelled) return;
@@ -12494,7 +12502,7 @@ function Chess3D({
         const launchBase = parkedTruck ? getSupportTruckMissileLaunchPosition(parkedTruck) : getAirPadAnchor(isWhiteSide, 'truck', 0);
         missileFx.root.position.copy(launchBase.clone());
         captureFxGroup.add(missileFx.root);
-        playAudio(missileLaunchSoundRef);
+        playMissileLaunchSound();
         activeCaptureFx.push({
           type: 'javelin',
           t: 0,
@@ -12687,6 +12695,7 @@ function Chess3D({
           missile.root.visible = false;
           captureFxGroup.add(missile.root);
         });
+        playAudio(jetSoundRef, { maxDurationMs: CAPTURE_JET_TOTAL * 1000 });
         activeCaptureFx.push({
           type: 'jet',
           t: 0,
@@ -12778,7 +12787,7 @@ function Chess3D({
         return withAuto3d({ moveDelayMs: 280 });
       }
       if (distance >= 2) {
-        playAudio(missileLaunchSoundRef);
+        playMissileLaunchSound();
         const missileFx = createFxMissile();
         missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         captureFxGroup.add(missileFx.root);
@@ -14883,7 +14892,7 @@ function Chess3D({
               } else {
                 if (!missile.didPlayLaunchSound) {
                   missile.didPlayLaunchSound = true;
-                  playAudio(missileLaunchSoundRef);
+                  playMissileLaunchSound();
                 }
                 const { pos: missilePos, next: missileNext } = getStraightDownMissilePose({
                   launchPos: missile.launchPos.clone(),
@@ -14974,7 +14983,7 @@ function Chess3D({
               anyMissileVisible = true;
               if (!missile.didPlayLaunchSound) {
                 missile.didPlayLaunchSound = true;
-                playAudio(missileLaunchSoundRef);
+                playMissileLaunchSound();
               }
               const { pos: missilePos, next: missileNext } = getCaptureAirJavelinPose({
                 launchPos: missile.launchPos.clone(),
@@ -15089,7 +15098,7 @@ function Chess3D({
               anyMissileVisible = true;
               if (!missile.didPlayLaunchSound) {
                 missile.didPlayLaunchSound = true;
-                playAudio(missileLaunchSoundRef);
+                playMissileLaunchSound();
               }
               const { pos: missilePos, next: missileNext } = getCaptureAirJavelinPose({
                 launchPos: missile.launchPos.clone(),
@@ -15849,6 +15858,7 @@ function Chess3D({
       laughSoundRef.current?.pause();
       swordSoundRef.current?.pause();
       droneSoundRef.current?.pause();
+      jetSoundRef.current?.pause();
       helicopterSoundRef.current?.pause();
       missileLaunchSoundRef.current?.pause();
       missileImpactSoundRef.current?.pause();


### PR DESCRIPTION
### Motivation
- Restore the original fighter jet flyover audio for Chess Battle Royal and make missile launches use the same jet-style sound so captures sound consistent and recognizable.
- Prevent long-running launch clips from overlapping by capping missile launch playback to a short duration.

### Description
- Added `JET_FLY_SOUND_URL` and `MISSILE_LAUNCH_SOUND_URL` constants and a `CHESS_MISSILE_JET_SOUND_MAX_MS` duration cap in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Introduced `jetSoundRef` and wired it into the existing audio setup so the fighter jet flyover plays as a looping source during jet captures (`jetSoundRef` is created, looped, and volume-managed like other audio refs).
- Replaced direct `missileLaunch` `playAudio` calls with a `playMissileLaunchSound` helper that plays the missile launch audio (pointed to the jet sound) with a `maxDurationMs` clamp to stop playback quickly.
- Included `jetSoundRef` in the sound enable/disable, volume-change, and cleanup paths so mute/volume behavior and disposal remain consistent.

### Testing
- Ran `npm --prefix webapp run build` and the production Vite build completed successfully without errors.
- Ran `git diff --check -- webapp/src/pages/Games/ChessBattleRoyal.jsx` to validate the diff and there were no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c1d013cc48329af8d009743a86d12)