### PR TITLE
Align bowling arena to HDRI ground and implement official foul restoration rules

### DIFF
--- a/test/bowlingTenPinRules.test.js
+++ b/test/bowlingTenPinRules.test.js
@@ -65,13 +65,15 @@ describe('official ten-pin bowling rules', () => {
     expect(frameComplete(spareBonus, 9)).toBe(true);
   });
 
-  test('counts foul rolls as delivered balls with zero scored pinfall', () => {
+  test('counts foul rolls as delivered balls with zero scored pinfall and restores pins when another delivery remains', () => {
     const player = makePlayer();
     const decision = addTenPinRoll(player, 8, { foul: true });
     addTenPinRoll(player, 5);
 
     expect(decision.foul).toBe(true);
     expect(decision.knocked).toBe(0);
+    expect(decision.resetPins).toBe(true);
+    expect(decision.foulRestoresPins).toBe(true);
     expect(player.frames[0].rolls).toEqual([0, 5]);
     expect(player.frames[0].cumulative).toBe(5);
   });

--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -93,6 +93,7 @@ type RollDecision = {
   rollIndex: number;
   frameEnded: boolean;
   resetPins: boolean;
+  foulRestoresPins?: boolean;
   gameFinished: boolean;
   knocked: number;
   foul?: boolean;
@@ -287,7 +288,7 @@ const RESULT_COMPLIMENTS = {
 } as const;
 
 // Keep the full bowling field grounded on the HDRI floor in portrait view.
-const BOWLING_HDRI_GROUND_SNAP_DROP = 0;
+const BOWLING_HDRI_GROUND_SNAP_DROP = 0.32;
 
 const CFG = {
   laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,
@@ -617,7 +618,8 @@ function shouldResetPinsForNextRoll(
 function describeRollResult(
   player: ScorePlayer,
   result: RollDecision,
-  knocked: number
+  knocked: number,
+  standingAfter: number
 ) {
   if (result.foul) {
     return {
@@ -650,7 +652,7 @@ function describeRollResult(
         : result.frameEnded
           ? 'Open frame: switch players'
           : 'Second ball: convert the spare',
-    lane: `${pocket} · ${Math.max(0, 10 - knocked)} pin${10 - knocked === 1 ? '' : 's'} left`
+    lane: `${pocket} · ${standingAfter} pin${standingAfter === 1 ? '' : 's'} left`
   };
 }
 
@@ -658,6 +660,32 @@ function standingPinsCount(pins: PinState[]) {
   return pins.filter(
     (p) => p.root.visible && p.standing && p.tilt < CFG.pinToppleThreshold
   ).length;
+}
+
+function standingPinIndexes(pins: PinState[]) {
+  return pins
+    .map((pin, index) => ({ pin, index }))
+    .filter(
+      ({ pin }) =>
+        pin.root.visible && pin.standing && pin.tilt < CFG.pinToppleThreshold
+    )
+    .map(({ index }) => index);
+}
+
+function restoreStandingPinLayout(pins: PinState[], standingIndexes: number[]) {
+  const restore = new Set(standingIndexes);
+  pins.forEach((pin, index) => {
+    const visible = restore.has(index);
+    pin.root.visible = visible;
+    pin.standing = visible;
+    pin.knocked = false;
+    pin.tilt = 0;
+    pin.vel.set(0, 0, 0);
+    pin.angularVel = 0;
+    pin.pos.copy(pin.start);
+    pin.root.position.copy(pin.start);
+    pin.root.rotation.set(0, 0, 0);
+  });
 }
 
 function enableShadow(obj: THREE.Object3D) {
@@ -2284,7 +2312,7 @@ function createEnvironment(
     resetMachine: new THREE.Group()
   };
   scene.add(group);
-  group.position.y = -0.32;
+  group.position.y = 0;
   let laneMat: THREE.Material;
   let woodMat: THREE.Material;
   try {
@@ -4861,7 +4889,10 @@ export default function MobileBowlingRealistic() {
       pinsWereMoving = false;
       settleTimer = 0;
       pendingIntent = null;
-      if (shouldResetRackBeforeNextRoll) resetPins(lanePins[0]);
+      if (foulRestoreStandingIndexes) {
+        restoreStandingPinLayout(lanePins[0], foulRestoreStandingIndexes);
+        foulRestoreStandingIndexes = null;
+      } else if (shouldResetRackBeforeNextRoll) resetPins(lanePins[0]);
       shouldResetRackBeforeNextRoll = false;
       const previousPlayer = player;
       player = playerRigs[activePlayer];
@@ -4890,7 +4921,14 @@ export default function MobileBowlingRealistic() {
       const playerBefore = localScores[scoringPlayerIndex];
       const result = addRollToPlayer(playerBefore, rawKnocked, foul);
       const knocked = result.knocked;
-      const rollRead = describeRollResult(playerBefore, result, knocked);
+      const rollRead = describeRollResult(
+        playerBefore,
+        result,
+        knocked,
+        result.foul && result.foulRestoresPins
+          ? lastShotStandingBefore
+          : afterStanding
+      );
       let status = foul
         ? `${playerBefore.name} fouled · 0 pins score`
         : `${playerBefore.name} knocked ${knocked} pin${knocked === 1 ? '' : 's'}`;
@@ -4901,6 +4939,10 @@ export default function MobileBowlingRealistic() {
       const strike = rollRead.isStrike;
       const spare = rollRead.isSpare;
       shouldResetRackBeforeNextRoll = result.resetPins;
+      foulRestoreStandingIndexes =
+        result.foul && result.foulRestoresPins
+          ? [...lastShotStandingIndexes]
+          : null;
       rackResetLane = 0;
       if (strike) {
         void new Audio(BOWLING_SFX.strike).play().catch(() => undefined);
@@ -5364,7 +5406,9 @@ export default function MobileBowlingRealistic() {
         player.throwT >= CFG.releaseT &&
         ball.held
       ) {
-        lastShotStandingBefore = standingPinsCount(activePins());
+        const pinsBeforeRelease = activePins();
+        lastShotStandingBefore = standingPinsCount(pinsBeforeRelease);
+        lastShotStandingIndexes = standingPinIndexes(pinsBeforeRelease);
         releaseBall(ball, pendingIntent, activeLaneCenter(), player);
         pendingIntent = null;
         setHud((prev) => ({

--- a/webapp/src/pages/Games/bowlingTenPinRules.js
+++ b/webapp/src/pages/Games/bowlingTenPinRules.js
@@ -1,5 +1,5 @@
 export const OFFICIAL_TEN_PIN_RULE_SUMMARY =
-  'Official ten-pin: 10 frames · max two rolls per frames 1-9 unless strike · strike scores 10 plus next two rolls · spare scores 10 plus next roll · open frame scores pinfall · 10th frame grants bonus rolls only after strike/spare · each full rack is limited to 10 pins · foul rolls score 0 while still counting as delivered balls.';
+  'Official ten-pin: 10 frames · frames 1-9 allow two deliveries unless the first is a strike · strike scores 10 plus the next two deliveries · spare scores 10 plus the next delivery · open frame scores pinfall · the 10th frame allows one or two bonus deliveries only after a strike/spare · each standing rack is capped at 10 pins · foul deliveries count as a ball, score 0, and restore the pre-foul standing pins when another delivery remains.';
 
 export function frameComplete(frame, index) {
   const r = frame.rolls || [];
@@ -84,9 +84,14 @@ export function shouldResetPinsForNextRoll(
   frameIndex,
   rollIndex,
   knocked,
-  frameEnded
+  frameEnded,
+  foul = false
 ) {
   if (frameEnded) return true;
+  // USBC/PBA-style foul handling: the delivery counts as zero, but if the
+  // bowler still has another delivery in the frame the pin deck must restore
+  // the pins that were standing before the foul ball.
+  if (foul) return true;
   if (frameIndex < 9) return knocked === 10;
   if (rollIndex === 0) return knocked === 10;
   if (rollIndex === 1)
@@ -116,8 +121,10 @@ export function addTenPinRoll(player, knocked, options = {}) {
       frameIndex,
       rollIndex,
       legalKnocked,
-      frameEnded
+      frameEnded,
+      foul
     ),
+    foulRestoresPins: foul && !frameEnded,
     gameFinished: playerFinished(player)
   };
 }


### PR DESCRIPTION
### Motivation
- Visuals: the bowling field (lane, approach, pins, ball, players) needed to sit at the same HDRI ground level in portrait so characters and props appear grounded together. 
- Rules: foul deliveries should follow USBC/PBA behaviour — count as a delivered ball, score zero, and restore the pre-foul standing pin layout when the bowler still has another delivery.

### Description
- Lowered the gameplay plane by applying an HDRI ground snap (`BOWLING_HDRI_GROUND_SNAP_DROP`) and removed the extra group Y-offset so the lane/approach/pins/ball/player positions share the HDRI floor. 
- Implemented foul restoration: `shouldResetPinsForNextRoll` now accepts a `foul` flag and returns restore semantics; `addTenPinRoll` returns `foulRestoresPins` when a foul leaves another delivery and should restore standing pins. 
- In the live scene, captured standing-pin indexes before release and restore that exact standing layout after a foul when required, and updated HUD lane messaging to report actual standing pins left. 
- Tests and small API changes: updated `OFFICIAL_TEN_PIN_RULE_SUMMARY`, added helper functions `standingPinIndexes`/`restoreStandingPinLayout`, adjusted `describeRollResult` signature, and updated unit tests to assert foul restoration behavior.

### Testing
- Ran unit tests: `npm test -- --runInBand test/bowlingTenPinRules.test.js` and all tests passed. 
- Production build: `npm --prefix webapp run build` completed successfully (Vite build emitted assets). 
- Visual check: installed Playwright and deps and captured a portrait screenshot of `/games/bowling` after running the dev server (`npx playwright install chromium && npx playwright install-deps chromium`), producing `/tmp/bowling-ground-check.png` to verify the lowered ground visually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23a2ea055c8329970edf87fab6e720)