### PR TITLE
Limit Showood table setup to cloth/top-rail/legs and wire dynamic cloth/finish options

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -75,60 +75,34 @@ export function resolvePoolRoyaleTableModel(modelId) {
 
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cloth',
-  'cushion',
-  'metalAccent',
-  'jaws',
   'topWoodRail',
   'legBase'
 ]);
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
-  cloth: 'a',
-  cushion: 'a',
-  metalAccent: 'a',
-  jaws: 'a',
-  topWoodRail: 'a',
-  legBase: 'b'
+  cloth: 'cabanGreenClassic',
+  cushion: 'cabanGreenClassic',
+  metalAccent: 'source',
+  jaws: 'source',
+  topWoodRail: 'woodTable001',
+  legBase: 'darkWood'
 });
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
-  cloth: { label: 'Field cloth', description: 'Only the flat playfield surface.' },
-  cushion: {
-    label: 'Cushions',
-    description: 'Matched green or Black rubber; source cushion texture is preserved like the reference preview.'
+  cloth: {
+    label: 'Field + cushions cloth',
+    description: 'Uses every cloth texture from the Pool Royale cloth library on the field and cushions.'
   },
-  metalAccent: {
-    label: 'Rail sights + side strip + feet',
-    description: 'One gold/chrome control for rail sights, side apron strip, rims, trims, plates, and feet.'
+  topWoodRail: {
+    label: 'Top rail frame',
+    description: 'Uses every Pool Royale table-finish texture on the main top wood rail frame.'
   },
-  jaws: { label: 'Jaws', description: 'Pocket jaws / cups: black or brown.' },
-  topWoodRail: { label: 'Top rail frame', description: 'Main top wood rail frame.' },
-  legBase: { label: 'Legs + base', description: 'Legs and lower base blocks together, separate from metal accents.' }
+  legBase: {
+    label: 'Legs + base',
+    description: 'Uses every Pool Royale table-finish texture on the legs and lower base blocks only.'
+  }
 });
 
-export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
-  cloth: Object.freeze({
-    a: Object.freeze({ label: 'Green field', color: '#0a7b33', metalness: 0, roughness: 1, envMapIntensity: 0.16 }),
-    b: Object.freeze({ label: 'Blue field', color: '#0d4fb8', metalness: 0, roughness: 1, envMapIntensity: 0.16 })
-  }),
-  cushion: Object.freeze({
-    a: Object.freeze({ label: 'Matched green', color: '#064f22', metalness: 0, roughness: 0.88, envMapIntensity: 0.55 }),
-    b: Object.freeze({ label: 'Black rubber', color: '#050505', metalness: 0, roughness: 0.86, envMapIntensity: 0.55 })
-  }),
-  metalAccent: Object.freeze({
-    a: Object.freeze({ label: 'Gold', color: '#d8b23d', metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 }),
-    b: Object.freeze({ label: 'Chrome', color: '#d7dde7', metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 })
-  }),
-  jaws: Object.freeze({
-    a: Object.freeze({ label: 'Black jaws', color: '#020202', metalness: 0, roughness: 0.96, envMapIntensity: 0.14 }),
-    b: Object.freeze({ label: 'Brown jaws', color: '#2a1207', metalness: 0, roughness: 0.88, envMapIntensity: 0.26 })
-  }),
-  topWoodRail: Object.freeze({
-    a: Object.freeze({ label: 'Walnut frame', color: '#5a2608', metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 }),
-    b: Object.freeze({ label: 'Black frame', color: '#070605', metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 })
-  }),
-  legBase: Object.freeze({
-    a: Object.freeze({ label: 'Brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }),
-    b: Object.freeze({ label: 'Black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 })
-  })
-});
+// PoolRoyale.jsx builds these option lists from the live cloth library and table finish registry
+// so the Showood GLB menu always exposes every available texture.
+export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -37,7 +37,6 @@ import {
   POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   POOL_ROYALE_SHOWOOD_CONTROL_META,
-  POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS,
   POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
   POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS,
   resolvePoolRoyaleTableModel
@@ -3771,6 +3770,105 @@ const CLOTH_COLOR_OPTIONS = Object.freeze(
     sourceId: cloth.sourceId
   }))
 );
