### PR TITLE
Use Showood GLB as default Pool Royale table and prefer local/CDN GLB assets

### DIFF
--- a/webapp/public/models/pool-royale/showood-seven-foot/README.md
+++ b/webapp/public/models/pool-royale/showood-seven-foot/README.md
@@ -1,6 +1,6 @@
 # Showood 7 ft table GLB
 
-Pool Royale expects the Showood 7 ft GLB at this runtime path:
+Pool Royale uses only the Showood 7 ft GLB table and expects the fastest same-origin copy at this runtime path:
 
 ```text
 webapp/public/models/pool-royale/showood-seven-foot/seven_foot_showood.glb
@@ -12,4 +12,4 @@ The `.glb` binary is intentionally not committed. Install it during deployment o
 npm run fetch:pool-royale-showood-table
 ```
 
-If the local file is not present, the app falls back at runtime to the public Pooltool CDN/raw URLs configured in `src/config/poolRoyaleTableModels.js`.
+If the local file is not present, the app still tries the public Pooltool CDN/raw Showood GLB URLs configured in `src/config/poolRoyaleTableModels.js`; it no longer falls back to the old procedural table.

--- a/webapp/public/pwa/gltf-assets.json
+++ b/webapp/public/pwa/gltf-assets.json
@@ -24,6 +24,8 @@
   "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Lantern/glTF-Binary/Lantern.glb",
   "https://raw.githubusercontent.com/cx20/gltf-test/master/sampleModels/Chess/glTF-Binary/Chess.glb",
   "https://raw.githubusercontent.com/quaterniusdev/ChessSet/master/Source/GLTF/ChessSet.glb",
+  "/models/pool-royale/showood-seven-foot/seven_foot_showood.glb",
   "https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb",
+  "https://fastly.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb",
   "https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb"
 ]

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1005,7 +1005,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'showood-rounded',
     name: 'Showood Rounded Chrome Plates',
     price: 420,
-    description: 'Rounded showroom-style chrome plates that can be used on both Royal Original and Showood tables.',
+    description: 'Rounded showroom-style chrome plates for the Showood GLB table.',
     thumbnail: swatchThumbnail(['#f6d56f', '#d6d8dc', '#2f2418'])
   },
   {

--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,50 +1,33 @@
-import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
-import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js'
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js'
 
-export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel'
 
 const POOLTOOL_RAW_BASE =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table'
+
+const SHOWOOD_TABLE_LOCAL_URL =
+  '/models/pool-royale/showood-seven-foot/seven_foot_showood.glb'
+const SHOWOOD_TABLE_CDN_URL =
+  'https://cdn.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb'
+const SHOWOOD_TABLE_FASTLY_URL =
+  'https://fastly.jsdelivr.net/gh/ekiefl/pooltool@main/pooltool/models/table/seven_foot_showood/seven_foot_showood.glb'
+const SHOWOOD_TABLE_RAW_URL = `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`
 
 export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
-  {
-    id: 'royal-original',
-    label: 'Royal Original',
-    description:
-      'Current TonPlaygram procedural wooden rails, procedural cushions, base, chrome plates, pockets, and jaws fitted to the same Showood GLB footprint and playfield layout.',
-    tableSizeId: '9ft',
-    finishId: 'peelingPaintWeathered',
-    baseId: 'classicCylinders',
-    assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
-    icon: '🎱',
-    kind: 'gltf',
-    fitScale: 1.055,
-    clothRepeatScale: 5.25,
-    fitStrategy: 'exact',
-    fitReference: 'upperTabletop',
-    matchNativeUpperComponentHeight: true,
-    useOriginalLayoutSurfaces: false,
-    usePoolRoyaleFinish: true,
-    usePoolRoyaleFinishRoles: ['cloth'],
-    cushionUsesClothFinish: false,
-    hideGeneratedCushionsAndJaws: false,
-    hideGeneratedPocketsAndJaws: false,
-    keepGeneratedPocketsAndJaws: true,
-    preserveSourceTextureRoles: [],
-    preserveOriginalSurfaceRoles: ['trim', 'wood'],
-    hideSurfaceRoles: ['trim', 'wood', 'cushion', 'pocket'],
-    keepGeneratedShell: true,
-    forceGeneratedChromePlates: true
-  },
   {
     id: 'showood-seven-foot',
     label: 'Showood 7 ft GLB',
     description:
-      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while preserving the GLB playfield and using Royal procedural bases plus only under-pocket nets, chrome holders, and leather straps.',
+      'Open-source Pooltool Showood showroom table matched to Pool Royale footprint while preserving the GLB playfield and using the Showood-focused support base plus only under-pocket nets, chrome holders, and leather straps.',
     tableSizeId: '9ft',
-    assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
+    assetUrl: SHOWOOD_TABLE_LOCAL_URL,
+    assetUrls: Object.freeze([
+      SHOWOOD_TABLE_LOCAL_URL,
+      SHOWOOD_TABLE_CDN_URL,
+      SHOWOOD_TABLE_FASTLY_URL,
+      SHOWOOD_TABLE_RAW_URL
+    ]),
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.055,
@@ -61,10 +44,11 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     lowerLegMaxHeightScale: 3.4,
     footWidthScale: 1.08,
     footHeightScale: 1,
-    railSightApronVisualScale: 1.045,
-    railSightVisualHeightScale: 1.065,
-    sideApronVisualHeightScale: 1.095,
-    sideApronOutwardOffset: 0.024,
+    railSightApronVisualScale: 1.028,
+    railSightOutwardOffset: 0.018,
+    railSightVisualHeightScale: 1.035,
+    sideApronVisualHeightScale: 1.055,
+    sideApronOutwardOffset: 0.034,
     clothRepeatScale: 5.25,
     fitStrategy: 'exact',
     fitReference: 'upperTabletop',
@@ -88,20 +72,17 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     hideSurfaceRoles: [],
     hideGeneratedRailMarkers: false
   }
-]);
+])
 
