### PR TITLE
Restore Chess Battle jet and missile sounds

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -2226,8 +2226,8 @@ const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const LAUGH_SOUND_URL = '/assets/sounds/Haha.mp3';
 const DRONE_FLY_SOUND_URL = '/assets/sounds/kimsa-kimsa-big-motorcycle-sound-394700.mp3';
+const JET_FLY_SOUND_URL = DRONE_FLY_SOUND_URL;
 const HELICOPTER_FLY_SOUND_URL = '/assets/sounds/dragon-studio-helicopter-sound-8d-372463.mp3';
-const BAZOOKA_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
 const LUDO_FIREARM_BROADCAST_PROFILE = LUDO_WEAPON_DIRECTOR_BRIDGE.firearmBroadcastProfile || {};
 const LUDO_WEAPON_TYPE_BY_ANIMATION_ID = LUDO_WEAPON_DIRECTOR_BRIDGE.weaponTypeByCaptureAnimationId || {};
@@ -8336,6 +8336,7 @@ function Chess3D({
   const laughSoundRef = useRef(null);
   const swordSoundRef = useRef(null);
   const droneSoundRef = useRef(null);
+  const jetSoundRef = useRef(null);
   const helicopterSoundRef = useRef(null);
   const missileLaunchSoundRef = useRef(null);
   const missileImpactSoundRef = useRef(null);
@@ -9490,7 +9491,7 @@ function Chess3D({
         } catch {}
       }
     }
-    [swordSoundRef, droneSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
+    [swordSoundRef, droneSoundRef, jetSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
       if (!ref.current) return;
       ref.current.volume = effectiveSoundEnabled ? volume : 0;
       if (!effectiveSoundEnabled) {
@@ -9527,7 +9528,7 @@ function Chess3D({
       if (laughSoundRef.current) {
         laughSoundRef.current.volume = settingsRef.current.soundEnabled ? volume : 0;
       }
-      [swordSoundRef, droneSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
+      [swordSoundRef, droneSoundRef, jetSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
         if (!ref.current) return;
         ref.current.volume = settingsRef.current.soundEnabled ? volume : 0;
       });
@@ -9955,9 +9956,11 @@ function Chess3D({
     swordSoundRef.current.volume = baseVolume;
     droneSoundRef.current = new Audio(DRONE_FLY_SOUND_URL);
     droneSoundRef.current.volume = baseVolume;
+    jetSoundRef.current = new Audio(JET_FLY_SOUND_URL);
+    jetSoundRef.current.volume = baseVolume;
     helicopterSoundRef.current = new Audio(HELICOPTER_FLY_SOUND_URL);
     helicopterSoundRef.current.volume = baseVolume;
-    missileLaunchSoundRef.current = new Audio(BAZOOKA_FIRE_SOUND_URL);
+    missileLaunchSoundRef.current = new Audio(JET_FLY_SOUND_URL);
     missileLaunchSoundRef.current.volume = baseVolume;
     missileImpactSoundRef.current = new Audio(MISSILE_IMPACT_SOUND_URL);
     missileImpactSoundRef.current.volume = baseVolume;
@@ -10052,6 +10055,7 @@ function Chess3D({
       const playCheckSound = () => playAudio(checkSoundRef);
       const playMateSound = () => playAudio(mateSoundRef);
       const playLaughSound = () => playAudio(laughSoundRef, { maxDurationMs: 6000 });
+      const playMissileLaunchSound = () => playAudio(missileLaunchSoundRef, { maxDurationMs: 900 });
       const chairTheme = mapChairOptionToTheme(chairOption);
       const chairBuild = await buildChessChairTemplate(chairTheme);
       if (cancelled) return;
@@ -12494,7 +12498,7 @@ function Chess3D({
         const launchBase = parkedTruck ? getSupportTruckMissileLaunchPosition(parkedTruck) : getAirPadAnchor(isWhiteSide, 'truck', 0);
         missileFx.root.position.copy(launchBase.clone());
         captureFxGroup.add(missileFx.root);
-        playAudio(missileLaunchSoundRef);
+        playMissileLaunchSound();
         activeCaptureFx.push({
           type: 'javelin',
           t: 0,
@@ -12687,6 +12691,7 @@ function Chess3D({
           missile.root.visible = false;
           captureFxGroup.add(missile.root);
         });
+        playAudio(jetSoundRef, { maxDurationMs: CAPTURE_JET_TOTAL * 1000 });
         activeCaptureFx.push({
           type: 'jet',
           t: 0,
@@ -12778,7 +12783,7 @@ function Chess3D({
         return withAuto3d({ moveDelayMs: 280 });
       }
       if (distance >= 2) {
-        playAudio(missileLaunchSoundRef);
+        playMissileLaunchSound();
         const missileFx = createFxMissile();
         missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         captureFxGroup.add(missileFx.root);
@@ -14883,7 +14888,7 @@ function Chess3D({
               } else {
                 if (!missile.didPlayLaunchSound) {
                   missile.didPlayLaunchSound = true;
-                  playAudio(missileLaunchSoundRef);
+                  playMissileLaunchSound();
                 }
                 const { pos: missilePos, next: missileNext } = getStraightDownMissilePose({
                   launchPos: missile.launchPos.clone(),
@@ -14974,7 +14979,7 @@ function Chess3D({
               anyMissileVisible = true;
               if (!missile.didPlayLaunchSound) {
                 missile.didPlayLaunchSound = true;
-                playAudio(missileLaunchSoundRef);
+                playMissileLaunchSound();
               }
               const { pos: missilePos, next: missileNext } = getCaptureAirJavelinPose({
                 launchPos: missile.launchPos.clone(),
@@ -15089,7 +15094,7 @@ function Chess3D({
               anyMissileVisible = true;
               if (!missile.didPlayLaunchSound) {
                 missile.didPlayLaunchSound = true;
-                playAudio(missileLaunchSoundRef);
+                playMissileLaunchSound();
               }
               const { pos: missilePos, next: missileNext } = getCaptureAirJavelinPose({
                 launchPos: missile.launchPos.clone(),
@@ -15849,6 +15854,7 @@ function Chess3D({
       laughSoundRef.current?.pause();
       swordSoundRef.current?.pause();
       droneSoundRef.current?.pause();
+      jetSoundRef.current?.pause();
       helicopterSoundRef.current?.pause();
       missileLaunchSoundRef.current?.pause();
       missileImpactSoundRef.current?.pause();


### PR DESCRIPTION
### Motivation
- Restore the original jet fly-by audio and make missile launches use the same sound so air-strike audio matches visuals for Chess Battle Royal.

### Description
- Added a `JET_FLY_SOUND_URL` alias and a new `jetSoundRef` audio ref in `webapp/src/pages/Games/ChessBattleRoyal.jsx` so the jet has a dedicated playback handle.
- Pointed `missileLaunchSoundRef` at the same jet fly asset and introduced a `playMissileLaunchSound` helper that calls `playAudio(missileLaunchSoundRef, { maxDurationMs: 900 })` to keep launch playback short.
- Replaced direct `playAudio(missileLaunchSoundRef)` calls with `playMissileLaunchSound()` and added calls to `playAudio(jetSoundRef, { maxDurationMs: CAPTURE_JET_TOTAL * 1000 })` when jet capture animations start.
- Included `jetSoundRef` in the volume/mute arrays and cleanup so the jet/missile audio follows existing `effectiveSoundEnabled` and pause/cleanup logic.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully and produced the application bundles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c1d013cc48329af8d009743a86d12)