+
+const SHOWOOD_LEGACY_CLOTH_CHOICES = Object.freeze({
+  a: DEFAULT_CLOTH_COLOR_ID,
+  b: CLOTH_COLOR_OPTIONS.find((option) => option.id === 'cabanBlueRoyal')?.id ?? DEFAULT_CLOTH_COLOR_ID
+});
+const SHOWOOD_LEGACY_WOOD_CHOICES = Object.freeze({
+  a: 'woodTable001',
+  b: 'darkWood'
+});
+
+function resolvePoolRoyaleShowoodControlChoice(control, choice) {
+  const rawChoice = typeof choice === 'string' ? choice : '';
+  if (control === 'cloth') {
+    const migrated = SHOWOOD_LEGACY_CLOTH_CHOICES[rawChoice] ?? rawChoice;
+    return CLOTH_TEXTURE_PRESETS[migrated] ? migrated : DEFAULT_CLOTH_COLOR_ID;
+  }
+  if (control === 'topWoodRail' || control === 'legBase') {
+    const migrated = SHOWOOD_LEGACY_WOOD_CHOICES[rawChoice] ?? rawChoice;
+    return TABLE_FINISHES[migrated] ? migrated : DEFAULT_TABLE_FINISH_ID;
+  }
+  return rawChoice || 'source';
+}
+
+function getPoolRoyaleShowoodControlOptions(control) {
+  if (control === 'cloth') {
+    return CLOTH_COLOR_OPTIONS.map((option) => ({
+      id: option.id,
+      label: option.label,
+      color: option.color,
+      thumbnail: option.thumbnail,
+      sourceId: option.sourceId
+    }));
+  }
+  if (control === 'topWoodRail' || control === 'legBase') {
+    return Object.values(TABLE_FINISHES).map((finish) => ({
+      id: finish.id,
+      label: finish.label,
+      color: finish.colors?.rail ?? finish.colors?.base ?? 0xffffff,
+      thumbnail: finish.thumbnail,
+      woodTextureId: finish.woodTextureId
+    }));
+  }
+  return [];
+}
+
+function applyPoolRoyaleShowoodClothChoice(material, choice) {
+  if (!material) return;
+  const option = CLOTH_COLOR_OPTIONS.find((item) => item.id === choice) ?? CLOTH_COLOR_OPTIONS[0];
+  const textures = createClothTextures(option?.textureKey ?? option?.id ?? DEFAULT_CLOTH_TEXTURE_KEY, 'polyhaven');
+  if (material.color && option?.color != null) material.color.set(option.color);
+  replaceMaterialTexture(material, 'map', textures.map, null);
+  replaceMaterialTexture(material, 'normalMap', textures.normal, null);
+  replaceMaterialTexture(material, 'roughnessMap', textures.roughness, null);
+  if (textures.normal) {
+    replaceMaterialTexture(material, 'bumpMap', null, null);
+    material.normalScale = POLYHAVEN_NORMAL_SCALE.clone();
+  } else {
+    replaceMaterialTexture(material, 'bumpMap', textures.bump, null);
+    material.bumpScale = CLOTH_BUMP_SCALE;
+  }
+  material.metalness = 0;
+  material.roughness = textures.roughness ? CLOTH_ROUGHNESS_TARGET : CLOTH_ROUGHNESS_BASE;
+  if ('sheen' in material) material.sheen = option?.detail?.sheen ?? BASE_CLOTH_DETAIL.sheen;
+  if ('sheenRoughness' in material) material.sheenRoughness = option?.detail?.sheenRoughness ?? BASE_CLOTH_DETAIL.sheenRoughness;
+  if ('envMapIntensity' in material) material.envMapIntensity = option?.detail?.envMapIntensity ?? BASE_CLOTH_DETAIL.envMapIntensity;
+  material.needsUpdate = true;
+}
+
+function applyPoolRoyaleShowoodWoodChoice(material, choice, control) {
+  if (!material) return;
+  const finish = TABLE_FINISHES[choice] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
+  const finishMaterials = typeof finish?.createMaterials === 'function' ? finish.createMaterials() : {};
+  const sourceMaterial = control === 'topWoodRail' ? finishMaterials.rail : finishMaterials.frame ?? finishMaterials.leg;
+  if (sourceMaterial?.color && material.color) material.color.copy(sourceMaterial.color);
+  ['roughness', 'metalness', 'clearcoat', 'clearcoatRoughness', 'sheen', 'sheenRoughness', 'reflectivity', 'envMapIntensity'].forEach((key) => {
+    if (typeof sourceMaterial?.[key] === 'number' && key in material) material[key] = sourceMaterial[key];
+  });
+  const woodOption = finish?.woodTextureId ? WOOD_GRAIN_OPTIONS_BY_ID[finish.woodTextureId] : null;
+  const surface = control === 'topWoodRail'
+    ? woodOption?.rail ?? woodOption?.frame
+    : woodOption?.frame ?? woodOption?.rail;
+  if (surface && finish?.disableWoodPattern !== true) {
+    applyWoodTextureToMaterial(material, {
+      ...surface,
+      textureSize: enforceHighFpsTableTextureSize(surface.textureSize),
+      woodRepeatScale: finish.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE
+    });
+  } else {
+    clearPoolRoyaleMaterialTextureMaps(material);
+  }
+  applyTableFinishDulling(material);
+  applyTableWoodVisibilityTuning(material);
+  if (finish?.surfaceStyle === 'matte') {
+    if (finish?.preserveFinishTintOnWood) applyMatteSurfacePropsOnly(material);
+    else applyMonoMattePlasticSurface(material);
+  }
+  applyFinishWoodTint(material, finish);
+  material.needsUpdate = true;
+}
 
 const DEFAULT_RAIL_MARKER_SHAPE = 'diamond';
 const RAIL_MARKER_SHAPE_OPTIONS = Object.freeze([
@@ -12145,7 +12243,7 @@ const poolRoyaleExternalTablePromises = new Map();
 
 const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   cloth: 'cloth',
-  cushion: 'cushion',
+  cushion: 'cloth',
   topWoodRail: 'topWoodRail',
   sideWoodApron: 'metalAccent',
   pocketCup: 'jaws',
@@ -12162,14 +12260,6 @@ const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   wood: 'topWoodRail',
   pocket: 'jaws'
 });
