### PR TITLE
Preserve Ludo weapon source textures

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -223,6 +223,20 @@ describe('cross-game inventory alignment', () => {
     });
   });
 
+  test('ludo battle royal preserves source-authored materials for non-Gunify weapons', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('function preserveCaptureWeaponSourceMaterial');
+    expect(source).toContain("sourceTexturePolicy: texturePolicy");
+    expect(source).toContain("preserveCaptureWeaponSourceMaterial(material, config?.texturePolicy || 'preserveSource')");
+
+    const setupStart = source.indexOf('root.traverse((node) => {', source.indexOf('async function loadCaptureWeaponModel'));
+    const setupEnd = source.indexOf('applyModelQualityToObject(root);', setupStart);
+    const materialSetup = source.slice(setupStart, setupEnd);
+    expect(materialSetup).not.toContain('material.transparent = false');
+    expect(materialSetup).not.toContain('material.opacity = 1');
+  });
+
   test('snake store mirrors ludo battle royal capture weapons', () => {
     const snakeCaptureStoreIds = new Set(
       SNAKE_STORE_ITEMS.filter((item) => item.type === 'captureWeapon').map((item) => item.optionId)

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -701,6 +701,19 @@ function applyGunifyWeaponTexturePolicy(material) {
   material.needsUpdate = true;
 }
 
+function preserveCaptureWeaponSourceMaterial(material, texturePolicy = 'preserveSource') {
+  if (!material) return;
+  // Every non-procedural weapon should keep the exact material state authored in
+  // its source GLB/GLTF.  That includes alpha modes, opacity, color factors,
+  // PBR factors, UV transforms and every image map.  We only tag the material
+  // for diagnostics and let the generic texture-quality pass raise sampling.
+  material.userData = {
+    ...(material.userData || {}),
+    sourceTexturePolicy: texturePolicy
+  };
+  material.needsUpdate = true;
+}
+
 const FIREARM_SHOTGUN_IDS = new Set([
   'shotgunBlastAttack',
   'polyShotgun01Attack',
@@ -1499,12 +1512,14 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         node.visible = true;
         const materials = Array.isArray(node.material) ? node.material : [node.material];
         materials.forEach((material) => {
-          if (material?.map) applySRGBColorSpace(material.map);
-          if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
-          if (config?.texturePolicy === 'gunifyPbr') applyGunifyWeaponTexturePolicy(material);
-          material.transparent = false;
-          material.opacity = 1;
-          material.needsUpdate = true;
+          if (!material) return;
+          if (material.map) applySRGBColorSpace(material.map);
+          if (material.emissiveMap) applySRGBColorSpace(material.emissiveMap);
+          if (config?.texturePolicy === 'gunifyPbr') {
+            applyGunifyWeaponTexturePolicy(material);
+          } else {
+            preserveCaptureWeaponSourceMaterial(material, config?.texturePolicy || 'preserveSource');
+          }
         });
       });
       applyModelQualityToObject(root);


### PR DESCRIPTION
### Motivation
- Capture weapon models from several sources should keep the authored GLB/GLTF material state so non-Gunify weapons retain their original textures, alpha modes, UVs and PBR factors instead of being forced to opaque/fallback settings.

### Description
- Add `preserveCaptureWeaponSourceMaterial(material, texturePolicy)` to tag and preserve source-authored material state for non-Gunify weapons in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Update `loadCaptureWeaponModel` material setup to apply the existing `applyGunifyWeaponTexturePolicy` only for Gunify models and route all other weapons through the new preservation path instead of forcing `material.transparent = false` and `material.opacity = 1`.
- Add a regression test `ludo battle royal preserves source-authored materials for non-Gunify weapons` in `test/inventoryCrossGameConfig.test.js` that asserts the new preservation function exists and that the material setup no longer contains forced opacity overrides.
- Affected files: `webapp/src/pages/Games/LudoBattleRoyal.jsx` and `test/inventoryCrossGameConfig.test.js`.

### Testing
- Ran `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` and the suite passed (the added test and related checks succeeded).
- The modified inventory cross-game test file executed successfully with all assertions passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fab3e02ac8329bca9802accdc1d90)