### PR TITLE
Fix Chess Battle Royal private lobby matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -638,39 +638,35 @@ function ensureRegistered(socket, tpcAccountNumber) {
   return true;
 }
 
-function getAvailableTable(
-  gameType,
-  stake = 0,
-  maxPlayers = 4,
-  matchMeta = {},
-  forcedTableId = null
-) {
-  const normalizedMeta = normalizeMatchMeta(matchMeta);
+function parseStructuredLobbyTableId(tableId) {
+  if (!tableId) return null;
+  const [prefix, capStr] = String(tableId).split('-');
+  const parsedCap = Number(capStr);
+  if (
+    !GAME_ONLINE_POLICY[prefix] ||
+    !Number.isFinite(parsedCap) ||
+    parsedCap <= 0
+  ) {
+    return null;
+  }
+  return { gameType: normalizeOnlineGameType(prefix), maxPlayers: parsedCap };
+}
+
+function getForcedTableJoinError(existing, gameType, stake, maxPlayers, normalizedMeta) {
+  if (!existing) return '';
+  if (existing.gameType !== gameType) return 'game_type_mismatch';
+  if (Number(existing.stake || 0) !== Number(stake || 0)) return 'stake_mismatch';
+  if (existing.maxPlayers !== maxPlayers) return 'table_unavailable';
+  if (existing.players.length >= existing.maxPlayers) return 'table_full';
+  if (!isMatchMetaCompatible(existing.meta, normalizedMeta, gameType)) return 'table_unavailable';
+  return '';
+}
+
+function createLobbyTable(gameType, stake, maxPlayers, normalizedMeta, tableId = randomUUID()) {
   const key = `${gameType}-${maxPlayers}`;
   if (!lobbyTables[key]) lobbyTables[key] = [];
-  if (forcedTableId) {
-    const existing = tableMap.get(forcedTableId);
-    if (existing) {
-      const normalizedStake = Number(stake) || 0;
-      const canJoinForced =
-        existing.gameType === gameType &&
-        Number(existing.stake || 0) === normalizedStake &&
-        existing.players.length < existing.maxPlayers &&
-        isMatchMetaCompatible(existing.meta, normalizedMeta, gameType);
-      if (canJoinForced) return existing;
-    }
-    // Ignore stale/non-existent forced ids so quick matchmaking can still pair
-    // users by game type + stake instead of trapping them in a private table.
-  }
-  const open = lobbyTables[key].find(
-    (t) =>
-      t.stake === stake &&
-      t.players.length < t.maxPlayers &&
-      isMatchMetaCompatible(t.meta, normalizedMeta, gameType)
-  );
-  if (open) return open;
   const table = {
-    id: randomUUID(),
+    id: tableId,
     gameType,
     stake,
     maxPlayers,
@@ -685,6 +681,53 @@ function getAvailableTable(
     `Created new table: ${table.id} (${gameType}, cap ${maxPlayers}, stake: ${stake})`
   );
   return table;
+}
+
+function getAvailableTable(
+  gameType,
+  stake = 0,
+  maxPlayers = 4,
+  matchMeta = {},
+  forcedTableId = null
+) {
+  const normalizedMeta = normalizeMatchMeta(matchMeta);
+  const key = `${gameType}-${maxPlayers}`;
+  if (!lobbyTables[key]) lobbyTables[key] = [];
+  const structuredForcedTable = parseStructuredLobbyTableId(forcedTableId);
+  const shouldReserveForcedTable =
+    structuredForcedTable &&
+    structuredForcedTable.gameType === gameType &&
+    structuredForcedTable.maxPlayers === maxPlayers;
+
+  if (forcedTableId) {
+    const existing = tableMap.get(forcedTableId);
+    if (existing) {
+      const forcedJoinError = getForcedTableJoinError(
+        existing,
+        gameType,
+        stake,
+        maxPlayers,
+        normalizedMeta
+      );
+      if (!forcedJoinError) return existing;
+      if (shouldReserveForcedTable) return { joinError: forcedJoinError };
+    }
+
+    if (shouldReserveForcedTable) {
+      return createLobbyTable(gameType, stake, maxPlayers, normalizedMeta, forcedTableId);
+    }
+
+    // Ignore stale/non-existent forced ids so quick matchmaking can still pair
+    // users by game type + stake instead of trapping them in a private table.
+  }
+  const open = lobbyTables[key].find(
+    (t) =>
+      t.stake === stake &&
+      t.players.length < t.maxPlayers &&
+      isMatchMetaCompatible(t.meta, normalizedMeta, gameType)
+  );
+  if (open) return open;
+  return createLobbyTable(gameType, stake, maxPlayers, normalizedMeta);
 }
 
 function resolveSeatIdentityFromTableId(tableId, fallbackGameType, fallbackMaxPlayers) {
@@ -1252,6 +1295,7 @@ async function seatTableSocket(
     matchMeta,
     forcedTableId
   );
+  if (!table || table.joinError) return table;
   const tableId = table.id;
   cleanupSeats();
   // Ensure this user is not seated at any other table
@@ -2148,7 +2192,7 @@ io.on('connection', (socket) => {
           safeMeta
         );
       }
-      if (table && cb) {
+      if (table && !table.joinError && cb) {
         cb({
           success: true,
           tableId: table.id,
@@ -2158,7 +2202,7 @@ io.on('connection', (socket) => {
           meta: table.meta
         });
       } else if (cb) {
-        cb({ success: false, error: 'table_join_failed' });
+        cb({ success: false, error: table?.joinError || 'table_join_failed' });
       }
     }
   );

--- a/test/chessPrivateCodeMatchmaking.test.js
+++ b/test/chessPrivateCodeMatchmaking.test.js
@@ -1,0 +1,159 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+function connectSocket(port) {
+  return io(`http://localhost:${port}`, { auth: { token: apiToken } });
+}
+
+function register(socket, playerId) {
+  return new Promise((resolve) => {
+    socket.emit('register', { playerId }, resolve);
+  });
+}
+
+function seat(socket, payload) {
+  return new Promise((resolve) => {
+    socket.emit('seatTable', payload, resolve);
+  });
+}
+
+test(
+  'chess private code reserves the requested table id so both phones join the same lobby',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const port = '3214';
+    const env = {
+      ...process.env,
+      PORT: port,
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const s1 = connectSocket(port);
+    const s2 = connectSocket(port);
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve))
+      ]);
+      await Promise.all([register(s1, 'chess-private-a'), register(s2, 'chess-private-b')]);
+
+      const privateTableId = 'chess-2-host-FRIEND123';
+      const firstSeat = await seat(s1, {
+        accountId: 'chess-private-a',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: privateTableId
+      });
+      const secondSeat = await seat(s2, {
+        accountId: 'chess-private-b',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: privateTableId
+      });
+
+      assert.equal(firstSeat.success, true);
+      assert.equal(firstSeat.tableId, privateTableId);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, privateTableId);
+      assert.equal(secondSeat.players.length, 2);
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      server.kill();
+    }
+  }
+);
+
+test(
+  'chess private code rejects a different stake instead of silently entering another table',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const port = '3215';
+    const env = {
+      ...process.env,
+      PORT: port,
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const s1 = connectSocket(port);
+    const s2 = connectSocket(port);
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve))
+      ]);
+      await Promise.all([register(s1, 'chess-stake-private-a'), register(s2, 'chess-stake-private-b')]);
+
+      const privateTableId = 'chess-2-host-STAKELOCK';
+      const firstSeat = await seat(s1, {
+        accountId: 'chess-stake-private-a',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: privateTableId
+      });
+      const mismatchedSeat = await seat(s2, {
+        accountId: 'chess-stake-private-b',
+        gameType: 'chess',
+        stake: 500,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: privateTableId
+      });
+
+      assert.equal(firstSeat.success, true);
+      assert.equal(firstSeat.tableId, privateTableId);
+      assert.equal(mismatchedSeat.success, false);
+      assert.equal(mismatchedSeat.error, 'stake_mismatch');
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      server.kill();
+    }
+  }
+);


