### PR TITLE
Default Pool Royale table → Showood GLB; hide lobby table options; tweak Showood branding & rail visuals

### DIFF
--- a/test/poolRoyaleTableModels.test.js
+++ b/test/poolRoyaleTableModels.test.js
@@ -7,12 +7,16 @@ import {
 } from '../webapp/src/config/poolRoyaleTableModels.js';
 
 describe('Pool Royale table models', () => {
-  test('defaults to the Royal Original procedural table', () => {
-    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'royal-original');
-    assert.equal(resolvePoolRoyaleTableModel(null).id, 'royal-original');
+  test('defaults to the Showood GLB table while keeping Royal Original available as procedural fallback', () => {
+    assert.equal(DEFAULT_POOL_ROYALE_TABLE_MODEL_ID, 'showood-seven-foot');
+    assert.equal(resolvePoolRoyaleTableModel(null).id, 'showood-seven-foot');
     assert.equal(
       resolvePoolRoyaleTableModel('unknown').id,
-      'royal-original'
+      'showood-seven-foot'
+    );
+    assert.ok(
+      POOL_ROYALE_TABLE_MODEL_OPTIONS.some((option) => option.id === 'royal-original'),
+      'Royal Original remains configured for the generated-table fallback path'
     );
   });
 
@@ -33,7 +37,7 @@ describe('Pool Royale table models', () => {
     assert.deepEqual(royal.hideSurfaceRoles, ['trim', 'wood', 'cushion', 'pocket']);
   });
 
-  test('Showood uses original GLB surface layout without procedural rail diamonds', () => {
+  test('Showood uses original GLB surface layout with outward generated branding and rail diamonds', () => {
     const showood = POOL_ROYALE_TABLE_MODEL_OPTIONS.find(
       (option) => option.id === 'showood-seven-foot'
     );
@@ -42,10 +46,9 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.kind, 'gltf');
     assert.equal(showood.useOriginalLayoutSurfaces, true);
     assert.equal(showood.useReferenceShowoodMapping, true);
-    assert.equal(showood.hideGeneratedRailMarkers, true);
+    assert.equal(showood.hideGeneratedRailMarkers, false);
     assert.deepEqual(showood.hideSurfaceRoles, []);
     assert.deepEqual(showood.preserveSourceTextureRoles, [
-      'railSight',
       'sideWoodApron',
       'baseFoot',
       'trim',
@@ -59,9 +62,13 @@ describe('Pool Royale table models', () => {
     assert.equal(showood.lowerLegFootReachScale, 1.28);
     assert.equal(showood.footWidthScale, 1.08);
     assert.equal(showood.footHeightScale, 1);
-    assert.equal(showood.railSightApronVisualScale, 1.026);
+    assert.equal(showood.brandPlateVisualScale, 1.08);
+    assert.equal(showood.brandPlateOutwardOffsetScale, 1.08);
+    assert.equal(showood.railMarkerOutwardOffset, 0.046);
+    assert.equal(showood.railSightApronVisualScale, 1.035);
+    assert.equal(showood.railSightOutwardOffset, 0.018);
     assert.equal(showood.sideApronVisualHeightScale, 1.07);
-    assert.equal(showood.sideApronOutwardOffset, 0.018);
+    assert.equal(showood.sideApronOutwardOffset, 0.038);
     assert.deepEqual(showood.usePoolRoyaleFinishRoles, ['cloth', 'cushion', 'wood']);
   });
 
@@ -97,29 +104,35 @@ describe('Pool Royale table models', () => {
     );
     assert.equal(
       resolvePoolRoyaleTableModel('traditional-fizyman-eight-foot').id,
-      'royal-original'
+      'showood-seven-foot'
     );
   });
 
-  test('Pool Royale lobby exposes model choices with Royal Original guidance', async () => {
+  test('Pool Royale lobby hides table choices and starts with the default GLB table', async () => {
     const lobby = await readFile(
       'webapp/src/pages/Games/PoolRoyaleLobby.jsx',
       'utf8'
     );
 
-    assert.ok(
+    assert.equal(
       lobby.includes('Royal Original keeps the clean procedural table'),
-      'lobby should explain the Royal Original table'
+      false,
+      'lobby should not mention table model choices'
     );
     assert.equal(
       lobby.includes('POOL_ROYALE_TABLE_MODEL_OPTIONS.map'),
-      true,
-      'lobby should render table model option cards'
+      false,
+      'lobby should not render table model option cards'
     );
     assert.equal(
       lobby.includes('setTableModelId'),
+      false,
+      'lobby should not allow switching table models'
+    );
+    assert.equal(
+      lobby.includes('const tableModelId = resolvePoolRoyaleTableModel().id'),
       true,
-      'lobby should allow switching table models'
+      'lobby should use the configured default table model'
     );
     assert.equal(
       lobby.includes('traditional-fizyman-eight-foot'),

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,10 +1,10 @@
-import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
-import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js'
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js'
 
-export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
 const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   {
@@ -61,10 +61,14 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     lowerLegMaxHeightScale: 3.4,
     footWidthScale: 1.08,
     footHeightScale: 1,
-    railSightApronVisualScale: 1.045,
-    railSightVisualHeightScale: 1.065,
-    sideApronVisualHeightScale: 1.095,
-    sideApronOutwardOffset: 0.024,
+    brandPlateVisualScale: 1.08,
+    brandPlateOutwardOffsetScale: 1.08,
+    railMarkerOutwardOffset: 0.046,
+    railSightApronVisualScale: 1.035,
+    railSightVisualHeightScale: 1.045,
+    railSightOutwardOffset: 0.018,
+    sideApronVisualHeightScale: 1.07,
+    sideApronOutwardOffset: 0.038,
     clothRepeatScale: 5.25,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
@@ -88,20 +92,20 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     hideSurfaceRoles: [],
     hideGeneratedRailMarkers: false
   }
-]);
+])
 
 export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
-  POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === 'royal-original')?.id ||
-  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+  POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === 'showood-seven-foot')?.id ||
+  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id
 
-export function resolvePoolRoyaleTableModel(modelId) {
-  const key = typeof modelId === 'string' ? modelId.trim() : '';
+export function resolvePoolRoyaleTableModel (modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : ''
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
+    POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === DEFAULT_POOL_ROYALE_TABLE_MODEL_ID) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  )
 }
-
 
 const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
   { id: 'peelingPaintWeathered', label: 'Wood Peeling Paint Weathered', color: '#b8b3aa', textureId: 'wood_peeling_paint_weathered' },
@@ -124,7 +128,7 @@ const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
   { id: 'carbonFiberAlligatorSand', label: 'LT Sand Fabric', color: '#8a7b5e', textureId: 'fabric_083' },
   { id: 'carbonFiberAlligatorMoss', label: 'LT Moss Fabric', color: '#4f6048', textureId: 'fabric_083' },
   { id: 'carbonFiberAlligatorNight', label: 'LT Night Fabric', color: '#2f3c32', textureId: 'fabric_083' }
-]);
+])
 
 const buildShowoodFinishOptions = () =>
   Object.freeze(
@@ -133,15 +137,15 @@ const buildShowoodFinishOptions = () =>
         ...option,
         finishId: option.id,
         thumbnail: option.textureId ? polyHavenThumb(option.textureId) : swatchThumbnail([option.color, '#ffffff'])
-      });
-      return acc;
+      })
+      return acc
     }, {})
