### PR TITLE
Align PolyPizza weapon tuning and pin HDRI during camera auto-look in Ludo Battle Royal

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -244,6 +244,50 @@ describe('cross-game inventory alignment', () => {
     });
   });
 
+
+  test('ludo battle royal matches chess Poly Pizza weapon rack multipliers', async () => {
+    const [ludoSource, chessSource] = await Promise.all([
+      readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8'),
+      readFile('webapp/src/pages/Games/ChessBattleRoyal.jsx', 'utf8')
+    ]);
+    const extractMultiplier = (source, id) => {
+      const match = source.match(new RegExp(`${id}:\\s*([0-9.]+)`));
+      return match ? Number(match[1]) : null;
+    };
+    const polyPizzaWeaponIds = [
+      'polyShotgun01Attack',
+      'polyAssaultRifle01Attack',
+      'polyPistol01Attack',
+      'polyRevolver01Attack',
+      'polySawedOff01Attack',
+      'polyRevolver02Attack',
+      'polyShotgun02Attack',
+      'polyShotgun03Attack',
+      'polySmg01Attack',
+      'polyRobotLargeGunAttack',
+      'polyRobotFlyingGunAttack',
+      'polyBazooka01Attack',
+      'polyGrenadeLauncher01Attack',
+      'polyDynamiteBomb01Attack',
+      'polyMolotov01Attack',
+      'polyGasTank01Attack',
+      'polyHandGrenade01Attack',
+      'polyTank01Attack'
+    ];
+
+    polyPizzaWeaponIds.forEach((id) => {
+      expect(extractMultiplier(ludoSource, id)).toBe(extractMultiplier(chessSource, id));
+    });
+  });
+
+  test('ludo grounded HDRI stays fixed during automatic camera look changes', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('const LUDO_HDRI_LOCK_GROUNDED_SKYBOX_SCALE = true');
+    expect(source).toContain('const scale = LUDO_HDRI_LOCK_GROUNDED_SKYBOX_SCALE ? 1');
+    expect(source).toContain('cameraSeatLockPositionRef.current?.isVector3');
+  });
+
   test('ludo battle royal preserves source-authored materials for non-Gunify weapons', async () => {
     const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
 

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -237,15 +237,15 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   sniperShotAttack: 2.8,
   shotgunBlastAttack: 2.2,
   grenadeBlastAttack: 0.45,
-  polyShotgun01Attack: 2.05,
-  polyAssaultRifle01Attack: 2.15,
-  polyPistol01Attack: 1.02,
-  polyRevolver01Attack: 1.08,
-  polySawedOff01Attack: 1.56,
-  polyRevolver02Attack: 1.08,
-  polyShotgun02Attack: 2.22,
-  polyShotgun03Attack: 2.1,
-  polySmg01Attack: 1.68,
+  polyShotgun01Attack: 2.2,
+  polyAssaultRifle01Attack: 2.2,
+  polyPistol01Attack: 2.2,
+  polyRevolver01Attack: 2.2,
+  polySawedOff01Attack: 2.2,
+  polyRevolver02Attack: 2.2,
+  polyShotgun02Attack: 2.2,
+  polyShotgun03Attack: 2.2,
+  polySmg01Attack: 2.2,
   polyRobotLargeGunAttack: 1.95,
   polyRobotFlyingGunAttack: 1.45,
   polyBazooka01Attack: 2.6,
@@ -4121,6 +4121,7 @@ const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
 const LUDO_CAMERA_BROADCAST_LOCKED_POSITION = true;
 const LUDO_CAMERA_SEAT_LOCK_ENABLED = true;
 const LUDO_CAMERA_ANIMATION_BOTTOM_TURN_VIEW = false;
+const LUDO_HDRI_LOCK_GROUNDED_SKYBOX_SCALE = true;
 const CAPTURE_ATTACK_CAMERA_FRAME = Object.freeze({
   fighterJetAttack: { focusWeight: 0.52, targetLift: 0.014, followPullback: 0.082, followLift: 0.022 },
   helicopterAttack: { focusWeight: 0.56, targetLift: 0.02, followPullback: 0.068, followLift: 0.026 },
@@ -10181,10 +10182,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const measuredRadius = camera.position.distanceTo(boardLookTarget);
       const baseRadius = baseCameraRadiusRef.current || measuredRadius || 1;
       const baseScale = baseSkyboxScaleRef.current || 1;
-      // Do not rescale the grounded HDRI during cinematic firearm camera moves;
-      // the camera intentionally changes position, but the environment must remain stable.
-      const radius = dynamicFirearmCameraRef.current ? baseRadius : measuredRadius;
-      const scale = clamp(radius / baseRadius, 0.35, 3.5);
+      // Keep grounded HDRIs visually pinned while the camera auto-looks at the
+      // next player, dice result, or cinematic target. Scaling the skybox by
+      // the active look radius makes the environment feel like it is moving or
+      // zooming on portrait screens.
+      const radius = LUDO_HDRI_LOCK_GROUNDED_SKYBOX_SCALE ? baseRadius : measuredRadius;
+      const scale = LUDO_HDRI_LOCK_GROUNDED_SKYBOX_SCALE ? 1 : clamp(radius / baseRadius, 0.35, 3.5);
       skybox.scale.setScalar(baseScale * scale);
       lastCameraRadiusRef.current = radius;
       const floorY = environmentFloorRef.current ?? 0;
@@ -10882,12 +10885,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           ? boardLookTargetRef.current.clone()
           : null;
         const liveFacePose = resolveSeatedFaceCameraPose(bottomActorEntry, gameplayTarget);
-        const hardLockedPosition = liveFacePose?.position?.isVector3
-          ? liveFacePose.position
-          : cameraLookStateRef.current.lockedPosition?.isVector3
-            ? cameraLookStateRef.current.lockedPosition
-            : cameraSeatLockPositionRef.current?.isVector3
-              ? cameraSeatLockPositionRef.current
+        const hardLockedPosition = cameraLookStateRef.current.lockedPosition?.isVector3
+          ? cameraLookStateRef.current.lockedPosition
+          : cameraSeatLockPositionRef.current?.isVector3
+            ? cameraSeatLockPositionRef.current
+            : liveFacePose?.position?.isVector3
+              ? liveFacePose.position
               : null;
         if (hardLockedPosition) {
           camera.position.copy(hardLockedPosition);
@@ -12660,11 +12663,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const bottomActorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === 0);
       const facePose = resolveSeatedFaceCameraPose(bottomActorEntry, resolveBottomPlayerGameplayTarget());
       if (facePose?.position?.isVector3 && facePose?.target?.isVector3) {
+        const lockedPosition = cameraSeatLockPositionRef.current?.isVector3
+          ? cameraSeatLockPositionRef.current.clone()
+          : facePose.position.clone();
         cameraTurnStateRef.current.baseTurnView = {
-          position: facePose.position.clone(),
+          position: lockedPosition,
           target: facePose.target.clone()
         };
-        animateCameraPose(facePose.target, facePose.position, duration);
+        animateCameraPose(facePose.target, lockedPosition, duration);
         return;
       }
       const initialBottomView = initialBottomCameraViewRef.current;


### PR DESCRIPTION
### Motivation
- Ensure Poly Pizza weapon display and scale for Ludo Battle Royal match the Chess Battle Royal configuration so parked weapons and rack poses are visually consistent across games. 
- Prevent the grounded HDRI skybox from appearing to move or zoom when the camera auto-focuses on the next player, dice results, or cinematic firearm moves on portrait screens.
- Keep turn-return camera positions anchored to the locked seat pose so automatic look changes don’t introduce subtle camera zoom/shift on return.

### Description
- Updated Poly Pizza weapon rack multipliers in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by aligning `FIREARM_RACK_SIZE_MULTIPLIER_BY_ID` entries (several `poly*` ids) to the same values used in Chess. 
- Added a new config flag `LUDO_HDRI_LOCK_GROUNDED_SKYBOX_SCALE` and changed the skybox sync logic in `syncSkyboxToCameraRef.current` so grounded HDRIs remain visually pinned when auto-looking; the skybox scale is forced to `1` while the lock is enabled. 
- Changed hard-lock camera precedence so `cameraLookStateRef.current.lockedPosition` and `cameraSeatLockPositionRef.current` are favored before falling back to `liveFacePose.position`, keeping camera position stable during auto-look. 
- When setting the bottom-player base turn view, prefer the locked seat position (if available) when composing `cameraTurnStateRef.current.baseTurnView` so turn-return animations use the anchored camera position. 
- Added regression tests in `test/inventoryCrossGameConfig.test.js` that assert parity of Poly Pizza weapon multipliers with Chess and verify that the HDRI lock flag + scale usage exist in Ludo source.

### Testing
- Ran unit tests: `npm test -- --runInBand test/inventoryCrossGameConfig.test.js`, and the suite passed (all added assertions succeeded). 
- Built the web app: `npm --prefix webapp run build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fc41a5cdc83298eec5fc45889664f)