### PR TITLE
Add remote firearm SFX pool and playback; tweak camera/layout and capture options

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -158,9 +158,15 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   },
   {
     id: 'droneAttack',
-    label: 'Drone Attack',
-    description: 'Attack drone sweep adapted from Chess Battle Royal scale.',
+    label: 'Shahad Drone',
+    description: 'Shahad-style attack drone sweep adapted from Chess Battle Royal scale.',
     thumbnail: captureWeaponThumb('🛸', '#0ea5e9')
+  },
+  {
+    id: 'ukrainianDroneAttack',
+    label: 'Ukrainian Drone',
+    description: 'Ukrainian FPV drone strike with compact no-smoke precision impact.',
+    thumbnail: captureWeaponThumb('🇺🇦', '#2563eb')
   },
   {
     id: 'fighterJetAttack',

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -2011,7 +2011,7 @@ input:focus {
 }
 
 .chess-battle-chat-bubble {
-  bottom: calc(env(safe-area-inset-bottom, 0px) + 5.6rem);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 4.55rem);
 }
 
 

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -716,8 +716,8 @@ const CAMERA_PULL_FORWARD_MIN = THREE.MathUtils.degToRad(15);
 const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(21); // raise forced 3D animation camera for a stronger portrait top-down feel.
 const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 1.18; // keep forced 3D animation wider during capture so the board stays fully readable
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 0; // keep projected avatars pinned to the seated character chest anchors
-const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(88); // tilt 3D view farther downward so the table/chairs/humans sit closer to the phone-bottom edge in portrait screens.
-const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.25; // move locked 3D camera closer so table/chairs/avatars feel nearer and lower in portrait play.
+const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(86.5); // portrait reference: opponent remains visible while board/gameplay sits lower on the phone.
+const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.285; // keep the full board readable above the lowered chat/gift buttons.
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.06;
 const PLAYER_FACE_CAMERA_SEAT_ANGLE = Math.PI / 2;
 // Keep Chess Battle Royal bottom-player camera aligned with Checkers Battle Royal
@@ -748,8 +748,8 @@ const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.68;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.42; // lift camera a bit higher while preserving table focus in portrait.
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.98; // mirror the slight upward lift for landscape framing.
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 1.35;
-const PLAYER_VIEW_LOOK_TARGET_UP_BIAS = 0.48; // lower look target slightly so the whole table/chair/human stack lands visually lower on portrait screens.
-const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 10.7; // shift arena lower so table, weapons, chairs, and seated avatars sit closer to the phone-bottom edge in portrait.
+const PLAYER_VIEW_LOOK_TARGET_UP_BIAS = 0.62; // looking a little higher makes the scene land visually lower in portrait.
+const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 11.65; // push gameplay lower toward the phone bottom, matching the reference framing.
 const FPV_FACE_FORWARD_OFFSET = 0.012; // keep the camera almost exactly at the eyes for a true first-person perspective.
 const FPV_FACE_UP_OFFSET = 0.0; // slight lift so the board edge does not clip while still feeling eye-level.
 const FPV_LOOK_AHEAD_DISTANCE = BOARD.tile * BOARD_SCALE * 5.8; // prioritize looking down the board journey toward the opponent side.
@@ -2346,6 +2346,33 @@ const DRONE_FLY_SOUND_URL = '/assets/sounds/kimsa-kimsa-big-motorcycle-sound-394
 const HELICOPTER_FLY_SOUND_URL = '/assets/sounds/dragon-studio-helicopter-sound-8d-372463.mp3';
 const BAZOOKA_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
+// Weapon model sources used here ship meshes/materials only; firearm audio is
+// streamed from attributed CC-BY source URLs so no binary MP3 files enter the PR.
+const CHESS_FIREARM_REMOTE_SFX = Object.freeze({
+  gunshot: {
+    url: 'https://www.orangefreesounds.com/wp-content/uploads/2015/01/Gunshot-sound-effect.mp3',
+    page: 'https://orangefreesounds.com/gunshot-sound-effect/',
+    credit: 'Gunshot Sound Effect by Alexander / Orange Free Sounds, CC BY 4.0'
+  },
+  shotgun: {
+    url: 'https://www.orangefreesounds.com/wp-content/uploads/2016/12/Shotgun-sound.mp3',
+    page: 'https://orangefreesounds.com/shotgun-sound/',
+    credit: 'Shotgun Sound by Alexander / Orange Free Sounds, CC BY 4.0'
+  },
+  launcher: {
+    url: 'https://www.orangefreesounds.com/wp-content/uploads/2017/03/Cannon-sound-effect.mp3',
+    page: 'https://orangefreesounds.com/cannon-sound-effect/',
+    credit: 'Cannon Sound Effect by Alexander / Orange Free Sounds, CC BY 4.0'
+  }
+});
+const CHESS_FIREARM_SFX_BY_TYPE = Object.freeze({
+  Pistol: { key: 'gunshot', volume: 0.92, playbackRate: 1.18, maxDurationMs: 620 },
+  SMG: { key: 'gunshot', volume: 0.56, playbackRate: 1.34, maxDurationMs: 360 },
+  Rifle: { key: 'gunshot', volume: 0.82, playbackRate: 0.86, maxDurationMs: 760 },
+  Sniper: { key: 'gunshot', volume: 1, playbackRate: 0.72, maxDurationMs: 980 },
+  Shotgun: { key: 'shotgun', volume: 1, playbackRate: 0.98, maxDurationMs: 950 },
+  GrenadeLauncher: { key: 'launcher', volume: 1, playbackRate: 1.04, maxDurationMs: 980 }
+});
 const LUDO_FIREARM_BROADCAST_PROFILE = LUDO_WEAPON_DIRECTOR_BRIDGE.firearmBroadcastProfile || {};
 const LUDO_WEAPON_TYPE_BY_ANIMATION_ID = LUDO_WEAPON_DIRECTOR_BRIDGE.weaponTypeByCaptureAnimationId || {};
 const CHESS_FIREARM_FATAL_BULLET_TRAVEL_MS = 1250; // match Ludo Battle Royal service-pistol final bullet travel.
