### PR TITLE
Improve tennis court scale and official scoring

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -111,7 +111,7 @@ type HumanRig = {
   yawVelocity: number;
 };
 
-type HudState = { nearScore: number; farScore: number; nearLabel?: string; farLabel?: string; nearGames?: number; farGames?: number; status: string; power: number; server?: PlayerSide; serveSide?: "deuce" | "ad"; firstServe?: boolean; debug?: string };
+type HudState = { nearScore: number; farScore: number; nearLabel?: string; farLabel?: string; nearGames?: number; farGames?: number; nearSets?: number; farSets?: number; inTiebreak?: boolean; status: string; power: number; server?: PlayerSide; serveSide?: "deuce" | "ad"; firstServe?: boolean; debug?: string };
 
 type ControlState = {
   active: boolean;
@@ -1696,14 +1696,36 @@ function makeUserTargetFromSwipe(
 
 function makeAiTarget(near: HumanRig, ball: BallState): DesiredHit {
   const pressure = clamp01((Math.abs(ball.pos.z) - 1.0 * CFG.worldScale) / (CFG.courtL / 2 - 1.0 * CFG.worldScale));
+  const stretched = clamp01((Math.abs(ball.pos.x) - CFG.courtW * 0.18) / (CFG.courtW * 0.28));
+  const nearDeep = near.pos.z > CFG.serviceLineZ * 0.72;
+  const openCourtSign = near.pos.x >= 0 ? -1 : 1;
+  const attackable = pressure > 0.48 && stretched < 0.68 && ball.pos.y > CFG.minContactHeight * 1.08;
+  const targetWide = openCourtSign * CFG.courtW * (attackable ? 0.38 : 0.28);
+  const recoveryPunish = Math.abs(near.pos.x) > CFG.courtW * 0.25 ? -Math.sign(near.pos.x) * CFG.courtW * 0.4 : targetWide;
   const x = clamp(
-    near.pos.x * 0.62 + (Math.random() - 0.5) * 1.15 * CFG.worldScale,
-    -CFG.courtW / 2 + 0.45 * CFG.worldScale,
-    CFG.courtW / 2 - 0.45 * CFG.worldScale
+    recoveryPunish + clamp(ball.vel.x * 0.065, -0.22 * CFG.worldScale, 0.22 * CFG.worldScale) + (Math.random() - 0.5) * (1 - CFG.aiDifficulty.accuracy) * CFG.worldScale,
+    -CFG.courtW / 2 + 0.48 * CFG.worldScale,
+    CFG.courtW / 2 - 0.48 * CFG.worldScale
   );
-  const z = lerp(1.35 * CFG.worldScale, CFG.courtL / 2 - 1.0 * CFG.worldScale, 0.35 + pressure * 0.55);
-  const power = clamp(0.48 + pressure * 0.38 + Math.random() * 0.12, CFG.shotPower.min, CFG.shotPower.max);
-  return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique: "flat" };
+  const shortReply = stretched > 0.72 || (nearDeep && Math.random() > 0.58);
+  const z = shortReply
+    ? lerp(1.2 * CFG.worldScale, CFG.serviceLineZ * 0.72, Math.random())
+    : lerp(CFG.serviceLineZ * 0.52, CFG.courtL / 2 - 0.92 * CFG.worldScale, 0.38 + pressure * 0.54);
+  const roll = Math.random();
+  const technique: ShotTechnique = shortReply
+    ? (stretched > 0.74 ? "block" : "drop")
+    : stretched > 0.72
+      ? "slice"
+      : attackable && roll > 0.18
+        ? "topspin"
+        : near.pos.z < CFG.serviceLineZ * 0.22 && roll > 0.68
+          ? "lob"
+          : roll > 0.78
+            ? "slice"
+            : "flat";
+  const powerBase = shortReply ? 0.38 : attackable ? 0.66 : 0.54;
+  const power = clamp(powerBase + pressure * 0.14 + CFG.aiDifficulty.power * 0.08, CFG.shotPower.min, CFG.shotPower.max);
+  return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique };
 }
 
 function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = false) {
@@ -1925,7 +1947,7 @@ export default function MobileThreeTennisPrototype() {
   const rivalName = query.get("mode") === "online" ? "Opponent" : "AI";
   const hostRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const [hud, setHud] = useState<HudState>({ nearScore: 0, farScore: 0, status: "Swipe up to serve", power: 0 });
+  const [hud, setHud] = useState<HudState>({ nearScore: 0, farScore: 0, nearSets: 0, farSets: 0, status: "Swipe up to serve", power: 0 });
   const [menuOpen, setMenuOpen] = useState(false);
   const [selectedHumanCharacterId, setSelectedHumanCharacterId] = useState(() => localStorage.getItem("tennisSelectedHumanCharacter") || MURLAN_CHARACTER_THEMES[0]?.id || "rpm-current");
   const tennisPoint = (score: number) => ["0", "15", "30", "40", "Ad"][Math.min(score, 4)];
@@ -2005,7 +2027,7 @@ export default function MobileThreeTennisPrototype() {
     let replayT = 0;
 
     const setHudSafe = (patch: Partial<HudState>) => setHud((prev) => ({ ...prev, ...patch }));
-    setHudSafe({ nearLabel: "0", farLabel: "0", nearGames: 0, farGames: 0, server: "near", serveSide: currentServeSide, firstServe: true });
+    setHudSafe({ nearLabel: "0", farLabel: "0", nearGames: 0, farGames: 0, nearSets: 0, farSets: 0, inTiebreak: false, server: "near", serveSide: currentServeSide, firstServe: true });
 
     const awardPoint = (winner: PlayerSide, reason: PointReason) => {
       if (pointLock) return;
@@ -2019,7 +2041,8 @@ export default function MobileThreeTennisPrototype() {
       serveController.start(score.server, currentServeSide);
       const reasonText = reason === "doubleFault" ? "Double Fault" : reason === "serviceFault" ? "Service fault" : reason === "out" ? "Out" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net" : "Point";
       const gameText = score.gameWonBy ? ` · Game ${score.gameWonBy === "near" ? "You" : "AI"}` : "";
-      replayText = `Replay: ${reasonText} — ${winner === "near" ? "You" : "AI"} scores${gameText}`;
+      const setText = score.setWonBy ? ` · Set ${score.setWonBy === "near" ? "You" : "AI"}` : "";
+      replayText = `Replay: ${reasonText} — ${winner === "near" ? "You" : "AI"} scores${gameText}${setText}`;
       replayT = 1.7;
       audioVfx.play("point");
       setHud({
@@ -2030,10 +2053,13 @@ export default function MobileThreeTennisPrototype() {
         farLabel: score.label.far,
         nearGames: score.games.near,
         farGames: score.games.far,
+        nearSets: score.sets.near,
+        farSets: score.sets.far,
+        inTiebreak: score.inTiebreak,
         server: score.server,
         serveSide: score.serveSide,
         firstServe: true,
-        status: `${reasonText}: ${winner === "near" ? "You" : "AI"} scores${gameText}`,
+        status: `${reasonText}: ${winner === "near" ? "You" : "AI"} scores${gameText}${setText}`,
         power: 0,
       });
     };
@@ -2317,7 +2343,7 @@ export default function MobileThreeTennisPrototype() {
           const serverPlayer = scoreManager.snapshot().server === "near" ? nearPlayer : farPlayer;
           resetBallForServe(ball, serverPlayer, currentServeSide);
           serveController.start(scoreManager.snapshot().server, currentServeSide);
-          setHudSafe({ status: scoreManager.snapshot().server === "near" ? (firstServeAttempt ? "Swipe up to serve from behind the baseline" : "Second serve") : "AI preparing serve", power: 0, serveSide: currentServeSide, firstServe: firstServeAttempt, server: scoreManager.snapshot().server });
+          setHudSafe({ status: scoreManager.snapshot().server === "near" ? (firstServeAttempt ? "Swipe up to serve from behind the baseline" : "Second serve") : "AI preparing serve", power: 0, serveSide: currentServeSide, firstServe: firstServeAttempt, server: scoreManager.snapshot().server, inTiebreak: scoreManager.snapshot().inTiebreak });
         }
       } else {
         ballController.accumulator = Math.min(ballController.accumulator + dt, CFG.fixedTimeStep * CFG.maxPhysicsSteps);

--- a/webapp/src/pages/Games/tennis/ScoreManager.ts
+++ b/webapp/src/pages/Games/tennis/ScoreManager.ts
@@ -1,4 +1,4 @@
-import { PlayerSide, ServeSide } from "./gameConfig";
+import { gameConfig, PlayerSide, ServeSide } from "./gameConfig";
 
 export type ScoreSnapshot = {
   points: Record<PlayerSide, number>;
@@ -9,26 +9,69 @@ export type ScoreSnapshot = {
   pointTotal: number;
   label: Record<PlayerSide, string>;
   gameWonBy?: PlayerSide;
+  setWonBy?: PlayerSide;
+  inTiebreak: boolean;
 };
 
+const otherSide = (side: PlayerSide): PlayerSide => (side === "near" ? "far" : "near");
+
+/**
+ * Singles scoring modelled after the standard ITF Rules of Tennis flow:
+ * - games use love/15/30/40, deuce, advantage, and two-clear-points game wins;
+ * - service starts from the deuce court each game and alternates deuce/ad by the
+ *   number of points played in the current game (not by total match points);
+ * - sets are first to six games, win by two, with a 7-point tie-break at 6-6;
+ * - tie-break service order is first point by the next server, then two points
+ *   per player, and tie-break points are won by two from seven.
+ */
 export class ScoreManager {
   private points: Record<PlayerSide, number> = { near: 0, far: 0 };
   private games: Record<PlayerSide, number> = { near: 0, far: 0 };
   private sets: Record<PlayerSide, number> = { near: 0, far: 0 };
   private pointTotal = 0;
+  private inTiebreakGame = false;
+  private tiebreakFirstServer: PlayerSide = "near";
   server: PlayerSide = "near";
 
   awardPoint(winner: PlayerSide): ScoreSnapshot {
     this.points[winner] += 1;
     this.pointTotal += 1;
     let gameWonBy: PlayerSide | undefined;
+    let setWonBy: PlayerSide | undefined;
+
+    if (this.inTiebreakGame) {
+      if (this.hasWonTiebreak(winner)) {
+        gameWonBy = winner;
+        setWonBy = winner;
+        this.games[winner] += 1;
+        this.sets[winner] += 1;
+        this.points = { near: 0, far: 0 };
+        this.games = { near: 0, far: 0 };
+        this.inTiebreakGame = false;
+        this.server = otherSide(this.tiebreakFirstServer);
+      } else {
+        this.server = this.tiebreakServerForPoint(this.points.near + this.points.far);
+      }
+      return { ...this.snapshot(), gameWonBy, setWonBy };
+    }
+
     if (this.hasWonGame(winner)) {
       gameWonBy = winner;
       this.games[winner] += 1;
       this.points = { near: 0, far: 0 };
-      this.server = this.server === "near" ? "far" : "near";
+      this.server = otherSide(this.server);
+
+      if (this.hasWonSet(winner)) {
+        setWonBy = winner;
+        this.sets[winner] += 1;
+        this.games = { near: 0, far: 0 };
+      } else if (this.games.near === 6 && this.games.far === 6) {
+        this.inTiebreakGame = true;
+        this.tiebreakFirstServer = this.server;
+      }
     }
-    return { ...this.snapshot(), gameWonBy };
+
+    return { ...this.snapshot(), gameWonBy, setWonBy };
   }
 
   snapshot(): ScoreSnapshot {
@@ -40,19 +83,38 @@ export class ScoreManager {
       serveSide: this.serveSide,
       pointTotal: this.pointTotal,
       label: this.pointLabels(),
+      inTiebreak: this.inTiebreakGame,
     };
   }
 
   get serveSide(): ServeSide {
-    return this.pointTotal % 2 === 0 ? "deuce" : "ad";
+    return (this.points.near + this.points.far) % 2 === 0 ? "deuce" : "ad";
   }
 
   private hasWonGame(side: PlayerSide) {
-    const other = side === "near" ? "far" : "near";
+    const other = otherSide(side);
     return this.points[side] >= 4 && this.points[side] - this.points[other] >= 2;
   }
 
+  private hasWonSet(side: PlayerSide) {
+    const other = otherSide(side);
+    return this.games[side] >= gameConfig.scoring.gamesPerSet && this.games[side] - this.games[other] >= 2;
+  }
+
+  private hasWonTiebreak(side: PlayerSide) {
+    const other = otherSide(side);
+    return this.points[side] >= gameConfig.scoring.tiebreakPoints && this.points[side] - this.points[other] >= 2;
+  }
+
+  private tiebreakServerForPoint(pointIndex: number): PlayerSide {
+    if (pointIndex === 0) return this.tiebreakFirstServer;
+    const pairIndex = Math.floor((pointIndex - 1) / 2);
+    return pairIndex % 2 === 0 ? otherSide(this.tiebreakFirstServer) : this.tiebreakFirstServer;
+  }
+
   private pointLabels(): Record<PlayerSide, string> {
+    if (this.inTiebreakGame) return { near: String(this.points.near), far: String(this.points.far) };
+
     const near = this.points.near;
     const far = this.points.far;
     if (near >= 3 && far >= 3) {

--- a/webapp/src/pages/Games/tennis/UIOverlay.tsx
+++ b/webapp/src/pages/Games/tennis/UIOverlay.tsx
@@ -7,6 +7,9 @@ export type TennisHud = {
   farLabel?: string;
   nearGames?: number;
   farGames?: number;
+  nearSets?: number;
+  farSets?: number;
+  inTiebreak?: boolean;
   status: string;
   power: number;
   server?: "near" | "far";
@@ -29,7 +32,7 @@ export function UIOverlay({ hud, playerName, rivalName, playerAvatar, onMenu }: 
         </div>
         <div style={{ textAlign: "center" }}>
           <div style={{ fontWeight: 950, fontSize: 18, letterSpacing: 1 }}>{hud.nearLabel ?? pointLabel(hud.nearScore)} : {hud.farLabel ?? pointLabel(hud.farScore)}</div>
-          <div style={{ fontSize: 10, opacity: .78 }}>Games {hud.nearGames ?? 0}-{hud.farGames ?? 0} · {hud.server === "far" ? rivalName : playerName} serves {hud.serveSide ?? "deuce"}</div>
+          <div style={{ fontSize: 10, opacity: .78 }}>Sets {hud.nearSets ?? 0}-{hud.farSets ?? 0} · Games {hud.nearGames ?? 0}-{hud.farGames ?? 0}{hud.inTiebreak ? " · TB" : ""} · {hud.server === "far" ? rivalName : playerName} serves {hud.serveSide ?? "deuce"}</div>
         </div>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 8, minWidth: 0 }}>
           <div style={{ textAlign: "right", minWidth: 0 }}><div style={{ fontSize: 11, opacity: .78 }}>Opponent</div><div style={{ fontWeight: 900, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{rivalName}</div></div>

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -29,12 +29,12 @@ export enum TennisBallState {
 }
 
 const BASE_WORLD_SCALE = 1.72;
-const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 3.52;
-const COURT_WIDTH_MULTIPLIER = 1.18;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 4.08;
+const COURT_WIDTH_MULTIPLIER = 1.22;
 const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
 // Keep camera scaling independent from world scale so camera framing can be
 // tuned precisely while the enlarged court keeps its regulation proportions.
-const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE * 1.42;
+const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE * 1.5;
 // Extra character scale keeps human avatars visibly bigger than the court uplift.
 const PLAYER_CHARACTER_SCALE = 1.42;
 const PLAYER_SCALE = WORLD_SCALE * PLAYER_CHARACTER_SCALE;
@@ -92,16 +92,16 @@ export const gameConfig = {
     anticipation: 0.74,
     maxBlendPerSecond: 5.8,
   },
-  scoring: { gamesPerSet: 6, winByTwoGames: true },
+  scoring: { gamesPerSet: 6, winByTwoGames: true, tiebreakAtGamesAll: 6, tiebreakPoints: 7 },
   aiDifficulty: {
-    reactionTime: 0.07,
-    moveSpeed: 13.5 * PLAYER_SCALE,
-    reachRadius: 1.95 * PLAYER_SCALE,
-    accuracy: 0.94,
-    power: 0.62,
-    spin: 0.88,
-    mistakeChance: 0.018,
-    serveQuality: 0.84,
+    reactionTime: 0.045,
+    moveSpeed: 15.2 * PLAYER_SCALE,
+    reachRadius: 2.16 * PLAYER_SCALE,
+    accuracy: 0.975,
+    power: 0.72,
+    spin: 0.94,
+    mistakeChance: 0.008,
+    serveQuality: 0.93,
   },
 } as const;
 


### PR DESCRIPTION
### Motivation
- Make the tennis play area larger and more arena-like on portrait mobile while aligning game logic with official singles tennis rules for accurate scoring and serves.
- Increase AI skill and tactical variety so single-player matches feel realistic and challenging.

### Description
- Enlarged court/player/camera scaling in `gameConfig` by adjusting `COURT_AND_CHARACTER_SIZE_MULTIPLIER`, `COURT_WIDTH_MULTIPLIER`, and `CAMERA_VIEW_SCALE` to keep regulation proportions while visually expanding the arena.
- Reworked scoring engine in `tennis/ScoreManager.ts` to follow standard singles rules: deuce/advantage games, serve-side determined per-game by points in the current game, games-to-6 win-by-two sets, and 7-point tiebreaks at 6–6; added tiebreak and set metadata (`inTiebreak`, `setWonBy`) to snapshots.
- Updated HUD and overlay in `Tennis.tsx` / `UIOverlay.tsx` to show sets, games, and tiebreak state and to surface set/tiebreak updates live during play.
- Strengthened AI in `Tennis.tsx` and tuned `aiDifficulty` in `gameConfig` to improve reaction, movement, reach, accuracy, power, and shot choice logic; AI now targets open court and chooses appropriate techniques (`topspin`, `slice`, `drop`, `lob`, `block`, `flat`) based on pressure/position.

### Testing
- Built production bundle with `npm --prefix webapp run build` (passed).
- Ran isolated scoring rules check with `npm exec --yes tsx test-score-manager.ts` to validate serve-side toggling, game wins, set wins and tiebreak entry (passed).
- Ran linter with `npm --prefix webapp run lint` (passed).
- Captured portrait gameplay video before and after changes for visual verification: `/tmp/tennis-before-video/...webm` and `/tmp/tennis-after-video/...webm` (videos recorded successfully; still screenshots via headless Chromium timed out under software WebGL rendering, so videos are the primary visual artifacts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23a1e6937c83298e1202f88ebf9275)