### PR TITLE
Prune Showood GLB legs and trim rail sights for procedural Pool Royale bases; update 7ft model and UI

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -49,9 +49,10 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     kind: 'gltf',
     fitScale: 1.055,
     upperFrameHeightScale: 0.58,
-    cornerRimHeightScale: 0.28,
+    cornerRimHeightScale: 0.16,
+    railSightBottomTrimToRail: true,
     trimCornerRimsToTopRailBottom: true,
-    cornerRimLift: 0.018,
+    cornerRimLift: 0,
     markingVisualLift: 0.024,
     lowerBaseHeightScale: 1.72,
     lowerLegFootReachScale: 1.28,
@@ -71,7 +72,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     usePoolRoyaleFinish: true,
     useReferenceShowoodMapping: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood'],
-    preserveSourceTextureRoles: ['railSight', 'sideWoodApron', 'baseFoot', 'trim', 'pocket'],
+    preserveSourceTextureRoles: ['railSight', 'sideWoodApron', 'trim', 'pocket'],
     preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: false,
     forceGeneratedChromePlates: false,
@@ -151,8 +152,7 @@ export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cushion',
   'metalAccent',
   'pocketJaw',
-  'topWoodRail',
-  'legBase'
+  'topWoodRail'
 ]);
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
@@ -161,7 +161,7 @@ export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   metalAccent: 'gold',
   pocketJaw: 'plastic-black',
   topWoodRail: 'woodTable001',
-  legBase: 'darkWood'
+  legBase: 'woodTable001'
 });
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
@@ -175,8 +175,8 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
     description: 'Gold, chrome, or black for Showood rail sights, side apron, feet, and Rooney/corner rims.'
   },
   pocketJaw: { label: 'Pockets + jaws', description: 'Uses the same pocket-jaw texture options as the main game menu.' },
-  topWoodRail: { label: 'Top rail frame', description: 'All GLTF table-finish textures for the main top wood rail frame.' },
-  legBase: { label: 'Legs + base', description: 'All GLTF table-finish textures for legs and lower base blocks only.' }
+  topWoodRail: { label: 'Table finish', description: 'All GLTF table-finish textures for the visible Showood rails and frame.' },
+  legBase: { label: 'Hidden GLB legs/base', description: 'Legacy fallback only; the visible Showood table uses the procedural Pool Royale base.' }
 });
 
 const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions();

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12184,12 +12184,12 @@ const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   cornerPocketPlate: 'metalAccent',
   middlePocketPlate: 'metalAccent',
   verticalCornerRim: 'metalAccent',
-  baseCornerBlock: 'legBase',
-  leg: 'legBase',
+  baseCornerBlock: 'topWoodRail',
+  leg: 'topWoodRail',
   baseFoot: 'metalAccent',
   lowerTrim: 'metalAccent',
   railSight: 'metalAccent',
-  underside: 'legBase',
+  underside: 'topWoodRail',
   trim: 'metalAccent',
   wood: 'topWoodRail',
   pocketCup: 'pocketJaw',
