### PR TITLE
Refactor Showood material mapping; add cloth/finish option sets and thumbnails

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,3 +1,6 @@
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+
 export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
 
 const POOLTOOL_RAW_BASE =
@@ -8,7 +11,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'royal-original',
     label: 'Royal Original',
     description:
-      'Current TonPlaygram rails, base, and chrome with Showood GLB playfield, GLB cushions, pockets, and jaw layout overlaid.',
+      'Current TonPlaygram procedural wooden rails, procedural cushions, base, and chrome plates with Showood GLB playfield cloth plus GLB pocket jaws aligned to the chrome cutouts.',
     tableSizeId: '9ft',
     finishId: 'peelingPaintWeathered',
     baseId: 'classicCylinders',
@@ -23,12 +26,13 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: false,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket'],
-    cushionUsesClothFinish: true,
-    hideGeneratedCushionsAndJaws: true,
-    preserveSourceTextureRoles: [],
+    usePoolRoyaleFinishRoles: ['cloth'],
+    cushionUsesClothFinish: false,
+    hideGeneratedCushionsAndJaws: false,
+    hideGeneratedPocketJaws: true,
+    preserveSourceTextureRoles: ['pocket'],
     preserveOriginalSurfaceRoles: ['trim', 'wood'],
-    hideSurfaceRoles: ['trim', 'wood'],
+    hideSurfaceRoles: ['trim', 'wood', 'cushion'],
     keepGeneratedShell: true,
     forceGeneratedChromePlates: true
   },
@@ -52,8 +56,18 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
     useReferenceShowoodMapping: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
-    preserveSourceTextureRoles: ['cushion', 'topWoodRail', 'leg', 'baseCornerBlock', 'underside'],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood'],
+    preserveSourceTextureRoles: [
+      'railSight',
+      'sideWoodApron',
+      'baseFoot',
+      'cornerPocketPlate',
+      'middlePocketPlate',
+      'verticalCornerRim',
+      'lowerTrim',
+      'trim',
+      'pocket'
+    ],
     preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: false,
     forceGeneratedChromePlates: false,
@@ -73,62 +87,90 @@ export function resolvePoolRoyaleTableModel(modelId) {
   );
 }
 
