### PR TITLE
Enable Pool Royale chrome plate ↔ Showood reference-part swap

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -28,6 +28,8 @@ describe('Pool Royale table models', () => {
     assert.equal(royal.keepGeneratedPocketsAndJaws, true);
     assert.equal(royal.hideGeneratedPocketsAndJaws, false);
     assert.equal(royal.forceGeneratedChromePlates, true);
+    assert.equal(royal.useReferenceShowoodPartVisibility, true);
+    assert.deepEqual(royal.referencePartsForExternalTrimStyle, ['railSight', 'sideWoodApron']);
     assert.equal(royal.fitScale, 1.055);
     assert.deepEqual(royal.usePoolRoyaleFinishRoles, ['cloth']);
     assert.deepEqual(royal.hideSurfaceRoles, ['trim', 'wood', 'cushion', 'pocket']);
@@ -52,6 +54,7 @@ describe('Pool Royale table models', () => {
       'pocket'
     ]);
     assert.equal(showood.forceGeneratedChromePlates, false);
+    assert.deepEqual(showood.hideReferencePartsWithGeneratedChrome, ['railSight', 'sideWoodApron']);
     assert.equal(showood.upperFrameHeightScale, 0.58);
     assert.equal(showood.cornerRimHeightScale, 0.28);
     assert.equal(showood.markingVisualLift, 0.024);
@@ -63,6 +66,23 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.sideApronVisualHeightScale, 1.07);
     assert.equal(showood.sideApronOutwardOffset, 0.018);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, ['cloth', 'cushion', 'wood']);
