### PR TITLE
Add Black chrome option; refactor Showood material mapping, finishes, and UI

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -715,7 +715,7 @@ export const POOL_ROYALE_DEFAULT_HDRI_ID = 'colorfulStudio';
 
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: ['peelingPaintWeathered'],
-  chromeColor: ['gold'],
+  chromeColor: ['gold', 'black'],
   chromePlateStyle: ['showood-rounded', 'royal-classic'],
   railMarkerColor: ['gold'],
   clothColor: [POOL_ROYALE_CLOTH_VARIANTS[0].id],
@@ -756,7 +756,8 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
-    gold: 'Gold'
+    gold: 'Gold',
+    black: 'Black'
   }),
   chromePlateStyle: Object.freeze({
     'royal-classic': 'Royal Classic Plates',
@@ -990,6 +991,15 @@ export const POOL_ROYALE_STORE_ITEMS = [
     thumbnail: swatchThumbnail(['#e2e8f0', '#94a3b8', '#f8fafc'])
   },
   {
+    id: 'chrome-black',
+    type: 'chromeColor',
+    optionId: 'black',
+    name: 'Black Fascias',
+    price: 360,
+    description: 'Gloss black hardware for rail sights, apron accents, feet, rims, and fascia details.',
+    thumbnail: swatchThumbnail(['#050505', '#171717', '#3f3f46'])
+  },
+  {
     id: 'chromeStyle-showoodRounded',
     type: 'chromePlateStyle',
     optionId: 'showood-rounded',
@@ -1205,6 +1215,7 @@ export const POOL_ROYALE_DEFAULT_LOADOUT = [
     label: 'Wood Peeling Paint Weathered Finish'
   },
   { type: 'chromeColor', optionId: 'gold', label: 'Gold Chrome Plates' },
+  { type: 'chromeColor', optionId: 'black', label: 'Black Fascias' },
   { type: 'chromePlateStyle', optionId: 'showood-rounded', label: 'Showood Rounded Chrome Plates' },
   { type: 'railMarkerColor', optionId: 'gold', label: 'Gold Diamond Markers' },
   {

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,3 +1,6 @@
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+
 export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
 
 const POOLTOOL_RAW_BASE =
@@ -8,7 +11,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     id: 'royal-original',
     label: 'Royal Original',
     description:
-      'Current TonPlaygram rails, base, and chrome with Showood GLB playfield, GLB cushions, pockets, and jaw layout overlaid.',
+      'Current TonPlaygram procedural wooden rails, procedural cushions, base, chrome plates, pockets, and jaws with only the Showood GLB playfield cloth overlaid.',
     tableSizeId: '9ft',
     finishId: 'peelingPaintWeathered',
     baseId: 'classicCylinders',
@@ -23,12 +26,13 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: false,
     usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'pocket'],
-    cushionUsesClothFinish: true,
-    hideGeneratedCushionsAndJaws: true,
+    usePoolRoyaleFinishRoles: ['cloth'],
+    cushionUsesClothFinish: false,
+    hideGeneratedCushionsAndJaws: false,
+    hideGeneratedPocketsAndJaws: false,
     preserveSourceTextureRoles: [],
     preserveOriginalSurfaceRoles: ['trim', 'wood'],
-    hideSurfaceRoles: ['trim', 'wood'],
+    hideSurfaceRoles: ['trim', 'wood', 'cushion', 'pocket'],
     keepGeneratedShell: true,
     forceGeneratedChromePlates: true
   },
@@ -52,8 +56,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     useOriginalLayoutSurfaces: true,
     usePoolRoyaleFinish: true,
     useReferenceShowoodMapping: true,
-    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood', 'pocket', 'trim'],
-    preserveSourceTextureRoles: ['cushion', 'topWoodRail', 'leg', 'baseCornerBlock', 'underside'],
+    usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood'],
+    preserveSourceTextureRoles: ['railSight', 'sideWoodApron', 'baseFoot', 'trim', 'pocket'],
     preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: false,
     forceGeneratedChromePlates: false,
@@ -73,62 +77,114 @@ export function resolvePoolRoyaleTableModel(modelId) {
   );
 }
 
+
+const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
+  { id: 'peelingPaintWeathered', label: 'Wood Peeling Paint Weathered', color: '#b8b3aa', textureId: 'wood_peeling_paint_weathered' },
+  { id: 'oakVeneer01', label: 'Oak Veneer 01', color: '#c89a64', textureId: 'oak_veneer_01' },
+  { id: 'woodTable001', label: 'Wood Table 001', color: '#a4724f', textureId: 'wood_table_001' },
+  { id: 'darkWood', label: 'Dark Wood', color: '#3d2f2a', textureId: 'dark_wood' },
+  { id: 'rosewoodVeneer01', label: 'Rosewood Veneer 01', color: '#6f3a2f', textureId: 'rosewood_veneer_01' },
+  { id: 'carbonFiberChalk', label: 'LT Black', color: '#2a313d', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkGrey', label: 'LT Grey', color: '#c8d0da', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkBeige', label: 'LT Dark Grey', color: '#727d8b', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkBlue', label: 'LT Burgundy', color: '#c17276', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkWhite', label: 'LT Milk Cream', color: '#f8eedf', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkGreen', label: 'LT Dark Green', color: '#548460', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkYellow', label: 'LT Dark Yellow', color: '#d1a652', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkBrown', label: 'LT Dark Brown', color: '#956b4f', textureId: 'fabric_083' },
+  { id: 'carbonFiberChalkDarkRed', label: 'LT Dark Red', color: '#aa5151', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorOlive', label: 'LT Olive Fabric', color: '#687047', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorSwamp', label: 'LT Swamp Fabric', color: '#52623f', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorClay', label: 'LT Clay Fabric', color: '#6f5b45', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorSand', label: 'LT Sand Fabric', color: '#8a7b5e', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorMoss', label: 'LT Moss Fabric', color: '#4f6048', textureId: 'fabric_083' },
+  { id: 'carbonFiberAlligatorNight', label: 'LT Night Fabric', color: '#2f3c32', textureId: 'fabric_083' }
+]);
+
+const buildShowoodFinishOptions = () =>
+  Object.freeze(
+    SHOWOOD_TABLE_FINISH_TEXTURES.reduce((acc, option) => {
+      acc[option.id] = Object.freeze({
+        ...option,
+        finishId: option.id,
+        thumbnail: option.textureId ? polyHavenThumb(option.textureId) : swatchThumbnail([option.color, '#ffffff'])
+      });
+      return acc;
+    }, {})
+  );
+
+const buildShowoodClothOptions = () =>
+  Object.freeze(
+    POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
+      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`;
+      acc[variant.id] = Object.freeze({
+        label: variant.name,
+        color,
+        textureKey: variant.id,
+        sourceId: variant.sourceId,
+        thumbnail: variant.thumbnail,
+        metalness: 0,
+        roughness: 1,
+        envMapIntensity: 0.16
+      });
+      return acc;
+    }, {})
+  );
+
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cloth',
   'cushion',
   'metalAccent',
-  'jaws',
+  'pocketJaw',
   'topWoodRail',
   'legBase'
 ]);
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
-  cloth: 'a',
-  cushion: 'a',
-  metalAccent: 'a',
-  jaws: 'a',
-  topWoodRail: 'a',
-  legBase: 'b'
+  cloth: 'cabanGreenClassic',
+  cushion: 'cabanGreenForest',
+  metalAccent: 'gold',
+  pocketJaw: 'plastic-black',
+  topWoodRail: 'woodTable001',
+  legBase: 'darkWood'
 });
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
-  cloth: { label: 'Field cloth', description: 'Only the flat playfield surface.' },
+  cloth: { label: 'Field cloth', description: 'All cloth-library textures for only the flat playfield surface.' },
   cushion: {
     label: 'Cushions',
-    description: 'Matched green or Black rubber; source cushion texture is preserved like the reference preview.'
+    description: 'All cloth-library textures for the cushion faces, separate from the field.'
   },
   metalAccent: {
-    label: 'Rail sights + side strip + feet',
-    description: 'One gold/chrome control for rail sights, side apron strip, rims, trims, plates, and feet.'
+    label: 'Rail sights + apron + feet + rims',
+    description: 'Gold, chrome, or black for Showood rail sights, side apron, feet, and Rooney/corner rims.'
   },
-  jaws: { label: 'Jaws', description: 'Pocket jaws / cups: black or brown.' },
-  topWoodRail: { label: 'Top rail frame', description: 'Main top wood rail frame.' },
-  legBase: { label: 'Legs + base', description: 'Legs and lower base blocks together, separate from metal accents.' }
+  pocketJaw: { label: 'Pockets + jaws', description: 'Uses the same pocket-jaw texture options as the main game menu.' },
+  topWoodRail: { label: 'Top rail frame', description: 'All GLTF table-finish textures for the main top wood rail frame.' },
+  legBase: { label: 'Legs + base', description: 'All GLTF table-finish textures for legs and lower base blocks only.' }
+});
+
+const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions();
+const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions();
+const SHOWOOD_METAL_ACCENT_OPTIONS = Object.freeze({
+  gold: Object.freeze({ label: 'Gold', color: '#d4af37', metalAccentId: 'gold' }),
+  chrome: Object.freeze({ label: 'Chrome', color: '#d6d8dc', metalAccentId: 'chrome' }),
+  black: Object.freeze({ label: 'Black', color: '#050505', metalAccentId: 'black' })
+});
+const SHOWOOD_POCKET_JAW_OPTIONS = Object.freeze({
+  'plastic-black': Object.freeze({ label: 'Plastic Black Jaws', color: '#151515', pocketLinerId: 'plastic-black' }),
+  'plastic-dark-grey': Object.freeze({ label: 'Plastic Dark Grey Jaws', color: '#2c2f33', pocketLinerId: 'plastic-dark-grey' }),
+  'plastic-grey': Object.freeze({ label: 'Plastic Grey Jaws', color: '#5b5f64', pocketLinerId: 'plastic-grey' }),
+  'plastic-light-grey': Object.freeze({ label: 'Plastic Light Grey Jaws', color: '#b8bcc2', pocketLinerId: 'plastic-light-grey' }),
+  'plastic-magnolia': Object.freeze({ label: 'Plastic Magnolia Jaws', color: '#f4f0e6', pocketLinerId: 'plastic-magnolia' }),
+  'brown-showood': Object.freeze({ label: 'Brown Showood Jaws', color: '#2a1207', pocketLinerId: 'brown-showood' })
 });
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
-  cloth: Object.freeze({
-    a: Object.freeze({ label: 'Green field', color: '#0a7b33', metalness: 0, roughness: 1, envMapIntensity: 0.16 }),
-    b: Object.freeze({ label: 'Blue field', color: '#0d4fb8', metalness: 0, roughness: 1, envMapIntensity: 0.16 })
-  }),
-  cushion: Object.freeze({
-    a: Object.freeze({ label: 'Matched green', color: '#064f22', metalness: 0, roughness: 0.88, envMapIntensity: 0.55 }),
-    b: Object.freeze({ label: 'Black rubber', color: '#050505', metalness: 0, roughness: 0.86, envMapIntensity: 0.55 })
-  }),
-  metalAccent: Object.freeze({
-    a: Object.freeze({ label: 'Gold', color: '#d8b23d', metalness: 0.98, roughness: 0.06, envMapIntensity: 6.8, clearcoat: 1, clearcoatRoughness: 0.03 }),
-    b: Object.freeze({ label: 'Chrome', color: '#d7dde7', metalness: 1, roughness: 0.055, envMapIntensity: 7.2, clearcoat: 1, clearcoatRoughness: 0.025 })
-  }),
-  jaws: Object.freeze({
-    a: Object.freeze({ label: 'Black jaws', color: '#020202', metalness: 0, roughness: 0.96, envMapIntensity: 0.14 }),
-    b: Object.freeze({ label: 'Brown jaws', color: '#2a1207', metalness: 0, roughness: 0.88, envMapIntensity: 0.26 })
-  }),
-  topWoodRail: Object.freeze({
-    a: Object.freeze({ label: 'Walnut frame', color: '#5a2608', metalness: 0.02, roughness: 0.38, envMapIntensity: 1.35, clearcoat: 0.42, clearcoatRoughness: 0.18 }),
-    b: Object.freeze({ label: 'Black frame', color: '#070605', metalness: 0.04, roughness: 0.28, envMapIntensity: 1.75, clearcoat: 0.7, clearcoatRoughness: 0.1 })
-  }),
-  legBase: Object.freeze({
-    a: Object.freeze({ label: 'Brown legs/base', color: '#3d1706', metalness: 0.02, roughness: 0.52, envMapIntensity: 1, clearcoat: 0.2, clearcoatRoughness: 0.36 }),
-    b: Object.freeze({ label: 'Black legs/base', color: '#070504', metalness: 0.04, roughness: 0.4, envMapIntensity: 1.22, clearcoat: 0.32, clearcoatRoughness: 0.26 })
-  })
+  cloth: SHOWOOD_CLOTH_OPTIONS,
+  cushion: SHOWOOD_CLOTH_OPTIONS,
+  metalAccent: SHOWOOD_METAL_ACCENT_OPTIONS,
+  pocketJaw: SHOWOOD_POCKET_JAW_OPTIONS,
+  topWoodRail: SHOWOOD_FINISH_OPTIONS,
+  legBase: SHOWOOD_FINISH_OPTIONS
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3666,6 +3666,16 @@ const CHROME_COLOR_OPTIONS = Object.freeze([
     clearcoat: 0.5,
     clearcoatRoughness: 0.06,
     envMapIntensity: 0.72
+  },
+  {
+    id: 'black',
+    label: 'Black',
+    color: 0x050505,
+    metalness: 0.72,
+    roughness: 0.2,
+    clearcoat: 0.52,
+    clearcoatRoughness: 0.08,
+    envMapIntensity: 0.62
   }
 ]);
 
@@ -12148,7 +12158,6 @@ const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   cushion: 'cushion',
   topWoodRail: 'topWoodRail',
   sideWoodApron: 'metalAccent',
-  pocketCup: 'jaws',
   cornerPocketPlate: 'metalAccent',
   middlePocketPlate: 'metalAccent',
   verticalCornerRim: 'metalAccent',
@@ -12160,23 +12169,36 @@ const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   underside: 'legBase',
   trim: 'metalAccent',
   wood: 'topWoodRail',
-  pocket: 'jaws'
+  pocketCup: 'pocketJaw',
+  pocket: 'pocketJaw'
 });
-const POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS = new Set([
-  'cushion',
-  'topWoodRail',
-  'leg',
-  'baseCornerBlock',
-  'underside'
-]);
+const POOL_ROYALE_SHOWOOD_LEGACY_CHOICE_FALLBACKS = Object.freeze({
+  cloth: { a: 'cabanGreenClassic', b: 'cabanBlueRoyal' },
+  cushion: { a: 'cabanGreenForest', b: 'cabanDarkGreyCharcoal' },
+  metalAccent: { a: 'gold', b: 'chrome' },
+  pocketJaw: { a: 'plastic-black', b: 'brown-showood' },
+  topWoodRail: { a: 'woodTable001', b: 'darkWood' },
+  legBase: { a: 'rosewoodVeneer01', b: 'darkWood' }
+});
 
 function resolvePoolRoyaleShowoodPalette(tableModel = null) {
-  return {
+  const raw = {
     ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
     ...(tableModel?.showoodPalette && typeof tableModel.showoodPalette === 'object'
       ? tableModel.showoodPalette
       : {})
   };
+  POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS.forEach((control) => {
+    const options = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control] || {};
+    const current = raw[control];
+    if (!options[current]) {
+      raw[control] =
+        POOL_ROYALE_SHOWOOD_LEGACY_CHOICE_FALLBACKS[control]?.[current] ||
+        POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] ||
+        Object.keys(options)[0];
+    }
+  });
+  return raw;
 }
 
 function clearPoolRoyaleMaterialTextureMaps(material) {
@@ -12190,6 +12212,157 @@ function clearPoolRoyaleMaterialTextureMaps(material) {
   material.emissiveMap = null;
   material.lightMap = null;
   material.alphaMap = null;
+}
+
+
+function copyPoolRoyaleMaterialLook(target, source) {
+  if (!target || !source) return;
+  if (source.color && target.color) target.color.copy(source.color);
+  if (source.emissive && target.emissive) target.emissive.copy(source.emissive);
+  [
+    'roughness',
+    'metalness',
+    'clearcoat',
+    'clearcoatRoughness',
+    'sheen',
+    'sheenRoughness',
+    'reflectivity',
+    'envMapIntensity',
+    'emissiveIntensity',
+    'bumpScale'
+  ].forEach((key) => {
+    if (typeof source[key] === 'number' && key in target) target[key] = source[key];
+  });
+  target.map = clonePoolRoyaleMaterialTexture(source.map, { isColor: true });
+  target.normalMap = clonePoolRoyaleMaterialTexture(source.normalMap);
+  target.roughnessMap = clonePoolRoyaleMaterialTexture(source.roughnessMap);
+  target.aoMap = clonePoolRoyaleMaterialTexture(source.aoMap);
+  target.metalnessMap = clonePoolRoyaleMaterialTexture(source.metalnessMap);
+  target.bumpMap = clonePoolRoyaleMaterialTexture(source.bumpMap);
+}
+
+function getPoolRoyaleShowoodWoodSurfaceForFinish(finish, control, finishInfo = null) {
+  const defaultWoodOption = WOOD_GRAIN_OPTIONS_BY_ID[DEFAULT_WOOD_GRAIN_ID] ?? WOOD_GRAIN_OPTIONS[0];
+  const resolvedWoodOption =
+    finish?.woodTexture ||
+    (finish?.woodTextureId && WOOD_GRAIN_OPTIONS_BY_ID[finish.woodTextureId]) ||
+    defaultWoodOption;
+  const fallbackSurface =
+    control === 'topWoodRail'
+      ? finishInfo?.parts?.woodSurfaces?.rail
+      : finishInfo?.parts?.woodSurfaces?.frame;
+  const baseSurface = resolveWoodSurfaceConfig(
+    resolvedWoodOption?.frame,
+    resolvedWoodOption?.rail ?? defaultWoodOption.frame ?? defaultWoodOption.rail ?? fallbackSurface
+  );
+  const usesPolyHavenWoodMaps =
+    typeof baseSurface.mapUrl === 'string' && baseSurface.mapUrl.includes('polyhaven.org');
+  const textureSize = usesPolyHavenWoodMaps
+    ? (baseSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE)
+    : enforceHighFpsTableTextureSize(baseSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE);
+  const repeatScale = clampWoodRepeatScaleValue(finish?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE);
+  const railMultiplier = control === 'topWoodRail' && usesPolyHavenWoodMaps
+    ? GLTF_RAIL_PATTERN_REPEAT_MULTIPLIER
+    : 1;
+  return {
+    repeat: new THREE.Vector2(
+      (baseSurface.repeat?.x ?? 1) * railMultiplier,
+      baseSurface.repeat?.y ?? 1
+    ),
+    rotation: baseSurface.rotation,
+    textureSize,
+    mapUrl: baseSurface.mapUrl,
+    roughnessMapUrl: baseSurface.roughnessMapUrl,
+    normalMapUrl: baseSurface.normalMapUrl,
+    woodRepeatScale: repeatScale
+  };
+}
+
+function applyPoolRoyaleShowoodWoodFinishMaterial(mat, control, option, finishInfo = null) {
+  const finish = TABLE_FINISHES[option?.finishId] ?? TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
+  const rawMaterials = typeof finish?.createMaterials === 'function'
+    ? finish.createMaterials()
+    : TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID].createMaterials();
+  const source = control === 'topWoodRail'
+    ? rawMaterials.rail || rawMaterials.frame
+    : rawMaterials.leg || rawMaterials.frame || rawMaterials.rail;
+  copyPoolRoyaleMaterialLook(mat, source);
+  mat.userData = {
+    ...(mat.userData || {}),
+    baseTintHex: mat.color?.getHex?.()
+  };
+  if (finish?.disableWoodPattern) {
+    if (finish?.useBrandCarbonTexture) applyLtCarbonFiberTexture(mat);
+    else clearPoolRoyaleMaterialTextureMaps(mat);
+  } else {
+    applyWoodTextureToMaterial(
+      mat,
+      getPoolRoyaleShowoodWoodSurfaceForFinish(finish, control, finishInfo)
+    );
+  }
+  applyTableFinishDulling(mat);
+  applyTableWoodVisibilityTuning(mat);
+  if (finish?.surfaceStyle === 'matte') {
+    if (finish?.preserveFinishTintOnWood) applyMatteSurfacePropsOnly(mat);
+    else applyMonoMattePlasticSurface(mat);
+  }
+  applyFinishWoodTint(mat, finish);
+}
+
+function applyPoolRoyaleShowoodClothLibraryMaterial(mat, control, option, finishInfo = null) {
+  const source = control === 'cushion' ? finishInfo?.cushionMat : finishInfo?.clothMat;
+  copyPoolRoyaleMaterialLook(mat, source || finishInfo?.clothMat);
+  const textureKey = option?.textureKey;
+  const textureSource = option?.sourceId || option?.textureKey || DEFAULT_CLOTH_TEXTURE_SOURCE_ID;
+  if (textureKey) {
+    const textures = createClothTextures(textureKey, textureSource);
+    const assignTexture = (prop, texture, isColor = false) => {
+      mat[prop] = texture;
+      if (!texture) return;
+      if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+      texture.wrapS = THREE.RepeatWrapping;
+      texture.wrapT = THREE.RepeatWrapping;
+      texture.anisotropy = resolveTextureAnisotropy(12);
+      texture.needsUpdate = true;
+    };
+    assignTexture('map', textures.map, true);
+    assignTexture('normalMap', textures.normal);
+    assignTexture('bumpMap', textures.normal ? null : textures.bump);
+    assignTexture('roughnessMap', textures.roughness);
+  }
+  if (mat.color && option?.color) mat.color.set(option.color);
+  if (mat.emissive && mat.color) mat.emissive.copy(mat.color).multiplyScalar(0.045);
+  if ('metalness' in mat) mat.metalness = option?.metalness ?? 0;
+  if ('roughness' in mat) mat.roughness = option?.roughness ?? mat.roughness ?? 1;
+  if ('envMapIntensity' in mat) mat.envMapIntensity = option?.envMapIntensity ?? 0;
+  mat.userData = {
+    ...(mat.userData || {}),
+    poolRoyaleMatchProceduralClothRepeat: true
+  };
+}
+
+function applyPoolRoyaleShowoodMetalAccentMaterial(mat, option) {
+  const preset = CHROME_COLOR_OPTIONS.find((entry) => entry.id === option?.metalAccentId || entry.id === option?.id) ||
+    CHROME_COLOR_OPTIONS.find((entry) => entry.id === 'gold') ||
+    CHROME_COLOR_OPTIONS[0];
+  if (!preset) return;
+  mat.color?.set?.(preset.color);
+  if ('metalness' in mat) mat.metalness = preset.metalness;
+  if ('roughness' in mat) mat.roughness = preset.roughness;
+  if ('clearcoat' in mat) mat.clearcoat = preset.clearcoat ?? 0;
+  if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = preset.clearcoatRoughness ?? 0;
+  if ('envMapIntensity' in mat) mat.envMapIntensity = preset.envMapIntensity ?? mat.envMapIntensity ?? 1;
+  mat.needsUpdate = true;
+}
+
+function applyPoolRoyaleShowoodPocketJawMaterial(mat, option, finishInfo = null) {
+  const linerId = option?.pocketLinerId || DEFAULT_POCKET_LINER_OPTION_ID;
+  const linerOption = POCKET_LINER_OPTIONS.find((entry) => entry.id === linerId) ||
+    POCKET_LINER_OPTIONS[0];
+  const liners = createPocketLinerMaterials(linerOption);
+  const source = liners?.jawMaterial || finishInfo?.materials?.pocketJaw;
+  copyPoolRoyaleMaterialLook(mat, source);
+  mat.needsUpdate = true;
 }
 
 function classifyPoolRoyaleShowoodReferencePart(child, material) {
@@ -12214,27 +12387,42 @@ function classifyPoolRoyaleShowoodReferencePart(child, material) {
   }
   if (/leg/.test(label)) return 'leg';
   if (/base|block|support|underside/.test(label)) return 'baseCornerBlock';
-  if (/rail|frame|top|wood|walnut|showood|apron|cabinet|corner/.test(label)) return 'topWoodRail';
+  if (/apron|side[_\s-]*(strip|apron|panel)|cabinet/.test(label)) return 'sideWoodApron';
+  if (/rail|frame|top|wood|walnut|showood|corner/.test(label)) return 'topWoodRail';
   if (green) return 'cloth';
   return 'sideWoodApron';
 }
 
-function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null) {
+function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null, finishInfo = null) {
   if (!material) return material;
   const mat = material.clone ? material.clone() : material;
+  preparePoolRoyaleExternalTexture(mat.map, true);
+  preparePoolRoyaleExternalTexture(mat.emissiveMap, true);
+  preparePoolRoyaleExternalTexture(mat.aoMap, false);
+  preparePoolRoyaleExternalTexture(mat.normalMap, false);
+  preparePoolRoyaleExternalTexture(mat.roughnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.metalnessMap, false);
+  preparePoolRoyaleExternalTexture(mat.bumpMap, false);
   const control = POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[part] || POOL_ROYALE_SHOWOOD_PART_TO_CONTROL[classifyPoolRoyaleExternalTableSurface(null, mat)] || 'topWoodRail';
   const palette = resolvePoolRoyaleShowoodPalette(tableModel);
-  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] || 'a';
-  const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice] || POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.a;
+  const choice = palette[control] || POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE[control] || Object.keys(POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control] || {})[0];
+  const option = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control]?.[choice];
   if (!option) return mat;
-  mat.color?.set?.(option.color);
-  if ('metalness' in mat) mat.metalness = option.metalness;
-  if ('roughness' in mat) mat.roughness = option.roughness;
-  if ('envMapIntensity' in mat) mat.envMapIntensity = option.envMapIntensity;
-  if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? 0;
-  if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? 0;
-  if (!POOL_ROYALE_SHOWOOD_KEEP_TEXTURE_PARTS.has(part)) {
-    clearPoolRoyaleMaterialTextureMaps(mat);
+  if (control === 'cloth' || control === 'cushion') {
+    applyPoolRoyaleShowoodClothLibraryMaterial(mat, control, option, finishInfo);
+  } else if (control === 'topWoodRail' || control === 'legBase') {
+    applyPoolRoyaleShowoodWoodFinishMaterial(mat, control, option, finishInfo);
+  } else if (control === 'metalAccent') {
+    applyPoolRoyaleShowoodMetalAccentMaterial(mat, option);
+  } else if (control === 'pocketJaw') {
+    applyPoolRoyaleShowoodPocketJawMaterial(mat, option, finishInfo);
+  } else {
+    mat.color?.set?.(option.color);
+    if ('metalness' in mat) mat.metalness = option.metalness;
+    if ('roughness' in mat) mat.roughness = option.roughness;
+    if ('envMapIntensity' in mat) mat.envMapIntensity = option.envMapIntensity;
+    if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? 0;
+    if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? 0;
   }
   mat.transparent = false;
   mat.opacity = 1;
@@ -12498,7 +12686,7 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
         child.visible = false;
       }
       if (tableModel?.useReferenceShowoodMapping) {
-        const nextMaterial = applyPoolRoyaleShowoodReferenceMaterial(material, referencePart || role, tableModel);
+        const nextMaterial = applyPoolRoyaleShowoodReferenceMaterial(material, referencePart || role, tableModel, finishInfo);
         normalizePoolRoyaleExternalClothTextureScale(child, nextMaterial, role);
         return nextMaterial;
       }
@@ -13486,6 +13674,12 @@ function mountPoolRoyaleExternalTableModel({
   if (resolvedTableOptions?.tableModel?.hideGeneratedCushionsAndJaws) {
     [
       ...(Array.isArray(table.userData.cushions) ? table.userData.cushions : []),
+      ...finishParts.pocketJawMeshes,
+      ...finishParts.pocketRimMeshes,
+      ...pocketMeshes
+    ].forEach(markGeneratedCushionsAndJawsHiddenByExternalTable);
+  } else if (resolvedTableOptions?.tableModel?.hideGeneratedPocketsAndJaws) {
+    [
       ...finishParts.pocketJawMeshes,
       ...finishParts.pocketRimMeshes,
       ...pocketMeshes
@@ -35887,6 +36081,15 @@ const shotPowerRef = useRef(0);
                                     style={{ backgroundColor: option.color }}
                                     aria-hidden="true"
                                   />
+                                  {option.thumbnail ? (
+                                    <img
+                                      src={option.thumbnail}
+                                      alt=""
+                                      className="h-5 w-8 rounded-md border border-white/20 object-cover"
+                                      loading="lazy"
+                                      aria-hidden="true"
+                                    />
+                                  ) : null}
                                   <span>{option.label}</span>
                                 </button>
                               );

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,10 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_SHOWOOD_CONTROL_META,
-  POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS,
-  POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
-  POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS,
   POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
@@ -43,7 +39,6 @@ const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
 const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
-const POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY = 'poolRoyaleShowoodMaterialPalette';
 
 function resolveTpcAccountNumber(player) {
   if (!player || typeof player !== 'object') return '';
@@ -91,24 +86,11 @@ export default function PoolRoyaleLobby() {
     } catch {}
     return resolvePoolRoyaleTableModel().id;
   });
-  const [showoodPalette, setShowoodPalette] = useState(() => {
-    try {
-      const stored = JSON.parse(
-        window.localStorage?.getItem(POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY) || 'null'
-      );
-      if (stored && typeof stored === 'object') {
-        return { ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE, ...stored };
-      }
-    } catch {}
-    return { ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE };
-  });
   const [players, setPlayers] = useState(8);
-  const selectedTableModel = useMemo(() => {
-    const model = resolvePoolRoyaleTableModel(tableModelId);
-    return model?.useReferenceShowoodMapping
-      ? { ...model, showoodPalette }
-      : model;
-  }, [showoodPalette, tableModelId]);
+  const selectedTableModel = useMemo(
+    () => resolvePoolRoyaleTableModel(tableModelId),
+    [tableModelId]
+  );
   const tableSize = resolveTableSize(
     selectedTableModel?.tableSizeId || searchParams.get('tableSize')
   ).id;
@@ -227,9 +209,6 @@ export default function PoolRoyaleLobby() {
       params.set('ballSet', 'american');
     }
     params.set('tableModel', selectedTableModel.id);
-    if (selectedTableModel.useReferenceShowoodMapping) {
-      params.set('showoodPalette', JSON.stringify(showoodPalette));
-    }
     params.set('type', playType);
     params.set('mode', 'online');
     params.set('tableId', startedId);
@@ -279,12 +258,6 @@ export default function PoolRoyaleLobby() {
         window.localStorage?.setItem(
           TABLE_BASE_STORAGE_KEY,
           selectedTableModel.baseId
-        );
-      }
-      if (selectedTableModel.useReferenceShowoodMapping) {
-        window.localStorage?.setItem(
-          POOL_ROYALE_SHOWOOD_PALETTE_STORAGE_KEY,
-          JSON.stringify(showoodPalette)
         );
       }
     } catch {}
@@ -358,9 +331,6 @@ export default function PoolRoyaleLobby() {
     }
     params.set('tableSize', tableSize);
     params.set('tableModel', selectedTableModel.id);
-    if (selectedTableModel.useReferenceShowoodMapping) {
-      params.set('showoodPalette', JSON.stringify(showoodPalette));
-    }
     params.set(
       'type',
       effectivePlayType === 'friendly' ? 'regular' : effectivePlayType
@@ -699,64 +669,8 @@ export default function PoolRoyaleLobby() {
             })}
           </div>
           <p className="text-xs text-white/60">
-            Royal Original now keeps TonPlaygram shell/chrome but uses GLB cushions and pocket jaws; Showood uses the reference texture mapping and option set.
+            Royal Original keeps the clean procedural table; Showood material setup is available inside the in-game menu only.
           </p>
-          {selectedTableModel.useReferenceShowoodMapping ? (
-            <div className="rounded-2xl border border-amber-300/20 bg-black/25 p-3">
-              <div className="mb-2 flex items-center justify-between gap-2">
-                <div>
-                  <h4 className="text-sm font-semibold text-white">Showood table setup</h4>
-                  <p className="text-[11px] text-white/55">Same material options as the supplied reference preview.</p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setShowoodPalette({ ...POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE })}
-                  className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-white/80"
-                >
-                  Reset
-                </button>
-              </div>
-              <div className="space-y-3">
-                {POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS.map((control) => {
-                  const meta = POOL_ROYALE_SHOWOOD_CONTROL_META[control];
-                  const options = POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS[control];
-                  return (
-                    <div key={control} className="rounded-xl border border-white/10 bg-white/5 p-2">
-                      <div className="mb-2">
-                        <p className="text-[11px] font-black uppercase tracking-[0.22em] text-emerald-100">{meta.label}</p>
-                        <p className="text-[10px] leading-snug text-white/50">{meta.description}</p>
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        {['a', 'b'].map((choice) => {
-                          const option = options[choice];
-                          const active = showoodPalette[control] === choice;
-                          return (
-                            <button
-                              key={`${control}-${choice}`}
-                              type="button"
-                              onClick={() => setShowoodPalette((current) => ({ ...current, [control]: choice }))}
-                              className={`flex flex-1 items-center justify-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-extrabold transition ${
-                                active
-                                  ? 'border-white/80 bg-white/20 text-white shadow-[0_0_14px_rgba(255,255,255,0.22)]'
-                                  : 'border-white/15 bg-white/5 text-white/70'
-                              }`}
-                            >
-                              <span
-                                className="h-3.5 w-3.5 rounded-full border border-white/40"
-                                style={{ backgroundColor: option.color }}
-                                aria-hidden="true"
-                              />
-                              <span>{option.label}</span>
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          ) : null}
         </div>
 
         <div className="space-y-3">


### PR DESCRIPTION
### Motivation
- Introduce a gloss black chrome hardware option to the store, defaults, and UI to expand visual choices for rails and trim.
- Replace the old simplistic Showood palette with a richer, modular material system that maps GLB reference parts to cloth, wood, metal, and pocket-jaw controls so external Showood models render correctly.
- Move Showood customization out of the lobby and into the in-game menu while adding robust texture/thumbnail support and legacy-fallback handling for palettes.

### Description
- Add `black` chrome color across `poolRoyaleInventoryConfig.js` including `POOL_ROYALE_DEFAULT_UNLOCKS`, `POOL_ROYALE_OPTION_LABELS.chromeColor`, a new store item, and include it in the `POOL_ROYALE_DEFAULT_LOADOUT`.
- Rework `poolRoyaleTableModels.js` to introduce `SHOWOOD_TABLE_FINISH_TEXTURES`, builder helpers for cloth/finish options, new `POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS` (cloth, cushion, metalAccent, pocketJaw, topWoodRail, legBase), and legacy choice fallbacks; rename and re-map jaw/pocket roles from `jaws` to `pocketJaw`.
- Implement multiple material utility functions in `poolRoyaleTableModels.js` such as `copyPoolRoyaleMaterialLook`, `getPoolRoyaleShowoodWoodSurfaceForFinish`, `applyPoolRoyaleShowoodWoodFinishMaterial`, `applyPoolRoyaleShowoodClothLibraryMaterial`, `applyPoolRoyaleShowoodMetalAccentMaterial`, and `applyPoolRoyaleShowoodPocketJawMaterial` to correctly apply textures, maps, and parameters to cloned materials for external GLTFs.
- Improve classification and preparation of external table surfaces and textures with updated `classifyPoolRoyaleShowoodReferencePart`, `classifyPoolRoyaleExternalTableSurface`, `applyPoolRoyaleShowoodReferenceMaterial`, and `preparePoolRoyaleExternalTableMaterials` to support thumbnails, KTX2 textures, and preserve or replace parts as appropriate.
- Update `PoolRoyale.jsx` to add the `black` entry to `CHROME_COLOR_OPTIONS`, expose thumbnails in Showood selection buttons, and integrate the new material mapping logic when mounting external tables.
- Simplify lobby behavior in `PoolRoyaleLobby.jsx` by removing persistent Showood palette state and the lobby palette editor while keeping table model selection behavior consistent.

### Testing
- Ran `npm run lint` and the code passed lint checks without errors.
- Built the production bundle with `npm run build` and the build completed successfully.
- Ran the test suite with `npm test` and unit tests passed (no failing tests reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3a6a09b48329b1c8821bea9c4485)