### PR TITLE
Add Ludo Battle Royal vehicles to Snake & Ladder inventory

### DIFF
--- a/webapp/public/pwa/app-build.js
+++ b/webapp/public/pwa/app-build.js
@@ -1,1 +1,1 @@
-self.__TONPLAYGRAM_APP_BUILD__ = "b1afcce";
+self.__TONPLAYGRAM_APP_BUILD__ = "68ef1e1";

--- a/webapp/public/version.json
+++ b/webapp/public/version.json
@@ -1,4 +1,4 @@
 {
-  "build": "b1afcce",
-  "generatedAt": "2026-06-01T05:36:06.214Z"
+  "build": "68ef1e1",
+  "generatedAt": "2026-06-03T08:30:17.347Z"
 }

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -767,6 +767,7 @@ const WEAPON_PARKED_PITCH_BY_KIND = Object.freeze({
   helicopter: 0,
   drone: 0,
   supportTruck: 0,
+  ukrainianDrone: 0,
   javelin: 0
 });
 const WEAPON_PARKED_ROLL_BY_KIND = Object.freeze({
@@ -774,6 +775,7 @@ const WEAPON_PARKED_ROLL_BY_KIND = Object.freeze({
   helicopter: 0,
   drone: 0,
   supportTruck: 0,
+  ukrainianDrone: 0,
   javelin: 0
 });
 const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
@@ -783,6 +785,9 @@ const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
   ukrainiandroneattack: 'ukrainianDrone',
   fighterJetAttack: 'fighter',
   helicopterAttack: 'helicopter',
+  supportTruckAttack: 'supportTruck',
+  supporttruckattack: 'supportTruck',
+  truck: 'supportTruck',
   fpsGunAttack: 'supportTruck',
   glockSidearmAttack: 'supportTruck',
   assaultRifleAttack: 'supportTruck',

--- a/webapp/src/config/buildInfo.js
+++ b/webapp/src/config/buildInfo.js
@@ -1,2 +1,2 @@
-export const APP_BUILD = "b1afcce";
-export const APP_BUILD_GENERATED_AT = "2026-06-01T05:36:06.214Z";
+export const APP_BUILD = "68ef1e1";
+export const APP_BUILD_GENERATED_AT = "2026-06-03T08:30:17.347Z";

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -109,7 +109,13 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
   headStyle: [SNAKE_PAWN_HEAD_OPTIONS[0].id],
   tokenShape: [SNAKE_TOKEN_SHAPE_OPTIONS[0].id],
-  captureWeapon: [SNAKE_CAPTURE_WEAPON_OPTIONS[0].id],
+  captureWeapon: [
+    SNAKE_CAPTURE_WEAPON_OPTIONS[0].id,
+    'fighterJetAttack',
+    'helicopterAttack',
+    'droneAttack',
+    'supportTruckAttack'
+  ],
   tables: [MURLAN_TABLE_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
   environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -1,3 +1,4 @@
+import { CAPTURE_ANIMATION_OPTIONS } from './ludoBattleOptions.js'
 import { swatchThumbnail, weaponSilhouetteThumbnail } from './storeThumbnails.js'
 
 const polyGlb = (uuid) => `https://static.poly.pizza/${uuid}.glb`
@@ -35,6 +36,29 @@ const gunifyWeapon = (id, label, modelName, colors) => ({
   texturePolicy: 'gunifyPbr'
 })
 
+
+const LUDO_CAPTURE_WEAPON_IDS = Object.freeze([
+  'fighterJetAttack',
+  'helicopterAttack',
+  'droneAttack'
+])
+const LUDO_CAPTURE_OPTION_BY_ID = Object.freeze(
+  CAPTURE_ANIMATION_OPTIONS.filter((option) => LUDO_CAPTURE_WEAPON_IDS.includes(option.id)).reduce((acc, option) => {
+    acc[option.id] = option
+    return acc
+  }, {})
+)
+
+const ludoVehicleWeapon = (id, vehicleKind, fallbackLabel, fallbackThumbnail, extra = {}) => ({
+  id,
+  label: LUDO_CAPTURE_OPTION_BY_ID[id]?.label || fallbackLabel,
+  description: LUDO_CAPTURE_OPTION_BY_ID[id]?.description,
+  thumbnail: LUDO_CAPTURE_OPTION_BY_ID[id]?.thumbnail || fallbackThumbnail,
+  source: 'Ludo Battle Royal',
+  vehicleKind,
+  ...extra
+})
+
 export const UKRAINIAN_DRONE_GLB_URLS = Object.freeze([
   'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
   'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
@@ -60,6 +84,32 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
     thumbnail: swatchThumbnail(['#60a5fa', '#facc15', '#1d4ed8']),
     urls: UKRAINIAN_DRONE_GLB_URLS,
     vehicleKind: 'ukrainianDrone'
+  },
+  ludoVehicleWeapon(
+    'fighterJetAttack',
+    'fighter',
+    'Fighter Jet Attack',
+    swatchThumbnail(['#9ca3af', '#475569', '#cbd5e1'])
+  ),
+  ludoVehicleWeapon(
+    'helicopterAttack',
+    'helicopter',
+    'Helicopter Strike',
+    swatchThumbnail(['#84cc16', '#3f6212', '#bef264'])
+  ),
+  ludoVehicleWeapon(
+    'droneAttack',
+    'drone',
+    'Shahad Drone',
+    swatchThumbnail(['#60a5fa', '#1d4ed8', '#bfdbfe'])
+  ),
+  {
+    id: 'supportTruckAttack',
+    label: 'Support Truck',
+    description: 'Ludo Battle Royal support truck parked with the same capture-vehicle inventory set.',
+    thumbnail: swatchThumbnail(['#f97316', '#7c2d12', '#fdba74']),
+    source: 'Ludo Battle Royal',
+    vehicleKind: 'supportTruck'
   },
   polyPizzaWeapon('poly-shotgun-01', 'Quaternius Shotgun', '032e6589-3188-41bc-b92b-e25528344275', ['#64748b', '#1e293b', '#f8fafc'], { creator: 'Quaternius', modelScale: 1 }),
   polyPizzaWeapon('poly-assault-rifle-01', 'Quaternius Assault Rifle', 'b3e6be61-0299-4866-a227-58f5f3fe610b', ['#334155', '#0f172a', '#94a3b8'], { creator: 'Quaternius', modelScale: 1.02 }),
@@ -90,9 +140,19 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
 ])
 
 export const SNAKE_CAPTURE_WEAPON_ALIAS_MAP = Object.freeze({
-  fighter: 'poly-assault-rifle-01',
-  helicopter: 'poly-shotgun-02',
-  supporttruck: 'poly-smg-01',
+  fighter: 'fighterJetAttack',
+  fighterjet: 'fighterJetAttack',
+  fighterjetattack: 'fighterJetAttack',
+  jet: 'fighterJetAttack',
+  helicopter: 'helicopterAttack',
+  helicopterattack: 'helicopterAttack',
+  shahad: 'droneAttack',
+  shahaddrone: 'droneAttack',
+  drone: 'droneAttack',
+  droneattack: 'droneAttack',
+  supporttruck: 'supportTruckAttack',
+  supporttruckattack: 'supportTruckAttack',
+  truck: 'supportTruckAttack',
   polyrobotlargegunattack: 'poly-robot-large-gun-01',
   polyrobotflyinggunattack: 'poly-robot-flying-gun-01',
   polybazooka01attack: 'poly-bazooka-01',
@@ -102,7 +162,6 @@ export const SNAKE_CAPTURE_WEAPON_ALIAS_MAP = Object.freeze({
   polygastank01attack: 'poly-gas-tank-01',
   polyhandgrenade01attack: 'poly-hand-grenade-01',
   polytank01attack: 'poly-tank-01',
-  drone: 'ukrainianDroneAttack',
   ukrainiandrone: 'ukrainianDroneAttack',
   ukrainiandroneattack: 'ukrainianDroneAttack'
 })


### PR DESCRIPTION
### Motivation
- Expose the same Ludo Battle Royal capture vehicles (fighter jet, helicopter, Shahad drone, and support truck) inside the Snake & Ladder game so players can select the identical capture animations/vehicles from the Snake inventory.

### Description
- Add Ludo capture options to the Snake catalog by importing `CAPTURE_ANIMATION_OPTIONS` and adding `fighterJetAttack`, `helicopterAttack`, `droneAttack` and `supportTruckAttack` entries in `webapp/src/config/snakeWeaponCatalog.js` using a `ludoVehicleWeapon` helper. 
- Wire common aliases to the new IDs by updating `SNAKE_CAPTURE_WEAPON_ALIAS_MAP` so shorthand terms like `jet`, `helicopter`, `drone`, and `truck` resolve to the Ludo vehicle options. 
- Unlock the new vehicles by default for Snake players by adding the new capture IDs to `SNAKE_DEFAULT_UNLOCKS.captureWeapon` in `webapp/src/config/snakeInventoryConfig.js`. 
- Ensure Snake 3D handling supports the Ludo truck mapping and parked-pose coverage by adding `supportTruckAttack`/`truck` mappings and `ukrainianDrone` parked entries in `webapp/src/components/SnakeBoard3D.jsx`. 
- Refresh build metadata (`webapp/src/config/buildInfo.js`, `webapp/public/version.json`, `webapp/public/pwa/app-build.js`) and produce a production build so the new assets/config are included.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fe5a7ced08329a1e2c67e852c6f83)