### PR TITLE
Tune Ludo FPS gun and dice result camera

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -226,7 +226,8 @@ const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
   'polyHandGrenade01Attack'
 ]);
 const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
-  fpsGunAttack: 2.2,
+  // Match Snake & Ladder's compact FPS Shotgun display instead of the large-rifle rack size.
+  fpsGunAttack: 1,
   glockSidearmAttack: 1,
   // May 9 05:00 table snapshot: keep these four legacy firearms at the exact
   // rack sizing used before the Gunify source/Poly Pizza additions.
@@ -381,6 +382,14 @@ const gunifyModelUrls = (modelName) => {
   ];
 };
 
+const SNAKE_FPS_GUN_URLS = Object.freeze([
+  'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
+  'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
+  'https://cdn.jsdelivr.net/gh/GarbajYT/godot-sniper-rifle@master/AWP.glb',
+  'https://raw.githubusercontent.com/GarbajYT/godot-sniper-rifle/master/AWP.glb'
+]);
+const SNAKE_FPS_GUN_MODEL_SCALE = 0.03;
+
 const GUNIFY_SPECULAR_GLOSSINESS_EXTENSION = 'KHR_materials_pbrSpecularGlossiness';
 
 function cloneGltfJsonValue(value) {
@@ -454,13 +463,9 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   },
   fpsGunAttack: {
     label: 'FPS Gun',
-    urls: [
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf',
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf'
-    ],
-    scale: 0.24
+    // Keep this FPS gun aligned with Snake & Ladder's FPS Shotgun source/fallback list.
+    urls: SNAKE_FPS_GUN_URLS,
+    scale: SNAKE_FPS_GUN_MODEL_SCALE
   },
   glockSidearmAttack: {
     label: 'Glock',
@@ -3999,7 +4004,7 @@ const AI_EXTRA_TURN_DELAY_MS = 1600;
 const HUMAN_ROLL_DELAY_MS = 1880;
 const AUTO_ROLL_DURATION_MS = 1100;
 const DICE_RESULT_EXTRA_HOLD_MS = 4500;
-const DICE_RESULT_CAMERA_HOLD_MS = 950;
+const DICE_RESULT_CAMERA_HOLD_MS = 1500;
 const ANIMATION_BASE_FPS = 60;
 const MIN_ANIMATION_SPEED_MULTIPLIER = 0.62;
 const MAX_ANIMATION_SPEED_MULTIPLIER = 1.2;
@@ -13496,15 +13501,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const hasBoardTokenBeforeRoll = hasAnyTokenOnBoard(player);
     const options = getMovableTokens(player, value);
     scheduleDiceClear();
-    if (!isHumanTurn || !lockUserTurnSeatViewRef.current) {
-      setCameraFocus({
-        target: landingFocus,
-        follow: false,
-        priority: 7,
-        offset: CAMERA_TARGET_LIFT + 0.03,
-        force: true
-      });
-    }
+    setCameraFocus({
+      target: landingFocus,
+      follow: false,
+      ttl: DICE_RESULT_CAMERA_HOLD_MS / 1000,
+      priority: 7,
+      offset: CAMERA_TARGET_LIFT + 0.03,
+      force: true
+    });
     if (!options.length) {
       clearTurnAdvanceTimeout();
       turnAdvanceTimeoutRef.current = window.setTimeout(() => {


### PR DESCRIPTION
### Motivation
- Make the Ludo Battle Royal FPS gun match the compact configuration used by Snake & Ladder so the in-hand / rack visuals and size align with the other board game experience. 
- Ensure the camera clearly shows dice roll results for at least 1.5 seconds so users can read outcomes on portrait mobile screens.

### Description
- Reduced the parked/rack scale multiplier for `fpsGunAttack` so the FPS gun uses the compact rack sizing instead of the large-rifle sizing. (changed `FIREARM_RACK_SIZE_MULTIPLIER_BY_ID` for `fpsGunAttack`).
- Added a Snake & Ladder FPS gun fallback list and compact model scale constants and wired `fpsGunAttack` to use those URLs/scale so the same source/scale is used as in Snake & Ladder. (added `SNAKE_FPS_GUN_URLS` and `SNAKE_FPS_GUN_MODEL_SCALE`, updated `CAPTURE_WEAPON_MODEL_CONFIG` entry for `fpsGunAttack`).
- Increased the dice-result camera hold time from `950ms` to `1500ms` and changed the dice-result camera focus call to force focus on the dice landing target with a TTL so the result is held for the configured duration. (updated `DICE_RESULT_CAMERA_HOLD_MS` and replaced the conditional camera-focus logic after `spinDice`).
- All changes are in the Ludo module: `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran `npm run build` in `webapp` and the production build completed successfully. (build artifacts produced).
- Ran `git diff --check` to validate formatting/whitespace; no issues found.
- Started the dev server (`vite`) and attempted an automated portrait preview with Playwright, but the headless Chromium could not launch in the container due to missing native libraries (`libatk-1.0.so.0`), so an automated screenshot could not be captured; `npx playwright install` was run to download browsers but the environment lacks required OS libs for Chrome Headless Shell.
- Committed the changes (commit message: "Tune Ludo FPS gun and dice result camera").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff63ea82883298317885af2fe3f2d)