### PR TITLE
Hide Showood GLB base/legs when using procedural Pool Royale bases

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -71,7 +71,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinish: true,
     useReferenceShowoodMapping: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood'],
-    preserveSourceTextureRoles: ['railSight', 'sideWoodApron', 'baseFoot', 'trim', 'pocket'],
+    preserveSourceTextureRoles: ['railSight', 'sideWoodApron', 'trim', 'pocket'],
     preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: false,
     forceGeneratedChromePlates: false,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12422,11 +12422,85 @@ function isPoolRoyaleShowoodOriginalBaseOrLeg(child, material, referencePart = n
   const childName = `${child?.name || ''}`.toLowerCase();
   const materialName = `${material?.name || ''}`.toLowerCase();
   const label = `${childName} ${materialName}`;
-  if (/pocket|hole|drop|net|liner|leather|cup|basket|holder|plate|chrome|rail|cushion|cloth|felt|slate|bed|playfield/.test(label)) {
+  if (/pocket|hole|drop|net|liner|leather|cup|basket|holder|plate|chrome|cushion|cloth|felt|slate|bed|playfield/.test(label)) {
     return false;
   }
   if (['leg', 'baseFoot', 'baseCornerBlock'].includes(referencePart)) return true;
   return /leg|foot|feet|base|support|underside|pedestal|stretcher|plinth/.test(label);
+}
+
+function hidePoolRoyaleShowoodOriginalBaseAndLegMeshes(model, tableModel, dims = null) {
+  if (
+    !model ||
+    !tableModel?.hideOriginalBaseAndLegsForProceduralBase ||
+    !tableModel?.useProceduralBaseWithExternal ||
+    !tableModel?.useReferenceShowoodMapping
+  ) {
+    return;
+  }
+
+  model.updateMatrixWorld(true);
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return;
+
+  const fullSize = fullBox.getSize(new THREE.Vector3());
+  const fullCenter = fullBox.getCenter(new THREE.Vector3());
+  const targetTop = Number.isFinite(dims?.targetTopLocal)
+    ? dims.targetTopLocal
+    : Number.isFinite(dims?.cushionTopLocal)
+      ? dims.cushionTopLocal
+      : fullBox.max.y;
+  const upperHeight = Number.isFinite(dims?.targetUpperComponentHeight)
+    ? Math.max(MICRO_EPS, dims.targetUpperComponentHeight)
+    : Math.max(MICRO_EPS, fullSize.y * 0.28);
+  const lowerHardwareTop = targetTop - upperHeight * 0.82;
+  const footZoneTop = fullBox.min.y + fullSize.y * 0.28;
+
+  model.traverse((child) => {
+    if (!child?.isMesh || child.userData?.poolRoyaleShowoodOriginalBaseHidden) return;
+    const materials = (Array.isArray(child.material) ? child.material : [child.material]).filter(Boolean);
+    const label = `${child.name || ''} ${materials.map((material) => material?.name || '').join(' ')}`.toLowerCase();
+    if (/pocket|hole|drop|net|liner|leather|cup|basket|holder|plate|chrome|cushion|cloth|felt|slate|bed|playfield/.test(label)) {
+      return;
+    }
+
+    const referenceParts = materials.map((material) => classifyPoolRoyaleShowoodReferencePart(child, material));
+    const explicitlyOriginalBase = referenceParts.some((part) =>
+      isPoolRoyaleShowoodOriginalBaseOrLeg(child, null, part)
+    );
+
+    const childBox = new THREE.Box3().setFromObject(child);
+    if (childBox.isEmpty()) return;
+    const childSize = childBox.getSize(new THREE.Vector3());
+    const childCenter = childBox.getCenter(new THREE.Vector3());
+    const maxFlatSpan = Math.max(childSize.x, childSize.z);
+    const nearCorner =
+      Math.abs(childCenter.x - fullCenter.x) > fullSize.x * 0.18 &&
+      Math.abs(childCenter.z - fullCenter.z) > fullSize.z * 0.18;
+    const belowUpperRails = childBox.max.y < lowerHardwareTop;
+    const lowFootZone = childBox.max.y < footZoneTop;
+    const lowerVerticalSupport =
+      belowUpperRails &&
+      childSize.y >= fullSize.y * 0.12 &&
+      childSize.y >= maxFlatSpan * 0.68 &&
+      maxFlatSpan <= Math.max(fullSize.x, fullSize.z) * 0.34;
+    const lowerFootOrPlinth =
+      lowFootZone &&
+      childSize.y <= fullSize.y * 0.22 &&
+      maxFlatSpan >= Math.max(MICRO_EPS, childSize.y) * 1.25 &&
+      maxFlatSpan <= Math.max(fullSize.x, fullSize.z) * 0.42;
+    const namedLowerSupport =
+      /leg|foot|feet|base|support|underside|pedestal|stretcher|plinth/.test(label) &&
+      childBox.max.y < targetTop - upperHeight * 0.18;
+
+    if (!(explicitlyOriginalBase || namedLowerSupport || (nearCorner && (lowerVerticalSupport || lowerFootOrPlinth)))) return;
+
+    child.visible = false;
+    child.userData = {
+      ...(child.userData || {}),
+      poolRoyaleShowoodOriginalBaseHidden: true
+    };
+  });
 }
 
 function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null, finishInfo = null) {
@@ -13238,6 +13312,7 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   stretchPoolRoyaleExternalLowerBase(model, tableModel, dims);
   stretchPoolRoyaleShowoodLegsToFeet(model, tableModel);
   subtlyWidenPoolRoyaleShowoodFeet(model, tableModel);
+  hidePoolRoyaleShowoodOriginalBaseAndLegMeshes(model, tableModel, dims);
   model.userData = {
     ...(model.userData || {}),
     poolRoyaleExternalTable: true,


### PR DESCRIPTION
### Motivation
- Prevent the Showood GLB's original lower supports (legs/feet/plinths) from remaining visible when using Pool Royale's procedural bases, so procedural bases are the single visible support.

### Description
- Removed `baseFoot` from `preserveSourceTextureRoles` in `webapp/src/config/poolRoyaleTableModels.js` so GLB feet are no longer forcibly preserved.
- Added `hidePoolRoyaleShowoodOriginalBaseAndLegMeshes` in `webapp/src/pages/Games/PoolRoyale.jsx` to detect and hide GLB meshes that represent legs, feet, plinths, and other lower supports while preserving playfield, cushions, pockets, and hardware.
- Invoked the new hide pass after the external Showood model is fitted and adjusted in the external-table mount flow so the procedural base remains visible under the playfield.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully.
- Ran `npm --prefix webapp run lint -- --quiet` which completed successfully with no reported lint errors.
- Attempted an automated Playwright mobile screenshot of `/games/poolroyale?tableModel=showood-seven-foot&mode=local`, but the headless Chromium screenshot timed out and external GLB/CDN fetches failed in that environment, so the in-browser visual verification could not be captured there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d81927c0c832981ae9edc3b1167ec)