-  );
+  )
 
 const buildShowoodClothOptions = () =>
   Object.freeze(
     POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
-      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`;
+      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`
       acc[variant.id] = Object.freeze({
         label: variant.name,
         color,
@@ -151,10 +155,10 @@ const buildShowoodClothOptions = () =>
         metalness: 0,
         roughness: 1,
         envMapIntensity: 0.16
-      });
-      return acc;
+      })
+      return acc
     }, {})
-  );
+  )
 
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cloth',
@@ -162,7 +166,7 @@ export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'metalAccent',
   'pocketJaw',
   'topWoodRail'
-]);
+])
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   cloth: 'cabanGreenClassic',
@@ -171,7 +175,7 @@ export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   pocketJaw: 'plastic-black',
   topWoodRail: 'woodTable001',
   legBase: 'darkWood'
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   cloth: { label: 'Field cloth', description: 'All cloth-library textures for only the flat playfield surface.' },
@@ -186,15 +190,15 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   pocketJaw: { label: 'Pockets + jaws', description: 'Uses the same pocket-jaw texture options as the main game menu.' },
   topWoodRail: { label: 'Top rail frame', description: 'All GLTF table-finish textures for the main top wood rail frame.' },
   legBase: { label: 'Legacy GLB legs + base', description: 'Hidden for the Showood table because Pool Royale uses the procedural base and table-finish texture instead.' }
-});
+})
 
