### PR TITLE
Tune Pool Royale table visuals and power

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,10 +1,10 @@
-import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
-import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js'
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js'
 
-export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
 const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
@@ -48,7 +48,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.055,
-    lowerBaseHeightScale: 1.16,
+    lowerBaseHeightScale: 1.28,
+    topRailFrameHeightScale: 0.88,
     clothRepeatScale: 5.25,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
@@ -65,20 +66,19 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     hideSurfaceRoles: [],
     hideGeneratedRailMarkers: true
   }
-]);
+])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === 'royal-original')?.id ||
-  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
-export function resolvePoolRoyaleTableModel(modelId) {
-  const key = typeof modelId === 'string' ? modelId.trim() : '';
+export function resolvePoolRoyaleTableModel (modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : ''
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  )
 }
-
 
 const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
   { id: 'peelingPaintWeathered', label: 'Wood Peeling Paint Weathered', color: '#b8b3aa', textureId: 'wood_peeling_paint_weathered' },
@@ -101,7 +101,7 @@ const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
   { id: 'carbonFiberAlligatorSand', label: 'LT Sand Fabric', color: '#8a7b5e', textureId: 'fabric_083' },
   { id: 'carbonFiberAlligatorMoss', label: 'LT Moss Fabric', color: '#4f6048', textureId: 'fabric_083' },
   { id: 'carbonFiberAlligatorNight', label: 'LT Night Fabric', color: '#2f3c32', textureId: 'fabric_083' }
-]);
+])
 
 const buildShowoodFinishOptions = () =>
   Object.freeze(
@@ -110,15 +110,15 @@ const buildShowoodFinishOptions = () =>
         ...option,
         finishId: option.id,
         thumbnail: option.textureId ? polyHavenThumb(option.textureId) : swatchThumbnail([option.color, '#ffffff'])
-      });
-      return acc;
+      })
+      return acc
     }, {})
-  );
+  )
 
 const buildShowoodClothOptions = () =>
   Object.freeze(
     POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
-      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`;
+      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`
       acc[variant.id] = Object.freeze({
         label: variant.name,
         color,
@@ -128,10 +128,10 @@ const buildShowoodClothOptions = () =>
         metalness: 0,
         roughness: 1,
         envMapIntensity: 0.16
-      });
-      return acc;
+      })
+      return acc
     }, {})
-  );
+  )
 
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cloth',
@@ -140,7 +140,7 @@ export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'pocketJaw',
   'topWoodRail',
   'legBase'
-]);
+])
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   cloth: 'cabanGreenClassic',
@@ -149,7 +149,7 @@ export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   pocketJaw: 'plastic-black',
   topWoodRail: 'woodTable001',
   legBase: 'darkWood'
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   cloth: { label: 'Field cloth', description: 'All cloth-library textures for only the flat playfield surface.' },
@@ -164,15 +164,15 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   pocketJaw: { label: 'Pockets + jaws', description: 'Uses the same pocket-jaw texture options as the main game menu.' },
   topWoodRail: { label: 'Top rail frame', description: 'All GLTF table-finish textures for the main top wood rail frame.' },
   legBase: { label: 'Legs + base', description: 'All GLTF table-finish textures for legs and lower base blocks only.' }
-});
+})
 
