### PR TITLE
Fix Ludo weapon source textures

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -223,6 +223,60 @@ describe('cross-game inventory alignment', () => {
     });
   });
 
+  test('ludo battle royal keeps non-Gunify weapons on original source texture assets', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    [
+      'gunsForBjsFpsGame',
+      'webaversePistol',
+      'webaverseUzi',
+      'friunsBingExtension',
+      'saaam3dModelBundle',
+      'mixedRealityToolkitGun'
+    ].forEach((sourceRefKey) => {
+      expect(source).toContain(sourceRefKey);
+    });
+    expect(source).toContain("texturePolicy: 'sourceOriginal'");
+    expect(source).toContain("'lando19/Guns-for-BJS-FPS-Game'");
+    expect(source).toContain('GITHUB_SOURCE_REFS.gunsForBjsFpsGame');
+    expect(source).toContain("'webaverse/pistol'");
+    expect(source).toContain('GITHUB_SOURCE_REFS.webaversePistol');
+    expect(source).toContain("'webaverse/uzi'");
+    expect(source).toContain('GITHUB_SOURCE_REFS.webaverseUzi');
+    expect(source).not.toContain('lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf');
+    expect(source).not.toContain('webaverse/pistol@master');
+    expect(source).not.toContain('webaverse/uzi@main');
+  });
+
+  test('ludo battle royal Poly Pizza weapon thumbnails use source renders instead of glyph placeholders', () => {
+    const polyPizzaWeaponIds = [
+      'polyShotgun01Attack',
+      'polyAssaultRifle01Attack',
+      'polyPistol01Attack',
+      'polyRevolver01Attack',
+      'polySawedOff01Attack',
+      'polyRevolver02Attack',
+      'polyShotgun02Attack',
+      'polyShotgun03Attack',
+      'polySmg01Attack',
+      'polyRobotLargeGunAttack',
+      'polyRobotFlyingGunAttack',
+      'polyBazooka01Attack',
+      'polyGrenadeLauncher01Attack',
+      'polyDynamiteBomb01Attack',
+      'polyMolotov01Attack',
+      'polyGasTank01Attack',
+      'polyHandGrenade01Attack',
+      'polyTank01Attack'
+    ];
+
+    polyPizzaWeaponIds.forEach((weaponId) => {
+      const option = CAPTURE_ANIMATION_OPTIONS.find((entry) => entry.id === weaponId);
+      expect(option?.thumbnail).toMatch(/^https:\/\/static\.poly\.pizza\/.+\.webp$/);
+      expect(option?.thumbnail).not.toContain('data:image/svg+xml');
+    });
+  });
+
   test('snake store mirrors ludo battle royal capture weapons', () => {
     const snakeCaptureStoreIds = new Set(
       SNAKE_STORE_ITEMS.filter((item) => item.type === 'captureWeapon').map((item) => item.optionId)

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -134,6 +134,28 @@ const captureWeaponGlyphThumb = (glyph = '▭', accent = '#334155') =>
 const GUNIFY_RAW_BASE = 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main';
 const gunifyImage = (fileName) => `${GUNIFY_RAW_BASE}/images/${fileName}`;
 
+const polyPizzaThumb = (assetId) => `https://static.poly.pizza/${assetId}.webp`;
+const CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS = Object.freeze({
+  polyShotgun01Attack: polyPizzaThumb('032e6589-3188-41bc-b92b-e25528344275'),
+  polyAssaultRifle01Attack: polyPizzaThumb('b3e6be61-0299-4866-a227-58f5f3fe610b'),
+  polyPistol01Attack: polyPizzaThumb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc'),
+  polyRevolver01Attack: polyPizzaThumb('9e728565-67a3-44db-9567-982320abff09'),
+  polySawedOff01Attack: polyPizzaThumb('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e'),
+  polyRevolver02Attack: polyPizzaThumb('7951b3b9-d3a5-4ec8-81b7-11111f1c8e88'),
+  polyShotgun02Attack: polyPizzaThumb('f71d6771-f512-4374-bd23-ba00b564db68'),
+  polyShotgun03Attack: polyPizzaThumb('08f27141-8e64-425a-9161-1bbd6956dfca'),
+  polySmg01Attack: polyPizzaThumb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710'),
+  polyRobotLargeGunAttack: polyPizzaThumb('78e23275-cb6a-4ba3-ae5e-48a9b4ee2e65'),
+  polyRobotFlyingGunAttack: polyPizzaThumb('6d0889f1-0c3f-4f98-b011-fbcf6c79a93b'),
+  polyBazooka01Attack: polyPizzaThumb('613e3b1b-d07c-496b-94a1-7c85b507bac4'),
+  polyGrenadeLauncher01Attack: polyPizzaThumb('503bb2c5-4a69-404b-9b82-13e85e8f8467'),
+  polyDynamiteBomb01Attack: polyPizzaThumb('38e858db-325f-4dce-9680-da62c20c5c31'),
+  polyMolotov01Attack: polyPizzaThumb('d7bb0b50-09af-49f8-b1f9-dbdb0c707d40'),
+  polyGasTank01Attack: polyPizzaThumb('9c4d2ac5-114b-4da2-a26a-8049e2b1ba04'),
+  polyHandGrenade01Attack: polyPizzaThumb('03fa7f5b-4df5-45d6-86fb-87e8590f28d7'),
+  polyTank01Attack: polyPizzaThumb('58c387b2-636f-49dc-a900-13b0852717d6')
+});
+
 const CAPTURE_WEAPON_SOURCE_THUMBNAILS = Object.freeze({
   glockSidearmAttack: gunifyImage('SigSauer.jpg'),
   pistolSidearmAttack: gunifyImage('Smith.jpeg'),
@@ -268,109 +290,109 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'polyShotgun01Attack',
     label: 'Quaternius Shotgun',
     description: 'Poly Pizza Quaternius shotgun model with preserved GLB materials.',
-    thumbnail: captureWeaponGlyphThumb('▬', '#0f766e')
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyShotgun01Attack
   },
   {
     id: 'polyAssaultRifle01Attack',
     label: 'Quaternius Assault Rifle',
     description: 'Poly Pizza Quaternius assault rifle model adapted for Ludo capture attacks.',
-    thumbnail: captureWeaponGlyphThumb('▰', '#1e3a8a')
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyAssaultRifle01Attack
   },
   {
     id: 'polyPistol01Attack',
     label: 'Quaternius Pistol',
     description: 'Poly Pizza Quaternius pistol sidearm capture animation.',
-    thumbnail: captureWeaponGlyphThumb('▮', '#1d4ed8')
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyPistol01Attack
   },
   {
     id: 'polyRevolver01Attack',
     label: 'Quaternius Heavy Revolver',
     description: 'Poly Pizza heavy revolver with compact one-hand pickup timing.',
-    thumbnail: captureWeaponGlyphThumb('◖', '#7c2d12')
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyRevolver01Attack
   },
   {
     id: 'polySawedOff01Attack',
     label: 'Quaternius Sawed-Off Shotgun',
     description: 'Poly Pizza sawed-off shotgun with short-range burst pacing.',
-    thumbnail: captureWeaponGlyphThumb('▭', '#b45309')
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polySawedOff01Attack
   },
   {
     id: 'polyRevolver02Attack',
     label: 'Quaternius Revolver Silver',
     description: 'Poly Pizza silver revolver variant with single-hand recoil profile.',
-    thumbnail: captureWeaponGlyphThumb('◗', '#475569')
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyRevolver02Attack
   },
   {
     id: 'polyShotgun02Attack',
     label: 'Quaternius Long Shotgun',
     description: 'Poly Pizza long shotgun with a larger rack silhouette.',
-    thumbnail: captureWeaponGlyphThumb('▤', '#166534')
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyShotgun02Attack
   },
   {
     id: 'polyShotgun03Attack',
     label: 'Quaternius Pump Shotgun',
     description: 'Poly Pizza pump shotgun tuned to match existing firearm proportions.',
-    thumbnail: captureWeaponGlyphThumb('▥', '#0f766e')
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyShotgun03Attack
   },
   {
     id: 'polySmg01Attack',
     label: 'Quaternius Submachine Gun',
     description: 'Poly Pizza compact SMG variant with fast burst behavior.',
-    thumbnail: captureWeaponGlyphThumb('▯', '#0f172a')
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polySmg01Attack
   },
   {
     id: 'polyRobotLargeGunAttack',
     label: 'Quaternius Robot Large Gun',
     description: 'Animated CC0 Poly Pizza robot heavy-gun model for premium Ludo capture attacks.',
-    thumbnail: 'https://static.poly.pizza/78e23275-cb6a-4ba3-ae5e-48a9b4ee2e65.webp'
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyRobotLargeGunAttack
   },
   {
     id: 'polyRobotFlyingGunAttack',
     label: 'Quaternius Robot Flying Gun',
     description: 'Animated CC0 Poly Pizza flying gun drone adapted as a compact capture weapon.',
-    thumbnail: 'https://static.poly.pizza/6d0889f1-0c3f-4f98-b011-fbcf6c79a93b.webp'
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyRobotFlyingGunAttack
   },
   {
     id: 'polyBazooka01Attack',
     label: 'CreativeTrio Bazooka',
     description: 'CC0 Poly Pizza bazooka/RPG launcher model added for explosive capture loadouts.',
-    thumbnail: 'https://static.poly.pizza/613e3b1b-d07c-496b-94a1-7c85b507bac4.webp'
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyBazooka01Attack
   },
   {
     id: 'polyGrenadeLauncher01Attack',
     label: 'CreativeTrio Grenade Launcher',
     description: 'CC0 Poly Pizza grenade launcher firearm with a heavy explosive ballistics profile.',
-    thumbnail: 'https://static.poly.pizza/503bb2c5-4a69-404b-9b82-13e85e8f8467.webp'
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyGrenadeLauncher01Attack
   },
   {
     id: 'polyDynamiteBomb01Attack',
     label: 'CreativeTrio Dynamite Bomb',
     description: 'CC0 Poly Pizza bomb/dynamite bundle for high-impact table capture effects.',
-    thumbnail: 'https://static.poly.pizza/38e858db-325f-4dce-9680-da62c20c5c31.webp'
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyDynamiteBomb01Attack
   },
   {
     id: 'polyMolotov01Attack',
     label: 'CreativeTrio Molotov',
     description: 'CC0 Poly Pizza molotov bottle for incendiary capture loadouts.',
-    thumbnail: 'https://static.poly.pizza/d7bb0b50-09af-49f8-b1f9-dbdb0c707d40.webp'
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyMolotov01Attack
   },
   {
     id: 'polyGasTank01Attack',
     label: 'Quaternius Gas Tank',
     description: 'CC0 Poly Pizza explosive gas tank model for demolition-style captures.',
-    thumbnail: 'https://static.poly.pizza/9c4d2ac5-114b-4da2-a26a-8049e2b1ba04.webp'
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyGasTank01Attack
   },
   {
     id: 'polyHandGrenade01Attack',
     label: 'CreativeTrio Hand Grenade',
     description: 'CC0 Poly Pizza hand grenade model added alongside the existing grenade fallback.',
-    thumbnail: 'https://static.poly.pizza/03fa7f5b-4df5-45d6-86fb-87e8590f28d7.webp'
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyHandGrenade01Attack
   },
   {
     id: 'polyTank01Attack',
     label: 'Quaternius Battle Tank',
     description: 'CC0 Poly Pizza tank model for heavy battle-royal capture strike cosmetics.',
-    thumbnail: 'https://static.poly.pizza/58c387b2-636f-49dc-a900-13b0852717d6.webp'
+    thumbnail: CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS.polyTank01Attack
   }
 
 ]);

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -355,6 +355,25 @@ const gunifyModelUrls = (modelName) => [
   `${GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
 ];
 
+const GITHUB_SOURCE_REFS = Object.freeze({
+  gunsForBjsFpsGame: '4b03f692a7159bcbb729fe9a7d9631b395be3bfa',
+  webaversePistol: '1b88663f4b501658990f1568ccec389cdaa6bf45',
+  webaverseUzi: '19abaa9455f6bc7edd416e203a8798d9cde1fc0b',
+  friunsBingExtension: '898ad2b55c78611e2f6e2d662d6502985bd16a15',
+  saaam3dModelBundle: 'd0652d386d91ecd8a4463a311ce884f6539813ad',
+  mixedRealityToolkitGun: '617f50508cc031385922812db8638f611f6bab31'
+});
+const githubRawUrl = (repo, ref, path) => `https://raw.githubusercontent.com/${repo}/${ref}/${path}`;
+const githubCdnUrl = (repo, ref, path) => `https://cdn.jsdelivr.net/gh/${repo}@${ref}/${path}`;
+const gunsForBjsFpsGameUrls = () => [
+  githubRawUrl('lando19/Guns-for-BJS-FPS-Game', GITHUB_SOURCE_REFS.gunsForBjsFpsGame, 'main/scene.gltf'),
+  githubCdnUrl('lando19/Guns-for-BJS-FPS-Game', GITHUB_SOURCE_REFS.gunsForBjsFpsGame, 'main/scene.gltf')
+];
+const webaversePistolUrls = (fileName) => [
+  githubCdnUrl('webaverse/pistol', GITHUB_SOURCE_REFS.webaversePistol, fileName),
+  githubRawUrl('webaverse/pistol', GITHUB_SOURCE_REFS.webaversePistol, fileName)
+];
+
 const GUNIFY_SPECULAR_GLOSSINESS_EXTENSION = 'KHR_materials_pbrSpecularGlossiness';
 
 function cloneGltfJsonValue(value) {
@@ -410,56 +429,50 @@ async function loadGunifyOriginalGltf(loader, candidateUrl) {
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
     label: 'MRTK Gun',
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
     urls: [
-      'https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
-      'https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
-      'https://raw.githubusercontent.com/Microsoft/MixedRealityToolkit/master/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
-      'https://cdn.jsdelivr.net/gh/Microsoft/MixedRealityToolkit@master/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb'
+      githubRawUrl('microsoft/MixedRealityToolkit', GITHUB_SOURCE_REFS.mixedRealityToolkitGun, 'SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb'),
+      githubCdnUrl('microsoft/MixedRealityToolkit', GITHUB_SOURCE_REFS.mixedRealityToolkitGun, 'SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb')
     ],
     scale: 0.132
   },
   pistolHolsterAttack: {
     label: 'Pistol Holster',
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
     urls: [
-      'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
-      'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb'
+      githubRawUrl('SAAAM-LLC/3D_model_bundle', GITHUB_SOURCE_REFS.saaam3dModelBundle, 'SAM_ASSET-PISTOL-IN-HOLSTER.glb'),
+      githubCdnUrl('SAAAM-LLC/3D_model_bundle', GITHUB_SOURCE_REFS.saaam3dModelBundle, 'SAM_ASSET-PISTOL-IN-HOLSTER.glb')
     ],
     scale: 0.138
   },
   fpsGunAttack: {
     label: 'FPS Gun',
-    urls: [
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf',
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf'
-    ],
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
+    urls: gunsForBjsFpsGameUrls(),
     scale: 0.24
   },
   glockSidearmAttack: {
     label: 'Glock',
-    urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb',
-      'https://raw.githubusercontent.com/webaverse/pistol/master/glock.glb'
-    ],
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
+    urls: webaversePistolUrls('glock.glb'),
     scale: 0.13
   },
   pistolSidearmAttack: {
     label: 'Pistol Sidearm',
-    urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb',
-      'https://raw.githubusercontent.com/webaverse/pistol/master/pistol.glb',
-      'https://cdn.statically.io/gh/webaverse/pistol/master/pistol.glb'
-    ],
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
+    urls: webaversePistolUrls('pistol.glb'),
     scale: 0.115
   },
   assaultRifleAttack: {
     label: 'Assault Rifle',
-    urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
-      'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
-      'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
-    ],
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
+    urls: webaversePistolUrls('military.glb'),
     scale: 0.13
   },
   uziSprayAttack: {
@@ -512,21 +525,19 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   },
   grenadeBlastAttack: {
     label: 'Grenade Blast',
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
     urls: [
-      'https://cdn.jsdelivr.net/gh/friuns2/bingextension@main/grenade.glb',
-      'https://raw.githubusercontent.com/friuns2/bingextension/main/grenade.glb',
-      'https://cdn.statically.io/gh/friuns2/bingextension/main/grenade.glb'
+      githubCdnUrl('friuns2/bingextension', GITHUB_SOURCE_REFS.friunsBingExtension, 'grenade.glb'),
+      githubRawUrl('friuns2/bingextension', GITHUB_SOURCE_REFS.friunsBingExtension, 'grenade.glb')
     ],
     scale: 0.11
   },
   shotgunBlastAttack: {
     label: 'Shotgun Blast',
-    urls: [
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf'
-    ],
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
+    urls: gunsForBjsFpsGameUrls(),
     scale: 0.24
   },
   sniperShotAttack: {
@@ -539,115 +550,151 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   },
   smgBurstAttack: {
     label: 'SMG',
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
     urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb'
+      githubCdnUrl('webaverse/uzi', GITHUB_SOURCE_REFS.webaverseUzi, 'uzi.glb'),
+      ...webaversePistolUrls('pistol.glb')
     ],
     scale: 0.2
   },
   compactCarbineAttack: {
     label: 'Compact Carbine',
-    urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
-      'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb'
-    ],
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
+    urls: webaversePistolUrls('military.glb'),
     scale: 0.21
   },
   marksmanDmrAttack: {
     label: 'Marksman DMR',
-    urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
-      'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb'
-    ],
+    source: 'Original',
+    texturePolicy: 'sourceOriginal',
+    urls: webaversePistolUrls('military.glb'),
     scale: 0.23
   },
   polyShotgun01Attack: {
     label: 'Quaternius Shotgun',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/032e6589-3188-41bc-b92b-e25528344275.glb'],
     scale: 0.205
   },
   polyAssaultRifle01Attack: {
     label: 'Quaternius Assault Rifle',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/b3e6be61-0299-4866-a227-58f5f3fe610b.glb'],
     scale: 0.208
   },
   polyPistol01Attack: {
     label: 'Quaternius Pistol',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/3b53f0fe-f86e-451c-816d-6ab9bd265cdc.glb'],
     scale: 0.122
   },
   polyRevolver01Attack: {
     label: 'Quaternius Heavy Revolver',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/9e728565-67a3-44db-9567-982320abff09.glb'],
     scale: 0.13
   },
   polySawedOff01Attack: {
     label: 'Quaternius Sawed-Off Shotgun',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/9a6ee0ee-068b-4774-8b0f-679c3cef0b6e.glb'],
     scale: 0.175
   },
   polyRevolver02Attack: {
     label: 'Quaternius Revolver Silver',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/7951b3b9-d3a5-4ec8-81b7-11111f1c8e88.glb'],
     scale: 0.13
   },
   polyShotgun02Attack: {
     label: 'Quaternius Long Shotgun',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/f71d6771-f512-4374-bd23-ba00b564db68.glb'],
     scale: 0.215
   },
   polyShotgun03Attack: {
     label: 'Quaternius Pump Shotgun',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/08f27141-8e64-425a-9161-1bbd6956dfca.glb'],
     scale: 0.21
   },
   polySmg01Attack: {
     label: 'Quaternius Submachine Gun',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710.glb'],
     scale: 0.17
   },
   polyRobotLargeGunAttack: {
     label: 'Quaternius Robot Large Gun',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/78e23275-cb6a-4ba3-ae5e-48a9b4ee2e65.glb'],
     scale: 0.17
   },
   polyRobotFlyingGunAttack: {
     label: 'Quaternius Robot Flying Gun',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/6d0889f1-0c3f-4f98-b011-fbcf6c79a93b.glb'],
     scale: 0.16
   },
   polyBazooka01Attack: {
     label: 'CreativeTrio Bazooka',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/613e3b1b-d07c-496b-94a1-7c85b507bac4.glb'],
     scale: 0.22
   },
   polyGrenadeLauncher01Attack: {
     label: 'CreativeTrio Grenade Launcher',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/503bb2c5-4a69-404b-9b82-13e85e8f8467.glb'],
     scale: 0.2
   },
   polyDynamiteBomb01Attack: {
     label: 'CreativeTrio Dynamite Bomb',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/38e858db-325f-4dce-9680-da62c20c5c31.glb'],
     scale: 0.12
   },
   polyMolotov01Attack: {
     label: 'CreativeTrio Molotov',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/d7bb0b50-09af-49f8-b1f9-dbdb0c707d40.glb'],
     scale: 0.095
   },
   polyGasTank01Attack: {
     label: 'Quaternius Gas Tank',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/9c4d2ac5-114b-4da2-a26a-8049e2b1ba04.glb'],
     scale: 0.12
   },
   polyHandGrenade01Attack: {
     label: 'CreativeTrio Hand Grenade',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/03fa7f5b-4df5-45d6-86fb-87e8590f28d7.glb'],
     scale: 0.075
   },
   polyTank01Attack: {
     label: 'Quaternius Battle Tank',
+    source: 'Poly Pizza',
+    texturePolicy: 'sourceOriginal',
     urls: ['https://static.poly.pizza/58c387b2-636f-49dc-a900-13b0852717d6.glb'],
     scale: 0.125
   }


