### PR TITLE
Increase Pool Royale shot power slightly

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1834,7 +1834,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.5; // preserve legacy cue response before the final mobile comfort trim
-const SHOT_GLOBAL_POWER_SCALE = 0.72; // increase Pool Royale shot pace by 50% while keeping the selected shot-power curve
+const SHOT_GLOBAL_POWER_SCALE = 0.78; // add a small Pool Royale shot pace bump while keeping the selected shot-power curve
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *


### PR DESCRIPTION
### Motivation
- Players requested a bit more shot power / pace in Pool Royale while keeping the existing mobile slider curve and visual feel.

### Description
- Bumped the global shot scaling constant from `SHOT_GLOBAL_POWER_SCALE = 0.72` to `0.78` in `webapp/src/pages/Games/PoolRoyale.jsx` to provide a modest overall power/pace increase.

### Testing
- Ran the production build via `npm --prefix webapp run build` and the build completed successfully (Vite produced the `dist/` bundle).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1c88c87083298a9b19fde7c356ac)