### PR TITLE
Add streamed CC‑BY firearm SFX for Chess Battle Royal with attribution, sound pool, and related UI/camera tweaks

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
 import {
   CHESS_BATTLE_DEFAULT_UNLOCKS,
@@ -241,6 +241,26 @@ describe('cross-game inventory alignment', () => {
       expect(source).toContain('https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/${GUNIFY_MAY_9_REF}');
       expect(source).toContain('https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@${GUNIFY_MAY_9_REF}');
       expect(source).toContain(`modelName: '${modelName}'`);
+    });
+  });
+
+
+  test('chess battle royal maps firearm families to attributed open source sound effects', async () => {
+    const source = await readFile('webapp/src/pages/Games/ChessBattleRoyal.jsx', 'utf8');
+    const attribution = await readFile('webapp/public/assets/sounds/chess-firearms/ATTRIBUTION.md', 'utf8');
+    const soundDirFiles = await readdir('webapp/public/assets/sounds/chess-firearms');
+
+    expect(soundDirFiles.filter((fileName) => /\.(mp3|wav|ogg|m4a)$/i.test(fileName))).toEqual([]);
+    expect(source).toContain('CHESS_FIREARM_SOUND_ATTRIBUTION');
+    expect(source).toContain('CHESS_FIREARM_SOUND_PROFILE_BY_TYPE');
+    expect(source).toContain('playFirearmSound(fx.bulletProfile)');
+    ['gunshot', 'shotgun', 'cannon'].forEach((soundKey) => {
+      expect(source).toContain(`soundKey: '${soundKey}'`);
+      expect(source).toContain('https://www.orangefreesounds.com/wp-content/uploads/');
+      expect(attribution).toContain('Creative Commons Attribution 4.0 International');
+    });
+    ['Pistol', 'Revolver', 'SMG', 'Rifle', 'AssaultRifle', 'SniperRifle', 'DMR', 'Shotgun', 'GrenadeLauncher', 'Launcher'].forEach((weaponType) => {
+      expect(source).toContain(`${weaponType}: { soundKey:`);
     });
   });
 

--- a/webapp/public/assets/sounds/chess-firearms/ATTRIBUTION.md
+++ b/webapp/public/assets/sounds/chess-firearms/ATTRIBUTION.md
@@ -1,0 +1,9 @@
+# Chess Battle Royal firearm sound attributions
+
+The GLTF firearm model sources used by Chess Battle Royal do not include source-authored audio tracks. To avoid committing binary audio files, Chess Battle Royal streams these free Creative Commons Attribution 4.0 International firearm effects from Orange Free Sounds at runtime:
+
+- Gunshot profile — "Gunshot Sound Effect" by Alexander / Orange Free Sounds, CC BY 4.0: https://orangefreesounds.com/gunshot-sound-effect/
+- Shotgun profile — "Shotgun Sound" by Alexander / Orange Free Sounds, CC BY 4.0: https://orangefreesounds.com/shotgun-sound/
+- Launcher profile — "Cannon Sound Effect" by Alexander / Orange Free Sounds, CC BY 4.0: https://orangefreesounds.com/cannon-sound-effect/
+
+Runtime MP3 URLs are kept in `CHESS_FIREARM_SOUND_URLS` instead of storing binary files in the repository.

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -158,9 +158,15 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   },
   {
     id: 'droneAttack',
-    label: 'Drone Attack',
-    description: 'Attack drone sweep adapted from Chess Battle Royal scale.',
+    label: 'Shahad Drone',
+    description: 'Shahad-style attack drone sweep adapted from Chess Battle Royal scale.',
     thumbnail: captureWeaponThumb('🛸', '#0ea5e9')
+  },
+  {
+    id: 'ukrainianDroneAttack',
+    label: 'Ukrainian Drone',
+    description: 'Ukrainian FPV drone strike with compact no-smoke precision impact.',
+    thumbnail: captureWeaponThumb('🇺🇦', '#2563eb')
   },
   {
     id: 'fighterJetAttack',

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -2011,7 +2011,7 @@ input:focus {
 }
 
 .chess-battle-chat-bubble {
-  bottom: calc(env(safe-area-inset-bottom, 0px) + 5.6rem);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 4.55rem);
 }
 
 

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -716,8 +716,8 @@ const CAMERA_PULL_FORWARD_MIN = THREE.MathUtils.degToRad(15);
 const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(21); // raise forced 3D animation camera for a stronger portrait top-down feel.
 const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 1.18; // keep forced 3D animation wider during capture so the board stays fully readable
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 0; // keep projected avatars pinned to the seated character chest anchors
-const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(88); // tilt 3D view farther downward so the table/chairs/humans sit closer to the phone-bottom edge in portrait screens.
-const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.25; // move locked 3D camera closer so table/chairs/avatars feel nearer and lower in portrait play.
+const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(86.5); // match the portrait reference: visible seated opponent up top while the board stays low and large.
+const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.285; // reference-frame distance keeps the full board visible above lowered chat/gift controls.
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.06;
 const PLAYER_FACE_CAMERA_SEAT_ANGLE = Math.PI / 2;
 // Keep Chess Battle Royal bottom-player camera aligned with Checkers Battle Royal
