### PR TITLE
Integrate shared snooker human rig, refine cue/pose logic and pocket capture

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -104,6 +104,11 @@ import {
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
+import {
+  createSnookerHumanRig,
+  chooseHumanEdgePosition as chooseProvidedSnookerHumanEdgePosition,
+  updateBilardoHumanPose as updateProvidedSnookerHumanPose
+} from './shared/snookerHumanRig.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -1340,8 +1345,8 @@ const POCKET_INTERIOR_CAPTURE_R =
   POCKET_VIS_R * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // match capture radius directly to the pocket bowl opening
 const SIDE_POCKET_INTERIOR_CAPTURE_R =
   SIDE_POCKET_RADIUS * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // keep middle-pocket capture identical to its bowl radius
-const POCKET_CAPTURE_ASSIST = 0; // keep capture sensors matched to the visible corner pocket mouth
-const SIDE_POCKET_CAPTURE_ASSIST = 0; // keep middle-pocket capture matched to the actual visible pocket size
+const POCKET_CAPTURE_ASSIST = BALL_R * 1.08; // portrait-friendly potting sensor allowance so balls that visibly enter a corner mouth are captured
+const SIDE_POCKET_CAPTURE_ASSIST = BALL_R * 1.0; // match the middle-pocket capture to the visible side-mouth opening without over-widening rails
 const CAPTURE_R =
   POCKET_INTERIOR_CAPTURE_R + POCKET_CAPTURE_ASSIST; // corner captures now use the physical pocket bowl instead of an oversized helper zone
 const SIDE_CAPTURE_R =
@@ -2064,70 +2069,59 @@ function poseSnookerHumanGlb(human, targetsLocal) {
 }
 
 function createSnookerRoyalHumanPlayer(parent, renderer) {
-  const human = {
-    root: new THREE.Group(),
-    modelRoot: new THREE.Group(),
-    fallback: createSnookerHumanFallbackRig(),
-    bones: {},
-    activeGlb: false,
-    yaw: 0,
-    poseT: 0,
-    loaded: false,
-    disabled: false,
-    loadFailed: false,
-    lastRootPosition: new THREE.Vector3(),
-    walkPhase: 0,
-    walkAmount: 0,
-    restQuats: new Map(),
-    theme: SNOOKER_HUMAN_CHARACTER_THEME
-  };
-  human.root.name = 'SnookerRoyalHumanPlayerRoot';
-  human.modelRoot.name = 'SnookerRoyalDominoCharacterRoot';
-  human.root.visible = false;
-  human.modelRoot.visible = false;
-  human.root.add(human.fallback);
-  human.orientationHelpers = createSnookerHumanOrientationHelpers();
-  human.root.add(human.orientationHelpers.group);
-  parent.add(human.root, human.modelRoot);
-  const urls = buildSnookerHumanModelUrls(human.theme);
   const loader = createSnookerHumanGLTFLoader(renderer);
-  loadSnookerHumanModelFromCatalog(loader, urls)
-    .then(({ model, url }) => {
-      normalizeSnookerHumanModel(model);
-      model.traverse((obj) => {
-        if (obj?.isBone) human.restQuats.set(obj, obj.quaternion.clone());
-        if (!obj?.isMesh) return;
-        obj.castShadow = true;
-        obj.receiveShadow = true;
-        obj.frustumCulled = false;
-        const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
-        mats.forEach(tuneSnookerHumanOriginalGlbMaterial);
-      });
-      human.bones = buildSnookerHumanBones(model);
-      human.activeGlb = Boolean(
-        human.bones.head &&
-        human.bones.spine &&
-        human.bones.leftUpperArm &&
-        human.bones.leftLowerArm &&
-        human.bones.rightUpperArm &&
-        human.bones.rightLowerArm
-      );
-      human.modelUrl = url;
-      human.modelRoot.add(model);
-      human.modelRoot.visible = human.root.visible && human.activeGlb;
-      human.fallback.visible = !human.activeGlb;
-      human.loaded = true;
-    })
-    .catch((error) => {
-      human.loadFailed = true;
-      human.activeGlb = false;
-      human.fallback.visible = true;
-      console.warn('Snooker Royal human GLB catalog failed; using fallback pose rig.', error);
-    })
-    .finally(() => disposeSnookerHumanGLTFLoader(loader));
+  const human = createSnookerHumanRig(parent, {
+    loader,
+    modelUrls: buildSnookerHumanModelUrls(SNOOKER_HUMAN_CHARACTER_THEME),
+    unit: SNOOKER_HUMAN_WORLD_SCALE,
+    tableW: PLAY_W,
+    tableL: PLAY_H,
+    tableTopY: BALL_CENTER_Y - BALL_R,
+    groundY: SNOOKER_HUMAN_CFG.floorY,
+    humanScale: 1.2 * SNOOKER_HUMAN_WORLD_SCALE,
+    humanVisualYawFix: Math.PI,
+    stanceWidth: 0.52 * SNOOKER_HUMAN_WORLD_SCALE,
+    edgeMargin: 0.5 * SNOOKER_HUMAN_WORLD_SCALE,
+    desiredShootDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgePalmTableLift: 0.006 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgePalmUnderCueDrop: 0,
+    bridgeVGrooveForward: 0.026 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgeVGrooveSide: -0.032 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgeCueLift: 0.018 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgeHandBackFromBall: 0.235 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgeHandSide: -0.012 * SNOOKER_HUMAN_WORLD_SCALE,
+    bridgePoseUsesConfiguredSide: false,
+    chinToCueHeight: 0.11 * SNOOKER_HUMAN_WORLD_SCALE,
+    footGroundY: 0.035 * SNOOKER_HUMAN_WORLD_SCALE,
+    kneeBendShot: 0.16 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightElbowShotRise: 0.18 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightElbowShotSide: -0.46 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightElbowShotBack: -0.78 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightForearmOutward: 0.36 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightForearmBack: 0.44 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightForearmDown: 0.48 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightForearmLength: 0.34 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightStrokePull: 0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+    rightStrokePush: 0.24 * SNOOKER_HUMAN_WORLD_SCALE,
+    strikeTime: 0.12,
+    holdTime: 0.05,
+    rightHandShotLift: -0.30 * SNOOKER_HUMAN_WORLD_SCALE,
+    shootCueGripFromBack: 0.58,
+    shootBendTowardCueStick: false,
+    shootBendMode: 'forward',
+    shootBendDirection: -1,
+    shootCounterLeanSide: -1,
+    shootUpperBodyCounterLean: 1,
+    shootForwardBendScale: 1,
+    forceTableFacingAim: false,
+    plantFeetDuringShot: true,
+    onStatus: (message) => console.info(`Snooker Royal human: ${message}`)
+  });
+  human.disabled = false;
+  human.usesProvidedCueLogic = true;
+  human.loader = loader;
   return human;
 }
-
 function getSnookerCueEndpoints(cueStick, cueLen) {
   if (!cueStick) return null;
   cueStick.updateMatrixWorld(true);
@@ -2141,6 +2135,16 @@ function getSnookerCueEndpoints(cueStick, cueLen) {
   return { tip, butt };
 }
 
+function applyProvidedCueEndpointPose(cueStick, cueBack, cueTip) {
+  if (!cueStick || !cueBack || !cueTip) return;
+  const cueDir = cueTip.clone().sub(cueBack);
+  if (cueDir.lengthSq() < 1e-8) return;
+  cueDir.normalize();
+  const buttDir = cueBack.clone().sub(cueTip).normalize();
+  cueStick.position.copy(cueBack).add(cueTip).multiplyScalar(0.5);
+  cueStick.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), buttDir);
+}
+
 function updateSnookerRoyalHumanPlayer(human, dt, options) {
   if (!human?.root || human.disabled) return;
   const {
@@ -2151,8 +2155,7 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     visible,
     power = 0,
     shooting = false,
-    cueAnimating = false,
-    tableCueVisible = true
+    cueAnimating = false
   } = options || {};
   const cuePos = cue?.pos;
   if (!cuePos || !cue?.active || !visible) {
@@ -2160,107 +2163,72 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     human.modelRoot.visible = false;
     return;
   }
-  const dir = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
-  if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
-  dir.normalize();
-  const side = new THREE.Vector3(-dir.z, 0, dir.x).normalize();
-  const cueBall = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
-  const cueEndpoints = resolveSnookerHumanCueEndpoints(cueStick, cueLen, cueBall, dir);
-  const pullPose = THREE.MathUtils.clamp((power ?? 0) * 0.7 + (shooting || cueAnimating ? 0.35 : 0), 0, 1);
-  // Orientation is driven from the actual shot line: the root stands behind
-  // the cue ball on -dir, then faces +dir back through cue ball/object ball.
-  // Keeping local +Z on the shot line prevents mirrored cue/hand placement.
-  const rootTarget = cueBall.clone()
-    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.idleDistance - pullPose * BALL_R * 1.8)
-    .addScaledVector(side, -SNOOKER_HUMAN_CFG.stanceSide * 0.32);
-  rootTarget.y = SNOOKER_HUMAN_CFG.floorY;
-  const playfieldTarget = new THREE.Vector3(0, cueBall.y, 0);
-  const cueFacing = cueBall.clone().sub(rootTarget).setY(0);
-  const tableFacing = playfieldTarget.clone().sub(rootTarget).setY(0);
-  const bodyForward = cueFacing.lengthSq() > 1e-8 ? cueFacing.normalize() : dir.clone();
-  if (tableFacing.lengthSq() > 1e-8 && bodyForward.dot(tableFacing.normalize()) < 0.18) {
-    bodyForward.lerp(tableFacing, 0.5).normalize();
-  }
-  const yawTarget = Math.atan2(bodyForward.x, bodyForward.z);
-  human.root.visible = true;
-  human.modelRoot.visible = human.loaded && human.activeGlb;
-  const travel = human.lastRootPosition.distanceTo(rootTarget);
-  human.walkAmount = snookerHumanDamp(human.walkAmount, snookerHumanClamp01(travel / Math.max(BALL_R * 4, 1e-4)), 8, dt);
-  human.walkPhase += dt * (4.5 + human.walkAmount * 5.5);
-  human.root.position.lerp(rootTarget, 1 - Math.exp(-SNOOKER_HUMAN_CFG.rootLambda * dt));
-  human.lastRootPosition.copy(human.root.position);
-  human.yaw = snookerHumanDampAngle(human.yaw, yawTarget, SNOOKER_HUMAN_CFG.rootLambda, dt);
-  human.root.rotation.set(0, human.yaw, 0);
-  human.modelRoot.position.copy(human.root.position);
-  human.modelRoot.rotation.copy(human.root.rotation);
-  human.poseT = snookerHumanDamp(human.poseT, 1, SNOOKER_HUMAN_CFG.poseLambda, dt);
-  const invRoot = new THREE.Matrix4().copy(human.root.matrixWorld).invert();
-  const toRootLocal = (v) => v.clone().applyMatrix4(invRoot);
-  const bridge = cueBall.clone()
-    .addScaledVector(dir, -SNOOKER_HUMAN_CFG.bridgeBackFromBall)
-    .addScaledVector(side, SNOOKER_HUMAN_CFG.bridgeSide)
-    .setY(CUE_Y + BALL_R * 0.08);
-  const gripBlend = tableCueVisible ? (0.37 + pullPose * 0.08) : 0.62;
-  const grip = cueEndpoints.butt
-    .clone()
-    .lerp(cueEndpoints.tip, gripBlend)
-    .addScaledVector(side, tableCueVisible ? 0 : BALL_R * 0.18)
-    .setY(tableCueVisible ? cueEndpoints.butt.y : CUE_Y + BALL_R * 0.52);
-  updateSnookerHumanOrientationHelpers(human, { rootTarget, cueBall, playfieldTarget, dir, bridge, grip });
-  const chestWorld = cueBall.clone().addScaledVector(dir, -0.44 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chestCueOffsetY);
-  const headWorld = cueBall.clone().addScaledVector(dir, -0.34 * SNOOKER_HUMAN_WORLD_SCALE).setY(CUE_Y + SNOOKER_HUMAN_CFG.chinCueOffsetY + 0.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const torso = toRootLocal(chestWorld).add(new THREE.Vector3(0, 0.16 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
-  const chest = toRootLocal(chestWorld);
-  const head = toRootLocal(headWorld);
-  const neck = chest.clone().lerp(head, 0.68);
-  const leftShoulder = chest.clone().add(new THREE.Vector3(-0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, -0.025 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightShoulder = chest.clone().add(new THREE.Vector3(0.13 * SNOOKER_HUMAN_WORLD_SCALE, 0.055 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE));
-  const leftHand = toRootLocal(bridge);
-  const rightHand = toRootLocal(grip);
-  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.58).add(new THREE.Vector3(-0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.05 * SNOOKER_HUMAN_WORLD_SCALE, 0.03 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightElbow = rightShoulder.clone().lerp(rightHand, 0.42).add(new THREE.Vector3(0.22 * SNOOKER_HUMAN_WORLD_SCALE, 0.20 * SNOOKER_HUMAN_WORLD_SCALE, -0.20 * SNOOKER_HUMAN_WORLD_SCALE));
-  const leftHip = new THREE.Vector3(-0.07 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.08 * SNOOKER_HUMAN_WORLD_SCALE);
-  const rightHip = new THREE.Vector3(0.08 * SNOOKER_HUMAN_WORLD_SCALE, 0.43 * SNOOKER_HUMAN_WORLD_SCALE, -0.12 * SNOOKER_HUMAN_WORLD_SCALE);
-  const walkLift = Math.sin(human.walkPhase) * 0.028 * SNOOKER_HUMAN_WORLD_SCALE * human.walkAmount;
-  const leftFoot = new THREE.Vector3(-SNOOKER_HUMAN_CFG.stanceSide, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, walkLift), SNOOKER_HUMAN_CFG.leftFootForward);
-  const rightFoot = new THREE.Vector3(SNOOKER_HUMAN_CFG.stanceSide * 0.62, 0.03 * SNOOKER_HUMAN_WORLD_SCALE + Math.max(0, -walkLift), -SNOOKER_HUMAN_CFG.rightFootBack);
-  const leftKnee = leftHip.clone().lerp(leftFoot, 0.55).add(new THREE.Vector3(-0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.12 * SNOOKER_HUMAN_WORLD_SCALE, 0.04 * SNOOKER_HUMAN_WORLD_SCALE));
-  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).add(new THREE.Vector3(0.03 * SNOOKER_HUMAN_WORLD_SCALE, 0.14 * SNOOKER_HUMAN_WORLD_SCALE, -0.03 * SNOOKER_HUMAN_WORLD_SCALE));
-  poseSnookerHumanFallback(human, {
-    root: human.root,
-    torso,
-    chest,
-    head,
-    neck,
-    leftShoulder,
-    rightShoulder,
-    leftElbow,
-    rightElbow,
-    leftHand,
-    rightHand,
-    leftHip,
-    rightHip,
-    leftKnee,
-    rightKnee,
-    leftFoot,
-    rightFoot
+
+  const aimForward = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
+  if (aimForward.lengthSq() < 1e-8) aimForward.set(0, 0, 1);
+  aimForward.normalize();
+  const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+  const cueBallWorld = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
+  const humanRootTarget = chooseProvidedSnookerHumanEdgePosition(cueBallWorld, aimForward, {
+    unit: SNOOKER_HUMAN_WORLD_SCALE,
+    tableW: PLAY_W,
+    tableL: PLAY_H,
+    edgeMargin: 0.5 * SNOOKER_HUMAN_WORLD_SCALE,
+    desiredShootDistance: 0.82 * SNOOKER_HUMAN_WORLD_SCALE,
+    groundY: SNOOKER_HUMAN_CFG.floorY
   });
-  const leftElbowTable = human.root.parent
-    ? human.root.parent.worldToLocal(human.root.localToWorld(leftElbow.clone()))
-    : leftElbow.clone();
-  const rightElbowTable = human.root.parent
-    ? human.root.parent.worldToLocal(human.root.localToWorld(rightElbow.clone()))
-    : rightElbow.clone();
-  poseSnookerHumanGlb(human, {
-    leftHandWorld: bridge,
-    rightHandWorld: grip,
-    leftElbowWorld: leftElbowTable,
-    rightElbowWorld: rightElbowTable,
-    headWorld: headWorld,
-    chestWorld: chestWorld,
-    cueTipWorld: cueEndpoints.tip
+  const bridgeHandTarget = cueBallWorld.clone()
+    .addScaledVector(aimForward, -0.235 * SNOOKER_HUMAN_WORLD_SCALE)
+    .addScaledVector(aimSide, -0.012 * SNOOKER_HUMAN_WORLD_SCALE)
+    .setY(BALL_CENTER_Y - BALL_R + 0.006 * SNOOKER_HUMAN_WORLD_SCALE);
+  const bridgeCuePoint = bridgeHandTarget.clone()
+    .addScaledVector(aimForward, 0.026 * SNOOKER_HUMAN_WORLD_SCALE)
+    .addScaledVector(aimSide, -0.032 * SNOOKER_HUMAN_WORLD_SCALE)
+    .add(new THREE.Vector3(0, 0.018 * SNOOKER_HUMAN_WORLD_SCALE, 0));
+  const activePower = THREE.MathUtils.clamp(power ?? 0, 0, 1);
+  const pull = (CUE_PULL_BASE || BALL_R * 4) * easeOutCubic(activePower);
+  const practiceStroke = !shooting && !cueAnimating && activePower > 0.02
+    ? Math.sin(performance.now() * 0.012) * 0.035 * SNOOKER_HUMAN_WORLD_SCALE * (0.25 + activePower * 0.75)
+    : 0;
+  const providedGap = CUE_TIP_GAP + (activePower > 0.02 && !shooting && !cueAnimating ? pull + practiceStroke : 0);
+  const providedCueTip = cueBallWorld.clone().addScaledVector(aimForward, -(BALL_R + providedGap));
+  const providedCueBack = bridgeCuePoint.clone()
+    .addScaledVector(aimForward, -(cueLen - 0.28 * SNOOKER_HUMAN_WORLD_SCALE - BALL_R - providedGap))
+    .add(new THREE.Vector3(0, 0.024 * SNOOKER_HUMAN_WORLD_SCALE, 0));
+  const cueEndpoints = shooting || cueAnimating
+    ? resolveSnookerHumanCueEndpoints(cueStick, cueLen, cueBallWorld, aimForward)
+    : { tip: providedCueTip, butt: providedCueBack };
+  if (!shooting && !cueAnimating) {
+    applyProvidedCueEndpointPose(cueStick, providedCueBack, providedCueTip);
+  }
+
+  const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
+  const idleRightHandTarget = humanRootTarget.clone().add(new THREE.Vector3(
+    0.31 * SNOOKER_HUMAN_WORLD_SCALE,
+    0.8 * SNOOKER_HUMAN_WORLD_SCALE,
+    -0.015 * SNOOKER_HUMAN_WORLD_SCALE
+  ).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+  const idleLeftHandTarget = humanRootTarget.clone().add(new THREE.Vector3(
+    -0.18 * SNOOKER_HUMAN_WORLD_SCALE,
+    1.08 * SNOOKER_HUMAN_WORLD_SCALE,
+    0.03 * SNOOKER_HUMAN_WORLD_SCALE
+  ).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+  const state = shooting || cueAnimating ? 'striking' : activePower > 0.02 ? 'dragging' : 'aiming';
+
+  updateProvidedSnookerHumanPose(human, dt, {
+    exactProvidedPose: true,
+    state,
+    rootTarget: humanRootTarget,
+    aimForward,
+    bridgeTarget: bridgeHandTarget,
+    idleRight: idleRightHandTarget,
+    idleLeft: idleLeftHandTarget,
+    cueBack: cueEndpoints.butt,
+    cueTip: cueEndpoints.tip,
+    power: activePower
   });
 }
+
 const MAX_BACKSPIN_TILT = THREE.MathUtils.degToRad(6.25);
 const CUE_LIFT_DRAG_SCALE = 0.0048;
 const CUE_LIFT_MAX_TILT = THREE.MathUtils.degToRad(12.5);
@@ -6395,8 +6363,8 @@ const resolvePocketEntranceForTarget = (targetPos, pocketIndex) => {
   if (!entry?.point) return resolvePocketMappedCenter(pocketCenter, pocketIndex, 0.6);
   return new THREE.Vector2(entry.point.x, entry.point.y);
 };
-const POCKET_CAPTURE_CENTER_INWARD_SCALE = 0.38;
-const SIDE_POCKET_CAPTURE_CENTER_INWARD_SCALE = 0.46;
+const POCKET_CAPTURE_CENTER_INWARD_SCALE = 0.12;
+const SIDE_POCKET_CAPTURE_CENTER_INWARD_SCALE = 0.14;
 const pocketCaptureCenters = () =>
   pocketCenters().map((center, index) =>
     resolvePocketMappedCenter(
@@ -22224,9 +22192,7 @@ const powerRef = useRef(hud.power);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      const snookerHumanPlayer = { disabled: true, root: new THREE.Group(), modelRoot: new THREE.Group() };
-      snookerHumanPlayer.root.visible = false;
-      snookerHumanPlayer.modelRoot.visible = false;
+      const snookerHumanPlayer = createSnookerRoyalHumanPlayer(table, renderer);
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
       const closeCueGallery = () => {
@@ -27288,12 +27254,15 @@ const powerRef = useRef(hud.power);
           table?.userData?.pockets && Array.isArray(table.userData.pockets)
             ? table.userData.pockets
             : [];
-        const captureCenters =
+        const mappedCaptureCenters = pocketCaptureCenters();
+        const rawCaptureCenters =
           pocketMarkers.length > 0
-            ? pocketMarkers.map(
-                (marker) => new THREE.Vector2(marker.position.x, marker.position.z)
-              )
+            ? pocketMarkers.map((marker) => new THREE.Vector2(marker.position.x, marker.position.z))
             : centers;
+        const captureCenters = mappedCaptureCenters.map((mapped, idx) => [
+          mapped,
+          rawCaptureCenters[idx] ?? mapped
+        ]);
         const captureRadii =
           pocketMarkers.length > 0
             ? pocketMarkers.map((marker, idx) =>
@@ -27307,9 +27276,9 @@ const powerRef = useRef(hud.power);
         balls.forEach((b) => {
           if (!b.active) return;
           for (let pocketIndex = 0; pocketIndex < captureCenters.length; pocketIndex++) {
-            const c = captureCenters[pocketIndex];
+            const c = mappedCaptureCenters[pocketIndex];
             const captureRadius = captureRadii[pocketIndex] ?? CAPTURE_R;
-            if (b.pos.distanceTo(c) < captureRadius) {
+            if (captureCenters[pocketIndex].some((captureCenter) => b.pos.distanceTo(captureCenter) < captureRadius)) {
               const entrySpeed = b.vel.length();
               const pocketVolume = THREE.MathUtils.clamp(
                 entrySpeed / POCKET_DROP_SPEED_REFERENCE,
@@ -27706,6 +27675,7 @@ const powerRef = useRef(hud.power);
         activeRenderCameraRef.current = null;
         snookerHumanPlayer?.root?.removeFromParent?.();
         snookerHumanPlayer?.modelRoot?.removeFromParent?.();
+        disposeSnookerHumanGLTFLoader(snookerHumanPlayer?.loader);
         cueBodyRef.current = null;
         tipGroupRef.current = null;
         try {

--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -1,10 +1,9 @@
-import * as THREE from 'three';
+import * as THREE from 'three'
 
-const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const Y_AXIS = new THREE.Vector3(0, 1, 0);
-const UP = Y_AXIS;
-const BASIS_MAT = new THREE.Matrix4();
-
+const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb'
+const Y_AXIS = new THREE.Vector3(0, 1, 0)
+const UP = Y_AXIS
+const BASIS_MAT = new THREE.Matrix4()
 
 const REALISTIC_HUMAN_MATERIALS = Object.freeze({
   skin: 0xd7a47b,
@@ -15,8 +14,7 @@ const REALISTIC_HUMAN_MATERIALS = Object.freeze({
   eyes: 0xf5f7fb,
   teeth: 0xf4eadc,
   defaultFabric: 0x8b5a3c
-});
-
+})
 
 const HUMAN_POLYHAVEN_TEXTURES = Object.freeze({
   // Poly Haven CC0 texture GLTF sets: each clothing role uses its own scanned material,
@@ -24,41 +22,41 @@ const HUMAN_POLYHAVEN_TEXTURES = Object.freeze({
   top: Object.freeze({ asset: 'cotton_jersey', tint: 0xdce6ee, repeat: 4.4, normalScale: 0.55 }),
   bottom: Object.freeze({ asset: 'denim_fabric', tint: 0xaab7ca, repeat: 5.2, normalScale: 0.72 }),
   shoes: Object.freeze({ asset: 'brown_leather', tint: 0x8a5f42, repeat: 3.2, normalScale: 0.5 })
-});
+})
 
-const HUMAN_POLYHAVEN_TEXTURE_CACHE = new Map();
-const HUMAN_POLYHAVEN_RESOLUTION = '1k';
-const HUMAN_POLYHAVEN_TEXTURE_BASE = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${HUMAN_POLYHAVEN_RESOLUTION}`;
-let humanTextureLoader = null;
+const HUMAN_POLYHAVEN_TEXTURE_CACHE = new Map()
+const HUMAN_POLYHAVEN_RESOLUTION = '1k'
+const HUMAN_POLYHAVEN_TEXTURE_BASE = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${HUMAN_POLYHAVEN_RESOLUTION}`
+let humanTextureLoader = null
 
-function getHumanTextureLoader() {
+function getHumanTextureLoader () {
   if (!humanTextureLoader) {
-    humanTextureLoader = new THREE.TextureLoader();
-    humanTextureLoader.setCrossOrigin?.('anonymous');
+    humanTextureLoader = new THREE.TextureLoader()
+    humanTextureLoader.setCrossOrigin?.('anonymous')
   }
-  return humanTextureLoader;
+  return humanTextureLoader
 }
 
-function configureHumanClothTexture(texture, { isColor = false, repeat = 4 } = {}) {
-  if (!texture) return texture;
-  texture.wrapS = THREE.RepeatWrapping;
-  texture.wrapT = THREE.RepeatWrapping;
-  texture.repeat.set(repeat, repeat);
-  texture.anisotropy = 8;
-  if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
-  texture.needsUpdate = true;
-  return texture;
+function configureHumanClothTexture (texture, { isColor = false, repeat = 4 } = {}) {
+  if (!texture) return texture
+  texture.wrapS = THREE.RepeatWrapping
+  texture.wrapT = THREE.RepeatWrapping
+  texture.repeat.set(repeat, repeat)
+  texture.anisotropy = 8
+  if (isColor) texture.colorSpace = THREE.SRGBColorSpace
+  texture.needsUpdate = true
+  return texture
 }
 
-function polyhavenTextureUrl(asset, suffix) {
-  return `${HUMAN_POLYHAVEN_TEXTURE_BASE}/${asset}/${asset}_${suffix}_${HUMAN_POLYHAVEN_RESOLUTION}.jpg`;
+function polyhavenTextureUrl (asset, suffix) {
+  return `${HUMAN_POLYHAVEN_TEXTURE_BASE}/${asset}/${asset}_${suffix}_${HUMAN_POLYHAVEN_RESOLUTION}.jpg`
 }
 
-function loadHumanPolyhavenTextureSet(role) {
-  const cfg = HUMAN_POLYHAVEN_TEXTURES[role];
-  if (!cfg) return null;
-  if (HUMAN_POLYHAVEN_TEXTURE_CACHE.has(role)) return HUMAN_POLYHAVEN_TEXTURE_CACHE.get(role);
-  const loader = getHumanTextureLoader();
+function loadHumanPolyhavenTextureSet (role) {
+  const cfg = HUMAN_POLYHAVEN_TEXTURES[role]
+  if (!cfg) return null
+  if (HUMAN_POLYHAVEN_TEXTURE_CACHE.has(role)) return HUMAN_POLYHAVEN_TEXTURE_CACHE.get(role)
+  const loader = getHumanTextureLoader()
   const textureSet = {
     cfg,
     map: configureHumanClothTexture(loader.load(polyhavenTextureUrl(cfg.asset, 'diff')), {
@@ -71,126 +69,126 @@ function loadHumanPolyhavenTextureSet(role) {
     roughnessMap: configureHumanClothTexture(loader.load(polyhavenTextureUrl(cfg.asset, 'rough')), {
       repeat: cfg.repeat
     })
-  };
-  HUMAN_POLYHAVEN_TEXTURE_CACHE.set(role, textureSet);
-  return textureSet;
+  }
+  HUMAN_POLYHAVEN_TEXTURE_CACHE.set(role, textureSet)
+  return textureSet
 }
 
-function cloneHumanTexture(texture) {
-  if (!texture) return null;
-  const clone = texture.clone();
-  clone.image = texture.image;
-  clone.needsUpdate = true;
-  return clone;
+function cloneHumanTexture (texture) {
+  if (!texture) return null
+  const clone = texture.clone()
+  clone.image = texture.image
+  clone.needsUpdate = true
+  return clone
 }
 
-function resolveHumanSurfaceRole(obj, mat) {
-  const key = cleanName(`${obj?.name || ''} ${mat?.name || ''}`);
-  if (key.includes('skin') || key.includes('head') || key.includes('face') || key.includes('hand') || key.includes('arm')) return 'skin';
-  if (key.includes('hair') || key.includes('beard') || key.includes('brow')) return 'hair';
-  if (key.includes('eye')) return 'eyes';
-  if (key.includes('teeth') || key.includes('tooth')) return 'teeth';
-  if (key.includes('shoe') || key.includes('footwear') || key.includes('boot')) return 'shoes';
-  if (key.includes('bottom') || key.includes('pant') || key.includes('trouser') || key.includes('jean') || key.includes('leg')) return 'bottom';
-  if (key.includes('top') || key.includes('shirt') || key.includes('hoodie') || key.includes('jacket') || key.includes('torso') || key.includes('outfit')) return 'top';
-  return 'fabric';
+function resolveHumanSurfaceRole (obj, mat) {
+  const key = cleanName(`${obj?.name || ''} ${mat?.name || ''}`)
+  if (key.includes('skin') || key.includes('head') || key.includes('face') || key.includes('hand') || key.includes('arm')) return 'skin'
+  if (key.includes('hair') || key.includes('beard') || key.includes('brow')) return 'hair'
+  if (key.includes('eye')) return 'eyes'
+  if (key.includes('teeth') || key.includes('tooth')) return 'teeth'
+  if (key.includes('shoe') || key.includes('footwear') || key.includes('boot')) return 'shoes'
+  if (key.includes('bottom') || key.includes('pant') || key.includes('trouser') || key.includes('jean') || key.includes('leg')) return 'bottom'
+  if (key.includes('top') || key.includes('shirt') || key.includes('hoodie') || key.includes('jacket') || key.includes('torso') || key.includes('outfit')) return 'top'
+  return 'fabric'
 }
 
-function applyPolyhavenHumanClothingMaterial(obj, mat) {
-  if (!mat || mat.userData?.polyhavenHumanClothApplied) return;
-  const role = resolveHumanSurfaceRole(obj, mat);
-  const textureSet = loadHumanPolyhavenTextureSet(role);
-  if (!textureSet) return;
-  mat.map = cloneHumanTexture(textureSet.map);
-  mat.normalMap = cloneHumanTexture(textureSet.normalMap);
-  mat.roughnessMap = cloneHumanTexture(textureSet.roughnessMap);
-  if (mat.color) mat.color.setHex(textureSet.cfg.tint);
-  if ('roughness' in mat) mat.roughness = 0.82;
-  if ('metalness' in mat) mat.metalness = 0.02;
-  if ('normalScale' in mat) mat.normalScale = new THREE.Vector2(textureSet.cfg.normalScale, textureSet.cfg.normalScale);
+function applyPolyhavenHumanClothingMaterial (obj, mat) {
+  if (!mat || mat.userData?.polyhavenHumanClothApplied) return
+  const role = resolveHumanSurfaceRole(obj, mat)
+  const textureSet = loadHumanPolyhavenTextureSet(role)
+  if (!textureSet) return
+  mat.map = cloneHumanTexture(textureSet.map)
+  mat.normalMap = cloneHumanTexture(textureSet.normalMap)
+  mat.roughnessMap = cloneHumanTexture(textureSet.roughnessMap)
+  if (mat.color) mat.color.setHex(textureSet.cfg.tint)
+  if ('roughness' in mat) mat.roughness = 0.82
+  if ('metalness' in mat) mat.metalness = 0.02
+  if ('normalScale' in mat) mat.normalScale = new THREE.Vector2(textureSet.cfg.normalScale, textureSet.cfg.normalScale)
   mat.userData = {
     ...(mat.userData || {}),
     polyhavenHumanClothApplied: true,
     polyhavenSource: textureSet.cfg.asset,
     polyhavenSourceFormat: 'Poly Haven texture GLTF material maps'
-  };
+  }
 }
 
-function createHumanFaceDetails(human) {
-  const head = human?.bones?.head;
-  if (!head || head.userData?.poolRoyaleFaceDetailsApplied) return;
+function createHumanFaceDetails (human) {
+  const head = human?.bones?.head
+  if (!head || head.userData?.poolRoyaleFaceDetailsApplied) return
   const browMat = new THREE.MeshStandardMaterial({
     color: REALISTIC_HUMAN_MATERIALS.hair,
     roughness: 0.92,
     metalness: 0
-  });
+  })
   const eyeMat = new THREE.MeshPhysicalMaterial({
     color: 0xf7fbff,
     roughness: 0.34,
     clearcoat: 0.65,
     clearcoatRoughness: 0.18,
     metalness: 0
-  });
-  const pupilMat = new THREE.MeshStandardMaterial({ color: 0x17120f, roughness: 0.48 });
-  const browGeom = new THREE.BoxGeometry(0.074, 0.01, 0.012);
-  const eyeGeom = new THREE.SphereGeometry(0.026, 16, 10);
-  const pupilGeom = new THREE.SphereGeometry(0.009, 10, 8);
+  })
+  const pupilMat = new THREE.MeshStandardMaterial({ color: 0x17120f, roughness: 0.48 })
+  const browGeom = new THREE.BoxGeometry(0.074, 0.01, 0.012)
+  const eyeGeom = new THREE.SphereGeometry(0.026, 16, 10)
+  const pupilGeom = new THREE.SphereGeometry(0.009, 10, 8)
   const makeEye = (x) => {
-    const eye = new THREE.Mesh(eyeGeom, eyeMat);
-    eye.name = x < 0 ? 'PoolRoyale_LeftEyeDetail' : 'PoolRoyale_RightEyeDetail';
-    eye.position.set(x, 0.055, -0.082);
-    eye.scale.set(1, 0.64, 0.45);
-    const pupil = new THREE.Mesh(pupilGeom, pupilMat);
-    pupil.name = `${eye.name}_Pupil`;
-    pupil.position.set(0, -0.001, -0.018);
-    pupil.scale.set(0.8, 0.8, 0.42);
-    eye.add(pupil);
-    return eye;
-  };
+    const eye = new THREE.Mesh(eyeGeom, eyeMat)
+    eye.name = x < 0 ? 'PoolRoyale_LeftEyeDetail' : 'PoolRoyale_RightEyeDetail'
+    eye.position.set(x, 0.055, -0.082)
+    eye.scale.set(1, 0.64, 0.45)
+    const pupil = new THREE.Mesh(pupilGeom, pupilMat)
+    pupil.name = `${eye.name}_Pupil`
+    pupil.position.set(0, -0.001, -0.018)
+    pupil.scale.set(0.8, 0.8, 0.42)
+    eye.add(pupil)
+    return eye
+  }
   const makeBrow = (x, zRot) => {
-    const brow = new THREE.Mesh(browGeom, browMat);
-    brow.name = x < 0 ? 'PoolRoyale_LeftEyebrowDetail' : 'PoolRoyale_RightEyebrowDetail';
-    brow.position.set(x, 0.092, -0.087);
-    brow.rotation.set(0.08, 0, zRot);
-    return brow;
-  };
-  head.add(makeEye(-0.034), makeEye(0.034), makeBrow(-0.036, 0.16), makeBrow(0.036, -0.16));
+    const brow = new THREE.Mesh(browGeom, browMat)
+    brow.name = x < 0 ? 'PoolRoyale_LeftEyebrowDetail' : 'PoolRoyale_RightEyebrowDetail'
+    brow.position.set(x, 0.092, -0.087)
+    brow.rotation.set(0.08, 0, zRot)
+    return brow
+  }
+  head.add(makeEye(-0.034), makeEye(0.034), makeBrow(-0.036, 0.16), makeBrow(0.036, -0.16))
   head.userData = {
     ...(head.userData || {}),
     poolRoyaleFaceDetailsApplied: true
-  };
+  }
 }
 
-function isMostlyGreyColor(color) {
-  if (!color) return true;
-  const max = Math.max(color.r, color.g, color.b);
-  const min = Math.min(color.r, color.g, color.b);
-  return max - min < 0.075;
+function isMostlyGreyColor (color) {
+  if (!color) return true
+  const max = Math.max(color.r, color.g, color.b)
+  const min = Math.min(color.r, color.g, color.b)
+  return max - min < 0.075
 }
 
-function pickHumanMaterialColor(obj, mat) {
-  const role = resolveHumanSurfaceRole(obj, mat);
-  if (role === 'skin') return REALISTIC_HUMAN_MATERIALS.skin;
-  if (role === 'hair') return REALISTIC_HUMAN_MATERIALS.hair;
-  if (role === 'eyes') return REALISTIC_HUMAN_MATERIALS.eyes;
-  if (role === 'teeth') return REALISTIC_HUMAN_MATERIALS.teeth;
-  if (role === 'shoes') return REALISTIC_HUMAN_MATERIALS.shoes;
-  if (role === 'bottom') return REALISTIC_HUMAN_MATERIALS.bottom;
-  if (role === 'top') return REALISTIC_HUMAN_MATERIALS.top;
-  return REALISTIC_HUMAN_MATERIALS.defaultFabric;
+function pickHumanMaterialColor (obj, mat) {
+  const role = resolveHumanSurfaceRole(obj, mat)
+  if (role === 'skin') return REALISTIC_HUMAN_MATERIALS.skin
+  if (role === 'hair') return REALISTIC_HUMAN_MATERIALS.hair
+  if (role === 'eyes') return REALISTIC_HUMAN_MATERIALS.eyes
+  if (role === 'teeth') return REALISTIC_HUMAN_MATERIALS.teeth
+  if (role === 'shoes') return REALISTIC_HUMAN_MATERIALS.shoes
+  if (role === 'bottom') return REALISTIC_HUMAN_MATERIALS.bottom
+  if (role === 'top') return REALISTIC_HUMAN_MATERIALS.top
+  return REALISTIC_HUMAN_MATERIALS.defaultFabric
 }
 
-function applyRealisticHumanMaterialFallback(obj, mat) {
-  if (!mat || !mat.color || mat.userData?.realisticHumanFallbackApplied) return;
-  const shouldTint = !mat.map || isMostlyGreyColor(mat.color);
-  if (!shouldTint) return;
-  mat.color.setHex(pickHumanMaterialColor(obj, mat));
-  if ('roughness' in mat) mat.roughness = Math.max(0.58, mat.roughness ?? 0.72);
-  if ('metalness' in mat) mat.metalness = Math.min(0.04, mat.metalness ?? 0);
+function applyRealisticHumanMaterialFallback (obj, mat) {
+  if (!mat || !mat.color || mat.userData?.realisticHumanFallbackApplied) return
+  const shouldTint = !mat.map || isMostlyGreyColor(mat.color)
+  if (!shouldTint) return
+  mat.color.setHex(pickHumanMaterialColor(obj, mat))
+  if ('roughness' in mat) mat.roughness = Math.max(0.58, mat.roughness ?? 0.72)
+  if ('metalness' in mat) mat.metalness = Math.min(0.04, mat.metalness ?? 0)
   mat.userData = {
     ...(mat.userData || {}),
     realisticHumanFallbackApplied: true
-  };
+  }
 }
 
 const BASE_CFG = {
@@ -251,196 +249,214 @@ const BASE_CFG = {
   bridgeArmStraightDown: false,
   forceTableFacingAim: true,
   addFaceDetails: true
-};
+}
 
-const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
-const clamp01 = (v) => clamp(v, 0, 1);
-const lerp = (a, b, t) => a + (b - a) * t;
-const easeOutCubic = (t) => 1 - (1 - t) ** 3;
-const easeInOut = (t) => t * t * (3 - 2 * t);
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v))
+const clamp01 = (v) => clamp(v, 0, 1)
+const lerp = (a, b, t) => a + (b - a) * t
+const easeOutCubic = (t) => 1 - (1 - t) ** 3
+const easeInOut = (t) => t * t * (3 - 2 * t)
 const dampScalar = (current, target, lambda, dt) =>
-  THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+  THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt))
 const dampVector = (current, target, lambda, dt) =>
-  current.lerp(target, 1 - Math.exp(-lambda * dt));
-const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
-const cleanName = (name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  current.lerp(target, 1 - Math.exp(-lambda * dt))
+const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z)
+const cleanName = (name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '')
 
-
-function resolveTableReference(frameData) {
-  return frameData.bridgeTarget || frameData.cueTip || frameData.gripTarget || frameData.cueBack || null;
+function resolveTableReference (frameData) {
+  return frameData.bridgeTarget || frameData.cueTip || frameData.gripTarget || frameData.cueBack || null
 }
 
-
-function resolveRootToTableForward(root, frameData) {
-  const cueReference = resolveTableReference(frameData);
-  if (!cueReference || !root) return null;
-  const rootToTable = cueReference.clone().sub(root);
-  rootToTable.y = 0;
-  if (rootToTable.lengthSq() < 1e-8) return null;
-  return rootToTable.normalize();
+function resolveRootToTableForward (root, frameData) {
+  const cueReference = resolveTableReference(frameData)
+  if (!cueReference || !root) return null
+  const rootToTable = cueReference.clone().sub(root)
+  rootToTable.y = 0
+  if (rootToTable.lengthSq() < 1e-8) return null
+  return rootToTable.normalize()
 }
 
-function resolveTableFacingForward(rawForward, root, frameData, cfg) {
-  const forward = rawForward?.clone?.() ?? new THREE.Vector3(0, 0, -1);
-  forward.y = 0;
-  if (forward.lengthSq() < 1e-8) forward.set(0, 0, -1);
-  forward.normalize();
+function resolveTableFacingForward (rawForward, root, frameData, cfg) {
+  const forward = rawForward?.clone?.() ?? new THREE.Vector3(0, 0, -1)
+  forward.y = 0
+  if (forward.lengthSq() < 1e-8) forward.set(0, 0, -1)
+  forward.normalize()
 
-  if (!cfg.forceTableFacingAim) return forward;
+  if (!cfg.forceTableFacingAim) return forward
 
-  const rootToTable = resolveRootToTableForward(root, frameData);
-  if (!rootToTable) return forward;
+  const rootToTable = resolveRootToTableForward(root, frameData)
+  if (!rootToTable) return forward
 
   // The avatar must always face from the stance/root toward the table/cue ball.
   // If caller math ever supplies the opposite cue axis, flip it here so every
   // downstream torso, bridge hand, grip hand and foot basis bends toward the cloth.
-  return forward.dot(rootToTable) < 0 ? forward.multiplyScalar(-1) : forward;
+  return forward.dot(rootToTable) < 0 ? forward.multiplyScalar(-1) : forward
 }
 
-function resolveShootBendSign(human, frameData, cfg) {
-  const fallbackSign = cfg.shootBendDirection >= 0 ? 1 : -1;
-  if (!cfg.shootBendTowardCueStick) return fallbackSign;
-  const cueReference = resolveTableReference(frameData);
-  if (!cueReference || !human?.root) return fallbackSign;
+function resolveShootBendSign (human, frameData, cfg) {
+  const fallbackSign = cfg.shootBendDirection >= 0 ? 1 : -1
+  if (!cfg.shootBendTowardCueStick) return fallbackSign
+  const cueReference = resolveTableReference(frameData)
+  if (!cueReference || !human?.root) return fallbackSign
   const rootToTableLocal = cueReference
     .clone()
     .sub(human.root.position)
-    .applyAxisAngle(Y_AXIS, -(human.yaw + (cfg.humanVisualYawFix || 0)));
+    .applyAxisAngle(Y_AXIS, -(human.yaw + (cfg.humanVisualYawFix || 0)))
   // Local -Z is the direction the rig is facing. Always fold the belly/chest/head
   // side toward the cue ball/table; feet and hips stay planted by the pose solver.
   return Math.abs(rootToTableLocal.z) > 1e-5
     ? (rootToTableLocal.z <= 0 ? -1 : 1)
-    : -1;
+    : -1
 }
 
-function ensureHumanFacingTable(human, frameData, cfg) {
-  if (!cfg.forceTableFacingAim || !human?.root) return;
-  const cueReference = resolveTableReference(frameData);
-  if (!cueReference) return;
-  const rootToTable = cueReference.clone().sub(human.root.position);
-  rootToTable.y = 0;
-  if (rootToTable.lengthSq() < 1e-8) return;
-  rootToTable.normalize();
-  const visualYaw = human.yaw + (cfg.humanVisualYawFix || 0);
-  const liveForward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, visualYaw).normalize();
+function ensureHumanFacingTable (human, frameData, cfg) {
+  if (!cfg.forceTableFacingAim || !human?.root) return
+  const cueReference = resolveTableReference(frameData)
+  if (!cueReference) return
+  const rootToTable = cueReference.clone().sub(human.root.position)
+  rootToTable.y = 0
+  if (rootToTable.lengthSq() < 1e-8) return
+  rootToTable.normalize()
+  const visualYaw = human.yaw + (cfg.humanVisualYawFix || 0)
+  const liveForward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, visualYaw).normalize()
   if (liveForward.dot(rootToTable) < -0.05) {
-    human.yaw = yawFromForward(rootToTable) - (cfg.humanVisualYawFix || 0);
+    human.yaw = yawFromForward(rootToTable) - (cfg.humanVisualYawFix || 0)
   }
 }
 
-function scaleVectorConfig(cfg) {
-  const next = { ...BASE_CFG, ...cfg };
+function scaleVectorConfig (cfg) {
+  const next = { ...BASE_CFG, ...cfg }
+  next.scale = Number.isFinite(next.scale) ? next.scale : next.unit
   if (!(next.rightHandCueSocketLocal instanceof THREE.Vector3)) {
-    const socket = next.rightHandCueSocketLocal || BASE_CFG.rightHandCueSocketLocal;
-    next.rightHandCueSocketLocal = new THREE.Vector3(socket.x, socket.y, socket.z);
+    const socket = next.rightHandCueSocketLocal || BASE_CFG.rightHandCueSocketLocal
+    next.rightHandCueSocketLocal = new THREE.Vector3(socket.x, socket.y, socket.z)
   } else {
-    next.rightHandCueSocketLocal = next.rightHandCueSocketLocal.clone();
+    next.rightHandCueSocketLocal = next.rightHandCueSocketLocal.clone()
   }
   if (!(next.idleCueDir instanceof THREE.Vector3)) {
-    const dir = next.idleCueDir || BASE_CFG.idleCueDir;
-    next.idleCueDir = new THREE.Vector3(dir.x, dir.y, dir.z);
+    const dir = next.idleCueDir || BASE_CFG.idleCueDir
+    next.idleCueDir = new THREE.Vector3(dir.x, dir.y, dir.z)
   } else {
-    next.idleCueDir = next.idleCueDir.clone();
+    next.idleCueDir = next.idleCueDir.clone()
   }
-  return next;
+  return next
 }
 
-
-function resolveWalkPerimeter(cfg) {
-  if (!cfg.perimeterWalk || !Number.isFinite(cfg.tableW) || !Number.isFinite(cfg.tableL)) return null;
-  const halfX = cfg.tableW / 2 + (cfg.edgeMargin || 0);
-  const halfZ = cfg.tableL / 2 + (cfg.edgeMargin || 0);
-  if (halfX <= 0 || halfZ <= 0) return null;
-  return { halfX, halfZ, length: 4 * (halfX + halfZ) };
+function resolveWalkPerimeter (cfg) {
+  if (!cfg.perimeterWalk || !Number.isFinite(cfg.tableW) || !Number.isFinite(cfg.tableL)) return null
+  const halfX = cfg.tableW / 2 + (cfg.edgeMargin || 0)
+  const halfZ = cfg.tableL / 2 + (cfg.edgeMargin || 0)
+  if (halfX <= 0 || halfZ <= 0) return null
+  return { halfX, halfZ, length: 4 * (halfX + halfZ) }
 }
 
-function clampPointToWalkPerimeter(point, perimeter) {
-  const { halfX, halfZ } = perimeter;
-  const x = clamp(point.x, -halfX, halfX);
-  const z = clamp(point.z, -halfZ, halfZ);
-  const dx = Math.min(Math.abs(x + halfX), Math.abs(x - halfX));
-  const dz = Math.min(Math.abs(z + halfZ), Math.abs(z - halfZ));
-  if (dx < dz) return new THREE.Vector3(x < 0 ? -halfX : halfX, 0, z);
-  return new THREE.Vector3(x, 0, z < 0 ? -halfZ : halfZ);
+function clampPointToWalkPerimeter (point, perimeter) {
+  const { halfX, halfZ } = perimeter
+  const x = clamp(point.x, -halfX, halfX)
+  const z = clamp(point.z, -halfZ, halfZ)
+  const dx = Math.min(Math.abs(x + halfX), Math.abs(x - halfX))
+  const dz = Math.min(Math.abs(z + halfZ), Math.abs(z - halfZ))
+  if (dx < dz) return new THREE.Vector3(x < 0 ? -halfX : halfX, 0, z)
+  return new THREE.Vector3(x, 0, z < 0 ? -halfZ : halfZ)
 }
 
-function pointToPerimeterT(point, perimeter) {
-  const p = clampPointToWalkPerimeter(point, perimeter);
-  const { halfX, halfZ, length } = perimeter;
-  let d = 0;
+function pointToPerimeterT (point, perimeter) {
+  const p = clampPointToWalkPerimeter(point, perimeter)
+  const { halfX, halfZ, length } = perimeter
+  let d = 0
   if (Math.abs(p.z + halfZ) < Math.abs(p.x - halfX) && Math.abs(p.z + halfZ) < Math.abs(p.z - halfZ)) {
-    d = p.x + halfX;
+    d = p.x + halfX
   } else if (Math.abs(p.x - halfX) <= Math.abs(p.z - halfZ)) {
-    d = 2 * halfX + (p.z + halfZ);
+    d = 2 * halfX + (p.z + halfZ)
   } else if (Math.abs(p.z - halfZ) <= Math.abs(p.x + halfX)) {
-    d = 2 * halfX + 2 * halfZ + (halfX - p.x);
+    d = 2 * halfX + 2 * halfZ + (halfX - p.x)
   } else {
-    d = 4 * halfX + 2 * halfZ + (halfZ - p.z);
+    d = 4 * halfX + 2 * halfZ + (halfZ - p.z)
   }
-  return THREE.MathUtils.euclideanModulo(d / length, 1);
+  return THREE.MathUtils.euclideanModulo(d / length, 1)
 }
 
-function perimeterTToPoint(t, perimeter) {
-  const { halfX, halfZ, length } = perimeter;
-  let d = THREE.MathUtils.euclideanModulo(t, 1) * length;
-  if (d <= 2 * halfX) return new THREE.Vector3(-halfX + d, 0, -halfZ);
-  d -= 2 * halfX;
-  if (d <= 2 * halfZ) return new THREE.Vector3(halfX, 0, -halfZ + d);
-  d -= 2 * halfZ;
-  if (d <= 2 * halfX) return new THREE.Vector3(halfX - d, 0, halfZ);
-  d -= 2 * halfX;
-  return new THREE.Vector3(-halfX, 0, halfZ - d);
+function perimeterTToPoint (t, perimeter) {
+  const { halfX, halfZ, length } = perimeter
+  let d = THREE.MathUtils.euclideanModulo(t, 1) * length
+  if (d <= 2 * halfX) return new THREE.Vector3(-halfX + d, 0, -halfZ)
+  d -= 2 * halfX
+  if (d <= 2 * halfZ) return new THREE.Vector3(halfX, 0, -halfZ + d)
+  d -= 2 * halfZ
+  if (d <= 2 * halfX) return new THREE.Vector3(halfX - d, 0, halfZ)
+  d -= 2 * halfX
+  return new THREE.Vector3(-halfX, 0, halfZ - d)
 }
 
-function moveRootAroundPerimeter(human, rootGoal, cfg, dt) {
-  const perimeter = resolveWalkPerimeter(cfg);
+function constrainHumanPerimeterStepExact (current, target, cfg) {
+  const xEdge = cfg.tableW / 2 + cfg.edgeMargin
+  const zEdge = cfg.tableL / 2 + cfg.edgeMargin
+  const groundY = cfg.groundY || 0
+  const project = (point) => {
+    const dx = Math.abs(Math.abs(point.x) - xEdge)
+    const dz = Math.abs(Math.abs(point.z) - zEdge)
+    if (dx < dz) return new THREE.Vector3(Math.sign(point.x || target.x || 1) * xEdge, groundY, clamp(point.z, -zEdge, zEdge))
+    return new THREE.Vector3(clamp(point.x, -xEdge, xEdge), groundY, Math.sign(point.z || target.z || 1) * zEdge)
+  }
+  const cur = current.lengthSq() > 1e-6 ? project(current) : project(target)
+  const goal = project(target)
+  const curOnX = Math.abs(Math.abs(cur.x) - xEdge) < Math.abs(Math.abs(cur.z) - zEdge)
+  const goalOnX = Math.abs(Math.abs(goal.x) - xEdge) < Math.abs(Math.abs(goal.z) - zEdge)
+  if (curOnX === goalOnX && (curOnX ? Math.sign(cur.x) === Math.sign(goal.x) : Math.sign(cur.z) === Math.sign(goal.z))) return goal
+  return curOnX
+    ? new THREE.Vector3(cur.x, groundY, Math.sign(goal.z || cur.z || 1) * zEdge)
+    : new THREE.Vector3(Math.sign(goal.x || cur.x || 1) * xEdge, groundY, cur.z)
+}
+
+function moveRootAroundPerimeter (human, rootGoal, cfg, dt) {
+  const perimeter = resolveWalkPerimeter(cfg)
   if (!perimeter) {
-    dampVector(human.root.position, rootGoal, cfg.moveLambda, dt);
-    human.root.position.y = cfg.groundY;
-    return human.root.position.distanceTo(rootGoal);
+    dampVector(human.root.position, rootGoal, cfg.moveLambda, dt)
+    human.root.position.y = cfg.groundY
+    return human.root.position.distanceTo(rootGoal)
   }
-  const goal = clampPointToWalkPerimeter(rootGoal, perimeter);
-  goal.y = cfg.groundY;
-  if (human.root.position.lengthSq() < 1e-6) human.root.position.copy(goal);
-  else human.root.position.copy(clampPointToWalkPerimeter(human.root.position, perimeter)).setY(cfg.groundY);
-  if (!Number.isFinite(human.perimeterT)) human.perimeterT = pointToPerimeterT(human.root.position, perimeter);
-  const targetT = pointToPerimeterT(goal, perimeter);
-  const loopDelta = THREE.MathUtils.euclideanModulo(targetT - human.perimeterT + 0.5, 1) - 0.5;
-  const maxStep = ((cfg.perimeterWalkSpeed || 4 * cfg.unit) * Math.max(dt, 1 / 240)) / perimeter.length;
-  human.perimeterT = THREE.MathUtils.euclideanModulo(human.perimeterT + clamp(loopDelta, -maxStep, maxStep), 1);
-  human.root.position.copy(perimeterTToPoint(human.perimeterT, perimeter)).setY(cfg.groundY);
-  return human.root.position.distanceTo(goal);
+  const goal = clampPointToWalkPerimeter(rootGoal, perimeter)
+  goal.y = cfg.groundY
+  if (human.root.position.lengthSq() < 1e-6) human.root.position.copy(goal)
+  else human.root.position.copy(clampPointToWalkPerimeter(human.root.position, perimeter)).setY(cfg.groundY)
+  if (!Number.isFinite(human.perimeterT)) human.perimeterT = pointToPerimeterT(human.root.position, perimeter)
+  const targetT = pointToPerimeterT(goal, perimeter)
+  const loopDelta = THREE.MathUtils.euclideanModulo(targetT - human.perimeterT + 0.5, 1) - 0.5
+  const maxStep = ((cfg.perimeterWalkSpeed || 4 * cfg.unit) * Math.max(dt, 1 / 240)) / perimeter.length
+  human.perimeterT = THREE.MathUtils.euclideanModulo(human.perimeterT + clamp(loopDelta, -maxStep, maxStep), 1)
+  human.root.position.copy(perimeterTToPoint(human.perimeterT, perimeter)).setY(cfg.groundY)
+  return human.root.position.distanceTo(goal)
 }
 
-function makeBasisQuaternion(side, up, forward) {
+function makeBasisQuaternion (side, up, forward) {
   BASIS_MAT.makeBasis(
     side.clone().normalize(),
     up.clone().normalize(),
     forward.clone().normalize()
-  );
-  return new THREE.Quaternion().setFromRotationMatrix(BASIS_MAT);
+  )
+  return new THREE.Quaternion().setFromRotationMatrix(BASIS_MAT)
 }
 
-function findBone(all, aliases) {
-  const list = all.map((bone) => ({ bone, name: cleanName(bone.name) }));
-  const names = aliases.map(cleanName);
+function findBone (all, aliases) {
+  const list = all.map((bone) => ({ bone, name: cleanName(bone.name) }))
+  const names = aliases.map(cleanName)
   for (const alias of names) {
-    const exact = list.find((x) => x.name === alias || x.name.endsWith(alias));
-    if (exact) return exact.bone;
+    const exact = list.find((x) => x.name === alias || x.name.endsWith(alias))
+    if (exact) return exact.bone
   }
   for (const alias of names) {
-    const loose = list.find((x) => x.name.includes(alias));
-    if (loose) return loose.bone;
+    const loose = list.find((x) => x.name.includes(alias))
+    if (loose) return loose.bone
   }
-  return undefined;
+  return undefined
 }
 
-function buildAvatarBones(model) {
-  const all = [];
+function buildAvatarBones (model) {
+  const all = []
   model.traverse((obj) => {
-    if (obj?.isBone) all.push(obj);
-  });
-  const f = (...names) => findBone(all, names);
+    if (obj?.isBone) all.push(obj)
+  })
+  const f = (...names) => findBone(all, names)
   return {
     hips: f('hips', 'pelvis', 'mixamorigHips'),
     spine: f('spine', 'spine01', 'mixamorigSpine'),
@@ -459,33 +475,33 @@ function buildAvatarBones(model) {
     rightUpperLeg: f('rightupleg', 'rightupperleg', 'rightthigh', 'mixamorigRightUpLeg'),
     rightLowerLeg: f('rightleg', 'rightlowerleg', 'rightcalf', 'mixamorigRightLeg'),
     rightFoot: f('rightfoot', 'footr', 'mixamorigRightFoot')
-  };
+  }
 }
 
-function collectFingerBones(hand) {
-  const out = [];
+function collectFingerBones (hand) {
+  const out = []
   hand?.traverse((obj) => {
-    if (!obj?.isBone || obj === hand) return;
-    const n = cleanName(obj.name);
+    if (!obj?.isBone || obj === hand) return
+    const n = cleanName(obj.name)
     if (['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((s) => n.includes(s))) {
-      out.push(obj);
+      out.push(obj)
     }
-  });
-  return out;
+  })
+  return out
 }
 
-function normalizeHuman(model, cfg) {
-  model.scale.setScalar(cfg.humanScale);
-  model.rotation.set(0, cfg.humanVisualYawFix, 0);
-  model.position.set(0, 0, 0);
-  model.updateMatrixWorld(true);
-  const box = new THREE.Box3().setFromObject(model);
-  const center = box.getCenter(new THREE.Vector3());
-  model.position.set(-center.x, -box.min.y, -center.z);
+function normalizeHuman (model, cfg) {
+  model.scale.setScalar(cfg.humanScale)
+  model.rotation.set(0, cfg.humanVisualYawFix, 0)
+  model.position.set(0, 0, 0)
+  model.updateMatrixWorld(true)
+  const box = new THREE.Box3().setFromObject(model)
+  const center = box.getCenter(new THREE.Vector3())
+  model.position.set(-center.x, -box.min.y, -center.z)
 }
 
-export function createHumanRig(scene, opts = {}) {
-  const cfg = scaleVectorConfig(opts);
+export function createHumanRig (scene, opts = {}) {
+  const cfg = scaleVectorConfig(opts)
   const human = {
     root: new THREE.Group(),
     modelRoot: new THREE.Group(),
@@ -507,297 +523,297 @@ export function createHumanRig(scene, opts = {}) {
     actions: {},
     currentAction: 'Idle',
     cfg
-  };
-  human.root.visible = false;
-  human.modelRoot.visible = false;
-  scene.add(human.root, human.modelRoot);
+  }
+  human.root.visible = false
+  human.modelRoot.visible = false
+  scene.add(human.root, human.modelRoot)
 
-  const { loader, modelUrl = HUMAN_URL, onStatus } = opts;
+  const { loader, modelUrl = HUMAN_URL, onStatus } = opts
   const modelUrls = Array.isArray(opts.modelUrls) && opts.modelUrls.length > 0
     ? opts.modelUrls.filter((url) => typeof url === 'string' && url.trim().length > 0)
-    : [modelUrl];
-  if (!loader) return human;
-  loader.setCrossOrigin?.('anonymous');
-  onStatus?.('Loading original skeleton human logic…');
+    : [modelUrl]
+  if (!loader) return human
+  loader.setCrossOrigin?.('anonymous')
+  onStatus?.('Loading original skeleton human logic…')
   const loadModelAt = (urlIndex = 0) => {
-    const activeUrl = modelUrls[urlIndex] || HUMAN_URL;
+    const activeUrl = modelUrls[urlIndex] || HUMAN_URL
     loader.load(
       activeUrl,
       (gltf) => {
-        const model = gltf?.scene;
-        if (!model) return;
-        normalizeHuman(model, cfg);
+        const model = gltf?.scene
+        if (!model) return
+        normalizeHuman(model, cfg)
         model.traverse((obj) => {
-          if (!obj?.isMesh) return;
-          obj.castShadow = true;
-          obj.receiveShadow = true;
-          obj.frustumCulled = false;
-          const sourceMats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
-          const mats = sourceMats.map((mat) => (mat?.clone ? mat.clone() : mat));
-          if (Array.isArray(obj.material)) obj.material = mats;
-          else if (mats[0]) obj.material = mats[0];
+          if (!obj?.isMesh) return
+          obj.castShadow = true
+          obj.receiveShadow = true
+          obj.frustumCulled = false
+          const sourceMats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : []
+          const mats = sourceMats.map((mat) => (mat?.clone ? mat.clone() : mat))
+          if (Array.isArray(obj.material)) obj.material = mats
+          else if (mats[0]) obj.material = mats[0]
           mats.forEach((mat) => {
             if (mat.map) {
-              mat.map.colorSpace = THREE.SRGBColorSpace;
-              mat.map.flipY = false;
-              mat.map.needsUpdate = true;
+              mat.map.colorSpace = THREE.SRGBColorSpace
+              mat.map.flipY = false
+              mat.map.needsUpdate = true
             }
-            applyRealisticHumanMaterialFallback(obj, mat);
-            applyPolyhavenHumanClothingMaterial(obj, mat);
-            mat.depthWrite = true;
-            mat.depthTest = true;
-            mat.needsUpdate = true;
-          });
-        });
-        human.mixer = new THREE.AnimationMixer(model);
-        const clipByName = new Map((gltf.animations || []).map((clip) => [String(clip.name || '').toLowerCase(), clip]));
+            applyRealisticHumanMaterialFallback(obj, mat)
+            applyPolyhavenHumanClothingMaterial(obj, mat)
+            mat.depthWrite = true
+            mat.depthTest = true
+            mat.needsUpdate = true
+          })
+        })
+        human.mixer = new THREE.AnimationMixer(model)
+        const clipByName = new Map((gltf.animations || []).map((clip) => [String(clip.name || '').toLowerCase(), clip]))
         const aliases = {
           Idle: ['idle'],
           Walk: ['walk', 'walking'],
           Run: ['run', 'running']
-        };
+        }
         Object.entries(aliases).forEach(([name, names]) => {
-          const clip = names.map((alias) => clipByName.get(alias)).find(Boolean);
-          if (!clip) return;
-          const action = human.mixer.clipAction(clip);
-          action.enabled = true;
-          action.setLoop(THREE.LoopRepeat, Infinity);
-          action.clampWhenFinished = false;
-          action.setEffectiveWeight(name === 'Idle' ? 1 : 0);
-          action.play();
-          human.actions[name] = action;
-        });
-        human.bones = buildAvatarBones(model);
-        human.leftFingers = collectFingerBones(human.bones.leftHand);
+          const clip = names.map((alias) => clipByName.get(alias)).find(Boolean)
+          if (!clip) return
+          const action = human.mixer.clipAction(clip)
+          action.enabled = true
+          action.setLoop(THREE.LoopRepeat, Infinity)
+          action.clampWhenFinished = false
+          action.setEffectiveWeight(name === 'Idle' ? 1 : 0)
+          action.play()
+          human.actions[name] = action
+        })
+        human.bones = buildAvatarBones(model)
+        human.leftFingers = collectFingerBones(human.bones.leftHand)
         human.rightFingers = collectFingerBones(human.bones.rightHand);
         [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((bone) => {
-          if (bone) human.restQuats.set(bone, bone.quaternion.clone());
-        });
+          if (bone) human.restQuats.set(bone, bone.quaternion.clone())
+        })
         if (human.cfg.addFaceDetails !== false) {
-          createHumanFaceDetails(human);
+          createHumanFaceDetails(human)
         }
-        const b = human.bones;
+        const b = human.bones
         human.activeGlb = Boolean(
           b.hips && b.spine && b.head && b.rightUpperArm && b.rightLowerArm && b.rightHand &&
           b.leftUpperLeg && b.leftLowerLeg && b.leftFoot && b.rightUpperLeg && b.rightLowerLeg && b.rightFoot
-        );
-        human.model = model;
-        human.modelRoot.add(model);
-        human.modelRoot.visible = human.activeGlb;
-        onStatus?.(human.activeGlb ? 'Original human skeleton logic restored' : 'Human loaded, skeleton aliases incomplete');
+        )
+        human.model = model
+        human.modelRoot.add(model)
+        human.modelRoot.visible = human.activeGlb
+        onStatus?.(human.activeGlb ? 'Original human skeleton logic restored' : 'Human loaded, skeleton aliases incomplete')
       },
       undefined,
       (error) => {
-        console.warn('ReadyPlayer human failed', { url: activeUrl, error });
+        console.warn('ReadyPlayer human failed', { url: activeUrl, error })
         if (urlIndex + 1 < modelUrls.length) {
-          loadModelAt(urlIndex + 1);
-          return;
+          loadModelAt(urlIndex + 1)
+          return
         }
-        onStatus?.('ReadyPlayer GLTF human failed');
+        onStatus?.('ReadyPlayer GLTF human failed')
       }
-    );
-  };
-  loadModelAt(0);
-  return human;
+    )
+  }
+  loadModelAt(0)
+  return human
 }
 
-function setBoneWorldQuaternion(bone, q) {
-  if (!bone || !q) return;
-  const parentQ = new THREE.Quaternion();
-  bone.parent?.getWorldQuaternion(parentQ);
-  bone.quaternion.copy(parentQ.invert().multiply(q));
-  bone.updateMatrixWorld(true);
+function setBoneWorldQuaternion (bone, q) {
+  if (!bone || !q) return
+  const parentQ = new THREE.Quaternion()
+  bone.parent?.getWorldQuaternion(parentQ)
+  bone.quaternion.copy(parentQ.invert().multiply(q))
+  bone.updateMatrixWorld(true)
 }
-function firstBoneChild(bone) {
-  return bone?.children.find((child) => child?.isBone);
+function firstBoneChild (bone) {
+  return bone?.children.find((child) => child?.isBone)
 }
-function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) {
-  if (!bone || strength <= 0) return;
-  const bonePos = bone.getWorldPosition(new THREE.Vector3());
+function rotateBoneToward (bone, target, strength = 1, fallbackDir = UP) {
+  if (!bone || strength <= 0) return
+  const bonePos = bone.getWorldPosition(new THREE.Vector3())
   const childPos = firstBoneChild(bone)?.getWorldPosition(new THREE.Vector3()) ||
-    bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25);
-  const current = childPos.sub(bonePos).normalize();
-  const desired = target.clone().sub(bonePos);
-  if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return;
+    bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25)
+  const current = childPos.sub(bonePos).normalize()
+  const desired = target.clone().sub(bonePos)
+  if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return
   const delta = new THREE.Quaternion().slerpQuaternions(
     new THREE.Quaternion(),
     new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()),
     clamp01(strength)
-  );
-  setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+  )
+  setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())))
 }
-function twistBone(bone, axis, amount) {
-  if (!bone || Math.abs(amount) < 1e-5) return;
+function twistBone (bone, axis, amount) {
+  if (!bone || Math.abs(amount) < 1e-5) return
   setBoneWorldQuaternion(
     bone,
     new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount)
       .multiply(bone.getWorldQuaternion(new THREE.Quaternion()))
-  );
+  )
 }
-function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) {
+function aimTwoBone (upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) {
   for (let i = 0; i < 4; i += 1) {
-    rotateBoneToward(upper, elbow, upperStrength, pole);
-    rotateBoneToward(lower, hand, lowerStrength, pole);
+    rotateBoneToward(upper, elbow, upperStrength, pole)
+    rotateBoneToward(lower, hand, lowerStrength, pole)
   }
 }
-function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) {
-  if (!bone || strength <= 0) return;
-  const q = makeBasisQuaternion(side, up, forward);
+function setHandBasis (bone, side, up, forward, roll = 0, strength = 1) {
+  if (!bone || strength <= 0) return
+  const q = makeBasisQuaternion(side, up, forward)
   if (Math.abs(roll) > 1e-4) {
-    q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+    q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll))
   }
-  setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength)));
+  setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength)))
 }
-function cueSocketOffsetWorld(side, up, forward, roll, socketLocal) {
-  const q = makeBasisQuaternion(side, up, forward);
-  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
-  return socketLocal.clone().applyQuaternion(q);
+function cueSocketOffsetWorld (side, up, forward, roll, socketLocal) {
+  const q = makeBasisQuaternion(side, up, forward)
+  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll))
+  return socketLocal.clone().applyQuaternion(q)
 }
-function poseFingers(fingers, mode, weight) {
-  const w = clamp01(weight);
+function poseFingers (fingers, mode, weight) {
+  const w = clamp01(weight)
   fingers.forEach((finger, i) => {
-    const n = cleanName(finger.name);
-    const thumb = n.includes('thumb');
-    const index = n.includes('index');
-    const middle = n.includes('middle');
-    const ring = n.includes('ring');
-    const pinky = n.includes('pinky') || n.includes('little');
-    const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal'));
-    const mid = n.includes('2') || n.includes('intermediate');
-    const tip = n.includes('3') || n.includes('distal');
+    const n = cleanName(finger.name)
+    const thumb = n.includes('thumb')
+    const index = n.includes('index')
+    const middle = n.includes('middle')
+    const ring = n.includes('ring')
+    const pinky = n.includes('pinky') || n.includes('little')
+    const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal'))
+    const mid = n.includes('2') || n.includes('intermediate')
+    const tip = n.includes('3') || n.includes('distal')
     if (mode === 'idle') {
-      finger.rotation.x += 0.018 * w;
-      finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1);
-      return;
+      finger.rotation.x += 0.018 * w
+      finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1)
+      return
     }
     if (mode === 'grip') {
       if (thumb) {
-        finger.rotation.x += 0.48 * w;
-        finger.rotation.y += -0.82 * w;
-        finger.rotation.z += 0.54 * w;
-        return;
+        finger.rotation.x += 0.48 * w
+        finger.rotation.y += -0.82 * w
+        finger.rotation.z += 0.54 * w
+        return
       }
-      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0;
-      finger.rotation.x += curl * w;
-      finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w;
-      finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w;
-      return;
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0
+      finger.rotation.x += curl * w
+      finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w
+      finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w
+      return
     }
     if (thumb) {
-      finger.rotation.x += -0.18 * w;
-      finger.rotation.y += 0.95 * w;
-      finger.rotation.z += -0.95 * w;
+      finger.rotation.x += -0.18 * w
+      finger.rotation.y += 0.95 * w
+      finger.rotation.z += -0.95 * w
     } else if (index) {
-      finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w;
-      finger.rotation.y += -0.46 * w;
-      finger.rotation.z += -0.42 * w;
+      finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w
+      finger.rotation.y += -0.46 * w
+      finger.rotation.z += -0.42 * w
     } else if (middle) {
-      finger.rotation.x += (base ? 0.18 : mid ? 0.32 : 0.22) * w;
-      finger.rotation.y += -0.12 * w;
-      finger.rotation.z += -0.14 * w;
+      finger.rotation.x += (base ? 0.18 : mid ? 0.32 : 0.22) * w
+      finger.rotation.y += -0.12 * w
+      finger.rotation.z += -0.14 * w
     } else if (ring || pinky) {
-      finger.rotation.x += (base ? (ring ? 0.08 : 0.05) : mid ? (ring ? 0.18 : 0.16) : tip ? (ring ? 0.12 : 0.1) : 0.1) * w;
-      finger.rotation.y += (ring ? 0.18 : 0.34) * w;
-      finger.rotation.z += (ring ? 0.28 : 0.46) * w;
+      finger.rotation.x += (base ? (ring ? 0.08 : 0.05) : mid ? (ring ? 0.18 : 0.16) : tip ? (ring ? 0.12 : 0.1) : 0.1) * w
+      finger.rotation.y += (ring ? 0.18 : 0.34) * w
+      finger.rotation.z += (ring ? 0.28 : 0.46) * w
     }
-  });
+  })
 }
 
-function setHumanAction(human, next, blend = 0.18) {
-  if (!human?.actions?.[next] || human.currentAction === next) return;
-  const previous = human.actions[human.currentAction];
-  const nextAction = human.actions[next];
+function setHumanAction (human, next, blend = 0.18) {
+  if (!human?.actions?.[next] || human.currentAction === next) return
+  const previous = human.actions[human.currentAction]
+  const nextAction = human.actions[next]
   if (previous && nextAction) {
-    nextAction.enabled = true;
-    nextAction.reset();
-    nextAction.setEffectiveTimeScale(1);
-    nextAction.setEffectiveWeight(1);
-    previous.crossFadeTo(nextAction, blend, false);
-    nextAction.play();
+    nextAction.enabled = true
+    nextAction.reset()
+    nextAction.setEffectiveTimeScale(1)
+    nextAction.setEffectiveWeight(1)
+    previous.crossFadeTo(nextAction, blend, false)
+    nextAction.play()
   }
-  human.currentAction = next;
+  human.currentAction = next
 }
 
-function updateGoalRushWalkAnimation(human, dt, frame) {
-  if (!human?.mixer || !human.actions?.Walk) return false;
-  const walkWeight = frame.walkAmount * (1 - easeInOut(clamp01(frame.t)));
-  const next = walkWeight > 0.05 ? 'Walk' : 'Idle';
-  setHumanAction(human, next);
-  const walk = human.actions.Walk;
+function updateGoalRushWalkAnimation (human, dt, frame) {
+  if (!human?.mixer || !human.actions?.Walk) return false
+  const walkWeight = frame.walkAmount * (1 - easeInOut(clamp01(frame.t)))
+  const next = walkWeight > 0.05 ? 'Walk' : 'Idle'
+  setHumanAction(human, next)
+  const walk = human.actions.Walk
   if (walk) {
-    const ref = human.cfg?.perimeterWalkSpeed || human.cfg?.unit || 1;
-    const normalizedSpeed = Math.max(0, Math.min(2, (human.lastMoveAmountRaw || 0) * 60 / Math.max(0.001, ref)));
-    walk.timeScale = THREE.MathUtils.clamp(normalizedSpeed || walkWeight, 0.7, 1.35);
+    const ref = human.cfg?.perimeterWalkSpeed || human.cfg?.unit || 1
+    const normalizedSpeed = Math.max(0, Math.min(2, (human.lastMoveAmountRaw || 0) * 60 / Math.max(0.001, ref)))
+    walk.timeScale = THREE.MathUtils.clamp(normalizedSpeed || walkWeight, 0.7, 1.35)
   }
-  human.mixer.update(dt);
-  return walkWeight > 0.05 && frame.t < 0.025;
+  human.mixer.update(dt)
+  return walkWeight > 0.05 && frame.t < 0.025
 }
 
-function driveHuman(human, frame) {
-  if (!human.activeGlb || !human.model) return;
-  const cfg = human.cfg;
-  human.modelRoot.visible = true;
-  human.modelRoot.position.copy(frame.rootWorld);
-  human.modelRoot.rotation.y = human.yaw;
-  human.modelRoot.updateMatrixWorld(true);
-  const usingGoalRushWalk = updateGoalRushWalkAnimation(human, frame.dt || 0, frame);
-  if (usingGoalRushWalk) return;
-  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
-  human.modelRoot.updateMatrixWorld(true);
-  const b = human.bones;
-  const ik = easeInOut(clamp01(frame.t));
-  const idle = 1 - ik;
-  const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
-  const standingCueDir = cfg.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
-  const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
+function driveHuman (human, frame) {
+  if (!human.activeGlb || !human.model) return
+  const cfg = human.cfg
+  human.modelRoot.visible = true
+  human.modelRoot.position.copy(frame.rootWorld)
+  human.modelRoot.rotation.y = human.yaw
+  human.modelRoot.updateMatrixWorld(true)
+  const usingGoalRushWalk = updateGoalRushWalkAnimation(human, frame.dt || 0, frame)
+  if (usingGoalRushWalk) return
+  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q))
+  human.modelRoot.updateMatrixWorld(true)
+  const b = human.bones
+  const ik = easeInOut(clamp01(frame.t))
+  const idle = 1 - ik
+  const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize()
+  const standingCueDir = cfg.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize()
+  const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward)
 
   if (frame.seated) {
     // Murlan Royale seated baseline: hips fold down into the cushion, legs stay
     // grounded in front of the chair and only light upper-body breathing remains.
-    if (b.hips) b.hips.rotation.x += THREE.MathUtils.degToRad(-9);
-    if (b.spine) b.spine.rotation.x += THREE.MathUtils.degToRad(-3);
-    if (b.chest) b.chest.rotation.x += THREE.MathUtils.degToRad(-2);
-    if (b.head) b.head.rotation.x += THREE.MathUtils.degToRad(3);
-    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += THREE.MathUtils.degToRad(-64);
-    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x += THREE.MathUtils.degToRad(-64);
-    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += THREE.MathUtils.degToRad(72);
-    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += THREE.MathUtils.degToRad(72);
-    if (b.leftUpperArm) b.leftUpperArm.rotation.x += THREE.MathUtils.degToRad(-42);
-    if (b.rightUpperArm) b.rightUpperArm.rotation.x += THREE.MathUtils.degToRad(-38);
-    if (b.leftLowerArm) b.leftLowerArm.rotation.x += THREE.MathUtils.degToRad(38);
-    if (b.rightLowerArm) b.rightLowerArm.rotation.x += THREE.MathUtils.degToRad(34);
-    human.modelRoot.updateMatrixWorld(true);
-    poseFingers(human.leftFingers, 'idle', 1);
-    poseFingers(human.rightFingers, 'grip', 0.7);
-    return;
+    if (b.hips) b.hips.rotation.x += THREE.MathUtils.degToRad(-9)
+    if (b.spine) b.spine.rotation.x += THREE.MathUtils.degToRad(-3)
+    if (b.chest) b.chest.rotation.x += THREE.MathUtils.degToRad(-2)
+    if (b.head) b.head.rotation.x += THREE.MathUtils.degToRad(3)
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += THREE.MathUtils.degToRad(-64)
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x += THREE.MathUtils.degToRad(-64)
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += THREE.MathUtils.degToRad(72)
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += THREE.MathUtils.degToRad(72)
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x += THREE.MathUtils.degToRad(-42)
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += THREE.MathUtils.degToRad(-38)
+    if (b.leftLowerArm) b.leftLowerArm.rotation.x += THREE.MathUtils.degToRad(38)
+    if (b.rightLowerArm) b.rightLowerArm.rotation.x += THREE.MathUtils.degToRad(34)
+    human.modelRoot.updateMatrixWorld(true)
+    poseFingers(human.leftFingers, 'idle', 1)
+    poseFingers(human.rightFingers, 'grip', 0.7)
+    return
   }
 
   if (frame.walkAmount * idle > 0.001) {
-    const s = Math.sin(human.walkT * 6.2);
-    const c = Math.cos(human.walkT * 6.2);
-    const w = frame.walkAmount * idle;
-    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
-    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
-    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
-    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
-    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
-    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
-    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
-    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+    const s = Math.sin(human.walkT * 6.2)
+    const c = Math.cos(human.walkT * 6.2)
+    const w = frame.walkAmount * idle
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w
+    if (b.spine) b.spine.rotation.z += c * 0.02 * w
+    if (b.hips) b.hips.rotation.z -= c * 0.014 * w
   }
 
   if (ik >= 0.025) {
-    rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
-    twistBone(b.hips, frame.side, -0.045 * ik);
-    twistBone(b.hips, frame.forward, -0.025 * ik);
-    rotateBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
-    twistBone(b.spine, frame.side, -0.2 * ik);
-    twistBone(b.spine, frame.forward, -0.04 * ik);
-    rotateBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
-    twistBone(b.chest, frame.side, -0.32 * ik);
-    twistBone(b.chest, frame.forward, -0.025 * ik);
-    rotateBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
-    twistBone(b.neck, frame.side, -0.12 * ik);
+    rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward)
+    twistBone(b.hips, frame.side, -0.045 * ik)
+    twistBone(b.hips, frame.forward, -0.025 * ik)
+    rotateBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward)
+    twistBone(b.spine, frame.side, -0.2 * ik)
+    twistBone(b.spine, frame.forward, -0.04 * ik)
+    rotateBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward)
+    twistBone(b.chest, frame.side, -0.32 * ik)
+    twistBone(b.chest, frame.forward, -0.025 * ik)
+    rotateBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward)
+    twistBone(b.neck, frame.side, -0.12 * ik)
     if (b.head) {
       setBoneWorldQuaternion(
         b.head,
@@ -807,208 +823,291 @@ function driveHuman(human, frame) {
             .multiply(new THREE.Quaternion().setFromAxisAngle(frame.forward, -0.025 * ik)),
           0.74 * ik
         )
-      );
+      )
     }