+  });
+
+  test('Pool Royale chrome plate styles swap Showood reference apron parts with procedural plates', async () => {
+    const game = await readFile('webapp/src/pages/Games/PoolRoyale.jsx', 'utf8');
+
+    assert.ok(
+      game.includes('chromePlateStyle.showGeneratedOnExternal'),
+      'game should show generated procedural chrome plates when the Royal Classic style is selected on external tables'
+    );
+    assert.ok(
+      game.includes('hideReferencePartsWithGeneratedChrome'),
+      'game should hide Showood rail sights and side aprons when generated chrome plates are selected'
+    );
+    assert.ok(
+      game.includes('referencePartsForExternalTrimStyle'),
+      'game should expose Showood rail sights and side aprons on Royal Original when the Showood rounded style preserves external trim'
+    );
   });
 
   test('Pool Royale game uses one shared table finish/base menu for Royal and Showood', async () => {

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -26,6 +26,8 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     matchNativeUpperComponentHeight: true,
     useOriginalLayoutSurfaces: false,
     usePoolRoyaleFinish: true,
+    useReferenceShowoodPartVisibility: true,
+    referencePartsForExternalTrimStyle: ['railSight', 'sideWoodApron'],
     usePoolRoyaleFinishRoles: ['cloth'],
     cushionUsesClothFinish: false,
     hideGeneratedCushionsAndJaws: false,
@@ -80,6 +82,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     preserveSourceTextureRoles: ['railSight', 'sideWoodApron', 'baseFoot', 'trim', 'pocket'],
     preserveOriginalSurfaceRoles: [],
     tintOriginalTrimGold: false,
+    hideReferencePartsWithGeneratedChrome: ['railSight', 'sideWoodApron'],
     forceGeneratedChromePlates: false,
     hideSurfaceRoles: [],
     hideGeneratedRailMarkers: true

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12888,10 +12888,28 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     const prepareMaterial = (material) => {
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
-      const referencePart = tableModel?.useReferenceShowoodMapping
+      const referencePart = (tableModel?.useReferenceShowoodMapping || tableModel?.useReferenceShowoodPartVisibility)
         ? classifyPoolRoyaleShowoodReferencePart(child, material)
         : null;
-      if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
+      const shownReferenceParts = Array.isArray(tableModel?.showReferenceParts)
+        ? tableModel.showReferenceParts
+        : [];
+      const hiddenReferenceParts = Array.isArray(tableModel?.hideReferenceParts)
+        ? tableModel.hideReferenceParts
+        : [];
+      const keepReferencePartVisible = Boolean(referencePart && shownReferenceParts.includes(referencePart));
+      if (referencePart && hiddenReferenceParts.includes(referencePart)) {
+        child.visible = false;
+        child.userData = {
+          ...(child.userData || {}),
+          poolRoyaleExternalReferencePartHidden: referencePart
+        };
+      }
+      if (
+        !keepReferencePartVisible &&
+        Array.isArray(tableModel?.hideSurfaceRoles) &&
+        tableModel.hideSurfaceRoles.includes(role)
+      ) {
         child.visible = false;
       }
       if (
@@ -14378,21 +14396,46 @@ function mountPoolRoyaleExternalTableModel({
   };
   const externalTableModelForMount =
     resolvedTableOptions?.tableModel?.kind === 'gltf'
-      ? {
-          ...resolvedTableOptions.tableModel,
-          preserveOriginalSurfaceRoles: resolvedTableOptions.tableModel.useReferenceShowoodMapping
-            ? (resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles || [])
-            : resolvedTableOptions.tableModel.useOriginalLayoutSurfaces
-              ? Array.from(new Set([
-                  ...(resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles || []),
-                  'trim'
-                ]))
-              : chromePlateStyle.preserveExternalTrim
-              ? resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles
-              : resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles?.filter(
-                  (role) => role !== 'trim'
-                )
-        }
+      ? (() => {
+          const tableModel = resolvedTableOptions.tableModel;
+          const showReferenceParts = new Set(
+            Array.isArray(tableModel.showReferenceParts) ? tableModel.showReferenceParts : []
+          );
+          const hideReferenceParts = new Set(
+            Array.isArray(tableModel.hideReferenceParts) ? tableModel.hideReferenceParts : []
+          );
+          if (chromePlateStyle.preserveExternalTrim) {
+            (Array.isArray(tableModel.referencePartsForExternalTrimStyle)
+              ? tableModel.referencePartsForExternalTrimStyle
+              : []
+            ).forEach((part) => showReferenceParts.add(part));
+          }
+          if (chromePlateStyle.showGeneratedOnExternal) {
+            (Array.isArray(tableModel.hideReferencePartsWithGeneratedChrome)
+              ? tableModel.hideReferencePartsWithGeneratedChrome
+              : []
+            ).forEach((part) => hideReferenceParts.add(part));
+          }
+          return {
+            ...tableModel,
+            forceGeneratedChromePlates:
+              Boolean(tableModel.forceGeneratedChromePlates) || Boolean(chromePlateStyle.showGeneratedOnExternal),
+            showReferenceParts: Array.from(showReferenceParts),
+            hideReferenceParts: Array.from(hideReferenceParts),
+            preserveOriginalSurfaceRoles: tableModel.useReferenceShowoodMapping
+              ? (tableModel.preserveOriginalSurfaceRoles || [])
+              : tableModel.useOriginalLayoutSurfaces
+                ? Array.from(new Set([
+                    ...(tableModel.preserveOriginalSurfaceRoles || []),
+                    'trim'
+                  ]))
+                : chromePlateStyle.preserveExternalTrim
+                ? tableModel.preserveOriginalSurfaceRoles
+                : tableModel.preserveOriginalSurfaceRoles?.filter(
+                    (role) => role !== 'trim'
+                  )
+          };
+        })()
       : null;
   const externalTable =
     externalTableModelForMount?.kind === 'gltf'


### PR DESCRIPTION
### Motivation
- Let the Royal Original procedural table and the Showood GLB interact so players can pick procedural chrome plates while preserving or hiding Showood reference parts as appropriate. 
- When a procedural chrome style (Royal Classic) is selected, the Showood GLB should be able to hide its `railSight` and `sideWoodApron` parts so generated chrome plates display cleanly. 
- When the Showood rounded chrome style preserves external trim, Royal Original should be able to surface the Showood `railSight` and `sideWoodApron` pieces on the procedural table.

### Description
- Add table-model flags to `webapp/src/config/poolRoyaleTableModels.js`: `useReferenceShowoodPartVisibility` and `referencePartsForExternalTrimStyle` for `royal-original`, and `hideReferencePartsWithGeneratedChrome` for `showood-seven-foot` to declare the two-way behavior. 
- Extend external-material preparation in `webapp/src/pages/Games/PoolRoyale.jsx` so `preparePoolRoyaleExternalTableMaterials` will detect `referencePart` for a mesh and apply new visibility rules using `showReferenceParts` / `hideReferenceParts`, and mark hidden reference parts with `poolRoyaleExternalReferencePartHidden`. 
- Compute a mounting-time `externalTableModelForMount` that merges `chromePlateStyle` policy with per-model `referencePartsForExternalTrimStyle` / `hideReferencePartsWithGeneratedChrome` so the final external model receives `showReferenceParts`, `hideReferenceParts`, and a `forceGeneratedChromePlates` flag when appropriate. 
- Add unit coverage in `test/poolRoyaleTableModels.test.js` for the new configuration fields and a test asserting the chrome-plate → reference-part swap behaviour is present in the source.

### Testing
- Ran the focused unit tests: `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and all tests in that file passed (7/7). 
- Built the webapp: `npm --prefix webapp run build` / top-level `npm run build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5bdbeab48329ba96f05f16ab86bf)