+
+const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
+  { id: 'peelingPaintWeathered', label: 'Wood Peeling Paint Weathered', color: '#b8b3aa', textureId: 'wood_peeling_paint_weathered' },
+  { id: 'oakVeneer01', label: 'Oak Veneer 01', color: '#c89a64', textureId: 'oak_veneer_01' },
+  { id: 'woodTable001', label: 'Wood Table 001', color: '#a4724f', textureId: 'wood_table_001' },
+  { id: 'darkWood', label: 'Dark Wood', color: '#3d2f2a', textureId: 'dark_wood' },
+  { id: 'rosewoodVeneer01', label: 'Rosewood Veneer 01', color: '#6f3a2f', textureId: 'rosewood_veneer_01' },
+  { id: 'carbonFiberChalk', label: 'LT Black', color: '#2a313d', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkGrey', label: 'LT Grey', color: '#c8d0da', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkBeige', label: 'LT Dark Grey', color: '#727d8b', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkBlue', label: 'LT Burgundy', color: '#c17276', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkWhite', label: 'LT Milk Cream', color: '#f8eedf', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkGreen', label: 'LT Dark Green', color: '#548460', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkYellow', label: 'LT Dark Yellow', color: '#d1a652', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkBrown', label: 'LT Dark Brown', color: '#956b4f', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkRed', label: 'LT Dark Red', color: '#aa5151', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorOlive', label: 'LT Olive Fabric', color: '#687047', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorSwamp', label: 'LT Swamp Fabric', color: '#52623f', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorClay', label: 'LT Clay Fabric', color: '#6f5b45', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorSand', label: 'LT Sand Fabric', color: '#8a7b5e', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorMoss', label: 'LT Moss Fabric', color: '#4f6048', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorNight', label: 'LT Night Fabric', color: '#2f3c32', textureId: 'fabric_083' }
+]);
+
+const buildShowoodFinishOptions = () =>
+  Object.freeze(
+    SHOWOOD_TABLE_FINISH_TEXTURES.reduce((acc, option) => {
+      acc[option.id] = Object.freeze({
+        ...option,
+        finishId: option.id,
+        thumbnail: option.textureId ? polyHavenThumb(option.textureId) : swatchThumbnail([option.color, '#ffffff'])
+      });
+      return acc;
+    }, {})
+  );
+
+const buildShowoodClothOptions = () =>
+  Object.freeze(
+    POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
+      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`;
+      acc[variant.id] = Object.freeze({
+        label: variant.name,
+        color,
+        textureKey: variant.id,
+        sourceId: variant.sourceId,
+        thumbnail: variant.thumbnail,
+        metalness: 0,
+        roughness: 1,
+        envMapIntensity: 0.16
+      });
+      return acc;
+    }, {})
+  );
+
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cloth',
   'cushion',
-  'metalAccent',
-  'jaws',
   'topWoodRail',
   'legBase'
 ]);
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
-  cloth: 'a',
-  cushion: 'a',
-  metalAccent: 'a',
-  jaws: 'a',
-  topWoodRail: 'a',
-  legBase: 'b'
+  cloth: 'cabanGreenClassic',
+  cushion: 'cabanGreenForest',
+  topWoodRail: 'woodTable001',
+  legBase: 'darkWood'
 });
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
-  cloth: { label: 'Field cloth', description: 'Only the flat playfield surface.' },
+  cloth: { label: 'Field cloth', description: 'All cloth-library textures for only the flat playfield surface.' },
   cushion: {
     label: 'Cushions',
-    description: 'Matched green or Black rubber; source cushion texture is preserved like the reference preview.'
+    description: 'All cloth-library textures for the cushion faces, separate from the field.'
   },
-  metalAccent: {
-    label: 'Rail sights + side strip + feet',
-    description: 'One gold/chrome control for rail sights, side apron strip, rims, trims, plates, and feet.'
-  },
-  jaws: { label: 'Jaws', description: 'Pocket jaws / cups: black or brown.' },
-  topWoodRail: { label: 'Top rail frame', description: 'Main top wood rail frame.' },
-  legBase: { label: 'Legs + base', description: 'Legs and lower base blocks together, separate from metal accents.' }
+  topWoodRail: { label: 'Top rail frame', description: 'All GLTF table-finish textures for the main top wood rail frame.' },
+  legBase: { label: 'Legs + base', description: 'All GLTF table-finish textures for legs and lower base blocks only.' }
 });
 
+const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions();
+const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions();
+
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
-  cloth: Object.freeze({
-    a: Object.freeze({ label: 'Green field', color: '#0a7b33', metalness: 0, roughness: 1, envMapIntensity: 0.16 }),
-    b: Object.freeze({ label: 'Blue field', color: '#0d4fb8', metalness: 0, roughness: 1, envMapIntensity: 0.16 })
-  }),
-  cushion: Object.freeze({
-    a: Object.freeze({ label: 'Matched green', color: '#064f22', metalness: 0, roughness: 0.88, envMapIntensity: 0.55 }),
-    b: Object.freeze({ label: 'Black rubber', color: '#050505', metalness: 0, roughness: 0.86, envMapIntensity: 0.55 })
-  }),
-  metalAccent: Object.freeze({
-    a: Object.freeze({ label: 'Gold', color: '#d8b23d', metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 }),
-    b: Object.freeze({ label: 'Chrome', color: '#d7dde7', metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 })
-  }),
-  jaws: Object.freeze({
-    a: Object.freeze({ label: 'Black jaws', color: '#020202', metalness: 0, roughness: 0.96, envMapIntensity: 0.14 }),
-    b: Object.freeze({ label: 'Brown jaws', color: '#2a1207', metalness: 0, roughness: 0.88, envMapIntensity: 0.26 })
-  }),
-  topWoodRail: Object.freeze({
-    a: Object.freeze({ label: 'Walnut frame', color: '#5a2608', metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 }),
-    b: Object.freeze({ label: 'Black frame', color: '#070605', metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 })
-  }),
-  legBase: Object.freeze({
-    a: Object.freeze({ label: 'Brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }),
-    b: Object.freeze({ label: 'Black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 })
-  })
+  cloth: SHOWOOD_CLOTH_OPTIONS,
+  cushion: SHOWOOD_CLOTH_OPTIONS,
+  topWoodRail: SHOWOOD_FINISH_OPTIONS,
+  legBase: SHOWOOD_FINISH_OPTIONS
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12147,36 +12147,48 @@ const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   cloth: 'cloth',
   cushion: 'cushion',
   topWoodRail: 'topWoodRail',
-  sideWoodApron: 'metalAccent',
-  pocketCup: 'jaws',
-  cornerPocketPlate: 'metalAccent',
-  middlePocketPlate: 'metalAccent',
-  verticalCornerRim: 'metalAccent',
   baseCornerBlock: 'legBase',
   leg: 'legBase',
-  baseFoot: 'metalAccent',
-  lowerTrim: 'metalAccent',
-  railSight: 'metalAccent',
   underside: 'legBase',
-  trim: 'metalAccent',
-  wood: 'topWoodRail',
-  pocket: 'jaws'
+  wood: 'topWoodRail'
 });
-const POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS = new Set([
-  'cushion',
-  'topWoodRail',
-  'leg',
-  'baseCornerBlock',
-  'underside'
+const POOL_ROYALE_SHOWOOD_IMMUTABLE_SOURCE_PARTS = new Set([
+  'sideWoodApron',
+  'railSight',
+  'baseFoot',
+  'cornerPocketPlate',
+  'middlePocketPlate',
+  'verticalCornerRim',
+  'lowerTrim',
+  'trim',
+  'pocketCup',
+  'pocket'
 ]);
+const POOL_ROYALE_SHOWOOD_LEGACY_CHOICE_FALLBACKS = Object.freeze({
+  cloth: { a: 'cabanGreenClassic', b: 'cabanBlueRoyal' },
+  cushion: { a: 'cabanGreenForest', b: 'cabanDarkGreyCharcoal' },
+  topWoodRail: { a: 'woodTable001', b: 'darkWood' },
+  legBase: { a: 'rosewoodVeneer01', b: 'darkWood' }
+});
 
 function resolvePoolRoyaleShowoodPalette(tableModel = null) {
-  return {
+  const raw = {
     ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
     ...(tableModel?.showoodPalette && typeof tableModel.showoodPalette === 'object'
       ? tableModel.showoodPalette
       : {})
   };
+  POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS.forEach((control) => {
+    const options = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control] || {};
+    const current = raw[control];
+    if (!options[current]) {
+      raw[control] =
+        POOL_ROYALE_SHOWOOD_LEGACY_CHOICE_FALLBACKS[control]?.[current] ||
+        POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] ||
+        Object.keys(options)[0];
+    }
+  });
+  return raw;
 }
 
 function clearPoolRoyaleMaterialTextureMaps(material) {
@@ -12190,6 +12202,132 @@ function clearPoolRoyaleMaterialTextureMaps(material) {
   material.emissiveMap = null;
   material.lightMap = null;
   material.alphaMap = null;
+}
+
+
+function copyPoolRoyaleMaterialLook(target, source) {
+  if (!target || !source) return;
+  if (source.color && target.color) target.color.copy(source.color);
+  if (source.emissive && target.emissive) target.emissive.copy(source.emissive);
+  [
+    'roughness',
+    'metalness',
+    'clearcoat',
+    'clearcoatRoughness',
+    'sheen',
+    'sheenRoughness',
+    'reflectivity',
+    'envMapIntensity',
+    'emissiveIntensity',
+    'bumpScale'
+  ].forEach((key) => {
+    if (typeof source[key] === 'number' && key in target) target[key] = source[key];
+  });
+  target.map = clonePoolRoyaleMaterialTexture(source.map, { isColor: true });
+  target.normalMap = clonePoolRoyaleMaterialTexture(source.normalMap);
+  target.roughnessMap = clonePoolRoyaleMaterialTexture(source.roughnessMap);
+  target.aoMap = clonePoolRoyaleMaterialTexture(source.aoMap);
+  target.metalnessMap = clonePoolRoyaleMaterialTexture(source.metalnessMap);
+  target.bumpMap = clonePoolRoyaleMaterialTexture(source.bumpMap);
+}
+
+function getPoolRoyaleShowoodWoodSurfaceForFinish(finish, control, finishInfo = null) {
+  const defaultWoodOption = WOOD_GRAIN_OPTIONS_BY_ID[DEFAULT_WOOD_GRAIN_ID] ?? WOOD_GRAIN_OPTIONS[0];
+  const resolvedWoodOption =
+    finish?.woodTexture ||
+    (finish?.woodTextureId && WOOD_GRAIN_OPTIONS_BY_ID[finish.woodTextureId]) ||
+    defaultWoodOption;
+  const fallbackSurface =
+    control === 'topWoodRail'
+      ? finishInfo?.parts?.woodSurfaces?.rail
+      : finishInfo?.parts?.woodSurfaces?.frame;
+  const baseSurface = resolveWoodSurfaceConfig(
+    resolvedWoodOption?.frame,
+    resolvedWoodOption?.rail ?? defaultWoodOption.frame ?? defaultWoodOption.rail ?? fallbackSurface
+  );
+  const usesPolyHavenWoodMaps =
+    typeof baseSurface.mapUrl === 'string' && baseSurface.mapUrl.includes('polyhaven.org');
+  const textureSize = usesPolyHavenWoodMaps
+    ? (baseSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE)
+    : enforceHighFpsTableTextureSize(baseSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE);
+  const repeatScale = clampWoodRepeatScaleValue(finish?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE);
+  const railMultiplier = control === 'topWoodRail' && usesPolyHavenWoodMaps
+    ? GLTF_RAIL_PATTERN_REPEAT_MULTIPLIER
+    : 1;
+  return {
+    repeat: new THREE.Vector2(
+      (baseSurface.repeat?.x ?? 1) * railMultiplier,
+      baseSurface.repeat?.y ?? 1
+    ),
+    rotation: baseSurface.rotation,
+    textureSize,
+    mapUrl: baseSurface.mapUrl,
+    roughnessMapUrl: baseSurface.roughnessMapUrl,
+    normalMapUrl: baseSurface.normalMapUrl,
+    woodRepeatScale: repeatScale
+  };
+}
+
+function applyPoolRoyaleShowoodWoodFinishMaterial(mat, control, option, finishInfo = null) {
+  const finish = TABLE_FINISHES[option?.finishId] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
+  const rawMaterials = typeof finish?.createMaterials === 'function'
+    ? finish.createMaterials()
+    : TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID].createMaterials();
+  const source = control === 'topWoodRail'
+    ? rawMaterials.rail || rawMaterials.frame
+    : rawMaterials.leg || rawMaterials.frame || rawMaterials.rail;
+  copyPoolRoyaleMaterialLook(mat, source);
+  mat.userData = {
+    ...(mat.userData || {}),
+    baseTintHex: mat.color?.getHex?.()
+  };
+  if (finish?.disableWoodPattern) {
+    if (finish?.useBrandCarbonTexture) applyLtCarbonFiberTexture(mat);
+    else clearPoolRoyaleMaterialTextureMaps(mat);
+  } else {
+    applyWoodTextureToMaterial(
+      mat,
+      getPoolRoyaleShowoodWoodSurfaceForFinish(finish, control, finishInfo)
+    );
+  }
+  applyTableFinishDulling(mat);
+  applyTableWoodVisibilityTuning(mat);
+  if (finish?.surfaceStyle === 'matte') {
+    if (finish?.preserveFinishTintOnWood) applyMatteSurfacePropsOnly(mat);
+    else applyMonoMattePlasticSurface(mat);
+  }
+  applyFinishWoodTint(mat, finish);
+}
+
+function applyPoolRoyaleShowoodClothLibraryMaterial(mat, control, option, finishInfo = null) {
+  const source = control === 'cushion' ? finishInfo?.cushionMat : finishInfo?.clothMat;
+  copyPoolRoyaleMaterialLook(mat, source || finishInfo?.clothMat);
+  const textureKey = option?.textureKey;
+  const textureSource = option?.sourceId || option?.textureKey || DEFAULT_CLOTH_TEXTURE_SOURCE_ID;
+  if (textureKey) {
+    const textures = createClothTextures(textureKey, textureSource);
+    const baseRepeat = source?.userData?.baseRepeat ?? source?.map?.repeat?.x ?? CLOTH_TEXTURE_REPEAT_HINT;
+    const repeatRatio = source?.userData?.repeatRatio ?? (source?.map?.repeat?.x ? source.map.repeat.y / source.map.repeat.x : 1);
+    const assignTexture = (prop, texture, isColor = false) => {
+      mat[prop] = texture;
+      if (!texture) return;
+      if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+      texture.repeat.set(baseRepeat, baseRepeat * repeatRatio);
+      texture.wrapS = THREE.RepeatWrapping;
+      texture.wrapT = THREE.RepeatWrapping;
+      texture.anisotropy = resolveTextureAnisotropy(12);
+      texture.needsUpdate = true;
+    };
+    assignTexture('map', textures.map, true);
+    assignTexture('normalMap', textures.normal);
+    assignTexture('bumpMap', textures.normal ? null : textures.bump);
+    assignTexture('roughnessMap', textures.roughness);
+  }
+  if (mat.color && option?.color) mat.color.set(option.color);
+  if (mat.emissive && mat.color) mat.emissive.copy(mat.color).multiplyScalar(0.045);
+  if ('metalness' in mat) mat.metalness = option?.metalness ?? 0;
+  if ('roughness' in mat) mat.roughness = option?.roughness ?? mat.roughness ?? 1;
+  if ('envMapIntensity' in mat) mat.envMapIntensity = option?.envMapIntensity ?? 0;
 }
 
 function classifyPoolRoyaleShowoodReferencePart(child, material) {
@@ -12206,35 +12344,52 @@ function classifyPoolRoyaleShowoodReferencePart(child, material) {
   if (/cloth|felt|fabric|surface|bed|slate|playfield|baize/.test(label) && !/cushion|rubber|bumper/.test(childName)) return 'cloth';
   if (/cushion|rubber|bumper|railrubber|rail[_\s-]*nose/.test(childName)) return 'cushion';
   if (/sight|diamond|marker|dot|inlay/.test(label)) return 'railSight';
+  if (/foot|feet/.test(label)) return 'baseFoot';
+  if (/apron|side[_\s-]*(strip|fascia|apron)|cabinet/.test(label)) return 'sideWoodApron';
   if (/pocket|hole|drop|net|liner|leather|cup|basket|holder/.test(label)) {
     return metalish && !black && !brown ? 'cornerPocketPlate' : 'pocketCup';
   }
+  if (/corner.*rim|rim.*corner|vertical.*rim|pocket.*rim|rim.*pocket/.test(label)) return 'verticalCornerRim';
   if (/trim|bezel|ring|metal|chrome|brass|gold|plate|cap|rim|guard|insert|hardware|bolt|screw/.test(label) || metalish) {
-    return /foot|feet/.test(label) ? 'baseFoot' : 'lowerTrim';
+    return /middle|side/.test(label) ? 'middlePocketPlate' : 'lowerTrim';
   }
   if (/leg/.test(label)) return 'leg';
   if (/base|block|support|underside/.test(label)) return 'baseCornerBlock';
-  if (/rail|frame|top|wood|walnut|showood|apron|cabinet|corner/.test(label)) return 'topWoodRail';
+  if (/rail|frame|top|wood|walnut|showood/.test(label)) return 'topWoodRail';
   if (green) return 'cloth';
   return 'sideWoodApron';
 }
 
-function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null) {
+function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null, finishInfo = null) {
   if (!material) return material;
   const mat = material.clone ? material.clone() : material;
+  preparePoolRoyaleExternalTexture(mat.map, true);
+  preparePoolRoyaleExternalTexture(mat.emissiveMap, true);
+  preparePoolRoyaleExternalTexture(mat.aoMap, false);
+  preparePoolRoyaleExternalTexture(mat.normalMap, false);
+  preparePoolRoyaleExternalTexture(mat.roughnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.metalnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.bumpMap, false);
+  if (POOL_ROYALE_SHOWOOD_IMMUTABLE_SOURCE_PARTS.has(part)) {
+    mat.needsUpdate = true;
+    return mat;
+  }
   const control = POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[part] || POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[classifyPoolRoyaleExternalTableSurface(null, mat)] || 'topWoodRail';
   const palette = resolvePoolRoyaleShowoodPalette(tableModel);
-  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] || 'a';
-  const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice] || POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.a;
+  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] || Object.keys(POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control] || {})[0];
+  const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice];
   if (!option) return mat;
-  mat.color?.set?.(option.color);
-  if ('metalness' in mat) mat.metalness = option.metalness;
-  if ('roughness' in mat) mat.roughness = option.roughness;
-  if ('envMapIntensity' in mat) mat.envMapIntensity = option.envMapIntensity;
-  if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? 0;
-  if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? 0;
-  if (!POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS.has(part)) {
-    clearPoolRoyaleMaterialTextureMaps(mat);
+  if (control === 'cloth' || control === 'cushion') {
+    applyPoolRoyaleShowoodClothLibraryMaterial(mat, control, option, finishInfo);
+  } else if (control === 'topWoodRail' || control === 'legBase') {
+    applyPoolRoyaleShowoodWoodFinishMaterial(mat, control, option, finishInfo);
+  } else {
+    mat.color?.set?.(option.color);
+    if ('metalness' in mat) mat.metalness = option.metalness;
+    if ('roughness' in mat) mat.roughness = option.roughness;
+    if ('envMapIntensity' in mat) mat.envMapIntensity = option.envMapIntensity;
+    if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? 0;
+    if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? 0;
   }
   mat.transparent = false;
   mat.opacity = 1;
@@ -12498,7 +12653,7 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
         child.visible = false;
       }
       if (tableModel?.useReferenceShowoodMapping) {
-        const nextMaterial = applyPoolRoyaleShowoodReferenceMaterial(material, referencePart || role, tableModel);
+        const nextMaterial = applyPoolRoyaleShowoodReferenceMaterial(material, referencePart || role, tableModel, finishInfo);
         normalizePoolRoyaleExternalClothTextureScale(child, nextMaterial, role);
         return nextMaterial;
       }
@@ -13486,6 +13641,12 @@ function mountPoolRoyaleExternalTableModel({
   if (resolvedTableOptions?.tableModel?.hideGeneratedCushionsAndJaws) {
     [
       ...(Array.isArray(table.userData.cushions) ? table.userData.cushions : []),
+      ...finishParts.pocketJawMeshes,
+      ...finishParts.pocketRimMeshes,
+      ...pocketMeshes
+    ].forEach(markGeneratedCushionsAndJawsHiddenByExternalTable);
+  } else if (resolvedTableOptions?.tableModel?.hideGeneratedPocketJaws) {
+    [
       ...finishParts.pocketJawMeshes,
       ...finishParts.pocketRimMeshes,
       ...pocketMeshes
@@ -35887,6 +36048,15 @@ const shotPowerRef = useRef(0);
                                     style={{ backgroundColor: option.color }}
                                     aria-hidden="true"
                                   />
+                                  {option.thumbnail ? (
+                                    <img
+                                      src={option.thumbnail}
+                                      alt=""
+                                      className="h-5 w-8 rounded-md border border-white/20 object-cover"
+                                      loading="lazy"
+                                      aria-hidden="true"
+                                    />
+                                  ) : null}
                                   <span>{option.label}</span>
                                 </button>
                               );

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -727,7 +727,7 @@ export default function PoolRoyaleLobby() {
                         <p className="text-[10px] leading-snug text-white/50">{meta.description}</p>
                       </div>
                       <div className="flex flex-wrap gap-2">
-                        {['a', 'b'].map((choice) => {
+                        {Object.keys(options).map((choice) => {
                           const option = options[choice];
                           const active = showoodPalette[control] === choice;
                           return (
@@ -746,6 +746,15 @@ export default function PoolRoyaleLobby() {
                                 style={{ backgroundColor: option.color }}
                                 aria-hidden="true"
                               />
+                              {option.thumbnail ? (
+                                <img
+                                  src={option.thumbnail}
+                                  alt=""
+                                  className="h-5 w-8 rounded-md border border-white/20 object-cover"
+                                  loading="lazy"
+                                  aria-hidden="true"
+                                />
+                              ) : null}
                               <span>{option.label}</span>
                             </button>
                           );


### PR DESCRIPTION
### Motivation
- Modernize and extend the Showood external-table material workflow to support the cloth library, richer wood/finish options, and preserve source textures for selected parts.
- Provide UI affordances (thumbnails) and safer defaults while handling legacy palette keys and finer control over generated cushions/pocket jaws visibility.

### Description
- Adjusted `POOL_ROYALE_TABLE_MODEL` defaults to change which texture roles are driven by Pool Royale finishes and to control generated cushion/jaw visibility via `hideGeneratedPocketJaws` and related flags. 
- Introduced `SHOWOOD_TABLE_FINISH_TEXTURES` and builders `buildShowoodFinishOptions`/`buildShowoodClothOptions` that populate `POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS` from `POOL_ROYALE_CLOTH_VARIANTS` and generate thumbnails via `polyHavenThumb`/`swatchThumbnail`. 
- Reworked mapping and classification: replaced legacy control parts with `POOL_ROYALE_SHOWOOD_IMMUTABLE_SOURCE_PARTS`, added `POOL_ROYALE_SHOWOOD_LEGACY_CHOICE_FALLBACKS`, and updated `POOL_ROYALE_SHOWOOD_PART_TO_CONTROL` and classification logic to better identify parts like `sideWoodApron`, `baseFoot`, `verticalCornerRim`, and pocket plates. 
- Added material helper functions `copyPoolRoyaleMaterialLook`, `getPoolRoyaleShowoodWoodSurfaceForFinish`, `applyPoolRoyaleShowoodWoodFinishMaterial`, and `applyPoolRoyaleShowoodClothLibraryMaterial` and integrated them into `applyPoolRoyaleShowoodReferenceMaterial` to apply cloth-library and wood-finish textures and props while preparing external textures. 
- Updated UI in `PoolRoyale.jsx` and `PoolRoyaleLobby.jsx` to iterate dynamic option keys and show thumbnails where available. 
- Adjusted generated-visual visibility logic to selectively hide only pocket jaws when `hideGeneratedPocketJaws` is set. 

### Testing
- Ran unit and integration test suite with `yarn test` and observed all tests passing. 
- Performed a production build with `yarn build` which completed successfully. 
- Ran linter/type checks with `yarn lint` and `yarn typecheck` with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3a6a09b48329b1c8821bea9c4485)