### PR TITLE
Adjust player face camera heights and improve firearm aiming/muzzle placement in Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -847,8 +847,8 @@ const PLAYER_FACE_CAMERA_SEAT_ANGLE = Math.PI / 2;
 // Keep Chess Battle Royal bottom-player camera aligned with Checkers Battle Royal
 // so portrait framing and left/right/up/down look limits match exactly.
 const PLAYER_FACE_CAMERA_RADIUS = TABLE_RADIUS * 0.98 * CHECKERS_CAMERA_FRAME_COMPENSATION;
-const PLAYER_FACE_CAMERA_EYE_HEIGHT = 2.05 * LAYOUT_SCALE_FACTOR;
-const PLAYER_FACE_CAMERA_TARGET_HEIGHT = 0.18 * LAYOUT_SCALE_FACTOR;
+const PLAYER_FACE_CAMERA_EYE_HEIGHT = 2.22 * LAYOUT_SCALE_FACTOR;
+const PLAYER_FACE_CAMERA_TARGET_HEIGHT = 0.22 * LAYOUT_SCALE_FACTOR;
 const PLAYER_FACE_CAMERA_YAW_LIMIT = THREE.MathUtils.degToRad(18);
 const PLAYER_FACE_CAMERA_PITCH_LIMIT = THREE.MathUtils.degToRad(12);
 const PLAYER_FACE_CAMERA_LOOK_DRAG_SPEED = 0.0045;
@@ -2500,6 +2500,9 @@ const CHESS_FIREARM_FATAL_BULLET_TRAVEL_MS = 1250; // match Ludo Battle Royal se
 const CHESS_FIREARM_FATAL_CAMERA_DISTANCE = 0.046;
 const CHESS_FIREARM_FATAL_CAMERA_HEIGHT = 0.03;
 const CHESS_FIREARM_FATAL_CAMERA_SIDE_DRIFT = 0.012;
+const CHESS_FIREARM_ATTACKER_TILE_LIFT = 0.11; // keep firearms visibly placed on the attacker tile instead of floating around the piece body.
+const CHESS_FIREARM_TARGET_AIM_HEIGHT_RATIO = 0.54; // aim at the target body while keeping the weapon rooted on the attacker tile.
+const CHESS_FIREARM_TILE_MUZZLE_FORWARD = 0.16;
 const CHESS_CAPTURE_SHATTER_PIECES = 14;
 const CHESS_CAPTURE_SHATTER_DURATION = 1.45;
 const CHESS_CAPTURE_SHATTER_GRAVITY = 1.58;
