### PR TITLE
Domino Royal: Add authoritative realtime engine and online sync

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -18,7 +18,7 @@ const GAME_ONLINE_POLICY = Object.freeze({
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
   checkersbattleroyal: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
-  'domino-royal': { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
+  'domino-royal': { maxPlayers: [2, 3, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   ludobattleroyal: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   texasholdem: { maxPlayers: [2, 6], allowMatchMeta: ['mode', 'token'] },
   airhockey: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },

--- a/bot/server.js
+++ b/bot/server.js
@@ -65,6 +65,11 @@ import {
 } from './config/onlineGamePolicy.js';
 import { createCheckersRealtimeStore } from './utils/checkersRealtimeState.js';
 import { applyAuthoritativeMove, SIDES } from './utils/checkersAuthoritativeEngine.js';
+import {
+  applyDominoRoyalAction,
+  createDominoRoyalState,
+  publicDominoRoyalState
+} from './utils/dominoRoyalRealtimeEngine.js';
 
 validateEnv();
 
@@ -481,11 +486,13 @@ const lobbyTables = {};
 const tableMap = new Map();
 const poolStates = new Map();
 const snookerStates = new Map();
+const dominoRoyalStates = new Map();
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
+const dominoMoveRateLimitMs = Number(process.env.DOMINO_MOVE_RATE_LIMIT_MS) || 180;
 
 const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token'];
 
@@ -946,6 +953,41 @@ async function settleCheckersMatch({
   return { ok: true, status: 'settled', settlement };
 }
 
+
+function emitDominoRoyalState(tableId, state = dominoRoyalStates.get(tableId), eventName = 'dominoState') {
+  if (!tableId || !state) return;
+  const table = tableMap.get(tableId);
+  const players = table?.players?.length ? table.players : state.players;
+  players.forEach((player) => {
+    const payload = publicDominoRoyalState(state, player.id);
+    const socketIds = new Set();
+    if (player.socketId) socketIds.add(player.socketId);
+    const registeredSockets = userSockets.get(String(player.id));
+    registeredSockets?.forEach((socketId) => socketIds.add(socketId));
+    if (!socketIds.size) {
+      io.to(tableId).emit(eventName, payload);
+      return;
+    }
+    socketIds.forEach((socketId) => io.to(socketId).emit(eventName, payload));
+  });
+}
+
+function ensureDominoRoyalState(tableId, table = tableMap.get(tableId)) {
+  if (!tableId || !table || table.gameType !== 'domino-royal') return null;
+  let state = dominoRoyalStates.get(tableId);
+  if (!state) {
+    state = createDominoRoyalState({
+      tableId,
+      players: table.players,
+      seed: `${tableId}:${table.players.map((player) => player.id).join('|')}:${Date.now()}`
+    });
+    dominoRoyalStates.set(tableId, state);
+    const activePlayer = state.players[state.currentSeat];
+    if (activePlayer) table.currentTurn = activePlayer.id;
+  }
+  return state;
+}
+
 async function seatTableSocket(
   accountId,
   gameType,
@@ -1064,6 +1106,12 @@ function maybeStartGame(table) {
         });
         ensureCheckersSession(table.id, table);
         io.to(table.id).emit('checkersState', { tableId: table.id, ...initial });
+      } else if (table.gameType === 'domino-royal') {
+        const initial = ensureDominoRoyalState(table.id, table);
+        if (initial) {
+          const activePlayer = initial.players[initial.currentSeat];
+          if (activePlayer) table.currentTurn = activePlayer.id;
+        }
       }
       io.to(table.id).emit('gameStart', {
         tableId: table.id,
@@ -1079,6 +1127,9 @@ function maybeStartGame(table) {
       );
       if (table.gameType === 'poolroyale') {
         poolStates.set(table.id, { state: null, hud: null, layout: null, ts: Date.now() });
+      }
+      if (table.gameType === 'domino-royal') {
+        emitDominoRoyalState(table.id, dominoRoyalStates.get(table.id), 'dominoState');
       }
       table.startTimeout = null;
     }, 1000);
@@ -1115,6 +1166,9 @@ function unseatTableSocket(accountId, tableId, socketId) {
       if (table.gameType === 'checkers') {
         checkersRealtimeStore.clearState(tableId);
         checkersMatchSessions.delete(tableId);
+      }
+      if (table.gameType === 'domino-royal') {
+        dominoRoyalStates.delete(tableId);
       }
       tableMap.delete(tableId);
       const key = `${table.gameType}-${table.maxPlayers}`;
@@ -1984,6 +2038,75 @@ io.on('connection', (socket) => {
     if (!tableId) return;
     const state = getChessState(tableId);
     socket.emit('chessState', { tableId, ...state });
+  });
+
+  socket.on('joinDominoTable', async (payload = {}) => {
+    const { tableId } = payload;
+    const accountId = resolveTpcIdentity(payload);
+    if (!tableId) return;
+    if (!ensureRegistered(socket, accountId)) return;
+    const table = tableMap.get(tableId);
+    if (!table || table.gameType !== 'domino-royal') {
+      socket.emit('dominoActionRejected', { tableId, error: 'table_not_found' });
+      return;
+    }
+    socket.join(tableId);
+    const tablePlayer = table.players.find((player) => String(player.id) === String(accountId));
+    if (tablePlayer) tablePlayer.socketId = socket.id;
+    await registerConnection({
+      userId: String(accountId),
+      roomId: tableId,
+      socketId: socket.id
+    });
+    const state = ensureDominoRoyalState(tableId, table);
+    socket.emit('dominoState', publicDominoRoyalState(state, accountId));
+  });
+
+  socket.on('dominoSyncRequest', (payload = {}) => {
+    const { tableId } = payload;
+    const accountId = resolveTpcIdentity(payload) || socket.data?.playerId;
+    if (!tableId || !accountId) return;
+    const state = ensureDominoRoyalState(tableId);
+    if (state) socket.emit('dominoState', publicDominoRoyalState(state, accountId));
+  });
+
+  socket.on('dominoAction', (payload = {}) => {
+    const { tableId, action = {}, clientActionId = null } = payload;
+    const accountId = resolveTpcIdentity(payload) || socket.data?.playerId;
+    if (!tableId || !accountId) return;
+    if (!ensureRegistered(socket, accountId)) return;
+    if (isRateLimited(socket, 'dominoAction', dominoMoveRateLimitMs)) {
+      socket.emit('dominoActionRejected', { tableId, clientActionId, error: 'action_rate_limited' });
+      return;
+    }
+    const table = tableMap.get(tableId);
+    if (!table || table.gameType !== 'domino-royal') {
+      socket.emit('dominoActionRejected', { tableId, clientActionId, error: 'table_not_found' });
+      return;
+    }
+    const state = ensureDominoRoyalState(tableId, table);
+    const result = applyDominoRoyalAction(state, action, accountId);
+    if (!result.ok) {
+      socket.emit('dominoActionRejected', { tableId, clientActionId, error: result.error });
+      return;
+    }
+    const activePlayer = state.players[state.currentSeat];
+    table.currentTurn = activePlayer?.id || null;
+    socket.emit('dominoActionAccepted', {
+      tableId,
+      clientActionId,
+      moveSeq: state.moveSeq,
+      action: result.action
+    });
+    emitDominoRoyalState(tableId, state, 'dominoState');
+    if (state.status === 'finished') {
+      io.to(tableId).emit('matchEnded', {
+        tableId,
+        winnerId: state.players[state.winnerSeat]?.id || null,
+        winnerSeat: state.winnerSeat,
+        reason: state.reason || 'domino_match_end'
+      });
+    }
   });
 
   socket.on('joinPoolTable', async ({ tableId, accountId }) => {

--- a/bot/utils/dominoRoyalRealtimeEngine.js
+++ b/bot/utils/dominoRoyalRealtimeEngine.js
@@ -1,0 +1,305 @@
+const DOMINO_MAX_PIP = 6;
+const DEFAULT_HAND_SIZE = 7;
+
+function normalizeSeed(seed = '') {
+  const value = String(seed || 'domino-royal');
+  let h = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function seededRandom(seed) {
+  let state = normalizeSeed(seed) || 1;
+  return () => {
+    state += 0x6D2B79F5;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function canonicalTile(tile) {
+  if (!tile || !Number.isInteger(tile.a) || !Number.isInteger(tile.b)) return null;
+  if (tile.a < 0 || tile.a > DOMINO_MAX_PIP || tile.b < 0 || tile.b > DOMINO_MAX_PIP) return null;
+  return tile.a <= tile.b ? { a: tile.a, b: tile.b } : { a: tile.b, b: tile.a };
+}
+
+function tileKey(tile) {
+  const normalized = canonicalTile(tile);
+  return normalized ? `${normalized.a}|${normalized.b}` : '';
+}
+
+function createDeck() {
+  const deck = [];
+  for (let a = 0; a <= DOMINO_MAX_PIP; a += 1) {
+    for (let b = a; b <= DOMINO_MAX_PIP; b += 1) {
+      deck.push({ a, b });
+    }
+  }
+  return deck;
+}
+
+function shuffleDeck(deck, seed) {
+  const rng = seededRandom(seed);
+  const copy = deck.map((tile) => ({ ...tile }));
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+function highestDoubleIndex(hand = []) {
+  let index = -1;
+  let best = -1;
+  hand.forEach((tile, idx) => {
+    if (tile?.a === tile?.b && tile.a > best) {
+      best = tile.a;
+      index = idx;
+    }
+  });
+  return index;
+}
+
+function pipSum(hand = []) {
+  return hand.reduce((sum, tile) => sum + (tile?.a || 0) + (tile?.b || 0), 0);
+}
+
+function canPlayTile(tile, ends) {
+  const t = canonicalTile(tile);
+  if (!t) return false;
+  if (!ends) return true;
+  return t.a === ends.L || t.b === ends.L || t.a === ends.R || t.b === ends.R;
+}
+
+function validSidesFor(tile, ends) {
+  const t = canonicalTile(tile);
+  if (!t || !ends) return { L: false, R: false };
+  return {
+    L: t.a === ends.L || t.b === ends.L,
+    R: t.a === ends.R || t.b === ends.R
+  };
+}
+
+function orientForSide(tile, side, ends) {
+  const t = canonicalTile(tile);
+  if (!t || !ends) return null;
+  const key = side === 'L' ? 'L' : 'R';
+  const want = ends[key];
+  if (key === 'L') {
+    if (t.b === want) return { a: t.a, b: t.b };
+    if (t.a === want) return { a: t.b, b: t.a };
+  } else {
+    if (t.a === want) return { a: t.a, b: t.b };
+    if (t.b === want) return { a: t.b, b: t.a };
+  }
+  return null;
+}
+
+function nextActiveSeat(state, fromSeat = state.currentSeat) {
+  const count = state.players.length;
+  for (let offset = 1; offset <= count; offset += 1) {
+    const idx = (fromSeat - offset + count) % count;
+    if (!state.players[idx]?.disconnected) return idx;
+  }
+  return fromSeat;
+}
+
+function sanitizePlayer(player, index) {
+  return {
+    id: String(player?.id || `seat-${index}`),
+    name: String(player?.name || `Player ${index + 1}`).slice(0, 60),
+    avatar: String(player?.avatar || '').slice(0, 500),
+    hand: []
+  };
+}
+
+export function createDominoRoyalState({ tableId, players = [], seed = '' } = {}) {
+  const safePlayers = players.slice(0, 4).map(sanitizePlayer);
+  const playerCount = Math.max(2, Math.min(4, safePlayers.length || 2));
+  while (safePlayers.length < playerCount) {
+    safePlayers.push(sanitizePlayer(null, safePlayers.length));
+  }
+
+  const state = {
+    tableId: String(tableId || ''),
+    players: safePlayers,
+    boneyard: shuffleDeck(createDeck(), seed || tableId || Date.now()),
+    chain: [],
+    ends: null,
+    currentSeat: 0,
+    moveSeq: 0,
+    status: 'playing',
+    winnerSeat: null,
+    reason: '',
+    lastAction: null,
+    passStreak: 0,
+    createdAt: Date.now(),
+    updatedAt: Date.now()
+  };
+
+  const handSize = DEFAULT_HAND_SIZE;
+  for (let round = 0; round < handSize; round += 1) {
+    state.players.forEach((player) => {
+      const tile = state.boneyard.shift();
+      if (tile) player.hand.push(tile);
+    });
+  }
+
+  let starterSeat = 0;
+  let starterTileIndex = -1;
+  let bestDouble = -1;
+  state.players.forEach((player, seat) => {
+    const index = highestDoubleIndex(player.hand);
+    if (index >= 0 && player.hand[index].a > bestDouble) {
+      bestDouble = player.hand[index].a;
+      starterSeat = seat;
+      starterTileIndex = index;
+    }
+  });
+  if (starterTileIndex < 0) {
+    let bestPips = -1;
+    state.players.forEach((player, seat) => {
+      player.hand.forEach((tile, index) => {
+        const sum = tile.a + tile.b;
+        if (sum > bestPips) {
+          bestPips = sum;
+          starterSeat = seat;
+          starterTileIndex = index;
+        }
+      });
+    });
+  }
+
+  const openingTile = state.players[starterSeat].hand.splice(starterTileIndex, 1)[0];
+  const tile = canonicalTile(openingTile);
+  state.chain.push({ tile, side: 'START', seat: starterSeat, seq: 0 });
+  state.ends = { L: tile.a, R: tile.b };
+  state.currentSeat = nextActiveSeat(state, starterSeat);
+  state.lastAction = { type: 'start', seat: starterSeat, tile, nextSeat: state.currentSeat };
+  return state;
+}
+
+export function getSeatForPlayer(state, playerId) {
+  const id = String(playerId || '');
+  return state?.players?.findIndex((player) => String(player.id) === id) ?? -1;
+}
+
+function concludeIfNeeded(state) {
+  const winner = state.players.findIndex((player) => player.hand.length === 0);
+  if (winner >= 0) {
+    state.status = 'finished';
+    state.winnerSeat = winner;
+    state.reason = `${state.players[winner].name} played every tile.`;
+    return true;
+  }
+
+  const nobodyCanPlay = state.players.every((player) => !player.hand.some((tile) => canPlayTile(tile, state.ends)));
+  if (state.boneyard.length === 0 && nobodyCanPlay) {
+    let bestSeat = 0;
+    let bestScore = Infinity;
+    state.players.forEach((player, seat) => {
+      const score = pipSum(player.hand);
+      if (score < bestScore) {
+        bestScore = score;
+        bestSeat = seat;
+      }
+    });
+    state.status = 'finished';
+    state.winnerSeat = bestSeat;
+    state.reason = `Blocked game. Lowest hand: ${state.players[bestSeat].name} (${bestScore}).`;
+    return true;
+  }
+  return false;
+}
+
+export function applyDominoRoyalAction(state, action = {}, actorId = '') {
+  if (!state || state.status !== 'playing') return { ok: false, error: 'match_not_active' };
+  const seat = getSeatForPlayer(state, actorId);
+  if (seat < 0) return { ok: false, error: 'seat_required' };
+  if (seat !== state.currentSeat) return { ok: false, error: 'not_your_turn' };
+
+  const type = String(action.type || '').toLowerCase();
+  let acceptedAction = null;
+
+  if (type === 'play') {
+    const side = action.side === 'L' || action.side === -1 || action.side === 'left' ? 'L' : 'R';
+    const requestedKey = tileKey(action.tile);
+    const handIndex = state.players[seat].hand.findIndex((tile) => tileKey(tile) === requestedKey);
+    if (!requestedKey || handIndex < 0) return { ok: false, error: 'tile_not_in_hand' };
+    const tile = state.players[seat].hand[handIndex];
+    const sides = validSidesFor(tile, state.ends);
+    if (!sides[side]) return { ok: false, error: 'illegal_tile_side' };
+    const oriented = orientForSide(tile, side, state.ends);
+    if (!oriented) return { ok: false, error: 'illegal_tile_side' };
+    state.players[seat].hand.splice(handIndex, 1);
+    if (side === 'L') state.ends.L = oriented.a;
+    else state.ends.R = oriented.b;
+    state.moveSeq += 1;
+    acceptedAction = { type: 'play', seat, side, tile: oriented, seq: state.moveSeq };
+    state.chain.push(acceptedAction);
+    state.passStreak = 0;
+  } else if (type === 'draw') {
+    if (state.players[seat].hand.some((tile) => canPlayTile(tile, state.ends))) {
+      return { ok: false, error: 'play_available' };
+    }
+    const drawn = [];
+    while (state.boneyard.length) {
+      const tile = state.boneyard.shift();
+      state.players[seat].hand.push(tile);
+      drawn.push(tile);
+      if (canPlayTile(tile, state.ends)) break;
+    }
+    if (!drawn.length) return { ok: false, error: 'boneyard_empty' };
+    state.moveSeq += 1;
+    acceptedAction = { type: 'draw', seat, count: drawn.length, seq: state.moveSeq };
+    state.passStreak = 0;
+  } else if (type === 'pass') {
+    if (state.players[seat].hand.some((tile) => canPlayTile(tile, state.ends))) {
+      return { ok: false, error: 'play_available' };
+    }
+    if (state.boneyard.length > 0) return { ok: false, error: 'must_draw' };
+    state.moveSeq += 1;
+    state.passStreak += 1;
+    acceptedAction = { type: 'pass', seat, seq: state.moveSeq };
+  } else {
+    return { ok: false, error: 'unknown_action' };
+  }
+
+  state.lastAction = acceptedAction;
+  if (!concludeIfNeeded(state)) {
+    state.currentSeat = nextActiveSeat(state, seat);
+  }
+  state.updatedAt = Date.now();
+  return { ok: true, state, action: acceptedAction };
+}
+
+export function publicDominoRoyalState(state, viewerId = '') {
+  const viewerSeat = getSeatForPlayer(state, viewerId);
+  return {
+    tableId: state.tableId,
+    players: state.players.map((player, seat) => ({
+      id: player.id,
+      name: player.name,
+      avatar: player.avatar,
+      hand: seat === viewerSeat || state.status === 'finished' ? player.hand.map((tile) => ({ ...tile })) : [],
+      handCount: player.hand.length
+    })),
+    boneyardCount: state.boneyard.length,
+    chain: state.chain.map((entry) => ({ ...entry, tile: { ...entry.tile } })),
+    ends: state.ends ? { ...state.ends } : null,
+    currentSeat: state.currentSeat,
+    currentPlayerId: state.players[state.currentSeat]?.id || null,
+    moveSeq: state.moveSeq,
+    status: state.status,
+    winnerSeat: state.winnerSeat,
+    reason: state.reason,
+    lastAction: state.lastAction ? { ...state.lastAction, tile: state.lastAction.tile ? { ...state.lastAction.tile } : undefined } : null,
+    viewerSeat,
+    updatedAt: state.updatedAt
+  };
+}

--- a/test/dominoRoyalRealtimeEngine.test.js
+++ b/test/dominoRoyalRealtimeEngine.test.js
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyDominoRoyalAction,
+  createDominoRoyalState,
+  publicDominoRoyalState
+} from '../bot/utils/dominoRoyalRealtimeEngine.js';
+
+test('Domino Royal realtime state starts with deterministic private hands', () => {
+  const players = [
+    { id: 'p1', name: 'A' },
+    { id: 'p2', name: 'B' },
+    { id: 'p3', name: 'C' }
+  ];
+  const state = createDominoRoyalState({ tableId: 'domino-test', players, seed: 'seed-1' });
+
+  assert.equal(state.players.length, 3);
+  assert.equal(state.chain.length, 1);
+  assert.equal(state.players.reduce((sum, player) => sum + player.hand.length, 0), 20);
+  assert.equal(state.boneyard.length, 7);
+
+  const p1View = publicDominoRoyalState(state, 'p1');
+  assert.equal(p1View.players[0].hand.length, p1View.players[0].handCount);
+  assert.equal(p1View.players[1].hand.length, 0);
+  assert.equal(p1View.players[1].handCount, state.players[1].hand.length);
+});
+
+test('Domino Royal realtime engine rejects out-of-turn and illegal actions', () => {
+  const state = createDominoRoyalState({
+    tableId: 'domino-test-2',
+    players: [
+      { id: 'p1', name: 'A' },
+      { id: 'p2', name: 'B' }
+    ],
+    seed: 'seed-2'
+  });
+  const currentId = state.players[state.currentSeat].id;
+  const otherId = state.players.find((player) => player.id !== currentId).id;
+
+  assert.equal(applyDominoRoyalAction(state, { type: 'pass' }, otherId).error, 'not_your_turn');
+
+  const playable = state.players[state.currentSeat].hand.find(
+    (tile) => tile.a === state.ends.L || tile.b === state.ends.L || tile.a === state.ends.R || tile.b === state.ends.R
+  );
+  if (playable) {
+    assert.equal(applyDominoRoyalAction(state, { type: 'pass' }, currentId).error, 'play_available');
+  }
+});
+
+test('Domino Royal realtime engine accepts a legal play and advances turn', () => {
+  const state = createDominoRoyalState({
+    tableId: 'domino-test-3',
+    players: [
+      { id: 'p1', name: 'A' },
+      { id: 'p2', name: 'B' }
+    ],
+    seed: 'seed-3'
+  });
+  const currentSeat = state.currentSeat;
+  const currentId = state.players[currentSeat].id;
+  const playable = state.players[currentSeat].hand.find(
+    (tile) => tile.a === state.ends.L || tile.b === state.ends.L || tile.a === state.ends.R || tile.b === state.ends.R
+  );
+
+  if (!playable) {
+    const result = applyDominoRoyalAction(state, { type: 'draw' }, currentId);
+    assert.equal(result.ok, true);
+    assert.equal(state.moveSeq, 1);
+    return;
+  }
+
+  const side = playable.a === state.ends.L || playable.b === state.ends.L ? 'L' : 'R';
+  const result = applyDominoRoyalAction(state, { type: 'play', tile: playable, side }, currentId);
+  assert.equal(result.ok, true);
+  assert.equal(state.chain.length, 2);
+  assert.notEqual(state.currentSeat, currentSeat);
+  assert.equal(state.moveSeq, 1);
+});

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1107,6 +1107,12 @@ function normalizeAvatarSource(src = '') {
 const entryMode = (urlParams.get('entry') || '').toLowerCase();
 const gameMode = (urlParams.get('mode') || 'local').toLowerCase();
 const isVsAiMatch = gameMode === 'local';
+const isOnlineMatch = gameMode === 'online';
+const onlineTableId = (urlParams.get('tableId') || urlParams.get('table') || '').trim();
+const onlineAccountId = accountId;
+const onlineSocket = typeof window !== 'undefined' ? window.__TONPLAYGRAM_SOCKET__ : null;
+let latestOnlineMoveSeq = -1;
+let detachOnlineDominoSync = null;
 const shouldRunHallwayEntry = !USE_MINIMAL_STAGE && entryMode === 'hallway';
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
@@ -10108,6 +10114,153 @@ function startGame({ resetRace = true } = {}) {
   if (current !== human) {
     scheduleCpuPlay();
   }
+
+}
+
+function placeOpeningTileFromOnline(firstTile) {
+  const tile = canonTile(firstTile) || firstTile;
+  if (!isValidTile(tile)) return false;
+  const firstRot = tile.a === tile.b ? Math.PI / 2 : 0;
+  chain.push({
+    tile,
+    x: 0,
+    z: 0,
+    rot: firstRot,
+    double: tile.a === tile.b
+  });
+  usedTileKeys.add(tileKey(tile));
+  const isDoubleStart = tile.a === tile.b;
+  if (!flipDir) {
+    ends = isDoubleStart
+      ? {
+          L: { v: tile.a, x: DOUBLE_END_SHIFT, z: 0, dir: [-1, 0], orient: Math.PI, span: getTileSpanAlongChain(true), fromStartDouble: true, hasInitialNeighbor: false },
+          R: { v: tile.b, x: -DOUBLE_END_SHIFT, z: 0, dir: [1, 0], orient: 0, span: getTileSpanAlongChain(true), fromStartDouble: true, hasInitialNeighbor: false }
+        }
+      : {
+          L: { v: tile.a, x: 0, z: 0, dir: [-1, 0], orient: Math.PI, span: getTileSpanAlongChain(false) },
+          R: { v: tile.b, x: 0, z: 0, dir: [1, 0], orient: 0, span: getTileSpanAlongChain(false) }
+        };
+  } else {
+    ends = isDoubleStart
+      ? {
+          L: { v: tile.a, x: -DOUBLE_END_SHIFT, z: 0, dir: [1, 0], orient: 0, span: getTileSpanAlongChain(true), fromStartDouble: true, hasInitialNeighbor: false },
+          R: { v: tile.b, x: DOUBLE_END_SHIFT, z: 0, dir: [-1, 0], orient: Math.PI, span: getTileSpanAlongChain(true), fromStartDouble: true, hasInitialNeighbor: false }
+        }
+      : {
+          L: { v: tile.a, x: 0, z: 0, dir: [1, 0], orient: 0, span: getTileSpanAlongChain(false) },
+          R: { v: tile.b, x: 0, z: 0, dir: [-1, 0], orient: Math.PI, span: getTileSpanAlongChain(false) }
+        };
+  }
+  return true;
+}
+
+function rebuildOnlineChain(serverChain = []) {
+  clearExistingDominoMeshes();
+  chain = [];
+  ends = null;
+  usedTileKeys.clear();
+  const opening = serverChain[0]?.tile;
+  if (!placeOpeningTileFromOnline(opening)) return;
+  serverChain.slice(1).forEach((entry) => {
+    const side = entry.side === 'L' ? -1 : 1;
+    placeOnBoard(entry.tile, side, { animate: false });
+  });
+}
+
+function emitDominoOnlineAction(action) {
+  if (!isOnlineMatch || !onlineSocket || !onlineTableId || !onlineAccountId) return false;
+  const clientActionId = `${onlineAccountId}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  onlineSocket.emit('dominoAction', {
+    tableId: onlineTableId,
+    accountId: onlineAccountId,
+    clientActionId,
+    action
+  });
+  return true;
+}
+
+function applyOnlineDominoState(state = {}) {
+  if (!isOnlineMatch || !state || state.tableId !== onlineTableId) return;
+  const moveSeq = Number(state.moveSeq ?? -1);
+  if (moveSeq < latestOnlineMoveSeq) return;
+  latestOnlineMoveSeq = moveSeq;
+
+  if (cpuMoveTimeout) {
+    clearTimeout(cpuMoveTimeout);
+    cpuMoveTimeout = null;
+  }
+  if (pendingTurnAdvanceTimeout) {
+    clearTimeout(pendingTurnAdvanceTimeout);
+    pendingTurnAdvanceTimeout = null;
+  }
+
+  const incomingPlayers = Array.isArray(state.players) ? state.players : [];
+  N = Math.max(2, Math.min(4, incomingPlayers.length || N || 2));
+  human = Number.isInteger(state.viewerSeat) && state.viewerSeat >= 0 ? state.viewerSeat : human;
+  players = Array.from({ length: N }, (_, seat) => {
+    const source = incomingPlayers[seat] || {};
+    const hand = Array.isArray(source.hand) && source.hand.length
+      ? source.hand.map((tile) => canonTile(tile)).filter(Boolean)
+      : Array.from({ length: Number(source.handCount || 0) }, () => ({ a: 0, b: 0, hidden: true }));
+    return {
+      id: source.id || seat,
+      name: source.name || `Player ${seat + 1}`,
+      avatar: source.avatar || '',
+      hand
+    };
+  });
+  current = Number.isInteger(state.currentSeat) ? state.currentSeat : current;
+  gameFinished = state.status === 'finished';
+  winnerIndex = Number.isInteger(state.winnerSeat) ? state.winnerSeat : null;
+  revealAllHands = gameFinished;
+  selectedTile = null;
+  clearMarkers();
+  clearSelectedHighlight();
+  boneyard = Array.from({ length: Math.max(0, Number(state.boneyardCount || 0)) }, () => ({ a: 0, b: 0 }));
+  renderBoneyardStack();
+  rebuildDominoCharactersForChairs();
+  rebuildOnlineChain(Array.isArray(state.chain) ? state.chain : []);
+  renderHands();
+  renderChain();
+  updateLeaderboardCard();
+
+  const currentName = players[current]?.name || `Player ${current + 1}`;
+  if (gameFinished) {
+    if (winnerIndex !== null) showWinnerHighlight(winnerIndex);
+    setStatus(state.reason || (winnerIndex === human ? 'You won!' : `${players[winnerIndex]?.name || 'Player'} won!`));
+    showWinnerOverlay({ winner: winnerIndex, reason: state.reason || '' });
+  } else {
+    setStatus(current === human ? 'Your turn' : `Turn: ${currentName}`);
+  }
+  setControlEnabled(!gameFinished && current === human);
+}
+
+function setupOnlineDominoSync() {
+  if (!isOnlineMatch || !onlineSocket || !onlineTableId || !onlineAccountId) return;
+  detachOnlineDominoSync?.();
+  const registerAndJoin = () => {
+    onlineSocket.emit('register', { playerId: onlineAccountId });
+    onlineSocket.emit('joinDominoTable', {
+      tableId: onlineTableId,
+      accountId: onlineAccountId,
+      name: seatAvatarUsername || 'Player'
+    });
+    onlineSocket.emit('dominoSyncRequest', { tableId: onlineTableId, accountId: onlineAccountId });
+  };
+  const handleRejected = ({ tableId, error } = {}) => {
+    if (tableId === onlineTableId && error) setStatus(`Move rejected: ${error}`);
+    onlineSocket.emit('dominoSyncRequest', { tableId: onlineTableId, accountId: onlineAccountId });
+  };
+  onlineSocket.on('dominoState', applyOnlineDominoState);
+  onlineSocket.on('dominoActionRejected', handleRejected);
+  onlineSocket.on('connect', registerAndJoin);
+  detachOnlineDominoSync = () => {
+    onlineSocket.off('dominoState', applyOnlineDominoState);
+    onlineSocket.off('dominoActionRejected', handleRejected);
+    onlineSocket.off('connect', registerAndJoin);
+    detachOnlineDominoSync = null;
+  };
+  registerAndJoin();
 }
 
 /* ---------- Placement & Snake ---------- */
@@ -10645,6 +10798,17 @@ renderer.domElement.addEventListener('pointerdown', (ev) => {
   }
   if (obj.userData && obj.userData.marker && selectedTile) {
     const side = obj.userData.side;
+    if (isOnlineMatch) {
+      emitDominoOnlineAction({
+        type: 'play',
+        tile: selectedTile,
+        side: side < 0 ? 'L' : 'R'
+      });
+      selectedTile = null;
+      clearMarkers();
+      clearSelectedHighlight();
+      return;
+    }
     const idx = players[human].hand.indexOf(selectedTile);
     let playedPlacement = null;
     if (idx >= 0) {
@@ -10776,6 +10940,10 @@ renderer.domElement.addEventListener('pointerleave', (ev) => {
 if (btnDraw) {
   btnDraw.addEventListener('click', () => {
   if (current !== human || gameFinished) return;
+  if (isOnlineMatch) {
+    emitDominoOnlineAction({ type: 'draw' });
+    return;
+  }
   let drewTile = false;
   while (boneyard.length) {
     const startWorld = getBoneyardTopWorld();
@@ -10800,6 +10968,12 @@ if (btnDraw) {
 if (btnPass) {
   btnPass.addEventListener('click', () => {
   if (current === human && !gameFinished) {
+    if (isOnlineMatch) {
+      clearMarkers();
+      selectedTile = null;
+      emitDominoOnlineAction({ type: 'pass' });
+      return;
+    }
     clearMarkers();
     selectedTile = null;
     SFX.pass();
@@ -10811,6 +10985,12 @@ if (btnPass) {
 async function bootstrapDominoRoyal() {
   try {
     await loadHumanProfileFromApi();
+    if (isOnlineMatch) {
+      setStatus('Connecting Domino Royal online table…');
+      setupOnlineDominoSync();
+      setControlEnabled(false);
+      return;
+    }
     startGame();
     setControlEnabled(true);
   } catch (error) {
@@ -11824,6 +12004,7 @@ function detachRuntimeListeners() {
   window.removeEventListener('beforeunload', onLifecycleShutdown);
   window.removeEventListener('unload', onLifecycleShutdown);
   window.removeEventListener('message', runtimeMessageHandler);
+  detachOnlineDominoSync?.();
 }
 
 function shutdownDominoRoyal(reason = 'unknown') {

--- a/webapp/src/pages/Games/DominoRoyal.jsx
+++ b/webapp/src/pages/Games/DominoRoyal.jsx
@@ -9,6 +9,19 @@ export default function DominoRoyal() {
   useTelegramBackButton();
   const { search } = useLocation();
 
+  if (typeof window !== 'undefined') {
+    window.__TONPLAYGRAM_SOCKET__ = socket;
+  }
+
+  useEffect(() => {
+    window.__TONPLAYGRAM_SOCKET__ = socket;
+    return () => {
+      if (window.__TONPLAYGRAM_SOCKET__ === socket) {
+        delete window.__TONPLAYGRAM_SOCKET__;
+      }
+    };
+  }, []);
+
   useEffect(() => {
     const params = new URLSearchParams(search);
     const mode = params.get('mode');
@@ -24,12 +37,12 @@ export default function DominoRoyal() {
       }
       if (cancelled || !resolvedAccountId) return;
       socket.emit('register', { playerId: resolvedAccountId });
-      socket.emit('joinRoom', {
-        roomId: tableId,
+      socket.emit('confirmReady', { accountId: resolvedAccountId, tableId });
+      socket.emit('joinDominoTable', {
+        tableId,
         accountId: resolvedAccountId,
         name: getTelegramUsername() || 'Player'
       });
-      socket.emit('confirmReady', { accountId: resolvedAccountId, tableId });
     };
 
     syncRuntime().catch(() => {});


### PR DESCRIPTION
### Motivation
- Provide an authoritative server-owned Domino game engine to ensure consistent deck/deal/turn logic and anti-cheat validation for online matches.
- Integrate Domino Royal into the existing Socket.IO lobby/room flow so web clients can join authoritative tables, receive per-player private views, and play synced matches.
- Reuse the existing lobby/start contract and minimize client-side authoritative assumptions (client becomes a renderer + action emitter in online mode).

### Description
- Added an authoritative realtime engine at `bot/utils/dominoRoyalRealtimeEngine.js` that implements seeded deck shuffle, 7-tile deal, opener selection, `play`/`draw`/`pass` validation, turn progression, block/winner resolution, and `publicDominoRoyalState` per-viewer snapshots.
- Wired server-side Socket.IO support in `bot/server.js` to create/ensure Domino state at `gameStart`, expose `joinDominoTable`, `dominoSyncRequest`, and `dominoAction` events, broadcast personalized `dominoState`, apply rate-limiting for moves, and cleanup match state on table close.
- Updated online policy to allow 2/3/4 player Domino tables via `bot/config/onlineGamePolicy.js` and cleaned up turn/table startup broadcasting to emit initial authoritative state.
- Updated the client runtime in `webapp/public/domino-royal-game.js` and React entry `webapp/src/pages/Games/DominoRoyal.jsx` to register the shared socket, join the authoritative table, request sync, rebuild the 3D chain from server state, and emit `play`/`draw`/`pass` actions via `dominoAction` when in `mode=online`.
- Added focused unit tests `test/dominoRoyalRealtimeEngine.test.js` that exercise deterministic private hands, out-of-turn / illegal action rejection, and legal play progression.

### Testing
- Ran unit tests: `npm test -- --runInBand test/dominoRoyalRealtimeEngine.test.js`, which passed (3 tests, 0 failures).
- Built the monorepo and frontend: `npm run build` and `npm --prefix webapp run build` completed successfully (TypeScript compile and Vite frontend build ran without blocking errors).
- Verified lint/test smoke locally for the new engine and that the server accepts/join/sync/action flows in the codebase (unit tests cover core engine behavior and build confirms integration compilation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d1bd4008c8329a360e1e626b338b9)