@@ -748,8 +748,8 @@ const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.68;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.42; // lift camera a bit higher while preserving table focus in portrait.
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.98; // mirror the slight upward lift for landscape framing.
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 1.35;
-const PLAYER_VIEW_LOOK_TARGET_UP_BIAS = 0.48; // lower look target slightly so the whole table/chair/human stack lands visually lower on portrait screens.
-const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 10.7; // shift arena lower so table, weapons, chairs, and seated avatars sit closer to the phone-bottom edge in portrait.
+const PLAYER_VIEW_LOOK_TARGET_UP_BIAS = 0.62; // aim slightly higher so the 3D scene visually drops toward the phone bottom like the reference.
+const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 11.65; // push the full 3D gameplay stack lower in portrait framing to match the provided reference.
 const FPV_FACE_FORWARD_OFFSET = 0.012; // keep the camera almost exactly at the eyes for a true first-person perspective.
 const FPV_FACE_UP_OFFSET = 0.0; // slight lift so the board edge does not clip while still feeling eye-level.
 const FPV_LOOK_AHEAD_DISTANCE = BOARD.tile * BOARD_SCALE * 5.8; // prioritize looking down the board journey toward the opponent side.
@@ -2346,6 +2346,36 @@ const DRONE_FLY_SOUND_URL = '/assets/sounds/kimsa-kimsa-big-motorcycle-sound-394
 const HELICOPTER_FLY_SOUND_URL = '/assets/sounds/dragon-studio-helicopter-sound-8d-372463.mp3';
 const BAZOOKA_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