-    human.modelRoot.updateMatrixWorld(true);
+    human.modelRoot.updateMatrixWorld(true)
   }
 
-  const rightGrip = frame.rightHandWorld.clone();
+  const rightGrip = frame.rightHandWorld.clone()
   const rightIdleElbow = rightGrip.clone()
     .addScaledVector(UP, 0.04 * cfg.unit + 0.14 * cfg.unit * ik)
     .addScaledVector(frame.side, -0.2 * cfg.unit)
-    .addScaledVector(frame.forward, -0.03 * cfg.unit * idle);
-  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
-  const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.32).addScaledVector(frame.forward, -0.55).normalize();
-  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, pole, 0.9 + 0.1 * ik, 1.0);
-  const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
-  const standingHandUp = UP.clone().multiplyScalar(-1.0).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
-  const handForwardForOrientation = ik >= 0.025 ? cueDir : standingCueDir;
-  setHandBasis(b.rightHand, standingHandSide, standingHandUp, handForwardForOrientation, cfg.rightHandRollIdle, 1.0);
-  poseFingers(human.rightFingers, 'grip', 0.95);
+    .addScaledVector(frame.forward, -0.03 * cfg.unit * idle)
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5)
+  const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.32).addScaledVector(frame.forward, -0.55).normalize()
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, pole, 0.9 + 0.1 * ik, 1.0)
+  const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(frame.forward, 0.16).normalize()
+  const standingHandUp = UP.clone().multiplyScalar(-1.0).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize()
+  const handForwardForOrientation = ik >= 0.025 ? cueDir : standingCueDir
+  setHandBasis(b.rightHand, standingHandSide, standingHandUp, handForwardForOrientation, cfg.rightHandRollIdle, 1.0)
+  poseFingers(human.rightFingers, 'grip', 0.95)
   if (ik < 0.025) {
-    poseFingers(human.leftFingers, 'idle', 1);
-    return;
+    poseFingers(human.leftFingers, 'idle', 1)
+    return
   }
 
   const bridgeIkHandSide = cfg.bridgePoseUsesConfiguredSide
     ? cfg.bridgeHandSide * 0.8
