### PR TITLE
Tune Pool Royale Showood table materials

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,3 +1,6 @@
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import { WOOD_GRAIN_OPTIONS } from '../utils/woodMaterials.js';
+
 export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
 
 const POOLTOOL_RAW_BASE =
@@ -8,7 +11,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'royal-original',
     label: 'Royal Original',
     description:
-      'Current TonPlaygram rails, base, and chrome with Showood GLB playfield, GLB cushions, pockets, and jaw layout overlaid.',
+      'Current TonPlaygram procedural cushions, wooden rail frame, base, chrome plates, and pocket jaws with the Showood GLB playfield aligned underneath.',
     tableSizeId: '9ft',
     finishId: 'peelingPaintWeathered',
     baseId: 'classicCylinders',
@@ -23,9 +26,9 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: false,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket'],
-    cushionUsesClothFinish: true,
-    hideGeneratedCushionsAndJaws: true,
+    usePoolRoyaleFinishRoles: ['cloth'],
+    cushionUsesClothFinish: false,
+    hideGeneratedCushionsAndJaws: false,
     preserveSourceTextureRoles: [],
     preserveOriginalSurfaceRoles: ['trim', 'wood'],
     hideSurfaceRoles: ['trim', 'wood'],
@@ -73,62 +76,99 @@ export function resolvePoolRoyaleTableModel(modelId) {
   );
 }
 
+const SHOWOOD_WOOD_SWATCHES = Object.freeze({
+  acg_walnut_quarter: '#6b3f24',
+  wood_peeling_paint_weathered: '#b8b3aa',
+  oak_veneer_01: '#c89a64',
+  wood_table_001: '#a4724f',
+  dark_wood: '#3d2f2a',
+  rosewood_veneer_01: '#6f3a2f',
+  kitchen_wood: '#a6784a',
+  japanese_sycamore: '#d1b07d',
+  oak_veneer_01_amber: '#c88d3f',
+  oak_veneer_01_cocoa: '#72513e',
+  oak_veneer_01_walnut: '#4f3224',
+  oak_veneer_01_mahogany_red: '#74322d',
+  oak_veneer_01_matte_black: '#11100f',
+  carbon_fiber_chalk: '#2a313d'
+});
+
+const swatchFromWoodId = (id) => {
+  if (SHOWOOD_WOOD_SWATCHES[id]) return SHOWOOD_WOOD_SWATCHES[id];
+  if (/black|night|dark/.test(id)) return '#15181d';
+  if (/grey|gray/.test(id)) return '#717b86';
+  if (/burgundy|red|mahogany/.test(id)) return '#74323a';
+  if (/green|olive|moss|swamp/.test(id)) return '#43573d';
+  if (/cream|sand|yellow|birch/.test(id)) return '#c7ad7d';
+  if (/fabric/.test(id)) return '#7f8790';
+  return '#8a5a36';
+};
+
+const createShowoodWoodOptions = () =>
+  Object.freeze(
+    WOOD_GRAIN_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = Object.freeze({
+        label: option.label,
+        color: swatchFromWoodId(option.id),
+        woodTextureId: option.id,
+        metalness: /plastic|carbon/.test(option.id) ? 0.04 : 0.02,
+        roughness: /matte|fabric/.test(option.id) ? 0.72 : 0.42,
+        envMapIntensity: /plastic|carbon/.test(option.id) ? 1.1 : 1.35,
+        clearcoat: /matte|fabric/.test(option.id) ? 0.08 : 0.36,
+        clearcoatRoughness: /matte|fabric/.test(option.id) ? 0.5 : 0.2
+      });
+      return acc;
+    }, {})
+  );
+
+const createShowoodClothOptions = () =>
+  Object.freeze(
+    POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
+      acc[variant.id] = Object.freeze({
+        label: variant.name,
+        color: `#${variant.baseColor.toString(16).padStart(6, '0')}`,
+        clothTextureKey: variant.id,
+        clothTextureSource: 'procedural',
+        metalness: 0,
+        roughness: 0.9,
+        envMapIntensity: 0.18,
+        sheen: 0.62,
+        sheenRoughness: 0.46
+      });
+      return acc;
+    }, {})
+  );
+
+const SHOWOOD_CLOTH_OPTIONS = createShowoodClothOptions();
+const SHOWOOD_WOOD_OPTIONS = createShowoodWoodOptions();
+
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cloth',
   'cushion',
