### PR TITLE
Server-authoritative chess move validation, client wire-board sync, and private online lobby support

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -722,12 +722,254 @@ function cleanupSeats() {
   }
 }
 
+
+function createInitialChessBoard() {
+  const rows = CHESS_START_FEN.split(' ')[0].split('/');
+  return rows.map((row) => {
+    const cells = [];
+    for (const ch of row) {
+      if (/\d/.test(ch)) {
+        for (let i = 0; i < Number(ch); i += 1) cells.push(null);
+      } else {
+        cells.push({ t: ch.toUpperCase(), w: ch === ch.toUpperCase(), hasMoved: false });
+      }
+    }
+    return cells;
+  });
+}
+
+function cloneChessBoard(board) {
+  return (Array.isArray(board) ? board : createInitialChessBoard()).map((row) =>
+    (Array.isArray(row) ? row : []).map((piece) =>
+      piece ? { t: piece.t, w: Boolean(piece.w), hasMoved: Boolean(piece.hasMoved) } : null
+    )
+  );
+}
+
+function normalizeChessBoard(board) {
+  if (!Array.isArray(board) || board.length !== 8) return createInitialChessBoard();
+  const normalized = board.map((row) => {
+    if (!Array.isArray(row) || row.length !== 8) return null;
+    return row.map((piece) => {
+      if (!piece) return null;
+      const type = String(piece.t || '').toUpperCase();
+      if (!['P', 'N', 'B', 'R', 'Q', 'K'].includes(type)) return null;
+      return { t: type, w: Boolean(piece.w), hasMoved: Boolean(piece.hasMoved) };
+    });
+  });
+  return normalized.every(Boolean) ? normalized : createInitialChessBoard();
+}
+
+function chessBoardToFen(board, whiteToMove = true) {
+  const rows = normalizeChessBoard(board).map((row) => {
+    let fenRow = '';
+    let empty = 0;
+    row.forEach((piece) => {
+      if (!piece) {
+        empty += 1;
+        return;
+      }
+      if (empty) {
+        fenRow += String(empty);
+        empty = 0;
+      }
+      fenRow += piece.w ? piece.t : piece.t.toLowerCase();
+    });
+    if (empty) fenRow += String(empty);
+    return fenRow || '8';
+  });
+  return `${rows.join('/')} ${whiteToMove ? 'w' : 'b'} - - 0 1`;
+}
+
+function chessInBoard(r, c) {
+  return r >= 0 && r < 8 && c >= 0 && c < 8;
+}
+
+const CHESS_KNIGHT_DELTAS = [
+  [-2, -1], [-2, 1], [-1, -2], [-1, 2],
+  [1, -2], [1, 2], [2, -1], [2, 1]
+];
+const CHESS_SLIDE_DIRS = {
+  B: [[-1, -1], [-1, 1], [1, -1], [1, 1]],
+  R: [[-1, 0], [1, 0], [0, -1], [0, 1]],
+  Q: [[-1, -1], [-1, 1], [1, -1], [1, 1], [-1, 0], [1, 0], [0, -1], [0, 1]]
+};
+
+function chessPseudoMoves(board, r, c) {
+  const piece = board?.[r]?.[c];
+  if (!piece) return [];
+  const moves = [];
+  const push = (rr, cc) => {
+    if (!chessInBoard(rr, cc)) return;
+    const target = board[rr][cc];
+    if (!target || target.w !== piece.w) moves.push([rr, cc]);
+  };
+  if (piece.t === 'P') {
+    const dir = piece.w ? -1 : 1;
+    const start = piece.w ? 6 : 1;
+    if (chessInBoard(r + dir, c) && !board[r + dir][c]) {
+      moves.push([r + dir, c]);
+      if (r === start && !board[r + dir * 2][c]) moves.push([r + dir * 2, c]);
+    }
+    [-1, 1].forEach((dc) => {
+      const rr = r + dir;
+      const cc = c + dc;
+      if (chessInBoard(rr, cc) && board[rr][cc] && board[rr][cc].w !== piece.w) moves.push([rr, cc]);
+    });
+  } else if (piece.t === 'N') {
+    CHESS_KNIGHT_DELTAS.forEach(([dr, dc]) => push(r + dr, c + dc));
+  } else if (CHESS_SLIDE_DIRS[piece.t]) {
+    CHESS_SLIDE_DIRS[piece.t].forEach(([dr, dc]) => {
+      let rr = r + dr;
+      let cc = c + dc;
+      while (chessInBoard(rr, cc)) {
+        if (board[rr][cc]) {
+          if (board[rr][cc].w !== piece.w) moves.push([rr, cc]);
+          break;
+        }
+        moves.push([rr, cc]);
+        rr += dr;
+        cc += dc;
+      }
+    });
+  } else if (piece.t === 'K') {
+    for (let dr = -1; dr <= 1; dr += 1) {
+      for (let dc = -1; dc <= 1; dc += 1) {
+        if (dr || dc) push(r + dr, c + dc);
+      }
+    }
+  }
+  return moves;
+}
+
+function findChessKing(board, white) {
+  for (let r = 0; r < 8; r += 1) {
+    for (let c = 0; c < 8; c += 1) {
+      const piece = board[r][c];
+      if (piece?.t === 'K' && piece.w === white) return [r, c];
+    }
+  }
+  return null;
+}
+
+function isChessSquareAttacked(board, r, c, byWhite) {
+  for (let rr = 0; rr < 8; rr += 1) {
+    for (let cc = 0; cc < 8; cc += 1) {
+      const piece = board[rr][cc];
+      if (!piece || piece.w !== byWhite) continue;
+      if (chessPseudoMoves(board, rr, cc).some(([r2, c2]) => r2 === r && c2 === c)) return true;
+    }
+  }
+  return false;
+}
+
+function isChessPlayerInCheck(board, white) {
+  const king = findChessKing(board, white);
+  return king ? isChessSquareAttacked(board, king[0], king[1], !white) : false;
+}
+
+function applyChessMoveOnBoard(board, fromR, fromC, toR, toC) {
+  const next = cloneChessBoard(board);
+  const piece = next[fromR][fromC];
+  if (!piece) return next;
+  const isCastling = piece.t === 'K' && Math.abs(toC - fromC) === 2;
+  if (isCastling) {
+    const rookFromC = toC > fromC ? 7 : 0;
+    const rookToC = toC > fromC ? 5 : 3;
+    const rook = next[fromR][rookFromC];
+    next[fromR][rookToC] = rook;
+    next[fromR][rookFromC] = null;
+    if (rook) rook.hasMoved = true;
+  }
+  next[toR][toC] = piece;
+  next[fromR][fromC] = null;
+  piece.hasMoved = true;
+  if (piece.t === 'P' && (toR === 0 || toR === 7)) piece.t = 'Q';
+  return next;
+}
+
+function getChessCastlingTargets(board, r, c, white) {
+  const piece = board?.[r]?.[c];
+  if (!piece || piece.t !== 'K' || piece.w !== white || piece.hasMoved) return [];
+  const homeRow = white ? 7 : 0;
+  if (r !== homeRow || c !== 4 || isChessPlayerInCheck(board, white)) return [];
+  const results = [];
+  const checkSide = (rookCol, emptyCols, transitCols, destCol) => {
+    const rook = board[homeRow][rookCol];
+    if (!rook || rook.t !== 'R' || rook.w !== white || rook.hasMoved) return;
+    if (emptyCols.some((col) => board[homeRow][col])) return;
+    if (transitCols.some((col) => isChessSquareAttacked(board, homeRow, col, !white))) return;
+    results.push([homeRow, destCol]);
+  };
+  checkSide(7, [5, 6], [5, 6], 6);
+  checkSide(0, [1, 2, 3], [3, 2], 2);
+  return results;
+}
+
+function getLegalChessMoves(board, r, c) {
+  const piece = board?.[r]?.[c];
+  if (!piece) return [];
+  const pseudo = chessPseudoMoves(board, r, c);
+  if (piece.t === 'K') pseudo.push(...getChessCastlingTargets(board, r, c, piece.w));
+  return pseudo.filter(([toR, toC]) => !isChessPlayerInCheck(applyChessMoveOnBoard(board, r, c, toR, toC), piece.w));
+}
+
+function hasAnyLegalChessMove(board, white) {
+  for (let r = 0; r < 8; r += 1) {
+    for (let c = 0; c < 8; c += 1) {
+      if (board?.[r]?.[c]?.w === white && getLegalChessMoves(board, r, c).length > 0) return true;
+    }
+  }
+  return false;
+}
+
+function validateAndApplyChessMove(state, playerId, move = {}) {
+  if (state.winner) return { ok: false, error: 'game_finished' };
+  const board = normalizeChessBoard(state.board);
+  const lastMove = move.lastMove || {};
+  const from = lastMove.from || {};
+  const to = lastMove.to || {};
+  const coords = [from.r, from.c, to.r, to.c].map((value) => Number(value));
+  if (!coords.every(Number.isInteger)) return { ok: false, error: 'invalid_coordinates' };
+  const [fromR, fromC, toR, toC] = coords;
+  if (!chessInBoard(fromR, fromC) || !chessInBoard(toR, toC)) return { ok: false, error: 'invalid_coordinates' };
+  const piece = board[fromR][fromC];
+  if (!piece) return { ok: false, error: 'empty_source' };
+  if (piece.w !== Boolean(state.turnWhite)) return { ok: false, error: 'wrong_turn_piece' };
+  const player = (state.players || []).find((p) => String(p.id) === String(playerId));
+  if (player?.side && player.side !== (piece.w ? 'white' : 'black')) return { ok: false, error: 'wrong_player_turn' };
+  const legal = getLegalChessMoves(board, fromR, fromC);
+  if (!legal.some(([r, c]) => r === toR && c === toC)) return { ok: false, error: 'illegal_move' };
+  const nextBoard = applyChessMoveOnBoard(board, fromR, fromC, toR, toC);
+  const turnWhite = !state.turnWhite;
+  const hasReply = hasAnyLegalChessMove(nextBoard, turnWhite);
+  const inCheck = isChessPlayerInCheck(nextBoard, turnWhite);
+  const winner = !hasReply && inCheck ? (turnWhite ? 'black' : 'white') : null;
+  const draw = !hasReply && !inCheck ? 'stalemate' : null;
+  return {
+    ok: true,
+    state: {
+      board: nextBoard,
+      fen: chessBoardToFen(nextBoard, turnWhite),
+      turnWhite,
+      lastMove: { from: { r: fromR, c: fromC }, to: { r: toR, c: toC } },
+      winner,
+      draw,
+      moveSeq: Number(state.moveSeq || 0) + 1
+    }
+  };
+}
+
 function getChessState(tableId) {
   if (!chessGames.has(tableId)) {
+    const board = createInitialChessBoard();
     chessGames.set(tableId, {
-      fen: CHESS_START_FEN,
+      board,
+      fen: chessBoardToFen(board, true),
       turnWhite: true,
       lastMove: null,
+      moveSeq: 0,
+      players: [],
       updatedAt: Date.now()
     });
   }
@@ -739,8 +981,10 @@ function updateChessState(tableId, nextState = {}) {
   const merged = {
     ...base,
     ...nextState,
+    board: normalizeChessBoard(nextState.board || base.board),
     updatedAt: Date.now()
   };
+  merged.fen = nextState.fen || chessBoardToFen(merged.board, merged.turnWhite);
   chessGames.set(tableId, merged);
   return merged;
 }
@@ -1048,7 +1292,15 @@ function maybeStartGame(table) {
         table.players = assignChessSides(table.players);
         const whitePlayer = table.players.find((p) => p.side === 'white');
         if (whitePlayer) table.currentTurn = whitePlayer.id;
-        const initial = updateChessState(table.id, { turnWhite: true, lastMove: null });
+        const board = createInitialChessBoard();
+        const initial = updateChessState(table.id, {
+          board,
+          fen: chessBoardToFen(board, true),
+          turnWhite: true,
+          lastMove: null,
+          moveSeq: 0,
+          players: table.players
+        });
         io.to(table.id).emit('chessState', { tableId: table.id, ...initial });
       } else if (table.gameType === 'checkers') {
         table.players = assignCheckersSides(table.players);
@@ -2136,14 +2388,31 @@ io.on('connection', (socket) => {
     socket.to(tableId).emit('snookerState', payload);
   });
 
-  socket.on('chessMove', ({ tableId, move }) => {
-    if (!tableId || !move) return;
-    const next = updateChessState(tableId, {
-      fen: move.fen || CHESS_START_FEN,
-      turnWhite: typeof move.turnWhite === 'boolean' ? move.turnWhite : true,
-      lastMove: move.lastMove || null
-    });
-    socket.to(tableId).emit('chessMove', { tableId, ...next });
+  socket.on('chessMove', ({ tableId, move }, cb) => {
+    if (!tableId || !move) {
+      cb && cb({ success: false, error: 'invalid_payload' });
+      return;
+    }
+    const playerId = String(socket.data?.playerId || '');
+    if (!playerId) {
+      cb && cb({ success: false, error: 'register_required' });
+      return;
+    }
+    const current = getChessState(tableId);
+    const result = validateAndApplyChessMove(current, playerId, move);
+    if (!result.ok) {
+      socket.emit('chessMoveRejected', {
+        tableId,
+        error: result.error,
+        state: { tableId, ...current }
+      });
+      cb && cb({ success: false, error: result.error, state: { tableId, ...current } });
+      return;
+    }
+    const next = updateChessState(tableId, result.state);
+    const payload = { tableId, ...next };
+    socket.to(tableId).emit('chessMove', payload);
+    cb && cb({ success: true, state: payload });
   });
 
   socket.on('checkersMove', async ({ tableId, move }) => {

--- a/test/chessLobbyHelpers.test.mjs
+++ b/test/chessLobbyHelpers.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import vm from 'vm';
+
+const source = fs.readFileSync('webapp/src/pages/Games/ChessBattleRoyalLobby.jsx', 'utf8');
+const helperNames = [
+  'buildChessGameParams',
+  'buildHostedTableId',
+  'extractHostCodeFromTableId',
+  'isChessHostedTableId',
+  'normalizeHostCode',
+  'resolveChessSide',
+  'resolveChessTableMode',
+  'resolveInitialOnlineQueue',
+  'resolveLobbyStatus',
+  'resolveSeatAccountId',
+  'resolveSeatErrorMessage'
+];
+
+const importEnd = source.indexOf('const DEV_ACCOUNT');
+const componentStart = source.indexOf('export default function ChessBattleRoyalLobby');
+const helpersSource = source
+  .slice(importEnd, componentStart)
+  .replace(/export \{[\s\S]*?\};/, '')
+  .replace(/import\.meta\.env/g, 'importMetaEnv');
+
+const sandbox = {
+  URLSearchParams,
+  window: {
+    Telegram: { WebApp: { initData: '' } },
+    localStorage: { getItem: () => 'stored-account' }
+  },
+  importMetaEnv: {},
+  getTpcAccountId: () => 'stored-account',
+  console
+};
+vm.createContext(sandbox);
+vm.runInContext(`${helpersSource}\nObject.assign(globalThis, { ${helperNames.join(', ')} });`, sandbox);
+
+test('chess private lobby codes normalize to stable hosted table ids', () => {
+  assert.equal(sandbox.normalizeHostCode(' friend 123!! '), 'FRIEND123');
+  assert.equal(sandbox.buildHostedTableId(' friend 123!! '), 'chess-2-host-FRIEND123');
+  assert.equal(sandbox.isChessHostedTableId('chess-2-host-FRIEND123'), true);
+  assert.equal(sandbox.extractHostCodeFromTableId('chess-2-host-FRIEND123'), 'FRIEND123');
+  assert.equal(sandbox.resolveChessTableMode('chess-2-host-FRIEND123'), 'private');
+  assert.equal(sandbox.resolveChessTableMode(''), 'quick');
+});
+
+test('chess lobby derives private queue from URL table or host code', () => {
+  const fromHostCode = sandbox.resolveInitialOnlineQueue(new URLSearchParams('hostCode=room-7'));
+  assert.equal(fromHostCode.requestedMode, 'private');
+  assert.equal(fromHostCode.requestedHostCode, 'ROOM-7');
+
+  const fromTable = sandbox.resolveInitialOnlineQueue(new URLSearchParams('tableId=chess-2-host-FRIEND'));
+  assert.equal(fromTable.requestedMode, 'private');
+  assert.equal(fromTable.requestedHostCode, 'FRIEND');
+  assert.equal(fromTable.requestedTableId, 'chess-2-host-FRIEND');
+});
+
+test('chess lobby status and side helpers match paired players', () => {
+  const players = [
+    { id: 'white-player', side: 'white', name: 'White' },
+    { id: 'black-player', side: 'black', name: 'Black' }
+  ];
+  assert.equal(sandbox.resolveLobbyStatus(players, ['white-player'], 'white-player'), 'Opponent joined. Locking seats…');
+  assert.equal(sandbox.resolveLobbyStatus(players, ['white-player', 'black-player'], 'white-player'), 'Both players ready. Starting match…');
+  assert.equal(sandbox.resolveChessSide(players, 'black-player'), 'black');
+});
+
+test('chess lobby builds online game params and seat account fallback', () => {
+  const params = sandbox.buildChessGameParams({
+    mode: 'online',
+    stake: { token: 'TPC', amount: 100 },
+    avatar: 'avatar.png',
+    tgId: 'tg-1',
+    trackedAccountId: 'tracked-1',
+    accountId: 'state-1',
+    selectedFlag: '🇦🇱',
+    selectedAiFlag: '🤖',
+    preferredSide: 'white',
+    extraParams: { tableId: 'chess-2-host-FRIEND', side: 'white' }
+  });
+  assert.equal(params.get('mode'), 'online');
+  assert.equal(params.get('accountId'), 'tracked-1');
+  assert.equal(params.get('tableId'), 'chess-2-host-FRIEND');
+  assert.equal(params.get('side'), 'white');
+  assert.equal(params.get('aiFlag'), null);
+  assert.equal(sandbox.resolveSeatAccountId('', 'state-1'), 'stored-account');
+  assert.match(sandbox.resolveSeatErrorMessage('stake_mismatch'), /different stake/);
+});

--- a/test/chessOnlineMoveValidation.test.js
+++ b/test/chessOnlineMoveValidation.test.js
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+function once(socket, event) {
+  return new Promise((resolve) => socket.once(event, resolve));
+}
+
+function emitAck(socket, event, payload) {
+  return new Promise((resolve) => socket.emit(event, payload, resolve));
+}
+
+test(
+  'chess online moves are server-authoritative and synchronized',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3213',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const white = io('http://localhost:3213', { auth: { token: apiToken } });
+    const black = io('http://localhost:3213', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([once(white, 'connect'), once(black, 'connect')]);
+      await Promise.all([
+        emitAck(white, 'register', { playerId: 'white-player' }),
+        emitAck(black, 'register', { playerId: 'black-player' })
+      ]);
+
+      const firstSeat = await emitAck(white, 'seatTable', {
+        accountId: 'white-player',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        preferredSide: 'white'
+      });
+      const secondSeat = await emitAck(black, 'seatTable', {
+        accountId: 'black-player',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        preferredSide: 'black'
+      });
+      assert.equal(firstSeat.success, true);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, firstSeat.tableId);
+
+      white.emit('confirmReady', { accountId: 'white-player', tableId: firstSeat.tableId });
+      black.emit('confirmReady', { accountId: 'black-player', tableId: firstSeat.tableId });
+      await Promise.all([once(white, 'gameStart'), once(black, 'gameStart')]);
+
+      white.emit('joinChessRoom', { tableId: firstSeat.tableId, accountId: 'white-player' });
+      black.emit('joinChessRoom', { tableId: firstSeat.tableId, accountId: 'black-player' });
+      await Promise.all([once(white, 'chessState'), once(black, 'chessState')]);
+
+      const illegalAck = await emitAck(black, 'chessMove', {
+        tableId: firstSeat.tableId,
+        move: { lastMove: { from: { r: 6, c: 4 }, to: { r: 4, c: 4 } } }
+      });
+      assert.equal(illegalAck.success, false);
+      assert.equal(illegalAck.error, 'wrong_player_turn');
+
+      const blackUpdate = once(black, 'chessMove');
+      const legalAck = await emitAck(white, 'chessMove', {
+        tableId: firstSeat.tableId,
+        move: { lastMove: { from: { r: 6, c: 4 }, to: { r: 4, c: 4 } } }
+      });
+      assert.equal(legalAck.success, true);
+      assert.equal(legalAck.state.turnWhite, false);
+      assert.equal(legalAck.state.board[4][4].t, 'P');
+      assert.equal(legalAck.state.board[4][4].w, true);
+      assert.equal(legalAck.state.board[4][4].hasMoved, true);
+
+      const synced = await blackUpdate;
+      assert.equal(synced.turnWhite, false);
+      assert.equal(synced.board[4][4].t, 'P');
+      assert.equal(synced.lastMove.from.r, 6);
+      assert.equal(synced.lastMove.to.r, 4);
+      await delay(50);
+    } finally {
+      white.disconnect();
+      black.disconnect();
+      server.kill();
+    }
+  }
+);

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7631,6 +7631,37 @@ function cloneBoard(b) {
   return b.map((r) => r.map((c) => (c ? { t: c.t, w: c.w, hasMoved: Boolean(c.hasMoved) } : null)));
 }
 
+function boardToWireBoard(board) {
+  if (!Array.isArray(board)) return null;
+  return board.map((row) =>
+    Array.isArray(row)
+      ? row.map((piece) =>
+          piece
+            ? {
+                t: piece.t,
+                w: Boolean(piece.w),
+                hasMoved: Boolean(piece.hasMoved)
+              }
+            : null
+        )
+      : Array(8).fill(null)
+  );
+}
+
+function parseWireBoard(wireBoard) {
+  if (!Array.isArray(wireBoard) || wireBoard.length !== 8) return null;
+  const next = wireBoard.map((row) => {
+    if (!Array.isArray(row) || row.length !== 8) return null;
+    return row.map((piece) => {
+      if (!piece) return null;
+      const type = String(piece.t || '').toUpperCase();
+      if (!['P', 'N', 'B', 'R', 'Q', 'K'].includes(type)) return null;
+      return { t: type, w: Boolean(piece.w), hasMoved: Boolean(piece.hasMoved) };
+    });
+  });
+  return next.every(Boolean) ? next : null;
+}
+
 // Offsets
 const DIRS = {
   N: [-1, 0],
@@ -8781,7 +8812,21 @@ function Chess3D({
     onlineRef.current.emitMove = ({ tableId: tid, move }) => {
       const target = tid || onlineRef.current.tableId;
       if (!target || !move) return;
-      socket.emit('chessMove', { tableId: target, move });
+      const emitter = typeof socket.timeout === 'function' ? socket.timeout(5000) : socket;
+      emitter.emit('chessMove', { tableId: target, move }, (errorOrResponse, maybeResponse) => {
+        if (!active) return;
+        const hasTimeoutSignature = maybeResponse !== undefined || errorOrResponse instanceof Error;
+        const error = hasTimeoutSignature ? errorOrResponse : null;
+        const response = hasTimeoutSignature ? maybeResponse || {} : errorOrResponse || {};
+        if (error || response?.success === false) {
+          onlineRef.current.requestSync?.();
+          return;
+        }
+        if (response?.state) {
+          onlineRef.current.synced = true;
+          onlineRef.current.applyRemoteMove?.(response.state);
+        }
+      });
     };
     onlineRef.current.requestSync = () => {
       const target = onlineRef.current.tableId;
@@ -13447,12 +13492,28 @@ function Chess3D({
     };
 
     const syncBoardFromState = (payload = {}) => {
-      const { fen, turnWhite = true, lastMove } = payload;
-      if (!fen) return;
+      const { fen, turnWhite = true, lastMove, board: syncedBoard, players = [] } = payload;
+      if (!fen && !syncedBoard) return;
       try {
-        board = parseFEN(fen.split(' ')[0]);
+        const parsedBoard = parseWireBoard(syncedBoard);
+        board = parsedBoard || parseFEN(String(fen || START_FEN).split(' ')[0]);
+        if (Array.isArray(players) && players.length) {
+          const me = players.find((p) => String(p.id) === String(accountId));
+          const opp = players.find((p) => String(p.id) !== String(accountId));
+          if (me?.side === 'white' || me?.side === 'black') {
+            onlineRef.current.side = me.side;
+          }
+          if (opp) setOpponent(opp);
+        }
         paintPiecesFromPrototypes(currentPiecePrototypes);
-        applyStatus(turnWhite, turnWhite ? 'White to move' : 'Black to move', null);
+        const statusText = payload.winner
+          ? `${payload.winner === 'white' ? 'White' : 'Black'} wins`
+          : payload.draw === 'stalemate'
+            ? 'Stalemate'
+            : turnWhite
+              ? 'White to move'
+              : 'Black to move';
+        applyStatus(turnWhite, statusText, payload.winner || null);
         if (lastMove?.from && lastMove?.to) {
           const { from, to } = lastMove;
           lastMoveRef.current = {
@@ -14302,6 +14363,7 @@ function Chess3D({
         const movePayload = {
           lastMove: { from: { r: sel.r, c: sel.c }, to: { r: rr, c: cc } },
           fen: boardToFEN(board, nextWhite),
+          board: boardToWireBoard(board),
           turnWhite: nextWhite
         };
         onlineRef.current.emitMove?.({ tableId: onlineRef.current.tableId, move: movePayload });

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -28,6 +28,8 @@ const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
 const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 const AI_FLAG_STORAGE_KEY = 'chessBattleRoyalAiFlag';
+const CHESS_HOST_CODE_STORAGE_KEY = 'chessBattleRoyalHostCode';
+const CHESS_ONLINE_TABLE_PREFIX = 'chess-2-host';
 
 const SOCKET_CONNECT_TIMEOUT_MS = 6000;
 const SOCKET_REGISTER_TIMEOUT_MS = 6000;
@@ -38,6 +40,164 @@ const MATCHMAKING_RECOVERABLE_ERRORS = new Set([
   'rate_limited',
   'identity_mismatch'
 ]);
+
+function normalizeHostCode(code = '') {
+  return String(code || '')
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]/g, '')
+    .toUpperCase()
+    .slice(0, 48);
+}
+
+function buildHostedTableId(code = '') {
+  const safeCode = normalizeHostCode(code);
+  if (!safeCode) return '';
+  return `${CHESS_ONLINE_TABLE_PREFIX}-${safeCode}`;
+}
+
+function isChessHostedTableId(tableId = '') {
+  return String(tableId || '').startsWith(`${CHESS_ONLINE_TABLE_PREFIX}-`);
+}
+
+function extractHostCodeFromTableId(tableId = '') {
+  const value = String(tableId || '');
+  return isChessHostedTableId(value)
+    ? value.slice(`${CHESS_ONLINE_TABLE_PREFIX}-`.length)
+    : '';
+}
+
+function resolvePlayerName(player) {
+  if (!player || typeof player !== 'object') return '';
+  return String(
+    player.name ||
+      player.username ||
+      player.telegramName ||
+      player.firstName ||
+      resolveTpcAccountNumber(player) ||
+      ''
+  ).trim();
+}
+
+function formatLobbyError(error) {
+  if (!error) return '';
+  return String(error).replace(/_/g, ' ');
+}
+
+function resolveSeatErrorMessage(error) {
+  const clean = formatLobbyError(error);
+  if (error === 'table_full') return 'That private chess table is already full.';
+  if (error === 'table_not_found') return 'That private chess table was not found.';
+  if (error === 'table_unavailable') return 'That private chess table is no longer available.';
+  if (error === 'stake_mismatch') return 'That chess table uses a different stake.';
+  if (error === 'game_type_mismatch') return 'That table is for another game.';
+  return `Could not join the online lobby. Please try again${clean ? ` (${clean})` : ''}.`;
+}
+
+function resolveSeatAccountId(primary, secondary) {
+  return String(getTpcAccountId() || primary || secondary || '').trim();
+}
+
+function resolveLobbyStatus(players = [], ready = [], seatAccountId = '') {
+  const list = Array.isArray(players) ? players : [];
+  const readyIds = new Set((Array.isArray(ready) ? ready : []).map((id) => String(id)));
+  const others = list.filter((p) => resolveTpcAccountNumber(p) !== String(seatAccountId));
+  if (others.length <= 0) return 'Waiting for another player…';
+  const everyoneReady = list.length >= 2 && list.every((p) => readyIds.has(resolveTpcAccountNumber(p)));
+  return everyoneReady ? 'Both players ready. Starting match…' : 'Opponent joined. Locking seats…';
+}
+
+function resolveChessSide(players = [], seatAccountId = '') {
+  const list = Array.isArray(players) ? players : [];
+  const meIndex = list.findIndex((p) => resolveTpcAccountNumber(p) === String(seatAccountId));
+  const me = list[meIndex];
+  return me?.side || (meIndex === 0 ? 'white' : 'black');
+}
+
+function resolveChessOpponent(players = [], seatAccountId = '') {
+  return (Array.isArray(players) ? players : []).find(
+    (p) => resolveTpcAccountNumber(p) !== String(seatAccountId)
+  );
+}
+
+function resolveChessTableMode(tableId = '') {
+  if (!tableId) return 'quick';
+  return isChessHostedTableId(tableId) ? 'private' : 'quick';
+}
+
+function resolvePrivateMatchStatus(tableId = '', hostCode = '') {
+  const code = normalizeHostCode(hostCode) || extractHostCodeFromTableId(tableId);
+  return code
+    ? `Private table ${code} ready. Waiting for your opponent…`
+    : 'Private table ready. Waiting for your opponent…';
+}
+
+function buildChessGameParams({
+  mode,
+  stake,
+  avatar,
+  tgId,
+  trackedAccountId,
+  accountId,
+  selectedFlag,
+  selectedAiFlag,
+  preferredSide,
+  extraParams = {}
+}) {
+  const params = new URLSearchParams();
+  const initData = window.Telegram?.WebApp?.initData;
+  const isOnline = mode === 'online';
+
+  if (isOnline && stake.token) params.set('token', stake.token);
+  if (isOnline && stake.amount) params.set('amount', stake.amount);
+  if (avatar) params.set('avatar', avatar);
+  if (tgId) params.set('tgId', tgId);
+  if (isOnline && (trackedAccountId || accountId)) {
+    params.set('accountId', trackedAccountId || accountId);
+  }
+  if (selectedFlag) params.set('flag', selectedFlag);
+  if (!isOnline && selectedAiFlag) params.set('aiFlag', selectedAiFlag);
+  if (preferredSide) params.set('preferredSide', preferredSide);
+  if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
+  if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
+  if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
+  if (isOnline && initData) params.set('init', encodeURIComponent(initData));
+  params.set('mode', mode);
+
+  Object.entries(extraParams).forEach(([key, value]) => {
+    if (value != null && key !== 'tgId' && key !== 'trackedAccountId') {
+      params.set(key, value);
+    }
+  });
+
+  return params;
+}
+
+function resolveInitialOnlineQueue(searchParams) {
+  const requestedTableId = (searchParams.get('tableId') || '').trim();
+  const requestedHostCode =
+    normalizeHostCode(searchParams.get('hostCode') || extractHostCodeFromTableId(requestedTableId));
+  const requestedMode = searchParams.get('queue') === 'private' || requestedHostCode
+    ? 'private'
+    : 'quick';
+  return { requestedTableId, requestedHostCode, requestedMode };
+}
+
+export {
+  buildChessGameParams,
+  buildHostedTableId,
+  extractHostCodeFromTableId,
+  formatLobbyError,
+  isChessHostedTableId,
+  normalizeHostCode,
+  resolveChessOpponent,
+  resolveChessSide,
+  resolveChessTableMode,
+  resolveInitialOnlineQueue,
+  resolveLobbyStatus,
+  resolvePlayerName,
+  resolveSeatAccountId,
+  resolveSeatErrorMessage
+};
 
 function resolveTpcAccountNumber(player) {
   if (!player || typeof player !== 'object') return '';
@@ -122,11 +282,14 @@ export default function ChessBattleRoyalLobby() {
   const { search } = useLocation();
   useTelegramBackButton();
   const searchParams = new URLSearchParams(search);
-  const requestedOnlineTableId = (searchParams.get('tableId') || '').trim();
+  const { requestedTableId, requestedHostCode, requestedMode } =
+    resolveInitialOnlineQueue(searchParams);
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [avatar, setAvatar] = useState('');
-  const [mode, setMode] = useState('ai');
+  const [mode, setMode] = useState(requestedTableId ? 'online' : 'ai');
+  const [onlineQueueMode, setOnlineQueueMode] = useState(requestedMode);
+  const [hostCodeInput, setHostCodeInput] = useState(requestedHostCode);
   const [showFlagPicker, setShowFlagPicker] = useState(false);
   const [showAiFlagPicker, setShowAiFlagPicker] = useState(false);
   const [playerFlagIndex, setPlayerFlagIndex] = useState(null);
@@ -142,6 +305,7 @@ export default function ChessBattleRoyalLobby() {
   const [matchError, setMatchError] = useState('');
   const preferredSide = 'auto';
   const pendingTableRef = useRef('');
+  const lobbyHandlersRef = useRef({ gameStart: null, lobbyUpdate: null });
   const cleanupRef = useRef(() => {});
   const matchmakingTimeoutRef = useRef(null);
   const spinIntervalRef = useRef(null);
@@ -176,6 +340,24 @@ export default function ChessBattleRoyalLobby() {
       if (idx >= 0) setAiFlagIndex(idx);
     } catch {}
   }, []);
+
+  useEffect(() => {
+    if (requestedTableId) {
+      setMode('online');
+      setOnlineQueueMode(resolveChessTableMode(requestedTableId));
+      const requestedCode = extractHostCodeFromTableId(requestedTableId);
+      if (requestedCode) setHostCodeInput(requestedCode);
+    }
+  }, [requestedTableId]);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage?.getItem(CHESS_HOST_CODE_STORAGE_KEY);
+      if (stored && !hostCodeInput && !requestedHostCode) {
+        setHostCodeInput(normalizeHostCode(stored));
+      }
+    } catch {}
+  }, [hostCodeInput, requestedHostCode]);
 
   useEffect(() => {
     let cancelled = false;
@@ -278,29 +460,17 @@ export default function ChessBattleRoyalLobby() {
   );
 
   const navigateToGame = (extraParams = {}) => {
-    const params = new URLSearchParams();
-    const initData = window.Telegram?.WebApp?.initData;
-    const isOnline = mode === 'online';
-
-    if (isOnline && stake.token) params.set('token', stake.token);
-    if (isOnline && stake.amount) params.set('amount', stake.amount);
-    if (avatar) params.set('avatar', avatar);
-    if (extraParams.tgId) params.set('tgId', extraParams.tgId);
-    if (isOnline && (extraParams.trackedAccountId || accountId))
-      params.set('accountId', extraParams.trackedAccountId || accountId);
-    if (selectedFlag) params.set('flag', selectedFlag);
-    if (!isOnline && selectedAiFlag) params.set('aiFlag', selectedAiFlag);
-    if (preferredSide) params.set('preferredSide', preferredSide);
-    if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
-    if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
-    if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
-    if (isOnline && initData) params.set('init', encodeURIComponent(initData));
-    params.set('mode', mode);
-
-    Object.entries(extraParams).forEach(([key, value]) => {
-      if (value != null && key !== 'tgId' && key !== 'trackedAccountId') {
-        params.set(key, value);
-      }
+    const params = buildChessGameParams({
+      mode,
+      stake,
+      avatar,
+      tgId: extraParams.tgId,
+      trackedAccountId: extraParams.trackedAccountId,
+      accountId,
+      selectedFlag,
+      selectedAiFlag,
+      preferredSide,
+      extraParams
     });
 
     navigate(`/games/chessbattleroyal?${params.toString()}`);
@@ -311,9 +481,13 @@ export default function ChessBattleRoyalLobby() {
       clearTimeout(matchmakingTimeoutRef.current);
       matchmakingTimeoutRef.current = null;
     }
-    socket.off('gameStart');
-    socket.off('gameStarted');
-    socket.off('lobbyUpdate');
+    const { gameStart, lobbyUpdate } = lobbyHandlersRef.current;
+    if (gameStart) {
+      socket.off('gameStart', gameStart);
+      socket.off('gameStarted', gameStart);
+    }
+    if (lobbyUpdate) socket.off('lobbyUpdate', lobbyUpdate);
+    lobbyHandlersRef.current = { gameStart: null, lobbyUpdate: null };
     if (!skipLeave && pendingTableRef.current && (account || accountId)) {
       socket.emit('leaveLobby', {
         accountId: account || accountId,
@@ -336,6 +510,19 @@ export default function ChessBattleRoyalLobby() {
     if (matching) return;
     let tgId;
     let trackedAccountId;
+    let stakeCharged = false;
+    const refundStakeIfNeeded = async (reason = 'matchmaking_cleanup') => {
+      if (!stakeCharged || !trackedAccountId) return;
+      try {
+        await addTransaction(tgId || getTelegramId(), stake.amount, 'stake_refund', {
+          game: 'chessbattle',
+          players: 2,
+          accountId: trackedAccountId,
+          reason
+        });
+        stakeCharged = false;
+      } catch {}
+    };
     if (isOnline) {
       try {
         trackedAccountId = await ensureAccountId();
@@ -352,6 +539,7 @@ export default function ChessBattleRoyalLobby() {
           players: 2,
           accountId: trackedAccountId
         });
+        stakeCharged = true;
       } catch {}
 
       if (!trackedAccountId) {
@@ -369,6 +557,26 @@ export default function ChessBattleRoyalLobby() {
       return;
     }
 
+    const hostedTableId =
+      onlineQueueMode === 'private'
+        ? requestedTableId || buildHostedTableId(hostCodeInput)
+        : '';
+    if (onlineQueueMode === 'private' && !hostedTableId) {
+      await refundStakeIfNeeded('missing_private_code');
+      setMatchError('Enter a private code to create or join a chess table.');
+      setMatching(false);
+      setMatchStatus('');
+      return;
+    }
+    if (onlineQueueMode === 'private') {
+      try {
+        window.localStorage?.setItem(
+          CHESS_HOST_CODE_STORAGE_KEY,
+          normalizeHostCode(hostCodeInput || extractHostCodeFromTableId(hostedTableId))
+        );
+      } catch {}
+    }
+
     setMatchError('');
     setMatching(true);
     setMatchStatus('Connecting to lobby…');
@@ -382,6 +590,7 @@ export default function ChessBattleRoyalLobby() {
 
     const socketReady = await ensureSocketConnected();
     if (!socketReady) {
+      await refundStakeIfNeeded('socket_connect_failed');
       setMatchError(
         'Lobby connection failed. Check your network and try again.'
       );
@@ -390,9 +599,10 @@ export default function ChessBattleRoyalLobby() {
       return;
     }
 
-    const seatAccountId = getTpcAccountId() || trackedAccountId || accountId;
+    const seatAccountId = resolveSeatAccountId(trackedAccountId, accountId);
     const socketRegistered = await ensureSocketRegistered(seatAccountId);
     if (!socketRegistered) {
+      await refundStakeIfNeeded('socket_register_failed');
       setMatchError('Unable to sync your online session. Please retry.');
       setMatching(false);
       setMatchStatus('');
@@ -405,37 +615,25 @@ export default function ChessBattleRoyalLobby() {
       ready = []
     } = {}) => {
       if (!tid || String(tid) !== String(pendingTableRef.current)) return;
-      setMatchPlayers(Array.isArray(list) ? list : []);
-      setReadyList(Array.isArray(ready) ? ready.map((id) => String(id)) : []);
-      const others = list.filter(
-        (p) => resolveTpcAccountNumber(p) !== String(seatAccountId)
-      );
-      if (others.length > 0) {
-        setMatchStatus('Opponent joined. Locking seats…');
-      } else {
-        setMatchStatus('Waiting for another player…');
-      }
+      const playersList = Array.isArray(list) ? list : [];
+      const readyIds = Array.isArray(ready) ? ready.map((id) => String(id)) : [];
+      setMatchPlayers(playersList);
+      setReadyList(readyIds);
+      setMatchStatus(resolveLobbyStatus(playersList, readyIds, seatAccountId));
     };
 
     const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
       if (!startedId || String(startedId) !== String(pendingTableRef.current)) return;
-      const meIndex = players.findIndex(
-        (p) => resolveTpcAccountNumber(p) === String(seatAccountId)
-      );
-      const opp = players.find(
-        (p) => resolveTpcAccountNumber(p) !== String(seatAccountId)
-      );
-      const mySide =
-        players.find(
-          (p) => resolveTpcAccountNumber(p) === String(seatAccountId)
-        )?.side || (meIndex === 0 ? 'white' : 'black');
+      stakeCharged = false;
+      const mySide = resolveChessSide(players, seatAccountId);
+      const opp = resolveChessOpponent(players, seatAccountId);
       cleanupLobby({ account: trackedAccountId, skipLeave: true });
       navigateToGame({
         tgId,
         trackedAccountId,
         tableId: startedId,
         side: mySide,
-        opponentName: opp?.name,
+        opponentName: resolvePlayerName(opp),
         opponentAvatar: opp?.avatar
       });
     };
@@ -446,12 +644,16 @@ export default function ChessBattleRoyalLobby() {
     socket.on('gameStart', handleGameStart);
     socket.on('gameStarted', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
+    lobbyHandlersRef.current = {
+      gameStart: handleGameStart,
+      lobbyUpdate: handleLobbyUpdate
+    };
 
-    const matchTimeout = window.setTimeout(() => {
+    const matchTimeout = window.setTimeout(async () => {
       if (!pendingTableRef.current) return;
       cleanupLobby({ account: trackedAccountId });
-      setMatchError('No opponent joined in time. Please try again.');
-      setMatchStatus('');
+      await refundStakeIfNeeded('matchmaking_timeout');
+      setMatchError('No opponent joined in time. Your stake was refunded.');
     }, MATCHMAKING_TIMEOUT_MS);
     matchmakingTimeoutRef.current = matchTimeout;
 
@@ -469,7 +671,7 @@ export default function ChessBattleRoyalLobby() {
           tpcAccountId: seatAccountId,
           gameType: 'chess',
           stake: stake.amount ?? 0,
-          tableId: requestedOnlineTableId || undefined,
+          tableId: hostedTableId || undefined,
           maxPlayers: 2,
           mode: 'online',
           playerName: friendlyName,
@@ -498,8 +700,9 @@ export default function ChessBattleRoyalLobby() {
                 const restored = await ensureSocketConnected();
                 if (!restored) {
                   cleanupLobby({ account: trackedAccountId });
+                  await refundStakeIfNeeded('socket_retry_failed');
                   setMatchError(
-                    'Lobby connection dropped while retrying. Please try again.'
+                    'Lobby connection dropped while retrying. Your stake was refunded.'
                   );
                   setMatchStatus('');
                   return;
@@ -509,8 +712,9 @@ export default function ChessBattleRoyalLobby() {
                     await ensureSocketRegistered(seatAccountId);
                   if (!reRegistered) {
                     cleanupLobby({ account: trackedAccountId });
+                    await refundStakeIfNeeded('socket_reregister_failed');
                     setMatchError(
-                      'Could not restore your online identity. Please try again.'
+                      'Could not restore your online identity. Your stake was refunded.'
                     );
                     setMatchStatus('');
                     return;
@@ -520,8 +724,10 @@ export default function ChessBattleRoyalLobby() {
               }, retryDelay);
               return;
             }
-            setMatchError('Could not join the online lobby. Please try again.');
+            await refundStakeIfNeeded('seat_table_failed');
+            const errorMessage = resolveSeatErrorMessage(res?.error);
             cleanupLobby({ account: trackedAccountId });
+            setMatchError(errorMessage);
             return;
           }
           pendingTableRef.current = res.tableId;
@@ -529,7 +735,11 @@ export default function ChessBattleRoyalLobby() {
           setReadyList(
             Array.isArray(res.ready) ? res.ready.map((id) => String(id)) : []
           );
-          setMatchStatus('Waiting for another player…');
+          setMatchStatus(
+            onlineQueueMode === 'private'
+              ? resolvePrivateMatchStatus(res.tableId, hostCodeInput)
+              : resolveLobbyStatus(res.players, res.ready, seatAccountId)
+          );
           socket.emit('confirmReady', {
             accountId: seatAccountId,
             tpcAccountNumber: seatAccountId,
@@ -708,6 +918,45 @@ export default function ChessBattleRoyalLobby() {
                 tokens={['TPC']}
               />
             </div>
+            <div className="mt-4 space-y-3 rounded-2xl border border-white/10 bg-black/20 p-3">
+              <div className="grid grid-cols-2 gap-2">
+                {[
+                  { key: 'quick', label: 'Quick Match', desc: 'Any same-stake player' },
+                  { key: 'private', label: 'Private Code', desc: 'Share table code' }
+                ].map((option) => {
+                  const active = onlineQueueMode === option.key;
+                  return (
+                    <button
+                      key={option.key}
+                      type="button"
+                      onClick={() => setOnlineQueueMode(option.key)}
+                      className={`rounded-xl border px-3 py-2 text-left transition ${
+                        active
+                          ? 'border-primary bg-primary/15 text-primary'
+                          : 'border-white/10 bg-white/5 text-white/70 hover:border-white/30'
+                      }`}
+                    >
+                      <p className="text-sm font-semibold">{option.label}</p>
+                      <p className="text-[11px] text-white/50">{option.desc}</p>
+                    </button>
+                  );
+                })}
+              </div>
+              {onlineQueueMode === 'private' && (
+                <label className="block text-xs text-white/60">
+                  Private table code
+                  <input
+                    value={hostCodeInput}
+                    onChange={(event) => setHostCodeInput(normalizeHostCode(event.target.value))}
+                    placeholder="FRIEND123"
+                    className="mt-1 w-full rounded-xl border border-white/10 bg-[#050914] px-3 py-2 text-sm text-white outline-none focus:border-primary"
+                  />
+                  <span className="mt-1 block text-[11px] text-white/45">
+                    Both phones must use the same code and stake to enter the same chess table.
+                  </span>
+                </label>
+              )}
+            </div>
             <p className="text-center text-white/60 text-xs">
               Staking uses your TPC account{accountId ? ` #${accountId}` : ''}{' '}
               as escrow for every online round.
@@ -724,7 +973,9 @@ export default function ChessBattleRoyalLobby() {
             <div className="lobby-tile w-full flex items-center justify-between">
               <span>🎯 {spinningPlayer || 'Searching…'}</span>
               <span className="text-xs text-white/60">
-                Stake {stake.amount} {stake.token}
+                {onlineQueueMode === 'private'
+                  ? `Code ${normalizeHostCode(hostCodeInput) || extractHostCodeFromTableId(pendingTableRef.current) || '—'}`
+                  : `Stake ${stake.amount} ${stake.token}`}
               </span>
             </div>
             {matchPlayers.length > 0 && (


### PR DESCRIPTION
### Motivation
- Make online chess authoritative on the server by validating moves and maintaining full board state instead of trusting client-provided FEN only. 
- Add a robust wire-format board sync so clients receive a canonical board representation and can recover from desyncs. 
- Add private-hosted table support and improve lobby UX and error handling for online chess matchmaking.

### Description
- Implement full chess board model and logic on the server including board creation/normalization, pseudo-legal and legal move generation, check/checkmate/stalemate detection, castling, promotion, move application, and FEN conversion, plus `validateAndApplyChessMove` to enforce server-side legality. 
- Replace the old `chessMove` handler with an authoritative flow that validates moves, emits `chessMoveRejected` on errors, returns an ack callback to the mover, and updates `chessGames` with `board`, `fen`, `turnWhite`, `lastMove`, `moveSeq`, `players`, and timestamps. 
- Update chess game initialization and `updateChessState` to use a normalized `board` and compute `fen` from the canonical board state. 
- Add client-side wire board serialization/parsing (`boardToWireBoard` and `parseWireBoard`) and change move emission to use socket ack/timeouts and to apply server response state, plus client sync logic now accepts `board` and `players` fields and updates UI status accordingly. 
- Add private-hosted table features in the lobby including host-code normalization, `buildHostedTableId`, `resolveInitialOnlineQueue`, UI for quick/private selection and host code input, persistence of host code to `localStorage`, improved lobby status messages, seat/account resolution, stake refund logic on matchmaking errors/timeouts, and robust socket registration/retry handling. 
- Add helper exports and refactor lobby functions to reuse `buildChessGameParams`, `resolveSeatAccountId`, `resolveLobbyStatus`, `resolveChessSide`, `resolveChessOpponent`, and related utilities.

### Testing
- Added `test/chessLobbyHelpers.test.mjs` which unit-tests host-code normalization, table id helpers, param builders, side/queue/status helpers, and seat error formatting; this test was executed and passed. 
- Added `test/chessOnlineMoveValidation.test.js` which is an integration test that spawns the server and uses two `socket.io` clients to verify server-authoritative move validation, proper rejections for wrong-turn moves, and synchronization of legal moves; this integration test was executed and passed. 
- Existing checkers/snooker flows were preserved and the changes were exercised indirectly by the integration test during matchmaking and game start sequences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d1d9af008832982be353dc858e9e4)