### PR TITLE
Tune Snake & Ladder: align Gunify weapons, shrink AWP, and adjust camera tuning

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -284,8 +284,8 @@ const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 // Portrait framing calibration: aim the camera at the physical board surface center,
 // not above the table, so the Snake board center projects to the exact phone center.
 const BOARD_SURFACE_CENTER_LIFT = BOARD_SCALE * (((0.07 + 0.26) * RAW_BOARD_SIZE) / 10.2) - 0.01;
-const CAMERA_TARGET_EXTRA = 0;
-const CAMERA_SIDE_LOOK_EXTRA = 0.6 * MODEL_SCALE;
+const CAMERA_TARGET_EXTRA = 0.055 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.76 * MODEL_SCALE;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
 const CAMERA_BROADCAST_TARGET_BLEND = 0.5;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
@@ -463,15 +463,15 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const FIREARM_DISPLAY_SIZE_MULTIPLIER = 0.86;
 const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
-  // Keep AK47 GLTF smaller than the shared firearm baseline.
-  'slot-10-ak47-gltf': 0.014,
+  // Match Ludo Battle Royal's Gunify rack scale baselines.
+  'slot-10-ak47-gltf': 0.24,
   // Match SigSauer GLTF visual size with Glock-sized sidearms.
-  'slot-15-sigsauer-gltf': 0.12,
+  'slot-15-sigsauer-gltf': 0.13,
   // Keep FPS Gun GLTF smaller than the shared firearm baseline.
   'slot-18-fps-gun-gltf': 0.03,
-  // Enlarge long rifles for clearer sniper identity in portrait view.
-  'slot-16-awp-glb': 3,
-  'slot-13-mosin-gltf': 3,
+  // Keep long sniper rifles near AK47's portrait footprint; AWP is just slightly bigger.
+  'slot-16-awp-glb': 0.27,
+  'slot-13-mosin-gltf': 0.504,
   'poly-shotgun-01': 1,
   'poly-assault-rifle-01': 1.02,
   'poly-pistol-01': 0.6,
@@ -594,11 +594,11 @@ const CAMERA_TOPDOWN_MAX_POLAR = THREE.MathUtils.degToRad(18);
 const CAMERA_TOPDOWN_RADIUS_FACTOR = 2.56;
 const CAMERA_TOPDOWN_MIN_RADIUS_FACTOR = 1.2;
 const CAMERA_TOPDOWN_MAX_RADIUS_FACTOR = 4.7;
-const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(42);
-const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
-const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
+const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(48);
+const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0062;
+const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(18);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
-const CAMERA_EXTRA_LIFT = -0.1;
+const CAMERA_EXTRA_LIFT = 0.06;
 const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.54;
 const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.65;
 const POINTER_TAP_MAX_DISTANCE = 14;
@@ -606,8 +606,8 @@ const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: 1.72,
   forwardOffset: 0.34,
