### PR TITLE
Make Chess Battle Royale online moves authoritative

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -722,12 +722,254 @@ function cleanupSeats() {
   }
 }
 
+
+function createInitialChessBoard() {
+  const rows = CHESS_START_FEN.split(' ')[0].split('/');
+  return rows.map((row) => {
+    const cells = [];
+    for (const ch of row) {
+      if (/\d/.test(ch)) {
+        for (let i = 0; i < Number(ch); i += 1) cells.push(null);
+      } else {
+        cells.push({ t: ch.toUpperCase(), w: ch === ch.toUpperCase(), hasMoved: false });
+      }
+    }
+    return cells;
+  });
+}
+
+function cloneChessBoard(board) {
+  return (Array.isArray(board) ? board : createInitialChessBoard()).map((row) =>
+    (Array.isArray(row) ? row : []).map((piece) =>
+      piece ? { t: piece.t, w: Boolean(piece.w), hasMoved: Boolean(piece.hasMoved) } : null
+    )
+  );
+}
+
+function normalizeChessBoard(board) {
+  if (!Array.isArray(board) || board.length !== 8) return createInitialChessBoard();
+  const normalized = board.map((row) => {
+    if (!Array.isArray(row) || row.length !== 8) return null;
+    return row.map((piece) => {
+      if (!piece) return null;
+      const type = String(piece.t || '').toUpperCase();
+      if (!['P', 'N', 'B', 'R', 'Q', 'K'].includes(type)) return null;
+      return { t: type, w: Boolean(piece.w), hasMoved: Boolean(piece.hasMoved) };
+    });
+  });
+  return normalized.every(Boolean) ? normalized : createInitialChessBoard();
+}
+
+function chessBoardToFen(board, whiteToMove = true) {
+  const rows = normalizeChessBoard(board).map((row) => {
+    let fenRow = '';
+    let empty = 0;
+    row.forEach((piece) => {
+      if (!piece) {
+        empty += 1;
+        return;
+      }
+      if (empty) {
+        fenRow += String(empty);
+        empty = 0;
+      }
+      fenRow += piece.w ? piece.t : piece.t.toLowerCase();
+    });
+    if (empty) fenRow += String(empty);
+    return fenRow || '8';
+  });
+  return `${rows.join('/')} ${whiteToMove ? 'w' : 'b'} - - 0 1`;
+}
+
+function chessInBoard(r, c) {
+  return r >= 0 && r < 8 && c >= 0 && c < 8;
+}
+
+const CHESS_KNIGHT_DELTAS = [
+  [-2, -1], [-2, 1], [-1, -2], [-1, 2],
+  [1, -2], [1, 2], [2, -1], [2, 1]
+];
+const CHESS_SLIDE_DIRS = {
+  B: [[-1, -1], [-1, 1], [1, -1], [1, 1]],
+  R: [[-1, 0], [1, 0], [0, -1], [0, 1]],
+  Q: [[-1, -1], [-1, 1], [1, -1], [1, 1], [-1, 0], [1, 0], [0, -1], [0, 1]]
+};
+
+function chessPseudoMoves(board, r, c) {
+  const piece = board?.[r]?.[c];
+  if (!piece) return [];
+  const moves = [];
+  const push = (rr, cc) => {
+    if (!chessInBoard(rr, cc)) return;
+    const target = board[rr][cc];
+    if (!target || target.w !== piece.w) moves.push([rr, cc]);
+  };
+  if (piece.t === 'P') {
+    const dir = piece.w ? -1 : 1;
+    const start = piece.w ? 6 : 1;
+    if (chessInBoard(r + dir, c) && !board[r + dir][c]) {
+      moves.push([r + dir, c]);
+      if (r === start && !board[r + dir * 2][c]) moves.push([r + dir * 2, c]);
+    }
+    [-1, 1].forEach((dc) => {
+      const rr = r + dir;
+      const cc = c + dc;
+      if (chessInBoard(rr, cc) && board[rr][cc] && board[rr][cc].w !== piece.w) moves.push([rr, cc]);
+    });
+  } else if (piece.t === 'N') {
+    CHESS_KNIGHT_DELTAS.forEach(([dr, dc]) => push(r + dr, c + dc));
+  } else if (CHESS_SLIDE_DIRS[piece.t]) {
+    CHESS_SLIDE_DIRS[piece.t].forEach(([dr, dc]) => {
+      let rr = r + dr;
+      let cc = c + dc;
+      while (chessInBoard(rr, cc)) {
+        if (board[rr][cc]) {
+          if (board[rr][cc].w !== piece.w) moves.push([rr, cc]);
+          break;
+        }
+        moves.push([rr, cc]);
+        rr += dr;
+        cc += dc;
+      }
+    });
+  } else if (piece.t === 'K') {
+    for (let dr = -1; dr <= 1; dr += 1) {
+      for (let dc = -1; dc <= 1; dc += 1) {
+        if (dr || dc) push(r + dr, c + dc);
+      }
+    }
+  }
+  return moves;
+}
+
+function findChessKing(board, white) {
+  for (let r = 0; r < 8; r += 1) {
+    for (let c = 0; c < 8; c += 1) {
+      const piece = board[r][c];
+      if (piece?.t === 'K' && piece.w === white) return [r, c];
+    }
+  }
+  return null;
+}
+
+function isChessSquareAttacked(board, r, c, byWhite) {
+  for (let rr = 0; rr < 8; rr += 1) {
+    for (let cc = 0; cc < 8; cc += 1) {
+      const piece = board[rr][cc];
+      if (!piece || piece.w !== byWhite) continue;
+      if (chessPseudoMoves(board, rr, cc).some(([r2, c2]) => r2 === r && c2 === c)) return true;
+    }
+  }
+  return false;
+}
+
+function isChessPlayerInCheck(board, white) {
+  const king = findChessKing(board, white);
+  return king ? isChessSquareAttacked(board, king[0], king[1], !white) : false;
+}
+
+function applyChessMoveOnBoard(board, fromR, fromC, toR, toC) {
+  const next = cloneChessBoard(board);
+  const piece = next[fromR][fromC];
+  if (!piece) return next;
+  const isCastling = piece.t === 'K' && Math.abs(toC - fromC) === 2;
+  if (isCastling) {
+    const rookFromC = toC > fromC ? 7 : 0;
+    const rookToC = toC > fromC ? 5 : 3;
+    const rook = next[fromR][rookFromC];
+    next[fromR][rookToC] = rook;
+    next[fromR][rookFromC] = null;
+    if (rook) rook.hasMoved = true;
+  }
+  next[toR][toC] = piece;
+  next[fromR][fromC] = null;
+  piece.hasMoved = true;
+  if (piece.t === 'P' && (toR === 0 || toR === 7)) piece.t = 'Q';
+  return next;
+}
+
+function getChessCastlingTargets(board, r, c, white) {
+  const piece = board?.[r]?.[c];
+  if (!piece || piece.t !== 'K' || piece.w !== white || piece.hasMoved) return [];
+  const homeRow = white ? 7 : 0;
+  if (r !== homeRow || c !== 4 || isChessPlayerInCheck(board, white)) return [];
+  const results = [];
+  const checkSide = (rookCol, emptyCols, transitCols, destCol) => {
+    const rook = board[homeRow][rookCol];
+    if (!rook || rook.t !== 'R' || rook.w !== white || rook.hasMoved) return;
+    if (emptyCols.some((col) => board[homeRow][col])) return;
+    if (transitCols.some((col) => isChessSquareAttacked(board, homeRow, col, !white))) return;
+    results.push([homeRow, destCol]);
+  };
+  checkSide(7, [5, 6], [5, 6], 6);
+  checkSide(0, [1, 2, 3], [3, 2], 2);
+  return results;
+}
+
+function getLegalChessMoves(board, r, c) {
+  const piece = board?.[r]?.[c];
+  if (!piece) return [];
+  const pseudo = chessPseudoMoves(board, r, c);
+  if (piece.t === 'K') pseudo.push(...getChessCastlingTargets(board, r, c, piece.w));
+  return pseudo.filter(([toR, toC]) => !isChessPlayerInCheck(applyChessMoveOnBoard(board, r, c, toR, toC), piece.w));
+}
+
+function hasAnyLegalChessMove(board, white) {
+  for (let r = 0; r < 8; r += 1) {
+    for (let c = 0; c < 8; c += 1) {
+      if (board?.[r]?.[c]?.w === white && getLegalChessMoves(board, r, c).length > 0) return true;
+    }
+  }
+  return false;
+}
+
+function validateAndApplyChessMove(state, playerId, move = {}) {
+  if (state.winner) return { ok: false, error: 'game_finished' };
+  const board = normalizeChessBoard(state.board);
+  const lastMove = move.lastMove || {};
+  const from = lastMove.from || {};
+  const to = lastMove.to || {};
+  const coords = [from.r, from.c, to.r, to.c].map((value) => Number(value));
+  if (!coords.every(Number.isInteger)) return { ok: false, error: 'invalid_coordinates' };
+  const [fromR, fromC, toR, toC] = coords;
+  if (!chessInBoard(fromR, fromC) || !chessInBoard(toR, toC)) return { ok: false, error: 'invalid_coordinates' };
+  const piece = board[fromR][fromC];
+  if (!piece) return { ok: false, error: 'empty_source' };
+  if (piece.w !== Boolean(state.turnWhite)) return { ok: false, error: 'wrong_turn_piece' };
+  const player = (state.players || []).find((p) => String(p.id) === String(playerId));
+  if (player?.side && player.side !== (piece.w ? 'white' : 'black')) return { ok: false, error: 'wrong_player_turn' };
+  const legal = getLegalChessMoves(board, fromR, fromC);
+  if (!legal.some(([r, c]) => r === toR && c === toC)) return { ok: false, error: 'illegal_move' };
+  const nextBoard = applyChessMoveOnBoard(board, fromR, fromC, toR, toC);
+  const turnWhite = !state.turnWhite;
+  const hasReply = hasAnyLegalChessMove(nextBoard, turnWhite);
+  const inCheck = isChessPlayerInCheck(nextBoard, turnWhite);
+  const winner = !hasReply && inCheck ? (turnWhite ? 'black' : 'white') : null;
+  const draw = !hasReply && !inCheck ? 'stalemate' : null;
+  return {
+    ok: true,
+    state: {
+      board: nextBoard,
+      fen: chessBoardToFen(nextBoard, turnWhite),
+      turnWhite,
+      lastMove: { from: { r: fromR, c: fromC }, to: { r: toR, c: toC } },
+      winner,
+      draw,
+      moveSeq: Number(state.moveSeq || 0) + 1
+    }
+  };
+}
+
 function getChessState(tableId) {
   if (!chessGames.has(tableId)) {
+    const board = createInitialChessBoard();
     chessGames.set(tableId, {
-      fen: CHESS_START_FEN,
+      board,
+      fen: chessBoardToFen(board, true),
       turnWhite: true,
       lastMove: null,
+      moveSeq: 0,
+      players: [],
       updatedAt: Date.now()
     });
   }
@@ -739,8 +981,10 @@ function updateChessState(tableId, nextState = {}) {
   const merged = {
     ...base,
     ...nextState,
+    board: normalizeChessBoard(nextState.board || base.board),
     updatedAt: Date.now()
   };
+  merged.fen = nextState.fen || chessBoardToFen(merged.board, merged.turnWhite);
   chessGames.set(tableId, merged);
   return merged;
 }
@@ -1048,7 +1292,15 @@ function maybeStartGame(table) {
         table.players = assignChessSides(table.players);
         const whitePlayer = table.players.find((p) => p.side === 'white');
         if (whitePlayer) table.currentTurn = whitePlayer.id;
-        const initial = updateChessState(table.id, { turnWhite: true, lastMove: null });
+        const board = createInitialChessBoard();
+        const initial = updateChessState(table.id, {
+          board,
+          fen: chessBoardToFen(board, true),
+          turnWhite: true,
+          lastMove: null,
+          moveSeq: 0,
+          players: table.players
+        });
         io.to(table.id).emit('chessState', { tableId: table.id, ...initial });
       } else if (table.gameType === 'checkers') {
         table.players = assignCheckersSides(table.players);
@@ -2136,14 +2388,31 @@ io.on('connection', (socket) => {
     socket.to(tableId).emit('snookerState', payload);
   });
 
-  socket.on('chessMove', ({ tableId, move }) => {
-    if (!tableId || !move) return;
-    const next = updateChessState(tableId, {
-      fen: move.fen || CHESS_START_FEN,
-      turnWhite: typeof move.turnWhite === 'boolean' ? move.turnWhite : true,
-      lastMove: move.lastMove || null
-    });
-    socket.to(tableId).emit('chessMove', { tableId, ...next });
+  socket.on('chessMove', ({ tableId, move }, cb) => {
+    if (!tableId || !move) {
+      cb && cb({ success: false, error: 'invalid_payload' });
+      return;
+    }
+    const playerId = String(socket.data?.playerId || '');
+    if (!playerId) {
+      cb && cb({ success: false, error: 'register_required' });
+      return;
+    }
+    const current = getChessState(tableId);
+    const result = validateAndApplyChessMove(current, playerId, move);
+    if (!result.ok) {
+      socket.emit('chessMoveRejected', {
+        tableId,
+        error: result.error,
+        state: { tableId, ...current }
+      });
+      cb && cb({ success: false, error: result.error, state: { tableId, ...current } });
+      return;
+    }
+    const next = updateChessState(tableId, result.state);
+    const payload = { tableId, ...next };
+    socket.to(tableId).emit('chessMove', payload);
+    cb && cb({ success: true, state: payload });
   });
 
   socket.on('checkersMove', async ({ tableId, move }) => {

--- a/test/chessOnlineMoveValidation.test.js
+++ b/test/chessOnlineMoveValidation.test.js
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+function once(socket, event) {
+  return new Promise((resolve) => socket.once(event, resolve));
+}
+
+function emitAck(socket, event, payload) {
+  return new Promise((resolve) => socket.emit(event, payload, resolve));
+}
+
+test(
+  'chess online moves are server-authoritative and synchronized',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3213',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const white = io('http://localhost:3213', { auth: { token: apiToken } });
+    const black = io('http://localhost:3213', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([once(white, 'connect'), once(black, 'connect')]);
+      await Promise.all([
+        emitAck(white, 'register', { playerId: 'white-player' }),
+        emitAck(black, 'register', { playerId: 'black-player' })
+      ]);
+
+      const firstSeat = await emitAck(white, 'seatTable', {
+        accountId: 'white-player',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        preferredSide: 'white'
+      });
+      const secondSeat = await emitAck(black, 'seatTable', {
+        accountId: 'black-player',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        preferredSide: 'black'
+      });
+      assert.equal(firstSeat.success, true);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, firstSeat.tableId);
+
+      white.emit('confirmReady', { accountId: 'white-player', tableId: firstSeat.tableId });
+      black.emit('confirmReady', { accountId: 'black-player', tableId: firstSeat.tableId });
+      await Promise.all([once(white, 'gameStart'), once(black, 'gameStart')]);
+
+      white.emit('joinChessRoom', { tableId: firstSeat.tableId, accountId: 'white-player' });
+      black.emit('joinChessRoom', { tableId: firstSeat.tableId, accountId: 'black-player' });
+      await Promise.all([once(white, 'chessState'), once(black, 'chessState')]);
+
+      const illegalAck = await emitAck(black, 'chessMove', {
+        tableId: firstSeat.tableId,
+        move: { lastMove: { from: { r: 6, c: 4 }, to: { r: 4, c: 4 } } }
+      });
+      assert.equal(illegalAck.success, false);
+      assert.equal(illegalAck.error, 'wrong_player_turn');
+
+      const blackUpdate = once(black, 'chessMove');
+      const legalAck = await emitAck(white, 'chessMove', {
+        tableId: firstSeat.tableId,
+        move: { lastMove: { from: { r: 6, c: 4 }, to: { r: 4, c: 4 } } }
+      });
+      assert.equal(legalAck.success, true);
+      assert.equal(legalAck.state.turnWhite, false);
+      assert.equal(legalAck.state.board[4][4].t, 'P');
+      assert.equal(legalAck.state.board[4][4].w, true);
+      assert.equal(legalAck.state.board[4][4].hasMoved, true);
+
+      const synced = await blackUpdate;
+      assert.equal(synced.turnWhite, false);
+      assert.equal(synced.board[4][4].t, 'P');
+      assert.equal(synced.lastMove.from.r, 6);
+      assert.equal(synced.lastMove.to.r, 4);
+      await delay(50);
+    } finally {
+      white.disconnect();
+      black.disconnect();
+      server.kill();
+    }
+  }
+);

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7631,6 +7631,37 @@ function cloneBoard(b) {
   return b.map((r) => r.map((c) => (c ? { t: c.t, w: c.w, hasMoved: Boolean(c.hasMoved) } : null)));
 }
 
+function boardToWireBoard(board) {
+  if (!Array.isArray(board)) return null;
+  return board.map((row) =>
+    Array.isArray(row)
+      ? row.map((piece) =>
+          piece
+            ? {
+                t: piece.t,
+                w: Boolean(piece.w),
+                hasMoved: Boolean(piece.hasMoved)
+              }
+            : null
+        )
+      : Array(8).fill(null)
+  );
+}
+
+function parseWireBoard(wireBoard) {
+  if (!Array.isArray(wireBoard) || wireBoard.length !== 8) return null;
+  const next = wireBoard.map((row) => {
+    if (!Array.isArray(row) || row.length !== 8) return null;
+    return row.map((piece) => {
+      if (!piece) return null;
+      const type = String(piece.t || '').toUpperCase();
+      if (!['P', 'N', 'B', 'R', 'Q', 'K'].includes(type)) return null;
+      return { t: type, w: Boolean(piece.w), hasMoved: Boolean(piece.hasMoved) };
+    });
+  });
+  return next.every(Boolean) ? next : null;
+}
+
 // Offsets
 const DIRS = {
   N: [-1, 0],
@@ -8781,7 +8812,21 @@ function Chess3D({
     onlineRef.current.emitMove = ({ tableId: tid, move }) => {
       const target = tid || onlineRef.current.tableId;
       if (!target || !move) return;
-      socket.emit('chessMove', { tableId: target, move });
+      const emitter = typeof socket.timeout === 'function' ? socket.timeout(5000) : socket;
+      emitter.emit('chessMove', { tableId: target, move }, (errorOrResponse, maybeResponse) => {
+        if (!active) return;
+        const hasTimeoutSignature = maybeResponse !== undefined || errorOrResponse instanceof Error;
+        const error = hasTimeoutSignature ? errorOrResponse : null;
+        const response = hasTimeoutSignature ? maybeResponse || {} : errorOrResponse || {};
+        if (error || response?.success === false) {
+          onlineRef.current.requestSync?.();
+          return;
+        }
+        if (response?.state) {
+          onlineRef.current.synced = true;
+          onlineRef.current.applyRemoteMove?.(response.state);
+        }
+      });
     };
     onlineRef.current.requestSync = () => {
       const target = onlineRef.current.tableId;
@@ -13447,12 +13492,28 @@ function Chess3D({
     };
 
     const syncBoardFromState = (payload = {}) => {
-      const { fen, turnWhite = true, lastMove } = payload;
-      if (!fen) return;
+      const { fen, turnWhite = true, lastMove, board: syncedBoard, players = [] } = payload;
+      if (!fen && !syncedBoard) return;
       try {
-        board = parseFEN(fen.split(' ')[0]);
+        const parsedBoard = parseWireBoard(syncedBoard);
+        board = parsedBoard || parseFEN(String(fen || START_FEN).split(' ')[0]);
+        if (Array.isArray(players) && players.length) {
+          const me = players.find((p) => String(p.id) === String(accountId));
+          const opp = players.find((p) => String(p.id) !== String(accountId));
+          if (me?.side === 'white' || me?.side === 'black') {
+            onlineRef.current.side = me.side;
+          }
+          if (opp) setOpponent(opp);
+        }
         paintPiecesFromPrototypes(currentPiecePrototypes);
-        applyStatus(turnWhite, turnWhite ? 'White to move' : 'Black to move', null);
+        const statusText = payload.winner
+          ? `${payload.winner === 'white' ? 'White' : 'Black'} wins`
+          : payload.draw === 'stalemate'
+            ? 'Stalemate'
+            : turnWhite
+              ? 'White to move'
+              : 'Black to move';
+        applyStatus(turnWhite, statusText, payload.winner || null);
         if (lastMove?.from && lastMove?.to) {
           const { from, to } = lastMove;
           lastMoveRef.current = {
@@ -14302,6 +14363,7 @@ function Chess3D({
         const movePayload = {
           lastMove: { from: { r: sel.r, c: sel.c }, to: { r: rr, c: cc } },
           fen: boardToFEN(board, nextWhite),
+          board: boardToWireBoard(board),
           turnWhite: nextWhite
         };
         onlineRef.current.emitMove?.({ tableId: onlineRef.current.tableId, move: movePayload });


### PR DESCRIPTION
### Motivation
- Ensure online Chess Battle Royal is server-authoritative to prevent client-side divergence and cheating by centralizing board state and move validation.  
- Provide robust socket ACK/reject flow so clients can recover from timeouts or invalid local moves and re-sync reliably.  
- Preserve full board fidelity (including `hasMoved` flags) so castling/promotions/checkmate/stalemate are handled correctly across client and server.  

### Description
- Server: added canonical per-table chess state and helpers (`createInitialChessBoard`, `normalizeChessBoard`, `chessBoardToFen`, move generation/validation utilities, `validateAndApplyChessMove`) and extended `updateChessState` to store/merge full `board` and derived `fen`.  
- Server: changed `chessMove` socket handler to perform authoritative validation, return ACKs with `{ success, state }`, emit `chessMoveRejected` with current authoritative state on invalid moves, and emit `chessMove` with the canonical state when a move is accepted.  
- Client: send/consume full board snapshots via `boardToWireBoard` / `parseWireBoard`, include `board` in outgoing move payloads, use a timeout-aware emit callback to retry/`requestSync` on failures, and apply server `state` (including opponent/side info) when receiving ACKs or syncs.  
- Tests & infra: added `test/chessOnlineMoveValidation.test.js` which verifies wrong-side moves are rejected and accepted moves synchronize opponent state; updated build artifacts and integrated client/server changes.  

### Testing
- Ran server static check `node --check bot/server.js` which succeeded.  
- Built the web client with `npm --prefix webapp run build` which completed successfully.  
- Executed integration tests `node --test test/chessOnlineMoveValidation.test.js test/chessLobbyPreferredSideMatchmaking.test.js` and the new `test/chessOnlineMoveValidation.test.js`, and both suites passed (server-authoritative move rejection and synchronization validated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d1d9af008832982be353dc858e9e4)