### PR TITLE
Raise Ludo human player's locked first‑person camera for portrait view

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4235,7 +4235,9 @@ const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.072 * MODEL_SCALE;
 // The bottom-seat gameplay camera is intentionally raised and pushed farther toward the table so
 // portrait players see over the local avatar and closer into the Ludo board/action area.
 const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.31 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.42 * MODEL_SCALE;
+// Lift the human player's locked first-person camera higher so portrait gameplay has a clearer
+// over-the-shoulder view of the dice, tokens, and board instead of sitting too low near the face.
+const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.56 * MODEL_SCALE;
 const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.255 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 9;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.34;


### PR DESCRIPTION
### Motivation
- Improve portrait/mobile readability by giving the local (human) player's locked first‑person camera a higher over‑the‑shoulder angle so the dice, tokens and board are more visible.

### Description
- Increased the bottom‑seat first‑person camera vertical offset `SEATED_FACE_CAMERA_GAMEPLAY_UP` from `0.42 * MODEL_SCALE` to `0.56 * MODEL_SCALE` and added a clarifying comment (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully.
- Installed Playwright and browser deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, both succeeded.
- Launched a local preview with `npm --prefix webapp run preview -- --host 127.0.0.1 --port 4173` and exercised the page using a Playwright capture script (portrait 390×844); a screenshot was produced for visual verification but the preview session logged remote asset fetch/certificate errors for external models and APIs (these are unrelated to the camera constant change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25032825108329882f50c53d24f91f)