-  'metalAccent',
-  'jaws',
   'topWoodRail',
   'legBase'
 ]);
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
-  cloth: 'a',
-  cushion: 'a',
-  metalAccent: 'a',
-  jaws: 'a',
-  topWoodRail: 'a',
-  legBase: 'b'
+  cloth: POOL_ROYALE_CLOTH_VARIANTS[0]?.id || 'cabanBlueSky',
+  cushion: POOL_ROYALE_CLOTH_VARIANTS[0]?.id || 'cabanBlueSky',
+  topWoodRail: 'acg_walnut_quarter',
+  legBase: 'dark_wood'
 });
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
-  cloth: { label: 'Field cloth', description: 'Only the flat playfield surface.' },
+  cloth: { label: 'Field cloth', description: 'Flat playfield surface using every cloth-library texture.' },
   cushion: {
     label: 'Cushions',
-    description: 'Matched green or Black rubber; source cushion texture is preserved like the reference preview.'
+    description: 'Cushion rubber uses the same full cloth-library texture list as the field.'
   },
-  metalAccent: {
-    label: 'Rail sights + side strip + feet',
-    description: 'One gold/chrome control for rail sights, side apron strip, rims, trims, plates, and feet.'
-  },
-  jaws: { label: 'Jaws', description: 'Pocket jaws / cups: black or brown.' },
-  topWoodRail: { label: 'Top rail frame', description: 'Main top wood rail frame.' },
-  legBase: { label: 'Legs + base', description: 'Legs and lower base blocks together, separate from metal accents.' }
+  topWoodRail: { label: 'Top rail frame', description: 'Main top rail frame using every GLTF table-finish texture.' },
+  legBase: { label: 'Legs + base', description: 'Legs and lower base blocks using every GLTF table-finish texture.' }
 });
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
-  cloth: Object.freeze({
-    a: Object.freeze({ label: 'Green field', color: '#0a7b33', metalness: 0, roughness: 1, envMapIntensity: 0.16 }),
-    b: Object.freeze({ label: 'Blue field', color: '#0d4fb8', metalness: 0, roughness: 1, envMapIntensity: 0.16 })
-  }),
-  cushion: Object.freeze({
-    a: Object.freeze({ label: 'Matched green', color: '#064f22', metalness: 0, roughness: 0.88, envMapIntensity: 0.55 }),
-    b: Object.freeze({ label: 'Black rubber', color: '#050505', metalness: 0, roughness: 0.86, envMapIntensity: 0.55 })
-  }),
-  metalAccent: Object.freeze({
-    a: Object.freeze({ label: 'Gold', color: '#d8b23d', metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 }),
-    b: Object.freeze({ label: 'Chrome', color: '#d7dde7', metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 })
-  }),
-  jaws: Object.freeze({
-    a: Object.freeze({ label: 'Black jaws', color: '#020202', metalness: 0, roughness: 0.96, envMapIntensity: 0.14 }),
-    b: Object.freeze({ label: 'Brown jaws', color: '#2a1207', metalness: 0, roughness: 0.88, envMapIntensity: 0.26 })
-  }),
-  topWoodRail: Object.freeze({
-    a: Object.freeze({ label: 'Walnut frame', color: '#5a2608', metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 }),
-    b: Object.freeze({ label: 'Black frame', color: '#070605', metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 })
-  }),
-  legBase: Object.freeze({
-    a: Object.freeze({ label: 'Brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }),
-    b: Object.freeze({ label: 'Black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 })
-  })
+  cloth: SHOWOOD_CLOTH_OPTIONS,
+  cushion: SHOWOOD_CLOTH_OPTIONS,
+  topWoodRail: SHOWOOD_WOOD_OPTIONS,
+  legBase: SHOWOOD_WOOD_OPTIONS
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12163,11 +12163,20 @@ const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   pocket: 'jaws'
 });
 const POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS = new Set([
-  'cushion',
   'topWoodRail',
   'leg',
   'baseCornerBlock',
   'underside'
+]);
+const POOL_ROYALE_SHOWOOD_PRESERVE_SOURCE_PARTS = new Set([
+  'railSight',
+  'sideWoodApron',
+  'baseFoot',
+  'lowerTrim',
+  'cornerPocketPlate',
+  'middlePocketPlate',
+  'verticalCornerRim',
+  'pocketCup'
 ]);
 
 function resolvePoolRoyaleShowoodPalette(tableModel = null) {
@@ -12219,22 +12228,78 @@ function classifyPoolRoyaleShowoodReferencePart(child, material) {
   return 'sideWoodApron';
 }
 
+function applyShowoodClothOptionToMaterial(mat, option) {
+  const textureKey = option?.clothTextureKey;
+  if (!textureKey) return;
+  const textures = createClothTextures(
+    textureKey,
+    option.clothTextureSource || DEFAULT_CLOTH_TEXTURE_SOURCE_ID
+  );
+  const repeat = new THREE.Vector2(
+    EXTERNAL_TABLE_CLOTH_REPEAT_SCALE,
+    EXTERNAL_TABLE_CLOTH_REPEAT_SCALE
+  );
+  replaceMaterialTexture(mat, 'map', textures.map, repeat);
+  replaceMaterialTexture(mat, 'normalMap', textures.normal, repeat);
+  replaceMaterialTexture(mat, 'roughnessMap', textures.roughness, repeat);
+  if (textures.normal) {
+    replaceMaterialTexture(mat, 'bumpMap', null, repeat);
+    if (mat.normalScale?.isVector2) mat.normalScale.copy(POLYHAVEN_NORMAL_SCALE);
+  } else {
+    replaceMaterialTexture(mat, 'bumpMap', textures.bump, repeat);
+    if ('bumpScale' in mat) mat.bumpScale = 0.045;
+  }
+}
+
+function applyShowoodWoodOptionToMaterial(mat, option, control) {
+  const woodOption = option?.woodTextureId && WOOD_GRAIN_OPTIONS_BY_ID[option.woodTextureId];
+  if (!woodOption) return;
+  const sourceSurface = control === 'topWoodRail'
+    ? woodOption.rail || woodOption.frame
+    : woodOption.frame || woodOption.rail;
+  const surface = resolveWoodSurfaceConfig(sourceSurface, sourceSurface);
+  applyWoodTextureToMaterial(mat, {
+    ...surface,
+    woodRepeatScale: 1
+  });
+  applyTableFinishDulling(mat);
+  applyTableWoodVisibilityTuning(mat);
+}
+
 function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null) {
   if (!material) return material;
   const mat = material.clone ? material.clone() : material;
+  preparePoolRoyaleExternalTexture(mat.map, true);
+  preparePoolRoyaleExternalTexture(mat.emissiveMap, true);
+  preparePoolRoyaleExternalTexture(mat.aoMap, false);
+  preparePoolRoyaleExternalTexture(mat.normalMap, false);
+  preparePoolRoyaleExternalTexture(mat.roughnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.metalnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.bumpMap, false);
+  if (POOL_ROYALE_SHOWOOD_PRESERVE_SOURCE_PARTS.has(part)) {
+    mat.needsUpdate = true;
+    return mat;
+  }
   const control = POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[part] || POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[classifyPoolRoyaleExternalTableSurface(null, mat)] || 'topWoodRail';
   const palette = resolvePoolRoyaleShowoodPalette(tableModel);
-  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] || 'a';
-  const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice] || POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.a;
+  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control];
+  const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice];
   if (!option) return mat;
   mat.color?.set?.(option.color);