@@ -8496,6 +8523,7 @@ function Chess3D({
   const helicopterSoundRef = useRef(null);
   const missileLaunchSoundRef = useRef(null);
   const missileImpactSoundRef = useRef(null);
+  const firearmSfxPoolRef = useRef(new Map());
   const audioStopTimeoutsRef = useRef(new Map());
   const lastBeepRef = useRef({ white: null, black: null });
   const suppressTimerBeepUntilRef = useRef(0);
@@ -9671,6 +9699,17 @@ function Chess3D({
         } catch {}
       }
     });
+    firearmSfxPoolRef.current.forEach((pool) => {
+      pool.forEach((audio) => {
+        audio.volume = effectiveSoundEnabled ? volume : 0;
+        if (!effectiveSoundEnabled) {
+          try {
+            audio.pause();
+            audio.currentTime = 0;
+          } catch {}
+        }
+      });
+    });
     if (!effectiveSoundEnabled) {
       audioStopTimeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
       audioStopTimeoutsRef.current.clear();
@@ -9701,6 +9740,11 @@ function Chess3D({
       [swordSoundRef, droneSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
         if (!ref.current) return;
         ref.current.volume = settingsRef.current.soundEnabled ? volume : 0;
+      });
+      firearmSfxPoolRef.current.forEach((pool) => {
+        pool.forEach((audio) => {
+          audio.volume = settingsRef.current.soundEnabled ? volume : 0;
+        });
       });
     };
     window.addEventListener('gameVolumeChanged', handleVolumeChange);
@@ -10132,6 +10176,18 @@ function Chess3D({
     missileLaunchSoundRef.current.volume = baseVolume;
     missileImpactSoundRef.current = new Audio(MISSILE_IMPACT_SOUND_URL);
     missileImpactSoundRef.current.volume = baseVolume;
+    firearmSfxPoolRef.current = new Map(
+      Object.entries(CHESS_FIREARM_REMOTE_SFX).map(([soundKey, source]) => [
+        soundKey,
+        Array.from({ length: 4 }, () => {
+          const audio = new Audio(source.url);
+          audio.preload = 'auto';
+          audio.volume = baseVolume;
+          audio.dataset.sourcePage = source.page;
+          return audio;
+        })
+      ])
+    );
 
     let stopCameraTween = () => {};
     let onResize = null;
@@ -10201,9 +10257,11 @@ function Chess3D({
       const pieceSetPromise = loadPieceSet(RAW_BOARD_SIZE);
       const playAudio = (audioRef, options = {}) => {
         if (!audioRef?.current || !settingsRef.current.soundEnabled) return;
-        const { maxDurationMs = null } = options;
+        const { maxDurationMs = null, volume = 1, playbackRate = 1 } = options;
         try {
           audioRef.current.currentTime = 0;
+          audioRef.current.volume = clamp01(getGameVolume() * volume, 0);
+          audioRef.current.playbackRate = Number.isFinite(playbackRate) && playbackRate > 0 ? playbackRate : 1;
           const playPromise = audioRef.current.play();
           if (maxDurationMs && Number.isFinite(maxDurationMs)) {
             clearAudioStopTimeout(audioRef);
@@ -10215,6 +10273,33 @@ function Chess3D({
               audioStopTimeoutsRef.current.delete(audioRef.current);
             }, maxDurationMs);
             audioStopTimeoutsRef.current.set(audioRef.current, timeoutId);
+          }
+          playPromise?.catch(() => {});
+        } catch {}
+      };
+      const playFirearmSfx = (profile = {}) => {
+        if (!settingsRef.current.soundEnabled) return;
+        const soundProfile = CHESS_FIREARM_SFX_BY_TYPE[profile.ludoType] || CHESS_FIREARM_SFX_BY_TYPE.Rifle;
+        const pool = firearmSfxPoolRef.current.get(soundProfile.key) || [];
+        const audio = pool.find((candidate) => candidate.paused || candidate.ended) || pool[0];
+        if (!audio) return;
+        try {
+          const existingTimeoutId = audioStopTimeoutsRef.current.get(audio);
+          if (existingTimeoutId) clearTimeout(existingTimeoutId);
+          audio.pause();
+          audio.currentTime = 0;
+          audio.volume = clamp01(getGameVolume() * (soundProfile.volume ?? 1), 0);
+          audio.playbackRate = soundProfile.playbackRate ?? 1;
+          const playPromise = audio.play();
+          if (soundProfile.maxDurationMs && Number.isFinite(soundProfile.maxDurationMs)) {
+            const timeoutId = setTimeout(() => {
+              try {
+                audio.pause();
+                audio.currentTime = 0;
+              } catch {}
+              audioStopTimeoutsRef.current.delete(audio);
+            }, soundProfile.maxDurationMs);
+            audioStopTimeoutsRef.current.set(audio, timeoutId);
           }
           playPromise?.catch(() => {});
         } catch {}
@@ -15614,9 +15699,7 @@ function Chess3D({
                 velocity: ejectSide.multiplyScalar(0.16).add(new THREE.Vector3(0, 0.11, 0)).addScaledVector(aimDir, -0.025),
                 startMs: now
               });
-              if (!fx.singleShot && fx.firedBullets < bulletsToFire) {
-                playAudio(missileImpactSoundRef, { volume: 0.25 });
-              }
+              playFirearmSfx(fx.bulletProfile);
             }
 
             if (!fx.hitTriggered && u >= fx.impactAt && !(fx.liveBullets || []).some((bullet) => bullet.cinematic)) {
@@ -16087,6 +16170,13 @@ function Chess3D({
       helicopterSoundRef.current?.pause();
       missileLaunchSoundRef.current?.pause();
       missileImpactSoundRef.current?.pause();
+      firearmSfxPoolRef.current.forEach((pool) => {
+        pool.forEach((audio) => {
+          audio.pause();
+          audio.currentTime = 0;
+        });
+      });
+      firearmSfxPoolRef.current.clear();
       activeCaptureFx.splice(0, activeCaptureFx.length);
       activeBulletCameraFollow = null;
       captureFxGroup?.clear?.();
@@ -16615,7 +16705,7 @@ function Chess3D({
             showInfo={false}
             showChat={false}
             showMute={false}
-            className="fixed right-3 bottom-28 z-50 flex flex-col gap-4"
+            className="fixed right-3 bottom-[calc(env(safe-area-inset-bottom,0px)+4.6rem)] z-50 flex flex-col gap-4"
             buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
             iconClassName="text-[1.65rem] leading-none"
             labelClassName="sr-only"
@@ -16627,7 +16717,7 @@ function Chess3D({
             showInfo={false}
             showGift={false}
             showMute={false}
-            className="fixed left-3 bottom-28 z-50 flex flex-col"
+            className="fixed left-3 bottom-[calc(env(safe-area-inset-bottom,0px)+4.6rem)] z-50 flex flex-col"
             buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
             iconClassName="text-[1.65rem] leading-none"
             labelClassName="sr-only"


### PR DESCRIPTION
### Motivation

- Provide streamed, attributed firearm sound effects (no binary MP3s committed) and play them correctly for different weapon types during capture animations.
- Improve portrait framing and UI placement for Chess Battle Royal by adjusting camera angles and bottom UI offsets.
- Add a couple of new capture animation entries and refine drone labeling/thumbnail text.

### Description

- Introduces `CHESS_FIREARM_REMOTE_SFX` and `CHESS_FIREARM_SFX_BY_TYPE` that point to CC-BY remote sound files and map weapon classes to playback parameters, and documents the attribution in-source. 
- Adds a pooled audio implementation (`firearmSfxPoolRef`) that preloads multiple `Audio` objects per remote SFX, exposes `playFirearmSfx` to play according to `ludoType`, and integrates it into the capture/firing code path in `Chess3D`. 
- Extends `playAudio` to accept `volume` and `playbackRate` options and ensures pooled firearm audio respects global sound settings and is stopped/cleared during dispose. 
- Adjusts camera framing constants (`CAMERA_LOCKED_3D_PHI`, `CAMERA_LOCKED_3D_RADIUS_SCALE`, `PLAYER_VIEW_LOOK_TARGET_UP_BIAS`, `TABLE_BOTTOM_PLAYER_BIAS_Z`) to shift gameplay lower on portrait screens.
- Updates capture animation options: renames the drone option to `Shahad Drone`, and adds a `Ukrainian Drone` option to `CAPTURE_ANIMATION_OPTIONS`.
- Updates UI layout/CSS to reposition chess-specific chat/gift/misc controls (changes in `index.css` for `.chess-battle-chat-bubble` and updated `BottomLeftIcons` placement using `env(safe-area-inset-bottom)` calc in `ChessBattleRoyal.jsx`).

### Testing

- Ran the project build (`yarn build`) and the build completed successfully. 
- Ran the test suite (`yarn test`) and unit tests passed. 
- Ran lint/type checks and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fcdb2f6b8832983c66df35963ad93)