### PR TITLE
Fix Domino Royal online lobby matching

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -16,7 +16,7 @@ import { loadAvatar } from '../../utils/avatarUtils.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
-import { socket } from '../../utils/socket.js';
+import { refreshSocketAuthIdentity, socket } from '../../utils/socket.js';
 import { getOnlineReadiness } from '../../config/onlineContract.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
@@ -113,7 +113,7 @@ export default function DominoRoyalLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState('local');
   const [avatar, setAvatar] = useState('');
-  const [playerCount, setPlayerCount] = useState(4);
+  const [playerCount, setPlayerCount] = useState(2);
   const [gameType, setGameType] = useState('single');
   const [targetPoints, setTargetPoints] = useState(51);
   const [frameRateId, setFrameRateId] = useState(DEFAULT_FRAME_RATE_ID);
@@ -263,10 +263,17 @@ export default function DominoRoyalLobby() {
       setMatchStatus('Connecting to Domino Royal online lobby…');
       pendingOnlineRef.current = { tableId: '', accountId, launched: false };
 
+      refreshSocketAuthIdentity(
+        { accountId: String(accountId) },
+        { reconnect: true }
+      );
+
       const connected = await waitForSocketConnection(socket);
       if (!connected) {
         setMatching(false);
-        setMatchingError('Could not connect to the online lobby. Check your network and try again.');
+        setMatchingError(
+          'Could not connect to the online lobby. Check your network and try again.'
+        );
         return;
       }
 
@@ -278,7 +285,9 @@ export default function DominoRoyalLobby() {
       });
       if (registered?.success === false) {
         setMatching(false);
-        setMatchingError('Unable to register this account for online Domino. Please retry.');
+        setMatchingError(
+          'Unable to register this account for online Domino. Please retry from a fresh lobby connection.'
+        );
         return;
       }
 
@@ -302,7 +311,9 @@ export default function DominoRoyalLobby() {
       });
       if (!res.success || !res.tableId) {
         setMatching(false);
-        setMatchingError('Unable to join Domino online table. Please try again.');
+        setMatchingError(
+          'Unable to join Domino online table. Check that both phones use different accounts, the same player count, stake, and game type.'
+        );
         return;
       }
 
@@ -692,7 +703,9 @@ export default function DominoRoyalLobby() {
                   </div>
                   <div className="text-center">
                     <p className="lobby-option-label">{value} Players</p>
-                    <p className="lobby-option-subtitle">Local table seats</p>
+                    <p className="lobby-option-subtitle">
+                      {mode === 'online' ? 'Online seats' : 'Local table seats'}
+                    </p>
                   </div>
                 </button>
               ))}


### PR DESCRIPTION
### Motivation

- Players could not reliably join Domino Royal online matches because the client socket auth identity was not refreshed before connecting, causing the server to see mismatched/absent account bindings during matchmaking.
- Two-device manual testing expects 2-player default queues, but the lobby defaulted to 4 which made tests wait for extra seats.

### Description

- Refresh Socket.IO auth identity before connecting the lobby by importing and calling `refreshSocketAuthIdentity` with the resolved `accountId` to ensure the server binds the correct player to the socket (`webapp/src/pages/Games/DominoRoyalLobby.jsx`).
- Change Domino Royal lobby default player count from 4 to 2 so quick two-device testing queues into a 2-player table by default (`playerCount` state in `DominoRoyalLobby.jsx`).
- Improve user-facing error messages for common online seat failures to explain likely mismatches (accounts, player count, stake, game type) and clarify retry guidance (`DominoRoyalLobby.jsx`).
- Update the player-count card subtitle to show "Online seats" when in online mode instead of always saying local seats (`DominoRoyalLobby.jsx`).

### Testing

- Ran unit/integration tests with `npm test -- --runInBand test/dominoRoyalOnlineLobby.test.js test/dominoRoyalRealtimeEngine.test.js` and both suites passed.
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully.
- Installed Playwright and OS deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) and captured a mobile portrait screenshot of the Domino Royal lobby to verify the online lobby flow visually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e69a094f4832992ed258b43b30747)