### PR TITLE
Showood table: expose full cloth & GLTF finish texture choices and preserve procedural rails/cushions

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,14 +1,17 @@
-export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js'
+import { polyHavenThumb } from './storeThumbnails.js'
+
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
 const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
     id: 'royal-original',
     label: 'Royal Original',
     description:
-      'Current TonPlaygram rails, base, and chrome with Showood GLB playfield, GLB cushions, pockets, and jaw layout overlaid.',
+      'Current TonPlaygram rails, procedural cushions, base, chrome plates, and pocket jaws with the Showood GLB playfield overlaid.',
     tableSizeId: '9ft',
     finishId: 'peelingPaintWeathered',
     baseId: 'classicCylinders',
@@ -23,12 +26,13 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: false,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket'],
+    usePoolRoyaleFinishRoles: ['cloth', 'pocket'],
     cushionUsesClothFinish: true,
-    hideGeneratedCushionsAndJaws: true,
+    hideGeneratedCushionsAndJaws: false,
+    keepGeneratedSurfaceRoles: ['cushion', 'pocketJaw', 'pocketRim'],
     preserveSourceTextureRoles: [],
     preserveOriginalSurfaceRoles: ['trim', 'wood'],
-    hideSurfaceRoles: ['trim', 'wood'],
+    hideSurfaceRoles: ['trim', 'wood', 'cushion'],
     keepGeneratedShell: true,
     forceGeneratedChromePlates: true
   },
@@ -59,76 +63,79 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: []
   }
-]);
+])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === 'royal-original')?.id ||
-  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
-export function resolvePoolRoyaleTableModel(modelId) {
-  const key = typeof modelId === 'string' ? modelId.trim() : '';
+export function resolvePoolRoyaleTableModel (modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : ''
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  )
 }
 
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cloth',
   'cushion',
-  'metalAccent',
-  'jaws',
   'topWoodRail',
   'legBase'
-]);
+])
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
-  cloth: 'a',
-  cushion: 'a',
-  metalAccent: 'a',
-  jaws: 'a',
-  topWoodRail: 'a',
-  legBase: 'b'
-});
+  cloth: 'cabanGreenClassic',
+  cushion: 'cabanGreenClassic',
+  topWoodRail: 'peelingPaintWeathered',
+  legBase: 'darkWood'
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
-  cloth: { label: 'Field cloth', description: 'Only the flat playfield surface.' },
+  cloth: { label: 'Field cloth', description: 'Uses every cloth-library texture on the flat playfield.' },
   cushion: {
     label: 'Cushions',
-    description: 'Matched green or Black rubber; source cushion texture is preserved like the reference preview.'
+    description: 'Uses every cloth-library texture on the cushion rubber.'
   },