-const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions();
-const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions();
+const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions()
+const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions()
 const SHOWOOD_METAL_ACCENT_OPTIONS = Object.freeze({
   gold: Object.freeze({ label: 'Gold', color: '#d4af37', metalAccentId: 'gold' }),
   chrome: Object.freeze({ label: 'Chrome', color: '#d6d8dc', metalAccentId: 'chrome' }),
   black: Object.freeze({ label: 'Black', color: '#050505', metalAccentId: 'black' })
-});
+})
 const SHOWOOD_POCKET_JAW_OPTIONS = Object.freeze({
   'plastic-black': Object.freeze({ label: 'Plastic Black Jaws', color: '#151515', pocketLinerId: 'plastic-black' }),
   'plastic-dark-grey': Object.freeze({ label: 'Plastic Dark Grey Jaws', color: '#2c2f33', pocketLinerId: 'plastic-dark-grey' }),
@@ -180,7 +180,7 @@ const SHOWOOD_POCKET_JAW_OPTIONS = Object.freeze({
   'plastic-light-grey': Object.freeze({ label: 'Plastic Light Grey Jaws', color: '#b8bcc2', pocketLinerId: 'plastic-light-grey' }),
   'plastic-magnolia': Object.freeze({ label: 'Plastic Magnolia Jaws', color: '#f4f0e6', pocketLinerId: 'plastic-magnolia' }),
   'brown-showood': Object.freeze({ label: 'Brown Showood Jaws', color: '#2a1207', pocketLinerId: 'brown-showood' })
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   cloth: SHOWOOD_CLOTH_OPTIONS,
@@ -189,4 +189,4 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   pocketJaw: SHOWOOD_POCKET_JAW_OPTIONS,
   topWoodRail: SHOWOOD_FINISH_OPTIONS,
   legBase: SHOWOOD_FINISH_OPTIONS
-});
+})

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1349,7 +1349,7 @@ const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // keep middle jaw arcs the same siz
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.12; // add Showood-like extra depth so side jaws match the corner jaw type
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = -TABLE.THICK * 0.01; // pull middle-pocket jaws a bit farther downward than corners
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.028; // reduce the outward shift so middle-pocket jaws sit a bit more inward toward table center
-const POCKET_JAW_INWARD_PULL = TABLE.THICK * 0.026; // pull procedural jaw centers slightly inward to match the Showood GLB pocket placement
+const POCKET_JAW_INWARD_PULL = TABLE.THICK * 0.034; // pull procedural jaw centers a bit more inward to match the Royal Original pocket placement
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.66; // shorten middle jaw side edges a bit more so all six jaws finish cleaner at the shoulders
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
@@ -1837,7 +1837,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
-const SHOT_GLOBAL_POWER_SCALE = 0.8; // trim Pool Royale shot pace a bit so cue-ball travel is slightly softer
+const SHOT_GLOBAL_POWER_SCALE = 0.72; // trim Pool Royale shot pace further so current Pool Royal power matches the softer target
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -9266,6 +9266,8 @@ export function Table3D(
   }
 
   const markingsGroup = new THREE.Group();
