### PR TITLE
Simplify camera look & retargeter code; remove material compatibility and FPS presentation features

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using Aiming.Gameplay.Rendering;
 using UnityEngine;
 
 namespace TonPlaygram.Gameplay.Weapons
@@ -131,7 +130,7 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private int minorPiecesPerNonFinalShot = 3;
 
         [Header("Camera anchors")]
-        [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, 0.08f, 0.28f);
+        [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, -0.04f, 0.18f);
         [SerializeField] private float aimPositionLerp = 20f;
         [SerializeField] private bool followAllBullets = true;
         [SerializeField] private bool forceAttackerAimAnchor = true;
@@ -142,13 +141,6 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Vector3 swapIconWorldOffset = new Vector3(0f, 0.11f, 0f);
         [SerializeField] private bool allowDynamicCameraOnlyDuringAnimation = true;
         [SerializeField] private float turnFocusDuration = 0.22f;
-        [SerializeField] private float aimPitchDownDegrees = 8f;
-        [SerializeField] private float maxLookUpDegrees = 8f;
-        [SerializeField] private float maxLookDownDegrees = 26f;
-
-        [Header("Material import behavior")]
-        [Tooltip("Keeps imported GLTF/GLB weapon materials untouched so original weapon textures stay exactly as authored.")]
-        [SerializeField] private bool preserveOriginalWeaponMaterials = true;
 
 
         private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();
@@ -197,10 +189,6 @@ namespace TonPlaygram.Gameplay.Weapons
             BuildProfileMap();
             CacheTokenPieces();
             CacheStaticAnchors();
-            if (!preserveOriginalWeaponMaterials)
-            {
-                ApplyWeaponMaterialCompatibility();
-            }
             _eventListeners = GetComponentsInParent<ILudoWeaponEvents>(true);
             _projectileListeners = GetComponentsInParent<ILudoProjectileBroadcastEvents>(true);
             Equip(startingWeapon);
@@ -593,7 +581,7 @@ namespace TonPlaygram.Gameplay.Weapons
 
                 playerCamera.fieldOfView = Mathf.Lerp(startFov, weapon.aimFov, t);
                 playerCamera.transform.localPosition = Vector3.Lerp(startPos, targetLocalPos, Mathf.Clamp01(Time.deltaTime * aimPositionLerp));
-                Quaternion toTarget = ResolveLimitedLookRotation(targetWorld - playerCamera.transform.position);
+                Quaternion toTarget = Quaternion.LookRotation((targetWorld - playerCamera.transform.position).normalized, Vector3.up);
                 playerCamera.transform.rotation = Quaternion.Slerp(playerCamera.transform.rotation, toTarget, Mathf.Clamp01(Time.deltaTime * cameraLookLerp));
                 yield return null;
             }
@@ -625,7 +613,7 @@ namespace TonPlaygram.Gameplay.Weapons
                 t += Time.deltaTime;
                 Vector3 targetPos = bulletTransform.position - (bulletTransform.forward * bulletFollowDistance) + (Vector3.up * bulletFollowHeight);
                 playerCamera.transform.position = Vector3.Lerp(playerCamera.transform.position, targetPos, Mathf.Clamp01(Time.deltaTime * cameraTrackLerp));
-                Quaternion toBullet = ResolveLimitedLookRotation(bulletTransform.position - playerCamera.transform.position, 0f);
+                Quaternion toBullet = Quaternion.LookRotation((bulletTransform.position - playerCamera.transform.position).normalized, Vector3.up);
                 playerCamera.transform.rotation = Quaternion.Slerp(playerCamera.transform.rotation, toBullet, Mathf.Clamp01(Time.deltaTime * cameraLookLerp));
                 yield return null;
             }
@@ -654,7 +642,7 @@ namespace TonPlaygram.Gameplay.Weapons
             {
                 t += Time.deltaTime;
                 Vector3 towardImpact = (impactPoint - playerCamera.transform.position).normalized;
-                Quaternion impactRot = ResolveLimitedLookRotation(towardImpact, 0f);
+                Quaternion impactRot = Quaternion.LookRotation(towardImpact, Vector3.up);
                 playerCamera.transform.rotation = Quaternion.Slerp(startRot, impactRot, Mathf.Clamp01(t / seconds));
                 yield return null;
             }
