### PR TITLE
Share Ludo dice roll logic with Snake and Ladder

### DIFF
--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -1,3 +1,5 @@
+import { clampDiceFace, rollLudoBattleRoyalDiceFace } from '../../lib/sharedDiceRoll.js';
+
 export const FINAL_TILE = 101;
 
 export function applySnakesAndLadders(pos, snakes, ladders) {
@@ -39,11 +41,10 @@ export class SnakeGame {
     const player = this.players[this.currentTurn];
     if (!player) return null;
 
-    const rand = () => Math.floor(Math.random() * 6) + 1;
     const provided = Number(diceValue);
     const dice = Number.isFinite(provided)
-      ? Math.max(1, Math.min(6, Math.floor(provided)))
-      : rand();
+      ? clampDiceFace(provided)
+      : rollLudoBattleRoyalDiceFace();
 
     let target = player.position;
     let extraTurn = false;

--- a/lib/sharedDiceRoll.js
+++ b/lib/sharedDiceRoll.js
@@ -1,0 +1,51 @@
+export const DICE_FACE_MIN = 1;
+export const DICE_FACE_MAX = 6;
+export const LUDO_BATTLE_ROYAL_DICE_TICK_MS = 50;
+export const LUDO_BATTLE_ROYAL_DICE_ITERATIONS = 20;
+
+export function clampDiceFace(value, fallback = DICE_FACE_MIN) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.max(DICE_FACE_MIN, Math.min(DICE_FACE_MAX, Math.floor(numeric)));
+}
+
+export function rollLudoBattleRoyalDiceFace(rng = Math.random) {
+  return DICE_FACE_MIN + Math.floor(rng() * DICE_FACE_MAX);
+}
+
+export function rollLudoBattleRoyalDiceValues(count = 1, rng = Math.random) {
+  const diceCount = Math.max(1, Math.floor(Number(count) || 1));
+  return Array.from({ length: diceCount }, () => rollLudoBattleRoyalDiceFace(rng));
+}
+
+export function normalizeDiceRollValues(value, fallbackCount = 1) {
+  if (Array.isArray(value)) {
+    return value
+      .map((candidate) => Number(candidate))
+      .filter((candidate) => Number.isFinite(candidate))
+      .map((candidate) => clampDiceFace(candidate));
+  }
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return [clampDiceFace(numeric)];
+  }
+
+  return Array(Math.max(1, Math.floor(Number(fallbackCount) || 1))).fill(DICE_FACE_MIN);
+}
+
+export function createLudoBattleRoyalDiceSpin(rng = Math.random) {
+  return {
+    spin: {
+      x: 1.2 + rng() * 0.7,
+      y: 1.35 + rng() * 0.65,
+      z: 1.05 + rng() * 0.75
+    },
+    wobble: {
+      x: (rng() - 0.5) * 0.16,
+      y: 0,
+      z: (rng() - 0.5) * 0.16
+    },
+    value: rollLudoBattleRoyalDiceFace(rng)
+  };
+}

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -2,6 +2,11 @@ import React, { useState, useEffect, useRef } from 'react';
 import { createDiceRollAudio } from '../utils/diceAudio.js';
 import Dice from './Dice.jsx';
 import { socket } from '../utils/socket.js';
