### PR TITLE
Prefer Showood GLB cushions/jaws and align rail/frame visuals for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,7 +1,7 @@
-export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
 const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
@@ -26,6 +26,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket'],
     cushionUsesClothFinish: true,
     hideGeneratedCushionsAndJaws: true,
+    removeGeneratedCushionsAndJaws: true,
+    liftExternalJawsAboveChrome: true,
     preserveSourceTextureRoles: [],
     preserveOriginalSurfaceRoles: ['trim', 'wood'],
     hideSurfaceRoles: ['trim', 'wood'],
@@ -59,18 +61,18 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }
-]);
+])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === 'royal-original')?.id ||
-  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
-export function resolvePoolRoyaleTableModel(modelId) {
-  const key = typeof modelId === 'string' ? modelId.trim() : '';
+export function resolvePoolRoyaleTableModel (modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : ''
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  )
 }
 
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
@@ -80,7 +82,7 @@ export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'jaws',
   'topWoodRail',
   'legBase'
-]);
+])
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   cloth: 'a',
@@ -89,22 +91,22 @@ export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   jaws: 'a',
   topWoodRail: 'a',
   legBase: 'b'
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   cloth: { label: 'Field cloth', description: 'Only the flat playfield surface.' },
   cushion: {
     label: 'Cushions',
-    description: 'Matched green or Black rubber; source cushion texture is preserved like the reference preview.'
+    description: 'Green or blue cloth-texture cushion options matching the field cloth; cushion underside shadows stay grey.'
   },
   metalAccent: {
     label: 'Rail sights + side strip + feet',
     description: 'One gold/chrome control for rail sights, side apron strip, rims, trims, plates, and feet.'
   },
   jaws: { label: 'Jaws', description: 'Pocket jaws / cups: black or brown.' },