-const POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS = new Set([
-  'cushion',
-  'topWoodRail',
-  'leg',
-  'baseCornerBlock',
-  'underside'
-]);
-
 function resolvePoolRoyaleShowoodPalette(tableModel = null) {
   return {
     ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
@@ -12214,7 +12304,8 @@ function classifyPoolRoyaleShowoodReferencePart(child, material) {
   }
   if (/leg/.test(label)) return 'leg';
   if (/base|block|support|underside/.test(label)) return 'baseCornerBlock';
-  if (/rail|frame|top|wood|walnut|showood|apron|cabinet|corner/.test(label)) return 'topWoodRail';
+  if (/apron|cabinet|side/.test(label) && !/top|rail[_\s-]*cap|upper/.test(label)) return 'sideWoodApron';
+  if (/rail|frame|top|wood|walnut|showood|corner/.test(label)) return 'topWoodRail';
   if (green) return 'cloth';
   return 'sideWoodApron';
 }
@@ -12224,17 +12315,19 @@ function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = nu
   const mat = material.clone ? material.clone() : material;
   const control = POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[part] || POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[classifyPoolRoyaleExternalTableSurface(null, mat)] || 'topWoodRail';
   const palette = resolvePoolRoyaleShowoodPalette(tableModel);
-  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] || 'a';
-  const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice] || POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.a;
-  if (!option) return mat;
-  mat.color?.set?.(option.color);
-  if ('metalness' in mat) mat.metalness = option.metalness;
-  if ('roughness' in mat) mat.roughness = option.roughness;
-  if ('envMapIntensity' in mat) mat.envMapIntensity = option.envMapIntensity;
-  if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? 0;
-  if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? 0;
-  if (!POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS.has(part)) {
-    clearPoolRoyaleMaterialTextureMaps(mat);
+  const choice = resolvePoolRoyaleShowoodControlChoice(control, palette[control]);
+  if (control === 'cloth') {
+    applyPoolRoyaleShowoodClothChoice(mat, choice);
+  } else if (control === 'topWoodRail' || control === 'legBase') {
+    applyPoolRoyaleShowoodWoodChoice(mat, choice, control);
+  } else {
+    preparePoolRoyaleExternalTexture(mat.map, true);
+    preparePoolRoyaleExternalTexture(mat.emissiveMap, true);
+    preparePoolRoyaleExternalTexture(mat.aoMap, false);
+    preparePoolRoyaleExternalTexture(mat.normalMap, false);
+    preparePoolRoyaleExternalTexture(mat.roughnessMap, false);
+    preparePoolRoyaleExternalTexture(mat.metalnessMap, false);
+    preparePoolRoyaleExternalTexture(mat.bumpMap, false);
   }
   mat.transparent = false;
   mat.opacity = 1;
@@ -35855,7 +35948,8 @@ const shotPowerRef = useRef(0);
                   <div className="space-y-3">
                     {POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS.map((control) => {
                       const meta = POOL_ROYALE_SHOWOOD_CONTROL_META[control];
-                      const options = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control];
+                      const options = getPoolRoyaleShowoodControlOptions(control);
+                      const activeChoice = resolvePoolRoyaleShowoodControlChoice(control, showoodPalette[control]);
                       return (
                         <div key={control} className="rounded-xl border border-white/10 bg-white/5 p-2">
                           <div className="mb-2">
@@ -35867,9 +35961,12 @@ const shotPowerRef = useRef(0);
                             </p>
                           </div>
                           <div className="flex flex-wrap gap-2">
-                            {Object.keys(options).map((choice) => {
-                              const option = options[choice];
-                              const active = showoodPalette[control] === choice;
+                            {options.map((option) => {
+                              const choice = option.id;
+                              const active = activeChoice === choice;
+                              const swatchColor = typeof option.color === 'number'
+                                ? `#${option.color.toString(16).padStart(6, '0')}`
+                                : option.color;
                               return (
                                 <button
                                   key={`${control}-${choice}`}
@@ -35884,7 +35981,7 @@ const shotPowerRef = useRef(0);
                                 >
                                   <span
                                     className="h-3.5 w-3.5 rounded-full border border-white/40"
-                                    style={{ backgroundColor: option.color }}
+                                    style={{ backgroundColor: swatchColor }}
                                     aria-hidden="true"
                                   />
                                   <span>{option.label}</span>


### PR DESCRIPTION
### Motivation
- Reduce the Showood GLB table setup controls to only the areas requested: field+cushions cloth, top wood rail frame, and legs+base, and stop exposing the railsight/side apron/feet/jaws chrome controls.
- Make the Showood setup use the live Pool Royale cloth library and the TABLE_FINISHES registry so users can pick every available cloth or wood finish rather than a tiny hard-coded palette.
- Preserve original chrome/trim/jaw source materials and keep procedural cushions/rail chrome plates behavior unchanged so playability and chrome pockets remain as before.

### Description
- Removed the extra Showood controls and default palette entries, leaving only `cloth`, `topWoodRail`, and `legBase` in `webapp/src/config/poolRoyaleTableModels.js` and replaced the static control options with a comment indicating options are built at runtime. 
- Added helpers and migrators in `webapp/src/pages/Games/PoolRoyale.jsx` to: resolve legacy choice mappings, build the Showood control option lists from `CLOTH_COLOR_OPTIONS` and `TABLE_FINISHES`, and apply a selected cloth or table-finish to an external Showood material (`applyPoolRoyaleShowoodClothChoice`, `applyPoolRoyaleShowoodWoodChoice`, `getPoolRoyaleShowoodControlOptions`, `resolvePoolRoyaleShowoodControlChoice`).
- Updated the Showood reference material application to route cushions -> cloth control and to apply cloth textures to both field and cushions and finish wood textures to top rail / legs/base while preparing (but not overwriting) the other preserved metal/trim/jaws materials. 
- Updated the Showood UI to render dynamic option lists and resolve the active choice consistently in the setup panel so mobile/tablet portrait flows show the new controls and swatches.

### Testing
- Ran `cd webapp && npm run lint -- --quiet`; the webapp lint target completed (warnings about repository-wide generated/dist files exist but are outside the change). — succeeded for the modified webapp files.
- Ran `cd webapp && npm run build`; Vite production build completed successfully and produced updated build artifacts. — succeeded.
- Installed Playwright browsers with `npx playwright install chromium` and system deps with `npx playwright install-deps chromium`; both commands completed (browsers and deps downloaded). — succeeded.
- Attempted an automated Playwright screenshot of the Showood setup route (`/games/poolroyale?tableModel=showood-seven-foot`) in this environment but `page.screenshot` timed out while rendering the live WebGL route; browser dependencies were installed but the capture did not complete here. — screenshot attempt timed out.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3a6a09b48329b1c8821bea9c4485)