### PR TITLE
Add Poly Pizza (Quaternius) weapons to Snake & Ladder and wire catalog + scales

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -310,5 +310,20 @@ describe('cross-game inventory alignment', () => {
 
     expect(snakeCaptureStoreIds).toEqual(snakeCatalogIds);
     expect(new Set(SNAKE_DEFAULT_UNLOCKS.captureWeapon)).toEqual(new Set([SNAKE_CAPTURE_WEAPON_OPTIONS[0]?.id]));
+
+    [
+      'poly-robot-large-gun-01',
+      'poly-robot-flying-gun-01',
+      'poly-bazooka-01',
+      'poly-grenade-launcher-01',
+      'poly-dynamite-bomb-01',
+      'poly-molotov-01',
+      'poly-gas-tank-01',
+      'poly-hand-grenade-01',
+      'poly-tank-01'
+    ].forEach((weaponId) => {
+      expect(snakeCatalogIds.has(weaponId)).toBe(true);
+      expect(snakeCaptureStoreIds.has(weaponId)).toBe(true);
+    });
   });
 });

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -471,7 +471,25 @@ const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
   'slot-18-fps-gun-gltf': 0.03,
   // Enlarge long rifles for clearer sniper identity in portrait view.
   'slot-16-awp-glb': 3,
-  'slot-13-mosin-gltf': 3
+  'slot-13-mosin-gltf': 3,
+  'poly-shotgun-01': 1,
+  'poly-assault-rifle-01': 1.02,
+  'poly-pistol-01': 0.6,
+  'poly-revolver-01': 0.64,
+  'poly-sawed-off-01': 0.85,
+  'poly-revolver-02': 0.64,
+  'poly-shotgun-02': 1.05,
+  'poly-shotgun-03': 1.03,
+  'poly-smg-01': 0.84,
+  'poly-robot-large-gun-01': 0.83,
+  'poly-robot-flying-gun-01': 0.78,
+  'poly-bazooka-01': 1.08,
+  'poly-grenade-launcher-01': 0.98,
+  'poly-dynamite-bomb-01': 0.58,
+  'poly-molotov-01': 0.46,
+  'poly-gas-tank-01': 0.62,
+  'poly-hand-grenade-01': 0.36,
+  'poly-tank-01': 0.7
 });
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
@@ -798,6 +816,15 @@ const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
   'poly-shotgun-02': 'polyShotgun02Attack',
   'poly-shotgun-03': 'polyShotgun03Attack',
   'poly-smg-01': 'polySmg01Attack',
+  'poly-robot-large-gun-01': 'polyRobotLargeGunAttack',
+  'poly-robot-flying-gun-01': 'polyRobotFlyingGunAttack',
+  'poly-bazooka-01': 'polyBazooka01Attack',
+  'poly-grenade-launcher-01': 'polyGrenadeLauncher01Attack',
+  'poly-dynamite-bomb-01': 'polyDynamiteBomb01Attack',
+  'poly-molotov-01': 'polyMolotov01Attack',
+  'poly-gas-tank-01': 'polyGasTank01Attack',
+  'poly-hand-grenade-01': 'polyHandGrenade01Attack',
+  'poly-tank-01': 'polyTank01Attack',
   'slot-10-ak47-gltf': 'ak47VolleyAttack',
   'slot-11-krsv-gltf': 'krsvBurstAttack',
   'slot-12-smith-gltf': 'smithSidearmAttack',
@@ -6162,7 +6189,9 @@ function createSeatWeaponMesh(weaponType = 'fighter', options = {}) {
     normalizedWeaponType
   );
   const firearmScale = isVehicleWeapon ? 1 : FIREARM_DISPLAY_SIZE_MULTIPLIER;