-    : -0.018 * cfg.unit;
+    : -0.018 * cfg.unit
   const bridgeIkElbowSide = cfg.bridgePoseUsesConfiguredSide
     ? cfg.bridgeHandSide * 1.15
-    : -0.05 * cfg.unit;
+    : -0.05 * cfg.unit
   const leftHand = frame.leftHandWorld.clone()
     .addScaledVector(frame.forward, 0.032 * cfg.unit * ik)
     .addScaledVector(frame.side, bridgeIkHandSide * ik)
-    .addScaledVector(UP, -0.018 * cfg.unit * ik);
+    .addScaledVector(UP, -0.018 * cfg.unit * ik)
   const leftElbow = frame.leftElbow.clone()
     .addScaledVector(frame.forward, 0.045 * cfg.unit * ik)
     .addScaledVector(frame.side, bridgeIkElbowSide * ik)
-    .addScaledVector(UP, -0.01 * cfg.unit * ik);
-  aimTwoBone(b.leftUpperArm, b.leftLowerArm, leftElbow, leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(), 0.98 * ik, 1.0 * ik);
-  twistBone(b.leftUpperArm, frame.forward, -0.2 * ik);
-  twistBone(b.leftLowerArm, frame.forward, 0.025 * ik);
-  const bridgeSide = frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize();
-  const bridgeUp = UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize();
-  setHandBasis(b.leftHand, bridgeSide, bridgeUp, cueDir, -0.68 * ik, 1.0 * ik);
-  poseFingers(human.leftFingers, 'bridge', ik);
-  aimTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
-  twistBone(b.leftUpperLeg, frame.forward, -0.035 * ik);
-  setHandBasis(b.leftFoot, frame.side, frame.up, frame.forward, -0.02 * ik, cfg.footLockStrength * ik);
-  aimTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
-  twistBone(b.rightUpperLeg, frame.forward, 0.03 * ik);
-  setHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, cfg.footLockStrength * ik);
+    .addScaledVector(UP, -0.01 * cfg.unit * ik)
+  aimTwoBone(b.leftUpperArm, b.leftLowerArm, leftElbow, leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(), 0.98 * ik, 1.0 * ik)
+  twistBone(b.leftUpperArm, frame.forward, -0.2 * ik)
+  twistBone(b.leftLowerArm, frame.forward, 0.025 * ik)
+  const bridgeSide = frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize()
+  const bridgeUp = UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize()
+  setHandBasis(b.leftHand, bridgeSide, bridgeUp, cueDir, -0.68 * ik, 1.0 * ik)
+  poseFingers(human.leftFingers, 'bridge', ik)
+  aimTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik)
+  twistBone(b.leftUpperLeg, frame.forward, -0.035 * ik)
+  setHandBasis(b.leftFoot, frame.side, frame.up, frame.forward, -0.02 * ik, cfg.footLockStrength * ik)
+  aimTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik)
+  twistBone(b.rightUpperLeg, frame.forward, 0.03 * ik)
+  setHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, cfg.footLockStrength * ik)
 }
 
