### PR TITLE
Restore Ludo camera and weapon thumbnails

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -460,7 +460,8 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
       'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
     ],
-    scale: 0.13
+    scale: 0.13,
+    textureOverrideUrls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg']
   },
   uziSprayAttack: {
     label: 'Gunify Uzi',
@@ -1497,6 +1498,26 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     try {
       const root = loadedRoot;
       if (!root) return null;
+      const textureOverrideUrls = Array.isArray(config?.textureOverrideUrls) && config?.source !== 'Gunify'
+        ? config.textureOverrideUrls.filter(Boolean)
+        : [];
+      let textureOverride = null;
+      if (textureOverrideUrls.length) {
+        const textureLoader = new THREE.TextureLoader();
+        textureLoader.setCrossOrigin?.('anonymous');
+        for (let t = 0; t < textureOverrideUrls.length; t += 1) {
+          try {
+            // eslint-disable-next-line no-await-in-loop
+            textureOverride = await withLoadTimeout(textureLoader.loadAsync(textureOverrideUrls[t]));
+            if (textureOverride) {
+              textureOverride.flipY = false;
+              applySRGBColorSpace(textureOverride);
+              textureOverride.needsUpdate = true;
+              break;
+            }
+          } catch {}
+        }
+      }
       root.traverse((node) => {
         if (!node?.isMesh) return;
         if (
@@ -1513,11 +1534,14 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         const materials = Array.isArray(node.material) ? node.material : [node.material];
         materials.forEach((material) => {
           if (!material) return;
+          if (textureOverride && !material.map) material.map = textureOverride;
           if (material.map) applySRGBColorSpace(material.map);
           if (material.emissiveMap) applySRGBColorSpace(material.emissiveMap);
           if (config?.texturePolicy === 'gunifyPbr') {
             applyGunifyWeaponTexturePolicy(material);
           } else {
+            material.transparent = false;
+            material.opacity = 1;
             preserveCaptureWeaponSourceMaterial(material, config?.texturePolicy || 'preserveSource');
           }
         });
@@ -11402,11 +11426,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               .copy(muzzleOrigin)
               .addScaledVector(cinematicAimDir, -(singleShotFirearm ? 0.18 : 0.22))
               .addScaledVector(cinematicSide, singleShotFirearm ? 0.022 : 0.032)
-              .addScaledVector(cameraWorldUp, THREE.MathUtils.lerp(0.048, singleShotFirearm ? 0.076 : 0.088, shoulderCameraBlend));
+              .addScaledVector(cameraWorldUp, THREE.MathUtils.lerp(0.12, singleShotFirearm ? 0.16 : 0.18, shoulderCameraBlend));
             cinematicTarget
               .copy(muzzleOrigin)
-              .lerp(muzzleTarget, THREE.MathUtils.lerp(0.62, 0.86, shoulderCameraBlend))
-              .addScaledVector(cameraWorldUp, 0.012);
+              .lerp(muzzleTarget, THREE.MathUtils.lerp(0.42, 0.72, shoulderCameraBlend))
+              .addScaledVector(cameraWorldUp, 0.018);
             setFirearmCinematicPose(cinematicPosition, cinematicTarget, elapsed < pickupLeadMs ? 0.1 : 0.18);
             muzzleFx.root.position.copy(muzzleOrigin);
             muzzleFx.root.visible = elapsed >= preFireLeadMs && elapsedShooting >= 0 && elapsedShooting < shots * cadenceMs;
@@ -11530,7 +11554,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 .copy(leadBulletPos)
                 .addScaledVector(bulletDir, followingFinalBullet ? -0.052 : -0.15)
                 .addScaledVector(cinematicSide, followingFinalBullet ? 0.01 : singleShotFirearm ? 0.018 : 0.03);
-              cinematicPosition.addScaledVector(cameraWorldUp, followingFinalBullet ? 0.034 : singleShotFirearm ? 0.07 : 0.082);
+              cinematicPosition.addScaledVector(cameraWorldUp, singleShotFirearm ? 0.07 : 0.082);
               cinematicTarget.copy(leadBulletPos).addScaledVector(bulletDir, followingFinalBullet ? 0.13 : 0.34);
               setFirearmCinematicPose(cinematicPosition, cinematicTarget, followingFinalBullet ? 0.9 : 0.72);
               if (leadBulletMesh && Number(leadBulletMesh.userData?.shotIndex ?? -1) >= shots - 1) {
@@ -13555,8 +13579,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                       if (optionIndex >= 0) setAppearance((prev) => ({ ...prev, captureAnimation: optionIndex }));
                     }}
                   >
-                    <div className="mx-auto mb-1 flex h-9 w-12 items-center justify-center rounded-lg border border-white/20 bg-gradient-to-br from-slate-950/85 to-slate-800/75">
-                      <QuickSwapWeaponIcon id={option.id} selected={selected} />
+                    <div className="mx-auto mb-1 flex h-9 w-12 items-center justify-center overflow-hidden rounded-lg border border-white/20 bg-gradient-to-br from-slate-950/85 to-slate-800/75">
+                      {option.thumbnail ? (
+                        <img
+                          src={option.thumbnail}
+                          alt={displayName}
+                          className="h-full w-full object-cover p-[1px]"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <QuickSwapWeaponIcon id={option.id} selected={selected} />
+                      )}
                     </div>
                     <div className="px-0.5 pb-0.5 leading-tight">{displayName}</div>
                   </button>


### PR DESCRIPTION
### Motivation
- Restore the Ludo firearm cinematic camera behavior to the May 9 baseline so shoulder-aim and final-bullet framing match the historical portrait feel. 
- Make non-Gunify weapon textures/thumbnails match the Chess Battle Royal configuration so in-game weapon visuals and quick-swap thumbnails are consistent across games while leaving Gunify/vehicle assets untouched.

### Description
- Restored shoulder/aim cinematic math by reverting the `cameraWorldUp` and muzzle-target lerp values used in the firearm cinematic pose (shoulder blend and final-bullet camera offsets) to the May 9 values in `LudoBattleRoyal.jsx`.
- Added a `textureOverrideUrls` entry for `assaultRifleAttack` in `CAPTURE_WEAPON_MODEL_CONFIG` and implemented non-Gunify texture override loading inside `loadCaptureWeaponModel`, so authored texture images (like the AK47 JPEG) are applied for non-Gunify sources.
- Kept Gunify assets on their `gunifyPbr` path and preserved the `loadGunifyOriginalGltf`/spec-gloss → PBR patching flow; applied `applyGunifyWeaponTexturePolicy` only for `gunifyPbr` weapons and preserved source material state for other weapons via `preserveCaptureWeaponSourceMaterial` (also set `material.transparent = false` and `material.opacity = 1` for non-Gunify loads).
- Updated quick-swap UI to render `option.thumbnail` images (same approach used by Chess Battle Royal) and fall back to the existing `QuickSwapWeaponIcon` SVG only when no thumbnail exists.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully (Vite build finished). (succeeded)
- Ran linting on the modified file with `npm --prefix webapp run lint -- src/pages/Games/LudoBattleRoyal.jsx` and no lint errors were reported. (succeeded)
- Verified diffs and whitespace with `git diff --check`; no outstanding issues were found. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fba9f6354832983330099dfae52a5)