-  const firearmModelScaleById = catalogWeaponType ? FIREARM_MODEL_SCALE_BY_ID[catalogWeaponType] ?? 1 : 1;
+  const firearmModelScaleById = catalogWeaponType
+    ? catalogOption?.modelScale ?? FIREARM_MODEL_SCALE_BY_ID[catalogWeaponType] ?? 1
+    : 1;
   if (catalogWeaponType && !catalogOption?.vehicleKind) {
     const holder = new THREE.Group();
     const fallback = createPolySeatWeaponMesh(normalizedWeaponType);

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -1,16 +1,30 @@
-import { swatchThumbnail, weaponSilhouetteThumbnail } from './storeThumbnails.js';
+import { swatchThumbnail, weaponSilhouetteThumbnail } from './storeThumbnails.js'
 
-const polyGlb = (uuid) => `https://static.poly.pizza/${uuid}.glb`;
+const polyGlb = (uuid) => `https://static.poly.pizza/${uuid}.glb`
+const polyWebp = (uuid) => `https://static.poly.pizza/${uuid}.webp`
+
+const polyPizzaWeapon = (id, label, uuid, colors, extra = {}) => ({
+  id,
+  label,
+  thumbnail: extra.thumbnail || polyWebp(uuid),
+  urls: [polyGlb(uuid)],
+  source: extra.source || 'Poly Pizza',
+  creator: extra.creator || undefined,
+  license: extra.license || 'CC0 / Poly Pizza source page',
+  modelScale: extra.modelScale,
+  ...Object.fromEntries(Object.entries(extra).filter(([key]) => !['thumbnail', 'source', 'creator', 'license', 'modelScale'].includes(key))),
+  fallbackThumbnail: weaponSilhouetteThumbnail(colors)
+})
 
 // Match Ludo Battle Royal's pinned Gunify snapshot so Snake & Ladder uses
 // the same authored GLTF material/texture tree instead of whatever is on main.
-export const SNAKE_GUNIFY_MAY_9_REF = '27232cf389a2be3f8f476c667cb293e978aaf5f9';
-const SNAKE_GUNIFY_RAW_BASE = `https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/${SNAKE_GUNIFY_MAY_9_REF}`;
-const SNAKE_GUNIFY_JSDELIVR_BASE = `https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@${SNAKE_GUNIFY_MAY_9_REF}`;
+export const SNAKE_GUNIFY_MAY_9_REF = '27232cf389a2be3f8f476c667cb293e978aaf5f9'
+const SNAKE_GUNIFY_RAW_BASE = `https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/${SNAKE_GUNIFY_MAY_9_REF}`
+const SNAKE_GUNIFY_JSDELIVR_BASE = `https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@${SNAKE_GUNIFY_MAY_9_REF}`
 const gunifyModelUrls = (modelName) => [
   `${SNAKE_GUNIFY_RAW_BASE}/models/${modelName}/scene.gltf`,
   `${SNAKE_GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
-];
+]
 const gunifyWeapon = (id, label, modelName, colors) => ({
   id,
   label,
@@ -19,13 +33,13 @@ const gunifyWeapon = (id, label, modelName, colors) => ({
   modelName,
   source: 'Gunify',
   texturePolicy: 'gunifyPbr'
-});
+})
 
 export const UKRAINIAN_DRONE_GLB_URLS = Object.freeze([
   'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
   'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
   'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
-]);
+])
 
 export const SNAKE_KNOWN_WORKING_GLB = Object.freeze({
   awp: 'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
@@ -37,7 +51,7 @@ export const SNAKE_KNOWN_WORKING_GLB = Object.freeze({
   pistolHolsterRaw: 'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
   fps: 'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
   fpsRaw: 'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf'
-});
+})
 
 export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   {
@@ -47,40 +61,57 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
     urls: UKRAINIAN_DRONE_GLB_URLS,
     vehicleKind: 'ukrainianDrone'
   },
-  { id: 'poly-shotgun-01', label: 'Quaternius Shotgun', thumbnail: weaponSilhouetteThumbnail(['#64748b','#1e293b','#f8fafc']), urls: [polyGlb('032e6589-3188-41bc-b92b-e25528344275')] },
-  { id: 'poly-assault-rifle-01', label: 'Quaternius Assault Rifle', thumbnail: weaponSilhouetteThumbnail(['#334155','#0f172a','#94a3b8']), urls: [polyGlb('b3e6be61-0299-4866-a227-58f5f3fe610b')] },
-  { id: 'poly-pistol-01', label: 'Quaternius Pistol', thumbnail: weaponSilhouetteThumbnail(['#6b7280','#111827','#e5e7eb']), urls: [polyGlb('3b53f0fe-f86e-451c-816d-6ab9bd265cdc')] },
-  { id: 'poly-revolver-01', label: 'Quaternius Heavy Revolver', thumbnail: weaponSilhouetteThumbnail(['#7c2d12','#1f2937','#fbbf24']), urls: [polyGlb('9e728565-67a3-44db-9567-982320abff09')] },
-  { id: 'poly-sawed-off-01', label: 'Quaternius Sawed-Off', thumbnail: weaponSilhouetteThumbnail(['#78350f','#0f172a','#d6d3d1']), urls: [polyGlb('9a6ee0ee-068b-4774-8b0f-679c3cef0b6e')] },
-  { id: 'poly-revolver-02', label: 'Quaternius Revolver Silver', thumbnail: weaponSilhouetteThumbnail(['#94a3b8','#1f2937','#f8fafc']), urls: [polyGlb('7951b3b9-d3a5-4ec8-81b7-11111f1c8e88')] },
-  { id: 'poly-shotgun-02', label: 'Quaternius Long Shotgun', thumbnail: weaponSilhouetteThumbnail(['#475569','#020617','#cbd5e1']), urls: [polyGlb('f71d6771-f512-4374-bd23-ba00b564db68')] },
-  { id: 'poly-shotgun-03', label: 'Quaternius Pump Shotgun', thumbnail: weaponSilhouetteThumbnail(['#52525b','#111827','#e2e8f0']), urls: [polyGlb('08f27141-8e64-425a-9161-1bbd6956dfca')] },
-  { id: 'poly-smg-01', label: 'Quaternius SMG', thumbnail: weaponSilhouetteThumbnail(['#374151','#030712','#d1d5db']), urls: [polyGlb('fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710')] },
-  gunifyWeapon('slot-10-ak47-gltf', 'AK47 GLTF', 'AK47', ['#7f1d1d','#111827','#f59e0b']),
-  gunifyWeapon('slot-11-krsv-gltf', 'KRSV GLTF', 'KRSV', ['#1d4ed8','#0f172a','#bfdbfe']),
-  gunifyWeapon('slot-12-smith-gltf', 'Smith GLTF', 'Smith', ['#6b7280','#0f172a','#f8fafc']),
-  gunifyWeapon('slot-13-mosin-gltf', 'Mosin GLTF', 'Mosin', ['#92400e','#1f2937','#fcd34d']),
-  gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e','#111827','#99f6e4']),
-  gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155','#020617','#f1f5f9']),
-  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b','#0f172a','#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
-  { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b','#111827','#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
-]);
-
+  polyPizzaWeapon('poly-shotgun-01', 'Quaternius Shotgun', '032e6589-3188-41bc-b92b-e25528344275', ['#64748b', '#1e293b', '#f8fafc'], { creator: 'Quaternius', modelScale: 1 }),
+  polyPizzaWeapon('poly-assault-rifle-01', 'Quaternius Assault Rifle', 'b3e6be61-0299-4866-a227-58f5f3fe610b', ['#334155', '#0f172a', '#94a3b8'], { creator: 'Quaternius', modelScale: 1.02 }),
+  polyPizzaWeapon('poly-pistol-01', 'Quaternius Pistol', '3b53f0fe-f86e-451c-816d-6ab9bd265cdc', ['#6b7280', '#111827', '#e5e7eb'], { creator: 'Quaternius', modelScale: 0.6 }),
+  polyPizzaWeapon('poly-revolver-01', 'Quaternius Heavy Revolver', '9e728565-67a3-44db-9567-982320abff09', ['#7c2d12', '#1f2937', '#fbbf24'], { creator: 'Quaternius', modelScale: 0.64 }),
+  polyPizzaWeapon('poly-sawed-off-01', 'Quaternius Sawed-Off', '9a6ee0ee-068b-4774-8b0f-679c3cef0b6e', ['#78350f', '#0f172a', '#d6d3d1'], { creator: 'Quaternius', modelScale: 0.85 }),
+  polyPizzaWeapon('poly-revolver-02', 'Quaternius Revolver Silver', '7951b3b9-d3a5-4ec8-81b7-11111f1c8e88', ['#94a3b8', '#1f2937', '#f8fafc'], { creator: 'Quaternius', modelScale: 0.64 }),
+  polyPizzaWeapon('poly-shotgun-02', 'Quaternius Long Shotgun', 'f71d6771-f512-4374-bd23-ba00b564db68', ['#475569', '#020617', '#cbd5e1'], { creator: 'Quaternius', modelScale: 1.05 }),
+  polyPizzaWeapon('poly-shotgun-03', 'Quaternius Pump Shotgun', '08f27141-8e64-425a-9161-1bbd6956dfca', ['#52525b', '#111827', '#e2e8f0'], { creator: 'Quaternius', modelScale: 1.03 }),
+  polyPizzaWeapon('poly-smg-01', 'Quaternius SMG', 'fb8ae707-d5b9-4eb8-ab8c-1c78d3c1f710', ['#374151', '#030712', '#d1d5db'], { creator: 'Quaternius', modelScale: 0.84 }),
+  polyPizzaWeapon('poly-robot-large-gun-01', 'Quaternius Robot Large Gun', '78e23275-cb6a-4ba3-ae5e-48a9b4ee2e65', ['#4b5563', '#111827', '#f97316'], { creator: 'Quaternius', modelScale: 0.83 }),
+  polyPizzaWeapon('poly-robot-flying-gun-01', 'Quaternius Robot Flying Gun', '6d0889f1-0c3f-4f98-b011-fbcf6c79a93b', ['#0f766e', '#0f172a', '#67e8f9'], { creator: 'Quaternius', modelScale: 0.78 }),
+  polyPizzaWeapon('poly-bazooka-01', 'CreativeTrio Bazooka', '613e3b1b-d07c-496b-94a1-7c85b507bac4', ['#14532d', '#111827', '#facc15'], { creator: 'CreativeTrio', modelScale: 1.08 }),
+  polyPizzaWeapon('poly-grenade-launcher-01', 'CreativeTrio Grenade Launcher', '503bb2c5-4a69-404b-9b82-13e85e8f8467', ['#365314', '#111827', '#f97316'], { creator: 'CreativeTrio', modelScale: 0.98 }),
+  polyPizzaWeapon('poly-dynamite-bomb-01', 'CreativeTrio Dynamite Bomb', '38e858db-325f-4dce-9680-da62c20c5c31', ['#7f1d1d', '#111827', '#fbbf24'], { creator: 'CreativeTrio', modelScale: 0.58 }),
+  polyPizzaWeapon('poly-molotov-01', 'CreativeTrio Molotov', 'd7bb0b50-09af-49f8-b1f9-dbdb0c707d40', ['#92400e', '#111827', '#fb923c'], { creator: 'CreativeTrio', modelScale: 0.46 }),
+  polyPizzaWeapon('poly-gas-tank-01', 'Quaternius Gas Tank', '9c4d2ac5-114b-4da2-a26a-8049e2b1ba04', ['#b91c1c', '#111827', '#e5e7eb'], { creator: 'Quaternius', modelScale: 0.62 }),
+  polyPizzaWeapon('poly-hand-grenade-01', 'CreativeTrio Hand Grenade', '03fa7f5b-4df5-45d6-86fb-87e8590f28d7', ['#3f6212', '#111827', '#a3e635'], { creator: 'CreativeTrio', modelScale: 0.36 }),
+  polyPizzaWeapon('poly-tank-01', 'Quaternius Battle Tank', '58c387b2-636f-49dc-a900-13b0852717d6', ['#334155', '#111827', '#94a3b8'], { creator: 'Quaternius', modelScale: 0.7 }),
+  gunifyWeapon('slot-10-ak47-gltf', 'AK47 GLTF', 'AK47', ['#7f1d1d', '#111827', '#f59e0b']),
+  gunifyWeapon('slot-11-krsv-gltf', 'KRSV GLTF', 'KRSV', ['#1d4ed8', '#0f172a', '#bfdbfe']),
+  gunifyWeapon('slot-12-smith-gltf', 'Smith GLTF', 'Smith', ['#6b7280', '#0f172a', '#f8fafc']),
+  gunifyWeapon('slot-13-mosin-gltf', 'Mosin GLTF', 'Mosin', ['#92400e', '#1f2937', '#fcd34d']),
+  gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e', '#111827', '#99f6e4']),
+  gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155', '#020617', '#f1f5f9']),
+  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
+  { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b', '#111827', '#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
+])
 
 export const SNAKE_CAPTURE_WEAPON_ALIAS_MAP = Object.freeze({
   fighter: 'poly-assault-rifle-01',
   helicopter: 'poly-shotgun-02',
   supporttruck: 'poly-smg-01',
+  polyrobotlargegunattack: 'poly-robot-large-gun-01',
+  polyrobotflyinggunattack: 'poly-robot-flying-gun-01',
+  polybazooka01attack: 'poly-bazooka-01',
+  polygrenadelauncher01attack: 'poly-grenade-launcher-01',
+  polydynamitebomb01attack: 'poly-dynamite-bomb-01',
+  polymolotov01attack: 'poly-molotov-01',
+  polygastank01attack: 'poly-gas-tank-01',
+  polyhandgrenade01attack: 'poly-hand-grenade-01',
+  polytank01attack: 'poly-tank-01',
   drone: 'ukrainianDroneAttack',
   ukrainiandrone: 'ukrainianDroneAttack',
   ukrainiandroneattack: 'ukrainianDroneAttack'
-});
+})
 
 export const normalizeSnakeWeaponId = (value) =>
-  typeof value === 'string' ? value.trim().toLowerCase() : '';
+  typeof value === 'string' ? value.trim().toLowerCase() : ''
 
 export const resolveSnakeCaptureWeaponId = (weaponId) => {
-  const normalized = normalizeSnakeWeaponId(weaponId);
-  if (!normalized) return '';
-  return SNAKE_CAPTURE_WEAPON_ALIAS_MAP[normalized] || normalized;
-};
+  const normalized = normalizeSnakeWeaponId(weaponId)
+  if (!normalized) return ''
+  return SNAKE_CAPTURE_WEAPON_ALIAS_MAP[normalized] || normalized
+}


### PR DESCRIPTION
### Motivation
- Bring Snake & Ladder capture weapons in line with the Chess/Ludo Battle Royal set by adding the same Poly Pizza / Quaternius assets and metadata so capture visuals and cross-game stores match.  
- Preserve source GLB/WebP URLs, author/license metadata, and per-model scale tuning so runtime loading/parking/flattening uses the same inputs as other games.

### Description
- Added a reusable helper `polyPizzaWeapon` and WebP helper to `webapp/src/config/snakeWeaponCatalog.js` and replaced the inline Poly Pizza entries with calls that include `urls`, `thumbnail`, `creator`, `license`, `modelScale`, and a `fallbackThumbnail`.  
- Expanded `SNAKE_CAPTURE_WEAPON_OPTIONS` with the extra Poly Pizza/Quaternius and CreativeTrio entries (robot guns, bazooka, grenade launcher, explosives, gas tank, hand grenade, tank).  
- Extended `SNAKE_CAPTURE_WEAPON_ALIAS_MAP` so capture animation IDs resolve to the new catalog IDs.  
- Wired new IDs into `webapp/src/components/SnakeBoard3D.jsx` by adding per-ID scale overrides to `FIREARM_MODEL_SCALE_BY_ID`, mapping new catalog IDs to capture kinds in `SNAKE_CAPTURE_WEAPON_KIND_MAP`, and using a catalog-level `modelScale` when computing loaded model scale in `createSeatWeaponMesh`.  
- Updated cross-game inventory test `test/inventoryCrossGameConfig.test.js` to assert the new Poly Pizza weapons are present in both the Snake catalog and Snake store items.

### Testing
- Ran linter: `npm --prefix webapp run lint -- src/config/snakeWeaponCatalog.js src/components/SnakeBoard3D.jsx` which completed successfully.  
- Ran cross-game inventory unit tests: `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` which passed.  
- Ran chess inventory unit tests: `npm test -- --runInBand test/chessBattleInventoryConfig.test.js` which previously failed due to an existing label mismatch for the drone (`expect` expects "Shahad Drone" vs current config reporting "Drone Attack`) — this is an unrelated pre-existing assertion mismatch and noted as known in the run.  
- Installed Playwright browsers and deps and captured a runtime screenshot of `/games/snake` to preview the changes (Playwright install + `npx playwright install-deps chromium` and screenshot step completed in the CI environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fcf1b38108329afe0e9ab663f869e)