@@ -12201,7 +12201,7 @@ const POOL_ROYALE_SHOWOOD_LEGACY_CHOICE_FALLBACKS = Object.freeze({
   metalAccent: { a: 'gold', b: 'chrome' },
   pocketJaw: { a: 'plastic-black', b: 'brown-showood' },
   topWoodRail: { a: 'woodTable001', b: 'darkWood' },
-  legBase: { a: 'rosewoodVeneer01', b: 'darkWood' }
+  legBase: { a: 'woodTable001', b: 'darkWood' }
 });
 
 function resolvePoolRoyaleShowoodPalette(tableModel = null) {
@@ -12427,6 +12427,142 @@ function isPoolRoyaleShowoodOriginalBaseOrLeg(child, material, referencePart = n
   }
   if (['leg', 'baseFoot', 'baseCornerBlock'].includes(referencePart)) return true;
   return /leg|foot|feet|base|support|underside|pedestal|stretcher|plinth/.test(label);
+}
+
+
+const POOL_ROYALE_SHOWOOD_ORIGINAL_BASE_PARTS = new Set(['leg', 'baseFoot', 'baseCornerBlock', 'underside']);
+
+function isPoolRoyaleShowoodProtectedUpperLabel(label = '') {
+  return /pocket|hole|drop|net|liner|leather|cup|basket|holder|cushion|rubber|bumper|cloth|felt|slate|bed|playfield|baize|sight|diamond|marker|dot|inlay/.test(label);
+}
+
+function materialIndexAtPoolRoyaleGeometryOffset(geometry, offset) {
+  const groups = geometry?.groups || [];
+  for (let i = 0; i < groups.length; i += 1) {
+    const group = groups[i];
+    if (offset >= group.start && offset < group.start + group.count) {
+      return group.materialIndex ?? 0;
+    }
+  }
+  return 0;
+}
+
+function shouldRemovePoolRoyaleShowoodOriginalBaseTriangle({
+  mesh,
+  material,
+  referencePart,
+  role,
+  centerY,
+  lowerCutoffY
+}) {
+  const childName = `${mesh?.name || ''}`.toLowerCase();
+  const materialName = `${material?.name || ''}`.toLowerCase();
+  const label = `${childName} ${materialName}`;
+  if (isPoolRoyaleShowoodProtectedUpperLabel(label)) return false;
+  if (isPoolRoyaleShowoodOriginalBaseOrLeg(mesh, material, referencePart)) return true;
+  if (POOL_ROYALE_SHOWOOD_ORIGINAL_BASE_PARTS.has(referencePart)) return true;
+  return ['wood', 'trim'].includes(role) && centerY <= lowerCutoffY;
+}
+
+function removePoolRoyaleShowoodOriginalBaseAndLegGeometry(root, tableModel = null) {
+  if (
+    !root ||
+    !tableModel?.hideOriginalBaseAndLegsForProceduralBase ||
+    !tableModel?.useProceduralBaseWithExternal ||
+    !tableModel?.useReferenceShowoodMapping
+  ) return 0;
+
+  root.updateMatrixWorld?.(true);
+  const fullBox = new THREE.Box3().setFromObject(root);
+  if (fullBox.isEmpty()) return 0;
+  const fullSize = fullBox.getSize(new THREE.Vector3());
+  const lowerCutoffY = fullBox.min.y + fullSize.y * 0.46;
+  const removableMeshes = [];
+  let removedTriangles = 0;
+  const tmpA = new THREE.Vector3();
+  const tmpB = new THREE.Vector3();
+  const tmpC = new THREE.Vector3();
+  const tmpCenter = new THREE.Vector3();
+
+  root.traverse((child) => {
+    if (!child?.isMesh || !child.geometry?.attributes?.position) return;
+    const mesh = child;
+    const geometry = mesh.geometry;
+    const position = geometry.attributes.position;
+    const index = geometry.index;
+    const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material].filter(Boolean);
+    if (!materials.length) return;
+
+    const total = index ? index.count : position.count;
+    const keptByMaterial = new Map();
+    let keptTriangles = 0;
+    let localRemovedTriangles = 0;
+
+    for (let i = 0; i + 2 < total; i += 3) {
+      const materialIndex = Math.max(
+        0,
+        Math.min(materialIndexAtPoolRoyaleGeometryOffset(geometry, i), materials.length - 1)
+      );
+      const material = materials[materialIndex];
+      const ai = index ? index.getX(i) : i;
+      const bi = index ? index.getX(i + 1) : i + 1;
+      const ci = index ? index.getX(i + 2) : i + 2;
+      tmpA.fromBufferAttribute(position, ai).applyMatrix4(mesh.matrixWorld);
+      tmpB.fromBufferAttribute(position, bi).applyMatrix4(mesh.matrixWorld);
+      tmpC.fromBufferAttribute(position, ci).applyMatrix4(mesh.matrixWorld);
+      tmpCenter.addVectors(tmpA, tmpB).add(tmpC).multiplyScalar(1 / 3);
+      const referencePart = classifyPoolRoyaleShowoodReferencePart(mesh, material);
+      const role = classifyPoolRoyaleExternalTableSurface(mesh, material);
+      const removeTriangle = shouldRemovePoolRoyaleShowoodOriginalBaseTriangle({
+        mesh,
+        material,
+        referencePart,
+        role,
+        centerY: tmpCenter.y,
+        lowerCutoffY
+      });
+      if (removeTriangle) {
+        localRemovedTriangles += 1;
+        continue;
+      }
+      if (!keptByMaterial.has(materialIndex)) keptByMaterial.set(materialIndex, []);
+      keptByMaterial.get(materialIndex).push(ai, bi, ci);
+      keptTriangles += 1;
+    }
+
+    if (!localRemovedTriangles) return;
+    removedTriangles += localRemovedTriangles;
+    if (!keptTriangles) {
+      removableMeshes.push(mesh);
+      return;
+    }
+
+    const nextIndex = [];
+    geometry.clearGroups();
+    Array.from(keptByMaterial.keys()).sort((a, b) => a - b).forEach((materialIndex) => {
+      const indices = keptByMaterial.get(materialIndex) || [];
+      const start = nextIndex.length;
+      nextIndex.push(...indices);
+      geometry.addGroup(start, indices.length, materialIndex);
+    });
+    geometry.setIndex(nextIndex);
+    geometry.computeBoundingBox?.();
+    geometry.computeBoundingSphere?.();
+    geometry.attributes.position.needsUpdate = true;
+    mesh.visible = true;
+    mesh.userData = {
+      ...(mesh.userData || {}),
+      poolRoyaleShowoodOriginalBasePruned: true
+    };
+    delete mesh.userData.poolRoyaleShowoodOriginalBaseHidden;
+  });
+
+  removableMeshes.forEach((mesh) => {
+    mesh.parent?.remove(mesh);
+    mesh.geometry?.dispose?.();
+  });
+  root.updateMatrixWorld?.(true);
+  return removedTriangles;
 }
 
 function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null, finishInfo = null) {
@@ -12765,6 +12901,7 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
 function clonePoolRoyaleExternalTableTemplate(template, tableModel = null, finishInfo = null) {
   const clone = template.clone(true);
   preparePoolRoyaleExternalTableMaterials(clone, tableModel, finishInfo);
+  removePoolRoyaleShowoodOriginalBaseAndLegGeometry(clone, tableModel);
   return clone;
 }
 
@@ -13049,6 +13186,57 @@ function shortenPoolRoyaleShowoodCornerRims(model, tableModel, dims) {
   model.updateMatrixWorld(true);
 }
 
+
+function trimPoolRoyaleShowoodRailSightsAndCornerRimsToSideRails(model, tableModel, dims) {
+  if (!model || !tableModel?.useReferenceShowoodMapping || tableModel?.railSightBottomTrimToRail === false) return;
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return;
+  const railBottomY = resolvePoolRoyaleShowoodTopRailBottomY(model, fullBox, dims);
+  if (!Number.isFinite(railBottomY)) return;
+  const fullSize = fullBox.getSize(new THREE.Vector3());
+  const targetTop = Number.isFinite(dims?.targetTopLocal)
+    ? dims.targetTopLocal
+    : Number.isFinite(dims?.cushionTopLocal)
+      ? dims.cushionTopLocal
+      : fullBox.max.y;
+  const upperHeight = Number.isFinite(dims?.targetUpperComponentHeight)
+    ? Math.max(MICRO_EPS, dims.targetUpperComponentHeight)
+    : Math.max(MICRO_EPS, fullSize.y * 0.28);
+  const upperCutoff = targetTop - upperHeight * 1.22;
+
+  model.traverse((child) => {
+    if (!child?.isMesh || child.userData?.poolRoyaleRailSightBottomTrimmed) return;
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+    const referenceParts = materials.map((entry) => classifyPoolRoyaleShowoodReferencePart(child, entry));
+    const shouldTrim = referenceParts.some((part) =>
+      ['railSight', 'verticalCornerRim', 'lowerTrim'].includes(part)
+    );
+    if (!shouldTrim) return;
+    const childBox = new THREE.Box3().setFromObject(child);
+    if (
+      childBox.isEmpty() ||
+      childBox.max.y < upperCutoff ||
+      childBox.min.y >= railBottomY - MICRO_EPS ||
+      childBox.max.y <= railBottomY + MICRO_EPS
+    ) return;
+    const parent = child.parent || model;
+    const anchorWorldY = Math.min(childBox.max.y, targetTop);
+    const anchorLocal = parent.worldToLocal(new THREE.Vector3(0, anchorWorldY, 0)).y;
+    const nextScale = THREE.MathUtils.clamp(
+      (anchorWorldY - railBottomY) / Math.max(MICRO_EPS, childBox.max.y - childBox.min.y),
+      0.04,
+      1
+    );
+    child.scale.y *= nextScale;
+    child.updateMatrixWorld(true);
+    const nextBox = new THREE.Box3().setFromObject(child);
+    const nextAnchorLocal = parent.worldToLocal(new THREE.Vector3(0, nextBox.max.y, 0)).y;
+    child.position.y += anchorLocal - nextAnchorLocal;
+    child.userData.poolRoyaleRailSightBottomTrimmed = true;
+  });
+  model.updateMatrixWorld(true);
+}
+
 function stretchPoolRoyaleShowoodLegsToFeet(model, tableModel) {
   const reachScale = Number(tableModel?.lowerLegFootReachScale);
   if (!model || !tableModel?.useReferenceShowoodMapping || !Number.isFinite(reachScale) || reachScale <= 1 + MICRO_EPS) return;
@@ -13235,9 +13423,13 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   model.updateMatrixWorld(true);
   shrinkPoolRoyaleExternalUpperFrame(model, tableModel, dims);
   shortenPoolRoyaleShowoodCornerRims(model, tableModel, dims);
-  stretchPoolRoyaleExternalLowerBase(model, tableModel, dims);
-  stretchPoolRoyaleShowoodLegsToFeet(model, tableModel);
-  subtlyWidenPoolRoyaleShowoodFeet(model, tableModel);
+  trimPoolRoyaleShowoodRailSightsAndCornerRimsToSideRails(model, tableModel, dims);
+  if (!tableModel?.useProceduralBaseWithExternal) {
+    stretchPoolRoyaleExternalLowerBase(model, tableModel, dims);
+    stretchPoolRoyaleShowoodLegsToFeet(model, tableModel);
+    subtlyWidenPoolRoyaleShowoodFeet(model, tableModel);
+  }
+  removePoolRoyaleShowoodOriginalBaseAndLegGeometry(model, tableModel);
   model.userData = {
     ...(model.userData || {}),
     poolRoyaleExternalTable: true,
@@ -36393,9 +36585,10 @@ const shotPowerRef = useRef(0);
                   </div>
                 </div>
               ) : null}
+              {!showShowoodTableSetup ? (
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Finish
+                  Royal Table Finish
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {availableTableFinishes.map((option) => {
@@ -36427,9 +36620,11 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
+              ) : null}
+              {!showShowoodTableSetup ? (
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Base
+                  Royal Procedural Base
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {availableTableBases.map((option) => {
@@ -36471,6 +36666,7 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   HDR Environment
@@ -36515,9 +36711,10 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
+              {!showShowoodTableSetup ? (
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Chrome Plates
+                  Royal Chrome Plates
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {availableChromeOptions.map((option) => {
@@ -36547,9 +36744,11 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
+              ) : null}
+              {!showShowoodTableSetup ? (
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Chrome Plate Shape
+                  Royal Chrome Plate Shape
                 </h3>
                 <div className="mt-2 grid grid-cols-1 gap-2">
                   {availableChromePlateStyles.map((option) => {
@@ -36586,6 +36785,7 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Cue Styles
@@ -36620,10 +36820,10 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
-              {availableClothOptions.length > 0 ? (
+              {!showShowoodTableSetup && availableClothOptions.length > 0 ? (
                 <div>
                   <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                    Cloth Color
+                    Royal Cloth Color
                   </h3>
                   <div className="mt-2 flex flex-wrap gap-2">
                     {availableClothOptions.map((option) => {
@@ -36708,9 +36908,10 @@ const shotPowerRef = useRef(0);
                   </div>
                 </div>
               ) : null}
+              {!showShowoodTableSetup ? (
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Rail Markers
+                  Royal Rail Markers
                 </h3>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {RAIL_MARKER_SHAPE_OPTIONS.map((option) => {
@@ -36760,6 +36961,7 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Graphics


### PR DESCRIPTION
### Motivation

- Allow the Pool Royale Showood GLB tables to be used with the procedural Pool Royale base by removing or pruning legacy GLB legs/base geometry and aligning rail sights/corner rims to the procedural rails.  
- Tune the Showood 7 ft model visual offsets and defaults to better match the Pool Royale footprint and finishes.  
- Simplify material mappings so legacy leg/base parts receive table finish controls and hide GLB-specific controls from the main Royal UI when using the Showood setup.

### Description

- Adjusted the `showood-seven-foot` table model: reduced `cornerRimHeightScale`, set `cornerRimLift` to zero, added `railSightBottomTrimToRail: true`, and updated preserved texture roles and defaults.  
- Remapped several Showood parts to use `topWoodRail` control (previously `legBase`) so legs/base parts receive table finish treatment, and changed legacy fallback/default palette entries accordingly.  
- Added geometry processing utilities: `materialIndexAtPoolRoyaleGeometryOffset`, `isPoolRoyaleShowoodProtectedUpperLabel`, `shouldRemovePoolRoyaleShowoodOriginalBaseTriangle`, and `removePoolRoyaleShowoodOriginalBaseAndLegGeometry` to prune or remove original GLB base/leg triangles and meshes when using the procedural base.  
- Added `trimPoolRoyaleShowoodRailSightsAndCornerRimsToSideRails` to scale/trim rail-sight and corner-rim meshes to the side rails based on detected rail bottom Y.  
- Integrated pruning/trim logic into the external table pipeline by invoking the trim during fit and running the removal step when cloning or fitting external templates, with a guard to skip stretching lower base/legs when `useProceduralBaseWithExternal` is enabled.  
- Updated UI labels and conditional rendering in the Pool Royale panel to surface "Royal"-prefixed controls and hide Showood-specific controls when `showShowoodTableSetup` is toggled.

### Testing

- Ran the app build with `yarn build` which completed successfully.  
- Executed the project's automated test suite with `yarn test` and the tests passed.  
- No new unit tests were added for the new geometry-pruning functions in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d81927c0c832981ae9edc3b1167ec)