### PR TITLE
Fix Pool Royale power slider commit and add high-end power scaling

### DIFF
--- a/test/poolRoyaleShotState.test.js
+++ b/test/poolRoyaleShotState.test.js
@@ -1,4 +1,4 @@
-import { SHOT_STATE, resolveCommittedShot, easeOut } from '../webapp/src/pages/Games/poolRoyaleShotState.js';
+import { SHOT_STATE, resolveCommittedShot, resolvePoolRoyaleShotPowerScale, easeOut } from '../webapp/src/pages/Games/poolRoyaleShotState.js';
 
 describe('Pool Royale shot state commit flow', () => {
   it('stays idle for low/zero captured power', () => {
@@ -20,6 +20,13 @@ describe('Pool Royale shot state commit flow', () => {
     expect(low.state).toBe(SHOT_STATE.IDLE);
     expect(high.shotPower).toBe(1);
     expect(high.state).toBe(SHOT_STATE.STRIKING);
+  });
+
+  it('boosts physical shot power above 60% without changing low/mid percentages', () => {
+    expect(resolvePoolRoyaleShotPowerScale(0.25)).toBeCloseTo(0.25, 6);
+    expect(resolvePoolRoyaleShotPowerScale(0.6)).toBeCloseTo(0.6, 6);
+    expect(resolvePoolRoyaleShotPowerScale(0.8)).toBeGreaterThan(0.8);
+    expect(resolvePoolRoyaleShotPowerScale(1)).toBeCloseTo(1.35, 6);
   });
 
   it('uses cubic ease-out for slider reset curve', () => {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19,6 +19,7 @@ import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
+import { resolvePoolRoyaleShotPowerScale } from './poolRoyaleShotState.js';
 import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -28561,7 +28562,8 @@ const shotPowerRef = useRef(0);
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
           const frameStateCurrent = frameRef.current ?? null;
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
-          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * clampedPower;
+          const shotPowerScale = resolvePoolRoyaleShotPowerScale(clampedPower);
+          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * shotPowerScale;
           const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
           const base = shotAimDir
             .clone()
@@ -34850,8 +34852,11 @@ const shotPowerRef = useRef(0);
       onStart: () => {
         captureCueStickAnchor();
       },
-      onCommit: () => {
-        fireRef.current?.();
+      onCommit: (value) => {
+        const committedPower = clampPower(value / 100, 0);
+        shotPowerRef.current = committedPower;
+        powerRef.current = committedPower;
+        fireRef.current?.(committedPower);
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);
@@ -34864,7 +34869,7 @@ const shotPowerRef = useRef(0);
       sliderInstanceRef.current = null;
       slider.destroy();
     };
-  }, [applySliderLock, applyPower, captureCueStickAnchor, showPowerSlider]);
+  }, [applySliderLock, applyPower, captureCueStickAnchor, clampPower, showPowerSlider]);
   useEffect(() => {
     if (shotActive || hud.over || hud.turn !== 0) return;
     const slider = sliderInstanceRef.current;
@@ -34872,6 +34877,7 @@ const shotPowerRef = useRef(0);
       slider.set(slider.min, { animate: true });
     }
     applyPower(0);
+    shotPowerRef.current = 0;
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;
   }, [applyPower, hud.over, hud.turn, shotActive]);

--- a/webapp/src/pages/Games/poolRoyaleShotState.js
+++ b/webapp/src/pages/Games/poolRoyaleShotState.js
@@ -19,4 +19,11 @@ export const resolveCommittedShot = ({
   };
 };
 
+export const resolvePoolRoyaleShotPowerScale = (power) => {
+  const clampedPower = THREE.MathUtils.clamp(Number.isFinite(power) ? power : 0, 0, 1);
+  const highEndT = THREE.MathUtils.clamp((clampedPower - 0.6) / 0.4, 0, 1);
+  const highEndBoost = highEndT * highEndT * 0.35;
+  return clampedPower * (1 + highEndBoost);
+};
+
 export const easeOut = (t) => 1 - Math.pow(1 - THREE.MathUtils.clamp(t, 0, 1), 3);


### PR DESCRIPTION
### Motivation
- Fix incorrect slider commit behavior so the exact slider value at release is used for the shot, preventing stale/low values from overriding a full pull. 
- Provide stronger physical response when players pull past ~60% so higher slider percentages feel more powerful while preserving the displayed 0–60% mapping.

### Description
- Commit the exact slider value on release by updating the slider `onCommit` handler to compute `committedPower`, set `shotPowerRef.current` and `powerRef.current`, and call `fire` with the committed value (changes in `PoolRoyale.jsx`).
- Add `resolvePoolRoyaleShotPowerScale` in `poolRoyaleShotState.js` which clamps the input and applies a smooth high-end boost that begins after 60% and reaches ~35% extra force at full power.
- Wire the new scale into shot velocity calculation by replacing the direct `clampedPower` usage with `resolvePoolRoyaleShotPowerScale(clampedPower)` when computing `powerScale`/`speedBase` (changes in `PoolRoyale.jsx`).
- Add unit test coverage for the high-end boost and update tests to import the new helper (`test/poolRoyaleShotState.test.js`).

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleShotState.test.js` and the suite passed (5 tests, all green). 
- Ran `npm run build` (TypeScript compile) which completed without errors. 
- Lint was executed; only file-ignore warnings were reported and no lint errors blocked the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d04229d1483299d142f4ee7bb572d)