-  if ('metalness' in mat) mat.metalness = option.metalness;
-  if ('roughness' in mat) mat.roughness = option.roughness;
-  if ('envMapIntensity' in mat) mat.envMapIntensity = option.envMapIntensity;
-  if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? 0;
-  if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? 0;
+  if ('metalness' in mat && Number.isFinite(option.metalness)) mat.metalness = option.metalness;
+  if ('roughness' in mat && Number.isFinite(option.roughness)) mat.roughness = option.roughness;
+  if ('envMapIntensity' in mat && Number.isFinite(option.envMapIntensity)) mat.envMapIntensity = option.envMapIntensity;
+  if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? mat.clearcoat ?? 0;
+  if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? mat.clearcoatRoughness ?? 0;
+  if ('sheen' in mat && Number.isFinite(option.sheen)) mat.sheen = option.sheen;
+  if ('sheenRoughness' in mat && Number.isFinite(option.sheenRoughness)) mat.sheenRoughness = option.sheenRoughness;
   if (!POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS.has(part)) {
     clearPoolRoyaleMaterialTextureMaps(mat);
+  }
+  if (control === 'cloth' || control === 'cushion') {
+    applyShowoodClothOptionToMaterial(mat, option);
+  } else if (control === 'topWoodRail' || control === 'legBase') {
+    applyShowoodWoodOptionToMaterial(mat, option, control);
   }
   mat.transparent = false;
   mat.opacity = 1;
