### PR TITLE
Restore Ludo Gunify weapon texture baseline

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -205,6 +205,24 @@ describe('cross-game inventory alignment', () => {
     });
   });
 
+
+  test('ludo battle royal pins Gunify weapon loading to the May 9 texture baseline', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+    const may9Ref = '27232cf389a2be3f8f476c667cb293e978aaf5f9';
+
+    expect(source).toContain(`const GUNIFY_MAY_9_REF = '${may9Ref}'`);
+    expect(source).toContain('loadGunifyOriginalGltf');
+    expect(source).toContain('patchGunifySpecularGlossinessMaterials');
+    expect(source).toContain('KHR_materials_pbrSpecularGlossiness');
+    expect(source).not.toContain('textureOverrideUrls: gunifyTextureUrls');
+
+    ['AK47', 'KRSV', 'Smith', 'Mosin', 'SigSauer', 'Uzi'].forEach((modelName) => {
+      expect(source).toContain('https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/${GUNIFY_MAY_9_REF}');
+      expect(source).toContain('https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@${GUNIFY_MAY_9_REF}');
+      expect(source).toContain(`modelName: '${modelName}'`);
+    });
+  });
+
   test('snake store mirrors ludo battle royal capture weapons', () => {
     const snakeCaptureStoreIds = new Set(
       SNAKE_STORE_ITEMS.filter((item) => item.type === 'captureWeapon').map((item) => item.optionId)

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -345,16 +345,67 @@ const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
   0: 2,
   2: 0
 });
-const GUNIFY_RAW_BASE = 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main';
-const GUNIFY_JSDELIVR_BASE = 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main';
+// Latest Gunify commit visible at the end of May 9, 2026; keep Ludo weapons
+// pinned to that tree so texture folders/material JSON cannot drift under main.
+const GUNIFY_MAY_9_REF = '27232cf389a2be3f8f476c667cb293e978aaf5f9';
+const GUNIFY_RAW_BASE = `https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/${GUNIFY_MAY_9_REF}`;
+const GUNIFY_JSDELIVR_BASE = `https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@${GUNIFY_MAY_9_REF}`;
 const gunifyModelUrls = (modelName) => [
   `${GUNIFY_RAW_BASE}/models/${modelName}/scene.gltf`,
   `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
 ];
-const gunifyTextureUrls = (modelName, textureFileName) => [
-  `${GUNIFY_RAW_BASE}/models/${modelName}/textures/${textureFileName}`,
-  `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/textures/${textureFileName}`
-];
+
+const GUNIFY_SPECULAR_GLOSSINESS_EXTENSION = 'KHR_materials_pbrSpecularGlossiness';
+
+function cloneGltfJsonValue(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function patchGunifySpecularGlossinessMaterials(gltfJson) {
+  if (!gltfJson?.materials?.length) return gltfJson;
+  let patchedAny = false;
+  const patched = {
+    ...gltfJson,
+    materials: gltfJson.materials.map((material) => {
+      const specGloss = material?.extensions?.[GUNIFY_SPECULAR_GLOSSINESS_EXTENSION];
+      if (!specGloss) return material;
+      patchedAny = true;
+      const metallicRoughness = {
+        ...(material.pbrMetallicRoughness || {}),
+        metallicFactor: 0,
+        roughnessFactor: Math.max(0.08, Math.min(1, 1 - (specGloss.glossinessFactor ?? 0.82)))
+      };
+      if (specGloss.diffuseFactor) metallicRoughness.baseColorFactor = cloneGltfJsonValue(specGloss.diffuseFactor);
+      if (specGloss.diffuseTexture) metallicRoughness.baseColorTexture = cloneGltfJsonValue(specGloss.diffuseTexture);
+      return {
+        ...material,
+        pbrMetallicRoughness: metallicRoughness,
+        extensions: Object.fromEntries(
+          Object.entries(material.extensions || {}).filter(
+            ([extensionName]) => extensionName !== GUNIFY_SPECULAR_GLOSSINESS_EXTENSION
+          )
+        )
+      };
+    })
+  };
+  if (patchedAny && Array.isArray(patched.extensionsUsed)) {
+    patched.extensionsUsed = patched.extensionsUsed.filter(
+      (extensionName) => extensionName !== GUNIFY_SPECULAR_GLOSSINESS_EXTENSION
+    );
+  }
+  return patched;
+}
+
+async function loadGunifyOriginalGltf(loader, candidateUrl) {
+  const response = await fetch(candidateUrl, { mode: 'cors' });
+  if (!response.ok) throw new Error(`Gunify GLTF fetch failed: ${response.status}`);
+  const gltfJson = patchGunifySpecularGlossinessMaterials(await response.json());
+  const basePath = new URL('.', candidateUrl).href;
+  loader.setPath?.(basePath);
+  loader.setResourcePath?.(basePath);
+  return loader.parseAsync(JSON.stringify(gltfJson), basePath);
+}
 
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
@@ -414,7 +465,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   uziSprayAttack: {
     label: 'Gunify Uzi',
     urls: gunifyModelUrls('Uzi'),
-    textureOverrideUrls: gunifyTextureUrls('Uzi', 'Material__90_baseColor.png'),
+    modelName: 'Uzi',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.2
@@ -422,7 +473,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   ak47VolleyAttack: {
     label: 'Gunify AK-47',
     urls: gunifyModelUrls('AK47'),
-    textureOverrideUrls: gunifyTextureUrls('AK47', 'Material.001_baseColor.png'),
+    modelName: 'AK47',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.24
@@ -430,7 +481,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   krsvBurstAttack: {
     label: 'Gunify KRSV',
     urls: gunifyModelUrls('KRSV'),
-    textureOverrideUrls: gunifyTextureUrls('KRSV', 'Steel_baseColor.png'),
+    modelName: 'KRSV',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.24
@@ -438,7 +489,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   smithSidearmAttack: {
     label: 'Gunify Smith',
     urls: gunifyModelUrls('Smith'),
-    textureOverrideUrls: gunifyTextureUrls('Smith', 'Metal_baseColor.png'),
+    modelName: 'Smith',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.13
@@ -446,7 +497,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mosinMarksmanAttack: {
     label: 'Gunify Mosin',
     urls: gunifyModelUrls('Mosin'),
-    textureOverrideUrls: gunifyTextureUrls('Mosin', 'Mosin_baseColor.png'),
+    modelName: 'Mosin',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.5125
@@ -454,7 +505,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   sigsauerTacticalAttack: {
     label: 'Gunify SigSauer Tactical',
     urls: gunifyModelUrls('SigSauer'),
-    textureOverrideUrls: gunifyTextureUrls('SigSauer', 'Material_diffuse.png'),
+    modelName: 'SigSauer',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.13
@@ -481,7 +532,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   sniperShotAttack: {
     label: 'Gunify Mosin Sniper Shot',
     urls: gunifyModelUrls('Mosin'),
-    textureOverrideUrls: gunifyTextureUrls('Mosin', 'Mosin_baseColor.png'),
+    modelName: 'Mosin',
     source: 'Gunify',
     texturePolicy: 'gunifyPbr',
     scale: 0.504
@@ -1377,11 +1428,23 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     for (let i = 0; i < candidateUrls.length; i += 1) {
       const candidateUrl = candidateUrls[i];
       try {
-        // Match the May 11 morning GLB/GLTF path: let GLTFLoader consume the
+        // Match the May 9 Gunify GLB/GLTF path: let GLTFLoader consume the
         // source asset first so its WebGL texture transforms, samplers, UVs,
         // embedded images, and KTX2/PNG/JPEG color-space metadata stay intact.
         // eslint-disable-next-line no-await-in-loop
-        loadedRoot = assignLoadedGltf(await withLoadTimeout(loader.loadAsync(candidateUrl)));
+        try {
+          const basePath = new URL('.', candidateUrl).href;
+          loader.setPath?.(basePath);
+          loader.setResourcePath?.(basePath);
+        } catch {
+          const basePath = candidateUrl.replace(/scene\.gltf(?:[?#].*)?$/i, '');
+          loader.setPath?.(basePath);
+          loader.setResourcePath?.(basePath);
+        }
+        const loadedGltf = config?.source === 'Gunify' && isGltfAssetUrl(candidateUrl)
+          ? await withLoadTimeout(loadGunifyOriginalGltf(loader, candidateUrl))
+          : await withLoadTimeout(loader.loadAsync(candidateUrl));
+        loadedRoot = assignLoadedGltf(loadedGltf);
       } catch (error) {
         if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl)) {
           if (i === candidateUrls.length - 1) {
@@ -1421,26 +1484,6 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     try {
       const root = loadedRoot;
       if (!root) return null;
-      const textureOverrideUrls = Array.isArray(config?.textureOverrideUrls) ? config.textureOverrideUrls.filter(Boolean) : [];
-      let textureOverride = null;
-      if (textureOverrideUrls.length) {
-        const textureLoader = new THREE.TextureLoader();
-        textureLoader.setCrossOrigin?.('anonymous');
-        for (let t = 0; t < textureOverrideUrls.length; t += 1) {
-          try {
-            // eslint-disable-next-line no-await-in-loop
-            textureOverride = await withLoadTimeout(textureLoader.loadAsync(textureOverrideUrls[t]));
-            if (textureOverride) {
-              textureOverride.flipY = false;
-              applySRGBColorSpace(textureOverride);
-              textureOverride.needsUpdate = true;
-              break;
-            }
-          } catch {
-            // keep trying next override
-          }
-        }
-      }
       root.traverse((node) => {
         if (!node?.isMesh) return;
         if (
@@ -1457,7 +1500,6 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         const materials = Array.isArray(node.material) ? node.material : [node.material];
         materials.forEach((material) => {
           if (material?.map) applySRGBColorSpace(material.map);
-          if (!material?.map && textureOverride) material.map = textureOverride;
           if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
           if (config?.texturePolicy === 'gunifyPbr') applyGunifyWeaponTexturePolicy(material);
           material.transparent = false;


### PR DESCRIPTION
### Motivation
- Gunify-sourced weapon models lost their original material/texture mapping due to a fallback «single-image override» path; the intent is to restore canonical GLTF material loading as it was on May 9 so original PBR textures show correctly. 

### Description
- Pin Gunify model URLs to the May 9, 2026 tree by introducing `GUNIFY_MAY_9_REF` and switching `GUNIFY_RAW_BASE` / CDN base to that ref so texture folder layout cannot drift. 
- Replace single-image `textureOverrideUrls` usage with `modelName` + direct GLTF loading and add `loadGunifyOriginalGltf` to fetch/parse the authored GLTF while preserving resource base paths. 
- Add `patchGunifySpecularGlossinessMaterials` to convert `KHR_materials_pbrSpecularGlossiness` spec-gloss materials into `pbrMetallicRoughness` so legacy spec/gloss assets render correctly in Three.js. 
- Update the capture-weapon loader to try original GLTF via the new loader path first, fall back to binary GLB image-inlining only if needed, and remove the override-path assignment to material maps. 
- Add a regression test in `test/inventoryCrossGameConfig.test.js` that asserts the May 9 baseline, presence of the loader/patch helpers, and that `textureOverrideUrls` are no longer used for Gunify weapons. 

### Testing
- Ran linter: `npm --prefix webapp run lint -- src/pages/Games/LudoBattleRoyal.jsx`, which completed without errors. (success)
- Ran the inventory test suite: `npx jest test/inventoryCrossGameConfig.test.js --runInBand`, all tests passed (11/11). (success)
- Built the webapp: `npm --prefix webapp run build`, which completed and produced the production bundle. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa034b6ec832987c9482cb35a0d5b)