### PR TITLE
Nudge Showood metal accents outward

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -54,8 +54,9 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.upperFrameHeightScale, 0.58);
     assert.equal(showood.cornerRimHeightScale, 0.28);
     assert.equal(showood.markingVisualLift, 0.024);
-    assert.equal(showood.lowerBaseHeightScale, 1.62);
-    assert.equal(showood.lowerLegFootReachScale, 1.02);
+    assert.equal(showood.metalAccentOutwardOffset, 0.012);
+    assert.equal(showood.lowerBaseHeightScale, 1.72);
+    assert.equal(showood.lowerLegFootReachScale, 1.28);
     assert.equal(showood.footWidthScale, 1.08);
     assert.equal(showood.footHeightScale, 1);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, ['cloth', 'cushion', 'wood']);

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -55,6 +55,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     originalBaseRemovalCutoffRatio: 0.66,
     accentBottomTrimOffset: 0.012,
     markingVisualLift: 0.024,
+    metalAccentOutwardOffset: 0.012,
     lowerBaseHeightScale: 1.72,
     lowerLegFootReachScale: 1.28,
     lowerLegReachTarget: 'footBottom',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12909,6 +12909,58 @@ function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tab
   return mat;
 }
 
+const POOL_ROYALE_SHOWOOD_OUTWARD_ACCENT_PARTS = new Set(['railSight', 'sideWoodApron']);
+
+function offsetPoolRoyaleShowoodMetalAccentParts(root, tableModel = null) {
+  const offset = Number(tableModel?.metalAccentOutwardOffset);
+  if (
+    !root ||
+    !tableModel?.useReferenceShowoodMapping ||
+    !Number.isFinite(offset) ||
+    Math.abs(offset) <= MICRO_EPS
+  ) return;
+
+  root.updateMatrixWorld?.(true);
+  const fullBox = new THREE.Box3().setFromObject(root);
+  if (fullBox.isEmpty()) return;
+  const tableCenter = fullBox.getCenter(new THREE.Vector3());
+  const childCenter = new THREE.Vector3();
+  const direction = new THREE.Vector3();
+
+  root.traverse((child) => {
+    if (!child?.isMesh || child.userData?.poolRoyaleShowoodMetalAccentOutwardOffset) return;
+    const materials = Array.isArray(child.material) ? child.material : [child.material].filter(Boolean);
+    const accentParts = materials
+      .map((material) => (
+        material?.userData?.poolRoyaleShowoodReferencePart ||
+        classifyPoolRoyaleShowoodReferencePart(child, material)
+      ))
+      .filter((part) => POOL_ROYALE_SHOWOOD_OUTWARD_ACCENT_PARTS.has(part));
+    if (!accentParts.length) return;
+    const usesMetalAccent = materials.some(
+      (material) => material?.userData?.poolRoyaleShowoodReferenceControl === 'metalAccent'
+    );
+    if (!usesMetalAccent) return;
+
+    const childBox = new THREE.Box3().setFromObject(child);
+    if (childBox.isEmpty()) return;
+    childBox.getCenter(childCenter);
+    direction.set(childCenter.x - tableCenter.x, 0, childCenter.z - tableCenter.z);
+    if (direction.lengthSq() <= MICRO_EPS) return;
+    direction.normalize().multiplyScalar(offset);
+    const parent = child.parent || root;
+    const currentLocalCenter = parent.worldToLocal(childCenter.clone());
+    const outwardLocalCenter = parent.worldToLocal(childCenter.clone().add(direction));
+    child.position.add(outwardLocalCenter.sub(currentLocalCenter));
+    child.userData = {
+      ...(child.userData || {}),
+      poolRoyaleShowoodMetalAccentOutwardOffset: offset,
+      poolRoyaleShowoodMetalAccentOutwardParts: Array.from(new Set(accentParts))
+    };
+  });
+  root.updateMatrixWorld?.(true);
+}
+
 function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finishInfo = null) {
   root?.traverse?.((child) => {
     if (!child?.isMesh) return;
@@ -12975,6 +13027,7 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
 function clonePoolRoyaleExternalTableTemplate(template, tableModel = null, finishInfo = null) {
   const clone = template.clone(true);
   preparePoolRoyaleExternalTableMaterials(clone, tableModel, finishInfo);
+  offsetPoolRoyaleShowoodMetalAccentParts(clone, tableModel);
   removePoolRoyaleShowoodOriginalBaseAndLegGeometry(clone, tableModel);
   return clone;
 }


### PR DESCRIPTION
### Motivation
- Make the Showood 7ft GLB table visuals match the requested styling by allowing rail sights and the side apron metal accents (gold/chrome/black) to be nudged slightly outward from the table shell. 

### Description
- Added a new configurable property `metalAccentOutwardOffset` to the Showood table model config so the outward nudge is adjustable (`webapp/src/config/poolRoyaleTableModels.js`).
- Implemented `offsetPoolRoyaleShowoodMetalAccentParts` which locates `railSight` and `sideWoodApron` parts using the metal-accent control and moves them a small amount outward from the table center, applied after reference materials are assigned (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Hooked the outward nudge into the external-template cloning flow by calling the offset function from `clonePoolRoyaleExternalTableTemplate`, and updated the Showood test expectations to cover the new value and current sizing constants (`test/poolRoyaleTableModels.test.js`).

### Testing
- Ran the unit test `test/poolRoyaleTableModels.test.js` with `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and it passed.
- Ran the webapp linter with `npx eslint --no-ignore --no-warn-ignored src/pages/Games/PoolRoyale.jsx` and no blocking issues were reported.
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db34b638883299e10b920b9f93b0c)