### PR TITLE
Strip Showood GLB base/legs and trim lower accents to use procedural Pool Royale base

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -52,6 +52,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     cornerRimHeightScale: 0.28,
     trimCornerRimsToTopRailBottom: true,
     cornerRimLift: 0.018,
+    originalBaseRemovalCutoffRatio: 0.66,
+    accentBottomTrimOffset: 0.012,
     markingVisualLift: 0.024,
     lowerBaseHeightScale: 1.72,
     lowerLegFootReachScale: 1.28,
@@ -151,8 +153,7 @@ export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cushion',
   'metalAccent',
   'pocketJaw',
-  'topWoodRail',
-  'legBase'
+  'topWoodRail'
 ]);
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
@@ -171,12 +172,12 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
     description: 'All cloth-library textures for the cushion faces, separate from the field.'
   },
   metalAccent: {
-    label: 'Rail sights + apron + feet + rims',
-    description: 'Gold, chrome, or black for Showood rail sights, side apron, feet, and Rooney/corner rims.'
+    label: 'Rail sights + apron + rims',
+    description: 'Gold, chrome, or black for Showood rail sights, side apron, and shorter side/corner rims.'
   },
   pocketJaw: { label: 'Pockets + jaws', description: 'Uses the same pocket-jaw texture options as the main game menu.' },
   topWoodRail: { label: 'Top rail frame', description: 'All GLTF table-finish textures for the main top wood rail frame.' },
-  legBase: { label: 'Legs + base', description: 'All GLTF table-finish textures for legs and lower base blocks only.' }
+  legBase: { label: 'Legacy GLB legs + base', description: 'Hidden for the Showood table because Pool Royale uses the procedural base and table-finish texture instead.' }
 });
 
 const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions();

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12429,6 +12429,145 @@ function isPoolRoyaleShowoodOriginalBaseOrLeg(child, material, referencePart = n
   return /leg|foot|feet|base|support|underside|pedestal|stretcher|plinth/.test(label);
 }
 