@@ -711,69 +699,9 @@ namespace TonPlaygram.Gameplay.Weapons
                 elapsed += Time.deltaTime;
                 Vector3 toTarget = (turnAnchor.position - playerCamera.transform.position).normalized;
                 Vector3 lerped = Vector3.Slerp(fromForward, toTarget, Mathf.Clamp01(elapsed / duration));
-                playerCamera.transform.rotation = ResolveLimitedLookRotation(lerped, 0f);
+                playerCamera.transform.rotation = Quaternion.LookRotation(lerped, Vector3.up);
                 yield return null;
             }
-        }
-
-        private Quaternion ResolveLimitedLookRotation(Vector3 worldDirection)
-        {
-            return ResolveLimitedLookRotation(worldDirection, aimPitchDownDegrees);
-        }
-
-        private Quaternion ResolveLimitedLookRotation(Vector3 worldDirection, float extraPitchDownDegrees)
-        {
-            if (worldDirection.sqrMagnitude <= 0.000001f)
-            {
-                return playerCamera != null ? playerCamera.transform.rotation : Quaternion.identity;
-            }
-
-            Vector3 direction = worldDirection.normalized;
-            Vector3 flatDirection = Vector3.ProjectOnPlane(direction, Vector3.up);
-            if (flatDirection.sqrMagnitude <= 0.000001f)
-            {
-                flatDirection = playerCamera != null ? Vector3.ProjectOnPlane(playerCamera.transform.forward, Vector3.up) : Vector3.forward;
-                if (flatDirection.sqrMagnitude <= 0.000001f)
-                {
-                    flatDirection = Vector3.forward;
-                }
-            }
-
-            flatDirection.Normalize();
-            float signedPitch = Mathf.Atan2(direction.y, flatDirection.magnitude) * Mathf.Rad2Deg - extraPitchDownDegrees;
-            signedPitch = Mathf.Clamp(signedPitch, -Mathf.Abs(maxLookDownDegrees), Mathf.Abs(maxLookUpDegrees));
-
-            Quaternion yaw = Quaternion.LookRotation(flatDirection, Vector3.up);
-            return yaw * Quaternion.AngleAxis(-signedPitch, Vector3.right);
-        }
-
-        private void ApplyWeaponMaterialCompatibility()
-        {
-            ApplyMaterialCompatibility(weaponRoot);
-
-            for (int i = 0; i < weaponProfiles.Count; i++)
-            {
-                WeaponBallisticsProfile profile = weaponProfiles[i];
-                Animator animator = profile != null && profile.gripPose != null ? profile.gripPose.animator : null;
-                if (animator != null)
-                {
-                    ApplyMaterialCompatibility(animator.transform);
-                }
-            }
-        }
-
-        private static void ApplyMaterialCompatibility(Transform root)
-        {
-            if (root == null)
-                return;
-
-            GltfMaterialCompatibilityAdapter adapter = root.GetComponent<GltfMaterialCompatibilityAdapter>();
-            if (adapter == null)
-            {
-                adapter = root.gameObject.AddComponent<GltfMaterialCompatibilityAdapter>();
-            }
-
-            adapter.ApplyCompatibilityPass();
         }
 
         private Vector3 ResolveLiveTargetPosition()

--- a/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
+++ b/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
@@ -87,18 +87,8 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Vector3 weaponGripPositionOffset;
         [SerializeField] private Vector3 weaponGripEulerOffset;
 
-        [Header("FPS screen presentation")]
-        [SerializeField] private Camera presentationCamera;
-        [SerializeField] private Transform fpsPresentationRoot;
-        [SerializeField] private bool keepWeaponVisibleInFpsView = true;
-        [SerializeField] private Vector3 cameraSpaceWeaponOffset = new Vector3(0.18f, -0.2f, 0.55f);
-        [SerializeField] private Vector3 cameraSpaceWeaponEuler = new Vector3(-4f, 2f, 0f);
-        [SerializeField] private Vector2 minWeaponViewport = new Vector2(0.12f, 0.06f);
-        [SerializeField] private Vector2 maxWeaponViewport = new Vector2(0.88f, 0.42f);
-
         private readonly List<Renderer> _hiddenOriginalHandRenderers = new List<Renderer>();
         private Quaternion _weaponGripRotationOffset;
-        private Quaternion _cameraSpaceWeaponRotationOffset;
         private Quaternion _originalGripToWeaponRotation = Quaternion.identity;
         private Vector3 _originalGripToWeaponPosition;
         private bool _hasOriginalGripToWeapon;
