### PR TITLE
Prune Showood GLB base/legs when using procedural Pool Royale base

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12429,6 +12429,142 @@ function isPoolRoyaleShowoodOriginalBaseOrLeg(child, material, referencePart = n
   return /leg|foot|feet|base|support|underside|pedestal|stretcher|plinth/.test(label);
 }
 
+
+const POOL_ROYALE_SHOWOOD_ORIGINAL_BASE_PARTS = new Set(['leg', 'baseFoot', 'baseCornerBlock', 'underside']);
+
+function isPoolRoyaleShowoodProtectedUpperLabel(label = '') {
+  return /pocket|hole|drop|net|liner|leather|cup|basket|holder|plate|chrome|cushion|rubber|bumper|cloth|felt|slate|bed|playfield|baize|sight|diamond|marker|dot|inlay/.test(label);
+}
+
+function materialIndexAtPoolRoyaleGeometryOffset(geometry, offset) {
+  const groups = geometry?.groups || [];
+  for (let i = 0; i < groups.length; i += 1) {
+    const group = groups[i];
+    if (offset >= group.start && offset < group.start + group.count) {
+      return group.materialIndex ?? 0;
+    }
+  }
+  return 0;
+}
+
+function shouldRemovePoolRoyaleShowoodOriginalBaseTriangle({
+  mesh,
+  material,
+  referencePart,
+  role,
+  centerY,
+  lowerCutoffY
+}) {
+  const childName = `${mesh?.name || ''}`.toLowerCase();
+  const materialName = `${material?.name || ''}`.toLowerCase();
+  const label = `${childName} ${materialName}`;
+  if (isPoolRoyaleShowoodProtectedUpperLabel(label)) return false;
+  if (isPoolRoyaleShowoodOriginalBaseOrLeg(mesh, material, referencePart)) return true;
+  if (POOL_ROYALE_SHOWOOD_ORIGINAL_BASE_PARTS.has(referencePart)) return true;
+  return role === 'wood' && centerY <= lowerCutoffY;
+}
+
+function removePoolRoyaleShowoodOriginalBaseAndLegGeometry(root, tableModel = null) {
+  if (
+    !root ||
+    !tableModel?.hideOriginalBaseAndLegsForProceduralBase ||
+    !tableModel?.useProceduralBaseWithExternal ||
+    !tableModel?.useReferenceShowoodMapping
+  ) return 0;
+
+  root.updateMatrixWorld?.(true);
+  const fullBox = new THREE.Box3().setFromObject(root);
+  if (fullBox.isEmpty()) return 0;
+  const fullSize = fullBox.getSize(new THREE.Vector3());
+  const lowerCutoffY = fullBox.min.y + fullSize.y * 0.46;
+  const removableMeshes = [];
+  let removedTriangles = 0;
+  const tmpA = new THREE.Vector3();
+  const tmpB = new THREE.Vector3();
+  const tmpC = new THREE.Vector3();
+  const tmpCenter = new THREE.Vector3();
+
+  root.traverse((child) => {
+    if (!child?.isMesh || !child.geometry?.attributes?.position) return;
+    const mesh = child;
+    const geometry = mesh.geometry;
+    const position = geometry.attributes.position;
+    const index = geometry.index;
+    const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material].filter(Boolean);
+    if (!materials.length) return;
+
+    const total = index ? index.count : position.count;
+    const keptByMaterial = new Map();
+    let keptTriangles = 0;
+    let localRemovedTriangles = 0;
+
+    for (let i = 0; i + 2 < total; i += 3) {
+      const materialIndex = Math.max(
+        0,
+        Math.min(materialIndexAtPoolRoyaleGeometryOffset(geometry, i), materials.length - 1)
+      );
+      const material = materials[materialIndex];
+      const ai = index ? index.getX(i) : i;
+      const bi = index ? index.getX(i + 1) : i + 1;
+      const ci = index ? index.getX(i + 2) : i + 2;
+      tmpA.fromBufferAttribute(position, ai).applyMatrix4(mesh.matrixWorld);
+      tmpB.fromBufferAttribute(position, bi).applyMatrix4(mesh.matrixWorld);
+      tmpC.fromBufferAttribute(position, ci).applyMatrix4(mesh.matrixWorld);
+      tmpCenter.addVectors(tmpA, tmpB).add(tmpC).multiplyScalar(1 / 3);
+      const referencePart = classifyPoolRoyaleShowoodReferencePart(mesh, material);
+      const role = classifyPoolRoyaleExternalTableSurface(mesh, material);
+      const removeTriangle = shouldRemovePoolRoyaleShowoodOriginalBaseTriangle({
+        mesh,
+        material,
+        referencePart,
+        role,
+        centerY: tmpCenter.y,
+        lowerCutoffY
+      });
+      if (removeTriangle) {
+        localRemovedTriangles += 1;
+        continue;
+      }
+      if (!keptByMaterial.has(materialIndex)) keptByMaterial.set(materialIndex, []);
+      keptByMaterial.get(materialIndex).push(ai, bi, ci);
+      keptTriangles += 1;
+    }
+
+    if (!localRemovedTriangles) return;
+    removedTriangles += localRemovedTriangles;
+    if (!keptTriangles) {
+      removableMeshes.push(mesh);
+      return;
+    }
+
+    const nextIndex = [];
+    geometry.clearGroups();
+    Array.from(keptByMaterial.keys()).sort((a, b) => a - b).forEach((materialIndex) => {
+      const indices = keptByMaterial.get(materialIndex) || [];
+      const start = nextIndex.length;
+      nextIndex.push(...indices);
+      geometry.addGroup(start, indices.length, materialIndex);
+    });
+    geometry.setIndex(nextIndex);
+    geometry.computeBoundingBox?.();
+    geometry.computeBoundingSphere?.();
+    geometry.attributes.position.needsUpdate = true;
+    mesh.visible = true;
+    mesh.userData = {
+      ...(mesh.userData || {}),
+      poolRoyaleShowoodOriginalBasePruned: true
+    };
+    delete mesh.userData.poolRoyaleShowoodOriginalBaseHidden;
+  });
+
+  removableMeshes.forEach((mesh) => {
+    mesh.parent?.remove(mesh);
+    mesh.geometry?.dispose?.();
+  });
+  root.updateMatrixWorld?.(true);
+  return removedTriangles;
+}
+
 function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null, finishInfo = null) {
   if (!material) return material;
   const mat = material.clone ? material.clone() : material;
@@ -12765,6 +12901,7 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
 function clonePoolRoyaleExternalTableTemplate(template, tableModel = null, finishInfo = null) {
   const clone = template.clone(true);
   preparePoolRoyaleExternalTableMaterials(clone, tableModel, finishInfo);
+  removePoolRoyaleShowoodOriginalBaseAndLegGeometry(clone, tableModel);
   return clone;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the Showood GLB's baked base/legs/feet geometry from appearing together with the procedural Pool Royale base when `useProceduralBaseWithExternal` is enabled.
- Keep upper table visuals (cloth, cushions, pockets, chrome plates, rail sights) intact while removing overlapping lower geometry so the procedural base renders cleanly.

### Description
- Added Showood-aware pruning helpers: `isPoolRoyaleShowoodProtectedUpperLabel`, `materialIndexAtPoolRoyaleGeometryOffset`, and `shouldRemovePoolRoyaleShowoodOriginalBaseTriangle` to identify triangles that belong to original GLB bases/legs while protecting upper surfaces. 
- Implemented `removePoolRoyaleShowoodOriginalBaseAndLegGeometry(root, tableModel)` that iterates meshes, strips out lower-base triangles, removes wholly-unused meshes, recomputes geometry bounds, and marks pruned meshes as kept/visible.
- Wired the pruning step into the external-table pipeline by calling `removePoolRoyaleShowoodOriginalBaseAndLegGeometry` from `clonePoolRoyaleExternalTableTemplate(template, tableModel, finishInfo)` so pruning runs before fitting/mounting the external GLB.
- Preserves partially-pruned meshes (keeps them visible) and only removes triangles/meshes when the table model flags `useProceduralBaseWithExternal`, `hideOriginalBaseAndLegsForProceduralBase`, and `useReferenceShowoodMapping` are set.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (build artifacts generated). 
- Ran `git diff --check` to verify no whitespace/merge issues; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d81927c0c832981ae9edc3b1167ec)