### PR TITLE
Fix Chess Battle Royal private lobby matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -638,6 +638,45 @@ function ensureRegistered(socket, tpcAccountNumber) {
   return true;
 }
 
+function isReservedHostedTableId(tableId, gameType, maxPlayers) {
+  const raw = String(tableId || '').trim();
+  if (!raw) return false;
+  const [prefix, capStr, kind] = raw.split('-');
+  if (kind !== 'host') return false;
+  const normalizedPrefix = normalizeOnlineGameType(prefix);
+  return (
+    normalizedPrefix === normalizeOnlineGameType(gameType) &&
+    Number(capStr) === Number(maxPlayers)
+  );
+}
+
+function createLobbyTable({
+  id = randomUUID(),
+  gameType,
+  stake = 0,
+  maxPlayers = 4,
+  meta = {}
+}) {
+  const key = `${gameType}-${maxPlayers}`;
+  if (!lobbyTables[key]) lobbyTables[key] = [];
+  const table = {
+    id,
+    gameType,
+    stake,
+    maxPlayers,
+    players: [],
+    currentTurn: null,
+    ready: new Set(),
+    meta
+  };
+  lobbyTables[key].push(table);
+  tableMap.set(table.id, table);
+  console.log(
+    `Created new table: ${table.id} (${gameType}, cap ${maxPlayers}, stake: ${stake})`
+  );
+  return table;
+}
+
 function getAvailableTable(
   gameType,
   stake = 0,
@@ -649,6 +688,7 @@ function getAvailableTable(
   const key = `${gameType}-${maxPlayers}`;
   if (!lobbyTables[key]) lobbyTables[key] = [];
   if (forcedTableId) {
+    const isHostedTable = isReservedHostedTableId(forcedTableId, gameType, maxPlayers);
     const existing = tableMap.get(forcedTableId);
     if (existing) {
       const normalizedStake = Number(stake) || 0;
@@ -658,6 +698,17 @@ function getAvailableTable(
         existing.players.length < existing.maxPlayers &&
         isMatchMetaCompatible(existing.meta, normalizedMeta, gameType);
       if (canJoinForced) return existing;
+      if (isHostedTable) return null;
+    }
+
+    if (isHostedTable) {
+      return createLobbyTable({
+        id: String(forcedTableId),
+        gameType,
+        stake,
+        maxPlayers,
+        meta: normalizedMeta
+      });
     }
     // Ignore stale/non-existent forced ids so quick matchmaking can still pair
     // users by game type + stake instead of trapping them in a private table.
@@ -669,22 +720,7 @@ function getAvailableTable(
       isMatchMetaCompatible(t.meta, normalizedMeta, gameType)
   );
   if (open) return open;
-  const table = {
-    id: randomUUID(),
-    gameType,
-    stake,
-    maxPlayers,
-    players: [],
-    currentTurn: null,
-    ready: new Set(),
-    meta: normalizedMeta
-  };
-  lobbyTables[key].push(table);
-  tableMap.set(table.id, table);
-  console.log(
-    `Created new table: ${table.id} (${gameType}, cap ${maxPlayers}, stake: ${stake})`
-  );
-  return table;
+  return createLobbyTable({ gameType, stake, maxPlayers, meta: normalizedMeta });
 }
 
 function resolveSeatIdentityFromTableId(tableId, fallbackGameType, fallbackMaxPlayers) {
@@ -1252,6 +1288,7 @@ async function seatTableSocket(
     matchMeta,
     forcedTableId
   );
+  if (!table) return null;
   const tableId = table.id;
   cleanupSeats();
   // Ensure this user is not seated at any other table

--- a/test/chessLobbyPrivateCodeIsolation.test.js
+++ b/test/chessLobbyPrivateCodeIsolation.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test(
+  'chess private code matchmaking keeps coded tables isolated from quick lobbies',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3214',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const quick = io('http://localhost:3214', { auth: { token: apiToken } });
+    const privateA = io('http://localhost:3214', { auth: { token: apiToken } });
+    const privateB = io('http://localhost:3214', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => quick.on('connect', resolve)),
+        new Promise((resolve) => privateA.on('connect', resolve)),
+        new Promise((resolve) => privateB.on('connect', resolve))
+      ]);
+
+      const register = (socket, playerId) =>
+        new Promise((resolve) => {
+          socket.emit('register', { playerId }, resolve);
+        });
+      await Promise.all([
+        register(quick, 'chess-private-quick'),
+        register(privateA, 'chess-private-a'),
+        register(privateB, 'chess-private-b')
+      ]);
+
+      const seat = (socket, payload) =>
+        new Promise((resolve) => {
+          socket.emit('seatTable', payload, resolve);
+        });
+
+      const quickSeat = await seat(quick, {
+        accountId: 'chess-private-quick',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC'
+      });
+      const codedSeatA = await seat(privateA, {
+        accountId: 'chess-private-a',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: 'chess-2-host-FRIEND123'
+      });
+      const codedSeatB = await seat(privateB, {
+        accountId: 'chess-private-b',
+        gameType: 'chessbattleroyal',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: 'chess-2-host-FRIEND123'
+      });
+
+      assert.equal(quickSeat.success, true);
+      assert.equal(codedSeatA.success, true);
+      assert.equal(codedSeatB.success, true);
+      assert.notEqual(codedSeatA.tableId, quickSeat.tableId);
+      assert.equal(codedSeatA.tableId, 'chess-2-host-FRIEND123');
+      assert.equal(codedSeatB.tableId, codedSeatA.tableId);
+    } finally {
+      quick.disconnect();
+      privateA.disconnect();
+      privateB.disconnect();
+      server.kill();
+    }
+  }
+);


### PR DESCRIPTION
### Motivation
- Private hosted table IDs like `chess-2-host-FRIEND123` were not reserved and could fall through into open quick-match tables, breaking isolation for private matches.
- The seating flow could dereference a missing table and throw when a forced/private table was unavailable.

### Description
- Add `isReservedHostedTableId` helper to recognize reserved hosted/private table IDs and `createLobbyTable` to centralize table creation in `bot/server.js`.
- Update `getAvailableTable` to treat `*-host-*` IDs as reserved: return an isolated hosted table when appropriate, or return `null` when a hosted id exists but cannot be joined to avoid leaking into quick lobbies.
- Guard `seatTableSocket` against a missing table by returning early if `getAvailableTable` returns `null` to prevent crashes.
- Add regression test `test/chessLobbyPrivateCodeIsolation.test.js` that verifies private-code players join the same hosted table while quick-match players remain in separate quick lobbies.

### Testing
- Ran the chess lobby and online-flow unit/integration tests: `node --test test/chessLobbyPrivateCodeIsolation.test.js`, `node --test test/chessLobbyStaleTableIdMatchmaking.test.js`, `node --test test/chessLobbyPreferredSideMatchmaking.test.js`, `node --test test/chessOnlineMoveValidation.test.js`, and `node --test test/chessLobbyHelpers.test.mjs`.
- All listed automated tests completed successfully (no failing tests reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6976f3ac8329861f004b944c2fa4)