-const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions();
-const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions();
+const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions()
+const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions()
 const SHOWOOD_METAL_ACCENT_OPTIONS = Object.freeze({
   gold: Object.freeze({ label: 'Gold', color: '#d4af37', metalAccentId: 'gold' }),
   chrome: Object.freeze({ label: 'Chrome', color: '#d6d8dc', metalAccentId: 'chrome' }),
   black: Object.freeze({ label: 'Black', color: '#050505', metalAccentId: 'black' })
-});
+})
 const SHOWOOD_POCKET_JAW_OPTIONS = Object.freeze({
   'plastic-black': Object.freeze({ label: 'Plastic Black Jaws', color: '#151515', pocketLinerId: 'plastic-black' }),
   'plastic-dark-grey': Object.freeze({ label: 'Plastic Dark Grey Jaws', color: '#2c2f33', pocketLinerId: 'plastic-dark-grey' }),
@@ -202,7 +206,7 @@ const SHOWOOD_POCKET_JAW_OPTIONS = Object.freeze({
   'plastic-light-grey': Object.freeze({ label: 'Plastic Light Grey Jaws', color: '#b8bcc2', pocketLinerId: 'plastic-light-grey' }),
   'plastic-magnolia': Object.freeze({ label: 'Plastic Magnolia Jaws', color: '#f4f0e6', pocketLinerId: 'plastic-magnolia' }),
   'brown-showood': Object.freeze({ label: 'Brown Showood Jaws', color: '#2a1207', pocketLinerId: 'brown-showood' })
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   cloth: SHOWOOD_CLOTH_OPTIONS,
@@ -211,4 +215,4 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   pocketJaw: SHOWOOD_POCKET_JAW_OPTIONS,
   topWoodRail: SHOWOOD_FINISH_OPTIONS,
   legBase: SHOWOOD_FINISH_OPTIONS
-});
+})

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -11234,11 +11234,20 @@ export function Table3D(
     return mat;
   };
   const brandPlateThickness = chromePlateThickness;