-export function updateHumanPose(human, dt, frameData) {
-  if (!human || !frameData || !Number.isFinite(dt) || dt < 0 || !frameData.rootTarget || !frameData.aimForward) return;
-  const cfg = human.cfg;
-  const state = frameData.state || 'idle';
-  const activeState = state === 'rolling' || state === 'turnEnd' || state === 'gameOver' ? 'idle' : state;
-  human.poseT = dampScalar(human.poseT, activeState === 'idle' || activeState === 'seated' ? 0 : 1, cfg.poseLambda, dt);
-  human.breathT += dt * (activeState === 'idle' || activeState === 'seated' ? 1.05 : 0.5);
-  human.settleT = dampScalar(human.settleT, activeState === 'dragging' ? 1 : 0, 5.5, dt);
+function updateProvidedExactHumanPose (human, dt, frameData) {
+  const cfg = human.cfg
+  const state = frameData.state || 'idle'
+  const rootTarget = frameData.rootTarget
+  const aimForward = frameData.aimForward
+  const bridgeTarget = frameData.bridgeTarget
+  const idleRight = frameData.idleRight
+  const idleLeft = frameData.idleLeft
+  const cueBack = frameData.cueBack
+  const cueTip = frameData.cueTip
+  const power = frameData.power || 0
+  human.poseT = dampScalar(human.poseT, state === 'idle' ? 0 : 1, cfg.poseLambda, dt)
+  human.breathT += dt * (state === 'idle' ? 1.05 : 0.5)
+  human.settleT = dampScalar(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt)
+  if (state === 'striking') {
+    if (human.strikeClock === 0) {
+      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget)
+      human.strikeYaw = human.yaw
+    }
+    human.strikeClock += dt
+  } else {
+    human.strikeClock = 0
+  }
+  const rootGoal = state === 'striking' ? human.strikeRoot : constrainHumanPerimeterStepExact(human.root.position, rootTarget, cfg)
+  dampVector(human.root.position, rootGoal, state === 'striking' ? 12 : cfg.moveLambda, dt)
+  human.root.position.y = cfg.groundY || 0
+  const moveAmountRaw = human.root.position.distanceTo(rootGoal)
+  human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / cfg.scale))
+  human.yaw = dampScalar(human.yaw, state === 'striking' ? human.strikeYaw : yawFromForward(aimForward), cfg.rotLambda, dt)
+  const t = easeInOut(human.poseT)
+  const idle = 1 - t
+  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * cfg.scale)
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12 / cfg.scale)
+  const walkAmount = clamp01(moveAmountRaw * 18 / cfg.scale) * idle
+  const dragStroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75) : 0
+  const strikeFollow = state === 'striking' ? Math.sin(clamp01(human.strikeClock / (cfg.strikeTime + cfg.holdTime)) * Math.PI) : 0
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, human.yaw).normalize()
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize()
+  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position)
+  const powerLean = power * t
+  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * cfg.scale)
+  rootWorld.y = cfg.groundY || 0
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) * cfg.scale + breath, (lerp(0.02, -0.16, t) - 0.014 * powerLean) * cfg.scale))
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) * cfg.scale + breath, (lerp(0.02, -0.42, t) - 0.024 * powerLean) * cfg.scale))
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) * cfg.scale + breath, (lerp(0.02, -0.61, t) - 0.028 * powerLean) * cfg.scale))
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) * cfg.scale + breath - cfg.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.72, t) - 0.028 * powerLean) * cfg.scale))
+  const leftShoulder = local(new THREE.Vector3(-0.23 * cfg.scale, lerp(1.58, 1.36, t) * cfg.scale + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * cfg.scale))
+  const rightShoulder = local(new THREE.Vector3(0.23 * cfg.scale, lerp(1.58, 1.36, t) * cfg.scale + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * cfg.scale))
+  const leftHip = local(new THREE.Vector3(-0.13 * cfg.scale, 0.92 * cfg.scale, 0.02 * cfg.scale))
+  const rightHip = local(new THREE.Vector3(0.13 * cfg.scale, 0.92 * cfg.scale, 0.02 * cfg.scale))
+  const leftFoot = local(new THREE.Vector3(-0.13 * cfg.scale, cfg.footGroundY, 0.03 * cfg.scale + walk * 0.018 * cfg.scale).lerp(new THREE.Vector3(-cfg.stanceWidth * 0.42, cfg.footGroundY, -0.34 * cfg.scale), t))
+  const rightFoot = local(new THREE.Vector3(0.13 * cfg.scale, cfg.footGroundY, -0.03 * cfg.scale - walk * 0.018 * cfg.scale).lerp(new THREE.Vector3(cfg.stanceWidth * 0.5, cfg.footGroundY, 0.34 * cfg.scale), t))
+  const bridgePalmTarget = bridgeTarget.clone()
+    .addScaledVector(forward, -0.006 * cfg.scale * t)
+    .addScaledVector(side, -0.012 * cfg.scale * t)
+    .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
+    .addScaledVector(UP, -cfg.bridgePalmUnderCueDrop * t)
+    .addScaledVector(UP, -0.01 * cfg.scale * human.settleT)
+  const leftHand = idleLeft.clone().lerp(bridgePalmTarget, t)
+  const cueDirForHand = cueTip.clone().sub(cueBack).normalize()
+  const handIk = easeInOut(clamp01(t))
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize()
+  const idleGripUp = UP.clone().multiplyScalar(-1).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize()
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize()
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize()
+  const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04 * cfg.scale, cfg.rightElbowShotRise, t)).addScaledVector(side, lerp(-0.18 * cfg.scale, cfg.rightElbowShotSide, t)).addScaledVector(forward, lerp(-0.04 * cfg.scale, cfg.rightElbowShotBack, t))
+  const forearmStroke = (state === 'dragging' ? -cfg.rightStrokePull * easeOutCubic(power) : 0) + (state === 'striking' ? cfg.rightStrokePush * strikeFollow : 0) + (state === 'dragging' ? dragStroke * 0.035 * cfg.scale : 0)
+  const forearmBase = lockedRightElbow.clone().addScaledVector(side, cfg.rightForearmOutward * t).addScaledVector(UP, -cfg.rightForearmDown * t).addScaledVector(UP, cfg.rightHandShotLift * t).addScaledVector(forward, -cfg.rightForearmBack * t).addScaledVector(cueDirForHand, cfg.rightForearmLength)
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke)
+  const idleWristTarget = idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal))
+  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - cfg.rightHandDownPose, handIk), cfg.rightHandCueSocketLocal))
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t)
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * cfg.scale * t).addScaledVector(side, -0.044 * cfg.scale * t).addScaledVector(forward, 0.065 * cfg.scale * t)
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.scale, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * cfg.scale * t).addScaledVector(side, -0.012 * cfg.scale * t)
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.scale, cfg.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * cfg.scale * t).addScaledVector(side, 0.014 * cfg.scale * t)
+  human.root.visible = true
+  driveHuman(human, { t, stroke: forearmStroke / cfg.scale, follow: strikeFollow, walkAmount, forward, side, up: UP, rootWorld, torsoCenterWorld: torso, chestCenterWorld: chest, neckWorld: neck, headCenterWorld: head, leftElbow, rightElbow: lockedRightElbow, leftHandWorld: leftHand, rightHandWorld: rightHand, leftKnee, rightKnee, leftFootWorld: leftFoot, rightFootWorld: rightFoot, cueBackWorld: cueBack, cueTipWorld: cueTip })
+}
+
+export function updateHumanPose (human, dt, frameData) {
+  if (!human || !frameData || !Number.isFinite(dt) || dt < 0 || !frameData.rootTarget || !frameData.aimForward) return
+  if (frameData.exactProvidedPose) {
+    updateProvidedExactHumanPose(human, dt, frameData)
+    return
+  }
+  const cfg = human.cfg
+  const state = frameData.state || 'idle'
+  const activeState = state === 'rolling' || state === 'turnEnd' || state === 'gameOver' ? 'idle' : state
+  human.poseT = dampScalar(human.poseT, activeState === 'idle' || activeState === 'seated' ? 0 : 1, cfg.poseLambda, dt)
+  human.breathT += dt * (activeState === 'idle' || activeState === 'seated' ? 1.05 : 0.5)
+  human.settleT = dampScalar(human.settleT, activeState === 'dragging' ? 1 : 0, 5.5, dt)
   if (activeState === 'striking') {
     if (human.strikeClock === 0) {
-      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : frameData.rootTarget);
-      human.strikeYaw = human.yaw;
+      human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : frameData.rootTarget)
+      human.strikeYaw = human.yaw
     }
