### PR TITLE
Preserve Ludo weapon source textures

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -223,6 +223,43 @@ describe('cross-game inventory alignment', () => {
     });
   });
 
+  test('ludo battle royal preserves source-authentic textures for non-Gunify weapons', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('const withOriginalWeaponTextures');
+    expect(source).toContain('preserveSourceTextures: true');
+    expect(source).toContain("texturePolicy: 'sourceOriginal'");
+    expect(source).toContain('config?.preserveSourceTextures');
+    expect(source).toContain('Source-authentic weapons must never run through the legacy image');
+    expect(source).toContain('!config?.preserveSourceTextures');
+    expect(source).not.toContain("textureOverrideUrls");
+
+    [
+      'mrtkGunAttack',
+      'pistolHolsterAttack',
+      'fpsGunAttack',
+      'glockSidearmAttack',
+      'pistolSidearmAttack',
+      'assaultRifleAttack',
+      'grenadeBlastAttack',
+      'shotgunBlastAttack',
+      'smgBurstAttack',
+      'compactCarbineAttack',
+      'marksmanDmrAttack',
+      'polyShotgun01Attack',
+      'polyAssaultRifle01Attack',
+      'polyPistol01Attack',
+      'polyRevolver01Attack',
+      'polySawedOff01Attack',
+      'polyRobotLargeGunAttack',
+      'polyBazooka01Attack',
+      'polyHandGrenade01Attack',
+      'polyTank01Attack'
+    ].forEach((weaponId) => {
+      expect(source).toContain(`${weaponId}: {`);
+    });
+  });
+
   test('snake store mirrors ludo battle royal capture weapons', () => {
     const snakeCaptureStoreIds = new Set(
       SNAKE_STORE_ITEMS.filter((item) => item.type === 'captureWeapon').map((item) => item.optionId)

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -407,7 +407,21 @@ async function loadGunifyOriginalGltf(loader, candidateUrl) {
   return loader.parseAsync(JSON.stringify(gltfJson), basePath);
 }
 
-const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
+const withOriginalWeaponTextures = (configs) =>
+  Object.freeze(
+    Object.fromEntries(
+      Object.entries(configs).map(([id, config]) => [
+        id,
+        Object.freeze({
+          preserveSourceTextures: true,
+          texturePolicy: 'sourceOriginal',
+          ...config
+        })
+      ])
+    )
+  );
+
+const CAPTURE_WEAPON_MODEL_CONFIG = withOriginalWeaponTextures({
   mrtkGunAttack: {
     label: 'MRTK Gun',
     urls: [
@@ -1446,7 +1460,7 @@ async function loadCaptureWeaponModel(captureAnimationId) {
           : await withLoadTimeout(loader.loadAsync(candidateUrl));
         loadedRoot = assignLoadedGltf(loadedGltf);
       } catch (error) {
-        if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl)) {
+        if (isGltfAssetUrl(candidateUrl) || isPolyPizzaAssetUrl(candidateUrl) || config?.preserveSourceTextures) {
           if (i === candidateUrls.length - 1) {
             console.warn('Capture weapon model load failed', normalizedCaptureAnimationId, candidateUrl, error);
           }
@@ -1454,6 +1468,12 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         }
       }
       if (loadedRoot) break;
+      if (config?.preserveSourceTextures) {
+        // Source-authentic weapons must never run through the legacy image
+        // data-URI fallback because that path can replace missing maps with
+        // checker placeholders. Prefer the next original host instead.
+        continue;
+      }
       try {
         // Binary GLB patching is only a fallback for legacy hosts that reject
         // referenced textures. It must not run before GLTFLoader because it
@@ -1502,8 +1522,10 @@ async function loadCaptureWeaponModel(captureAnimationId) {
           if (material?.map) applySRGBColorSpace(material.map);
           if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
           if (config?.texturePolicy === 'gunifyPbr') applyGunifyWeaponTexturePolicy(material);
-          material.transparent = false;
-          material.opacity = 1;
+          if (!config?.preserveSourceTextures) {
+            material.transparent = false;
+            material.opacity = 1;
+          }
           material.needsUpdate = true;
         });
       });


### PR DESCRIPTION
### Motivation
- Fix incorrect/overwritten weapon textures by preserving original authored textures for non-Gunify capture weapons and keep Gunify weapons pinned to the May 9 baseline for their patched GLTFs.
- Avoid the legacy GLB image-data-URI fallback for source-authentic weapons because it can replace missing authored maps with placeholder images.

### Description
- Add `withOriginalWeaponTextures` helper and wrap `CAPTURE_WEAPON_MODEL_CONFIG` so weapon entries default to `preserveSourceTextures: true` and `texturePolicy: 'sourceOriginal'` for source-authentic assets (file `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Skip the binary GLB image data-URI fallback when `config?.preserveSourceTextures` is set, preferring the next original host instead (modifies the model-load control flow in `loadCaptureWeaponModel`).
- Preserve authored material transparency/opacity for source-authentic weapons by not forcing `material.transparent = false` / `material.opacity = 1` when `preserveSourceTextures` is true.
- Add a regression test `ludo battle royal preserves source-authentic textures for non-Gunify weapons` to `test/inventoryCrossGameConfig.test.js` to assert the new config wrapper and behavior are present.

### Testing
- Ran the inventory alignment unit tests with `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` and received `PASS` for the suite (12 tests passed). 
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully (Vite bundle produced without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fab3e02ac8329bca9802accdc1d90)