### PR TITLE
Integrate Gunify weapons into Ludo Battle Royal (models, thumbnails, texture policy)

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -60,6 +60,14 @@ const HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS = new Set([
   'assaultRifleAttack'
 ]);
 
+const GUNIFY_CAPTURE_ANIMATION_IDS = new Set([
+  'ak47VolleyAttack',
+  'krsvBurstAttack',
+  'mosinMarksmanAttack',
+  'sigsauerTacticalAttack',
+  'smithSidearmAttack',
+  'uziSprayAttack'
+]);
 
 const PREFERRED_CAPTURE_ANIMATION_BY_FAMILY = Object.freeze({
   pistol: 'sigsauerTacticalAttack',
@@ -120,6 +128,7 @@ const CAPTURE_ANIMATION_FAMILY_BY_ID = Object.freeze({
 
 const shouldShowCaptureAnimationInStore = (optionId) => {
   if (HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS.has(optionId)) return false;
+  if (GUNIFY_CAPTURE_ANIMATION_IDS.has(optionId)) return true;
   const family = CAPTURE_ANIMATION_FAMILY_BY_ID[optionId];
   if (!family) return true;
   return PREFERRED_CAPTURE_ANIMATION_BY_FAMILY[family] === optionId;

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -131,18 +131,22 @@ const captureWeaponGlyphThumb = (glyph = '▭', accent = '#334155') =>
     </svg>`
   )}`;
 
+const GUNIFY_RAW_BASE = 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main';
+const gunifyImage = (fileName) => `${GUNIFY_RAW_BASE}/images/${fileName}`;
+
 const CAPTURE_WEAPON_SOURCE_THUMBNAILS = Object.freeze({
-  glockSidearmAttack: 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/SigSauer.jpg',
-  pistolSidearmAttack: 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Smith.jpeg',
-  assaultRifleAttack: 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg',
-  ak47VolleyAttack:
-    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg',
-  smithSidearmAttack:
-    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Smith.jpeg',
+  glockSidearmAttack: gunifyImage('SigSauer.jpg'),
+  pistolSidearmAttack: gunifyImage('Smith.jpeg'),
+  assaultRifleAttack: gunifyImage('AK47.jpeg'),
+  ak47VolleyAttack: gunifyImage('AK47.jpeg'),
+  krsvBurstAttack: gunifyImage('KRSV.jpg'),
+  mosinMarksmanAttack: gunifyImage('Mosin.png'),
+  sigsauerTacticalAttack: gunifyImage('SigSauer.jpg'),
+  smithSidearmAttack: gunifyImage('Smith.jpeg'),
+  uziSprayAttack: gunifyImage('Uzi.png'),
   shotgunBlastAttack:
     'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/textures/shotgun_baseColor.png',
-  sniperShotAttack:
-    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Mosin.png'
+  sniperShotAttack: gunifyImage('Mosin.png')
 });
 
 export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
@@ -190,9 +194,9 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   },
   {
     id: 'uziSprayAttack',
-    label: 'Uzi Spray',
-    description: 'Fast SMG capture variation inspired by Tirana 2040 Uzi loadout.',
-    thumbnail: captureWeaponThumb('🔫', '#1e293b')
+    label: 'Gunify Uzi Spray',
+    description: 'Fast SMG capture using Gunify Uzi GLTF textures, metallic maps, and original preview art.',
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.uziSprayAttack
   },
   {
     id: 'ak47VolleyAttack',
@@ -202,9 +206,9 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   },
   {
     id: 'krsvBurstAttack',
-    label: 'KRSV Burst',
-    description: 'KRSV firearm burst using Gunify GLTF textures/material mapping.',
-    thumbnail: captureWeaponThumb('🎖️', '#6d28d9')
+    label: 'Gunify KRSV Burst',
+    description: 'KRSV firearm burst using Gunify steel base-color, normal, metallic-roughness, and emissive texture maps.',
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.krsvBurstAttack
   },
   {
     id: 'smithSidearmAttack',
@@ -214,15 +218,15 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   },
   {
     id: 'mosinMarksmanAttack',
-    label: 'Mosin Marksman',
-    description: 'Mosin long-range strike using Gunify GLTF textures and preserved materials.',
-    thumbnail: captureWeaponThumb('🎯', '#0f172a')
+    label: 'Gunify Mosin Marksman',
+    description: 'Mosin long-range strike using Gunify wood/metal PBR textures with original material mapping.',
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.mosinMarksmanAttack
   },
   {
     id: 'sigsauerTacticalAttack',
-    label: 'SigSauer Tactical',
-    description: 'SigSauer tactical burst using Gunify GLTF texture/material files.',
-    thumbnail: captureWeaponThumb('🔫', '#1d4ed8')
+    label: 'Gunify SigSauer Tactical',
+    description: 'SigSauer tactical burst using Gunify diffuse, normal, occlusion, emissive, and specular-gloss textures.',
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.sigsauerTacticalAttack
   },
   {
     id: 'grenadeBlastAttack',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -345,6 +345,17 @@ const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
   0: 2,
   2: 0
 });
+const GUNIFY_RAW_BASE = 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main';
+const GUNIFY_JSDELIVR_BASE = 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main';
+const gunifyModelUrls = (modelName) => [
+  `${GUNIFY_RAW_BASE}/models/${modelName}/scene.gltf`,
+  `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
+];
+const gunifyTextureUrls = (modelName, textureFileName) => [
+  `${GUNIFY_RAW_BASE}/models/${modelName}/textures/${textureFileName}`,
+  `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/textures/${textureFileName}`
+];
+
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
     label: 'MRTK Gun',
@@ -401,51 +412,51 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
     scale: 0.13
   },
   uziSprayAttack: {
-    label: 'Uzi',
-    urls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Uzi/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Uzi/scene.gltf'
-    ],
+    label: 'Gunify Uzi',
+    urls: gunifyModelUrls('Uzi'),
+    textureOverrideUrls: gunifyTextureUrls('Uzi', 'Material__90_baseColor.png'),
+    source: 'Gunify',
+    texturePolicy: 'gunifyPbr',
     scale: 0.2
   },
   ak47VolleyAttack: {
-    label: 'AK-47',
-    urls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
-    ],
+    label: 'Gunify AK-47',
+    urls: gunifyModelUrls('AK47'),
+    textureOverrideUrls: gunifyTextureUrls('AK47', 'Material.001_baseColor.png'),
+    source: 'Gunify',
+    texturePolicy: 'gunifyPbr',
     scale: 0.24
   },
   krsvBurstAttack: {
-    label: 'KRSV',
-    urls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf'
-    ],
+    label: 'Gunify KRSV',
+    urls: gunifyModelUrls('KRSV'),
+    textureOverrideUrls: gunifyTextureUrls('KRSV', 'Steel_baseColor.png'),
+    source: 'Gunify',
+    texturePolicy: 'gunifyPbr',
     scale: 0.24
   },
   smithSidearmAttack: {
-    label: 'Smith',
-    urls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf'
-    ],
+    label: 'Gunify Smith',
+    urls: gunifyModelUrls('Smith'),
+    textureOverrideUrls: gunifyTextureUrls('Smith', 'Metal_baseColor.png'),
+    source: 'Gunify',
+    texturePolicy: 'gunifyPbr',
     scale: 0.13
   },
   mosinMarksmanAttack: {
-    label: 'Mosin',
-    urls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Mosin/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Mosin/scene.gltf'
-    ],
+    label: 'Gunify Mosin',
+    urls: gunifyModelUrls('Mosin'),
+    textureOverrideUrls: gunifyTextureUrls('Mosin', 'Mosin_baseColor.png'),
+    source: 'Gunify',
+    texturePolicy: 'gunifyPbr',
     scale: 0.5125
   },
   sigsauerTacticalAttack: {
-    label: 'SigSauer Tactical',
-    urls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/SigSauer/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/SigSauer/scene.gltf'
-    ],
+    label: 'Gunify SigSauer Tactical',
+    urls: gunifyModelUrls('SigSauer'),
+    textureOverrideUrls: gunifyTextureUrls('SigSauer', 'Material_diffuse.png'),
+    source: 'Gunify',
+    texturePolicy: 'gunifyPbr',
     scale: 0.13
   },
   grenadeBlastAttack: {
@@ -468,11 +479,11 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
     scale: 0.24
   },
   sniperShotAttack: {
-    label: 'Sniper Shot',
-    urls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Mosin/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Mosin/scene.gltf'
-    ],
+    label: 'Gunify Mosin Sniper Shot',
+    urls: gunifyModelUrls('Mosin'),
+    textureOverrideUrls: gunifyTextureUrls('Mosin', 'Mosin_baseColor.png'),
+    source: 'Gunify',
+    texturePolicy: 'gunifyPbr',
     scale: 0.504
   },
   smgBurstAttack: {
@@ -622,6 +633,21 @@ function applyModelQualityToObject(root) {
       material.needsUpdate = true;
     });
   });
+}
+
+function applyGunifyWeaponTexturePolicy(material) {
+  if (!material) return;
+  ['map', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'emissiveMap', 'specularMap'].forEach((textureKey) => {
+    const texture = material[textureKey];
+    if (!texture) return;
+    if (textureKey === 'map' || textureKey === 'emissiveMap') applySRGBColorSpace(texture);
+    texture.flipY = false;
+    texture.anisotropy = Math.max(texture.anisotropy || 1, activeModelTextureAnisotropy);
+    texture.needsUpdate = true;
+  });
+  if (typeof material.roughness === 'number') material.roughness = Math.min(0.9, Math.max(0.34, material.roughness));
+  if (typeof material.metalness === 'number') material.metalness = Math.min(1, Math.max(0.18, material.metalness));
+  material.needsUpdate = true;
 }
 
 const FIREARM_SHOTGUN_IDS = new Set([
@@ -1433,6 +1459,7 @@ async function loadCaptureWeaponModel(captureAnimationId) {
           if (material?.map) applySRGBColorSpace(material.map);
           if (!material?.map && textureOverride) material.map = textureOverride;
           if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
+          if (config?.texturePolicy === 'gunifyPbr') applyGunifyWeaponTexturePolicy(material);
           material.transparent = false;
           material.opacity = 1;
           material.needsUpdate = true;


### PR DESCRIPTION
### Motivation
- Make the Gunify weapon set usable and visible in the Ludo Battle Royal inventory and capture flows using the Gunify GLTFs and their authored PBR textures. 
- Preserve Gunify material maps and color correctness when loading remote GLTF/GLB assets so weapons render correctly in Three.js scenes.

### Description
- Expose Gunify capture animations in the store by adding a `GUNIFY_CAPTURE_ANIMATION_IDS` allowlist and updating `shouldShowCaptureAnimationInStore` to always show those ids (changes in `webapp/src/config/ludoBattleInventoryConfig.js`).
- Replace inline Gunify thumbnail URLs with a reusable `gunifyImage` helper and update capture option labels/descriptions to reference Gunify preview art (changes in `webapp/src/config/ludoBattleOptions.js`).
- Centralize Gunify model/texture URLs via `gunifyModelUrls` and `gunifyTextureUrls` helpers and route Gunify weapon entries through them (changes in `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Add a `gunifyPbr` texture policy and `applyGunifyWeaponTexturePolicy` to enforce `flipY`, anisotropy, correct sRGB handling for color/emissive maps, and sane `roughness`/`metalness` ranges during model setup, and wire it into the GLTF load/material normalization path (changes in `webapp/src/pages/Games/LudoBattleRoyal.jsx`).

### Testing
- Ran `npm run lint` in `webapp` and it completed without errors.
- Ran full production build with `npm run build` in `webapp` and the build completed successfully (Vite production build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e566476488329a997df9f44418ace)