-    human.strikeClock += dt;
+    human.strikeClock += dt
   } else {
-    human.strikeClock = 0;
+    human.strikeClock = 0
   }
 
-  const rootGoal = activeState === 'striking' ? human.strikeRoot : frameData.rootTarget;
-  const directRootTarget = frameData.directRootTarget || activeState === 'seated';
+  const rootGoal = activeState === 'striking' ? human.strikeRoot : frameData.rootTarget
+  const directRootTarget = frameData.directRootTarget || activeState === 'seated'
   const moveAmountRaw = activeState === 'striking' || directRootTarget
     ? (() => {
-        dampVector(human.root.position, rootGoal, directRootTarget ? cfg.moveLambda : 12, dt);
-        human.root.position.y = cfg.groundY;
-        return human.root.position.distanceTo(rootGoal);
+        dampVector(human.root.position, rootGoal, directRootTarget ? cfg.moveLambda : 12, dt)
+        human.root.position.y = cfg.groundY
+        return human.root.position.distanceTo(rootGoal)
       })()
-    : moveRootAroundPerimeter(human, rootGoal, cfg, dt);
-  human.walkT += dt * (2 + Math.min(7, (moveAmountRaw * 10) / cfg.unit));
-  const shootingPoseActive = activeState === 'dragging' || activeState === 'striking';
-  const tableForward = resolveRootToTableForward(human.root.position, frameData);
+    : moveRootAroundPerimeter(human, rootGoal, cfg, dt)
+  human.walkT += dt * (2 + Math.min(7, (moveAmountRaw * 10) / cfg.unit))
+  const shootingPoseActive = activeState === 'dragging' || activeState === 'striking'
+  const tableForward = resolveRootToTableForward(human.root.position, frameData)
   const facingForward = shootingPoseActive && tableForward
     ? tableForward