-  const brandPlateDepth = Math.min(endRailW * 0.66, TABLE.THICK * 0.96);
-  const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
+  const brandPlateVisualScale = THREE.MathUtils.clamp(
+    Number(resolvedTableOptions?.tableModel?.brandPlateVisualScale) || 1,
+    0.85,
+    1.16
+  );
+  const brandPlateDepth = Math.min(endRailW * 0.66, TABLE.THICK * 0.96) * brandPlateVisualScale;
+  const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23)) * brandPlateVisualScale;
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.92;
+  const brandPlateOutwardShift = endRailW * 0.92 * THREE.MathUtils.clamp(
+    Number(resolvedTableOptions?.tableModel?.brandPlateOutwardOffsetScale) || 1,
+    0.8,
+    1.22
+  );
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -11378,8 +11387,12 @@ export function Table3D(
     clearRailMarkerMeshes();
     const longDiamondSpacing = PLAY_H / 8;
     const shortDiamondSpacing = PLAY_W / 4;
-    const longRailX = halfW + longRailW + railMarkerOutset - railMarkerInwardShift;
-    const shortRailZ = halfH + endRailW + railMarkerOutset - railMarkerInwardShift;
+    const externalRailMarkerOutwardOffset = Number(resolvedTableOptions?.tableModel?.railMarkerOutwardOffset);
+    const railMarkerExternalOutset = Number.isFinite(externalRailMarkerOutwardOffset)
+      ? Math.max(0, externalRailMarkerOutwardOffset)
+      : 0;
+    const longRailX = halfW + longRailW + railMarkerOutset - railMarkerInwardShift + railMarkerExternalOutset;
+    const shortRailZ = halfH + endRailW + railMarkerOutset - railMarkerInwardShift + railMarkerExternalOutset;
     const addMarker = (x, z, rotation = 0) => {
       const mesh = new THREE.Mesh(geometry, railMarkerMat);
       mesh.position.set(x, railMarkerLift, z);
@@ -12224,7 +12237,7 @@ const POOL_ROYALE_SHOWOOD_PART_TO_CONTROL = Object.freeze({
   cloth: 'cloth',
   cushion: 'cushion',
   topWoodRail: 'topWoodRail',
-  sideWoodApron: 'metalAccent',
+  sideWoodApron: 'topWoodRail',
   cornerPocketPlate: 'metalAccent',
   middlePocketPlate: 'metalAccent',
   verticalCornerRim: 'metalAccent',
@@ -12642,6 +12655,12 @@ function applyPoolRoyaleShowoodReferenceMaterial(material, part, tableModel = nu
     if ('envMapIntensity' in mat) mat.envMapIntensity = option.envMapIntensity;
     if ('clearcoat' in mat) mat.clearcoat = option.clearcoat ?? 0;
     if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = option.clearcoatRoughness ?? 0;
+  }
+  if (part === 'railSight' || part === 'sideWoodApron') {
+    if ('roughness' in mat) mat.roughness = Math.min(mat.roughness ?? 0.42, part === 'railSight' ? 0.24 : 0.36);
+    if ('clearcoat' in mat) mat.clearcoat = Math.max(mat.clearcoat ?? 0, part === 'railSight' ? 0.56 : 0.28);
+    if ('clearcoatRoughness' in mat) mat.clearcoatRoughness = Math.min(mat.clearcoatRoughness ?? 0.28, 0.22);
+    if ('envMapIntensity' in mat) mat.envMapIntensity = Math.max(mat.envMapIntensity ?? 0, part === 'railSight' ? 0.9 : 0.55);
   }
   mat.transparent = false;
   mat.opacity = 1;
@@ -13514,12 +13533,14 @@ function subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel) {
   const visualScale = Number(tableModel?.railSightApronVisualScale);
   const railSightHeightScale = Number(tableModel?.railSightVisualHeightScale);
   const sideApronHeightScale = Number(tableModel?.sideApronVisualHeightScale);
+  const railSightOutwardOffset = Number(tableModel?.railSightOutwardOffset);
   const sideApronOutwardOffset = Number(tableModel?.sideApronOutwardOffset);
   const hasScale = Number.isFinite(visualScale) && visualScale > 1 + MICRO_EPS;
   const hasRailSightHeight = Number.isFinite(railSightHeightScale) && railSightHeightScale > 1 + MICRO_EPS;
   const hasSideApronHeight = Number.isFinite(sideApronHeightScale) && sideApronHeightScale > 1 + MICRO_EPS;
+  const hasRailSightOffset = Number.isFinite(railSightOutwardOffset) && Math.abs(railSightOutwardOffset) > MICRO_EPS;
   const hasSideApronOffset = Number.isFinite(sideApronOutwardOffset) && Math.abs(sideApronOutwardOffset) > MICRO_EPS;
-  if (!hasScale && !hasRailSightHeight && !hasSideApronHeight && !hasSideApronOffset) return;
+  if (!hasScale && !hasRailSightHeight && !hasSideApronHeight && !hasRailSightOffset && !hasSideApronOffset) return;
   if (model.userData?.poolRoyaleShowoodRailSightApronExpanded) return;
 
   const fullBox = new THREE.Box3().setFromObject(model);
@@ -13545,16 +13566,19 @@ function subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel) {
     const heightScale = isSideApron ? safeSideApronHeightScale : safeRailSightHeightScale;
     if (heightScale > 1) child.scale.y *= heightScale;
 
-    if (isSideApron && hasSideApronOffset) {
+    const outwardOffset = isSideApron
+      ? (hasSideApronOffset ? sideApronOutwardOffset : 0)
+      : (hasRailSightOffset ? railSightOutwardOffset : 0);
+    if (Math.abs(outwardOffset) > MICRO_EPS) {
       const childBox = new THREE.Box3().setFromObject(child);
       if (!childBox.isEmpty()) {
         const childCenter = childBox.getCenter(new THREE.Vector3());
         const awayX = childCenter.x - fullCenter.x;
         const awayZ = childCenter.z - fullCenter.z;
         if (Math.abs(awayX) >= Math.abs(awayZ) && Math.abs(awayX) > MICRO_EPS) {
-          child.position.x += Math.sign(awayX) * sideApronOutwardOffset;
+          child.position.x += Math.sign(awayX) * outwardOffset;
         } else if (Math.abs(awayZ) > MICRO_EPS) {
-          child.position.z += Math.sign(awayZ) * sideApronOutwardOffset;
+          child.position.z += Math.sign(awayZ) * outwardOffset;
         }
       }
     }

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,7 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
@@ -77,15 +76,7 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const [tableModelId, setTableModelId] = useState(() => {
-    try {
-      const stored = window.localStorage?.getItem(
-        POOL_ROYALE_TABLE_MODEL_STORAGE_KEY
-      );
-      return resolvePoolRoyaleTableModel(stored).id;
-    } catch {}
-    return resolvePoolRoyaleTableModel().id;
-  });
+  const tableModelId = resolvePoolRoyaleTableModel().id;
   const [players, setPlayers] = useState(8);
   const selectedTableModel = useMemo(
     () => resolvePoolRoyaleTableModel(tableModelId),
@@ -630,48 +621,6 @@ export default function PoolRoyaleLobby() {
           </p>
         </div>
 
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Pool Table</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-              GLB Arena
-            </span>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
-              const active = tableModelId === option.id;
-              return (
-                <button
-                  key={option.id}
-                  type="button"
-                  onClick={() => setTableModelId(option.id)}
-                  className={`lobby-option-card ${
-                    active
-                      ? 'lobby-option-card-active'
-                      : 'lobby-option-card-inactive'
-                  }`}
-                >
-                  <div className="lobby-option-thumb bg-gradient-to-br from-fuchsia-400/20 via-amber-500/10 to-transparent">
-                    <div className="lobby-option-thumb-inner text-2xl">
-                      {option.icon || '🎱'}
-                    </div>
-                  </div>
-                  <div className="text-center">
-                    <p className="lobby-option-label">{option.label}</p>
-                    <p className="lobby-option-subtitle">
-                      {option.kind === 'gltf'
-                        ? `${option.tableSizeId} · original textures`
-                        : 'Current table'}
-                    </p>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-          <p className="text-xs text-white/60">
-            Royal Original keeps the clean procedural table; Showood material setup is available inside the in-game menu only.
-          </p>
-        </div>
 
         <div className="space-y-3">
           <div className="flex items-center justify-between">


### PR DESCRIPTION
### Motivation
- Make the Showood GLB the default visible table in the Pool Royale lobby while keeping the procedural "Royal Original" as a generated fallback for physics/playfield continuity. 
- Remove the in-lobby table-selection UI to simplify onboarding and always present the preferred GLB by default. 
- Improve Showood GLB visual fidelity by enlarging/outward-shifting brand plates and rail markers, and smoothing rail-sight / side-apron materials so markings don't visually overlap rails.

### Description
- Set default table model to the GLB by changing `DEFAULT_POOL_ROYALE_TABLE_MODEL_ID` in `webapp/src/config/poolRoyaleTableModels.js` to `showood-seven-foot` and add new tuning fields: `brandPlateVisualScale`, `brandPlateOutwardOffsetScale`, `railMarkerOutwardOffset`, and `railSightOutwardOffset`.
- Hide lobby table selection and always use the configured default by removing the table cards and switching the lobby to use a resolved default `tableModelId` in `webapp/src/pages/Games/PoolRoyaleLobby.jsx` (now `const tableModelId = resolvePoolRoyaleTableModel().id`).
- Apply Showood visual/placement changes in `webapp/src/pages/Games/PoolRoyale.jsx`: scale/outward-shift brand plates, add `railMarkerOutwardOffset` to rail-diamond placement, expose `railSightOutwardOffset` and `sideApronOutwardOffset` to push apron/rail-sight geometry outward, and map `sideWoodApron` to the `topWoodRail` control so the apron matches wood-rail finish choices.
- Smooth and tune reference materials in `applyPoolRoyaleShowoodReferenceMaterial` by reducing roughness and increasing clearcoat/env intensity for `railSight` and `sideWoodApron` parts so rail-sight/apron look smoother and avoid visual collision with rails.
- Keep `royal-original` model available in `POOL_ROYALE_TABLE_MODEL_OPTIONS` so procedural fallback remains available via `resolvePoolRoyaleTableModel`.
- Update unit test expectations in `test/poolRoyaleTableModels.test.js` to validate the new default, hidden lobby controls, and the Showood outward/visual tuning.

### Testing
- Ran the focused Jest suite `test/poolRoyaleTableModels.test.js` with `npm test -- --runInBand test/poolRoyaleTableModels.test.js` and all tests passed (6/6). 
- Ran repository TypeScript build via `npm run build` and the webapp build via `npm --prefix webapp run build`; both completed successfully.
- Linted the changed webapp files with `npm --prefix webapp run lint` and auto-fixed where appropriate; lint passes for the targeted files.
- Installed Playwright browsers and dependencies (`npx playwright install chromium` and `npx playwright install-deps chromium`) and captured a mobile-portrait lobby screenshot to verify the lobby hides table options (`artifacts/pool-royale-lobby-no-table-options.png`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e8313a3688329a67d7d30e0f381d1)