### PR TITLE
Lock cue to shot anchor and refine human/camera cue pose logic

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -2191,12 +2191,20 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     human.modelRoot.visible = false;
     return;
   }
+  const cueAnchor = options?.cueAnchor;
+  const lockCueToShotAnchor = Boolean(
+    (shooting || cueAnimating || options?.sliderDragging) &&
+      Number.isFinite(cueAnchor?.x) &&
+      Number.isFinite(cueAnchor?.z)
+  );
+  const cueWorldX = lockCueToShotAnchor ? cueAnchor.x : cuePos.x;
+  const cueWorldZ = lockCueToShotAnchor ? cueAnchor.z : cuePos.y;
 
   const aimForward = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
   if (aimForward.lengthSq() < 1e-8) aimForward.set(0, 0, 1);
   aimForward.normalize();
   const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
-  const cueBallWorld = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
+  const cueBallWorld = new THREE.Vector3(cueWorldX, CUE_Y, cueWorldZ);
   const humanRootTarget = chooseProvidedSnookerHumanEdgePosition(cueBallWorld, aimForward, {
     unit: SNOOKER_HUMAN_WORLD_SCALE,
     tableW: PLAY_W,
@@ -2243,21 +2251,20 @@ function updateSnookerRoyalHumanPlayer(human, dt, options) {
     1.08 * SNOOKER_HUMAN_WORLD_SCALE,
     0.03 * SNOOKER_HUMAN_WORLD_SCALE
   ).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+  const cameraStanding = options?.cameraStanding ?? !tableCueVisible;
   const humanCueState = shooting || cueAnimating
     ? 'striking'
     : activePower > 0.02
       ? 'dragging'
-      : tableCueVisible
-        ? 'aiming'
-        : 'idle';
+      : cameraStanding
+        ? 'idle'
+        : 'aiming';
   const idleCuePose = resolveProvidedSnookerIdleCuePose(idleRightHandTarget, standingYaw, cueLen);
   const cueEndpoints = humanCueState === 'idle'
     ? idleCuePose
     : { tip: providedCueTip, butt: providedCueBack };
-  if (humanCueState !== 'idle') {
-    applyProvidedCueEndpointPose(cueStick, providedCueBack, providedCueTip);
-    cueStick.visible = true;
-  }
+  applyProvidedCueEndpointPose(cueStick, cueEndpoints.butt, cueEndpoints.tip);
+  cueStick.visible = true;
 
   updateProvidedSnookerHumanPose(human, dt, {
     exactProvidedPose: true,
@@ -26737,7 +26744,14 @@ const powerRef = useRef(hud.power);
             power: (shooting || cueAnimating) ? lastShotPower : (powerRef.current ?? activeAiPlan?.power ?? 0),
             shooting,
             cueAnimating,
-            tableCueVisible: cueStick.visible
+            tableCueVisible: cueStick.visible,
+            cameraStanding: (() => {
+              const renderCamera = activeRenderCameraRef.current ?? cameraRef.current ?? camera;
+              const cueBallY = cue?.pos ? CUE_Y : BALL_CENTER_Y;
+              return ((renderCamera?.position?.y ?? cueBallY) - cueBallY) > BALL_R * 3.4;
+            })(),
+            sliderDragging: Boolean(sliderInstanceRef.current?.dragging),
+            cueAnchor: cueStickAnchorRef.current
           });
         } catch (error) {
           snookerHumanPlayer.disabled = true;


### PR DESCRIPTION
### Motivation
- Ensure the visible cue behaves like the provided human rig: it stays in a standing idle pose when the camera is high and moves onto the table and lines up with the aim when the shot/camera lowers. 
- Make the visual stroke anchor to the captured slider/shot anchor during pullback and release so the cue pushes to contact and does not chase the moving cue ball.
- Feed camera and input state into the human pose update so the character consistently holds the cue with the same provided pose logic.

### Description
- `updateSnookerRoyalHumanPlayer` now uses a computed `cueWorldX`/`cueWorldZ` which locks to `options.cueAnchor` while the shot is active or the slider is dragging, preventing the cue from following the ball mid-shot and keeping the tip aligned to the aim line via the provided endpoint pose logic (uses `applyProvidedCueEndpointPose`).
- The human cue state selection was adjusted to use a `cameraStanding` hint (derived from camera height or passed in) so the system switches between standing `idle` and on-table `aiming` correctly; the cue endpoint pose is always applied and `cueStick.visible` is set accordingly.
- The main loop now passes additional frame options into `updateSnookerRoyalHumanPlayer`: `cameraStanding`, `sliderDragging`, and `cueAnchor` so the human rig receives the exact inputs it needs to reproduce the provided pose/behaviour.

### Testing
- Ran lint with `npm --prefix webapp run lint -- src/pages/Games/SnookerRoyal.jsx` and it completed successfully.
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.
- Attempted an automated Playwright mobile preview screenshot of `/games/snookerroyale?mode=practice` to validate the runtime pose/visuals; the page loaded but the screenshot capture timed out against the active WebGL scene in this environment (screenshot step failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d5116da1083299cecfa83f3f9c961)