### PR TITLE
Tune Pool Royale table legs, corner rims, and shot power

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,10 +1,10 @@
-import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
-import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js'
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js'
 
-export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
 const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
@@ -49,10 +49,10 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     kind: 'gltf',
     fitScale: 1.055,
     upperFrameHeightScale: 0.58,
-    cornerRimHeightScale: 0.42,
+    cornerRimHeightScale: 0.3,
     cornerRimLift: 0.018,
     lowerBaseHeightScale: 1.62,
-    lowerLegFootReachScale: 1.18,
+    lowerLegFootReachScale: 1.65,
     footWidthScale: 1.08,
     footHeightScale: 1,
     clothRepeatScale: 5.25,
@@ -71,20 +71,19 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     hideSurfaceRoles: [],
     hideGeneratedRailMarkers: true
   }
-]);
+])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
   POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === 'royal-original')?.id ||
-  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
-export function resolvePoolRoyaleTableModel(modelId) {
-  const key = typeof modelId === 'string' ? modelId.trim() : '';
+export function resolvePoolRoyaleTableModel (modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : ''
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  )
 }
-
 
 const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
   { id: 'peelingPaintWeathered', label: 'Wood Peeling Paint Weathered', color: '#b8b3aa', textureId: 'wood_peeling_paint_weathered' },
@@ -107,7 +106,7 @@ const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
   { id: 'carbonFiberAlligatorSand', label: 'LT Sand Fabric', color: '#8a7b5e', textureId: 'fabric_083' },
   { id: 'carbonFiberAlligatorMoss', label: 'LT Moss Fabric', color: '#4f6048', textureId: 'fabric_083' },
   { id: 'carbonFiberAlligatorNight', label: 'LT Night Fabric', color: '#2f3c32', textureId: 'fabric_083' }
-]);
+])
 
 const buildShowoodFinishOptions = () =>
   Object.freeze(
@@ -116,15 +115,15 @@ const buildShowoodFinishOptions = () =>
         ...option,
         finishId: option.id,
         thumbnail: option.textureId ? polyHavenThumb(option.textureId) : swatchThumbnail([option.color, '#ffffff'])
-      });
-      return acc;
+      })
+      return acc
     }, {})
-  );
+  )
 
 const buildShowoodClothOptions = () =>
   Object.freeze(
     POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
-      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`;
+      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`
       acc[variant.id] = Object.freeze({
         label: variant.name,
         color,
@@ -134,10 +133,10 @@ const buildShowoodClothOptions = () =>
         metalness: 0,
         roughness: 1,
         envMapIntensity: 0.16
-      });
-      return acc;
+      })
+      return acc
     }, {})
-  );
+  )
 
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cloth',
@@ -146,7 +145,7 @@ export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'pocketJaw',
   'topWoodRail',
   'legBase'
-]);
+])
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   cloth: 'cabanGreenClassic',
@@ -155,7 +154,7 @@ export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   pocketJaw: 'plastic-black',
   topWoodRail: 'woodTable001',
   legBase: 'darkWood'
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   cloth: { label: 'Field cloth', description: 'All cloth-library textures for only the flat playfield surface.' },
@@ -170,15 +169,15 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   pocketJaw: { label: 'Pockets + jaws', description: 'Uses the same pocket-jaw texture options as the main game menu.' },
   topWoodRail: { label: 'Top rail frame', description: 'All GLTF table-finish textures for the main top wood rail frame.' },
   legBase: { label: 'Legs + base', description: 'All GLTF table-finish textures for legs and lower base blocks only.' }
-});
+})
 
-const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions();
-const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions();
+const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions()
+const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions()
 const SHOWOOD_METAL_ACCENT_OPTIONS = Object.freeze({
   gold: Object.freeze({ label: 'Gold', color: '#d4af37', metalAccentId: 'gold' }),
   chrome: Object.freeze({ label: 'Chrome', color: '#d6d8dc', metalAccentId: 'chrome' }),
   black: Object.freeze({ label: 'Black', color: '#050505', metalAccentId: 'black' })
-});
+})
 const SHOWOOD_POCKET_JAW_OPTIONS = Object.freeze({
   'plastic-black': Object.freeze({ label: 'Plastic Black Jaws', color: '#151515', pocketLinerId: 'plastic-black' }),
   'plastic-dark-grey': Object.freeze({ label: 'Plastic Dark Grey Jaws', color: '#2c2f33', pocketLinerId: 'plastic-dark-grey' }),
@@ -186,7 +185,7 @@ const SHOWOOD_POCKET_JAW_OPTIONS = Object.freeze({
   'plastic-light-grey': Object.freeze({ label: 'Plastic Light Grey Jaws', color: '#b8bcc2', pocketLinerId: 'plastic-light-grey' }),
   'plastic-magnolia': Object.freeze({ label: 'Plastic Magnolia Jaws', color: '#f4f0e6', pocketLinerId: 'plastic-magnolia' }),
   'brown-showood': Object.freeze({ label: 'Brown Showood Jaws', color: '#2a1207', pocketLinerId: 'brown-showood' })
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   cloth: SHOWOOD_CLOTH_OPTIONS,
@@ -195,4 +194,4 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   pocketJaw: SHOWOOD_POCKET_JAW_OPTIONS,
   topWoodRail: SHOWOOD_FINISH_OPTIONS,
   legBase: SHOWOOD_FINISH_OPTIONS
-});
+})

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -829,6 +829,7 @@ const CHROME_SIDE_FIELD_PULL_SCALE = 0;
 const CHROME_PLATE_REFLECTION_SCALE = 0.28; // kill pocket-cut reflections by damping env-map intensity on fascia cuts
 const CHROME_PLATE_ROUGHNESS_LIFT = 0.08; // lift roughness on fascia cuts so pocket arches stop casting hot spots on cloth
 const CHROME_PLATE_THICKNESS_SCALE = 0.0306; // match diamond thickness on the wooden rails for fascia depth
