### PR TITLE
Add Gunify asset fetcher and integrate local Gunify GLTF support with spec-gloss patching

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -13,7 +13,8 @@
     "postinstall": "node scripts/postinstall.mjs",
     "fetch:murlan-agent47": "node scripts/fetch-murlan-agent47.mjs --asset agent-47",
     "fetch:murlan-characters": "node scripts/fetch-murlan-agent47.mjs --asset all",
-    "fetch:pool-royale-showood-table": "node scripts/fetch-pool-royale-showood-table.mjs"
+    "fetch:pool-royale-showood-table": "node scripts/fetch-pool-royale-showood-table.mjs",
+    "fetch:gunify-weapons": "node scripts/fetch-gunify-weapons.mjs"
   },
   "type": "module",
   "dependencies": {

--- a/webapp/scripts/fetch-gunify-weapons.mjs
+++ b/webapp/scripts/fetch-gunify-weapons.mjs
@@ -1,0 +1,43 @@
+import { spawnSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const repoUrl = 'https://github.com/KrishBharadwaj5678/Gunify.git';
+const repoRoot = resolve(new URL('..', import.meta.url).pathname);
+const publicModelsDir = join(repoRoot, 'public', 'models');
+const destinationDir = join(publicModelsDir, 'gunify');
+const tempDir = join(tmpdir(), `tonplaygram-gunify-${Date.now()}`);
+const requiredModels = ['AK47', 'KRSV', 'Mosin', 'SigSauer', 'Smith', 'Uzi'];
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    shell: false,
+    ...options
+  });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`);
+  }
+}
+
+try {
+  mkdirSync(publicModelsDir, { recursive: true });
+  mkdirSync(destinationDir, { recursive: true });
+  rmSync(tempDir, { recursive: true, force: true });
+  run('git', ['clone', '--depth', '1', repoUrl, tempDir]);
+
+  requiredModels.forEach((modelName) => {
+    const source = join(tempDir, 'models', modelName);
+    if (!existsSync(source)) {
+      throw new Error(`Gunify model folder missing: ${modelName}`);
+    }
+    const destination = join(destinationDir, modelName);
+    rmSync(destination, { recursive: true, force: true });
+    cpSync(source, destination, { recursive: true });
+  });
+
+  console.log(`Gunify weapon GLTF assets copied to ${destinationDir}`);
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -347,14 +347,58 @@ const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
 });
 const GUNIFY_RAW_BASE = 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main';
 const GUNIFY_JSDELIVR_BASE = 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main';
+const GUNIFY_LOCAL_BASE = '/models/gunify';
 const gunifyModelUrls = (modelName) => [
   `${GUNIFY_RAW_BASE}/models/${modelName}/scene.gltf`,
-  `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
+  `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`,
+  `${GUNIFY_LOCAL_BASE}/${modelName}/scene.gltf`
 ];