-    : resolveTableFacingForward(frameData.aimForward, rootGoal, frameData, cfg);
+    : resolveTableFacingForward(frameData.aimForward, rootGoal, frameData, cfg)
   // When the low cue camera/shot pose is active, lock yaw directly toward the
   // cue-ball/table reference. Damped yaw could leave the upper body bending toward
   // the previous direction for a few frames, which made the pose look backwards.
-  const targetRootYaw = yawFromForward(facingForward) - (cfg.humanVisualYawFix || 0);
+  const targetRootYaw = yawFromForward(facingForward) - (cfg.humanVisualYawFix || 0)
   human.yaw = shootingPoseActive
     ? targetRootYaw
-    : dampScalar(human.yaw, targetRootYaw, cfg.rotLambda, dt);
-  ensureHumanFacingTable(human, frameData, cfg);
+    : dampScalar(human.yaw, targetRootYaw, cfg.rotLambda, dt)
+  ensureHumanFacingTable(human, frameData, cfg)
 
-  const t = easeInOut(human.poseT);
-  const idle = 1 - t;
-  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * cfg.unit);
-  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, (moveAmountRaw * 12) / cfg.unit);
-  human.lastMoveAmountRaw = moveAmountRaw;
-  const walkAmount = clamp01((moveAmountRaw * 18) / cfg.unit) * idle;
-  const dragStroke = activeState === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + (frameData.power || 0) * 0.75) : 0;
-  const strikeFollow = activeState === 'striking' ? Math.sin(clamp01(human.strikeClock / (cfg.strikeTime + cfg.holdTime)) * Math.PI) : 0;
-  const visualYaw = human.yaw + (cfg.humanVisualYawFix || 0);
-  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, visualYaw).normalize();
-  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
-  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, visualYaw).add(human.root.position);
-  const powerLean = (frameData.power || 0) * t;
-  const bendDirection = resolveShootBendSign(human, frameData, cfg);
-  const counterLeanSide = cfg.shootCounterLeanSide >= 0 ? 1 : -1;
+  const t = easeInOut(human.poseT)
+  const idle = 1 - t
+  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * cfg.unit)
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, (moveAmountRaw * 12) / cfg.unit)
+  human.lastMoveAmountRaw = moveAmountRaw
+  const walkAmount = clamp01((moveAmountRaw * 18) / cfg.unit) * idle
+  const dragStroke = activeState === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + (frameData.power || 0) * 0.75) : 0
+  const strikeFollow = activeState === 'striking' ? Math.sin(clamp01(human.strikeClock / (cfg.strikeTime + cfg.holdTime)) * Math.PI) : 0
+  const visualYaw = human.yaw + (cfg.humanVisualYawFix || 0)
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, visualYaw).normalize()
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize()
+  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, visualYaw).add(human.root.position)
+  const powerLean = (frameData.power || 0) * t
+  const bendDirection = resolveShootBendSign(human, frameData, cfg)
+  const counterLeanSide = cfg.shootCounterLeanSide >= 0 ? 1 : -1
   const upperBodyCounterLean = Number.isFinite(cfg.shootUpperBodyCounterLean)
     ? Math.max(0, cfg.shootUpperBodyCounterLean)
