### PR TITLE
Tune Snake & Ladder weapons and camera

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -280,12 +280,12 @@ const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const CAMERA_FOV = ARENA_CAMERA_DEFAULTS.fov;
 const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
-const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
+const CAMERA_TARGET_LIFT = 0.12 * MODEL_SCALE;
 // Portrait framing calibration: aim the camera at the physical board surface center,
 // not above the table, so the Snake board center projects to the exact phone center.
 const BOARD_SURFACE_CENTER_LIFT = BOARD_SCALE * (((0.07 + 0.26) * RAW_BOARD_SIZE) / 10.2) - 0.01;
 const CAMERA_TARGET_EXTRA = 0;
-const CAMERA_SIDE_LOOK_EXTRA = 0.6 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.82 * MODEL_SCALE;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
 const CAMERA_BROADCAST_TARGET_BLEND = 0.5;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
@@ -463,15 +463,17 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const FIREARM_DISPLAY_SIZE_MULTIPLIER = 0.86;
 const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
-  // Keep AK47 GLTF smaller than the shared firearm baseline.
-  'slot-10-ak47-gltf': 0.014,
-  // Match SigSauer GLTF visual size with Glock-sized sidearms.
-  'slot-15-sigsauer-gltf': 0.12,
+  // Gunify weapons mirror Ludo Battle Royal's May 9 display scale tuning.
+  'slot-10-ak47-gltf': 0.24,
+  'slot-11-krsv-gltf': 0.24,
+  'slot-12-smith-gltf': 0.13,
+  'slot-13-mosin-gltf': 0.504,
+  'slot-14-uzi-gltf': 0.2,
+  'slot-15-sigsauer-gltf': 0.13,
+  // Keep the standalone GLB sniper close to AK47 size, only a little larger.
+  'slot-16-awp-glb': 0.28,
   // Keep FPS Gun GLTF smaller than the shared firearm baseline.
   'slot-18-fps-gun-gltf': 0.03,
-  // Enlarge long rifles for clearer sniper identity in portrait view.
-  'slot-16-awp-glb': 3,
-  'slot-13-mosin-gltf': 3,
   'poly-shotgun-01': 1,
   'poly-assault-rifle-01': 1.02,
   'poly-pistol-01': 0.6,
@@ -598,7 +600,7 @@ const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(42);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
-const CAMERA_EXTRA_LIFT = -0.1;
+const CAMERA_EXTRA_LIFT = 0.14;
 const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.54;
 const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.65;
 const POINTER_TAP_MAX_DISTANCE = 14;
@@ -607,7 +609,7 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: 1.72,
   forwardOffset: 0.34,
   heightOffset: 2.46,