+// The imported GLTF weapon sources (Gunify/Webaverse/Poly Pizza) do not ship audio tracks,
+// so Chess Battle Royal maps every firearm family to streamed CC-BY 4.0 firearm SFX
+// instead of committing binary audio assets to the repo.
+const CHESS_FIREARM_SOUND_ATTRIBUTION = Object.freeze({
+  source: 'Orange Free Sounds',
+  license: 'Creative Commons Attribution 4.0 International',
+  sounds: Object.freeze({
+    gunshot: 'https://orangefreesounds.com/gunshot-sound-effect/',
+    shotgun: 'https://orangefreesounds.com/shotgun-sound/',
+    cannon: 'https://orangefreesounds.com/cannon-sound-effect/'
+  })
+});
+const CHESS_FIREARM_SOUND_URLS = Object.freeze({
+  gunshot: 'https://www.orangefreesounds.com/wp-content/uploads/2015/01/Gunshot-sound-effect.mp3',
+  shotgun: 'https://www.orangefreesounds.com/wp-content/uploads/2016/12/Shotgun-sound.mp3',
+  cannon: 'https://www.orangefreesounds.com/wp-content/uploads/2017/03/Cannon-sound-effect.mp3'
+});
+const CHESS_FIREARM_SOUND_PROFILE_BY_TYPE = Object.freeze({
+  Pistol: { soundKey: 'gunshot', volume: 0.92, playbackRate: 1.18, maxDurationMs: 620 },
+  Revolver: { soundKey: 'gunshot', volume: 0.98, playbackRate: 0.92, maxDurationMs: 760 },
+  SMG: { soundKey: 'gunshot', volume: 0.56, playbackRate: 1.34, maxDurationMs: 360 },
+  Rifle: { soundKey: 'gunshot', volume: 0.82, playbackRate: 0.86, maxDurationMs: 760 },
+  AssaultRifle: { soundKey: 'gunshot', volume: 0.82, playbackRate: 0.84, maxDurationMs: 760 },
+  Sniper: { soundKey: 'gunshot', volume: 1, playbackRate: 0.72, maxDurationMs: 980 },
+  SniperRifle: { soundKey: 'gunshot', volume: 1, playbackRate: 0.72, maxDurationMs: 980 },
+  DMR: { soundKey: 'gunshot', volume: 0.94, playbackRate: 0.78, maxDurationMs: 900 },
+  Shotgun: { soundKey: 'shotgun', volume: 1, playbackRate: 0.98, maxDurationMs: 950 },
+  GrenadeLauncher: { soundKey: 'cannon', volume: 1, playbackRate: 1.08, maxDurationMs: 900 },
+  Launcher: { soundKey: 'cannon', volume: 1, playbackRate: 0.94, maxDurationMs: 1050 }
+});
 const LUDO_FIREARM_BROADCAST_PROFILE = LUDO_WEAPON_DIRECTOR_BRIDGE.firearmBroadcastProfile || {};
 const LUDO_WEAPON_TYPE_BY_ANIMATION_ID = LUDO_WEAPON_DIRECTOR_BRIDGE.weaponTypeByCaptureAnimationId || {};
 const CHESS_FIREARM_FATAL_BULLET_TRAVEL_MS = 1250; // match Ludo Battle Royal service-pistol final bullet travel.
@@ -8496,6 +8526,7 @@ function Chess3D({
   const helicopterSoundRef = useRef(null);
   const missileLaunchSoundRef = useRef(null);
   const missileImpactSoundRef = useRef(null);
+  const firearmSoundPoolRef = useRef(new Map());
   const audioStopTimeoutsRef = useRef(new Map());
   const lastBeepRef = useRef({ white: null, black: null });
   const suppressTimerBeepUntilRef = useRef(0);
@@ -9671,6 +9702,17 @@ function Chess3D({
         } catch {}
       }
     });