@@ -12246,6 +12311,7 @@ function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = nu
     poolRoyaleShowoodReferenceControl: control,
     poolRoyaleShowoodReferenceChoice: choice
   };
+  mat.needsUpdate = true;
   return mat;
 }
 

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -699,14 +699,14 @@ export default function PoolRoyaleLobby() {
             })}
           </div>
           <p className="text-xs text-white/60">
-            Royal Original now keeps TonPlaygram shell/chrome but uses GLB cushions and pocket jaws; Showood uses the reference texture mapping and option set.
+            Royal Original keeps the procedural wooden rails, procedural cushions, chrome plates, and pocket jaws; Showood keeps rail sights, side apron, feet, chrome, and jaws unchanged while exposing cloth and GLTF finish texture choices.
           </p>
           {selectedTableModel.useReferenceShowoodMapping ? (
             <div className="rounded-2xl border border-amber-300/20 bg-black/25 p-3">
               <div className="mb-2 flex items-center justify-between gap-2">
                 <div>
                   <h4 className="text-sm font-semibold text-white">Showood table setup</h4>
-                  <p className="text-[11px] text-white/55">Same material options as the supplied reference preview.</p>
+                  <p className="text-[11px] text-white/55">Field/cushions use the cloth library; rail frame and legs/base use every GLTF table-finish texture.</p>
                 </div>
                 <button
                   type="button"
@@ -727,7 +727,7 @@ export default function PoolRoyaleLobby() {
                         <p className="text-[10px] leading-snug text-white/50">{meta.description}</p>
                       </div>
                       <div className="flex flex-wrap gap-2">
-                        {['a', 'b'].map((choice) => {
+                        {Object.keys(options).map((choice) => {
                           const option = options[choice];
                           const active = showoodPalette[control] === choice;
                           return (


### PR DESCRIPTION
### Motivation
- Expose the full cloth library for the Showood GLB field and cushions and expose all GLTF table-finish textures for the Showood top rail frame and legs/base so artists can pick any available procedural/GLTF finish. 
- Keep rail sight, side apron, feet, chrome plates and pocket jaws from the source GLB unchanged while letting the rest adopt Pool Royale finishes. 
- Restore the Royal Original table to use the procedural cushions and the procedural wooden rail/frame while preserving existing chrome plates and pocket jaws.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to: import the cloth presets and wood grain options, change `royal-original` to use only `cloth` as Pool Royale finish role and to keep generated cushions/rails procedural, and add programmatic Showood controls that enumerate every `POOL_ROYALE_CLOTH_VARIANTS` (for cloth/cushions) and every `WOOD_GRAIN_OPTIONS` (for top rail / legs + base) as selectable options. 
- Extended `webapp/src/pages/Games/PoolRoyale.jsx` to: preserve source parts (rail sights, side apron, feet, chrome/trim pieces and pocket cups) for Showood, add `applyShowoodClothOptionToMaterial` and `applyShowoodWoodOptionToMaterial` helpers, and route Showood GLB material application through the new logic so cloth and wood options are applied only to the intended parts while preserved parts keep their original maps. 
- Updated `webapp/src/pages/Games/PoolRoyaleLobby.jsx` UI text and controls so the Showood setup iterates the full options sets (instead of hard-coded A/B choices) and clearly explains the field/cushions vs rail-frame/legs behavior in the lobby setup panel.

### Testing
- Ran `git diff --check` on modified files and fixed any whitespace issues; the check passed. 
- Built the webapp with `npm --prefix webapp run build`; the Vite production build completed successfully. 
- Launched the dev server and produced a mobile-portrait screenshot of the lobby with the Showood table selected using Playwright (screenshot saved at `/tmp/pool-royale-showood-setup.png`), confirming the updated lobby UI and options render correctly; Playwright required installing browser deps which were installed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3a6a09b48329b1c8821bea9c4485)