-  metalAccent: {
-    label: 'Rail sights + side strip + feet',
-    description: 'One gold/chrome control for rail sights, side apron strip, rims, trims, plates, and feet.'
-  },
-  jaws: { label: 'Jaws', description: 'Pocket jaws / cups: black or brown.' },
-  topWoodRail: { label: 'Top rail frame', description: 'Main top wood rail frame.' },
-  legBase: { label: 'Legs + base', description: 'Legs and lower base blocks together, separate from metal accents.' }
-});
+  topWoodRail: { label: 'Top rail frame', description: 'Uses every GLTF table-finish texture on the main top wood rail frame.' },
+  legBase: { label: 'Legs + base', description: 'Uses every GLTF table-finish texture on the legs and lower base blocks only.' }
+})
+
+export const POOL_ROYALE_SHOWOOD_TABLE_FINISH_TEXTURE_OPTIONS = Object.freeze([
+  { id: 'peelingPaintWeathered', label: 'Wood Peeling Paint Weathered', color: '#b8b3aa', thumbnail: polyHavenThumb('wood_peeling_paint_weathered') },
+  { id: 'oakVeneer01', label: 'Oak Veneer 01', color: '#c89a64', thumbnail: polyHavenThumb('oak_veneer_01') },
+  { id: 'woodTable001', label: 'Wood Table 001', color: '#a4724f', thumbnail: polyHavenThumb('wood_table_001') },
+  { id: 'darkWood', label: 'Dark Wood', color: '#3d2f2a', thumbnail: polyHavenThumb('dark_wood') },
+  { id: 'rosewoodVeneer01', label: 'Rosewood Veneer 01', color: '#6f3a2f', thumbnail: polyHavenThumb('rosewood_veneer_01') },
+  { id: 'carbonFiberChalk', label: 'LT Black', color: '#2a313d', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberChalkGrey', label: 'LT Grey', color: '#c8d0da', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberChalkBeige', label: 'LT Dark Grey', color: '#727d8b', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberChalkDarkBlue', label: 'LT Burgundy', color: '#c17276', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberChalkWhite', label: 'LT Milk Cream', color: '#f8eedf', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberChalkDarkGreen', label: 'LT Dark Green', color: '#548460', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberChalkDarkYellow', label: 'LT Dark Yellow', color: '#d1a652', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberChalkDarkBrown', label: 'LT Dark Brown', color: '#956b4f', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberChalkDarkRed', label: 'LT Dark Red', color: '#aa5151', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberAlligatorOlive', label: 'LT Olive Fabric', color: '#556b3f', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberAlligatorSwamp', label: 'LT Swamp Fabric', color: '#3f5a3c', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberAlligatorClay', label: 'LT Clay Fabric', color: '#a06e55', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberAlligatorSand', label: 'LT Sand Fabric', color: '#c3ad83', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberAlligatorMoss', label: 'LT Moss Fabric', color: '#4d644b', thumbnail: polyHavenThumb('fabric_083') },
+  { id: 'carbonFiberAlligatorNight', label: 'LT Night Fabric', color: '#1b222b', thumbnail: polyHavenThumb('fabric_083') }
+])
+
+export const POOL_ROYALE_SHOWOOD_CLOTH_TEXTURE_OPTIONS = Object.freeze(
+  POOL_ROYALE_CLOTH_VARIANTS.map((variant) => ({
+    id: variant.id,
+    label: variant.name,
+    color: variant.swatches?.[0] ?? `#${variant.baseColor.toString(16).padStart(6, '0')}`,
+    thumbnail: variant.thumbnail
+  }))
+)
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
-  cloth: Object.freeze({
-    a: Object.freeze({ label: 'Green field', color: '#0a7b33', metalness: 0, roughness: 1, envMapIntensity: 0.16 }),
-    b: Object.freeze({ label: 'Blue field', color: '#0d4fb8', metalness: 0, roughness: 1, envMapIntensity: 0.16 })
-  }),
-  cushion: Object.freeze({
-    a: Object.freeze({ label: 'Matched green', color: '#064f22', metalness: 0, roughness: 0.88, envMapIntensity: 0.55 }),
-    b: Object.freeze({ label: 'Black rubber', color: '#050505', metalness: 0, roughness: 0.86, envMapIntensity: 0.55 })
-  }),
-  metalAccent: Object.freeze({
-    a: Object.freeze({ label: 'Gold', color: '#d8b23d', metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 }),
-    b: Object.freeze({ label: 'Chrome', color: '#d7dde7', metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 })
-  }),
-  jaws: Object.freeze({
-    a: Object.freeze({ label: 'Black jaws', color: '#020202', metalness: 0, roughness: 0.96, envMapIntensity: 0.14 }),
-    b: Object.freeze({ label: 'Brown jaws', color: '#2a1207', metalness: 0, roughness: 0.88, envMapIntensity: 0.26 })
-  }),
-  topWoodRail: Object.freeze({
-    a: Object.freeze({ label: 'Walnut frame', color: '#5a2608', metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 }),
-    b: Object.freeze({ label: 'Black frame', color: '#070605', metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 })
-  }),
-  legBase: Object.freeze({
-    a: Object.freeze({ label: 'Brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }),
-    b: Object.freeze({ label: 'Black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 })
-  })
-});
+  cloth: POOL_ROYALE_SHOWOOD_CLOTH_TEXTURE_OPTIONS,
+  cushion: POOL_ROYALE_SHOWOOD_CLOTH_TEXTURE_OPTIONS,
+  topWoodRail: POOL_ROYALE_SHOWOOD_TABLE_FINISH_TEXTURE_OPTIONS,
+  legBase: POOL_ROYALE_SHOWOOD_TABLE_FINISH_TEXTURE_OPTIONS
+})

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -37,7 +37,6 @@ import {
   POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   POOL_ROYALE_SHOWOOD_CONTROL_META,
-  POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS,
   POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
   POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS,
   resolvePoolRoyaleTableModel
@@ -12162,13 +12161,19 @@ const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   wood: 'topWoodRail',
   pocket: 'jaws'
 });