### PR DESCRIPTION
### Motivation
- Private lobby codes like `chess-2-host-XXXX` should reserve a table so two phones using the same code join the same lobby instead of falling through to unrelated quick-match tables.
- When a forced/private table id is provided, the server must reject incompatible joins (stake, game type, capacity, fullness, or metadata) with explicit errors instead of silently seating the player elsewhere.

### Description
- Added structured private-table handling in `bot/server.js` by parsing structured lobby ids and adding `parseStructuredLobbyTableId`, `getForcedTableJoinError`, and `createLobbyTable` helpers to centralize reserved-table logic.
- Changed `getAvailableTable` to reserve or validate structured forced ids and return a `{ joinError }` when a reserved id exists but the join is incompatible, otherwise create or reuse the proper table.
- Updated `seatTableSocket` and the `seatTable` acknowledgement flow to propagate `joinError` back to the client so callers receive clear failure codes (e.g., `stake_mismatch`, `table_full`, `game_type_mismatch`).
- Added regression tests `test/chessPrivateCodeMatchmaking.test.js` covering same-code private seating and stake-mismatch rejection, and included the test file in the repo.

### Testing
- Ran the new and related test suites with `node --test test/chessPrivateCodeMatchmaking.test.js` and `node --test test/chessLobbyPreferredSideMatchmaking.test.js test/chessLobbyStaleTableIdMatchmaking.test.js test/chessOnlineMoveValidation.test.js`, all of which passed (tests reported as passing in the run logs).
- Executed the webapp linter with `npm --prefix webapp run lint -- --quiet` which completed without errors.
- Verified socket seat/confirm flows by exercising `seatTable`/`confirmReady` in the unit tests that simulate multiple clients and asserted expected `tableId` and error responses (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6976f3ac8329861f004b944c2fa4)