### PR TITLE
Fix Domino Royal online lobby connection

### DIFF
--- a/test/dominoRoyalRuntimeScript.test.js
+++ b/test/dominoRoyalRuntimeScript.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, test } from '@jest/globals';
+import fs from 'fs';
+
+const scriptPath = new URL('../webapp/public/domino-royal-game.js', import.meta.url);
+
+describe('Domino Royal runtime script', () => {
+  test('declares accountId before onlineAccountId so online mode can bootstrap', () => {
+    const source = fs.readFileSync(scriptPath, 'utf8');
+    const accountIndex = source.indexOf("const accountId = (urlParams.get('accountId') || '').trim();");
+    const onlineIndex = source.indexOf('const onlineAccountId = accountId;');
+
+    expect(accountIndex).toBeGreaterThanOrEqual(0);
+    expect(onlineIndex).toBeGreaterThan(accountIndex);
+  });
+});

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -40,6 +40,20 @@ describe('online game policy', () => {
     });
   });
 
+  test('accepts two-player Domino Royal online tables for direct tests', () => {
+    const domino = validateSeatTableRequest({
+      gameType: 'domino-royal',
+      stake: 100,
+      maxPlayers: 2,
+      matchMeta: { variant: 'single', mode: 'online', token: 'TPC' }
+    });
+
+    expect(domino.ok).toBe(true);
+    expect(domino.normalizedGameType).toBe('domino-royal');
+    expect(domino.normalizedMaxPlayers).toBe(2);
+    expect(domino.safeMatchMeta).toEqual({ variant: 'single', mode: 'online', token: 'TPC' });
+  });
+
   test('accepts chess and checkers lobby aliases used by seatTable clients', () => {
     const chess = validateSeatTableRequest({
       gameType: 'chess',

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1109,7 +1109,6 @@ const gameMode = (urlParams.get('mode') || 'local').toLowerCase();
 const isVsAiMatch = gameMode === 'local';
 const isOnlineMatch = gameMode === 'online';
 const onlineTableId = (urlParams.get('tableId') || urlParams.get('table') || '').trim();
-const onlineAccountId = accountId;
 let onlineSocket = typeof window !== 'undefined' ? window.__TONPLAYGRAM_SOCKET__ : null;
 let latestOnlineMoveSeq = -1;
 let detachOnlineDominoSync = null;
@@ -1117,6 +1116,7 @@ const shouldRunHallwayEntry = !USE_MINIMAL_STAGE && entryMode === 'hallway';
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
 const accountId = (urlParams.get('accountId') || '').trim();
+const onlineAccountId = accountId;
 const telegramId = (
   urlParams.get('tgId') ||
   urlParams.get('telegramId') ||

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -16,7 +16,7 @@ import { loadAvatar } from '../../utils/avatarUtils.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
-import { socket } from '../../utils/socket.js';
+import { refreshSocketAuthIdentity, socket } from '../../utils/socket.js';
 import { getOnlineReadiness } from '../../config/onlineContract.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
@@ -50,6 +50,14 @@ const TARGET_POINTS_OPTIONS = [51, 101];
 
 const SOCKET_CONNECT_TIMEOUT_MS = 12000;
 const SOCKET_ACK_TIMEOUT_MS = 7000;
+const MATCHMAKING_TIMEOUT_MS = 45000;
+
+const MATCHMAKING_RECOVERABLE_ERRORS = new Set([
+  'identity_mismatch',
+  'register_required',
+  'rate_limited',
+  'timeout'
+]);
 
 function waitForSocketConnection(socketInstance, timeoutMs = SOCKET_CONNECT_TIMEOUT_MS) {
   if (!socketInstance) return Promise.resolve(false);
@@ -126,8 +134,42 @@ export default function DominoRoyalLobby() {
   const [matchStatus, setMatchStatus] = useState('');
   const [matchingError, setMatchingError] = useState('');
   const pendingOnlineRef = useRef({ tableId: '', accountId: '', launched: false });
+  const matchmakingTimeoutRef = useRef(null);
+  const stakeDebitedRef = useRef(false);
+  const stakeRefundedRef = useRef(false);
   const startBet = stake.amount / 100;
   const readiness = getOnlineReadiness('domino-royal');
+
+  const clearMatchmakingTimeout = () => {
+    if (matchmakingTimeoutRef.current) {
+      clearTimeout(matchmakingTimeoutRef.current);
+      matchmakingTimeoutRef.current = null;
+    }
+  };
+
+  const refundOnlineStake = async (reason, accountId, tgId) => {
+    if (!accountId || !stakeDebitedRef.current || stakeRefundedRef.current) return;
+    stakeRefundedRef.current = true;
+    await addTransaction(tgId || getTelegramId(), stake.amount, 'stake_refund', {
+      game: 'domino-online',
+      players: totalPlayers,
+      accountId,
+      reason
+    }).catch(() => {});
+  };
+
+  const resetPendingOnlineSeat = ({ leave = false } = {}) => {
+    const pending = pendingOnlineRef.current;
+    clearMatchmakingTimeout();
+    if (leave && pending.tableId && pending.accountId && !pending.launched) {
+      socket.emit('leaveLobby', {
+        accountId: pending.accountId,
+        tpcAccountNumber: pending.accountId,
+        tableId: pending.tableId
+      });
+    }
+    pendingOnlineRef.current = { tableId: '', accountId: '', launched: false };
+  };
 
   const maxPlayers = PLAYER_OPTIONS[PLAYER_OPTIONS.length - 1];
   const totalPlayers = Math.max(2, Math.min(maxPlayers, playerCount));
@@ -244,15 +286,18 @@ export default function DominoRoyalLobby() {
       accountId = await ensureAccountId();
       tgId = getTelegramId();
       if (mode !== 'local') {
+        stakeDebitedRef.current = false;
+        stakeRefundedRef.current = false;
         const balRes = await getAccountBalance(accountId);
         if ((balRes.balance || 0) < stake.amount) {
           alert('Insufficient balance');
           return;
         }
         await addTransaction(tgId, -stake.amount, 'stake', {
-          game: 'domino',
+          game: 'domino-online',
           accountId
         });
+        stakeDebitedRef.current = true;
       }
     } catch {}
 
@@ -261,12 +306,16 @@ export default function DominoRoyalLobby() {
       setMatching(true);
       setMatchingError('');
       setMatchStatus('Connecting to Domino Royal online lobby…');
+      resetPendingOnlineSeat({ leave: true });
       pendingOnlineRef.current = { tableId: '', accountId, launched: false };
+      refreshSocketAuthIdentity({ accountId: String(accountId) }, { reconnect: true });
 
       const connected = await waitForSocketConnection(socket);
       if (!connected) {
         setMatching(false);
-        setMatchingError('Could not connect to the online lobby. Check your network and try again.');
+        setMatchingError('Could not connect to the online lobby. Your stake was refunded.');
+        await refundOnlineStake('socket_connect_failed', accountId, tgId);
+        resetPendingOnlineSeat();
         return;
       }
 
@@ -278,14 +327,17 @@ export default function DominoRoyalLobby() {
       });
       if (registered?.success === false) {
         setMatching(false);
-        setMatchingError('Unable to register this account for online Domino. Please retry.');
+        setMatchingError('Unable to register this account for online Domino. Your stake was refunded.');
+        await refundOnlineStake('register_failed', accountId, tgId);
+        resetPendingOnlineSeat();
         return;
       }
 
       setMatchStatus(`Finding a ${totalPlayers}-player Domino table…`);
-      const res = await emitWithAck(socket, 'seatTable', {
+      const buildSeatPayload = () => ({
         accountId,
         tpcAccountNumber: accountId,
+        tpcAccountId: accountId,
         gameType: 'domino-royal',
         stake: Number(stake.amount) || 0,
         maxPlayers: totalPlayers,
@@ -300,13 +352,38 @@ export default function DominoRoyalLobby() {
           variant
         }
       });
+      let res = await emitWithAck(socket, 'seatTable', buildSeatPayload());
+      if ((!res.success || !res.tableId) && MATCHMAKING_RECOVERABLE_ERRORS.has(res.error)) {
+        setMatchStatus('Retrying Domino Royal matchmaking…');
+        if (res.error === 'identity_mismatch' || res.error === 'register_required') {
+          refreshSocketAuthIdentity({ accountId: String(accountId) }, { reconnect: true });
+          await waitForSocketConnection(socket, 5000);
+          await emitWithAck(socket, 'register', {
+            playerId: accountId,
+            accountId,
+            tpcAccountNumber: accountId
+          });
+        } else {
+          await new Promise((resolve) => setTimeout(resolve, 750));
+        }
+        res = await emitWithAck(socket, 'seatTable', buildSeatPayload());
+      }
       if (!res.success || !res.tableId) {
         setMatching(false);
-        setMatchingError('Unable to join Domino online table. Please try again.');
+        setMatchingError('Unable to join Domino online table. Your stake was refunded.');
+        await refundOnlineStake(`seat_failed:${res.error || 'unknown'}`, accountId, tgId);
+        resetPendingOnlineSeat({ leave: true });
         return;
       }
 
       pendingOnlineRef.current = { tableId: res.tableId, accountId, launched: false };
+      clearMatchmakingTimeout();
+      matchmakingTimeoutRef.current = setTimeout(() => {
+        setMatching(false);
+        setMatchingError('No Domino players joined in time. Your stake was refunded.');
+        refundOnlineStake('matchmaking_timeout', accountId, tgId);
+        resetPendingOnlineSeat({ leave: true });
+      }, MATCHMAKING_TIMEOUT_MS);
       const readyCount = Array.isArray(res.ready) ? res.ready.length : 0;
       const playerTotal = Array.isArray(res.players) ? res.players.length : 1;
       setMatchStatus(
@@ -363,6 +440,10 @@ export default function DominoRoyalLobby() {
         : null;
       if (!seat || pending.launched) return;
       pendingOnlineRef.current = { ...pending, tableId, launched: true };
+      clearMatchmakingTimeout();
+      setMatching(false);
+      stakeDebitedRef.current = false;
+      stakeRefundedRef.current = false;
       setMatchStatus('Starting Domino Royal synced match…');
       const token = meta?.token || stake.token || onlineStake?.token || 'TPC';
       const amount = Number(onlineStake?.amount || stake.amount || 0);
@@ -379,9 +460,12 @@ export default function DominoRoyalLobby() {
 
     socket.on('lobbyUpdate', handleLobbyUpdate);
     socket.on('gameStart', handleGameStart);
+    socket.on('gameStarted', handleGameStart);
     return () => {
       socket.off('lobbyUpdate', handleLobbyUpdate);
       socket.off('gameStart', handleGameStart);
+      socket.off('gameStarted', handleGameStart);
+      clearMatchmakingTimeout();
       const pending = pendingOnlineRef.current;
       if (pending.tableId && pending.accountId && !pending.launched) {
         socket.emit('leaveLobby', {


### PR DESCRIPTION
### Motivation
- The Domino Royal online flow could fail to bootstrap because the runtime derived `onlineAccountId` before `accountId` was declared, preventing socket sync in online matches.  
- Lobby seating was brittle: transient socket identity/register failures or slow joins could leave pending seats, not refund stakes, or never start a match.  
- Improve robustness so players can reliably connect from the lobby and recover from recoverable socket errors.

### Description
- Move runtime declaration so `accountId` is defined before `onlineAccountId` in `webapp/public/domino-royal-game.js` to allow online bootstrapping.  
- Harden lobby matchmaking in `webapp/src/pages/Games/DominoRoyalLobby.jsx` by adding a matchmaking timeout (`MATCHMAKING_TIMEOUT_MS`), pending-seat cleanup (`resetPendingOnlineSeat`), stake bookkeeping (`stakeDebitedRef` / `stakeRefundedRef`) and automatic refund via `addTransaction` on failures.  
- Add identity refresh and retry logic: call `refreshSocketAuthIdentity` and retry `register`/`seatTable` when recoverable errors (`identity_mismatch`, `register_required`, `rate_limited`, `timeout`) occur, and re-attempt seating before failing.  
- Clear matchmaking timers and stop matching spinner when the match starts, and listen for both `gameStart` and `gameStarted` events to reliably launch the synced Domino match.  
- Tests: add `test/dominoRoyalRuntimeScript.test.js` to assert runtime declaration order and extend `test/onlineGamePolicy.test.js` with a two-player `domino-royal` policy case.

### Testing
- Ran unit tests with `npm test -- --runInBand test/dominoRoyalRuntimeScript.test.js test/onlineGamePolicy.test.js` and both suites passed.  
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.  
- Attempted the end-to-end lobby integration test `node --test test/dominoRoyalOnlineLobby.test.js` but it was blocked in this environment due to a missing bot dependency (`compression`), so full integration run was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e69a094f4832992ed258b43b30747)