+import {
+  LUDO_BATTLE_ROYAL_DICE_ITERATIONS,
+  LUDO_BATTLE_ROYAL_DICE_TICK_MS,
+  rollLudoBattleRoyalDiceValues
+} from '../../../lib/sharedDiceRoll.js';
 
 export default function DiceRoller({
   onRollEnd,
@@ -63,26 +68,12 @@ export default function DiceRoller({
     setRolling(true);
     onRollStart && onRollStart();
 
-    const rand = () => {
-      if (window.crypto?.getRandomValues) {
-        const arr = new Uint32Array(1);
-        const maxUnbiased = Math.floor(0x100000000 / 6) * 6;
-        let value = 0;
-        do {
-          window.crypto.getRandomValues(arr);
-          value = arr[0];
-        } while (value >= maxUnbiased);
-        return (value % 6) + 1;
-      }
-      return Math.floor(Math.random() * 6) + 1;
-    };
-
-    const tick = 50; // ms between face changes
-    const iterations = 20; // ~1 second of rolling
+    const tick = LUDO_BATTLE_ROYAL_DICE_TICK_MS; // ms between face changes
+    const iterations = LUDO_BATTLE_ROYAL_DICE_ITERATIONS; // ~1 second of rolling
     let count = 0;
 
     const id = setInterval(() => {
-      const results = Array.from({ length: numDice }, rand);
+      const results = rollLudoBattleRoyalDiceValues(numDice);
       setValues(results);
       count += 1;
       if (count >= iterations) {

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -66,6 +66,7 @@ import {
 } from '../../utils/ludoBattleInventory.js';
 import { giftSounds } from '../../utils/giftSounds.js';
 import { playLudoDiceRollSfx, playLudoTokenStepSfx } from '../../utils/ludoSfx.js';
+import { createLudoBattleRoyalDiceSpin } from '../../../../lib/sharedDiceRoll.js';
 import { socket } from '../../utils/socket.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -7574,13 +7575,10 @@ function spinDice(
     const start = performance.now();
     const startPos = dice.position.clone();
     const endPos = targetPosition.clone();
-    const spinVec = new THREE.Vector3(
-      1.2 + Math.random() * 0.7,
-      1.35 + Math.random() * 0.65,
-      1.05 + Math.random() * 0.75
-    );
-    const wobble = new THREE.Vector3((Math.random() - 0.5) * 0.16, 0, (Math.random() - 0.5) * 0.16);
-    const targetValue = 1 + Math.floor(Math.random() * 6);
+    const rollPlan = createLudoBattleRoyalDiceSpin();
+    const spinVec = new THREE.Vector3(rollPlan.spin.x, rollPlan.spin.y, rollPlan.spin.z);
+    const wobble = new THREE.Vector3(rollPlan.wobble.x, rollPlan.wobble.y, rollPlan.wobble.z);
+    const targetValue = rollPlan.value;
 
     const step = () => {
       const now = performance.now();

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1,6 +1,10 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import coinConfetti from "../../utils/coinConfetti";
 import DiceRoller from "../../components/DiceRoller.jsx";
+import {
+  normalizeDiceRollValues,
+  rollLudoBattleRoyalDiceFace
+} from "../../../../lib/sharedDiceRoll.js";
 import SnakeBoard3D from "../../components/SnakeBoard3D.jsx";
 import { FINAL_TILE as BOARD_FINAL_TILE } from "../../components/SnakeBoard.jsx";
 import {
@@ -1518,19 +1522,10 @@ export default function SnakeAndLadder() {
     setDiceBoardEvent(phase);
   }, []);
 
-  const normalizeAuthoritativeDiceValues = useCallback((value, fallbackCount = 1) => {
-    if (Array.isArray(value)) {
-      return value
-        .map((candidate) => Number(candidate))
-        .filter((candidate) => Number.isFinite(candidate))
-        .map((candidate) => Math.max(1, Math.min(6, Math.floor(candidate))));
-    }
-    const numeric = Number(value);
-    if (Number.isFinite(numeric)) {
-      return [Math.max(1, Math.min(6, Math.floor(numeric)))];
-    }
-    return Array(Math.max(1, fallbackCount || 1)).fill(1);
-  }, []);
+  const normalizeAuthoritativeDiceValues = useCallback(
+    (value, fallbackCount = 1) => normalizeDiceRollValues(value, fallbackCount),
+    []
+  );
 
   const startCaptureAnimation = useCallback(
     ({ attackerIndex, fromCell, targetCell, victimIndices = [], weaponType, onComplete }) => {
@@ -2570,7 +2565,7 @@ export default function SnakeAndLadder() {
     );
     let over = state.gameOver ?? false;
     while (elapsed > 0 && !over) {
-      const roll = Math.floor(Math.random() * 6) + 1;
+      const roll = rollLudoBattleRoyalDiceFace();
       if (turn === 0) {
         if (p === 0) {
           if (roll === 6) p = 1;
@@ -2971,7 +2966,7 @@ export default function SnakeAndLadder() {
     setMoving(true);
     const value = Array.isArray(vals)
       ? vals.reduce((a, b) => a + b, 0)
-      : vals ?? Math.floor(Math.random() * 6) + 1;
+      : vals ?? rollLudoBattleRoyalDiceFace();
     const rolledSix = Array.isArray(vals)
       ? vals.some((v) => Number(v) === 6)
       : Number(value) === 6;
@@ -3219,7 +3214,7 @@ export default function SnakeAndLadder() {
         return;
       }
       const idxPlayer = rollOrder[idx];
-      const roll = Math.floor(Math.random() * 6) + 1;
+      const roll = rollLudoBattleRoyalDiceFace();
       results.push({ index: idxPlayer, roll });
       setTurnMessage(<>{playerName(idxPlayer)} rolled {roll}</>);
       setTimeout(() => rollNext(idx + 1), 1000);


### PR DESCRIPTION
### Motivation
- Ensure Snake & Ladder uses the same dice face generation, timing, and 3D spin plan as the Ludo Battle Royal so client and server behave consistently and code is shared.
- Reduce duplicate random/dice heuristics and centralize normalization and spin planning for easier maintenance and predictable behavior across games.

### Description
- Added `lib/sharedDiceRoll.js` exposing dice constants, normalization (`normalizeDiceRollValues`), face/values generators (`rollLudoBattleRoyalDiceFace`, `rollLudoBattleRoyalDiceValues`), and a 3D roll plan factory (`createLudoBattleRoyalDiceSpin`).
- Updated server Snake logic (`bot/logic/snakeGame.js`) to use `clampDiceFace` and `rollLudoBattleRoyalDiceFace` for provided and fallback dice values.
- Updated the reusable UI roller (`webapp/src/components/DiceRoller.jsx`) to use shared tick/iteration constants and `rollLudoBattleRoyalDiceValues` for face updates during animation.
- Updated Ludo 3D spin code (`webapp/src/pages/Games/LudoBattleRoyal.jsx`) to consume `createLudoBattleRoyalDiceSpin` for deterministic spin/wobble/value plans.
- Updated Snake & Ladder client (`webapp/src/pages/Games/SnakeAndLadder.jsx`) to use `normalizeDiceRollValues` for authoritative dice normalization and `rollLudoBattleRoyalDiceFace` for local/AI/fast-forward rolls and initial-turn ordering.

### Testing
- Ran a small import/behavior smoke-check with Node: `node --input-type=module -e "import { rollLudoBattleRoyalDiceFace, rollLudoBattleRoyalDiceValues, normalizeDiceRollValues, createLudoBattleRoyalDiceSpin } from './lib/sharedDiceRoll.js'; ..."` which executed successfully.
- Ran server unit tests with `npm --prefix bot test` and all tests passed.
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20091f2aa083299484ad7d89ca4613)