### PR TITLE
Sync Snooker Royal human/cue logic with Provided rig and fix pocket capture mapping

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -104,6 +104,11 @@ import {
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
+import {
+  createSnookerHumanRig,
+  chooseHumanEdgePosition as chooseProvidedSnookerHumanEdgePosition,
+  updateBilardoHumanPose as updateProvidedSnookerHumanPose
+} from './shared/snookerHumanRig.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -1340,8 +1345,8 @@ const POCKET_INTERIOR_CAPTURE_R =
   POCKET_VIS_R * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // match capture radius directly to the pocket bowl opening
 const SIDE_POCKET_INTERIOR_CAPTURE_R =
   SIDE_POCKET_RADIUS * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // keep middle-pocket capture identical to its bowl radius
-const POCKET_CAPTURE_ASSIST = 0; // keep capture sensors matched to the visible corner pocket mouth
-const SIDE_POCKET_CAPTURE_ASSIST = 0; // keep middle-pocket capture matched to the actual visible pocket size
+const POCKET_CAPTURE_ASSIST = BALL_R * 0.62; // portrait-friendly potting sensor allowance so balls that visibly enter a corner mouth are captured
+const SIDE_POCKET_CAPTURE_ASSIST = BALL_R * 0.58; // match the middle-pocket capture to the visible side-mouth opening without over-widening rails
 const CAPTURE_R =
   POCKET_INTERIOR_CAPTURE_R + POCKET_CAPTURE_ASSIST; // corner captures now use the physical pocket bowl instead of an oversized helper zone
 const SIDE_CAPTURE_R =
@@ -2064,70 +2069,53 @@ function poseSnookerHumanGlb(human, targetsLocal) {
 }
 
 function createSnookerRoyalHumanPlayer(parent, renderer) {
-  const human = {
-    root: new THREE.Group(),
-    modelRoot: new THREE.Group(),
-    fallback: createSnookerHumanFallbackRig(),
-    bones: {},
-    activeGlb: false,
-    yaw: 0,
-    poseT: 0,
-    loaded: false,
-    disabled: false,
-    loadFailed: false,
-    lastRootPosition: new THREE.Vector3(),
-    walkPhase: 0,
-    walkAmount: 0,
-    restQuats: new Map(),
-    theme: SNOOKER_HUMAN_CHARACTER_THEME
-  };
-  human.root.name = 'SnookerRoyalHumanPlayerRoot';
-  human.modelRoot.name = 'SnookerRoyalDominoCharacterRoot';
-  human.root.visible = false;
-  human.modelRoot.visible = false;
-  human.root.add(human.fallback);
-  human.orientationHelpers = createSnookerHumanOrientationHelpers();
-  human.root.add(human.orientationHelpers.group);
-  parent.add(human.root, human.modelRoot);
-  const urls = buildSnookerHumanModelUrls(human.theme);
   const loader = createSnookerHumanGLTFLoader(renderer);
-  loadSnookerHumanModelFromCatalog(loader, urls)
-    .then(({ model, url }) => {
-      normalizeSnookerHumanModel(model);
-      model.traverse((obj) => {
-        if (obj?.isBone) human.restQuats.set(obj, obj.quaternion.clone());
-        if (!obj?.isMesh) return;
-        obj.castShadow = true;
-        obj.receiveShadow = true;
-        obj.frustumCulled = false;
-        const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
-        mats.forEach(tuneSnookerHumanOriginalGlbMaterial);
-      });
-      human.bones = buildSnookerHumanBones(model);
-      human.activeGlb = Boolean(
-        human.bones.head &&
-        human.bones.spine &&
-        human.bones.leftUpperArm &&
-        human.bones.leftLowerArm &&
-        human.bones.rightUpperArm &&
-        human.bones.rightLowerArm
-      );
-      human.modelUrl = url;
-      human.modelRoot.add(model);
-      human.modelRoot.visible = human.root.visible && human.activeGlb;
-      human.fallback.visible = !human.activeGlb;
-      human.loaded = true;
-    })
-    .catch((error) => {
-      human.loadFailed = true;
-      human.activeGlb = false;
-      human.fallback.visible = true;
-      console.warn('Snooker Royal human GLB catalog failed; using fallback pose rig.', error);
-    })
-    .finally(() => disposeSnookerHumanGLTFLoader(loader));
+  const human = createSnookerHumanRig(parent, {
+    loader,
+    modelUrls: buildSnookerHumanModelUrls(SNOOKER_HUMAN_CHARACTER_THEME),
+    unit: SNOOKER_HUMAN_WORLD_SCALE,
+    tableW: PLAY_W,
+    tableL: PLAY_H,
+    tableTopY: BALL_CENTER_Y - BALL_R,
+    groundY: SNOOKER_HUMAN_CFG.floorY,
+    humanScale: 1.2 * SNOOKER_HUMAN_WORLD_SCALE,
+    humanVisualYawFix: Math.PI,
+    stanceWidth: 0.52 * SNOOKER_HUMAN_WORLD_SCALE,
+    edgeMargin: 0.5 * SNOOKER_HUMAN_WORLD_SCALE,
+    desiredShootDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgePalmTableLift: 0.006 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgeHandBackFromBall: 0.235 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgeHandSide: -0.012 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgePoseUsesConfiguredSide: false,
+    chinToCueHeight: 0.11 * SNOOKER_HUMAN_WORLD_SCALE,
+    footGroundY: 0.035 * SNOOKER_HUMAN_WORLD_SCALE,
+    kneeBendShot: 0.16 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightElbowShotRise: 0.18 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightElbowShotSide: -0.46 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightElbowShotBack: -0.78 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightForearmOutward: 0.36 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightForearmBack: 0.44 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightForearmDown: 0.48 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightForearmLength: 0.34 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightStrokePull: 0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightStrokePush: 0.24 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightHandShotLift: -0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+    shootCueGripFromBack: 0.58,
+    shootBendTowardCueStick: false,
+    shootBendMode: 'forward',
+    shootBendDirection: -1,
+    shootCounterLeanSide: -1,
+    shootUpperBodyCounterLean: 1,
+    shootForwardBendScale: 1,
+    forceTableFacingAim: false,
+    plantFeetDuringShot: true,
+    onStatus: (message) => console.info(`Snooker Royal human: ${message}`)
+  });
+  human.disabled = false;
+  human.usesProvidedCueLogic = true;
+  human.loader = loader;
   return human;
 }
-
 function getSnookerCueEndpoints(cueStick, cueLen) {
   if (!cueStick) return null;
   cueStick.updateMatrixWorld(true);
@@ -2151,8 +2139,7 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     visible,
     power = 0,
     shooting = false,
-    cueAnimating = false,
-    tableCueVisible = true
+    cueAnimating = false
   } = options || {};
   const cuePos = cue?.pos;
   if (!cuePos || !cue?.active || !visible) {
@@ -2160,105 +2147,49 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     human.modelRoot.visible = false;
     return;
   }
+
   const dir = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
   if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
   dir.normalize();
-  const side = new THREE.Vector3(-dir.z, 0, dir.x).normalize();
+  const side = new THREE.Vector3(dir.z, 0, -dir.x).normalize();
   const cueBall = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
   const cueEndpoints = resolveSnookerHumanCueEndpoints(cueStick, cueLen, cueBall, dir);
-  const pullPose = THREE.MathUtils.clamp((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0), 0, 1);
-  // Orientation is driven from the actual shot line: the root stands behind
-  // the cue ball on -dir, then faces +dir back through cue ball/object ball.
-  // Keeping local +Z on the shot line prevents mirrored cue/hand placement.
-  const rootTarget = cueBall.clone()
-    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.idleDistance - pullPose * BALL_R * 1.8)
-    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceSide * 0.32);
-  rootTarget.y = SNOOKER_HUMAN_CFG.floorY;
-  const playfieldTarget = new THREE.Vector3(0, cueBall.y, 0);
-  const cueFacing = cueBall.clone().sub(rootTarget).setY(0);
-  const tableFacing = playfieldTarget.clone().sub(rootTarget).setY(0);
-  const bodyForward = cueFacing.lengthSq() > 1e-8 ? cueFacing.normalize() : dir.clone();
-  if (tableFacing.lengthSq() > 1e-8 && bodyForward.dot(tableFacing.normalize()) < 0.18) {
-    bodyForward.lerp(tableFacing, 0.5).normalize();
-  }
-  const yawTarget = Math.atan2(bodyForward.x, bodyForward.z);
-  human.root.visible = true;
-  human.modelRoot.visible = human.loaded && human.activeGlb;
-  const travel = human.lastRootPosition.distanceTo(rootTarget);
-  human.walkAmount = snookerHumanDamp(human.walkAmount, snookerHumanClamp01(travel / Math.max(BALL_R * 4, 1e-4)), 8, dt);
-  human.walkPhase += dt * (4.5 + human.walkAmount * 5.5);
-  human.root.position.lerp(rootTarget, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
-  human.lastRootPosition.copy(human.root.position);
-  human.yaw = snookerHumanDampAngle(human.yaw, yawTarget, SNOOKER_HUMAN_CFG.rootLambda, dt);
-  human.root.rotation.set(0, human.yaw, 0);
-  human.modelRoot.position.copy(human.root.position);
-  human.modelRoot.rotation.copy(human.root.rotation);
-  human.poseT = snookerHumanDamp(human.poseT, 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
-  const invRoot = new THREE.Matrix4().copy(human.root.matrixWorld).invert();
-  const toRootLocal = (v) => v.clone().applyMatrix4(invRoot);
-  const bridge = cueBall.clone()
-    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
-    .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
-    .setY(CUE_Y + BALL_R * 0.08);
-  const gripBlend = tableCueVisible ? (0.37 + pullPose * 0.08) : 0.62;
-  const grip = cueEndpoints.butt
-    .clone()
-    .lerp(cueEndpoints.tip, gripBlend)
-    .addScaledVector(side, tableCueVisible ? 0 : BALL_R * 0.18)
-    .setY(tableCueVisible ? cueEndpoints.butt.y : CUE_Y + BALL_R * 0.52);
-  updateSnookerHumanOrientationHelpers(human, { rootTarget, cueBall, playfieldTarget, dir, bridge, grip });
-  const chestWorld = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
-  const headWorld = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const torso = toRootLocal(chestWorld).add(new THREE.Vector3(0, 0.16 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
-  const chest = toRootLocal(chestWorld);
-  const head = toRootLocal(headWorld);
-  const neck = chest.clone().lerp(head, 0.68);
-  const leftShoulder = chest.clone().add(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, -0.025 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightShoulder = chest.clone().add(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.055 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
-  const leftHand = toRootLocal(bridge);
-  const rightHand = toRootLocal(grip);
-  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.58).add(new THREE.Vector3(-0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.03 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightElbow = rightShoulder.clone().lerp(rightHand, 0.42).add(new THREE.Vector3(0.22 * SNOOKER_HUMAN_WORLD_SCALE, 0.20 * SNOOKER_HUMAN_WORLD_SCALE, -0.20 * SNOOKER_HUMAN_WORLD_SCALE));
-  const leftHip = new THREE.Vector3(-0.07 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const rightHip = new THREE.Vector3(0.08 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.12 * SNOOKER_HUMAN_WORLD_SCALE);
-  const walkLift = Math.sin(human.walkPhase) * 0.028 * SNOOKER_HUMAN_WORLD_SCALE * human.walkAmount;
-  const leftFoot = new THREE.Vector3(-SNOOKER_HUMAN_CFG.stanceSide, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, walkLift), SNOOKER_HUMAN_CFG.leftFootForward);
-  const rightFoot = new THREE.Vector3(SNOOKER_HUMAN_CFG.stanceSide * 0.62, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, -walkLift), -SNOOKER_HUMAN_CFG.rightFootBack);
-  const leftKnee = leftHip.clone().lerp(leftFoot, 0.55).add(new THREE.Vector3(-0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.12 * SNOOKER_HUMAN_WORLD_SCALE, 0.04 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).add(new THREE.Vector3(0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.14 * SNOOKER_HUMAN_WORLD_SCALE, -0.03 * SNOOKER_HUMAN_WORLD_SCALE));
-  poseSnookerHumanFallback(human, {
-    root: human.root,
-    torso,
-    chest,
-    head,
-    neck,
-    leftShoulder,
-    rightShoulder,
-    leftElbow,
-    rightElbow,
-    leftHand,
-    rightHand,
-    leftHip,
-    rightHip,
-    leftKnee,
-    rightKnee,
-    leftFoot,
-    rightFoot
+  const bridgeTarget = cueBall.clone()
+    .addScaledVector(dir, -0.235 * SNOOKER_HUMAN_WORLD_SCALE)
+    .addScaledVector(side, -0.012 * SNOOKER_HUMAN_WORLD_SCALE)
+    .setY(BALL_CENTER_Y - BALL_R + 0.018 * SNOOKER_HUMAN_WORLD_SCALE);
+  const rootTarget = chooseProvidedSnookerHumanEdgePosition(cueBall, dir, {
+    unit: SNOOKER_HUMAN_WORLD_SCALE,
+    tableW: PLAY_W,
+    tableL: PLAY_H,
+    edgeMargin: 0.5 * SNOOKER_HUMAN_WORLD_SCALE,
+    desiredShootDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
+    groundY: SNOOKER_HUMAN_CFG.floorY
   });
-  const leftElbowTable = human.root.parent
-    ? human.root.parent.worldToLocal(human.root.localToWorld(leftElbow.clone()))
-    : leftElbow.clone();
-  const rightElbowTable = human.root.parent
-    ? human.root.parent.worldToLocal(human.root.localToWorld(rightElbow.clone()))
-    : rightElbow.clone();
-  poseSnookerHumanGlb(human, {
-    leftHandWorld: bridge,
-    rightHandWorld: grip,
-    leftElbowWorld: leftElbowTable,
-    rightElbowWorld: rightElbowTable,
-    headWorld: headWorld,
-    chestWorld: chestWorld,
-    cueTipWorld: cueEndpoints.tip
+  const idleRight = rootTarget.clone()
+    .addScaledVector(side, 0.31 * SNOOKER_HUMAN_WORLD_SCALE)
+    .addScaledVector(dir, -0.015 * SNOOKER_HUMAN_WORLD_SCALE)
+    .setY(0.8 * SNOOKER_HUMAN_WORLD_SCALE);
+  const idleLeft = rootTarget.clone()
+    .addScaledVector(side, -0.24 * SNOOKER_HUMAN_WORLD_SCALE)
+    .addScaledVector(dir, 0.08 * SNOOKER_HUMAN_WORLD_SCALE)
+    .setY(0.86 * SNOOKER_HUMAN_WORLD_SCALE);
+  const pullPose = THREE.MathUtils.clamp((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0), 0, 1);
+  const gripTarget = cueEndpoints.butt.clone().lerp(cueEndpoints.tip, 0.37 + pullPose * 0.08);
+  const state = shooting || cueAnimating ? 'striking' : 'dragging';
+
+  updateProvidedSnookerHumanPose(human, dt, {
+    state,
+    rootTarget,
+    aimForward: dir,
+    bridgeTarget,
+    idleRight,
+    idleLeft,
+    cueBack: cueEndpoints.butt,
+    cueTip: cueEndpoints.tip,
+    gripTarget,
+    power: THREE.MathUtils.clamp(power ?? 0, 0, 1),
+    directRootTarget: false
   });
 }
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
@@ -6395,8 +6326,8 @@ const resolvePocketEntranceForTarget = (targetPos, pocketIndex) => {
   if (!entry?.point) return resolvePocketMappedCenter(pocketCenter, pocketIndex, 0.6);
   return new THREE.Vector2(entry.point.x, entry.point.y);
 };
-const POCKET_CAPTURE_CENTER_INWARD_SCALE = 0.38;
-const SIDE_POCKET_CAPTURE_CENTER_INWARD_SCALE = 0.46;
+const POCKET_CAPTURE_CENTER_INWARD_SCALE = 0.18;
+const SIDE_POCKET_CAPTURE_CENTER_INWARD_SCALE = 0.22;
 const pocketCaptureCenters = () =>
   pocketCenters().map((center, index) =>
     resolvePocketMappedCenter(
@@ -22224,9 +22155,7 @@ const powerRef = useRef(hud.power);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      const snookerHumanPlayer = { disabled: true, root: new THREE.Group(), modelRoot: new THREE.Group() };
-      snookerHumanPlayer.root.visible = false;
-      snookerHumanPlayer.modelRoot.visible = false;
+      const snookerHumanPlayer = createSnookerRoyalHumanPlayer(table, renderer);
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
       const closeCueGallery = () => {
@@ -27288,12 +27217,7 @@ const powerRef = useRef(hud.power);
           table?.userData?.pockets && Array.isArray(table.userData.pockets)
             ? table.userData.pockets
             : [];
-        const captureCenters =
-          pocketMarkers.length > 0
-            ? pocketMarkers.map(
-                (marker) => new THREE.Vector2(marker.position.x, marker.position.z)
-              )
-            : centers;
+        const captureCenters = pocketCaptureCenters();
         const captureRadii =
           pocketMarkers.length > 0
             ? pocketMarkers.map((marker, idx) =>
@@ -27706,6 +27630,7 @@ const powerRef = useRef(hud.power);
         activeRenderCameraRef.current = null;
         snookerHumanPlayer?.root?.removeFromParent?.();
         snookerHumanPlayer?.modelRoot?.removeFromParent?.();
+        disposeSnookerHumanGLTFLoader(snookerHumanPlayer?.loader);
         cueBodyRef.current = null;
         tipGroupRef.current = null;
         try {


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal scene use the same human + cuestick orientation and stroke behaviour as the Provided implementation so the onscreen character holds and animates the cue identically. 
- Improve portrait/pot detection so visible pots are captured reliably on mobile (portrait UI). 

### Description
- Replaced the in-file Snooker Royal human rig plumbing with the shared rig by importing `createSnookerHumanRig`, `chooseHumanEdgePosition` and `updateBilardoHumanPose` from `shared/snookerHumanRig.js` and creating the player with `createSnookerHumanRig(...)` so the character uses the same pose solver and cue endpoints as the Provided build. 
- Reworked `updateSnookerRoyalHumanPlayer(...)` to compute cue endpoints, bridge/grip targets and shot state and forward them to the shared `update` routine so the human and cue follow identical orientation/behaviour as `SnookerRoyalProvided.jsx`. 
- Enabled the human player instance in the Snooker Royal scene (replaced the previously disabled placeholder) and added cleanup to dispose the GLTF loader on world teardown. 
- Adjusted pocket mapping and capture logic: switched live capture to `pocketCaptureCenters()` (mapped centers), reduced the inward mapping scale for capture centers, and introduced portrait-friendly capture assistance by increasing `POCKET_CAPTURE_ASSIST` and `SIDE_POCKET_CAPTURE_ASSIST` so balls that visually enter the mouth on portrait screens are captured more reliably. 

### Testing
- Ran `npm --prefix webapp run lint -- src/pages/Games/SnookerRoyal.jsx` and the linter ran (no blocking errors). (succeeded)
- Ran `npm --prefix webapp run build` to build the webapp and verified the production build completed without errors. (succeeded)
- Attempted an automated Playwright portrait screenshot to visually validate the human+cue and pocket captures, installed Playwright browsers and native deps, but the headless Chromium screenshot timed out in this environment so visual snapshot capture did not complete. (attempted, timed out)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d013696f08329821b998f6ecb1cca)