-    : 1;
+    : 1
   const forwardBendScale = Number.isFinite(cfg.shootForwardBendScale)
     ? Math.max(0, cfg.shootForwardBendScale)
-    : 1;
-  const plantFeetDuringShot = cfg.plantFeetDuringShot !== false;
-  const shotBendZ = (value) => Math.abs(value) * bendDirection * forwardBendScale;
-  const shotCounterLeanX = (value) => value * counterLeanSide * upperBodyCounterLean;
-  const rootWorld = human.root.position.clone();
-  rootWorld.y = cfg.groundY;
+    : 1
+  const plantFeetDuringShot = cfg.plantFeetDuringShot !== false
+  const shotBendZ = (value) => Math.abs(value) * bendDirection * forwardBendScale
+  const shotCounterLeanX = (value) => value * counterLeanSide * upperBodyCounterLean
+  const rootWorld = human.root.position.clone()
+  rootWorld.y = cfg.groundY
 
   // Real pool stance: feet/hips stay grounded and carry the weight; the fold is
   // from the belly upward, lowering the head toward the cue line without pushing
   // the entire body backward or off the floor.
-  const torso = local(new THREE.Vector3(shotCounterLeanX(0.012 * t) * cfg.unit, lerp(1.3, 1.2, t) * cfg.unit + breath, shotBendZ(lerp(0.01, -0.08, t) - 0.008 * powerLean) * cfg.unit));
-  const chest = local(new THREE.Vector3(shotCounterLeanX(0.038 * t + 0.006 * powerLean) * cfg.unit, lerp(1.52, 1.32, t) * cfg.unit + breath, shotBendZ(lerp(0.015, -0.26, t) - 0.014 * powerLean) * cfg.unit));
-  const neck = local(new THREE.Vector3(shotCounterLeanX(0.055 * t + 0.008 * powerLean) * cfg.unit, lerp(1.68, 1.42, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.38, t) - 0.016 * powerLean) * cfg.unit));
-  const head = local(new THREE.Vector3(shotCounterLeanX(0.066 * t + 0.01 * powerLean) * cfg.unit, lerp(1.84, 1.5, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.22 * t, shotBendZ(lerp(0.03, -0.44, t) - 0.018 * powerLean) * cfg.unit));
-  const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.048 * t)) * cfg.unit, lerp(1.58, 1.42, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.31, t) - 0.012 * human.settleT) * cfg.unit));
-  const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.034 * t)) * cfg.unit, lerp(1.58, 1.42, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.25, t) - 0.012 * human.settleT) * cfg.unit));
-  const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
-  const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit));
-  const footWalkBlend = plantFeetDuringShot ? idle : 1;
+  const torso = local(new THREE.Vector3(shotCounterLeanX(0.012 * t) * cfg.unit, lerp(1.3, 1.2, t) * cfg.unit + breath, shotBendZ(lerp(0.01, -0.08, t) - 0.008 * powerLean) * cfg.unit))
+  const chest = local(new THREE.Vector3(shotCounterLeanX(0.038 * t + 0.006 * powerLean) * cfg.unit, lerp(1.52, 1.32, t) * cfg.unit + breath, shotBendZ(lerp(0.015, -0.26, t) - 0.014 * powerLean) * cfg.unit))
+  const neck = local(new THREE.Vector3(shotCounterLeanX(0.055 * t + 0.008 * powerLean) * cfg.unit, lerp(1.68, 1.42, t) * cfg.unit + breath, shotBendZ(lerp(0.02, -0.38, t) - 0.016 * powerLean) * cfg.unit))
+  const head = local(new THREE.Vector3(shotCounterLeanX(0.066 * t + 0.01 * powerLean) * cfg.unit, lerp(1.84, 1.5, t) * cfg.unit + breath - cfg.chinToCueHeight * 0.22 * t, shotBendZ(lerp(0.03, -0.44, t) - 0.018 * powerLean) * cfg.unit))
+  const leftShoulder = local(new THREE.Vector3((-0.23 + shotCounterLeanX(0.048 * t)) * cfg.unit, lerp(1.58, 1.42, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.31, t) - 0.012 * human.settleT) * cfg.unit))
+  const rightShoulder = local(new THREE.Vector3((0.23 + shotCounterLeanX(0.034 * t)) * cfg.unit, lerp(1.58, 1.42, t) * cfg.unit + breath, shotBendZ(lerp(0, -0.25, t) - 0.012 * human.settleT) * cfg.unit))
+  const leftHip = local(new THREE.Vector3(-0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit))
+  const rightHip = local(new THREE.Vector3(0.13 * cfg.unit, 0.92 * cfg.unit, 0.02 * cfg.unit))
+  const footWalkBlend = plantFeetDuringShot ? idle : 1
   const plantedLeftFootLocal = new THREE.Vector3(
     -cfg.stanceWidth * 0.42,
     cfg.footGroundY,
     -0.34 * cfg.unit
-  );
+  )
   const plantedRightFootLocal = new THREE.Vector3(
     cfg.stanceWidth * 0.5,
     cfg.footGroundY,
     0.34 * cfg.unit
-  );
+  )
   const leftFoot = local(new THREE.Vector3(
     -0.13 * cfg.unit,
     cfg.footGroundY,
     0.03 * cfg.unit + walk * 0.018 * cfg.unit * footWalkBlend
-  ).lerp(plantedLeftFootLocal, t));
+  ).lerp(plantedLeftFootLocal, t))
   const rightFoot = local(new THREE.Vector3(
     0.13 * cfg.unit,
     cfg.footGroundY,
     -0.03 * cfg.unit - walk * 0.018 * cfg.unit * footWalkBlend
-  ).lerp(plantedRightFootLocal, t));
+  ).lerp(plantedRightFootLocal, t))
 
   const bridgePalmSide = cfg.bridgePoseUsesConfiguredSide
     ? cfg.bridgeHandSide