-  topWoodRail: { label: 'Top rail frame', description: 'Main top wood rail frame.' },
-  legBase: { label: 'Legs + base', description: 'Legs and lower base blocks together, separate from metal accents.' }
-});
+  topWoodRail: { label: 'Top rail frame', description: 'Uses the GLB good_wood texture for every top rail frame tint, not procedural wood.' },
+  legBase: { label: 'Legs + base', description: 'Uses the GLB good_wood / black-plastic texture set for legs and lower base, not procedural wood.' }
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   cloth: Object.freeze({
@@ -112,8 +114,8 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
     b: Object.freeze({ label: 'Blue field', color: '#0d4fb8', metalness: 0, roughness: 1, envMapIntensity: 0.16 })
   }),
   cushion: Object.freeze({
-    a: Object.freeze({ label: 'Matched green', color: '#064f22', metalness: 0, roughness: 0.88, envMapIntensity: 0.55 }),
-    b: Object.freeze({ label: 'Black rubber', color: '#050505', metalness: 0, roughness: 0.86, envMapIntensity: 0.55 })
+    a: Object.freeze({ label: 'Green cloth cushions', color: '#0a7b33', metalness: 0, roughness: 1, envMapIntensity: 0.16 }),
+    b: Object.freeze({ label: 'Blue cloth cushions', color: '#0d4fb8', metalness: 0, roughness: 1, envMapIntensity: 0.16 })
   }),
   metalAccent: Object.freeze({
     a: Object.freeze({ label: 'Gold', color: '#d8b23d', metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 }),
@@ -124,11 +126,11 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
     b: Object.freeze({ label: 'Brown jaws', color: '#2a1207', metalness: 0, roughness: 0.88, envMapIntensity: 0.26 })
   }),
   topWoodRail: Object.freeze({
-    a: Object.freeze({ label: 'Walnut frame', color: '#5a2608', metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 }),
-    b: Object.freeze({ label: 'Black frame', color: '#070605', metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 })
+    a: Object.freeze({ label: 'GLB walnut frame', color: '#5a2608', metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 }),
+    b: Object.freeze({ label: 'GLB black frame', color: '#070605', metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 })
   }),
   legBase: Object.freeze({
-    a: Object.freeze({ label: 'Brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }),
-    b: Object.freeze({ label: 'Black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 })
+    a: Object.freeze({ label: 'GLB brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }),
+    b: Object.freeze({ label: 'GLB black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 })
   })
-});
+})

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -848,12 +848,12 @@ const CHROME_CORNER_POCKET_CUT_SCALE = 1.045; // open only the corner chrome rou
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.03; // open middle-pocket chrome rounded cuts a tiny bit more so the arc reads slightly larger
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // reduce inward pull so middle pocket chrome cuts sit a bit farther out
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 1.045; // match the wooden rail pocket relief to the Showood jaw outside diameter
-const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.958; // shrink the wooden corner rounded cut a touch more so only the wood corner radius reads slightly tighter
+const WOOD_CORNER_RELIEF_INWARD_SCALE = 1; // keep wooden corner pocket cuts matched to the Showood/chrome rounded cuts
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
-  (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
-const WOOD_CORNER_POCKET_CUT_CENTER_OUTSET_SCALE = -0.018; // push only the wooden corner rounded cut outward a touch without moving side-pocket cuts
-const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1.045; // keep middle rail rounded cuts identical to the corner/showood-style pocket arcs
-const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = -0.068; // move middle wooden relief outward a bit more with the shifted side-pocket geometry
+  (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // cancel the global relief so corner wood arches use the same radius as Showood
+const WOOD_CORNER_POCKET_CUT_CENTER_OUTSET_SCALE = 0; // keep wooden corner cut centers exactly on the Showood/chrome pocket centers
+const WOOD_SIDE_RAIL_POCKET_RELIEF_SCALE = 1 / WOOD_RAIL_POCKET_RELIEF_SCALE; // cancel the global relief so middle wood cuts match the Showood side arcs
+const WOOD_SIDE_POCKET_CUT_CENTER_OUTSET_SCALE = 0; // keep middle wooden relief centered on the Showood side-pocket cut
 
 function buildChromePlateGeometry({
   width,
@@ -12160,7 +12160,8 @@ const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   underside: 'legBase',
   trim: 'metalAccent',
   wood: 'topWoodRail',
-  pocket: 'jaws'
+  pocket: 'jaws',
+  cushionShadow: 'cushion'
 });
 const POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS = new Set([
   'cushion',
@@ -12203,15 +12204,17 @@ function classifyPoolRoyaleShowoodReferencePart(child, material) {
   const gold = color.r > 0.42 && color.g > 0.29 && color.b < 0.25 && color.r >= color.g * 0.88;
   const metalish = (material?.metalness ?? 0) > 0.16 || (material?.clearcoat ?? 0) > 0.58 || gold;
 
+  if (/shadow/.test(label) && /cushion|rail/.test(label)) return 'cushionShadow';
   if (/cloth|felt|fabric|surface|bed|slate|playfield|baize/.test(label) && !/cushion|rubber|bumper/.test(childName)) return 'cloth';
   if (/cushion|rubber|bumper|railrubber|rail[_\s-]*nose/.test(childName)) return 'cushion';
   if (/sight|diamond|marker|dot|inlay/.test(label)) return 'railSight';
-  if (/pocket|hole|drop|net|liner|leather|cup|basket|holder/.test(label)) {
+  if (/pocket|hole|drop|net|liner|leather|cup|basket|holder|bevel/.test(label)) {
     return metalish && !black && !brown ? 'cornerPocketPlate' : 'pocketCup';
   }
   if (/trim|bezel|ring|metal|chrome|brass|gold|plate|cap|rim|guard|insert|hardware|bolt|screw/.test(label) || metalish) {
     return /foot|feet/.test(label) ? 'baseFoot' : 'lowerTrim';
   }
+  if (black && /plastic|material|bevel/.test(label)) return 'pocketCup';
   if (/leg/.test(label)) return 'leg';
   if (/base|block|support|underside/.test(label)) return 'baseCornerBlock';
   if (/rail|frame|top|wood|walnut|showood|apron|cabinet|corner/.test(label)) return 'topWoodRail';
@@ -12227,6 +12230,25 @@ function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = nu
   const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] || 'a';
   const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice] || POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.a;
   if (!option) return mat;
+  if (part === 'cushionShadow') {
+    mat.color?.set?.('#8a8f98');
+    if ('metalness' in mat) mat.metalness = 0;
+    if ('roughness' in mat) mat.roughness = 1;
+    if ('envMapIntensity' in mat) mat.envMapIntensity = 0.08;
+    mat.transparent = true;
+    mat.opacity = 0.58;
+    mat.depthWrite = false;
+    mat.side = THREE.DoubleSide;
+    mat.userData = {
+      ...(mat.userData || {}),
+      poolRoyaleShowoodReferencePart: part,
+      poolRoyaleShowoodReferenceControl: control,
+      poolRoyaleShowoodReferenceChoice: choice,
+      poolRoyaleCushionShadowGrey: true
+    };
+    mat.needsUpdate = true;
+    return mat;
+  }
   mat.color?.set?.(option.color);
   if ('metalness' in mat) mat.metalness = option.metalness;
   if ('roughness' in mat) mat.roughness = option.roughness;
@@ -12256,11 +12278,11 @@ function classifyPoolRoyaleExternalTableSurface(child, material) {
   // Showood uses a shared "cloth" material on the cushion meshes, so mesh names
   // must win over material names for physics mapping and finish assignment.
   if (/cushion|rubber|bumper|rail[_\s-]*nose/.test(childName)) return 'cushion';
-  if (/pocket|liner|leather|net|basket|drop|holder/.test(childName)) return 'pocket';
+  if (/pocket|liner|leather|net|basket|drop|holder|bevel/.test(childName)) return 'pocket';
   if (/diamond|gold|metal|chrome|sight|marker|plate|trim|screw|bolt/.test(childName)) return 'trim';
   if (/slate|cloth|felt|baize|bed|playfield|playing[_\s-]*surface/.test(childName)) return 'cloth';
   if (/cloth|felt|baize|slate|bed|playfield|playing[_\s-]*surface/.test(label)) return 'cloth';
-  if (/pocket|liner|leather|net|basket|drop/.test(label)) return 'pocket';
+  if (/pocket|liner|leather|net|basket|drop|bevel/.test(label)) return 'pocket';
   if (/metal|chrome|gold|diamond|sight|marker|plate|trim|screw|bolt/.test(label)) return 'trim';
   if (/leg|foot|base|support|frame|wood|rail|apron|cabinet|showood|bevel/.test(label)) return 'wood';
   return 'wood';
@@ -12637,6 +12659,31 @@ function resolvePoolRoyaleExternalTableFitBounds(model, tableModel = null) {
   return { fullBox, footprintBox };
 }
 
+
+function applyPoolRoyaleExternalTablePartAdjustments(model, tableModel = null) {
+  if (!model || !tableModel) return;
+  const jawLift = tableModel.liftExternalJawsAboveChrome ? TABLE.THICK * 0.07 : 0;
+  if (!Number.isFinite(jawLift) || Math.abs(jawLift) <= MICRO_EPS) return;
+  const inverseScaleY = 1 / Math.max(MICRO_EPS, Math.abs(model.scale?.y || 1));
+  model.traverse((child) => {
+    if (!child?.isMesh) return;
+    const material = Array.isArray(child.material) ? child.material[0] : child.material;
+    const referencePart = classifyPoolRoyaleShowoodReferencePart(child, material);
+    const role = classifyPoolRoyaleExternalTableSurface(child, material);
+    const shouldLiftJaw =
+      role === 'pocket' ||
+      referencePart === 'pocketCup' ||
+      /bevel|pocket|holder|liner|cup/i.test(`${child.name || ''} ${material?.name || ''}`);
+    if (!shouldLiftJaw) return;
+    child.position.y += jawLift * inverseScaleY;
+    child.userData = {
+      ...(child.userData || {}),
+      poolRoyaleExternalJawLift: jawLift
+    };
+  });
+  model.updateMatrixWorld(true);
+}
+
 function stretchPoolRoyaleExternalLowerBase(model, tableModel, dims) {
   const scale = Number(tableModel?.lowerBaseHeightScale);
   if (!model || !Number.isFinite(scale) || scale <= 1 + MICRO_EPS) return;
@@ -12733,6 +12780,7 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   model.position.y += targetTopLocal - fullBox.max.y + (tableModel?.verticalOffset ?? 0);
   model.updateMatrixWorld(true);
   stretchPoolRoyaleExternalLowerBase(model, tableModel, dims);
+  applyPoolRoyaleExternalTablePartAdjustments(model, tableModel);
   model.userData = {
     ...(model.userData || {}),
     poolRoyaleExternalTable: true,
@@ -13491,10 +13539,27 @@ function mountPoolRoyaleExternalTableModel({
       ...pocketMeshes
     ].forEach(markGeneratedCushionsAndJawsHiddenByExternalTable);
   }
+  const detachGeneratedObjectForExternalTable = (object) => {
+    if (!object?.parent || object.userData?.externalTableDetachedFromParent) return;
+    object.userData = {
+      ...(object.userData || {}),
+      externalTableDetachedFromParent: object.parent
+    };
+    table.userData.detachedGeneratedExternalSurfaces = table.userData.detachedGeneratedExternalSurfaces || [];
+    table.userData.detachedGeneratedExternalSurfaces.push(object);
+    object.parent.remove(object);
+  };
   const setGeneratedVisualsVisible = (visible) => {
     generatedVisualObjects.forEach((object) => {
       const forceGeneratedChrome = Boolean(externalTableModelForMount?.forceGeneratedChromePlates);
       if (!visible && externalTableModelForMount?.keepGeneratedShell) {
+        if (
+          externalTableModelForMount?.removeGeneratedCushionsAndJaws &&
+          object.userData?.externalTableHideWhenMounted
+        ) {
+          detachGeneratedObjectForExternalTable(object);
+          return;
+        }
         object.visible = object.userData?.externalTableHideWhenMounted
           ? false
           : !object.userData?.externalTableReplaceableSurface;


### PR DESCRIPTION
### Motivation
- Ensure the runtime uses the supplied Showood GLB cushions and pocket jaws (not the procedural/generated cushions), match the wooden rail pocket cuts to the Showood chrome cuts, and expose Showood-specific setup options so finishes and cushion choices visually match the reference GLB.

### Description
- Added table-model flags (`removeGeneratedCushionsAndJaws`, `liftExternalJawsAboveChrome`) and updated Showood control metadata so cushions use cloth-style green/blue options and rail/leg labels reference GLB textures (`webapp/src/config/poolRoyaleTableModels.js`).
- Reclassified several GLB parts (bevels/holders) and introduced a `cushionShadow` role so cushion underside/shadows render as grey while visible GLB cushion surfaces keep their texture maps (`webapp/src/pages/Games/PoolRoyale.jsx`).
- When mounting a GLB external table, remove or detach the generated cushions/jaws (when configured), lift external GLB jaw/pocket meshes above chrome plates, and add a helper to apply per-model jaw lifting for proper visual stacking.
- Adjusted wooden rail pocket relief math so wooden frame cutouts align with Showood/chrome rounded pocket arcs instead of using slightly different procedural relief values.

### Testing
- Ran `npm run lint -- src/pages/Games/PoolRoyale.jsx src/config/poolRoyaleTableModels.js` and the lint run completed after fixes (no remaining reported errors).
- Built the webapp with `npm run build` and the Vite production build completed successfully.
- Attempted an automated Playwright screenshot of the Pool Royale page to visually validate the GLB mount, but the headless Chromium failed in this environment due to missing system library `libatk-1.0.so.0`, so no screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c24f81b6c8329b72463523f5981bd)