-  heightOffset: 2.46,
-  targetLift: BOARD_SURFACE_CENTER_LIFT
+  heightOffset: 2.58,
+  targetLift: BOARD_SURFACE_CENTER_LIFT + 0.045 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.9,
@@ -7157,8 +7157,8 @@ export default function SnakeBoard3D({
                 const up = new THREE.Vector3().crossVectors(right, forward).normalize();
                 const lookTarget = baseTarget
                   .clone()
-                  .addScaledVector(right, look.yaw * focusDistance * 0.52)
-                  .addScaledVector(up, look.pitch * focusDistance * 0.4);
+                  .addScaledVector(right, look.yaw * focusDistance * 0.6)
+                  .addScaledVector(up, (look.pitch + 0.035) * focusDistance * 0.44);
                 camera.lookAt(lookTarget);
               }
             }

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -22,18 +22,36 @@ const polyPizzaWeapon = (id, label, uuid, colors, extra = {}) => ({
 export const SNAKE_GUNIFY_MAY_9_REF = '27232cf389a2be3f8f476c667cb293e978aaf5f9'
 const SNAKE_GUNIFY_RAW_BASE = `https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/${SNAKE_GUNIFY_MAY_9_REF}`
 const SNAKE_GUNIFY_JSDELIVR_BASE = `https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@${SNAKE_GUNIFY_MAY_9_REF}`
-const gunifyModelUrls = (modelName) => [
-  `${SNAKE_GUNIFY_RAW_BASE}/models/${modelName}/scene.gltf`,
-  `${SNAKE_GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
-]
-const gunifyWeapon = (id, label, modelName, colors) => ({
+const SNAKE_GUNIFY_MODEL_FOLDER_BY_NAME = Object.freeze({
+  Uzi: 'models2',
+  Mosin: 'models2',
+  SigSauer: 'models3'
+})
+const gunifyModelUrls = (modelName) => {
+  const modelFolder = SNAKE_GUNIFY_MODEL_FOLDER_BY_NAME[modelName] || 'models'
+  return [
+    `${SNAKE_GUNIFY_RAW_BASE}/${modelFolder}/${modelName}/scene.gltf`,
+    `${SNAKE_GUNIFY_JSDELIVR_BASE}/${modelFolder}/${modelName}/scene.gltf`
+  ]
+}
+const SNAKE_GUNIFY_MODEL_SCALE_BY_NAME = Object.freeze({
+  AK47: 0.24,
+  KRSV: 0.24,
+  Smith: 0.13,
+  Mosin: 0.504,
+  Uzi: 0.2,
+  SigSauer: 0.13
+})
+const gunifyWeapon = (id, label, modelName, colors, extra = {}) => ({
   id,
   label,
   thumbnail: weaponSilhouetteThumbnail(colors),
   urls: gunifyModelUrls(modelName),
   modelName,
   source: 'Gunify',
-  texturePolicy: 'gunifyPbr'
+  texturePolicy: 'gunifyPbr',
+  modelScale: SNAKE_GUNIFY_MODEL_SCALE_BY_NAME[modelName],
+  ...extra
 })
 
 
@@ -135,7 +153,7 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   gunifyWeapon('slot-13-mosin-gltf', 'Mosin GLTF', 'Mosin', ['#92400e', '#1f2937', '#fcd34d']),
   gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e', '#111827', '#99f6e4']),
   gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155', '#020617', '#f1f5f9']),
-  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
+  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw], modelScale: 0.27 },
   { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b', '#111827', '#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
 ])
 


### PR DESCRIPTION
### Motivation
- Align Snake & Ladder capture-weapon loading and texture handling with the Ludo Battle Royal Gunify snapshot so models and PBR textures behave identically across games. 
- Make the Sniper GLB visually closer in size to the AK47 baseline instead of appearing oversized on portrait phones. 
- Improve portrait camera framing and turn-look behavior so player left/right look and camera lift read better on mobile portrait screens.

### Description
- Updated `webapp/src/config/snakeWeaponCatalog.js` to match Ludo's Gunify mapping by adding `SNAKE_GUNIFY_MODEL_FOLDER_BY_NAME`, `SNAKE_GUNIFY_MODEL_SCALE_BY_NAME`, and passing `modelScale` from `gunifyWeapon` (keeps `texturePolicy: 'gunifyPbr'`).
- Set a calibrated `modelScale` for the AWP GLB (`slot-16-awp-glb`) so the sniper is much smaller (`modelScale: 0.27`) and adjusted firearm scale baselines (e.g. AK47, SigSauer) to match Ludo baselines.
- Modified `webapp/src/components/SnakeBoard3D.jsx` camera and look tuning: changed `CAMERA_TARGET_EXTRA`, `CAMERA_SIDE_LOOK_EXTRA`, `CAMERA_LOOK_YAW_LIMIT`, `CAMERA_LOOK_YAW_DRAG_FACTOR`, `CAMERA_LOOK_PITCH_LIMIT`, `CAMERA_EXTRA_LIFT` and portrait `heightOffset`/`targetLift` to lift the portrait camera and widen left/right look responsiveness.
- Tweaked the run-time look target math to bias upward and amplify yaw look influence so player-turn look feels visually stronger on portrait mobile screens.

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully and produced app bundles (no runtime errors surfaced during the build). 
- Ran `git diff --check` which produced no check failures.
- Note: no headless browser screenshot/visual tests were available in the environment, so visual verification should be performed on device/emulator to confirm proportions and camera feel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff5775d688329aeec9901c4caaf84)