-    : -0.012 * cfg.unit;
+    : -0.012 * cfg.unit
   const bridgePalmTarget = frameData.bridgeTarget.clone()
     .addScaledVector(forward, -0.006 * cfg.unit * t)
     .addScaledVector(side, bridgePalmSide * t)
     .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
-    .addScaledVector(UP, -0.01 * cfg.unit * human.settleT);
-  const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);
-  const cueDirForHand = frameData.cueTip.clone().sub(frameData.cueBack).normalize();
-  const handIk = easeInOut(clamp01(t));
-  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
-  const idleGripUp = UP.clone().multiplyScalar(-1.0).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
-  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
-  const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
+    .addScaledVector(UP, -0.01 * cfg.unit * human.settleT)
+  const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t)
+  const cueDirForHand = frameData.cueTip.clone().sub(frameData.cueBack).normalize()
+  const handIk = easeInOut(clamp01(t))
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize()
+  const idleGripUp = UP.clone().multiplyScalar(-1.0).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize()
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize()
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize()
   const lockedRightElbow = rightShoulder.clone()
     .addScaledVector(UP, lerp(0.04 * cfg.unit, cfg.rightElbowShotRise, t))
     .addScaledVector(side, lerp(-0.18 * cfg.unit, cfg.rightElbowShotSide, t))
-    .addScaledVector(forward, lerp(-0.04 * cfg.unit, cfg.rightElbowShotBack, t));
-  const pullBack = activeState === 'dragging' ? -cfg.rightStrokePull * easeOutCubic(frameData.power || 0) : 0;
-  const pushForward = activeState === 'striking' ? cfg.rightStrokePush * strikeFollow : 0;
-  const smallPractice = activeState === 'dragging' ? dragStroke * 0.035 * cfg.unit : 0;
-  const forearmStroke = pullBack + pushForward + smallPractice;
+    .addScaledVector(forward, lerp(-0.04 * cfg.unit, cfg.rightElbowShotBack, t))
+  const pullBack = activeState === 'dragging' ? -cfg.rightStrokePull * easeOutCubic(frameData.power || 0) : 0
+  const pushForward = activeState === 'striking' ? cfg.rightStrokePush * strikeFollow : 0
+  const smallPractice = activeState === 'dragging' ? dragStroke * 0.035 * cfg.unit : 0
+  const forearmStroke = pullBack + pushForward + smallPractice
   const forearmBase = lockedRightElbow.clone()
     .addScaledVector(side, cfg.rightForearmOutward * t)
     .addScaledVector(UP, -cfg.rightForearmDown * t)
     .addScaledVector(UP, cfg.rightHandShotLift * t)
     .addScaledVector(forward, -cfg.rightForearmBack * t)
-    .addScaledVector(cueDirForHand, cfg.rightForearmLength);
-  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
-  if (frameData.gripTarget) liveCueGripPoint.lerp(frameData.gripTarget, 0.72 * t);
-  const idleWristTarget = frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal));
-  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - cfg.rightHandDownPose, handIk), cfg.rightHandCueSocketLocal));
-  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+    .addScaledVector(cueDirForHand, cfg.rightForearmLength)
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke)
+  if (frameData.gripTarget) liveCueGripPoint.lerp(frameData.gripTarget, 0.72 * t)
+  const idleWristTarget = frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal))
+  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - cfg.rightHandDownPose, handIk), cfg.rightHandCueSocketLocal))
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t)
   const bridgeArmDownElbow = leftHand.clone()
     .addScaledVector(UP, 0.34 * cfg.unit)
     .addScaledVector(side, -0.01 * cfg.unit)
-    .addScaledVector(forward, 0.012 * cfg.unit);
+    .addScaledVector(forward, 0.012 * cfg.unit)
   const extendedBridgeElbow = leftShoulder.clone()
     .lerp(leftHand, 0.58)
     .addScaledVector(UP, -0.035 * cfg.unit * t)
     .addScaledVector(side, -0.028 * cfg.unit * t)
-    .addScaledVector(forward, -0.055 * cfg.unit * t);
-  const leftElbow = extendedBridgeElbow.lerp(bridgeArmDownElbow, cfg.bridgeArmStraightDown ? t : 0);
-  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * cfg.unit * t).addScaledVector(side, -0.012 * cfg.unit * t);
-  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * cfg.unit * t).addScaledVector(side, 0.014 * cfg.unit * t);
+    .addScaledVector(forward, -0.055 * cfg.unit * t)
+  const leftElbow = extendedBridgeElbow.lerp(bridgeArmDownElbow, cfg.bridgeArmStraightDown ? t : 0)
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * cfg.unit * t).addScaledVector(side, -0.012 * cfg.unit * t)
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * cfg.unit, cfg.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * cfg.unit * t).addScaledVector(side, 0.014 * cfg.unit * t)
 
-  human.root.visible = true;
+  human.root.visible = true
   driveHuman(human, {
     t,
     dt,
@@ -1034,20 +1133,20 @@ export function updateHumanPose(human, dt, frameData) {
     cueBackWorld: frameData.cueBack,
     cueTipWorld: frameData.cueTip,
     seated: activeState === 'seated'
-  });
+  })
 }
 
-export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
-  const cfg = scaleVectorConfig(opts);
-  const desired = cueBallWorld.clone().addScaledVector(aimForward, -cfg.desiredShootDistance);
-  const xEdge = (opts.tableW ?? 2.0) / 2 + cfg.edgeMargin;
-  const zEdge = (opts.tableL ?? 3.6) / 2 + cfg.edgeMargin;
-  const groundY = cfg.groundY || 0;
+export function chooseHumanEdgePosition (cueBallWorld, aimForward, opts = {}) {
+  const cfg = scaleVectorConfig(opts)
+  const desired = cueBallWorld.clone().addScaledVector(aimForward, -cfg.desiredShootDistance)
+  const xEdge = (opts.tableW ?? 2.0) / 2 + cfg.edgeMargin
+  const zEdge = (opts.tableL ?? 3.6) / 2 + cfg.edgeMargin
+  const groundY = cfg.groundY || 0
   const candidates = [
     new THREE.Vector3(-xEdge, groundY, clamp(desired.z, -zEdge, zEdge)),
     new THREE.Vector3(xEdge, groundY, clamp(desired.z, -zEdge, zEdge)),
     new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), groundY, -zEdge),
     new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), groundY, zEdge)
-  ];
-  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+  ]
+  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone()
 }


### PR DESCRIPTION
### Motivation

- Replace duplicated, game-specific human rig and pose math in Snooker Royal with a shared, configurable human rig to centralize avatar behavior and make poses consistent across games.
- Improve visual potting behavior by tuning pocket capture radii and capture-center mapping so that balls that visibly enter a pocket are captured reliably without over-widening side pockets.
- Simplify cue endpoint handling for provided (non-GLB) poses and ensure the human rig loader is disposed on cleanup.

### Description

- SnookerRoyal.jsx now imports and uses `createSnookerHumanRig`, `chooseHumanEdgePosition`, and `updateBilardoHumanPose` (renamed usage) from a shared `snookerHumanRig.js` instead of hand-rolled rig creation and pose math, and exposes configuration options to the shared rig (scale, table dims, stance, bridge offsets, stroke timing, callbacks, etc.).
- Replaced custom human creation code with `createSnookerHumanRig(...)` and set `human.usesProvidedCueLogic` and `human.loader` for proper lifecycle handling; dispose the GLTF loader during scene teardown with `disposeSnookerHumanGLTFLoader(...)`.
- Added `applyProvidedCueEndpointPose` to apply computed cue endpoints to the cue stick when using the provided (non-GLB) pose path, and refactored `updateSnookerRoyalHumanPlayer` to drive the shared rig: compute bridge/idle targets, provided cue endpoints, and call the shared pose updater with `exactProvidedPose` where appropriate.
- Tuned pocket capture behavior: changed `POCKET_CAPTURE_ASSIST` and `SIDE_POCKET_CAPTURE_ASSIST` to use ball-radius based allowances; reduced `POCKET_CAPTURE_CENTER_INWARD_SCALE` and `SIDE_POCKET_CAPTURE_CENTER_INWARD_SCALE` to bring capture centers inward; changed how capture centers are mapped so both a mapped (visual) center and raw marker center are considered for capture checks.
- Big refactor/cleanup of `shared/humanRigCore.js`: formatting/whitespace normalization and many functional updates including added perimeter helpers, a provided exact-pose updater (`updateProvidedExactHumanPose`), improved configuration scaling, updated math helpers, and general consolidation of pose and IK code used by `updateHumanPose`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d013696f08329821b998f6ecb1cca)