### PR DESCRIPTION
### Motivation
- Ensure non-Gunify weapons keep their original texture folders/material references instead of drifting to upstream branches or alternate hosting paths.
- Use original source thumbnails for Poly Pizza weapons instead of generic glyph placeholders so store previews match source renders.

### Description
- Add pinned source refs and helper URL builders (`GITHUB_SOURCE_REFS`, `githubRawUrl`, `githubCdnUrl`, `gunsForBjsFpsGameUrls`, `webaversePistolUrls`) and mark non-Gunify models with `source: 'Original'` and `texturePolicy: 'sourceOriginal'` in `CAPTURE_WEAPON_MODEL_CONFIG` (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Keep Gunify models on the existing pinned Gunify baseline and maintain `gunifyPbr` handling and the `loadGunifyOriginalGltf` patcher for spec-gloss materials (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Replace Poly Pizza weapon glyph thumbnails with direct Poly Pizza source WebP thumbnails and expose `CAPTURE_POLY_PIZZA_SOURCE_THUMBNAILS` for use in `CAPTURE_ANIMATION_OPTIONS` (`webapp/src/config/ludoBattleOptions.js`).
- Add regression tests to `test/inventoryCrossGameConfig.test.js` that assert non-Gunify weapons use pinned source refs and Poly Pizza thumbnails reference `static.poly.pizza` source renders.

### Testing
- Ran `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` and all tests in that suite passed (13/13). 
- Built the webapp with `npm --prefix webapp run build` and the Vite production build completed successfully (with existing chunk-size warnings). 
- Installed Playwright browsers with `npx playwright install chromium`, but a headless screenshot run failed to launch Chromium in this environment due to a missing system library (`libatk-1.0.so.0`), so automated visual screenshot capture was blocked by the CI environment limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fab3e02ac8329bca9802accdc1d90)