-export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
-  POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === 'royal-original')?.id ||
-  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID = 'showood-seven-foot'
 
-export function resolvePoolRoyaleTableModel(modelId) {
-  const key = typeof modelId === 'string' ? modelId.trim() : '';
+export function resolvePoolRoyaleTableModel (modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : ''
   return (
     POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
     POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
-  );
+  )
 }
-
 
 const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
   { id: 'peelingPaintWeathered', label: 'Wood Peeling Paint Weathered', color: '#b8b3aa', textureId: 'wood_peeling_paint_weathered' },
@@ -124,7 +105,7 @@ const SHOWOOD_TABLE_FINISH_TEXTURES = Object.freeze([
   { id: 'carbonFiberAlligatorSand', label: 'LT Sand Fabric', color: '#8a7b5e', textureId: 'fabric_083' },
   { id: 'carbonFiberAlligatorMoss', label: 'LT Moss Fabric', color: '#4f6048', textureId: 'fabric_083' },
   { id: 'carbonFiberAlligatorNight', label: 'LT Night Fabric', color: '#2f3c32', textureId: 'fabric_083' }
-]);
+])
 
 const buildShowoodFinishOptions = () =>
   Object.freeze(
@@ -133,15 +114,15 @@ const buildShowoodFinishOptions = () =>
         ...option,
         finishId: option.id,
         thumbnail: option.textureId ? polyHavenThumb(option.textureId) : swatchThumbnail([option.color, '#ffffff'])
-      });
-      return acc;
+      })
+      return acc
     }, {})
-  );
+  )
 
 const buildShowoodClothOptions = () =>
   Object.freeze(
     POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, variant) => {
-      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`;
+      const color = `#${variant.baseColor.toString(16).padStart(6, '0')}`
       acc[variant.id] = Object.freeze({
         label: variant.name,
         color,
@@ -151,10 +132,10 @@ const buildShowoodClothOptions = () =>
         metalness: 0,
         roughness: 1,
         envMapIntensity: 0.16
-      });
-      return acc;
+      })
+      return acc
     }, {})
-  );
+  )
 
 export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'cloth',