+
+const POOL_ROYALE_SHOWOOD_ORIGINAL_BASE_PARTS = new Set(['leg', 'baseFoot', 'baseCornerBlock', 'underside']);
+
+function isPoolRoyaleShowoodProtectedUpperLabel(label = '') {
+  return /pocket|hole|drop|net|liner|leather|cup|basket|holder|plate|chrome|cushion|rubber|bumper|cloth|felt|slate|bed|playfield|baize|sight|diamond|marker|dot|inlay/.test(label);
+}
+
+function materialIndexAtPoolRoyaleGeometryOffset(geometry, offset) {
+  const groups = geometry?.groups || [];
+  for (let i = 0; i < groups.length; i += 1) {
+    const group = groups[i];
+    if (offset >= group.start && offset < group.start + group.count) {
+      return group.materialIndex ?? 0;
+    }
+  }
+  return 0;
+}
+
+function shouldRemovePoolRoyaleShowoodOriginalBaseTriangle({
+  mesh,
+  material,
+  referencePart,
+  role,
+  centerY,
+  lowerCutoffY
+}) {
+  const childName = `${mesh?.name || ''}`.toLowerCase();
+  const materialName = `${material?.name || ''}`.toLowerCase();
+  const label = `${childName} ${materialName}`;
+  if (isPoolRoyaleShowoodProtectedUpperLabel(label)) return false;
+  if (isPoolRoyaleShowoodOriginalBaseOrLeg(mesh, material, referencePart)) return true;
+  if (POOL_ROYALE_SHOWOOD_ORIGINAL_BASE_PARTS.has(referencePart)) return true;
+  return role === 'wood' && centerY <= lowerCutoffY;
+}
+
+function removePoolRoyaleShowoodOriginalBaseAndLegGeometry(root, tableModel = null) {
+  if (
+    !root ||
+    !tableModel?.hideOriginalBaseAndLegsForProceduralBase ||
+    !tableModel?.useProceduralBaseWithExternal ||
+    !tableModel?.useReferenceShowoodMapping
+  ) return 0;
+
+  root.updateMatrixWorld?.(true);
+  const fullBox = new THREE.Box3().setFromObject(root);
+  if (fullBox.isEmpty()) return 0;
+  const fullSize = fullBox.getSize(new THREE.Vector3());
+  const cutoffRatio = Number.isFinite(tableModel?.originalBaseRemovalCutoffRatio)
+    ? THREE.MathUtils.clamp(tableModel.originalBaseRemovalCutoffRatio, 0.35, 0.82)
+    : 0.66;
+  const lowerCutoffY = fullBox.min.y + fullSize.y * cutoffRatio;
+  const removableMeshes = [];
+  let removedTriangles = 0;
+  const tmpA = new THREE.Vector3();
+  const tmpB = new THREE.Vector3();
+  const tmpC = new THREE.Vector3();
+  const tmpCenter = new THREE.Vector3();
+
+  root.traverse((child) => {
+    if (!child?.isMesh || !child.geometry?.attributes?.position) return;
+    const mesh = child;
+    const geometry = mesh.geometry;
+    const position = geometry.attributes.position;
+    const index = geometry.index;
+    const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material].filter(Boolean);
+    if (!materials.length) return;
+
+    const total = index ? index.count : position.count;
+    const keptByMaterial = new Map();
+    let keptTriangles = 0;
+    let localRemovedTriangles = 0;
+
+    for (let i = 0; i + 2 < total; i += 3) {
+      const materialIndex = Math.max(
+        0,
+        Math.min(materialIndexAtPoolRoyaleGeometryOffset(geometry, i), materials.length - 1)
+      );
+      const material = materials[materialIndex];
+      const ai = index ? index.getX(i) : i;
+      const bi = index ? index.getX(i + 1) : i + 1;
+      const ci = index ? index.getX(i + 2) : i + 2;
+      tmpA.fromBufferAttribute(position, ai).applyMatrix4(mesh.matrixWorld);
+      tmpB.fromBufferAttribute(position, bi).applyMatrix4(mesh.matrixWorld);
+      tmpC.fromBufferAttribute(position, ci).applyMatrix4(mesh.matrixWorld);
+      tmpCenter.addVectors(tmpA, tmpB).add(tmpC).multiplyScalar(1 / 3);
+      const referencePart = classifyPoolRoyaleShowoodReferencePart(mesh, material);
+      const role = classifyPoolRoyaleExternalTableSurface(mesh, material);
+      const removeTriangle = shouldRemovePoolRoyaleShowoodOriginalBaseTriangle({
+        mesh,
+        material,
+        referencePart,
+        role,
+        centerY: tmpCenter.y,
+        lowerCutoffY
+      });
+      if (removeTriangle) {
+        localRemovedTriangles += 1;
+        continue;
+      }
+      if (!keptByMaterial.has(materialIndex)) keptByMaterial.set(materialIndex, []);
+      keptByMaterial.get(materialIndex).push(ai, bi, ci);
+      keptTriangles += 1;
+    }
+
+    if (!localRemovedTriangles) return;
+    removedTriangles += localRemovedTriangles;
+    if (!keptTriangles) {
+      removableMeshes.push(mesh);
+      return;
+    }
+
+    const nextIndex = [];
+    geometry.clearGroups();
+    Array.from(keptByMaterial.keys()).sort((a, b) => a - b).forEach((materialIndex) => {
+      const indices = keptByMaterial.get(materialIndex) || [];
+      const start = nextIndex.length;
+      nextIndex.push(...indices);
+      geometry.addGroup(start, indices.length, materialIndex);
+    });
+    geometry.setIndex(nextIndex);
+    geometry.computeBoundingBox?.();
+    geometry.computeBoundingSphere?.();
+    geometry.attributes.position.needsUpdate = true;
+    mesh.visible = true;
+    mesh.userData = {
+      ...(mesh.userData || {}),
+      poolRoyaleShowoodOriginalBasePruned: true
+    };
+    delete mesh.userData.poolRoyaleShowoodOriginalBaseHidden;
+  });
+
+  removableMeshes.forEach((mesh) => {
+    mesh.parent?.remove(mesh);
+    mesh.geometry?.dispose?.();
+  });
+  root.updateMatrixWorld?.(true);
+  return removedTriangles;
+}
+
 function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = null, finishInfo = null) {
   if (!material) return material;
   const mat = material.clone ? material.clone() : material;
@@ -12765,6 +12904,7 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
 function clonePoolRoyaleExternalTableTemplate(template, tableModel = null, finishInfo = null) {
   const clone = template.clone(true);
   preparePoolRoyaleExternalTableMaterials(clone, tableModel, finishInfo);
+  removePoolRoyaleShowoodOriginalBaseAndLegGeometry(clone, tableModel);
   return clone;
 }
 
@@ -12975,6 +13115,94 @@ function resolvePoolRoyaleShowoodTopRailBottomY(model, fullBox, dims) {
   railBottoms.sort((a, b) => a - b);
   const index = THREE.MathUtils.clamp(Math.floor(railBottoms.length * 0.35), 0, railBottoms.length - 1);
   return railBottoms[index];
+}
+
+
+function trimPoolRoyaleShowoodLowerAccentTriangles(model, tableModel, dims) {
+  if (!model || !tableModel?.useReferenceShowoodMapping || tableModel?.trimCornerRimsToTopRailBottom === false) return 0;
+  const fullBox = new THREE.Box3().setFromObject(model);
+  if (fullBox.isEmpty()) return 0;
+  const railBottomY = resolvePoolRoyaleShowoodTopRailBottomY(model, fullBox, dims);
+  if (!Number.isFinite(railBottomY)) return 0;
+  const bottomTrimOffset = Number.isFinite(tableModel?.accentBottomTrimOffset)
+    ? tableModel.accentBottomTrimOffset
+    : 0;
+  const trimBelowY = railBottomY + bottomTrimOffset;
+  const removableParts = new Set(['railSight', 'verticalCornerRim', 'lowerTrim', 'cornerPocketPlate', 'middlePocketPlate']);
+  const removableMeshes = [];
+  let trimmedTriangles = 0;
+  const tmpA = new THREE.Vector3();
+  const tmpB = new THREE.Vector3();
+  const tmpC = new THREE.Vector3();
+  const tmpCenter = new THREE.Vector3();
+
+  model.traverse((child) => {
+    if (!child?.isMesh || !child.geometry?.attributes?.position) return;
+    const mesh = child;
+    const geometry = mesh.geometry;
+    const position = geometry.attributes.position;
+    const index = geometry.index;
+    const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material].filter(Boolean);
+    if (!materials.length) return;
+    const total = index ? index.count : position.count;
+    const keptByMaterial = new Map();
+    let localTrimmed = 0;
+    let keptTriangles = 0;
+
+    for (let i = 0; i + 2 < total; i += 3) {
+      const materialIndex = Math.max(
+        0,
+        Math.min(materialIndexAtPoolRoyaleGeometryOffset(geometry, i), materials.length - 1)
+      );
+      const material = materials[materialIndex];
+      const referencePart = classifyPoolRoyaleShowoodReferencePart(mesh, material);
+      const ai = index ? index.getX(i) : i;
+      const bi = index ? index.getX(i + 1) : i + 1;
+      const ci = index ? index.getX(i + 2) : i + 2;
+      tmpA.fromBufferAttribute(position, ai).applyMatrix4(mesh.matrixWorld);
+      tmpB.fromBufferAttribute(position, bi).applyMatrix4(mesh.matrixWorld);
+      tmpC.fromBufferAttribute(position, ci).applyMatrix4(mesh.matrixWorld);
+      tmpCenter.addVectors(tmpA, tmpB).add(tmpC).multiplyScalar(1 / 3);
+      const shouldTrim = removableParts.has(referencePart) && tmpCenter.y < trimBelowY;
+      if (shouldTrim) {
+        localTrimmed += 1;
+        continue;
+      }
+      if (!keptByMaterial.has(materialIndex)) keptByMaterial.set(materialIndex, []);
+      keptByMaterial.get(materialIndex).push(ai, bi, ci);
+      keptTriangles += 1;
+    }
+
+    if (!localTrimmed) return;
+    trimmedTriangles += localTrimmed;
+    if (!keptTriangles) {
+      removableMeshes.push(mesh);
+      return;
+    }
+    const nextIndex = [];
+    geometry.clearGroups();
+    Array.from(keptByMaterial.keys()).sort((a, b) => a - b).forEach((materialIndex) => {
+      const indices = keptByMaterial.get(materialIndex) || [];
+      const start = nextIndex.length;
+      nextIndex.push(...indices);
+      geometry.addGroup(start, indices.length, materialIndex);
+    });
+    geometry.setIndex(nextIndex);
+    geometry.computeBoundingBox?.();
+    geometry.computeBoundingSphere?.();
+    geometry.attributes.position.needsUpdate = true;
+    mesh.userData = {
+      ...(mesh.userData || {}),
+      poolRoyaleShowoodAccentBottomTrimmed: true
+    };
+  });
+
+  removableMeshes.forEach((mesh) => {
+    mesh.parent?.remove(mesh);
+    mesh.geometry?.dispose?.();
+  });
+  if (trimmedTriangles > 0) model.updateMatrixWorld(true);
+  return trimmedTriangles;
 }
 
 function shortenPoolRoyaleShowoodCornerRims(model, tableModel, dims) {
@@ -13235,6 +13463,7 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   model.updateMatrixWorld(true);
   shrinkPoolRoyaleExternalUpperFrame(model, tableModel, dims);
   shortenPoolRoyaleShowoodCornerRims(model, tableModel, dims);
+  trimPoolRoyaleShowoodLowerAccentTriangles(model, tableModel, dims);
   stretchPoolRoyaleExternalLowerBase(model, tableModel, dims);
   stretchPoolRoyaleShowoodLegsToFeet(model, tableModel);
   subtlyWidenPoolRoyaleShowoodFeet(model, tableModel);
@@ -36327,7 +36556,7 @@ const shotPowerRef = useRef(0);
                         Showood Table Setup
                       </h3>
                       <p className="mt-1 text-[0.68rem] leading-snug text-white/60">
-                        These controls appear only for the Showood GLB table.
+                        These controls appear only for the Showood GLB table. The GLB base/legs are removed, so base texture comes from Table Finish below.
                       </p>
                     </div>
                     <button
@@ -36395,8 +36624,13 @@ const shotPowerRef = useRef(0);
               ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Finish
+                  {showShowoodTableSetup ? 'Showood / Procedural Base Finish' : 'Royal Original Table Finish'}
                 </h3>
+                <p className="mt-1 text-[0.68rem] leading-snug text-white/60">
+                  {showShowoodTableSetup
+                    ? 'Changes the procedural base texture and the shared Showood wood finish without showing any GLB base/leg controls.'
+                    : 'Changes the current Royal Original table wood, rails, legs, and base finish.'}
+                </p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {availableTableFinishes.map((option) => {
                     const active = option.id === tableFinishId;
@@ -36427,12 +36661,16 @@ const shotPowerRef = useRef(0);
                   })}
                 </div>
               </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Base
-                </h3>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {availableTableBases.map((option) => {
+              {!showShowoodTableSetup ? (
+                <div>
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                    Royal Original Table Base
+                  </h3>
+                  <p className="mt-1 text-[0.68rem] leading-snug text-white/60">
+                    Shape options for the current procedural Royal Original base and legs.
+                  </p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {availableTableBases.map((option) => {
                     const active = option.id === tableBaseId;
                     const swatchA = option.swatches?.[0] ?? '#0f172a';
                     const swatchB = option.swatches?.[1] ?? '#1f2937';
@@ -36468,9 +36706,10 @@ const shotPowerRef = useRef(0);
                         )}
                       </button>
                     );
-                  })}
+                    })}
+                  </div>
                 </div>