@@ -171,11 +161,6 @@ namespace TonPlaygram.Gameplay.Weapons
         private void CacheRuntimeOffsets()
         {
             _weaponGripRotationOffset = Quaternion.Euler(weaponGripEulerOffset);
-            _cameraSpaceWeaponRotationOffset = Quaternion.Euler(cameraSpaceWeaponEuler);
-            if (presentationCamera == null)
-            {
-                presentationCamera = Camera.main;
-            }
             if (weaponRoot != null && originalFpsRightGrip != null)
             {
                 _originalGripToWeaponRotation = Quaternion.Inverse(originalFpsRightGrip.rotation) * weaponRoot.rotation;
@@ -202,30 +187,11 @@ namespace TonPlaygram.Gameplay.Weapons
             {
                 weaponRoot.rotation = humanRightGrip.rotation * _originalGripToWeaponRotation * _weaponGripRotationOffset;
                 weaponRoot.position = humanRightGrip.position + (humanRightGrip.rotation * (_originalGripToWeaponPosition + weaponGripPositionOffset));
-                KeepWeaponVisibleInFpsView();
                 return;
             }
 
             weaponRoot.position = humanRightGrip.TransformPoint(weaponGripPositionOffset);
             weaponRoot.rotation = humanRightGrip.rotation * _weaponGripRotationOffset;
-            KeepWeaponVisibleInFpsView();
-        }
-
-        private void KeepWeaponVisibleInFpsView()
-        {
-            Transform presentationRoot = fpsPresentationRoot != null ? fpsPresentationRoot : weaponRoot;
-            if (!keepWeaponVisibleInFpsView || presentationCamera == null || presentationRoot == null)
-                return;
-
-            Vector3 viewportPoint = presentationCamera.WorldToViewportPoint(presentationRoot.position);
-            bool behindCamera = viewportPoint.z <= presentationCamera.nearClipPlane;
-            bool outsideSafeBottomFrame = viewportPoint.x < minWeaponViewport.x || viewportPoint.x > maxWeaponViewport.x || viewportPoint.y < minWeaponViewport.y || viewportPoint.y > maxWeaponViewport.y;
-            if (!behindCamera && !outsideSafeBottomFrame)
-                return;
-
-            Transform cameraTransform = presentationCamera.transform;
-            presentationRoot.position = cameraTransform.TransformPoint(cameraSpaceWeaponOffset);
-            presentationRoot.rotation = cameraTransform.rotation * _cameraSpaceWeaponRotationOffset;
         }
 
         private void AddExtraOriginalHandRenderers()


### PR DESCRIPTION
### Motivation
- Reduce complexity in camera aiming by removing custom pitch clamping and using a straightforward look rotation for dynamic camera behaviors. 
- Remove rarely-used import/conversion behaviors for weapon materials and the FPS presentation constraints to simplify initialization and retargeting code. 
- Adjust default aim offset to better match the updated look/pose behavior.

### Description
- Replaced custom `ResolveLimitedLookRotation` logic with direct `Quaternion.LookRotation(..., Vector3.up)` calls in aiming and bullet-follow camera routines, and removed the `ResolveLimitedLookRotation` method and its related pitch/limit fields (`aimPitchDownDegrees`, `maxLookUpDegrees`, `maxLookDownDegrees`).
- Removed GLTF/GLB material compatibility behavior by deleting the `preserveOriginalWeaponMaterials` field, the `ApplyWeaponMaterialCompatibility` method, and the `ApplyMaterialCompatibility` helper, and removed the call from `Awake` in `BattleRoyaleWeaponDirector`.
- Updated `firstPersonAimOffset` default from `new Vector3(0.08f, 0.08f, 0.28f)` to `new Vector3(0.08f, -0.04f, 0.18f)` in `BattleRoyaleWeaponDirector` to match the revised camera behavior.
- Removed FPS presentation related fields and logic from `FpsGunHumanHandRetargeter` including `presentationCamera`, `fpsPresentationRoot`, `keepWeaponVisibleInFpsView`, camera-space offsets, the `_cameraSpaceWeaponRotationOffset` private field, and the `KeepWeaponVisibleInFpsView` method, and removed associated calls from `CacheRuntimeOffsets` and `SnapWeaponToHumanGrip`.
- Removed an unused using directive (`Aiming.Gameplay.Rendering`) from `BattleRoyaleWeaponDirector`.

### Testing
- Performed an automated Unity Editor script compilation check which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bed7a7f148329a240743b04d40fcf)