### PR TITLE
Tune Snake & Ladder Gunify weapon configs, sniper size, and camera framing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -284,9 +284,9 @@ const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 // Portrait framing calibration: aim the camera at the physical board surface center,
 // not above the table, so the Snake board center projects to the exact phone center.
 const BOARD_SURFACE_CENTER_LIFT = BOARD_SCALE * (((0.07 + 0.26) * RAW_BOARD_SIZE) / 10.2) - 0.01;
-const CAMERA_TARGET_EXTRA = 0;
-const CAMERA_SIDE_LOOK_EXTRA = 0.6 * MODEL_SCALE;
-const CAMERA_TURN_PLAYER_LERP = 0.44;
+const CAMERA_TARGET_EXTRA = 0.055 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.82 * MODEL_SCALE;
+const CAMERA_TURN_PLAYER_LERP = 0.5;
 const CAMERA_BROADCAST_TARGET_BLEND = 0.5;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
 const CAM = {
@@ -469,8 +469,9 @@ const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
   'slot-15-sigsauer-gltf': 0.12,
   // Keep FPS Gun GLTF smaller than the shared firearm baseline.
   'slot-18-fps-gun-gltf': 0.03,
-  // Enlarge long rifles for clearer sniper identity in portrait view.
-  'slot-16-awp-glb': 3,
+  // Keep the GLB sniper close to AK-47 visual size, only slightly bigger.
+  'slot-16-awp-glb': 0.018,
+  // Keep Gunify Mosin using the larger Ludo marksman silhouette.
   'slot-13-mosin-gltf': 3,
   'poly-shotgun-01': 1,
   'poly-assault-rifle-01': 1.02,
@@ -598,7 +599,7 @@ const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(42);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
-const CAMERA_EXTRA_LIFT = -0.1;
+const CAMERA_EXTRA_LIFT = 0.08;
 const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.54;
 const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.65;
 const POINTER_TAP_MAX_DISTANCE = 14;

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -22,18 +22,27 @@ const polyPizzaWeapon = (id, label, uuid, colors, extra = {}) => ({
 export const SNAKE_GUNIFY_MAY_9_REF = '27232cf389a2be3f8f476c667cb293e978aaf5f9'
 const SNAKE_GUNIFY_RAW_BASE = `https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/${SNAKE_GUNIFY_MAY_9_REF}`
 const SNAKE_GUNIFY_JSDELIVR_BASE = `https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@${SNAKE_GUNIFY_MAY_9_REF}`
-const gunifyModelUrls = (modelName) => [
-  `${SNAKE_GUNIFY_RAW_BASE}/models/${modelName}/scene.gltf`,
-  `${SNAKE_GUNIFY_JSDELIVR_BASE}/models/${modelName}/scene.gltf`
-]
-const gunifyWeapon = (id, label, modelName, colors) => ({
+const SNAKE_GUNIFY_MODEL_FOLDER_BY_NAME = Object.freeze({
+  Uzi: 'models2',
+  Mosin: 'models2',
+  SigSauer: 'models3'
+})
+const gunifyModelUrls = (modelName) => {
+  const modelFolder = SNAKE_GUNIFY_MODEL_FOLDER_BY_NAME[modelName] || 'models'
+  return [
+    `${SNAKE_GUNIFY_RAW_BASE}/${modelFolder}/${modelName}/scene.gltf`,
+    `${SNAKE_GUNIFY_JSDELIVR_BASE}/${modelFolder}/${modelName}/scene.gltf`
+  ]
+}
+const gunifyWeapon = (id, label, modelName, colors, extra = {}) => ({
   id,
   label,
   thumbnail: weaponSilhouetteThumbnail(colors),
   urls: gunifyModelUrls(modelName),
   modelName,
   source: 'Gunify',
-  texturePolicy: 'gunifyPbr'
+  texturePolicy: 'gunifyPbr',
+  ...extra
 })
 
 
@@ -129,12 +138,12 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   polyPizzaWeapon('poly-gas-tank-01', 'Quaternius Gas Tank', '9c4d2ac5-114b-4da2-a26a-8049e2b1ba04', ['#b91c1c', '#111827', '#e5e7eb'], { creator: 'Quaternius', modelScale: 0.62 }),
   polyPizzaWeapon('poly-hand-grenade-01', 'CreativeTrio Hand Grenade', '03fa7f5b-4df5-45d6-86fb-87e8590f28d7', ['#3f6212', '#111827', '#a3e635'], { creator: 'CreativeTrio', modelScale: 0.36 }),
   polyPizzaWeapon('poly-tank-01', 'Quaternius Battle Tank', '58c387b2-636f-49dc-a900-13b0852717d6', ['#334155', '#111827', '#94a3b8'], { creator: 'Quaternius', modelScale: 0.7 }),
-  gunifyWeapon('slot-10-ak47-gltf', 'AK47 GLTF', 'AK47', ['#7f1d1d', '#111827', '#f59e0b']),
-  gunifyWeapon('slot-11-krsv-gltf', 'KRSV GLTF', 'KRSV', ['#1d4ed8', '#0f172a', '#bfdbfe']),
-  gunifyWeapon('slot-12-smith-gltf', 'Smith GLTF', 'Smith', ['#6b7280', '#0f172a', '#f8fafc']),
-  gunifyWeapon('slot-13-mosin-gltf', 'Mosin GLTF', 'Mosin', ['#92400e', '#1f2937', '#fcd34d']),
-  gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e', '#111827', '#99f6e4']),
-  gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155', '#020617', '#f1f5f9']),
+  gunifyWeapon('slot-10-ak47-gltf', 'AK47 GLTF', 'AK47', ['#7f1d1d', '#111827', '#f59e0b'], { ludoCaptureScale: 0.24 }),
+  gunifyWeapon('slot-11-krsv-gltf', 'KRSV GLTF', 'KRSV', ['#1d4ed8', '#0f172a', '#bfdbfe'], { ludoCaptureScale: 0.24 }),
+  gunifyWeapon('slot-12-smith-gltf', 'Smith GLTF', 'Smith', ['#6b7280', '#0f172a', '#f8fafc'], { ludoCaptureScale: 0.13 }),
+  gunifyWeapon('slot-13-mosin-gltf', 'Mosin GLTF', 'Mosin', ['#92400e', '#1f2937', '#fcd34d'], { ludoCaptureScale: 0.5125 }),
+  gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e', '#111827', '#99f6e4'], { ludoCaptureScale: 0.2 }),
+  gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155', '#020617', '#f1f5f9'], { ludoCaptureScale: 0.13 }),
   { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
   { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b', '#111827', '#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
 ])


### PR DESCRIPTION
### Motivation
- Make Snake & Ladder use the exact Gunify material/texture layout and capture-scale values used by Ludo Battle Royal so weapon visuals and PBR mapping match across games.
- Adjust sniper/firearm sizes so the GLB sniper reads visually near the AK47 baseline on portrait phones while keeping Mosin as a marksman silhouette.
- Improve portrait camera framing and turn-focus behavior so left/right player turns look slightly more left/right and the scene reads higher on mobile screens.

### Description
- Updated `webapp/src/config/snakeWeaponCatalog.js` to pin the same May 9 Gunify tree and add `SNAKE_GUNIFY_MODEL_FOLDER_BY_NAME` + `gunifyModelUrls` folder routing, extended `gunifyWeapon` to accept `extra` fields, and added `ludoCaptureScale` metadata to Gunify entries for AK47/KRSV/Smith/Mosin/Uzi/SigSauer.
- Tuned weapon sizing in `webapp/src/components/SnakeBoard3D.jsx` by reducing the GLB sniper scale (`'slot-16-awp-glb'`) to sit only slightly larger than the AK-47 and keeping the Mosin marksman scale intact via `FIREARM_MODEL_SCALE_BY_ID`.
- Adjusted portrait camera constants in `webapp/src/components/SnakeBoard3D.jsx` to raise/look-targets and widen side-look: changed `CAMERA_TARGET_EXTRA`, `CAMERA_SIDE_LOOK_EXTRA`, `CAMERA_TURN_PLAYER_LERP`, and `CAMERA_EXTRA_LIFT` to improve visual framing for mobile portrait orientation.
- Preserved the existing Gunify texture policy (`texturePolicy: 'gunifyPbr'`) and left material/texture patching logic intact so authored GLTF/GLB PBR maps are still applied and normalized by the existing loaders/helpers.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Installed Playwright browsers and dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium` which completed without errors.
- Launched the dev server and performed a mobile smoke capture using Playwright to navigate to `/games/snake` and save a screenshot, which ran and produced the screenshot file successfully (console logs contained some network resource warnings but the render completed).
- Ran `git diff --check` as part of the workflow and no code-style blocking issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff5775d688329aeec9901c4caaf84)