### PR TITLE
Align Ludo FPS gun to Snake baseline and extend dice result camera hold to 1.5s

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -244,6 +244,28 @@ describe('cross-game inventory alignment', () => {
     });
   });
 
+
+  test('ludo fps gun mirrors snake and ladder May 9 fps gun config only', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+    const snakeSource = await readFile('webapp/src/config/snakeWeaponCatalog.js', 'utf8');
+
+    expect(snakeSource).toContain('export const SNAKE_FPS_GUN_MODEL_CONFIG = Object.freeze({');
+    expect(source).toContain("import { SNAKE_FPS_GUN_MODEL_CONFIG } from '../../config/snakeWeaponCatalog.js';");
+    expect(source).toContain('urls: [...SNAKE_FPS_GUN_MODEL_CONFIG.urls]');
+    expect(source).toContain('scale: SNAKE_FPS_GUN_MODEL_CONFIG.ludoModelScale');
+    expect(source).toContain('fpsGunAttack: SNAKE_FPS_GUN_MODEL_CONFIG.ludoRackSizeMultiplier');
+    expect(source).toContain('fpsGunAttack: SNAKE_FPS_GUN_MODEL_CONFIG.ludoHandScaleMultiplier');
+  });
+
+  test('ludo camera holds each dice result focus for at least 1.5 seconds', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('const DICE_RESULT_CAMERA_HOLD_MS = 1500');
+    expect(source).toContain('ttl: DICE_RESULT_CAMERA_HOLD_MS / 1000');
+    expect(source).toContain('beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });');
+    expect(source).toContain('}, DICE_RESULT_CAMERA_HOLD_MS);');
+  });
+
   test('ludo battle royal preserves source-authored materials for non-Gunify weapons', async () => {
     const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
 

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -77,6 +77,22 @@ export const SNAKE_KNOWN_WORKING_GLB = Object.freeze({
   fpsRaw: 'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf'
 })
 
+export const SNAKE_FPS_GUN_MODEL_CONFIG = Object.freeze({
+  id: 'slot-18-fps-gun-gltf',
+  label: 'FPS Shotgun',
+  thumbnail: weaponSilhouetteThumbnail(['#f59e0b', '#111827', '#fde68a']),
+  urls: Object.freeze([
+    SNAKE_KNOWN_WORKING_GLB.fps,
+    SNAKE_KNOWN_WORKING_GLB.fpsRaw,
+    SNAKE_KNOWN_WORKING_GLB.awp,
+    SNAKE_KNOWN_WORKING_GLB.awpRaw
+  ]),
+  // May 9 05:00 baseline used by Ludo Battle Royal for the same FPS gun asset.
+  ludoModelScale: 0.24,
+  ludoRackSizeMultiplier: 2.2,
+  ludoHandScaleMultiplier: 3.2
+})
+
 export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   {
     id: 'ukrainianDroneAttack',
@@ -136,7 +152,7 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e', '#111827', '#99f6e4']),
   gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155', '#020617', '#f1f5f9']),
   { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
-  { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b', '#111827', '#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
+  SNAKE_FPS_GUN_MODEL_CONFIG
 ])
 
 export const SNAKE_CAPTURE_WEAPON_ALIAS_MAP = Object.freeze({

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -54,6 +54,7 @@ import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../../config/murlanThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from '../../config/poolRoyaleInventoryConfig.js';
 import { LUDO_WEAPON_DIRECTOR_BRIDGE } from '../../config/ludoWeaponDirectorBridge.js';
+import { SNAKE_FPS_GUN_MODEL_CONFIG } from '../../config/snakeWeaponCatalog.js';
 import { TOKEN_TYPE_SEQUENCE } from '../../utils/ludoTokenConstants.js';
 import {
   getLudoBattleInventory,
@@ -226,7 +227,7 @@ const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
   'polyHandGrenade01Attack'
 ]);
 const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
-  fpsGunAttack: 2.2,
+  fpsGunAttack: SNAKE_FPS_GUN_MODEL_CONFIG.ludoRackSizeMultiplier,
   glockSidearmAttack: 1,
   // May 9 05:00 table snapshot: keep these four legacy firearms at the exact
   // rack sizing used before the Gunify source/Poly Pizza additions.
@@ -454,13 +455,9 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   },
   fpsGunAttack: {
     label: 'FPS Gun',
-    urls: [
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf',
-      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf'
-    ],
-    scale: 0.24
+    // Keep only the FPS gun matched to Snake & Ladder's May 9 05:00 asset order/size.
+    urls: [...SNAKE_FPS_GUN_MODEL_CONFIG.urls],
+    scale: SNAKE_FPS_GUN_MODEL_CONFIG.ludoModelScale
   },
   glockSidearmAttack: {
     label: 'Glock',
@@ -1036,7 +1033,7 @@ const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   // seated humans keep a consistent hand fit around the trigger/handle zone.
   mrtkGunAttack: 1.16,
   pistolHolsterAttack: 1.14,
-  fpsGunAttack: 3.2,
+  fpsGunAttack: SNAKE_FPS_GUN_MODEL_CONFIG.ludoHandScaleMultiplier,
   glockSidearmAttack: 1.2,
   pistolSidearmAttack: 1.16,
   uziSprayAttack: 1.85,
@@ -3999,7 +3996,7 @@ const AI_EXTRA_TURN_DELAY_MS = 1600;
 const HUMAN_ROLL_DELAY_MS = 1880;
 const AUTO_ROLL_DURATION_MS = 1100;
 const DICE_RESULT_EXTRA_HOLD_MS = 4500;
-const DICE_RESULT_CAMERA_HOLD_MS = 950;
+const DICE_RESULT_CAMERA_HOLD_MS = 1500;
 const ANIMATION_BASE_FPS = 60;
 const MIN_ANIMATION_SPEED_MULTIPLIER = 0.62;
 const MAX_ANIMATION_SPEED_MULTIPLIER = 1.2;
@@ -13496,15 +13493,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const hasBoardTokenBeforeRoll = hasAnyTokenOnBoard(player);
     const options = getMovableTokens(player, value);
     scheduleDiceClear();
-    if (!isHumanTurn || !lockUserTurnSeatViewRef.current) {
-      setCameraFocus({
-        target: landingFocus,
-        follow: false,
-        priority: 7,
-        offset: CAMERA_TARGET_LIFT + 0.03,
-        force: true
-      });
-    }
+    setCameraFocus({
+      target: landingFocus,
+      follow: false,
+      ttl: DICE_RESULT_CAMERA_HOLD_MS / 1000,
+      priority: 7,
+      offset: CAMERA_TARGET_LIFT + 0.03,
+      force: true
+    });
     if (!options.length) {
       clearTurnAdvanceTimeout();
       turnAdvanceTimeoutRef.current = window.setTimeout(() => {
@@ -13516,7 +13512,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (player === 0) {
       preserveUserTurnCameraRef.current = true;
       lockUserTurnSeatViewRef.current = true;
-      beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
+      clearTurnAdvanceTimeout();
+      turnAdvanceTimeoutRef.current = window.setTimeout(() => {
+        turnAdvanceTimeoutRef.current = null;
+        beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
+      }, DICE_RESULT_CAMERA_HOLD_MS);
       return;
     }
     const choice = chooseMoveOption(state, player, value, options);


### PR DESCRIPTION
### Motivation
- Ensure the Ludo Battle Royal `fpsGunAttack` uses the same model URLs and sizing that Snake & Ladder used on the May 9 snapshot so the FPS gun looks/behaves identically across games. 
- Make dice-roll results clearer to players by keeping the camera focused on the landed dice long enough for users to perceive the value before selection or turn advance.

### Description
- Added a shared Snake FPS baseline `SNAKE_FPS_GUN_MODEL_CONFIG` in `webapp/src/config/snakeWeaponCatalog.js` containing the ordered model URLs and May 9 size multipliers (`ludoModelScale`, `ludoRackSizeMultiplier`, `ludoHandScaleMultiplier`).
- Updated `webapp/src/pages/Games/LudoBattleRoyal.jsx` to import `SNAKE_FPS_GUN_MODEL_CONFIG` and drive Ludo's `fpsGunAttack` `urls`, rack size (`FIREARM_RACK_SIZE_MULTIPLIER_BY_ID`), and hand attach scale (`FIREARM_ATTACH_SCALE_MULTIPLIER`) from that shared config, leaving other weapons untouched.
- Increased dice-focus timing by changing `DICE_RESULT_CAMERA_HOLD_MS` from `950` to `1500` and adjusted camera focus logic to apply a TTL (`ttl: DICE_RESULT_CAMERA_HOLD_MS / 1000`) for both human and AI rolls, plus deferred human selection start by `DICE_RESULT_CAMERA_HOLD_MS` to ensure the user sees the result.
- Added two regression tests in `test/inventoryCrossGameConfig.test.js` verifying the `SNAKE_FPS_GUN_MODEL_CONFIG` bridge is wired into Ludo and that the dice camera hold is set to `1500` ms.

### Testing
- Ran targeted unit tests: `npm test -- --runInBand test/inventoryCrossGameConfig.test.js -t "ludo fps gun|ludo camera"` and both new tests passed. (pass)
- Ran full inventory cross-game test file: `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` which shows the newly added tests passing while an existing unrelated test (`snake store mirrors ludo battle royal capture weapons`) fails; this failure is pre-existing and not caused by these changes. (partial)
- Built the webapp production bundle: `npm --prefix webapp run build` and the build completed successfully. (pass)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff63ea82883298317885af2fe3f2d)