### PR TITLE
Align Snake & Ladder visuals with Ludo Battle Royal (Gunify textures, dice cadence, Ukrainian drone)

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -263,8 +263,8 @@ const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
-// Keep Snake dice motion aligned with Ludo Battle Royal's single-arc spinDice roll.
-const DICE_ROLL_DURATION = 900;
+// Keep Snake dice motion aligned with Ludo Battle Royal's frame-synced single-arc spinDice roll.
+const DICE_ROLL_DURATION = 1100;
 const DICE_SETTLE_DURATION = 220;
 const DICE_RESULT_HOLD_DURATION = 720;
 const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.78;
@@ -1822,6 +1822,92 @@ function createConfiguredGLTFLoader(renderer = null) {
   }
   loader.setKTX2Loader(sharedKtx2Loader);
   return loader;
+}
+
+
+const GUNIFY_SPECULAR_GLOSSINESS_EXTENSION = 'KHR_materials_pbrSpecularGlossiness';
+const isGltfAssetUrl = (url) => /\.gltf(?:[?#].*)?$/i.test(String(url || ''));
+
+function cloneGltfJsonValue(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function patchGunifySpecularGlossinessMaterials(gltfJson) {
+  if (!gltfJson?.materials?.length) return gltfJson;
+  let patchedAny = false;
+  const patched = {
+    ...gltfJson,
+    materials: gltfJson.materials.map((material) => {
+      const specGloss = material?.extensions?.[GUNIFY_SPECULAR_GLOSSINESS_EXTENSION];
+      if (!specGloss) return material;
+      patchedAny = true;
+      const metallicRoughness = {
+        ...(material.pbrMetallicRoughness || {}),
+        metallicFactor: 0,
+        roughnessFactor: Math.max(0.08, Math.min(1, 1 - (specGloss.glossinessFactor ?? 0.82)))
+      };
+      if (specGloss.diffuseFactor) metallicRoughness.baseColorFactor = cloneGltfJsonValue(specGloss.diffuseFactor);
+      if (specGloss.diffuseTexture) metallicRoughness.baseColorTexture = cloneGltfJsonValue(specGloss.diffuseTexture);
+      return {
+        ...material,
+        pbrMetallicRoughness: metallicRoughness,
+        extensions: Object.fromEntries(
+          Object.entries(material.extensions || {}).filter(
+            ([extensionName]) => extensionName !== GUNIFY_SPECULAR_GLOSSINESS_EXTENSION
+          )
+        )
+      };
+    })
+  };
+  if (patchedAny && Array.isArray(patched.extensionsUsed)) {
+    patched.extensionsUsed = patched.extensionsUsed.filter(
+      (extensionName) => extensionName !== GUNIFY_SPECULAR_GLOSSINESS_EXTENSION
+    );
+  }
+  return patched;
+}
+
+async function loadGunifyOriginalGltf(loader, candidateUrl) {
+  const response = await fetch(candidateUrl, { mode: 'cors' });
+  if (!response.ok) throw new Error(`Gunify GLTF fetch failed: ${response.status}`);
+  const gltfJson = patchGunifySpecularGlossinessMaterials(await response.json());
+  const basePath = new URL('.', candidateUrl).href;
+  loader.setPath?.(basePath);
+  loader.setResourcePath?.(basePath);
+  return loader.parseAsync(JSON.stringify(gltfJson), basePath);
+}
+
+function applyGunifyWeaponTexturePolicy(material) {
+  if (!material) return;
+  ['map', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'emissiveMap', 'specularMap'].forEach((textureKey) => {
+    const texture = material[textureKey];
+    if (!texture) return;
+    if (textureKey === 'map' || textureKey === 'emissiveMap') applySRGBColorSpace(texture);
+    texture.flipY = false;
+    texture.anisotropy = Math.max(texture.anisotropy || 1, 8);
+    texture.needsUpdate = true;
+  });
+  if (typeof material.roughness === 'number') material.roughness = Math.min(0.9, Math.max(0.34, material.roughness));
+  if (typeof material.metalness === 'number') material.metalness = Math.min(1, Math.max(0.18, material.metalness));
+  material.needsUpdate = true;
+}
+
+function applyCaptureWeaponTexturePolicy(root, texturePolicy = 'preserveSource') {
+  if (!root) return;
+  root.traverse((node) => {
+    if (!node?.isMesh) return;
+    const materials = Array.isArray(node.material) ? node.material : node.material ? [node.material] : [];
+    materials.forEach((material) => {
+      if (!material) return;
+      if (texturePolicy === 'gunifyPbr') {
+        applyGunifyWeaponTexturePolicy(material);
+      } else {
+        material.userData = { ...(material.userData || {}), sourceTexturePolicy: texturePolicy };
+        material.needsUpdate = true;
+      }
+    });
+  });
 }
 
 function applyOriginalTextureMapping(root) {
@@ -5790,7 +5876,7 @@ async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cach
 }
 
 async function loadCaptureVehicleModel(kind = 'fighter') {
-  if (kind === 'drone' || kind === 'ukrainianDrone') {
+  if (kind === 'ukrainianDrone') {
     const cacheKey = `${kind}:exactUkrainianDrone`;
     if (!SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.has(cacheKey)) {
       SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.set(cacheKey, loadExactUkrainianDroneModel().then((model) => normalizeCaptureVehicleModel(model)));
@@ -6016,10 +6102,13 @@ async function loadCaptureWeaponCatalogModel(weaponId) {
         for (const url of urls) {
           try {
             // eslint-disable-next-line no-await-in-loop
-            const gltf = await loader.loadAsync(url);
+            const gltf = option?.source === 'Gunify' && isGltfAssetUrl(url)
+              ? await loadGunifyOriginalGltf(loader, url)
+              : await loader.loadAsync(url);
             const root = gltf?.scene || gltf?.scenes?.[0] || null;
             if (!root) continue;
             prepareLoadedModel(root);
+            applyCaptureWeaponTexturePolicy(root, option?.texturePolicy || 'preserveSource');
             const normalized = normalizeCaptureVehicleModel(root);
             if (weaponId === 'slot-10-ak47-gltf') stripAk47RearWoodStock(normalized);
             return normalized;

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -2,6 +2,25 @@ import { swatchThumbnail, weaponSilhouetteThumbnail } from './storeThumbnails.js
 
 const polyGlb = (uuid) => `https://static.poly.pizza/${uuid}.glb`;
 
+// Match Ludo Battle Royal's pinned Gunify snapshot so Snake & Ladder uses
+// the same authored GLTF material/texture tree instead of whatever is on main.
+export const SNAKE_GUNIFY_MAY_9_REF = '27232cf389a2be3f8f476c667cb293e978aaf5f9';
+const SNAKE_GUNIFY_RAW_BASE = `https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/${SNAKE_GUNIFY_MAY_9_REF}`;
+const SNAKE_GUNIFY_JSDELIVR_BASE = `https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@${SNAKE_GUNIFY_MAY_9_REF}`;
+const gunifyModelUrls = (modelName) => [
+  `${SNAKE_GUNIFY_RAW_BASE}/models/${modelName}/scene.gltf`,
+  `${SNAKE_GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
+];
+const gunifyWeapon = (id, label, modelName, colors) => ({
+  id,
+  label,
+  thumbnail: weaponSilhouetteThumbnail(colors),
+  urls: gunifyModelUrls(modelName),
+  modelName,
+  source: 'Gunify',
+  texturePolicy: 'gunifyPbr'
+});
+
 export const UKRAINIAN_DRONE_GLB_URLS = Object.freeze([
   'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
   'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
@@ -26,7 +45,7 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
     label: 'Ukrainian Drone',
     thumbnail: swatchThumbnail(['#60a5fa', '#facc15', '#1d4ed8']),
     urls: UKRAINIAN_DRONE_GLB_URLS,
-    vehicleKind: 'drone'
+    vehicleKind: 'ukrainianDrone'
   },
   { id: 'poly-shotgun-01', label: 'Quaternius Shotgun', thumbnail: weaponSilhouetteThumbnail(['#64748b','#1e293b','#f8fafc']), urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')] },
   { id: 'poly-assault-rifle-01', label: 'Quaternius Assault Rifle', thumbnail: weaponSilhouetteThumbnail(['#334155','#0f172a','#94a3b8']), urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')] },
@@ -37,12 +56,12 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   { id: 'poly-shotgun-02', label: 'Quaternius Long Shotgun', thumbnail: weaponSilhouetteThumbnail(['#475569','#020617','#cbd5e1']), urls: [polyGlb('f71d6771-f512-4374-bd23-ba00b564db68')] },
   { id: 'poly-shotgun-03', label: 'Quaternius Pump Shotgun', thumbnail: weaponSilhouetteThumbnail(['#52525b','#111827','#e2e8f0']), urls: [polyGlb('08f27141-8e64-425a-9161-1bbd6956dfca')] },
   { id: 'poly-smg-01', label: 'Quaternius SMG', thumbnail: weaponSilhouetteThumbnail(['#374151','#030712','#d1d5db']), urls: [polyGlb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710')] },
-  { id: 'slot-10-ak47-gltf', label: 'AK47 GLTF', thumbnail: weaponSilhouetteThumbnail(['#7f1d1d','#111827','#f59e0b']), urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'] },
-  { id: 'slot-11-krsv-gltf', label: 'KRSV GLTF', thumbnail: weaponSilhouetteThumbnail(['#1d4ed8','#0f172a','#bfdbfe']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf', SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkRaw] },
-  { id: 'slot-12-smith-gltf', label: 'Smith GLTF', thumbnail: weaponSilhouetteThumbnail(['#6b7280','#0f172a','#f8fafc']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf', SNAKE_KNOWN_WORKING_GLB.pistolHolster, SNAKE_KNOWN_WORKING_GLB.pistolHolsterRaw] },
-  { id: 'slot-13-mosin-gltf', label: 'Mosin GLTF', thumbnail: weaponSilhouetteThumbnail(['#92400e','#1f2937','#fcd34d']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Mosin/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Mosin/scene.gltf', SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
-  { id: 'slot-14-uzi-gltf', label: 'Uzi GLTF', thumbnail: weaponSilhouetteThumbnail(['#0f766e','#111827','#99f6e4']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Uzi/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Uzi/scene.gltf', SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkMaster] },
-  { id: 'slot-15-sigsauer-gltf', label: 'SigSauer GLTF', thumbnail: weaponSilhouetteThumbnail(['#334155','#020617','#f1f5f9']), urls: ['https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/SigSauer/scene.gltf', 'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/SigSauer/scene.gltf', SNAKE_KNOWN_WORKING_GLB.pistolHolster, SNAKE_KNOWN_WORKING_GLB.pistolHolsterRaw] },
+  gunifyWeapon('slot-10-ak47-gltf', 'AK47 GLTF', 'AK47', ['#7f1d1d','#111827','#f59e0b']),
+  gunifyWeapon('slot-11-krsv-gltf', 'KRSV GLTF', 'KRSV', ['#1d4ed8','#0f172a','#bfdbfe']),
+  gunifyWeapon('slot-12-smith-gltf', 'Smith GLTF', 'Smith', ['#6b7280','#0f172a','#f8fafc']),
+  gunifyWeapon('slot-13-mosin-gltf', 'Mosin GLTF', 'Mosin', ['#92400e','#1f2937','#fcd34d']),
+  gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e','#111827','#99f6e4']),
+  gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155','#020617','#f1f5f9']),
   { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b','#0f172a','#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
   { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b','#111827','#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
 ]);


### PR DESCRIPTION
### Motivation
- Make Snake & Ladder capture weapons visually identical to Ludo Battle Royal by using the same pinned Gunify snapshot and texture/material policy. 
- Ensure dice motion matches Ludo Battle Royal so roll timing and feel are consistent across games. 
- Use the exact Ukrainian drone model and loading path so the in-game Ukrainian drone matches the Ludo asset precisely.

### Description
- Pin Gunify to the May 9 snapshot and add a `gunifyWeapon` helper in `webapp/src/config/snakeWeaponCatalog.js`, replacing the six Gunify catalog entries with calls that include `source: 'Gunify'` and `texturePolicy: 'gunifyPbr'`, and change the Ukrainian drone catalog entry to `vehicleKind: 'ukrainianDrone'`.
- Add GLTF/texture patching and a Gunify-specific loader path in `webapp/src/components/SnakeBoard3D.jsx` including `patchGunifySpecularGlossinessMaterials`, `loadGunifyOriginalGltf`, `applyGunifyWeaponTexturePolicy`, and `applyCaptureWeaponTexturePolicy` so Gunify GLTFs keep authored PBR mapping and are converted to consistent metallic/roughness values when needed.
- Update `loadCaptureWeaponCatalogModel` to use the Gunify loader for `source: 'Gunify'` GLTF URLs and to apply the capture-weapon texture policy after `prepareLoadedModel`.
- Make `loadCaptureVehicleModel` treat only `ukrainianDrone` specially (loading the exact drone via `loadExactUkrainianDroneModel`) instead of treating every `drone` kind the same.
- Match dice timing by updating the Snake dice constant `DICE_ROLL_DURATION` from `900` to `1100` ms so the roll animation cadence equals Ludo Battle Royal.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production build artifacts (Vite build succeeded). 
- Ran `npx playwright install chromium` to prepare browser preview assets which downloaded required browsers successfully. 
- Attempted an automated headless preview/screenshot run with Playwright which failed to launch headless Chromium in this container due to a missing system library (`libatk-1.0.so.0`), so the in-container screenshot preview did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbcbfec048329a1691cc178d07e2d)