-const POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS = new Set([
-  'cushion',
-  'topWoodRail',
-  'leg',
-  'baseCornerBlock',
-  'underside'
+const POOL_ROYALE_SHOWOOD_PRESERVE_SOURCE_PARTS = new Set([
+  'railSight',
+  'sideWoodApron',
+  'baseFoot',
+  'cornerPocketPlate',
+  'middlePocketPlate',
+  'verticalCornerRim',
+  'lowerTrim',
+  'trim',
+  'pocketCup'
 ]);
+const POOL_ROYALE_SHOWOOD_CLOTH_CONTROLS = new Set(['cloth', 'cushion']);
+const POOL_ROYALE_SHOWOOD_FINISH_CONTROLS = new Set(['topWoodRail', 'legBase']);
 
 function resolvePoolRoyaleShowoodPalette(tableModel = null) {
   return {
@@ -12177,19 +12182,6 @@ function resolvePoolRoyaleShowoodPalette(tableModel = null) {
       ? tableModel.showoodPalette
       : {})
   };
-}
-
-function clearPoolRoyaleMaterialTextureMaps(material) {
-  if (!material) return;
-  material.map = null;
-  material.normalMap = null;
-  material.bumpMap = null;
-  material.roughnessMap = null;
-  material.metalnessMap = null;
-  material.aoMap = null;
-  material.emissiveMap = null;
-  material.lightMap = null;
-  material.alphaMap = null;
 }
 
 function classifyPoolRoyaleShowoodReferencePart(child, material) {
@@ -12213,40 +12205,160 @@ function classifyPoolRoyaleShowoodReferencePart(child, material) {
     return /foot|feet/.test(label) ? 'baseFoot' : 'lowerTrim';
   }
   if (/leg/.test(label)) return 'leg';
+  if (/foot|feet/.test(label)) return 'baseFoot';
+  if (/side[_\s-]*apron|apron[_\s-]*side|side[_\s-]*(strip|panel)/.test(label)) return 'sideWoodApron';
   if (/base|block|support|underside/.test(label)) return 'baseCornerBlock';
   if (/rail|frame|top|wood|walnut|showood|apron|cabinet|corner/.test(label)) return 'topWoodRail';
   if (green) return 'cloth';
   return 'sideWoodApron';
 }
 
-function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null) {
+
+function preservePoolRoyaleShowoodSourceMaterial(material, part, control = null) {
   if (!material) return material;
   const mat = material.clone ? material.clone() : material;
-  const control = POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[part] || POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[classifyPoolRoyaleExternalTableSurface(null, mat)] || 'topWoodRail';
-  const palette = resolvePoolRoyaleShowoodPalette(tableModel);
-  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] || 'a';
-  const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice] || POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.a;
-  if (!option) return mat;
-  mat.color?.set?.(option.color);
-  if ('metalness' in mat) mat.metalness = option.metalness;
-  if ('roughness' in mat) mat.roughness = option.roughness;
-  if ('envMapIntensity' in mat) mat.envMapIntensity = option.envMapIntensity;
-  if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? 0;
-  if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? 0;
-  if (!POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS.has(part)) {
-    clearPoolRoyaleMaterialTextureMaps(mat);
-  }
-  mat.transparent = false;
-  mat.opacity = 1;
-  mat.depthWrite = true;
-  mat.side = THREE.DoubleSide;
+  preparePoolRoyaleExternalTexture(mat.map, true);
+  preparePoolRoyaleExternalTexture(mat.emissiveMap, true);
+  preparePoolRoyaleExternalTexture(mat.aoMap, false);
+  preparePoolRoyaleExternalTexture(mat.normalMap, false);
+  preparePoolRoyaleExternalTexture(mat.roughnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.metalnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.bumpMap, false);
   mat.userData = {
     ...(mat.userData || {}),
     poolRoyaleShowoodReferencePart: part,
     poolRoyaleShowoodReferenceControl: control,
-    poolRoyaleShowoodReferenceChoice: choice
+    poolRoyaleShowoodPreserveSourceMaterial: true
   };
+  mat.needsUpdate = true;
   return mat;
+}
+
+function applyPoolRoyaleShowoodClothMaterial(material, part, choice) {
+  const mat = material.clone ? material.clone() : material;
+  const preset = CLOTH_TEXTURE_PRESETS[choice] ?? CLOTH_TEXTURE_PRESETS[DEFAULT_CLOTH_TEXTURE_KEY];
+  const clothOption = CLOTH_COLOR_OPTIONS.find((option) => option.id === preset?.id) ?? CLOTH_COLOR_OPTIONS[0];
+  const palette = preset?.palette ?? CLOTH_TEXTURE_PRESETS[DEFAULT_CLOTH_TEXTURE_KEY]?.palette;
+  const textures = createClothTextures(preset?.id ?? DEFAULT_CLOTH_TEXTURE_KEY, DEFAULT_CLOTH_TEXTURE_SOURCE_ID);
+  const baseColor = new THREE.Color(clothOption?.color ?? palette?.base ?? 0x2d7f4b);
+  mat.color?.copy?.(baseColor);
+  if (mat.emissive?.isColor) mat.emissive.copy(baseColor.clone().multiplyScalar(0.045));
+  if ('metalness' in mat) mat.metalness = 0;
+  if ('roughness' in mat) mat.roughness = textures.roughness ? CLOTH_ROUGHNESS_TARGET : CLOTH_ROUGHNESS_BASE;
+  if ('sheen' in mat) mat.sheen = clothOption?.detail?.sheen ?? BASE_CLOTH_DETAIL.sheen;
+  if ('sheenRoughness' in mat) mat.sheenRoughness = clothOption?.detail?.sheenRoughness ?? BASE_CLOTH_DETAIL.sheenRoughness;
+  if ('envMapIntensity' in mat) mat.envMapIntensity = clothOption?.detail?.envMapIntensity ?? BASE_CLOTH_DETAIL.envMapIntensity;
+  if ('clearcoat' in mat) mat.clearcoat = 0;
+  if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = 1;
+  mat.map = clonePoolRoyaleMaterialTexture(textures.map, { isColor: true });
+  mat.normalMap = clonePoolRoyaleMaterialTexture(textures.normal);
+  mat.roughnessMap = clonePoolRoyaleMaterialTexture(textures.roughness);
+  mat.bumpMap = textures.normal ? null : clonePoolRoyaleMaterialTexture(textures.bump);
+  if (mat.normalMap) mat.normalScale = POLYHAVEN_NORMAL_SCALE.clone();
+  if (Number.isFinite(clothOption?.detail?.bumpMultiplier)) {
+    mat.bumpScale = (mat.bumpScale || 0.05) * clothOption.detail.bumpMultiplier;
+  }
+  mat.side = THREE.DoubleSide;
+  mat.transparent = false;
+  mat.opacity = 1;
+  mat.depthWrite = true;
+  mat.userData = {
+    ...(mat.userData || {}),
+    poolRoyaleShowoodLibraryTexture: preset?.id,
+    poolRoyaleShowoodReferencePart: part,
+    poolRoyaleShowoodReferenceControl: POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[part] || part,
+    poolRoyaleShowoodReferenceChoice: preset?.id
+  };
+  preparePoolRoyaleExternalTexture(mat.map, true);
+  preparePoolRoyaleExternalTexture(mat.normalMap, false);
+  preparePoolRoyaleExternalTexture(mat.roughnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.bumpMap, false);
+  mat.needsUpdate = true;
+  return mat;
+}
+
+function copyPoolRoyaleMaterialSurface(source, target) {
+  if (!source || !target) return;
+  if (source.color && target.color) target.color.copy(source.color);
+  [
+    'roughness',
+    'metalness',
+    'clearcoat',
+    'clearcoatRoughness',
+    'sheen',
+    'sheenRoughness',
+    'reflectivity',
+    'envMapIntensity',
+    'bumpScale'
+  ].forEach((key) => {
+    if (typeof source[key] === 'number' && key in target) target[key] = source[key];
+  });
+  target.map = clonePoolRoyaleMaterialTexture(source.map, { isColor: true });
+  target.normalMap = clonePoolRoyaleMaterialTexture(source.normalMap);
+  target.roughnessMap = clonePoolRoyaleMaterialTexture(source.roughnessMap);
+  target.aoMap = clonePoolRoyaleMaterialTexture(source.aoMap);
+  target.metalnessMap = clonePoolRoyaleMaterialTexture(source.metalnessMap);
+  target.bumpMap = clonePoolRoyaleMaterialTexture(source.bumpMap);
+}
+
+function applyPoolRoyaleShowoodTableFinishMaterial(material, part, choice) {
+  const finish = TABLE_FINISHES[choice] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
+  const mat = material.clone ? material.clone() : material;
+  const materials = typeof finish?.createMaterials === 'function'
+    ? finish.createMaterials()
+    : TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID].createMaterials();
+  const control = POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[part] || part;
+  const source = control === 'topWoodRail'
+    ? (materials.rail ?? materials.frame)
+    : (materials.leg ?? materials.frame ?? materials.rail);
+  copyPoolRoyaleMaterialSurface(source, mat);
+  if (mat.color) {
+    mat.userData = mat.userData || {};
+    mat.userData.baseTintHex = mat.color.getHex();
+  }
+  applyWoodTextureToMaterial(mat, { woodRepeatScale: finish?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE });
+  applyTableFinishDulling(mat);
+  applyTableWoodVisibilityTuning(mat);
+  if (finish?.surfaceStyle === 'matte') {
+    if (finish?.preserveFinishTintOnWood) applyMatteSurfacePropsOnly(mat);
+    else applyMonoMattePlasticSurface(mat);
+  }
+  applyFinishWoodTint(mat, finish);
+  mat.side = THREE.DoubleSide;
+  mat.transparent = false;
+  mat.opacity = 1;
+  mat.depthWrite = true;
+  mat.userData = {
+    ...(mat.userData || {}),
+    poolRoyaleShowoodTableFinishTexture: finish?.id,
+    poolRoyaleShowoodReferencePart: part,
+    poolRoyaleShowoodReferenceControl: control,
+    poolRoyaleShowoodReferenceChoice: finish?.id
+  };
+  preparePoolRoyaleExternalTexture(mat.map, true);
+  preparePoolRoyaleExternalTexture(mat.normalMap, false);
+  preparePoolRoyaleExternalTexture(mat.roughnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.metalnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.bumpMap, false);
+  mat.needsUpdate = true;
+  return mat;
+}
+
+function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null) {
+  if (!material) return material;
+  const control = POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[part] || POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[classifyPoolRoyaleExternalTableSurface(null, material)] || 'topWoodRail';
+  if (POOL_ROYALE_SHOWOOD_PRESERVE_SOURCE_PARTS.has(part) || !POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS.includes(control)) {
+    return preservePoolRoyaleShowoodSourceMaterial(material, part, control);
+  }
+  const palette = resolvePoolRoyaleShowoodPalette(tableModel);
+  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control];
+  if (POOL_ROYALE_SHOWOOD_CLOTH_CONTROLS.has(control)) {
+    return applyPoolRoyaleShowoodClothMaterial(material, part, choice);
+  }
+  if (POOL_ROYALE_SHOWOOD_FINISH_CONTROLS.has(control)) {
+    return applyPoolRoyaleShowoodTableFinishMaterial(material, part, choice);
+  }
+  return preservePoolRoyaleShowoodSourceMaterial(material, part, control);
 }
 
 function classifyPoolRoyaleExternalTableSurface(child, material) {
@@ -13462,20 +13574,20 @@ function mountPoolRoyaleExternalTableModel({
   const generatedUpperComponentSize = generatedUpperComponentBounds.isEmpty()
     ? new THREE.Vector3(TABLE.W, TABLE.THICK, TABLE.H)
     : generatedUpperComponentBounds.getSize(new THREE.Vector3());
-  const markReplaceableGeneratedSurface = (object) => {
+  const markReplaceableGeneratedSurface = (object, role = null) => {
     if (!object) return;
     object.userData = {
       ...(object.userData || {}),
-      externalTableReplaceableSurface: true
+      externalTableReplaceableSurface: true,
+      ...(role ? { externalTableGeneratedSurfaceRole: role } : {})
     };
   };
-  [
-    cloth,
-    ...(Array.isArray(table.userData.cushions) ? table.userData.cushions : []),
-    ...finishParts.pocketJawMeshes,
-    ...finishParts.pocketRimMeshes,
-    ...pocketMeshes
-  ].forEach(markReplaceableGeneratedSurface);
+  markReplaceableGeneratedSurface(cloth, 'cloth');
+  (Array.isArray(table.userData.cushions) ? table.userData.cushions : [])
+    .forEach((object) => markReplaceableGeneratedSurface(object, 'cushion'));
+  finishParts.pocketJawMeshes.forEach((object) => markReplaceableGeneratedSurface(object, 'pocketJaw'));
+  finishParts.pocketRimMeshes.forEach((object) => markReplaceableGeneratedSurface(object, 'pocketRim'));
+  pocketMeshes.forEach((object) => markReplaceableGeneratedSurface(object, 'pocket'));
   const markGeneratedCushionsAndJawsHiddenByExternalTable = (object) => {
     if (!object) return;
     object.userData = {
@@ -13495,9 +13607,14 @@ function mountPoolRoyaleExternalTableModel({
     generatedVisualObjects.forEach((object) => {
       const forceGeneratedChrome = Boolean(externalTableModelForMount?.forceGeneratedChromePlates);
       if (!visible && externalTableModelForMount?.keepGeneratedShell) {
+        const keepGeneratedRoles = Array.isArray(externalTableModelForMount?.keepGeneratedSurfaceRoles)
+          ? externalTableModelForMount.keepGeneratedSurfaceRoles
+          : [];
+        const generatedRole = object.userData?.externalTableGeneratedSurfaceRole;
+        const keepGeneratedSurface = generatedRole && keepGeneratedRoles.includes(generatedRole);
         object.visible = object.userData?.externalTableHideWhenMounted
           ? false
-          : !object.userData?.externalTableReplaceableSurface;
+          : keepGeneratedSurface || !object.userData?.externalTableReplaceableSurface;
         if (object.userData?.isChromePlate && forceGeneratedChrome) object.visible = true;
         return;
       }
@@ -35855,7 +35972,8 @@ const shotPowerRef = useRef(0);
                   <div className="space-y-3">
                     {POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS.map((control) => {
                       const meta = POOL_ROYALE_SHOWOOD_CONTROL_META[control];
-                      const options = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control];
+                      const isClothControl = control === 'cloth' || control === 'cushion';
+                      const options = isClothControl ? CLOTH_COLOR_OPTIONS : TABLE_FINISH_OPTIONS;
                       return (
                         <div key={control} className="rounded-xl border border-white/10 bg-white/5 p-2">
                           <div className="mb-2">
@@ -35866,28 +35984,42 @@ const shotPowerRef = useRef(0);
                               {meta.description}
                             </p>
                           </div>
-                          <div className="flex flex-wrap gap-2">
-                            {Object.keys(options).map((choice) => {
-                              const option = options[choice];
+                          <div className="flex max-h-36 flex-wrap gap-2 overflow-y-auto pr-1">
+                            {options.map((option) => {
+                              const choice = option.id;
                               const active = showoodPalette[control] === choice;
+                              const swatchColor = isClothControl
+                                ? toHexColor(option.color)
+                                : toHexColor(option.colors?.rail ?? option.colors?.base ?? 0xffffff);
+                              const thumb = option.thumbnail;
                               return (
                                 <button
                                   key={`${control}-${choice}`}
                                   type="button"
                                   onClick={() => handleShowoodPaletteSelection(control, choice)}
                                   aria-pressed={active}
-                                  className={`flex flex-1 items-center justify-center gap-2 rounded-full border px-3 py-1.5 text-[10px] font-extrabold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                                  className={`flex min-w-[8.5rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[10px] font-extrabold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
                                     active
                                       ? 'border-white/80 bg-white/20 text-white shadow-[0_0_14px_rgba(255,255,255,0.22)]'
                                       : 'border-white/15 bg-white/5 text-white/70 hover:bg-white/10'
                                   }`}
                                 >
-                                  <span
-                                    className="h-3.5 w-3.5 rounded-full border border-white/40"
-                                    style={{ backgroundColor: option.color }}
-                                    aria-hidden="true"
-                                  />
-                                  <span>{option.label}</span>
+                                  <span className="flex min-w-0 items-center gap-2">
+                                    <span
+                                      className="h-3.5 w-3.5 shrink-0 rounded-full border border-white/40"
+                                      style={{ backgroundColor: swatchColor }}
+                                      aria-hidden="true"
+                                    />
+                                    <span className="truncate">{option.label}</span>
+                                  </span>
+                                  {thumb ? (
+                                    <img
+                                      src={thumb}
+                                      alt={option.label}
+                                      className="h-6 w-10 shrink-0 rounded-lg border border-white/20 object-cover"
+                                      loading="lazy"
+                                    />
+                                  ) : null}
                                 </button>
                               );
                             })}

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -699,14 +699,14 @@ export default function PoolRoyaleLobby() {
             })}
           </div>
           <p className="text-xs text-white/60">
-            Royal Original now keeps TonPlaygram shell/chrome but uses GLB cushions and pocket jaws; Showood uses the reference texture mapping and option set.
+            Royal Original keeps the procedural cushions, wooden rail frame, chrome plates, and pocket jaws; Showood exposes cloth-library and GLTF table-finish texture choices.
           </p>
           {selectedTableModel.useReferenceShowoodMapping ? (
             <div className="rounded-2xl border border-amber-300/20 bg-black/25 p-3">
               <div className="mb-2 flex items-center justify-between gap-2">
                 <div>
                   <h4 className="text-sm font-semibold text-white">Showood table setup</h4>
-                  <p className="text-[11px] text-white/55">Same material options as the supplied reference preview.</p>
+                  <p className="text-[11px] text-white/55">Cloth and cushions use the cloth library; rail frame and legs/base use GLTF table-finish textures.</p>
                 </div>
                 <button
                   type="button"
@@ -726,27 +726,37 @@ export default function PoolRoyaleLobby() {
                         <p className="text-[11px] font-black uppercase tracking-[0.22em] text-emerald-100">{meta.label}</p>
                         <p className="text-[10px] leading-snug text-white/50">{meta.description}</p>
                       </div>
-                      <div className="flex flex-wrap gap-2">
-                        {['a', 'b'].map((choice) => {
-                          const option = options[choice];
+                      <div className="flex max-h-36 flex-wrap gap-2 overflow-y-auto pr-1">
+                        {options.map((option) => {
+                          const choice = option.id;
                           const active = showoodPalette[control] === choice;
                           return (
                             <button
                               key={`${control}-${choice}`}
                               type="button"
                               onClick={() => setShowoodPalette((current) => ({ ...current, [control]: choice }))}
-                              className={`flex flex-1 items-center justify-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-extrabold transition ${
+                              className={`flex min-w-[8.5rem] flex-1 items-center justify-between gap-2 rounded-full border px-3 py-1.5 text-[11px] font-extrabold transition ${
                                 active
                                   ? 'border-white/80 bg-white/20 text-white shadow-[0_0_14px_rgba(255,255,255,0.22)]'
                                   : 'border-white/15 bg-white/5 text-white/70'
                               }`}
                             >
-                              <span
-                                className="h-3.5 w-3.5 rounded-full border border-white/40"
-                                style={{ backgroundColor: option.color }}
-                                aria-hidden="true"
-                              />
-                              <span>{option.label}</span>
+                              <span className="flex min-w-0 items-center gap-2">
+                                <span
+                                  className="h-3.5 w-3.5 shrink-0 rounded-full border border-white/40"
+                                  style={{ backgroundColor: option.color }}
+                                  aria-hidden="true"
+                                />
+                                <span className="truncate">{option.label}</span>
+                              </span>
+                              {option.thumbnail ? (
+                                <img
+                                  src={option.thumbnail}
+                                  alt={option.label}
+                                  className="h-6 w-10 shrink-0 rounded-lg border border-white/20 object-cover"
+                                  loading="lazy"
+                                />
+                              ) : null}
                             </button>
                           );
                         })}


### PR DESCRIPTION
### Motivation
- Provide full control over Showood 7 ft GLB materials so the playfield and cushions can use the complete cloth-library textures while top rail frame and legs/base can use all GLTF table-finish textures, and ensure small hardware (rail sight / side apron / feet / trims / pocket cups) keep their original GLB appearance.
- Keep the procedural table behavior for the Royal Original option (procedural cushions and wooden frame) and avoid breaking chrome plates and pocket jaws already used by the game.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to change the Royal Original model options (preserve procedural cushions/pocket jaws, adjust finish role lists, and allow keeping generated surface roles) and to add full Showood catalogs: `POOL_ROYALE_SHOWOOD_TABLE_FINISH_TEXTURE_OPTIONS` and `POOL_ROYALE_SHOWOOD_CLOTH_TEXTURE_OPTIONS`, then wired those into `POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS` so controls now map to full texture sets instead of simple A/B palettes.
- Reworked the Showood material application in `webapp/src/pages/Games/PoolRoyale.jsx` by adding helper functions to preserve source materials where required, apply cloth-library textures to `cloth` and `cushion` parts, and apply GLTF table-finish textures to `topWoodRail` and `legBase` parts while explicitly preserving parts like `railSight`, `sideWoodApron`, `baseFoot`, trims, and pocket cups.
- Added generated-surface role tagging and mounting visibility logic so external GLB mounting can hide or keep generated/procedural cushions, pocket jaws, and rims according to the selected model configuration and `keepGeneratedSurfaceRoles` set.
- Updated the in-match Showood setup UI and the lobby Showood picker to render scrollable full-choice lists with swatches and thumbnails (cloth-library entries for field/cushions and table-finish thumbnails for rail/legs), and updated explanatory copy to match the new behavior.

### Testing
- Ran linter: `npm run lint -- src/pages/Games/PoolRoyale.jsx src/pages/Games/PoolRoyaleLobby.jsx src/config/poolRoyaleTableModels.js` and it completed with no remaining errors after automated fixes. (Succeeded)
- Built production bundle: `npm run build` from the `webapp` package and the build completed successfully. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3a6a09b48329b1c8821bea9c4485)