-  targetLift: BOARD_SURFACE_CENTER_LIFT
+  targetLift: BOARD_SURFACE_CENTER_LIFT + 0.08
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.9,
@@ -3205,11 +3207,11 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   }
   if (seatIndex === 1) {
     target.x += CAMERA_SIDE_LOOK_EXTRA;
-    target.z += TILE_SIZE * 0.18;
+    target.z += TILE_SIZE * 0.24;
   }
   if (seatIndex === 3) {
     target.x -= CAMERA_SIDE_LOOK_EXTRA;
-    target.z += TILE_SIZE * 0.18;
+    target.z += TILE_SIZE * 0.24;
   }
   const boardToCamera = camera.position.clone().sub(boardLookTarget).setY(0);
   if (boardToCamera.lengthSq() > 1e-6) {

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -22,18 +22,36 @@ const polyPizzaWeapon = (id, label, uuid, colors, extra = {}) => ({
 export const SNAKE_GUNIFY_MAY_9_REF = '27232cf389a2be3f8f476c667cb293e978aaf5f9'
 const SNAKE_GUNIFY_RAW_BASE = `https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/${SNAKE_GUNIFY_MAY_9_REF}`
 const SNAKE_GUNIFY_JSDELIVR_BASE = `https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@${SNAKE_GUNIFY_MAY_9_REF}`
-const gunifyModelUrls = (modelName) => [
-  `${SNAKE_GUNIFY_RAW_BASE}/models/${modelName}/scene.gltf`,
-  `${SNAKE_GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
-]
-const gunifyWeapon = (id, label, modelName, colors) => ({
+const SNAKE_GUNIFY_MODEL_FOLDER_BY_NAME = Object.freeze({
+  Uzi: 'models2',
+  Mosin: 'models2',
+  SigSauer: 'models3'
+})
+const SNAKE_GUNIFY_MODEL_SCALE_BY_NAME = Object.freeze({
+  Uzi: 0.2,
+  AK47: 0.24,
+  KRSV: 0.24,
+  Smith: 0.13,
+  Mosin: 0.504,
+  SigSauer: 0.13
+})
+const gunifyModelUrls = (modelName) => {
+  const modelFolder = SNAKE_GUNIFY_MODEL_FOLDER_BY_NAME[modelName] || 'models'
+  return [
+    `${SNAKE_GUNIFY_RAW_BASE}/${modelFolder}/${modelName}/scene.gltf`,
+    `${SNAKE_GUNIFY_JSDELIVR_BASE}/${modelFolder}/${modelName}/scene.gltf`
+  ]
+}
+const gunifyWeapon = (id, label, modelName, colors, extra = {}) => ({
   id,
   label,
   thumbnail: weaponSilhouetteThumbnail(colors),
   urls: gunifyModelUrls(modelName),
   modelName,
   source: 'Gunify',
-  texturePolicy: 'gunifyPbr'
+  texturePolicy: 'gunifyPbr',
+  modelScale: SNAKE_GUNIFY_MODEL_SCALE_BY_NAME[modelName] ?? 1,
+  ...extra
 })
 
 
@@ -135,7 +153,7 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   gunifyWeapon('slot-13-mosin-gltf', 'Mosin GLTF', 'Mosin', ['#92400e', '#1f2937', '#fcd34d']),
   gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e', '#111827', '#99f6e4']),
   gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155', '#020617', '#f1f5f9']),
-  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
+  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw], modelScale: 0.28 },
   { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b', '#111827', '#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
 ])
 


### PR DESCRIPTION
### Motivation
- Make Snake & Ladder capture weapons use the same pinned Gunify material/texture mapping and visual scales as Ludo Battle Royal so imported GLTF/GLB weapons look consistent across games.
- Reduce the AWP sniper visual dominance so it is only slightly larger than the AK47 when shown on the portrait phone screen.
- Improve portrait camera framing and side-player turn-look offsets so players on left/right seats appear visually more left/right and the board sits higher on mobile portrait displays.

### Description
- Added Gunify per-model folder and scale maps and updated the Gunify helper so `gunifyWeapon` now preserves `texturePolicy` and carries a `modelScale` value (file `webapp/src/config/snakeWeaponCatalog.js`).
- Set explicit model-scale overrides for Gunify weapons to match Ludo Battle Royal tuning and reduced the AWP GLB `modelScale` to `0.28` so it is only marginally larger than the AK (`slot-10-ak47-gltf`) (file `webapp/src/components/SnakeBoard3D.jsx` and `webapp/src/config/snakeWeaponCatalog.js`).
- Adjusted camera constants for portrait framing: increased `CAMERA_TARGET_LIFT`, `CAMERA_EXTRA_LIFT`, and portrait `targetLift` tuning so the board projects visually higher on portrait phones (file `webapp/src/components/SnakeBoard3D.jsx`).
- Increased `CAMERA_SIDE_LOOK_EXTRA` and side-seat `target.z` offsets to make left/right player turn-focus look more visually left/right (file `webapp/src/components/SnakeBoard3D.jsx`).
- Updated the `FIREARM_MODEL_SCALE_BY_ID` / display-scale overrides so parked/preview firearms use the Ludo-aligned display scales on the Snake board (file `webapp/src/components/SnakeBoard3D.jsx`).

### Testing
- Built the webapp with `npm run build` and the Vite production build completed successfully.
- Installed Playwright and OS deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully.
- Launched a headless Playwright run emulating a mobile portrait device and captured a screenshot at `/tmp/tonplaygram-screens/snake-camera-weapons.png` to verify visual framing and weapon sizes (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff5775d688329aeec9901c4caaf84)