@@ -12120,6 +12123,36 @@ function Chess3D({
       targetPos.y += lift;
       return targetPos;
     };
+    const getFirearmAttackerTilePose = (fallback, lift = CHESS_FIREARM_ATTACKER_TILE_LIFT) => {
+      // Keep the visible firearm locked to the capture start square. Do not
+      // derive this from the live moving mesh, because that mesh can be
+      // reparented/animated during capture cleanup and pull the weapon toward
+      // the target square on slower portrait devices.
+      const tilePos = fallback?.clone?.() || new THREE.Vector3();
+      tilePos.y += lift;
+      return tilePos;
+    };
+    const getFirearmTargetAimPosition = (fallback, targetMesh = null) => {
+      const aimPos = fallback?.clone?.() || new THREE.Vector3();
+      if (targetMesh?.parent) {
+        const worldBounds = new THREE.Box3().setFromObject(targetMesh);
+        if (!worldBounds.isEmpty()) {
+          aimPos.x = (worldBounds.min.x + worldBounds.max.x) * 0.5;
+          aimPos.z = (worldBounds.min.z + worldBounds.max.z) * 0.5;
+          aimPos.y = THREE.MathUtils.lerp(
+            worldBounds.min.y,
+            worldBounds.max.y,
+            CHESS_FIREARM_TARGET_AIM_HEIGHT_RATIO
+          );
+        } else {
+          targetMesh.getWorldPosition(aimPos);
+          aimPos.y += Math.max(0.035, LUDO_FIREARM_BROADCAST_PROFILE.aimLift ?? 0.064);
+        }
+      } else {
+        aimPos.y += Math.max(0.035, LUDO_FIREARM_BROADCAST_PROFILE.aimLift ?? 0.064);
+      }
+      return aimPos;
+    };
     const getSeatedHumanFirearmPose = (playerIndex, targetPos, fallbackPos) => {
       const actorEntry = seatedHumanActorsRef.current.find((entry) => entry?.playerIndex === playerIndex);
       const rig = actorEntry?.rig;
@@ -15668,35 +15701,26 @@ function Chess3D({
             }
           } else if (fx.type === 'firearm') {
             const targetPos = getLiveTargetPosition(fx.to, fx.targetMesh, 0);
+            const targetAimPos = getFirearmTargetAimPosition(fx.to, fx.targetMesh);
             fx.to.copy(targetPos);
-            const pieceWorld = new THREE.Vector3();
-            fx.movingMesh?.getWorldPosition?.(pieceWorld);
-            const pieceBounds = fx.movingMesh?.parent ? new THREE.Box3().setFromObject(fx.movingMesh) : null;
-            let shooterPos = pieceWorld.lengthSq() ? pieceWorld : fx.from.clone().lerp(targetPos, 0.24);
-            shooterPos = shooterPos.clone();
-            if (pieceBounds && !pieceBounds.isEmpty()) {
-              shooterPos.x = (pieceBounds.min.x + pieceBounds.max.x) * 0.5;
-              shooterPos.z = (pieceBounds.min.z + pieceBounds.max.z) * 0.5;
-              shooterPos.y = THREE.MathUtils.lerp(pieceBounds.min.y, pieceBounds.max.y, 0.68);
-            } else {
-              shooterPos.y += 0.26;
-            }
-            const aimOrigin = shooterPos;
-            const aimDir = targetPos.clone().sub(aimOrigin).normalize();
-            const muzzlePos = aimOrigin.clone().addScaledVector(aimDir, (fx.shortMissile ? 0.18 : (LUDO_FIREARM_BROADCAST_PROFILE.aimLift ?? 0.064) + 0.055));
-            muzzlePos.y += fx.shortMissile ? 0.05 : 0.015;
+            const aimOrigin = getFirearmAttackerTilePose(fx.from);
+            const aimDir = targetAimPos.clone().sub(aimOrigin);
+            if (aimDir.lengthSq() > 1e-8) aimDir.normalize();
+            else aimDir.set(0, 0, 1);
+            const muzzleForward = fx.shortMissile ? 0.18 : CHESS_FIREARM_TILE_MUZZLE_FORWARD;
+            const muzzlePos = aimOrigin.clone().addScaledVector(aimDir, muzzleForward);
+            muzzlePos.y += fx.shortMissile ? 0.05 : 0.018;
             fx.missileFx.root.visible = true;
             fx.missileFx.root.position.copy(muzzlePos).addScaledVector(aimDir, 0.08);
             orientForwardKeepingUp(fx.missileFx.root, aimDir);
             if (fx.firearmFx) {
               fx.firearmFx.visible = true;
-              const liveAimTarget = targetPos.clone();
-              liveAimTarget.y += Math.max(0.035, LUDO_FIREARM_BROADCAST_PROFILE.aimLift ?? 0.064);
+              const liveAimTarget = getFirearmTargetAimPosition(fx.to, fx.targetMesh);
               const liveAimDir = liveAimTarget.clone().sub(aimOrigin);
               if (liveAimDir.lengthSq() > 1e-8) liveAimDir.normalize();
               else liveAimDir.copy(aimDir);
               fx.firearmFx.position.copy(
-                aimOrigin.clone().addScaledVector(liveAimDir, -(fx.shortMissile ? 0.04 : (LUDO_FIREARM_BROADCAST_PROFILE.aimRearPullback ?? 0.124)))
+                aimOrigin.clone().addScaledVector(liveAimDir, -(fx.shortMissile ? 0.035 : 0.055))
               );
               fx.firearmFx.position.y += 0.02 + Math.sin(u * Math.PI * 8) * 0.006;
               orientForwardKeepingUp(fx.firearmFx, liveAimDir);
@@ -15714,7 +15738,7 @@ function Chess3D({
             }
             if (fx.fpsArmsFx) {
               fx.fpsArmsFx.visible = true;
-              fx.fpsArmsFx.position.copy(aimOrigin).addScaledVector(aimDir, -(fx.shortMissile ? 0.095 : (LUDO_FIREARM_BROADCAST_PROFILE.aimRearPullback ?? 0.124) + 0.035));
+              fx.fpsArmsFx.position.copy(aimOrigin).addScaledVector(aimDir, -(fx.shortMissile ? 0.095 : 0.075));
               fx.fpsArmsFx.position.y += 0.004 + Math.sin(u * Math.PI * Math.max(4, fx.bulletCount || 1)) * 0.004;
               orientForwardKeepingUp(fx.fpsArmsFx, aimDir);
             }
@@ -15848,7 +15872,7 @@ function Chess3D({
               const shotIndex = fx.firedBullets - 1;
               const spread = (shotIndex - (bulletsToFire - 1) * 0.5) * (fx.bulletProfile?.pelletCount ? 0.012 : 0.004);
               const side = new THREE.Vector3().crossVectors(WORLD_UP, aimDir).normalize();
-              const bulletTo = targetPos.clone().addScaledVector(side, spread);
+              const bulletTo = getFirearmTargetAimPosition(fx.to, fx.targetMesh).addScaledVector(side, spread);
               const missileProjectile = fx.shortMissile ? createFxGroundMissile() : null;
               const bullet = missileProjectile?.root || createFirearmBulletMesh(fx.bulletProfile);
               if (missileProjectile) bullet.scale.setScalar(CAPTURE_MISSILE_SCALE * 0.78);


### PR DESCRIPTION
### Motivation
- Align portrait/landscape player face framing and make seated-character portraits more consistent by adjusting camera eye/target heights.
- Prevent visible firearms from drifting away from the attacker tile during capture animations on slower/portrait devices and improve aim targeting so shots visually hit the intended body area.

### Description
- Increased `PLAYER_FACE_CAMERA_EYE_HEIGHT` and `PLAYER_FACE_CAMERA_TARGET_HEIGHT` to raise and reframe seated player portraits.
- Added constants `CHESS_FIREARM_ATTACKER_TILE_LIFT`, `CHESS_FIREARM_TARGET_AIM_HEIGHT_RATIO`, and `CHESS_FIREARM_TILE_MUZZLE_FORWARD` to control firearm tile lift, target aim height interpolation, and muzzle forward offset.
- Introduced `getFirearmAttackerTilePose` and `getFirearmTargetAimPosition` helpers to lock visible weapons to the attacker tile and compute a stable aim point on the target mesh (using world bounds and an aim-height ratio fallback).
- Reworked firearm capture logic to use the new attacker tile pose as the `aimOrigin`, normalize aim directions defensively, compute `muzzlePos` from the tile pose and `CHESS_FIREARM_TILE_MUZZLE_FORWARD`, and use the target aim helper for bullet targets and firearm/fps-arm placements.
- Tweaked various small placement offsets (firearm/fps arm rear pullback and muzzle vertical offsets) to match the new tile-anchored approach.

### Testing
- Ran the frontend test suite with `yarn test`; all tests passed.
- Performed a local development build (`yarn build`) and smoke-tested capture/firearm animations in the browser; no visual regressions observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2503de49f48329af107dea8c0790fa)