@@ -162,7 +143,7 @@ export const POOL_ROYALE_SHOWOOD_MATERIAL_CONTROL_PARTS = Object.freeze([
   'metalAccent',
   'pocketJaw',
   'topWoodRail'
-]);
+])
 
 export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   cloth: 'cabanGreenClassic',
@@ -171,7 +152,7 @@ export const POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE = Object.freeze({
   pocketJaw: 'plastic-black',
   topWoodRail: 'woodTable001',
   legBase: 'darkWood'
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   cloth: { label: 'Field cloth', description: 'All cloth-library textures for only the flat playfield surface.' },
@@ -186,15 +167,15 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_META = Object.freeze({
   pocketJaw: { label: 'Pockets + jaws', description: 'Uses the same pocket-jaw texture options as the main game menu.' },
   topWoodRail: { label: 'Top rail frame', description: 'All GLTF table-finish textures for the main top wood rail frame.' },
   legBase: { label: 'Legacy GLB legs + base', description: 'Hidden for the Showood table because Pool Royale uses the procedural base and table-finish texture instead.' }
-});
+})
 
-const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions();
-const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions();
+const SHOWOOD_CLOTH_OPTIONS = buildShowoodClothOptions()
+const SHOWOOD_FINISH_OPTIONS = buildShowoodFinishOptions()
 const SHOWOOD_METAL_ACCENT_OPTIONS = Object.freeze({
   gold: Object.freeze({ label: 'Gold', color: '#d4af37', metalAccentId: 'gold' }),
   chrome: Object.freeze({ label: 'Chrome', color: '#d6d8dc', metalAccentId: 'chrome' }),
   black: Object.freeze({ label: 'Black', color: '#050505', metalAccentId: 'black' })
-});
+})
 const SHOWOOD_POCKET_JAW_OPTIONS = Object.freeze({
   'plastic-black': Object.freeze({ label: 'Plastic Black Jaws', color: '#151515', pocketLinerId: 'plastic-black' }),
   'plastic-dark-grey': Object.freeze({ label: 'Plastic Dark Grey Jaws', color: '#2c2f33', pocketLinerId: 'plastic-dark-grey' }),
@@ -202,7 +183,7 @@ const SHOWOOD_POCKET_JAW_OPTIONS = Object.freeze({
   'plastic-light-grey': Object.freeze({ label: 'Plastic Light Grey Jaws', color: '#b8bcc2', pocketLinerId: 'plastic-light-grey' }),
   'plastic-magnolia': Object.freeze({ label: 'Plastic Magnolia Jaws', color: '#f4f0e6', pocketLinerId: 'plastic-magnolia' }),
   'brown-showood': Object.freeze({ label: 'Brown Showood Jaws', color: '#2a1207', pocketLinerId: 'brown-showood' })
-});
+})
 
 export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   cloth: SHOWOOD_CLOTH_OPTIONS,
@@ -211,4 +192,4 @@ export const POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS = Object.freeze({
   pocketJaw: SHOWOOD_POCKET_JAW_OPTIONS,
   topWoodRail: SHOWOOD_FINISH_OPTIONS,
   legBase: SHOWOOD_FINISH_OPTIONS
-});
+})

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -35,7 +35,6 @@ import { PoolRoyaleRules } from '../../../../src/rules/PoolRoyaleRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   POOL_ROYALE_SHOWOOD_CONTROL_OPTIONS,
   POOL_ROYALE_SHOWOOD_DEFAULT_PALETTE,
@@ -1349,7 +1348,7 @@ const SIDE_POCKET_JAW_RADIUS_EXPANSION = 1; // keep middle jaw arcs the same siz
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.16; // add Showood-like extra depth so side jaws match the corner jaw type
 const SIDE_POCKET_JAW_VERTICAL_TWEAK = -TABLE.THICK * 0.01; // pull middle-pocket jaws a bit farther downward than corners
 const SIDE_POCKET_JAW_OUTWARD_SHIFT = TABLE.THICK * 0.02; // reduce the outward shift so middle-pocket jaws sit a bit more inward toward table center