+const CHROME_CORNER_BOTTOM_TRIM_SCALE = 0.72; // trim the visible lower corner-rim drop while keeping the top aligned to the rails
 const CHROME_SIDE_PLATE_THICKNESS_BOOST = 1.18; // thicken the middle fascia so its depth now matches the corner plates
 const CHROME_PLATE_VERTICAL_LIFT_SCALE = 0.06; // lift fascia slightly with the raised rail/cushion profile so chrome stays aligned on all six pockets
 const CHROME_PLATE_DOWNWARD_EXPANSION_SCALE = 0; // keep fascia depth identical to snooker
@@ -1833,7 +1834,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 // Keep the slider range unchanged, but trim the global pace so released shots travel less aggressively.
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
-const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
+const SHOT_POWER_INCREASE = 1.95; // add 30% more Pool Royale shot strength over the previous tuning
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.5; // preserve legacy cue response before the final mobile comfort trim
 const SHOT_GLOBAL_POWER_SCALE = 0.48; // reduce Pool Royale shot pace by 25% so ball travel better matches the selected shot power
@@ -9711,8 +9712,9 @@ export function Table3D(
     SIDE_POCKET_SPAN = Math.max(MICRO_EPS, resolvedSpan);
   }
 
-  const chromePlateThickness = railH * CHROME_PLATE_THICKNESS_SCALE; // mirror snooker fascia thickness using rail height as the driver
-  const sideChromePlateThickness = chromePlateThickness * CHROME_SIDE_PLATE_THICKNESS_BOOST; // match middle-pocket fascia depth to snooker
+  const baseChromePlateThickness = railH * CHROME_PLATE_THICKNESS_SCALE; // mirror snooker fascia thickness using rail height as the driver
+  const chromePlateThickness = baseChromePlateThickness * CHROME_CORNER_BOTTOM_TRIM_SCALE; // trim only the lower corner rims; keep top surfaces flush
+  const sideChromePlateThickness = baseChromePlateThickness * CHROME_SIDE_PLATE_THICKNESS_BOOST; // keep middle-pocket fascia depth unchanged
   const chromePlateInset = TABLE.THICK * 0.02;
   const chromeCornerPlateTrim =
     TABLE.THICK * (0.03 + CHROME_CORNER_FIELD_TRIM_SCALE);


### PR DESCRIPTION
### Motivation
- Make the Pool Royale / Showood table visuals match the portrait-phone reference by visually extending lower legs so they meet the feet.
- Trim the visible lower corner chrome rims so the corner plates read shorter from the bottom while keeping side-pocket fascia unchanged.
- Increase shot strength so Pool Royale shots feel ~30% stronger to match requested gameplay tuning.

### Description
- Raised the Showood builder leg reach by changing `lowerLegFootReachScale` from `1.18` to `1.65` in `webapp/src/config/poolRoyaleTableModels.js` so lower legs extend farther toward foot pads. 
- Added `CHROME_CORNER_BOTTOM_TRIM_SCALE` and applied it to compute corner chrome thickness (using a corner-only multiplier) while preserving side-plate thickness in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Increased in-game shot tuning by changing `SHOT_POWER_INCREASE` from `1.5` to `1.95` in `webapp/src/pages/Games/PoolRoyale.jsx` to provide ~30% more power over the previous pass. 
- Minor code-style/format fixes applied by the linter in the table-model config during the change set.

### Testing
- Ran linting with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx webapp/src/config/poolRoyaleTableModels.js --no-ignore --no-warn-ignored`, which passed after fixes. 
- Built the web app with `npm --prefix webapp run build`, which completed successfully (production build output produced). 
- Attempted a mobile Playwright screenshot to visually confirm table adjustments, but the headless Chromium capture timed out / failed in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d4fda94dc8329999513a02aabe5cf)