-              </div>
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   HDR Environment


### PR DESCRIPTION
### Motivation
- Allow the Showood GLB tables to be used with the procedural Pool Royale base by removing or trimming GLB geometry that conflicts with the generated base and shared finishes.
- Provide tunable cutoffs to control how much of the original GLB base/accents are removed so the GLB playfield/upper components remain intact while lower decorative geometry is replaced by the procedural base.

### Description
- Added two table model options in `poolRoyaleTableModels.js`: `originalBaseRemovalCutoffRatio` and `accentBottomTrimOffset` to control removal/trimming thresholds for Showood GLBs. 
- Implemented geometry pruning helpers in `PoolRoyale.jsx`: `removePoolRoyaleShowoodOriginalBaseAndLegGeometry`, `trimPoolRoyaleShowoodLowerAccentTriangles`, and supporting helpers (`materialIndexAtPoolRoyaleGeometryOffset`, `isPoolRoyaleShowoodProtectedUpperLabel`, and `POOL_ROYALE_SHOWOOD_ORIGINAL_BASE_PARTS`) that remove or trim lower/base triangles based on reference parts, role and world-space Y cutoff.
- Hooked pruning into the GLB handling pipeline by calling `removePoolRoyaleShowoodOriginalBaseAndLegGeometry` during template cloning and `trimPoolRoyaleShowoodLowerAccentTriangles` during fit/placement; retained other fitting steps (`shortenPoolRoyaleShowoodCornerRims`, leg/foot adjustments, etc.).
- Updated Showood material/control configuration and UI copy: removed `legBase` from the material control parts list, adjusted control metadata and default palette captions, and added conditional UI behavior and explanatory copy for when the Showood GLB is being used with the procedural base versus the Royal original base.

### Testing
- Ran the project's automated unit tests with `yarn test` and the test suite completed successfully. 
- Ran the linter with `yarn lint` and no lint errors were reported. 
- Performed a production build with `yarn build` which completed without build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d81927c0c832981ae9edc3b1167ec)