### PR TITLE
Align Snake & Ladder dice animation and weapon SFX with Ludo Battle Royal

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -28,6 +28,8 @@ import {
   DEFAULT_TABLE_CUSTOMIZATION
 } from '../utils/tableCustomizationOptions.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../utils/colorSpace.js';
+import { getGameVolume } from '../utils/sound.js';
+import { playLudoCaptureWeaponSfx } from '../utils/ludoSfx.js';
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const clamp01 = (v) => clamp(v, 0, 1);
 const smootherstep01 = (v) => {
@@ -841,6 +843,69 @@ const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
   'slot-17-mrtk-gun-glb': 'glockSidearmAttack',
   'slot-18-fps-gun-gltf': 'shotgunBlastAttack'
 });
+const SNAKE_CAPTURE_WEAPON_SFX_ID_MAP = Object.freeze({
+  missileJavelin: 'missileJavelin',
+  droneAttack: 'droneAttack',
+  ukrainianDroneAttack: 'ukrainianDroneAttack',
+  ukrainiandroneattack: 'ukrainianDroneAttack',
+  fighterJetAttack: 'fighterJetAttack',
+  helicopterAttack: 'helicopterAttack',
+  supportTruckAttack: 'missileJavelin',
+  supporttruckattack: 'missileJavelin',
+  truck: 'missileJavelin',
+  fpsGunAttack: 'fpsGunAttack',
+  glockSidearmAttack: 'glockSidearmAttack',
+  assaultRifleAttack: 'assaultRifleAttack',
+  uziSprayAttack: 'uziSprayAttack',
+  ak47VolleyAttack: 'ak47VolleyAttack',
+  krsvBurstAttack: 'krsvBurstAttack',
+  smithSidearmAttack: 'smithSidearmAttack',
+  mosinMarksmanAttack: 'mosinMarksmanAttack',
+  sigsauerTacticalAttack: 'sigsauerTacticalAttack',
+  grenadeBlastAttack: 'grenadeBlastAttack',
+  shotgunBlastAttack: 'shotgunBlastAttack',
+  sniperShotAttack: 'sniperShotAttack',
+  smgBurstAttack: 'smgBurstAttack',
+  compactCarbineAttack: 'compactCarbineAttack',
+  marksmanDmrAttack: 'marksmanDmrAttack',
+  polyShotgun01Attack: 'shotgunBlastAttack',
+  polyAssaultRifle01Attack: 'assaultRifleAttack',
+  polyPistol01Attack: 'glockSidearmAttack',
+  polyRevolver01Attack: 'smithSidearmAttack',
+  polySawedOff01Attack: 'shotgunBlastAttack',
+  polyRevolver02Attack: 'smithSidearmAttack',
+  polyShotgun02Attack: 'shotgunBlastAttack',
+  polyShotgun03Attack: 'shotgunBlastAttack',
+  polySmg01Attack: 'smgBurstAttack',
+  'poly-shotgun-01': 'shotgunBlastAttack',
+  'poly-assault-rifle-01': 'assaultRifleAttack',
+  'poly-pistol-01': 'glockSidearmAttack',
+  'poly-revolver-01': 'smithSidearmAttack',
+  'poly-sawed-off-01': 'shotgunBlastAttack',
+  'poly-revolver-02': 'smithSidearmAttack',
+  'poly-shotgun-02': 'shotgunBlastAttack',
+  'poly-shotgun-03': 'shotgunBlastAttack',
+  'poly-smg-01': 'smgBurstAttack',
+  'poly-robot-large-gun-01': 'assaultRifleAttack',
+  'poly-robot-flying-gun-01': 'smgBurstAttack',
+  'poly-bazooka-01': 'polyBazooka01Attack',
+  'poly-grenade-launcher-01': 'polyGrenadeLauncher01Attack',
+  'poly-dynamite-bomb-01': 'polyDynamiteBomb01Attack',
+  'poly-molotov-01': 'polyMolotov01Attack',
+  'poly-gas-tank-01': 'polyGasTank01Attack',
+  'poly-hand-grenade-01': 'polyHandGrenade01Attack',
+  'poly-tank-01': 'polyTank01Attack',
+  'slot-10-ak47-gltf': 'ak47VolleyAttack',
+  'slot-11-krsv-gltf': 'krsvBurstAttack',
+  'slot-12-smith-gltf': 'smithSidearmAttack',
+  'slot-13-mosin-gltf': 'mosinMarksmanAttack',
+  'slot-14-uzi-gltf': 'uziSprayAttack',
+  'slot-15-sigsauer-gltf': 'sigsauerTacticalAttack',
+  'slot-16-awp-glb': 'sniperShotAttack',
+  'slot-17-mrtk-gun-glb': 'glockSidearmAttack',
+  'slot-18-fps-gun-gltf': 'shotgunBlastAttack'
+});
+const resolveSnakeCaptureWeaponSfxId = (weaponType) => SNAKE_CAPTURE_WEAPON_SFX_ID_MAP[weaponType] || weaponType || 'missileJavelin';
 const WEAPON_TABLE_PARKING_ROTATION_BY_POSE = Object.freeze({
   // Portrait screen: top/bottom player weapons lie flat left-to-right on the tabletop.
   horizontal: Object.freeze({ yaw: 0, preferAxis: 'x' }),
@@ -3601,6 +3666,7 @@ function createDiceRollAnimation(
   const wobbleVectors = diceArray.map(
     () => new THREE.Vector3((Math.random() - 0.5) * 0.16, 0, (Math.random() - 0.5) * 0.16)
   );
+  const targetValues = diceArray.map(() => 1 + Math.floor(Math.random() * 6));
 
   return {
     type: 'diceRoll',
@@ -3629,6 +3695,12 @@ function createDiceRollAnimation(
         diceArray.forEach((die, index) => {
           const base = basePositions[index];
           if (!base) return;
+          const targetValue = targetValues[index] ?? 1;
+          if (typeof die.userData?.setValue === 'function') {
+            die.userData.setValue(targetValue);
+          } else {
+            setDiceOrientation(die, targetValue);
+          }
           die.position.copy(base);
           die.position.y = baseY;
         });
@@ -6386,7 +6458,8 @@ export default function SnakeBoard3D({
   cameraViewMode = '3d',
   camera2dTilt = 0.2,
   onCameraTiltChange,
-  onDiceTap
+  onDiceTap,
+  soundEnabled = true
 }) {
   const mountRef = useRef(null);
   const cameraRef = useRef(null);
@@ -7580,7 +7653,15 @@ export default function SnakeBoard3D({
       captureStartMs: performance.now(),
       captureEndMs: 0
     };
+    const sfxWeaponId = resolveSnakeCaptureWeaponSfxId(captureEvent.weaponType || 'missileJavelin');
+    const playCaptureSfx = (stage, multiplier = 1) => {
+      playLudoCaptureWeaponSfx(sfxWeaponId, stage, {
+        volume: getGameVolume() * multiplier,
+        muted: !soundEnabled
+      });
+    };
     const completeCaptureAnimation = () => {
+      playCaptureSfx('loopStop');
       seatedHumanActionRef.current = {
         ...seatedHumanActionRef.current,
         captureEndMs: performance.now()
@@ -7648,6 +7729,8 @@ export default function SnakeBoard3D({
     missileProjectile.trail?.forEach((puff) => {
       puff.visible = !isUkrainianDroneAircraft;
     });
+    playCaptureSfx('loopStart');
+    playCaptureSfx('launch');
 
     const startTime = performance.now();
     const stageFlightDuration = CAPTURE_MISSILE_FLIGHT_MS / Math.max(0.58, captureTuning.speed || 1);
@@ -7665,6 +7748,12 @@ export default function SnakeBoard3D({
     const returnDuration = CAPTURE_RETURN_MS;
     let aircraftMissileLaunchStartedAt = null;
     let aircraftMissileLaunchFrom = null;
+    let impactSfxPlayed = false;
+    const playImpactSfxOnce = () => {
+      if (impactSfxPlayed) return;
+      impactSfxPlayed = true;
+      playCaptureSfx('impact');
+    };
     const camera = cameraRef.current;
     const controls = board.controls;
     if (cameraViewMode !== '2d' && camera && controls) {
@@ -7827,6 +7916,7 @@ export default function SnakeBoard3D({
           primaryVehicle.root.visible = false;
           const impactElapsed = Math.max(0, missileElapsed - perMissileFlight);
           if (impactElapsed <= impactDuration) {
+            playImpactSfxOnce();
             explosion.root.position.copy(impact);
             updateCaptureExplosionRig(explosion, impactElapsed / 1000);
             setCameraTrack(impact);
@@ -7884,6 +7974,7 @@ export default function SnakeBoard3D({
         missileProjectile.root.visible = false;
         const impactElapsed = attackElapsed - (vehicleKind === 'drone' ? droneAttackDuration : volleyDuration);
         if (impactElapsed <= impactDuration) {
+          playImpactSfxOnce();
           explosion.root.position.copy(impact);
           updateCaptureExplosionRig(explosion, impactElapsed / 1000);
           setCameraTrack(impact);
@@ -7919,7 +8010,7 @@ export default function SnakeBoard3D({
         return false;
       }
     });
-  }, [captureEvent, onCaptureAnimationComplete]);
+  }, [captureEvent, onCaptureAnimationComplete, soundEnabled]);
 
   useEffect(() => {
     const handle = () => fitRef.current();

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3654,6 +3654,7 @@ export default function SnakeAndLadder() {
           camera2dTilt={camera2dTilt}
           onCameraTiltChange={setCamera2dTilt}
           onDiceTap={handleRollButtonClick}
+          soundEnabled={!muted}
         />
       </div>
       <div

--- a/webapp/src/utils/ludoSfx.js
+++ b/webapp/src/utils/ludoSfx.js
@@ -2,6 +2,99 @@ let sharedCtx = null;
 const LUDO_DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
 let ludoDiceRollAudio = null;
 
+export const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';
+export const LUDO_CAPTURE_MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
+export const LUDO_CAPTURE_FIREARM_SHOT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
+export const LUDO_CAPTURE_FIREARM_SHELL_SOUND_URL = '/assets/sounds/cueshootsound.mp3';
+export const LUDO_CAPTURE_DRONE_SOUND_URL = '/assets/sounds/kimsa-kimsa-big-motorcycle-sound-394700.mp3';
+export const LUDO_CAPTURE_FIGHTER_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
+export const LUDO_CAPTURE_HELICOPTER_SOUND_URL = '/assets/sounds/dragon-studio-helicopter-sound-8d-372463.mp3';
+
+const LUDO_CAPTURE_FIREARM_SOURCE_SOUND_URL_BY_ID = Object.freeze({
+  glockSidearmAttack: 'https://cdn.freesound.org/previews/414/414888_5121236-lq.mp3',
+  smithSidearmAttack: 'https://cdn.freesound.org/previews/414/414888_5121236-lq.mp3',
+  sigsauerTacticalAttack: 'https://cdn.freesound.org/previews/414/414888_5121236-lq.mp3',
+  uziSprayAttack: 'https://cdn.freesound.org/previews/171/171104_2437358-lq.mp3',
+  smgBurstAttack: 'https://cdn.freesound.org/previews/171/171104_2437358-lq.mp3',
+  assaultRifleAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
+  ak47VolleyAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
+  krsvBurstAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
+  compactCarbineAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
+  sniperShotAttack: 'https://cdn.freesound.org/previews/533/533981_11861866-lq.mp3',
+  mosinMarksmanAttack: 'https://cdn.freesound.org/previews/533/533981_11861866-lq.mp3',
+  marksmanDmrAttack: 'https://cdn.freesound.org/previews/533/533981_11861866-lq.mp3',
+  shotgunBlastAttack: 'https://cdn.freesound.org/previews/456/456035_5121236-lq.mp3',
+  fpsGunAttack: 'https://cdn.freesound.org/previews/456/456035_5121236-lq.mp3',
+  grenadeBlastAttack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyBazooka01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyGrenadeLauncher01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyDynamiteBomb01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyMolotov01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyGasTank01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyHandGrenade01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3',
+  polyTank01Attack: 'https://cdn.freesound.org/previews/514/514644_9960520-lq.mp3'
+});
+
+const ludoCaptureAudioCache = new Map();
+
+function playCachedAudio(url, { volume = 1, loop = false } = {}) {
+  if (typeof Audio === 'undefined' || !url) return null;
+  let audio = ludoCaptureAudioCache.get(url);
+  if (!audio) {
+    audio = new Audio(url);
+    audio.preload = 'auto';
+    ludoCaptureAudioCache.set(url, audio);
+  }
+  audio.pause();
+  audio.currentTime = 0;
+  audio.volume = Math.max(0, Math.min(1, volume));
+  audio.loop = loop;
+  audio.play().catch(() => {});
+  return audio;
+}
+
+export function stopLudoCaptureLoopSfx() {
+  ludoCaptureAudioCache.forEach((audio, url) => {
+    if (![LUDO_CAPTURE_DRONE_SOUND_URL, LUDO_CAPTURE_FIGHTER_SOUND_URL, LUDO_CAPTURE_HELICOPTER_SOUND_URL].includes(url)) return;
+    audio.pause();
+    audio.currentTime = 0;
+    audio.loop = false;
+  });
+}
+
+export function playLudoCaptureWeaponSfx(weaponId, stage = 'launch', { volume = 1, muted = false } = {}) {
+  if (stage === 'loopStop') {
+    stopLudoCaptureLoopSfx();
+    return true;
+  }
+  if (muted || volume <= 0) return false;
+  const normalized = typeof weaponId === 'string' ? weaponId : '';
+  const v = Math.max(0, Math.min(1, volume));
+  if (stage === 'loopStart') {
+    if (normalized === 'droneAttack' || normalized === 'ukrainianDroneAttack') return !!playCachedAudio(LUDO_CAPTURE_DRONE_SOUND_URL, { volume: v * 0.42, loop: true });
+    if (normalized === 'fighterJetAttack') return !!playCachedAudio(LUDO_CAPTURE_FIGHTER_SOUND_URL, { volume: v, loop: true });
+    if (normalized === 'helicopterAttack') return !!playCachedAudio(LUDO_CAPTURE_HELICOPTER_SOUND_URL, { volume: v, loop: true });
+    return false;
+  }
+  if (stage === 'impact') {
+    const impact = playCachedAudio(LUDO_CAPTURE_MISSILE_IMPACT_SOUND_URL, { volume: v });
+    return !!impact;
+  }
+  if (stage === 'shot') {
+    playCachedAudio(LUDO_CAPTURE_FIREARM_SHOT_SOUND_URL, { volume: v });
+    playCachedAudio(LUDO_CAPTURE_FIREARM_SHELL_SOUND_URL, { volume: v });
+    const sourceUrl = LUDO_CAPTURE_FIREARM_SOURCE_SOUND_URL_BY_ID[normalized];
+    if (sourceUrl) playCachedAudio(sourceUrl, { volume: v * 0.9 });
+    return true;
+  }
+  if (stage === 'launch') {
+    if (LUDO_CAPTURE_FIREARM_SOURCE_SOUND_URL_BY_ID[normalized]) return playLudoCaptureWeaponSfx(normalized, 'shot', { volume: v, muted });
+    return !!playCachedAudio(LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL, { volume: v });
+  }
+  return false;
+}
+
+
 function getAudioContext() {
   if (typeof window === 'undefined') return null;
   const Ctx = window.AudioContext || window.webkitAudioContext;


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder experience visually and audibly consistent with Ludo Battle Royal by matching the dice rolling cadence and reusing the same capture/weapon SFX behavior and assets.

### Description
- Added a small Ludo capture SFX API to `webapp/src/utils/ludoSfx.js` exposing capture sound URLs, a cached playback helper, `playLudoCaptureWeaponSfx(...)` and `stopLudoCaptureLoopSfx()` to centralize launch/loop/impact/shot/shell playback.
- Wired Snake 3D board to reuse that API by importing `getGameVolume` and `playLudoCaptureWeaponSfx` in `webapp/src/components/SnakeBoard3D.jsx`, mapping Snake weapon identifiers to Ludo SFX IDs (`SNAKE_CAPTURE_WEAPON_SFX_ID_MAP`) and playing/stopping appropriate stages (`loopStart`, `launch`, `impact`, `loopStop`, `shot`) during the capture animation sequence.
- Updated Snake dice roll animation in `SnakeBoard3D.jsx` so the roll phase now applies a frame-synced spin cadence then resolves to a random visible face prior to the authoritative settle phase (matches Ludo's visual feel), by choosing per-die `targetValues` during the roll animation and applying them when the roll animation completes.
- Plumbed the game mute state into the 3D board by passing `soundEnabled={!muted}` from `webapp/src/pages/Games/SnakeAndLadder.jsx` and using this flag to mute capture SFX playback so sounds respect the game's mute/volume settings.

### Testing
- Built the webapp production bundle with `npm --prefix webapp run build` and the build completed successfully (Vite build completed and produced the application bundles).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f5c555008329adeefd8ae6f2213c)