-const POCKET_JAW_INWARD_PULL = TABLE.THICK * 0.052; // pull procedural jaw centers just a bit more inward to match the Royal Original pocket placement
+const POCKET_JAW_INWARD_PULL = TABLE.THICK * 0.052; // pull procedural jaw centers just a bit more inward to match the Showood pocket placement
 const SIDE_POCKET_JAW_EDGE_TRIM_START = POCKET_JAW_EDGE_FLUSH_START; // reuse the corner jaw shoulder timing
 const SIDE_POCKET_JAW_EDGE_TRIM_SCALE = 0.66; // shorten middle jaw side edges a bit more so all six jaws finish cleaner at the shoulders
 const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // mirror the taper curve from the corner profile
@@ -3683,7 +3682,7 @@ const CHROME_PLATE_STYLE_OPTIONS = Object.freeze([
   {
     id: 'showood-rounded',
     label: 'Showood Rounded',
-    description: 'Rounded showroom pocket plates shared by Showood and Royal Original tables.',
+    description: 'Rounded showroom pocket plates for the Showood GLB table.',
     swatches: ['#f6d56f', '#d6d8dc'],
     showGeneratedOnExternal: false,
     preserveExternalTrim: true,
@@ -11234,11 +11233,11 @@ export function Table3D(
     return mat;
   };
   const brandPlateThickness = chromePlateThickness;
-  const brandPlateDepth = Math.min(endRailW * 0.66, TABLE.THICK * 0.96);
-  const brandPlateWidth = Math.min(PLAY_W * 0.32, Math.max(BALL_R * 9.6, PLAY_W * 0.23));
+  const brandPlateDepth = Math.min(endRailW * 0.72, TABLE.THICK * 1.04);
+  const brandPlateWidth = Math.min(PLAY_W * 0.36, Math.max(BALL_R * 10.8, PLAY_W * 0.255));
   const brandPlateY = railsTopY + brandPlateThickness * 0.5 + MICRO_EPS * 8;
   const shortRailCenterZ = halfH + endRailW * 0.5;
-  const brandPlateOutwardShift = endRailW * 0.92;
+  const brandPlateOutwardShift = endRailW * 1.04;
   const brandPlateGeom = new THREE.BoxGeometry(
     brandPlateWidth,
     brandPlateThickness,
@@ -11285,7 +11284,9 @@ export function Table3D(
         }
       : { shape: DEFAULT_RAIL_MARKER_SHAPE, colorId: DEFAULT_RAIL_MARKER_COLOR_ID };
   const railMarkerOutset = longRailW * 0.08;
-  const railMarkerInwardShift = Math.max(BALL_R * 0.35, longRailW * 0.08);
+  const railMarkerInwardShift = resolvedTableOptions?.tableModel?.useReferenceShowoodMapping
+    ? -Math.max(BALL_R * 0.18, longRailW * 0.045)
+    : Math.max(BALL_R * 0.35, longRailW * 0.08);
   const railMarkerGroup = new THREE.Group();
   const railMarkerThickness = RAIL_MARKER_THICKNESS;
   const railMarkerWidth = ORIGINAL_RAIL_WIDTH * 0.64;
@@ -13029,7 +13030,11 @@ async function loadPoolRoyaleExternalTableTemplate(tableModel, renderer = null) 
   const promise = (async () => {
     const loader = createConfiguredGLTFLoader(renderer);
     let lastError = null;
-    const urls = [tableModel.assetUrl, tableModel.fallbackAssetUrl].filter(Boolean);
+    const urls = Array.from(new Set([
+      ...(Array.isArray(tableModel.assetUrls) ? tableModel.assetUrls : []),
+      tableModel.assetUrl,
+      tableModel.fallbackAssetUrl
+    ].filter(Boolean)));
     for (const url of urls) {
       try {
         // eslint-disable-next-line no-await-in-loop
@@ -13514,12 +13519,14 @@ function subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel) {
   const visualScale = Number(tableModel?.railSightApronVisualScale);
   const railSightHeightScale = Number(tableModel?.railSightVisualHeightScale);
   const sideApronHeightScale = Number(tableModel?.sideApronVisualHeightScale);
+  const railSightOutwardOffset = Number(tableModel?.railSightOutwardOffset);
   const sideApronOutwardOffset = Number(tableModel?.sideApronOutwardOffset);
   const hasScale = Number.isFinite(visualScale) && visualScale > 1 + MICRO_EPS;
   const hasRailSightHeight = Number.isFinite(railSightHeightScale) && railSightHeightScale > 1 + MICRO_EPS;
   const hasSideApronHeight = Number.isFinite(sideApronHeightScale) && sideApronHeightScale > 1 + MICRO_EPS;
+  const hasRailSightOffset = Number.isFinite(railSightOutwardOffset) && Math.abs(railSightOutwardOffset) > MICRO_EPS;
   const hasSideApronOffset = Number.isFinite(sideApronOutwardOffset) && Math.abs(sideApronOutwardOffset) > MICRO_EPS;
-  if (!hasScale && !hasRailSightHeight && !hasSideApronHeight && !hasSideApronOffset) return;
+  if (!hasScale && !hasRailSightHeight && !hasSideApronHeight && !hasRailSightOffset && !hasSideApronOffset) return;
   if (model.userData?.poolRoyaleShowoodRailSightApronExpanded) return;
 
   const fullBox = new THREE.Box3().setFromObject(model);
@@ -13545,16 +13552,21 @@ function subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel) {
     const heightScale = isSideApron ? safeSideApronHeightScale : safeRailSightHeightScale;
     if (heightScale > 1) child.scale.y *= heightScale;
 
-    if (isSideApron && hasSideApronOffset) {
+    const outwardOffset = isRailSight && hasRailSightOffset
+      ? railSightOutwardOffset
+      : isSideApron && hasSideApronOffset
+        ? sideApronOutwardOffset
+        : 0;
+    if (Math.abs(outwardOffset) > MICRO_EPS) {
       const childBox = new THREE.Box3().setFromObject(child);
       if (!childBox.isEmpty()) {
         const childCenter = childBox.getCenter(new THREE.Vector3());
         const awayX = childCenter.x - fullCenter.x;
         const awayZ = childCenter.z - fullCenter.z;
         if (Math.abs(awayX) >= Math.abs(awayZ) && Math.abs(awayX) > MICRO_EPS) {
-          child.position.x += Math.sign(awayX) * sideApronOutwardOffset;
+          child.position.x += Math.sign(awayX) * outwardOffset;
         } else if (Math.abs(awayZ) > MICRO_EPS) {
-          child.position.z += Math.sign(awayZ) * sideApronOutwardOffset;
+          child.position.z += Math.sign(awayZ) * outwardOffset;
         }
       }
     }
@@ -13665,6 +13677,7 @@ function mountPoolRoyaleExternalTableModel({
     tableModelId: tableModel.id
   };
   table.add(externalRoot);
+  setGeneratedVisualsVisible?.(false);
   let disposed = false;
 
   loadPoolRoyaleExternalTableTemplate(tableModel, renderer)
@@ -13677,11 +13690,11 @@ function mountPoolRoyaleExternalTableModel({
       setGeneratedVisualsVisible?.(false);
     })
     .catch((error) => {
-      console.warn('Pool Royale external table failed to load; keeping native table', {
+      console.warn('Pool Royale Showood GLB table failed to load; generated placeholder table remains hidden', {
         tableModelId: tableModel.id,
         error
       });
-      if (!disposed) setGeneratedVisualsVisible?.(true);
+      if (!disposed) setGeneratedVisualsVisible?.(false);
     });
 
   return {
@@ -14334,7 +14347,7 @@ function mountPoolRoyaleExternalTableModel({
   table.userData.cushionLipClearance = clothPlaneWorld;
   table.userData.clothPlaneLocal = clothPlaneLocal;
   table.userData.finish = finishInfo;
-  table.userData.tableModelId = resolvedTableOptions?.tableModel?.id || 'royal-original';
+  table.userData.tableModelId = resolvedTableOptions?.tableModel?.id || 'showood-seven-foot';
 
   const generatedVisualObjects = [];
   const generatedStructuralObjects = [];
@@ -15088,34 +15101,6 @@ function PoolRoyaleGame({
   const activeTableSize = useMemo(
     () => resolveTableSize(tableSizeKey),
     [tableSizeKey]
-  );
-  const updateGameSearchParams = useCallback(
-    (updates = {}) => {
-      const params = new URLSearchParams(location.search);
-      Object.entries(updates).forEach(([key, value]) => {
-        if (value === null || typeof value === 'undefined' || value === '') params.delete(key);
-        else params.set(key, String(value));
-      });
-      const nextSearch = params.toString();
-      navigate(
-        {
-          pathname: location.pathname,
-          search: nextSearch ? `?${nextSearch}` : ''
-        },
-        { replace: true }
-      );
-    },
-    [location.pathname, location.search, navigate]
-  );
-  const handleTableModelSelection = useCallback(
-    (modelId) => {
-      const model = resolvePoolRoyaleTableModel(modelId);
-      try {
-        window.localStorage?.setItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY, model.id);
-      } catch {}
-      updateGameSearchParams({ tableModel: model.id, showoodPalette: null });
-    },
-    [updateGameSearchParams]
   );
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
   const resolvedAccountId = useMemo(
@@ -36663,50 +36648,13 @@ const shotPowerRef = useRef(0);
                   </button>
                 </div>
               ) : null}
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Table Model
-                </h3>
-                <p className="mt-1 text-[0.7rem] text-white/60">
-                  Choose Royal Original or the full Showood GLB without leaving the match.
-                </p>
-                <div className="mt-2 grid grid-cols-1 gap-2">
-                  {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
-                    const active = option.id === activeTableModel.id;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        onClick={() => handleTableModelSelection(option.id)}
-                        aria-pressed={active}
-                        className={`w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                            : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                        }`}
-                      >
-                        <span className="flex items-center justify-between gap-2">
-                          <span className="text-[11px] font-semibold uppercase tracking-[0.24em]">
-                            {option.icon ? `${option.icon} ` : ''}{option.label}
-                          </span>
-                          <span className="text-[10px] font-semibold uppercase tracking-[0.18em] opacity-80">
-                            {option.tableSizeId}
-                          </span>
-                        </span>
-                        <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] opacity-70">
-                          {option.kind === 'gltf' ? 'GLB table' : 'Pool Royale table'}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
+
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Shared Table Finish
                 </h3>
                 <p className="mt-1 text-[0.68rem] leading-snug text-white/60">
-                  Changes the wood, rail, leg, and procedural base finish for both Royal Original and Showood GLB tables.
+                  Changes the wood, rail, leg, and procedural base finish for the Showood GLB table.
                 </p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {availableTableFinishes.map((option) => {
@@ -36743,7 +36691,7 @@ const shotPowerRef = useRef(0);
                   Shared Table Base
                 </h3>
                 <p className="mt-1 text-[0.68rem] leading-snug text-white/60">
-                  Shape options for the shared procedural base and legs used by both Royal Original and Showood GLB tables.
+                  Shape options for the procedural support base and legs under the Showood GLB table.
                 </p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {availableTableBases.map((option) => {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -13,7 +13,6 @@ import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
 import {
-  POOL_ROYALE_TABLE_MODEL_OPTIONS,
   POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
   resolvePoolRoyaleTableModel
 } from '../../config/poolRoyaleTableModels.js';
@@ -77,7 +76,7 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
-  const [tableModelId, setTableModelId] = useState(() => {
+  const [tableModelId] = useState(() => {
     try {
       const stored = window.localStorage?.getItem(
         POOL_ROYALE_TABLE_MODEL_STORAGE_KEY
@@ -96,6 +95,38 @@ export default function PoolRoyaleLobby() {
   ).id;
   const defaultTableSize = resolveTableSize().id;
   const onlineTableSize = tableSize || defaultTableSize;
+
+  useEffect(() => {
+    const urls = Array.from(new Set([
+      ...(Array.isArray(selectedTableModel?.assetUrls) ? selectedTableModel.assetUrls : []),
+      selectedTableModel?.assetUrl
+    ].filter(Boolean)));
+    const primaryUrl = urls[0];
+    const cdnUrl = urls.find((url) => typeof url === 'string' && url.startsWith('https://'));
+    const links = [];
+    if (cdnUrl) {
+      try {
+        const origin = new URL(cdnUrl).origin;
+        const preconnect = document.createElement('link');
+        preconnect.rel = 'preconnect';
+        preconnect.href = origin;
+        preconnect.crossOrigin = 'anonymous';
+        document.head.appendChild(preconnect);
+        links.push(preconnect);
+      } catch {}
+    }
+    if (primaryUrl) {
+      const preload = document.createElement('link');
+      preload.rel = 'preload';
+      preload.as = 'fetch';
+      preload.href = primaryUrl;
+      preload.crossOrigin = 'anonymous';
+      document.head.appendChild(preload);
+      links.push(preload);
+    }
+    return () => links.forEach((link) => link.parentNode?.removeChild(link));
+  }, [selectedTableModel]);
+
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -627,49 +658,6 @@ export default function PoolRoyaleLobby() {
           </div>
           <p className="mt-3 text-xs text-white/60">
             Your lobby choices persist into the match intro.
-          </p>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-white">Pool Table</h3>
-            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-              GLB Arena
-            </span>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
-              const active = tableModelId === option.id;
-              return (
-                <button
-                  key={option.id}
-                  type="button"
-                  onClick={() => setTableModelId(option.id)}
-                  className={`lobby-option-card ${
-                    active
-                      ? 'lobby-option-card-active'
-                      : 'lobby-option-card-inactive'
-                  }`}
-                >
-                  <div className="lobby-option-thumb bg-gradient-to-br from-fuchsia-400/20 via-amber-500/10 to-transparent">
-                    <div className="lobby-option-thumb-inner text-2xl">
-                      {option.icon || '🎱'}
-                    </div>
-                  </div>
-                  <div className="text-center">
-                    <p className="lobby-option-label">{option.label}</p>
-                    <p className="lobby-option-subtitle">
-                      {option.kind === 'gltf'
-                        ? `${option.tableSizeId} · original textures`
-                        : 'Current table'}
-                    </p>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-          <p className="text-xs text-white/60">
-            Royal Original keeps the clean procedural table; Showood material setup is available inside the in-game menu only.
           </p>
         </div>
 


### PR DESCRIPTION
### Motivation
- Prefer the Showood GLB model as the canonical Pool Royale table and serve the fastest same-origin copy when available. 
- Reduce runtime fallback to the old procedural table and improve load performance by preconnecting/preloading GLB sources.

### Description
- Added a local runtime path and CDN/fastly/raw mirrors for the Showood GLB, exposed as `assetUrls` and used `SHOWOOD_TABLE_LOCAL_URL`, `SHOWOOD_TABLE_CDN_URL`, `SHOWOOD_TABLE_FASTLY_URL`, and raw URL constants in `poolRoyaleTableModels.js`, and made `showood-seven-foot` the default table via `DEFAULT_POOL_ROYALE_TABLE_MODEL_ID` and removed the `royal-original` option.
- Updated the GLTF loader to try a deduplicated list of `assetUrls` (and fallbacks) when loading external table models in `PoolRoyale.jsx`, and adjusted error handling and generated-visual visibility so the procedural visuals remain hidden while attempting to load the GLB.
- Added local and fastly CDN entries for the Showood GLB to `public/pwa/gltf-assets.json`, updated the Showood model README to reflect the new fallback behavior, and adjusted related descriptive strings and thumbnails in inventory/table config files.
- Removed in-lobby and in-game manual table-model switching UI, added preconnect/preload of the table model URLs in `PoolRoyaleLobby.jsx`, and made several geometry/visual tweaks (brand plate sizes, rail/marker offsets, pocket/jaw comments) and small formatting/lint cleanups to align visuals with the Showood GLB.

### Testing
- Built the webapp with `npm run build` to ensure the bundle compiles and asset references resolve, and the build completed successfully.
- Ran the project test suite via `npm test` and the unit tests passed.
- Performed an automated smoke check of the `PoolRoyale` page during CI to confirm the external GLB load path is exercised and no loader exceptions were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e8313a3688329a67d7d30e0f381d1)