### PR TITLE
Align Showood rail sight and side apron to fitted table dimensions

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -13583,7 +13583,7 @@ function subtlyWidenPoolRoyaleShowoodFeet(model, tableModel) {
   model.updateMatrixWorld(true);
 }
 
-function subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel) {
+function subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel, dims = null) {
   if (!model || !tableModel?.useReferenceShowoodMapping) return;
   const visualScale = Number(tableModel?.railSightApronVisualScale);
   const railSightHeightScale = Number(tableModel?.railSightVisualHeightScale);
@@ -13601,6 +13601,8 @@ function subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel) {
   const fullBox = new THREE.Box3().setFromObject(model);
   if (fullBox.isEmpty()) return;
   const fullCenter = fullBox.getCenter(new THREE.Vector3());
+  const targetHalfWidth = Number.isFinite(dims?.targetWidth) ? Math.max(MICRO_EPS, dims.targetWidth * 0.5) : null;
+  const targetHalfLength = Number.isFinite(dims?.targetLength) ? Math.max(MICRO_EPS, dims.targetLength * 0.5) : null;
   const safeVisualScale = hasScale ? THREE.MathUtils.clamp(visualScale, 1, 1.18) : 1;
   const safeRailSightHeightScale = hasRailSightHeight ? THREE.MathUtils.clamp(railSightHeightScale, 1, 1.22) : 1;
   const safeSideApronHeightScale = hasSideApronHeight ? THREE.MathUtils.clamp(sideApronHeightScale, 1, 1.24) : 1;
@@ -13621,21 +13623,30 @@ function subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel) {
     const heightScale = isSideApron ? safeSideApronHeightScale : safeRailSightHeightScale;
     if (heightScale > 1) child.scale.y *= heightScale;
 
-    const outwardOffset = isRailSight && hasRailSightOffset
+    const configuredOffset = isRailSight && hasRailSightOffset
       ? railSightOutwardOffset
       : isSideApron && hasSideApronOffset
         ? sideApronOutwardOffset
         : 0;
-    if (Math.abs(outwardOffset) > MICRO_EPS) {
-      const childBox = new THREE.Box3().setFromObject(child);
-      if (!childBox.isEmpty()) {
-        const childCenter = childBox.getCenter(new THREE.Vector3());
-        const awayX = childCenter.x - fullCenter.x;
-        const awayZ = childCenter.z - fullCenter.z;
-        if (Math.abs(awayX) >= Math.abs(awayZ) && Math.abs(awayX) > MICRO_EPS) {
-          child.position.x += Math.sign(awayX) * outwardOffset;
-        } else if (Math.abs(awayZ) > MICRO_EPS) {
-          child.position.z += Math.sign(awayZ) * outwardOffset;
+    const childBox = new THREE.Box3().setFromObject(child);
+    if (!childBox.isEmpty()) {
+      const childCenter = childBox.getCenter(new THREE.Vector3());
+      const awayX = childCenter.x - fullCenter.x;
+      const awayZ = childCenter.z - fullCenter.z;
+      const followsWidth = Math.abs(awayX) >= Math.abs(awayZ);
+      const axis = followsWidth ? 'x' : 'z';
+      const away = followsWidth ? awayX : awayZ;
+      const targetHalf = followsWidth ? targetHalfWidth : targetHalfLength;
+      if (Math.abs(away) > MICRO_EPS) {
+        const direction = Math.sign(away);
+        let outwardOffset = configuredOffset;
+        if (targetHalf != null) {
+          const outerFace = direction > 0 ? childBox.max[axis] : -childBox.min[axis];
+          const targetOuterFace = targetHalf + configuredOffset;
+          outwardOffset = Math.max(-0.18, Math.min(0.18, targetOuterFace - outerFace));
+        }
+        if (Math.abs(outwardOffset) > MICRO_EPS) {
+          child.position[axis] += direction * outwardOffset;
         }
       }
     }
@@ -13715,7 +13726,7 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   stretchPoolRoyaleExternalLowerBase(model, tableModel, dims);
   stretchPoolRoyaleShowoodLegsToFeet(model, tableModel);
   subtlyWidenPoolRoyaleShowoodFeet(model, tableModel);
-  subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel);
+  subtlyExpandPoolRoyaleShowoodRailSightsAndAprons(model, tableModel, dims);
   model.userData = {
     ...(model.userData || {}),
     poolRoyaleExternalTable: true,


### PR DESCRIPTION
### Motivation
- Ensure the Showood GLB rail sight (`railSight`) and side apron (`sideWoodApron`) visuals match the currently fitted Pool Royale table footprint so accents line up with the playfield after the external GLB is scaled and centered.

### Description
- Added an optional `dims` parameter to `subtlyExpandPoolRoyaleShowoodRailSightsAndAprons` and compute `targetHalfWidth` / `targetHalfLength` from `dims.targetWidth` / `dims.targetLength` so adjustments can reference the fitted table size rather than only the GLB bounds.
- Replace the previous naïve outward-translation with logic that selects the dominant axis (width or length), computes the GLB part outer face, and snaps that outer face toward the fitted table outer face while preserving the configured offsets and clamping movement (keeps corrections small and stable).
- Pass the `dims` object into the call site inside `fitPoolRoyaleExternalTableModel` after the external model is scaled/positioned so the rail sight/apron pass has accurate fitted dimensions.
- Change is localized to `webapp/src/pages/Games/PoolRoyale.jsx` and only affects the Showood external-table visual fitting flow.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully (build output contains chunk-size warnings but succeeded).
- Installed Playwright browsers with `npx playwright install chromium`, which completed successfully.
- Attempted an automated mobile screenshot run using Playwright to verify the visual result; the Chromium headless process could not start in the environment due to a missing native library (`libatk-1.0.so.0`), so the screenshot step failed (environment issue, not code compilation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2526320e388329b71b5fa135b14cbf)