+    firearmSoundPoolRef.current.forEach((pool) => {
+      pool.forEach((audio) => {
+        audio.volume = effectiveSoundEnabled ? volume : 0;
+        if (!effectiveSoundEnabled) {
+          try {
+            audio.pause();
+            audio.currentTime = 0;
+          } catch {}
+        }
+      });
+    });
     if (!effectiveSoundEnabled) {
       audioStopTimeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
       audioStopTimeoutsRef.current.clear();
@@ -9701,6 +9743,11 @@ function Chess3D({
       [swordSoundRef, droneSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
         if (!ref.current) return;
         ref.current.volume = settingsRef.current.soundEnabled ? volume : 0;
+      });
+      firearmSoundPoolRef.current.forEach((pool) => {
+        pool.forEach((audio) => {
+          audio.volume = settingsRef.current.soundEnabled ? volume : 0;
+        });
       });
     };
     window.addEventListener('gameVolumeChanged', handleVolumeChange);
@@ -10132,6 +10179,18 @@ function Chess3D({
     missileLaunchSoundRef.current.volume = baseVolume;
     missileImpactSoundRef.current = new Audio(MISSILE_IMPACT_SOUND_URL);
     missileImpactSoundRef.current.volume = baseVolume;
+    firearmSoundPoolRef.current = new Map(
+      Object.entries(CHESS_FIREARM_SOUND_URLS).map(([soundKey, soundUrl]) => [
+        soundKey,
+        Array.from({ length: 5 }, () => {
+          const audio = new Audio(soundUrl);
+          audio.volume = baseVolume;
+          audio.preload = 'auto';
+          return audio;
+        })
+      ])
+    );
+    firearmSoundPoolRef.current.attribution = CHESS_FIREARM_SOUND_ATTRIBUTION;
 
     let stopCameraTween = () => {};
     let onResize = null;
@@ -10201,9 +10260,11 @@ function Chess3D({
       const pieceSetPromise = loadPieceSet(RAW_BOARD_SIZE);
       const playAudio = (audioRef, options = {}) => {
         if (!audioRef?.current || !settingsRef.current.soundEnabled) return;
-        const { maxDurationMs = null } = options;
+        const { maxDurationMs = null, volume = 1, playbackRate = 1 } = options;
         try {
           audioRef.current.currentTime = 0;
+          audioRef.current.volume = clamp01(getGameVolume() * volume, 0);
+          audioRef.current.playbackRate = Number.isFinite(playbackRate) && playbackRate > 0 ? playbackRate : 1;
           const playPromise = audioRef.current.play();
           if (maxDurationMs && Number.isFinite(maxDurationMs)) {
             clearAudioStopTimeout(audioRef);
@@ -10215,6 +10276,35 @@ function Chess3D({
               audioStopTimeoutsRef.current.delete(audioRef.current);
             }, maxDurationMs);
             audioStopTimeoutsRef.current.set(audioRef.current, timeoutId);
+          }
+          playPromise?.catch(() => {});
+        } catch {}
+      };
+      const playFirearmSound = (profile = {}) => {
+        if (!settingsRef.current.soundEnabled) return;
+        const ludoType = profile.ludoType || 'Rifle';
+        const soundProfile =
+          CHESS_FIREARM_SOUND_PROFILE_BY_TYPE[ludoType] || CHESS_FIREARM_SOUND_PROFILE_BY_TYPE.Rifle;
+        const pool = firearmSoundPoolRef.current.get(soundProfile.soundKey) || [];
+        const audio = pool.find((candidate) => candidate.paused || candidate.ended) || pool[0];
+        if (!audio) return;
+        try {
+          audio.pause();
+          audio.currentTime = 0;
+          audio.volume = clamp01(getGameVolume() * (soundProfile.volume ?? 1), 0);
+          audio.playbackRate = soundProfile.playbackRate ?? 1;
+          const playPromise = audio.play();
+          if (soundProfile.maxDurationMs && Number.isFinite(soundProfile.maxDurationMs)) {
+            const existingTimeoutId = audioStopTimeoutsRef.current.get(audio);
+            if (existingTimeoutId) clearTimeout(existingTimeoutId);
+            const timeoutId = setTimeout(() => {
+              try {
+                audio.pause();
+                audio.currentTime = 0;
+              } catch {}
+              audioStopTimeoutsRef.current.delete(audio);
+            }, soundProfile.maxDurationMs);
+            audioStopTimeoutsRef.current.set(audio, timeoutId);
           }
           playPromise?.catch(() => {});
         } catch {}
@@ -15614,9 +15704,7 @@ function Chess3D({
                 velocity: ejectSide.multiplyScalar(0.16).add(new THREE.Vector3(0, 0.11, 0)).addScaledVector(aimDir, -0.025),
                 startMs: now
               });
-              if (!fx.singleShot && fx.firedBullets < bulletsToFire) {
-                playAudio(missileImpactSoundRef, { volume: 0.25 });
-              }
+              playFirearmSound(fx.bulletProfile);
             }
 
             if (!fx.hitTriggered && u >= fx.impactAt && !(fx.liveBullets || []).some((bullet) => bullet.cinematic)) {
@@ -16087,6 +16175,13 @@ function Chess3D({
       helicopterSoundRef.current?.pause();
       missileLaunchSoundRef.current?.pause();
       missileImpactSoundRef.current?.pause();
+      firearmSoundPoolRef.current.forEach((pool) => {
+        pool.forEach((audio) => {
+          audio.pause();
+          audio.currentTime = 0;
+        });
+      });
+      firearmSoundPoolRef.current.clear();
       activeCaptureFx.splice(0, activeCaptureFx.length);
       activeBulletCameraFollow = null;
       captureFxGroup?.clear?.();
@@ -16615,7 +16710,7 @@ function Chess3D({
             showInfo={false}
             showChat={false}
             showMute={false}
-            className="fixed right-3 bottom-28 z-50 flex flex-col gap-4"
+            className="fixed right-3 bottom-[calc(env(safe-area-inset-bottom,0px)+4.6rem)] z-50 flex flex-col gap-4"
             buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
             iconClassName="text-[1.65rem] leading-none"
             labelClassName="sr-only"
@@ -16627,7 +16722,7 @@ function Chess3D({
             showInfo={false}
             showGift={false}
             showMute={false}
-            className="fixed left-3 bottom-28 z-50 flex flex-col"
+            className="fixed left-3 bottom-[calc(env(safe-area-inset-bottom,0px)+4.6rem)] z-50 flex flex-col"
             buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
             iconClassName="text-[1.65rem] leading-none"
             labelClassName="sr-only"


### PR DESCRIPTION
### Motivation

- Provide attributed open-source firearm sound effects for Chess Battle Royal without committing binary audio files to the repository.
- Keep cross-game inventory/config tests and UI/frame layout aligned with the reference framing and safe-area insets.

### Description

- Add an `ATTRIBUTION.md` at `webapp/public/assets/sounds/chess-firearms` documenting the CC BY 4.0 sources and the decision to stream MP3s instead of committing binaries.
- Implement `CHESS_FIREARM_SOUND_ATTRIBUTION`, `CHESS_FIREARM_SOUND_URLS`, and `CHESS_FIREARM_SOUND_PROFILE_BY_TYPE` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` and create a pooled `Audio` map (`firearmSoundPoolRef`) to preload/serve firearm SFX; add `playFirearmSound` to apply per-type volume/playbackRate/maxDuration handling and integrate it into capture/firearm firing logic, plus proper volume/update/cleanup handling.
- Adjust camera/layout constants in `ChessBattleRoyal.jsx` (`CAMERA_LOCKED_3D_PHI`, `CAMERA_LOCKED_3D_RADIUS_SCALE`, `PLAYER_VIEW_LOOK_TARGET_UP_BIAS`, `TABLE_BOTTOM_PLAYER_BIAS_Z`) to better match the portrait reference and update bottom-left UI icon positioning to account for `env(safe-area-inset-bottom)`.
- Update `webapp/src/index.css` to change the chess battle chat bubble vertical offset to match the new layout placement.
- Update `webapp/src/config/ludoBattleOptions.js` to rename one drone label to `Shahad Drone` and add a `ukrainianDroneAttack` option with thumbnail and description.
- Extend the test `test/inventoryCrossGameConfig.test.js` to import `readdir` and add a new test that asserts presence of the firearm sound constants, attribution file contents, and that no local audio files were committed for the `chess-firearms` directory.

### Testing

- Ran the updated unit test file with `npm test -- test/inventoryCrossGameConfig.test.js`, which exercised the new assertions for firearm SFX and attribution and completed successfully.
- Ran the project test suite via `npm test` and verified there were no regressions related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fcdb2f6b8832983c66df35963ad93)