### PR TITLE
Allow Pool Royale Showood chrome rail swaps

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3687,6 +3687,7 @@ const CHROME_PLATE_STYLE_OPTIONS = Object.freeze([
     swatches: ['#f6d56f', '#d6d8dc'],
     showGeneratedOnExternal: false,
     preserveExternalTrim: true,
+    preserveExternalReferenceParts: ['railSight', 'sideWoodApron'],
     cornerWidthScale: 1.1,
     cornerHeightScale: 1.08,
     cornerRadiusScale: 1.9,
@@ -3704,6 +3705,7 @@ const CHROME_PLATE_STYLE_OPTIONS = Object.freeze([
     swatches: ['#d6d8dc', '#d4af37'],
     showGeneratedOnExternal: true,
     preserveExternalTrim: false,
+    hideExternalReferenceParts: ['railSight', 'sideWoodApron'],
     cornerWidthScale: 1,
     cornerHeightScale: 1,
     cornerRadiusScale: 1,
@@ -12756,6 +12758,37 @@ function normalizePoolRoyaleExternalClothTextureScale(mesh, material, role) {
   material.needsUpdate = true;
 }
 
+function resolvePoolRoyaleExternalReferencePartsForStyle(tableModel, chromePlateStyle, propertyName) {
+  const parts = new Set();
+  if (Array.isArray(tableModel?.[propertyName])) {
+    tableModel[propertyName].forEach((part) => {
+      if (typeof part === 'string' && part.trim()) parts.add(part.trim());
+    });
+  }
+  if (Array.isArray(chromePlateStyle?.[propertyName])) {
+    chromePlateStyle[propertyName].forEach((part) => {
+      if (typeof part === 'string' && part.trim()) parts.add(part.trim());
+    });
+  }
+  return parts;
+}
+
+function shouldHidePoolRoyaleExternalTableSurface({ tableModel, role, referencePart, referenceParts }) {
+  if (!tableModel) return false;
+  const allReferenceParts = Array.isArray(referenceParts) && referenceParts.length
+    ? referenceParts
+    : [referencePart].filter(Boolean);
+  const preserveReferenceParts = Array.isArray(tableModel.preserveExternalReferenceParts)
+    ? tableModel.preserveExternalReferenceParts
+    : [];
+  if (allReferenceParts.some((part) => preserveReferenceParts.includes(part))) return false;
+  const hideReferenceParts = Array.isArray(tableModel.hideExternalReferenceParts)
+    ? tableModel.hideExternalReferenceParts
+    : [];
+  if (allReferenceParts.some((part) => hideReferenceParts.includes(part))) return true;
+  return Array.isArray(tableModel.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role);
+}
+
 function applyPoolRoyaleFinishToExternalMaterial(material, role, finishInfo, tableModel = null) {
   if (!material || !finishInfo) return material;
   const finishRoles = Array.isArray(tableModel?.usePoolRoyaleFinishRoles)
@@ -12885,14 +12918,33 @@ function preparePoolRoyaleExternalTableMaterials(root, tableModel = null, finish
     child.receiveShadow = true;
     child.frustumCulled = false;
 
+    const needsReferencePartVisibility = tableModel?.useReferenceShowoodMapping ||
+      Array.isArray(tableModel?.preserveExternalReferenceParts) ||
+      Array.isArray(tableModel?.hideExternalReferenceParts);
+    const childMaterials = Array.isArray(child.material) ? child.material : [child.material].filter(Boolean);
+    const childReferenceParts = needsReferencePartVisibility
+      ? childMaterials.map((entry) => classifyPoolRoyaleShowoodReferencePart(child, entry))
+      : [];
+
     const prepareMaterial = (material) => {
       if (!material) return material;
       const role = classifyPoolRoyaleExternalTableSurface(child, material);
-      const referencePart = tableModel?.useReferenceShowoodMapping
+      const referencePart = needsReferencePartVisibility
         ? classifyPoolRoyaleShowoodReferencePart(child, material)
         : null;
-      if (Array.isArray(tableModel?.hideSurfaceRoles) && tableModel.hideSurfaceRoles.includes(role)) {
+      if (shouldHidePoolRoyaleExternalTableSurface({
+        tableModel,
+        role,
+        referencePart,
+        referenceParts: childReferenceParts
+      })) {
         child.visible = false;
+        child.userData = {
+          ...(child.userData || {}),
+          poolRoyaleExternalSurfaceHidden: true,
+          poolRoyaleExternalSurfaceHiddenRole: role,
+          poolRoyaleExternalSurfaceHiddenReferencePart: referencePart
+        };
       }
       if (
         tableModel?.hideOriginalBaseAndLegsForProceduralBase &&
@@ -14380,6 +14432,23 @@ function mountPoolRoyaleExternalTableModel({
     resolvedTableOptions?.tableModel?.kind === 'gltf'
       ? {
           ...resolvedTableOptions.tableModel,
+          forceGeneratedChromePlates: Boolean(
+            resolvedTableOptions.tableModel.forceGeneratedChromePlates || chromePlateStyle.showGeneratedOnExternal
+          ),
+          preserveExternalReferenceParts: Array.from(
+            resolvePoolRoyaleExternalReferencePartsForStyle(
+              resolvedTableOptions.tableModel,
+              chromePlateStyle,
+              'preserveExternalReferenceParts'
+            )
+          ),
+          hideExternalReferenceParts: Array.from(
+            resolvePoolRoyaleExternalReferencePartsForStyle(
+              resolvedTableOptions.tableModel,
+              chromePlateStyle,
+              'hideExternalReferenceParts'
+            )
+          ),
           preserveOriginalSurfaceRoles: resolvedTableOptions.tableModel.useReferenceShowoodMapping
             ? (resolvedTableOptions.tableModel.preserveOriginalSurfaceRoles || [])
             : resolvedTableOptions.tableModel.useOriginalLayoutSurfaces


### PR DESCRIPTION
### Motivation
- Enable mutually-compatible chrome plate behavior between the procedural Royal Original table and the external Showood GLB so users can choose procedural chrome plates without visual overlap. 
- Allow the Showood GLB to retain its original `railSight` and `sideWoodApron` when a Showood-style chrome is selected for the hybrid Royal Original configuration. 
- Provide finer-grained control over which semantic GLB parts (rail sights, side aprons, etc.) are preserved or hidden when mounting external table models.

### Description
- Added new chrome style metadata properties on `CHROME_PLATE_STYLE_OPTIONS`: `preserveExternalReferenceParts` and `hideExternalReferenceParts` and augmented the `showood-rounded` and `royal-classic` styles to preserve or hide `railSight` and `sideWoodApron` as required. 
- Introduced helper functions `resolvePoolRoyaleExternalReferencePartsForStyle` and `shouldHidePoolRoyaleExternalTableSurface` to aggregate style + model signals and decide visibility at the semantic reference-part level. 
- Updated `preparePoolRoyaleExternalTableMaterials` to compute per-mesh `referenceParts` (multi-material-aware) and to hide or keep meshes based on the new helpers; marked hidden meshes via `userData` flags so downstream code can reason about them. 
- Wired the resolved style decisions into the external mount workflow by extending the `externalTableModelForMount` object to include `forceGeneratedChromePlates`, computed `preserveExternalReferenceParts`, and `hideExternalReferenceParts`, enabling procedural chrome plates to be forced or GLB parts to be hidden when appropriate.

### Testing
- Ran `npm run build` (TypeScript compile) and it completed successfully. 
- Ran `git diff --check -- webapp/src/pages/Games/PoolRoyale.jsx` and there were no whitespace/indexing errors. 
- Ran ESLint on the file; ESLint returned a project ignore warning for this file (no lint errors were applied to `PoolRoyale.jsx`), so no lint failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5bdbeab48329ba96f05f16ab86bf)