+  markingsGroup.userData.externalTableKeepVisible = true;
+  markingsGroup.userData.externalTableKeepVisibleWithOriginalSurfaces = true;
   const markingMat = new THREE.MeshBasicMaterial({
     color: palette.markings,
     transparent: true,
@@ -9295,6 +9297,12 @@ export function Table3D(
   const topCushionZ = PLAY_H / 2;
   addSpot(0, (topCushionZ + 0) / 2);
   markingsGroup.traverse((child) => {
+    child.userData = {
+      ...(child.userData || {}),
+      externalTableKeepVisible: true,
+      externalTableKeepVisibleWithOriginalSurfaces: true,
+      externalTableReplaceableSurface: false
+    };
     if (child.isMesh) {
       child.renderOrder = cloth.renderOrder + 1;
       child.castShadow = false;
@@ -12840,6 +12848,30 @@ function stretchPoolRoyaleExternalLowerBase(model, tableModel, dims) {
   model.updateMatrixWorld(true);
 }
 
+function compressPoolRoyaleExternalTopRailFrame(model, tableModel) {
+  const scale = Number(tableModel?.topRailFrameHeightScale);
+  if (!model || !Number.isFinite(scale) || scale >= 1 - MICRO_EPS || scale <= MICRO_EPS) return;
+  model.traverse((child) => {
+    if (!child?.isMesh || child.userData?.poolRoyaleTopRailFrameCompressed) return;
+    const material = Array.isArray(child.material) ? child.material[0] : child.material;
+    const referencePart = material?.userData?.poolRoyaleShowoodReferencePart ||
+      classifyPoolRoyaleShowoodReferencePart(child, material);
+    if (!['topWoodRail', 'sideWoodApron'].includes(referencePart)) return;
+    const childBox = new THREE.Box3().setFromObject(child);
+    if (childBox.isEmpty()) return;
+    const anchorWorldY = childBox.max.y;
+    const parent = child.parent || model;
+    const anchorLocal = parent.worldToLocal(new THREE.Vector3(0, anchorWorldY, 0)).y;
+    child.scale.y *= scale;
+    child.updateMatrixWorld(true);
+    const nextBox = new THREE.Box3().setFromObject(child);
+    const nextAnchorLocal = parent.worldToLocal(new THREE.Vector3(0, nextBox.max.y, 0)).y;
+    child.position.y += anchorLocal - nextAnchorLocal;
+    child.userData.poolRoyaleTopRailFrameCompressed = true;
+  });
+  model.updateMatrixWorld(true);
+}
+
 function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   if (!model || !dims) return;
   model.position.set(0, 0, 0);
@@ -12901,6 +12933,7 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   const targetTopLocal = dims.targetTopLocal ?? dims.cushionTopLocal;
   model.position.y += targetTopLocal - fullBox.max.y + (tableModel?.verticalOffset ?? 0);
   model.updateMatrixWorld(true);
+  compressPoolRoyaleExternalTopRailFrame(model, tableModel);
   stretchPoolRoyaleExternalLowerBase(model, tableModel, dims);
   model.userData = {
     ...(model.userData || {}),
@@ -13694,6 +13727,7 @@ function mountPoolRoyaleExternalTableModel({
       if (
         !visible &&
         (
+          object.userData?.externalTableKeepVisibleWithOriginalSurfaces ||
           (!externalTableModelForMount?.useOriginalLayoutSurfaces && object.userData?.externalTableKeepVisible) ||
           (object.userData?.isChromePlate && forceGeneratedChrome)
         )


### PR DESCRIPTION
### Motivation
- Bring the Showood GLB table appearance closer to the Royal Original by tightening pocket jaw placement and matching the top rail/frame proportions. 
- Soften Pool Royale shot feel to better match the target power used elsewhere in the game. 
- Keep the playfield height and important play markings (baulk line, penalty spot) visible when mounting the Showood GLB so gameplay remains consistent.

### Description
- Increased procedural jaw inward pull by updating `POCKET_JAW_INWARD_PULL` to better align procedural jaws with the Royal Original layout in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Reduced runtime shot strength by lowering `SHOT_GLOBAL_POWER_SCALE` to `0.72` to produce softer cue-ball travel in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Added `topRailFrameHeightScale` and bumped `lowerBaseHeightScale` in `webapp/src/config/poolRoyaleTableModels.js` and implemented `compressPoolRoyaleExternalTopRailFrame()` in `webapp/src/pages/Games/PoolRoyale.jsx` so mounted GLB models have a shorter top rail frame while the lower base/legs are extended to preserve the playfield height.
- Ensured white baulk line and penalty spot remain visible when an external Showood GLB is mounted by tagging the generated `markingsGroup` with `externalTableKeepVisible*` flags and allowing the generated-visual visibility logic to honor those flags.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully. 
- Ran unit tests with `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and all tests passed. 
- Applied lint fixes (`npx eslint --no-ignore --fix webapp/src/config/poolRoyaleTableModels.js`) and ran lint via project scripts; lint/fix was applied for the modified config file. 
- Attempted an automated Playwright portrait screenshot to validate the mounted GLB but Chromium failed to launch in the container due to a missing system library (`libatk-1.0.so.0`), so visual screenshot capture could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c8d139b3083298e812d62f3ad9a78)