-const gunifyTextureUrls = (modelName, textureFileName) => [
-  `${GUNIFY_RAW_BASE}/models/${modelName}/textures/${textureFileName}`,
-  `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/textures/${textureFileName}`
-];
+
+const GUNIFY_SPECULAR_GLOSSINESS_EXTENSION = 'KHR_materials_pbrSpecularGlossiness';
+
+function cloneJsonValue(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function patchGunifySpecularGlossinessMaterials(gltfJson) {
+  if (!gltfJson?.materials?.length) return gltfJson;
+  const patched = { ...gltfJson, materials: gltfJson.materials.map((material) => ({ ...material })) };
+  let patchedAny = false;
+  patched.materials = patched.materials.map((material) => {
+    const specGloss = material?.extensions?.[GUNIFY_SPECULAR_GLOSSINESS_EXTENSION];
+    if (!specGloss) return material;
+    patchedAny = true;
+    const metallicRoughness = {
+      ...(material.pbrMetallicRoughness || {}),
+      metallicFactor: 0,
+      roughnessFactor: Math.max(0.08, Math.min(1, 1 - (specGloss.glossinessFactor ?? 0.82)))
+    };
+    if (specGloss.diffuseFactor) metallicRoughness.baseColorFactor = cloneJsonValue(specGloss.diffuseFactor);
+    if (specGloss.diffuseTexture) metallicRoughness.baseColorTexture = cloneJsonValue(specGloss.diffuseTexture);
+    return {
+      ...material,
+      pbrMetallicRoughness: metallicRoughness,
+      extensions: Object.fromEntries(
+        Object.entries(material.extensions || {}).filter(([extensionName]) => extensionName !== GUNIFY_SPECULAR_GLOSSINESS_EXTENSION)
+      )
+    };
+  });
+  if (patchedAny && Array.isArray(patched.extensionsUsed)) {
+    patched.extensionsUsed = patched.extensionsUsed.filter((extensionName) => extensionName !== GUNIFY_SPECULAR_GLOSSINESS_EXTENSION);
+  }
+  return patched;
+}
+
+async function loadGunifyOriginalGltf(loader, candidateUrl) {
+  const response = await fetch(candidateUrl, { mode: 'cors' });
+  if (!response.ok) throw new Error(`Gunify GLTF fetch failed: ${response.status}`);
+  const gltfJson = patchGunifySpecularGlossinessMaterials(await response.json());
+  const basePath = new URL('.', candidateUrl).href;
+  loader.setPath?.(basePath);
+  loader.setResourcePath?.(basePath);
+  return loader.parseAsync(JSON.stringify(gltfJson), basePath);
+}
 
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
@@ -414,7 +458,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   uziSprayAttack: {
     label: 'Gunify Uzi',
     urls: gunifyModelUrls('Uzi'),
-    textureOverrideUrls: gunifyTextureUrls('Uzi', 'Material__90_baseColor.png'),
+    modelName: 'Uzi',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.2
@@ -422,7 +466,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   ak47VolleyAttack: {
     label: 'Gunify AK-47',
     urls: gunifyModelUrls('AK47'),
-    textureOverrideUrls: gunifyTextureUrls('AK47', 'Material.001_baseColor.png'),
+    modelName: 'AK47',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.24
@@ -430,7 +474,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   krsvBurstAttack: {
     label: 'Gunify KRSV',
     urls: gunifyModelUrls('KRSV'),
-    textureOverrideUrls: gunifyTextureUrls('KRSV', 'Steel_baseColor.png'),
+    modelName: 'KRSV',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.24
@@ -438,7 +482,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   smithSidearmAttack: {
     label: 'Gunify Smith',
     urls: gunifyModelUrls('Smith'),
-    textureOverrideUrls: gunifyTextureUrls('Smith', 'Metal_baseColor.png'),
+    modelName: 'Smith',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.13
@@ -446,7 +490,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mosinMarksmanAttack: {
     label: 'Gunify Mosin',
     urls: gunifyModelUrls('Mosin'),
-    textureOverrideUrls: gunifyTextureUrls('Mosin', 'Mosin_baseColor.png'),
+    modelName: 'Mosin',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.5125
@@ -454,7 +498,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   sigsauerTacticalAttack: {
     label: 'Gunify SigSauer Tactical',
     urls: gunifyModelUrls('SigSauer'),
-    textureOverrideUrls: gunifyTextureUrls('SigSauer', 'Material_diffuse.png'),
+    modelName: 'SigSauer',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.13
@@ -481,7 +525,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   sniperShotAttack: {
     label: 'Gunify Mosin Sniper Shot',
     urls: gunifyModelUrls('Mosin'),
-    textureOverrideUrls: gunifyTextureUrls('Mosin', 'Mosin_baseColor.png'),
+    modelName: 'Mosin',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.504
@@ -645,8 +689,6 @@ function applyGunifyWeaponTexturePolicy(material) {
     texture.anisotropy = Math.max(texture.anisotropy || 1, activeModelTextureAnisotropy);
     texture.needsUpdate = true;
   });
-  if (typeof material.roughness === 'number') material.roughness = Math.min(0.9, Math.max(0.34, material.roughness));
-  if (typeof material.metalness === 'number') material.metalness = Math.min(1, Math.max(0.18, material.metalness));
   material.needsUpdate = true;
 }
 
@@ -1381,7 +1423,19 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         // source asset first so its WebGL texture transforms, samplers, UVs,
         // embedded images, and KTX2/PNG/JPEG color-space metadata stay intact.
         // eslint-disable-next-line no-await-in-loop
-        loadedRoot = assignLoadedGltf(await withLoadTimeout(loader.loadAsync(candidateUrl)));
+        try {
+          const basePath = new URL('.', candidateUrl).href;
+          loader.setPath?.(basePath);
+          loader.setResourcePath?.(basePath);
+        } catch {
+          const basePath = candidateUrl.replace(/scene\.gltf(?:[?#].*)?$/i, '');
+          loader.setPath?.(basePath);
+          loader.setResourcePath?.(basePath);
+        }
+        const loadedGltf = config?.source === 'Gunify' && isGltfAssetUrl(candidateUrl)
+          ? await withLoadTimeout(loadGunifyOriginalGltf(loader, candidateUrl))
+          : await withLoadTimeout(loader.loadAsync(candidateUrl));
+        loadedRoot = assignLoadedGltf(loadedGltf);
       } catch (error) {
         if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl)) {
           if (i === candidateUrls.length - 1) {
@@ -1421,26 +1475,6 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     try {
       const root = loadedRoot;
       if (!root) return null;
-      const textureOverrideUrls = Array.isArray(config?.textureOverrideUrls) ? config.textureOverrideUrls.filter(Boolean) : [];
-      let textureOverride = null;
-      if (textureOverrideUrls.length) {
-        const textureLoader = new THREE.TextureLoader();
-        textureLoader.setCrossOrigin?.('anonymous');
-        for (let t = 0; t < textureOverrideUrls.length; t += 1) {
-          try {
-            // eslint-disable-next-line no-await-in-loop
-            textureOverride = await withLoadTimeout(textureLoader.loadAsync(textureOverrideUrls[t]));
-            if (textureOverride) {
-              textureOverride.flipY = false;
-              applySRGBColorSpace(textureOverride);
-              textureOverride.needsUpdate = true;
-              break;
-            }
-          } catch {
-            // keep trying next override
-          }
-        }
-      }
       root.traverse((node) => {
         if (!node?.isMesh) return;
         if (
@@ -1457,7 +1491,6 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         const materials = Array.isArray(node.material) ? node.material : [node.material];
         materials.forEach((material) => {
           if (material?.map) applySRGBColorSpace(material.map);
-          if (!material?.map && textureOverride) material.map = textureOverride;
           if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
           if (config?.texturePolicy === 'gunifyPbr') applyGunifyWeaponTexturePolicy(material);
           material.transparent = false;


### PR DESCRIPTION
### Motivation
- Introduce a script to fetch Gunify weapon models into the app `public/models` to allow serving assets locally and reduce reliance on external CDNs. 
- Improve loading of Gunify GLTFs by handling `KHR_materials_pbrSpecularGlossiness` materials so models render under the app's PBR pipeline. 
- Simplify texture handling for Gunify models to prefer baked GLTF resources and a local fallback path. 

### Description
- Add `webapp/scripts/fetch-gunify-weapons.mjs` which clones the Gunify repo, copies required model folders (`AK47`, `KRSV`, `Mosin`, `SigSauer`, `Smith`, `Uzi`) into `public/models/gunify`, and cleans up a temporary dir. 
- Add `fetch:gunify-weapons` script to `webapp/package.json` to run the new fetcher. 
- In `LudoBattleRoyal.jsx` add a local base `GUNIFY_LOCAL_BASE = '/models/gunify'` and include it as a fallback in `gunifyModelUrls`. 
- Implement `patchGunifySpecularGlossinessMaterials` (with helper `cloneJsonValue`) to convert `KHR_materials_pbrSpecularGlossiness` properties into `pbrMetallicRoughness` equivalents and strip the extension from materials and `extensionsUsed`. 
- Add `loadGunifyOriginalGltf` to fetch, patch, and parse GLTF JSON for Gunify GLTF assets and integrate it into the existing loader flow so Gunify GLTF URLs are processed via the JSON patcher before being parsed by the GLTF loader. 
- Update model configuration entries to use `modelName` for Gunify items and remove previous `textureOverrideUrls` usage for those models. 
- Remove canned clamping of `material.roughness` and `material.metalness` inside `applyGunifyWeaponTexturePolicy` to preserve converted PBR values. 
- Ensure loader path/resource path is set before loading to preserve relative texture resolution. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e868d1ad083299d56f70665ad985e)