### PR TITLE
Restore Gunify weapon texture mapping and add spec-gloss → PBR conversion

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -347,14 +347,66 @@ const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
 });
 const GUNIFY_RAW_BASE = 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main';
 const GUNIFY_JSDELIVR_BASE = 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main';
+const GUNIFY_LOCAL_BASE = '/models/gunify';
 const gunifyModelUrls = (modelName) => [
   `${GUNIFY_RAW_BASE}/models/${modelName}/scene.gltf`,
-  `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
+  `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`,
+  `${GUNIFY_LOCAL_BASE}/${modelName}/scene.gltf`
 ];
-const gunifyTextureUrls = (modelName, textureFileName) => [
-  `${GUNIFY_RAW_BASE}/models/${modelName}/textures/${textureFileName}`,
-  `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/textures/${textureFileName}`
-];
+
+const GUNIFY_SPECULAR_GLOSSINESS_EXTENSION = 'KHR_materials_pbrSpecularGlossiness';
+
+function cloneJsonValue(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function patchGunifySpecularGlossinessMaterials(gltfJson) {
+  if (!gltfJson?.materials?.length) return gltfJson;
+  const patched = { ...gltfJson, materials: gltfJson.materials.map((material) => ({ ...material })) };
+  let patchedAny = false;
+  patched.materials = patched.materials.map((material) => {
+    const specGloss = material?.extensions?.[GUNIFY_SPECULAR_GLOSSINESS_EXTENSION];
+    if (!specGloss) return material;
+    patchedAny = true;
+    const metallicRoughness = {
+      ...(material.pbrMetallicRoughness || {}),
+      metallicFactor: 0,
+      roughnessFactor: Math.max(0.08, Math.min(1, 1 - (specGloss.glossinessFactor ?? 0.82)))
+    };
+    if (specGloss.diffuseFactor) metallicRoughness.baseColorFactor = cloneJsonValue(specGloss.diffuseFactor);
+    if (specGloss.diffuseTexture) metallicRoughness.baseColorTexture = cloneJsonValue(specGloss.diffuseTexture);
+    return {
+      ...material,
+      pbrMetallicRoughness: metallicRoughness,
+      extensions: Object.fromEntries(
+        Object.entries(material.extensions || {}).filter(([extensionName]) => extensionName !== GUNIFY_SPECULAR_GLOSSINESS_EXTENSION)
+      )
+    };
+  });
+  if (patchedAny && Array.isArray(patched.extensionsUsed)) {
+    patched.extensionsUsed = patched.extensionsUsed.filter((extensionName) => extensionName !== GUNIFY_SPECULAR_GLOSSINESS_EXTENSION);
+  }
+  return patched;
+}
+
+function resolveGltfBasePath(candidateUrl) {
+  try {
+    return new URL('.', candidateUrl).href;
+  } catch {
+    return candidateUrl.replace(/[^/]*(?:[?#].*)?$/, '');
+  }
+}
+
+async function loadGunifyOriginalGltf(loader, candidateUrl) {
+  const response = await fetch(candidateUrl, { mode: 'cors' });
+  if (!response.ok) throw new Error(`Gunify GLTF fetch failed: ${response.status}`);
+  const gltfJson = patchGunifySpecularGlossinessMaterials(await response.json());
+  const basePath = resolveGltfBasePath(candidateUrl);
+  loader.setPath?.(basePath);
+  loader.setResourcePath?.(basePath);
+  return loader.parseAsync(JSON.stringify(gltfJson), basePath);
+}
 
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
@@ -414,7 +466,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   uziSprayAttack: {
     label: 'Gunify Uzi',
     urls: gunifyModelUrls('Uzi'),
-    textureOverrideUrls: gunifyTextureUrls('Uzi', 'Material__90_baseColor.png'),
+    modelName: 'Uzi',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.2
@@ -422,7 +474,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   ak47VolleyAttack: {
     label: 'Gunify AK-47',
     urls: gunifyModelUrls('AK47'),
-    textureOverrideUrls: gunifyTextureUrls('AK47', 'Material.001_baseColor.png'),
+    modelName: 'AK47',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.24
@@ -430,7 +482,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   krsvBurstAttack: {
     label: 'Gunify KRSV',
     urls: gunifyModelUrls('KRSV'),
-    textureOverrideUrls: gunifyTextureUrls('KRSV', 'Steel_baseColor.png'),
+    modelName: 'KRSV',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.24
@@ -438,7 +490,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   smithSidearmAttack: {
     label: 'Gunify Smith',
     urls: gunifyModelUrls('Smith'),
-    textureOverrideUrls: gunifyTextureUrls('Smith', 'Metal_baseColor.png'),
+    modelName: 'Smith',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.13
@@ -446,7 +498,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mosinMarksmanAttack: {
     label: 'Gunify Mosin',
     urls: gunifyModelUrls('Mosin'),
-    textureOverrideUrls: gunifyTextureUrls('Mosin', 'Mosin_baseColor.png'),
+    modelName: 'Mosin',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.5125
@@ -454,7 +506,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   sigsauerTacticalAttack: {
     label: 'Gunify SigSauer Tactical',
     urls: gunifyModelUrls('SigSauer'),
-    textureOverrideUrls: gunifyTextureUrls('SigSauer', 'Material_diffuse.png'),
+    modelName: 'SigSauer',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.13
@@ -481,7 +533,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   sniperShotAttack: {
     label: 'Gunify Mosin Sniper Shot',
     urls: gunifyModelUrls('Mosin'),
-    textureOverrideUrls: gunifyTextureUrls('Mosin', 'Mosin_baseColor.png'),
+    modelName: 'Mosin',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.504
@@ -1381,7 +1433,13 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         // source asset first so its WebGL texture transforms, samplers, UVs,
         // embedded images, and KTX2/PNG/JPEG color-space metadata stay intact.
         // eslint-disable-next-line no-await-in-loop
-        loadedRoot = assignLoadedGltf(await withLoadTimeout(loader.loadAsync(candidateUrl)));
+        const basePath = resolveGltfBasePath(candidateUrl);
+        loader.setPath?.(basePath);
+        loader.setResourcePath?.(basePath);
+        const loadedGltf = config?.source === 'Gunify' && isGltfAssetUrl(candidateUrl)
+          ? await withLoadTimeout(loadGunifyOriginalGltf(loader, candidateUrl))
+          : await withLoadTimeout(loader.loadAsync(candidateUrl));
+        loadedRoot = assignLoadedGltf(loadedGltf);
       } catch (error) {
         if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl)) {
           if (i === candidateUrls.length - 1) {
@@ -1457,7 +1515,7 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         const materials = Array.isArray(node.material) ? node.material : [node.material];
         materials.forEach((material) => {
           if (material?.map) applySRGBColorSpace(material.map);
-          if (!material?.map && textureOverride) material.map = textureOverride;
+          if (!material?.map && textureOverride && config?.source !== 'Gunify') material.map = textureOverride;
           if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
           if (config?.texturePolicy === 'gunifyPbr') applyGunifyWeaponTexturePolicy(material);
           material.transparent = false;


### PR DESCRIPTION
### Motivation
- Fix missing original Gunify weapon textures by restoring the GLTF material/texture handling to the same behavior used on May 9 so authored diffuse/normal/metallic maps remain visible. 
- Ensure Gunify GLTFs that use `KHR_materials_pbrSpecularGlossiness` (e.g. SigSauer) are converted to metal/roughness PBR so Three.js shows their original textures. 
- Prefer original GLTF loader + base-path handling over flattening to a single override texture and add a local fallback path for offline/dev use. 

### Description
- Restored and extended the Gunify loading path in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by adding `GUNIFY_LOCAL_BASE` and reordering `gunifyModelUrls` to include local, raw GitHub and jsDelivr fallbacks. 
- Added `patchGunifySpecularGlossinessMaterials`, `cloneJsonValue`, `resolveGltfBasePath` and `loadGunifyOriginalGltf` to fetch/patch `.gltf` JSON and convert `KHR_materials_pbrSpecularGlossiness` materials into `pbrMetallicRoughness` so original diffuse textures remain referenced. 
- Replaced per-model `textureOverrideUrls` for Gunify entries with `modelName` and `texturePolicy: 'gunifyPbr'`, and updated the loader logic to route Gunify `.gltf` URLs through `loadGunifyOriginalGltf` first (while preserving non-Gunify texture overrides for other sources). 
- Adjusted texture-override assignment so global fallback textures are not applied to Gunify-sourced models (`if (!material?.map && textureOverride && config?.source !== 'Gunify')`). 

### Testing
- Ran `npm --prefix webapp run lint -- --quiet` and it completed without reported linter errors. 
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build output generated). 
- Attempted an automated in-browser screenshot using Playwright to validate textures at `http://127.0.0.1:4173/games/ludobattleroyal`, but Playwright browser binaries were not installed in this environment so the screenshot step could not run (install with `npx playwright install` to enable this check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa034b6ec832987c9482cb35a0d5b)