### PR TITLE
Add Murlan tables & Domino human characters to 4-in-row inventory/store

### DIFF
--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -76,6 +76,99 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
 });
 
 
+export const DOMINO_ROYAL_HUMAN_CHARACTER_OPTIONS = Object.freeze([
+  {
+    id: 'rpm-current-domino',
+    label: 'Domino Royal Denim',
+    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'],
+    thumbnail: swatchThumbnail(['#2f5f9f', '#9b6b3f', '#d8dee9']),
+    dominoClothTheme: 'royalDenim',
+    hairColor: 0x24150f,
+    eyeColor: 0x2f5d7c,
+    skinTone: 0xd9a27d,
+    source: 'Domino Battle Royal seated human'
+  },
+  {
+    id: 'rpm-67d411-domino',
+    label: 'Domino Casino Check',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    thumbnail: swatchThumbnail(['#b7375d', '#243e70', '#f4d7a1']),
+    dominoClothTheme: 'casinoCheck',
+    hairColor: 0x14100c,
+    eyeColor: 0x5a3d2b,
+    skinTone: 0xc78f68,
+    source: 'Domino Battle Royal seated human'
+  },
+  {
+    id: 'rpm-67f433-domino',
+    label: 'Domino Linen Street',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    thumbnail: swatchThumbnail(['#b68452', '#374151', '#4a6fa4']),
+    dominoClothTheme: 'linenStreet',
+    hairColor: 0x2c1b12,
+    eyeColor: 0x406a45,
+    skinTone: 0xe0b18d,
+    source: 'Domino Battle Royal seated human'
+  },
+  {
+    id: 'rpm-67e1b5-domino',
+    label: 'Domino Jacquard Night',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    thumbnail: swatchThumbnail(['#7c3f88', '#1f335f', '#e3c16f']),
+    dominoClothTheme: 'jacquardNight',
+    hairColor: 0x3a2418,
+    eyeColor: 0x364f7d,
+    skinTone: 0xb87957,
+    source: 'Domino Battle Royal seated human'
+  },
+  {
+    id: 'webgl-vietnam-human-domino',
+    label: 'Domino Soft Fleece',
+    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb'],
+    thumbnail: swatchThumbnail(['#556070', '#8b633f', '#b88ab8']),
+    dominoClothTheme: 'softFleece',
+    hairColor: 0x120d0a,
+    eyeColor: 0x33271e,
+    skinTone: 0xd39a72,
+    source: 'Domino Battle Royal seated human'
+  },
+  {
+    id: 'webgl-ai-teacher-domino',
+    label: 'Domino Patterned Red',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb'],
+    thumbnail: swatchThumbnail(['#c44f42', '#263f73', '#f1f5f9']),
+    dominoClothTheme: 'patternedRed',
+    hairColor: 0x231915,
+    eyeColor: 0x3d5f73,
+    skinTone: 0xc88b64,
+    source: 'Domino Battle Royal seated human'
+  },
+  {
+    id: 'webgl-ai-teacher-1-domino',
+    label: 'Domino Mixed Denim',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb'],
+    thumbnail: swatchThumbnail(['#3b6ea8', '#4f6f93', '#d6a35f']),
+    dominoClothTheme: 'mixedDenim',
+    hairColor: 0x0f0b08,
+    eyeColor: 0x4c3425,
+    skinTone: 0xe3b08b,
+    source: 'Domino Battle Royal seated human'
+  }
+]);
+
+
 const DOMINO_TABLE_CLOTH_THUMBNAILS = Object.freeze({
   crimson: swatchThumbnail(['#960019', '#4a0012', '#fecaca']),
   emerald: swatchThumbnail(['#0f6a2f', '#054d24', '#bbf7d0']),

--- a/webapp/src/config/fourInRowInventoryConfig.js
+++ b/webapp/src/config/fourInRowInventoryConfig.js
@@ -6,6 +6,7 @@ import {
 } from './poolRoyaleInventoryConfig.js'
 import { swatchThumbnail } from './storeThumbnails.js'
 import { MURLAN_STOOL_THEMES } from './murlanThemes.js'
+import { DOMINO_ROYAL_HUMAN_CHARACTER_OPTIONS } from './dominoRoyalInventoryConfig.js'
 
 const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id
 
@@ -13,6 +14,7 @@ const FOUR_IN_ROW_POLYHAVEN_CHAIR_OPTIONS = MURLAN_STOOL_THEMES.filter((option) 
 
 export const FOUR_IN_ROW_CHAIR_OPTIONS = Object.freeze([...FOUR_IN_ROW_POLYHAVEN_CHAIR_OPTIONS])
 export const FOUR_IN_ROW_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES])
+export const FOUR_IN_ROW_HUMAN_CHARACTER_OPTIONS = Object.freeze([...DOMINO_ROYAL_HUMAN_CHARACTER_OPTIONS])
 
 export const FOUR_IN_ROW_BOARD_LAYOUTS = Object.freeze([
   { id: 'classic7x6', label: 'Classic 7×6', rows: 6, cols: 7 },
@@ -94,6 +96,7 @@ export const FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   boardTheme: [FOUR_IN_ROW_BOARD_THEMES[0]?.id],
   boardLayout: [FOUR_IN_ROW_BOARD_LAYOUTS[0]?.id],
   stoneStyle: [FOUR_IN_ROW_STONE_STYLES[0]?.id],
+  humanCharacter: [FOUR_IN_ROW_HUMAN_CHARACTER_OPTIONS[0]?.id],
   environmentHdri: [DEFAULT_HDRI_ID]
 })
 
@@ -107,6 +110,7 @@ export const FOUR_IN_ROW_BATTLE_OPTION_LABELS = Object.freeze({
   boardTheme: Object.freeze(FOUR_IN_ROW_BOARD_THEMES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardLayout: Object.freeze(FOUR_IN_ROW_BOARD_LAYOUTS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   stoneStyle: Object.freeze(FOUR_IN_ROW_STONE_STYLES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  humanCharacter: Object.freeze(FOUR_IN_ROW_HUMAN_CHARACTER_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   environmentHdri: Object.freeze(POOL_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => ({ ...acc, [variant.id]: `${variant.name} HDRI` }), {}))
 })
 
@@ -174,6 +178,16 @@ export const FOUR_IN_ROW_BATTLE_STORE_ITEMS = [
     name: option.label,
     price: option.price ?? 320 + idx * 20,
     description: option.description || `${option.label} seating tuned for 4 in a Row.`,
+    thumbnail: option.thumbnail,
+    previewShape: 'chair'
+  })),
+  ...FOUR_IN_ROW_HUMAN_CHARACTER_OPTIONS.slice(1).map((option, idx) => ({
+    id: `fourinrow-human-${option.id}`,
+    type: 'humanCharacter',
+    optionId: option.id,
+    name: option.label,
+    price: 520 + idx * 45,
+    description: `${option.label} seated human from Domino Battle Royal for the 4 in a Row table.`,
     thumbnail: option.thumbnail,
     previewShape: 'chair'
   })),

--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -24,6 +24,7 @@ import {
   FOUR_IN_ROW_RING_FINISH_OPTIONS,
   FOUR_IN_ROW_STONE_STYLES,
   FOUR_IN_ROW_TABLE_OPTIONS,
+  FOUR_IN_ROW_HUMAN_CHARACTER_OPTIONS,
   FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT,
   FOUR_IN_ROW_BOARD_LAYOUTS,
   FOUR_IN_ROW_BATTLE_OPTION_LABELS
@@ -151,6 +152,9 @@ const FOUR_IN_ROW_CHARACTER_PROPORTION_SCALE = 1.9;
 const FOUR_IN_ROW_CHARACTER_EXTRA_LOWER_OFFSET = 0.4;
 const FOUR_IN_ROW_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.42;
 const FOUR_IN_ROW_CHARACTER_MODEL_CACHE = new Map();
+const FOUR_IN_ROW_DOMINO_HUMAN_OPTIONS = Object.freeze(
+  FOUR_IN_ROW_HUMAN_CHARACTER_OPTIONS.filter((option) => Array.isArray(option?.modelUrls) && option.modelUrls.length)
+);
 const FOUR_IN_ROW_CHESS_HUMAN_OPTIONS = Object.freeze(
   CHESS_HUMAN_CHARACTER_OPTIONS.filter((option) => Array.isArray(option?.modelUrls) && option.modelUrls.length)
 );
@@ -1365,6 +1369,70 @@ async function resolvePolyhavenModelCandidates(assetId) {
   return [...fromManifest, ...fallback];
 }
 
+function fitFourInRowPolyhavenTable(root) {
+  if (!root) return;
+  root.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(root);
+  const size = box.getSize(new THREE.Vector3());
+  const maxHorizontal = Math.max(size.x, size.z, 0.001);
+  const targetHorizontal = TABLE_RADIUS * 2.05;
+  const targetHeight = Math.max(TABLE_HEIGHT * 1.38, 0.001);
+  const heightScale = size.y > 0.001 ? targetHeight / size.y : targetHorizontal / maxHorizontal;
+  root.scale.multiplyScalar(Math.min(targetHorizontal / maxHorizontal, heightScale));
+  root.updateMatrixWorld(true);
+  const fitBox = new THREE.Box3().setFromObject(root);
+  const center = fitBox.getCenter(new THREE.Vector3());
+  root.position.x -= center.x;
+  root.position.z -= center.z;
+  root.position.y -= fitBox.min.y;
+}
+
+async function createFourInRowTableModel(tableTheme, renderer = null, tableFinish = null) {
+  const container = new THREE.Group();
+  const theme = tableTheme || FOUR_IN_ROW_TABLE_OPTIONS[0];
+  if (theme?.source === 'polyhaven' && theme?.assetId) {
+    const loader = createConfiguredGLTFLoader(renderer);
+    let lastError = null;
+    const candidates = await resolvePolyhavenModelCandidates(theme.assetId);
+    for (const candidate of candidates) {
+      try {
+        if (MeshoptDecoder?.ready) await MeshoptDecoder.ready;
+        const candidateUrl = candidate?.url;
+        if (!candidateUrl) continue;
+        const activeLoader = candidate?.includeUrlMap
+          ? createPolyhavenGltfLoader(renderer, candidate.includeUrlMap)
+          : loader;
+        const resolvedUrl = new URL(candidateUrl, typeof window !== 'undefined' ? window.location?.href : candidateUrl).href;
+        activeLoader.setResourcePath(resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1));
+        activeLoader.setPath('');
+        const gltf = await activeLoader.loadAsync(resolvedUrl);
+        const root = gltf.scene || gltf.scenes?.[0];
+        if (!root) continue;
+        root.traverse((obj) => {
+          if (!obj?.isMesh) return;
+          obj.castShadow = true;
+          obj.receiveShadow = true;
+        });
+        preserveOriginalGltfTextureMapping(root);
+        fitFourInRowPolyhavenTable(root);
+        container.add(root);
+        return { group: container, parts: null };
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    console.warn('Four in Row table model failed to load; using procedural table.', theme.id, lastError);
+  }
+  const procedural = createMurlanStyleTable({
+    arena: container,
+    renderer,
+    tableRadius: TABLE_RADIUS,
+    tableHeight: TABLE_HEIGHT
+  });
+  applyTableMaterials(procedural.parts, tableFinish || MURLAN_TABLE_FINISHES[0]);
+  return { group: container, parts: procedural.parts };
+}
+
 async function createChairModel(chairTheme, renderer = null) {
   const loader = createConfiguredGLTFLoader(renderer);
   const fallbackAssetId = 'painted_wooden_chair_01';
@@ -1470,6 +1538,7 @@ export default function FourInRowRoyal() {
     getArenaYOffsetForHdri(POOL_ROYALE_DEFAULT_HDRI_ID)
   );
   const tablePartsRef = useRef(null);
+  const tableObjectRef = useRef(null);
   const chairMeshesRef = useRef([]);
   const characterRigsRef = useRef(new Map());
   const characterChipActionsRef = useRef([]);
@@ -1547,6 +1616,10 @@ export default function FourInRowRoyal() {
       inventory.stoneStyle?.[0] ||
       FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT.stoneStyle?.[0] ||
       FOUR_IN_ROW_STONE_STYLES[0]?.id,
+    humanCharacter:
+      inventory.humanCharacter?.[0] ||
+      FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT.humanCharacter?.[0] ||
+      FOUR_IN_ROW_HUMAN_CHARACTER_OPTIONS[0]?.id,
     hdriId:
       inventory.environmentHdri?.[0] ||
       FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT.environmentHdri?.[0] ||
@@ -1941,19 +2014,9 @@ export default function FourInRowRoyal() {
     keyLightRef.current = key;
     scene.add(key);
 
-    const table = createMurlanStyleTable({
-      arena: arenaRoot,
-      renderer,
-      tableRadius: TABLE_RADIUS,
-      tableHeight: TABLE_HEIGHT,
-      tableThemeId: appearance.tableId
-    });
-    tablePartsRef.current = table.parts;
-    applyTableMaterials(
-      table.parts,
-      MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
-        MURLAN_TABLE_FINISHES[0]
-    );
+    const tableMount = new THREE.Group();
+    tableObjectRef.current = tableMount;
+    arenaRoot.add(tableMount);
 
     const chairTheme =
       FOUR_IN_ROW_CHAIR_OPTIONS.find(
@@ -1984,10 +2047,12 @@ export default function FourInRowRoyal() {
       arenaRoot.add(chair);
     });
     characterRigsRef.current.clear();
-    const humanOptions = FOUR_IN_ROW_CHESS_HUMAN_OPTIONS.length
-      ? FOUR_IN_ROW_CHESS_HUMAN_OPTIONS
-      : CHESS_HUMAN_CHARACTER_OPTIONS;
-    const requestedHumanId = params.get('humanCharacter');
+    const humanOptions = FOUR_IN_ROW_DOMINO_HUMAN_OPTIONS.length
+      ? FOUR_IN_ROW_DOMINO_HUMAN_OPTIONS
+      : FOUR_IN_ROW_CHESS_HUMAN_OPTIONS.length
+        ? FOUR_IN_ROW_CHESS_HUMAN_OPTIONS
+        : CHESS_HUMAN_CHARACTER_OPTIONS;
+    const requestedHumanId = appearance.humanCharacter || params.get('humanCharacter');
     const playerHumanOption =
       humanOptions.find((option) => option.id === requestedHumanId) ||
       humanOptions[0] ||
@@ -2562,11 +2627,13 @@ export default function FourInRowRoyal() {
       });
       characterChipActionsRef.current = [];
       characterRigsRef.current.clear();
+      tableObjectRef.current = null;
       renderer.dispose();
       mount.removeChild(renderer.domElement);
     };
   }, [
     characterSeed,
+    appearance.humanCharacter,
     rows,
     cols,
     boardWidth,
@@ -2825,6 +2892,29 @@ export default function FourInRowRoyal() {
   }, [appearance.graphics]);
 
   useEffect(() => {
+    const tableMount = tableObjectRef.current;
+    if (!tableMount) return;
+    let cancelled = false;
+    const theme =
+      FOUR_IN_ROW_TABLE_OPTIONS.find((item) => item.id === appearance.tableId) ||
+      FOUR_IN_ROW_TABLE_OPTIONS[0];
+    const finish =
+      MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
+      MURLAN_TABLE_FINISHES[0];
+    tableMount.clear();
+    tablePartsRef.current = null;
+    createFourInRowTableModel(theme, rendererRef.current, finish).then((table) => {
+      if (cancelled || tableObjectRef.current !== tableMount) return;
+      tableMount.clear();
+      tableMount.add(table.group);
+      tablePartsRef.current = table.parts;
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [appearance.tableId, appearance.tableFinish]);
+
+  useEffect(() => {
     if (!tablePartsRef.current) return;
     const finish =
       MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
@@ -2918,6 +3008,15 @@ export default function FourInRowRoyal() {
 
   const optionGroups = [
     {
+      key: 'tableId',
+      label: 'Tables',
+      options: FOUR_IN_ROW_TABLE_OPTIONS.map((item) => ({
+        id: item.id,
+        label: item.label,
+        thumbnail: item.thumbnail
+      }))
+    },
+    {
       key: 'chairId',
       label: 'Chairs',
       options: FOUR_IN_ROW_CHAIR_OPTIONS.map((item) => ({
@@ -2984,6 +3083,15 @@ export default function FourInRowRoyal() {
       key: 'stoneStyle',
       label: 'Pieces',
       options: FOUR_IN_ROW_STONE_STYLES.map((item) => ({
+        id: item.id,
+        label: item.label,
+        thumbnail: item.thumbnail
+      }))
+    },
+    {
+      key: 'humanCharacter',
+      label: 'Humans',
+      options: FOUR_IN_ROW_HUMAN_CHARACTER_OPTIONS.map((item) => ({
         id: item.id,
         label: item.label,
         thumbnail: item.thumbnail

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -473,9 +473,13 @@ const TAVULL_TYPE_LABELS = {
 };
 
 const FOUR_IN_ROW_TYPE_LABELS = {
-  tables: 'Table Models',
+  tables: 'Murlan Royale Table Models',
   tableFinish: 'Table Finish',
   chairColor: 'Chairs',
+  humanCharacter: 'Domino Human Characters',
+  boardFinish: 'Board Finish',
+  boardFrameFinish: 'Board Frames',
+  ringFinish: 'Slot Rings',
   boardTheme: 'Board Skins',
   boardLayout: 'Board Sizes',
   stoneStyle: 'Stone Sets',


### PR DESCRIPTION
### Motivation
- Surface the existing Murlan Royale table models and Domino Battle Royal seated human characters in the 4 in a Row (FourInRow) store so players can purchase and use tables and seated humans in the FourInRow scene.
- Reuse the Domino human model catalog to avoid duplicating model metadata and to keep character/theme metadata consistent between Domino and FourInRow.

### Description
- Added a reusable Domino human catalog `DOMINO_ROYAL_HUMAN_CHARACTER_OPTIONS` with model URLs, thumbnails and cloth/skin/hair/eye metadata in `webapp/src/config/dominoRoyalInventoryConfig.js` and exported it for reuse.
- Exposed those humans in FourInRow by adding `FOUR_IN_ROW_HUMAN_CHARACTER_OPTIONS`, wiring `humanCharacter` into `FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS`, `FOUR_IN_ROW_BATTLE_OPTION_LABELS`, and the FourInRow store items (`fourinrow-human-*`) in `webapp/src/config/fourInRowInventoryConfig.js` so characters are purchasable and presented in the store.
- Updated the FourInRow scene and UI (`webapp/src/pages/Games/FourInRowRoyal.jsx`) to: add table selection using the Murlan/PolyHaven table catalog, dynamically load/refit PolyHaven table GLTFs with `createFourInRowTableModel`/`fitFourInRowPolyhavenTable`, add a `humanCharacter` option group in the in-game menu, and prefer Domino human options (falling back to chess/legacy options) when instantiating seated humans.
- Updated Store labeling and type labels in `webapp/src/pages/Store.jsx` so FourInRow shows the new table and human categories clearly (e.g., `Murlan Royale Table Models`, `Domino Human Characters`).

### Testing
- Ran the production frontend build with `npm run build` for the webapp and confirmed the Vite build completed successfully and produced `dist` bundles.
- Performed an inventory/catalog sanity check via a quick Node script (`node --input-type=module ...`) to confirm table/human counts and store item mappings (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a251bbe0f9c832996410ff3e9fbd483)