### PR TITLE
Domino Royal: add online lobby/runtime socket sync and lobby flow improvements

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -18,7 +18,7 @@ const GAME_ONLINE_POLICY = Object.freeze({
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
   checkersbattleroyal: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
-  'domino-royal': { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
+  'domino-royal': { maxPlayers: [2, 3, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   ludobattleroyal: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   texasholdem: { maxPlayers: [2, 6], allowMatchMeta: ['mode', 'token'] },
   airhockey: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },

--- a/bot/server.js
+++ b/bot/server.js
@@ -440,6 +440,7 @@ const lobbyTables = {};
 const tableMap = new Map();
 const poolStates = new Map();
 const snookerStates = new Map();
+const dominoRoyalStates = new Map();
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
@@ -1328,6 +1329,9 @@ function maybeStartGame(table) {
       if (table.gameType === 'poolroyale') {
         poolStates.set(table.id, { state: null, hud: null, layout: null, ts: Date.now() });
       }
+      if (table.gameType === 'domino-royal') {
+        dominoRoyalStates.set(table.id, { state: null, seq: 0, updatedAt: Date.now() });
+      }
       table.startTimeout = null;
     }, 1000);
   }
@@ -1363,6 +1367,9 @@ function unseatTableSocket(accountId, tableId, socketId) {
       if (table.gameType === 'checkers') {
         checkersRealtimeStore.clearState(tableId);
         checkersMatchSessions.delete(tableId);
+      }
+      if (table.gameType === 'domino-royal') {
+        dominoRoyalStates.delete(tableId);
       }
       tableMap.delete(tableId);
       const key = `${table.gameType}-${table.maxPlayers}`;
@@ -2107,6 +2114,84 @@ io.on('connection', (socket) => {
       }
     }
   );
+
+
+  socket.on('joinGameTable', (payload = {}, cb) => {
+    const { tableId } = payload;
+    const resolvedAccountId = resolveTpcIdentity(payload);
+    if (hasConflictingIdentities(payload)) {
+      return cb && cb({ success: false, error: 'identity_mismatch' });
+    }
+    if (!tableId) {
+      return cb && cb({ success: false, error: 'table_required' });
+    }
+    const table = tableMap.get(tableId);
+    if (!table) {
+      return cb && cb({ success: false, error: 'table_not_found' });
+    }
+    if (!ensureRegistered(socket, resolvedAccountId)) {
+      return cb && cb({ success: false, error: 'register_required' });
+    }
+    const seated = table.players.some((player) => String(player.id) === String(resolvedAccountId));
+    if (!seated) {
+      return cb && cb({ success: false, error: 'seat_required' });
+    }
+    socket.join(tableId);
+    cb && cb({
+      success: true,
+      tableId,
+      gameType: table.gameType,
+      players: table.players,
+      currentTurn: table.currentTurn,
+      stake: table.stake,
+      meta: table.meta,
+      dominoState: table.gameType === 'domino-royal' ? dominoRoyalStates.get(tableId)?.state || null : null,
+      dominoSeq: table.gameType === 'domino-royal' ? dominoRoyalStates.get(tableId)?.seq || 0 : undefined
+    });
+  });
+
+  socket.on('dominoRoyalState', (payload = {}, cb) => {
+    const { tableId, state, action } = payload;
+    const resolvedAccountId = resolveTpcIdentity(payload);
+    if (hasConflictingIdentities(payload)) {
+      return cb && cb({ success: false, error: 'identity_mismatch' });
+    }
+    const table = tableMap.get(tableId);
+    if (!table || table.gameType !== 'domino-royal') {
+      return cb && cb({ success: false, error: 'table_not_found' });
+    }
+    if (!ensureRegistered(socket, resolvedAccountId)) {
+      return cb && cb({ success: false, error: 'register_required' });
+    }
+    const seatIndex = table.players.findIndex((player) => String(player.id) === String(resolvedAccountId));
+    if (seatIndex < 0) {
+      return cb && cb({ success: false, error: 'seat_required' });
+    }
+    const currentSeat = Number(state?.current);
+    const nextTurnPlayer = Number.isInteger(currentSeat) ? table.players[currentSeat] : null;
+    if (action !== 'init' && table.currentTurn && String(table.currentTurn) !== String(resolvedAccountId)) {
+      return cb && cb({ success: false, error: 'not_your_turn' });
+    }
+    if (action === 'init' && seatIndex !== 0) {
+      return cb && cb({ success: false, error: 'host_required' });
+    }
+    const previous = dominoRoyalStates.get(tableId) || { seq: 0 };
+    const seq = Number(previous.seq || 0) + 1;
+    const safeState = state && typeof state === 'object' ? state : null;
+    dominoRoyalStates.set(tableId, { state: safeState, seq, updatedAt: Date.now() });
+    if (nextTurnPlayer) {
+      table.currentTurn = nextTurnPlayer.id;
+    }
+    io.to(tableId).emit('dominoRoyalState', {
+      tableId,
+      state: safeState,
+      seq,
+      action: action || 'sync',
+      accountId: resolvedAccountId,
+      currentTurn: table.currentTurn
+    });
+    cb && cb({ success: true, seq, currentTurn: table.currentTurn });
+  });
 
   socket.on('leaveLobby', (payload = {}) => {
     const { tableId } = payload;

--- a/test/dominoRoyalOnlineFlow.test.js
+++ b/test/dominoRoyalOnlineFlow.test.js
@@ -1,0 +1,148 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+function once(socket, event) {
+  return new Promise((resolve) => socket.once(event, resolve));
+}
+
+function emitAck(socket, event, payload) {
+  return new Promise((resolve) => socket.emit(event, payload, resolve));
+}
+
+test('Domino Royal seats lobby players and syncs table state through runtime sockets', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+  const env = {
+    ...process.env,
+    PORT: '3222',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+  const server = await startServer(env);
+  const lobbyA = io('http://localhost:3222', { auth: { token: apiToken } });
+  const lobbyB = io('http://localhost:3222', { auth: { token: apiToken } });
+
+  try {
+    await Promise.all([once(lobbyA, 'connect'), once(lobbyB, 'connect')]);
+    await Promise.all([
+      emitAck(lobbyA, 'register', { playerId: 'domino-a' }),
+      emitAck(lobbyB, 'register', { playerId: 'domino-b' })
+    ]);
+
+    const firstSeat = await emitAck(lobbyA, 'seatTable', {
+      accountId: 'domino-a',
+      gameType: 'domino-royal',
+      stake: 100,
+      maxPlayers: 2,
+      playerName: 'A',
+      mode: 'online',
+      token: 'TPC',
+      variant: 'single'
+    });
+    const secondSeat = await emitAck(lobbyB, 'seatTable', {
+      accountId: 'domino-b',
+      gameType: 'domino-royal',
+      stake: 100,
+      maxPlayers: 2,
+      playerName: 'B',
+      mode: 'online',
+      token: 'TPC',
+      variant: 'single'
+    });
+
+    assert.equal(firstSeat.success, true);
+    assert.equal(secondSeat.success, true);
+    assert.equal(secondSeat.tableId, firstSeat.tableId);
+
+    lobbyA.emit('confirmReady', { accountId: 'domino-a', tableId: firstSeat.tableId });
+    lobbyB.emit('confirmReady', { accountId: 'domino-b', tableId: firstSeat.tableId });
+    const [startA, startB] = await Promise.all([
+      once(lobbyA, 'gameStart'),
+      once(lobbyB, 'gameStart')
+    ]);
+    assert.equal(startA.tableId, firstSeat.tableId);
+    assert.equal(startB.players.length, 2);
+
+    const runtimeA = io('http://localhost:3222', { auth: { token: apiToken, accountId: 'domino-a' } });
+    const runtimeB = io('http://localhost:3222', { auth: { token: apiToken, accountId: 'domino-b' } });
+    await Promise.all([once(runtimeA, 'connect'), once(runtimeB, 'connect')]);
+    await Promise.all([
+      emitAck(runtimeA, 'register', { playerId: 'domino-a' }),
+      emitAck(runtimeB, 'register', { playerId: 'domino-b' })
+    ]);
+
+    const joinA = await emitAck(runtimeA, 'joinGameTable', {
+      accountId: 'domino-a',
+      tableId: firstSeat.tableId,
+      gameType: 'domino-royal'
+    });
+    const joinB = await emitAck(runtimeB, 'joinGameTable', {
+      accountId: 'domino-b',
+      tableId: firstSeat.tableId,
+      gameType: 'domino-royal'
+    });
+    assert.equal(joinA.success, true);
+    assert.equal(joinB.success, true);
+    assert.equal(joinB.players.length, 2);
+
+    const state = {
+      players: [
+        { id: 0, hand: [{ a: 6, b: 5 }] },
+        { id: 1, hand: [{ a: 1, b: 1 }] }
+      ],
+      boneyard: [],
+      chain: [{ tile: { a: 6, b: 6 }, x: 0, z: 0, rot: 1.5708, double: true }],
+      ends: {
+        L: { v: 6, x: 0, z: 0, dir: [-1, 0], orient: 3.14159 },
+        R: { v: 6, x: 0, z: 0, dir: [1, 0], orient: 0 }
+      },
+      current: 0,
+      gameFinished: false
+    };
+
+    const received = once(runtimeB, 'dominoRoyalState');
+    const syncAck = await emitAck(runtimeA, 'dominoRoyalState', {
+      accountId: 'domino-a',
+      tableId: firstSeat.tableId,
+      action: 'init',
+      state
+    });
+    assert.equal(syncAck.success, true);
+    const message = await received;
+    assert.equal(message.tableId, firstSeat.tableId);
+    assert.equal(message.state.players[0].hand[0].a, 6);
+    assert.equal(message.currentTurn, 'domino-a');
+
+    runtimeA.disconnect();
+    runtimeB.disconnect();
+  } finally {
+    lobbyA.disconnect();
+    lobbyB.disconnect();
+    server.kill();
+  }
+});

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1106,7 +1106,11 @@ function normalizeAvatarSource(src = '') {
 
 const entryMode = (urlParams.get('entry') || '').toLowerCase();
 const gameMode = (urlParams.get('mode') || 'local').toLowerCase();
-const isVsAiMatch = gameMode === 'local';
+const isOnlineMatch = gameMode === 'online';
+const onlineTableId = (urlParams.get('tableId') || '').trim();
+const onlineSocketUrl = (urlParams.get('socketUrl') || '').trim();
+const onlineSocketPath = (urlParams.get('socketPath') || '/socket.io').trim() || '/socket.io';
+const isVsAiMatch = !isOnlineMatch && (gameMode === 'local' || gameMode === 'ai' || gameMode === 'vs-ai');
 const shouldRunHallwayEntry = !USE_MINIMAL_STAGE && entryMode === 'hallway';
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
@@ -9095,6 +9099,205 @@ let cpuMoveTimeout = null;
 let pendingTurnAdvanceTimeout = null;
 const activeHandMeshes = new Set();
 
+let onlineSocket = null;
+let onlinePlayers = [];
+let onlineSeatIndex = 0;
+let onlineStateSeq = 0;
+let applyingOnlineState = false;
+let onlineHostShouldCreateInitialState = false;
+
+function encodeDominoTile(tile) {
+  const clean = canonTile(tile);
+  return clean ? { a: clean.a, b: clean.b } : null;
+}
+
+function serializeDominoState() {
+  return {
+    players: players.map((player) => ({
+      id: player.id,
+      hand: Array.isArray(player.hand) ? player.hand.map(encodeDominoTile).filter(Boolean) : []
+    })),
+    boneyard: boneyard.map(encodeDominoTile).filter(Boolean),
+    chain: chain.map((segment) => ({
+      tile: encodeDominoTile(segment.tile),
+      x: Number(segment.x) || 0,
+      z: Number(segment.z) || 0,
+      rot: Number(segment.rot) || 0,
+      double: !!segment.double
+    })).filter((segment) => segment.tile),
+    ends: ends ? JSON.parse(JSON.stringify(ends)) : null,
+    current,
+    human: onlineSeatIndex,
+    flipDir,
+    gameFinished,
+    winnerIndex,
+    revealAllHands,
+    racePenaltyTotals,
+    raceDisqualifiedPlayers,
+    raceRoundNumber,
+    lastHandWinnerIndex,
+    isPointsRace
+  };
+}
+
+function applyDominoState(state = {}) {
+  if (!state || typeof state !== 'object') return;
+  applyingOnlineState = true;
+  try {
+    clearMarkers();
+    clearExistingDominoMeshes();
+    selectedTile = null;
+    clearSelectedHighlight();
+    players = Array.isArray(state.players)
+      ? state.players.slice(0, N).map((player, idx) => ({
+          id: idx,
+          hand: Array.isArray(player?.hand)
+            ? player.hand.map(encodeDominoTile).filter(Boolean)
+            : []
+        }))
+      : players;
+    while (players.length < N) players.push({ id: players.length, hand: [] });
+    boneyard = Array.isArray(state.boneyard)
+      ? state.boneyard.map(encodeDominoTile).filter(Boolean)
+      : [];
+    chain = Array.isArray(state.chain)
+      ? state.chain.map((segment) => ({
+          tile: encodeDominoTile(segment?.tile),
+          x: Number(segment?.x) || 0,
+          z: Number(segment?.z) || 0,
+          rot: Number(segment?.rot) || 0,
+          double: !!segment?.double,
+          mesh: null
+        })).filter((segment) => segment.tile)
+      : [];
+    ends = state.ends || null;
+    current = Number.isInteger(state.current) ? state.current : current;
+    human = onlineSeatIndex;
+    flipDir = !!state.flipDir;
+    gameFinished = !!state.gameFinished;
+    winnerIndex = Number.isInteger(state.winnerIndex) ? state.winnerIndex : null;
+    revealAllHands = !!state.revealAllHands;
+    racePenaltyTotals = Array.isArray(state.racePenaltyTotals) ? state.racePenaltyTotals : racePenaltyTotals;
+    raceDisqualifiedPlayers = Array.isArray(state.raceDisqualifiedPlayers) ? state.raceDisqualifiedPlayers : raceDisqualifiedPlayers;
+    raceRoundNumber = Number.isFinite(state.raceRoundNumber) ? state.raceRoundNumber : raceRoundNumber;
+    lastHandWinnerIndex = Number.isInteger(state.lastHandWinnerIndex) ? state.lastHandWinnerIndex : lastHandWinnerIndex;
+    usedTileKeys.clear();
+    chain.forEach((segment) => usedTileKeys.add(tileKey(segment.tile)));
+    renderBoneyardStack();
+    renderHands();
+    renderChain();
+    updateInteractivity();
+    if (gameFinished) {
+      if (Number.isInteger(winnerIndex)) showWinnerHighlight(winnerIndex);
+      setStatus(winnerIndex === human ? 'You won!' : winnerIndex !== null ? `Player ${winnerIndex + 1} won!` : 'Game over');
+    }
+  } finally {
+    applyingOnlineState = false;
+  }
+}
+
+function emitDominoOnlineState(action = 'sync') {
+  if (!isOnlineMatch || applyingOnlineState || !onlineSocket || !onlineTableId || !accountId) return;
+  onlineSocket.emit('dominoRoyalState', {
+    tableId: onlineTableId,
+    accountId,
+    action,
+    state: serializeDominoState()
+  }, (res = {}) => {
+    if (!res.success && res.error) {
+      setStatus(`Online sync error: ${res.error}`);
+    }
+  });
+}
+
+function loadSocketIoClient() {
+  if (window.io) return Promise.resolve(window.io);
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector('script[data-domino-socket-io="true"]');
+    if (existing) {
+      existing.addEventListener('load', () => resolve(window.io), { once: true });
+      existing.addEventListener('error', reject, { once: true });
+      return;
+    }
+    const script = document.createElement('script');
+    const socketClientBase = onlineSocketUrl ? onlineSocketUrl.replace(/\/$/, '') : '';
+    script.src = `${socketClientBase}${onlineSocketPath.replace(/\/$/, '')}/socket.io.js`;
+    script.async = true;
+    script.dataset.dominoSocketIo = 'true';
+    script.onload = () => resolve(window.io);
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}
+
+function connectDominoOnlineRuntime() {
+  if (!isOnlineMatch) return Promise.resolve({ online: false });
+  if (!onlineTableId || !accountId) {
+    setStatus('Missing online table. Return to lobby.');
+    return Promise.resolve({ online: true, success: false });
+  }
+  setStatus('Connecting online table…');
+  return loadSocketIoClient().then((ioFactory) => new Promise((resolve) => {
+    if (!ioFactory) {
+      setStatus('Socket client unavailable. Return to lobby.');
+      resolve({ online: true, success: false });
+      return;
+    }
+    onlineSocket = ioFactory(onlineSocketUrl || window.location.origin, {
+      path: onlineSocketPath,
+      transports: ['websocket', 'polling'],
+      auth: { accountId },
+      reconnectionAttempts: 8,
+      reconnectionDelay: 500,
+      timeout: 20000
+    });
+    const timeout = window.setTimeout(() => {
+      setStatus('Online table connection timed out.');
+      resolve({ online: true, success: false });
+    }, 12000);
+    const join = () => {
+      onlineSocket.emit('register', { playerId: accountId });
+      onlineSocket.emit('joinGameTable', {
+        accountId,
+        tableId: onlineTableId,
+        gameType: 'domino-royal'
+      }, (res = {}) => {
+        window.clearTimeout(timeout);
+        if (!res.success) {
+          setStatus(`Could not join table${res.error ? `: ${res.error}` : ''}.`);
+          resolve({ online: true, success: false });
+          return;
+        }
+        onlinePlayers = Array.isArray(res.players) ? res.players : [];
+        const found = onlinePlayers.findIndex((player) => String(player?.id || '') === String(accountId));
+        onlineSeatIndex = found >= 0 ? found : 0;
+        human = onlineSeatIndex;
+        N = Math.max(2, Math.min(4, onlinePlayers.length || N));
+        onlineHostShouldCreateInitialState = onlineSeatIndex === 0 && !res.dominoState;
+        if (res.dominoState) {
+          onlineStateSeq = Number(res.dominoSeq) || 0;
+          applyDominoState(res.dominoState);
+        }
+        onlineSocket.on('dominoRoyalState', (message = {}) => {
+          if (message.tableId !== onlineTableId) return;
+          const seq = Number(message.seq) || 0;
+          if (seq && seq <= onlineStateSeq) return;
+          onlineStateSeq = seq || onlineStateSeq;
+          if (message.state) applyDominoState(message.state);
+        });
+        setStatus(onlineHostShouldCreateInitialState ? 'Creating online hand…' : 'Online table synced.');
+        resolve({ online: true, success: true, hasState: !!res.dominoState, host: onlineHostShouldCreateInitialState });
+      });
+    };
+    onlineSocket.on('connect', join);
+    onlineSocket.on('connect_error', () => setStatus('Reconnecting online table…'));
+  })).catch((error) => {
+    console.warn('Domino online connection failed', error);
+    setStatus('Online connection failed. Return to lobby.');
+    return { online: true, success: false };
+  });
+}
+
 function tileKey(tile) {
   const ct = canonTile(tile);
   return ct ? `${ct.a}|${ct.b}` : '';
@@ -10105,6 +10308,10 @@ function startGame({ resetRace = true } = {}) {
   renderChain();
   current = (starter - 1 + N) % N;
   updateInteractivity();
+  if (isOnlineMatch) {
+    emitDominoOnlineState('init');
+    return;
+  }
   if (current !== human) {
     scheduleCpuPlay();
   }
@@ -10794,6 +11001,7 @@ if (btnDraw) {
   renderHands();
   if (drewTile) {
     SFX.drawTile();
+    emitDominoOnlineState('draw');
   }
   });
 }
@@ -10811,7 +11019,18 @@ if (btnPass) {
 async function bootstrapDominoRoyal() {
   try {
     await loadHumanProfileFromApi();
-    startGame();
+    const onlineJoin = await connectDominoOnlineRuntime();
+    if (onlineJoin.online && !onlineJoin.success) {
+      setControlEnabled(false);
+      return;
+    }
+    if (!onlineJoin.online || onlineJoin.host) {
+      startGame();
+    } else if (onlineJoin.hasState) {
+      updateInteractivity();
+    } else {
+      setStatus('Waiting for host to create the online hand…');
+    }
     setControlEnabled(true);
   } catch (error) {
     console.error('Domino Royal failed to start', error);
@@ -10934,6 +11153,7 @@ function finishGame({ winner = null, reason = '', revealAll = false } = {}) {
     SFX.drawGame();
   }
   showWinnerOverlay({ winner: winnerIndex, reason });
+  emitDominoOnlineState('finish');
 }
 
 
@@ -11032,10 +11252,13 @@ function nextTurn() {
     return;
   }
   updateInteractivity();
+  if (isOnlineMatch) {
+    emitDominoOnlineState('turn');
+  }
   if (gameFinished) {
     return;
   }
-  if (current !== human) {
+  if (!isOnlineMatch && current !== human) {
     scheduleCpuPlay();
   }
 }
@@ -11827,6 +12050,9 @@ function detachRuntimeListeners() {
 }
 
 function shutdownDominoRoyal(reason = 'unknown') {
+  try {
+    onlineSocket?.disconnect?.();
+  } catch {}
   if (isGameShuttingDown) return;
   isGameShuttingDown = true;
   try {

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -16,7 +16,7 @@ import { loadAvatar } from '../../utils/avatarUtils.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
-import { socket } from '../../utils/socket.js';
+import { refreshSocketAuthIdentity, socket } from '../../utils/socket.js';
 import { getOnlineReadiness } from '../../config/onlineContract.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
@@ -64,6 +64,8 @@ export default function DominoRoyalLobby() {
   const [flagsManuallySelected, setFlagsManuallySelected] = useState(false);
   const [dominoPlayerFlag, setDominoPlayerFlag] = useState(null);
   const [dominoAiFlag, setDominoAiFlag] = useState(null);
+  const [matching, setMatching] = useState(false);
+  const [matchError, setMatchError] = useState('');
   const startBet = stake.amount / 100;
   const readiness = getOnlineReadiness('domino-royal');
 
@@ -171,9 +173,33 @@ export default function DominoRoyalLobby() {
     if (DEV_ACCOUNT) params.set('dev', DEV_ACCOUNT);
     if (DEV_ACCOUNT_1) params.set('dev1', DEV_ACCOUNT_1);
     if (DEV_ACCOUNT_2) params.set('dev2', DEV_ACCOUNT_2);
+    if (mode === 'online') {
+      const socketUri = socket?.io?.uri || '';
+      const socketPath = socket?.io?.opts?.path || '';
+      if (socketUri) params.set('socketUrl', socketUri);
+      if (socketPath) params.set('socketPath', socketPath);
+    }
     if (frameRateId) params.set('frameRateId', frameRateId);
     navigate(`/games/domino-royal?${params.toString()}`);
   };
+
+  const waitForSocketConnection = () =>
+    new Promise((resolve) => {
+      if (socket.connected) {
+        resolve(true);
+        return;
+      }
+      const timeout = window.setTimeout(() => {
+        socket.off('connect', handleConnect);
+        resolve(false);
+      }, 8000);
+      function handleConnect() {
+        window.clearTimeout(timeout);
+        resolve(true);
+      }
+      socket.once('connect', handleConnect);
+      socket.connect();
+    });
 
   const startGame = async (flagOverride = flags) => {
     let tgId;
@@ -195,6 +221,18 @@ export default function DominoRoyalLobby() {
     } catch {}
 
     if (mode === 'online' && accountId) {
+      setMatchError('');
+      setMatching(true);
+      refreshSocketAuthIdentity({ accountId }, { reconnect: false });
+      const connected = await waitForSocketConnection();
+      if (!connected) {
+        setMatching(false);
+        setMatchError('Unable to connect to the online lobby. Your stake was refunded.');
+        try {
+          await addTransaction(tgId, stake.amount, 'refund', { game: 'domino', accountId });
+        } catch {}
+        return;
+      }
       socket.emit('register', { playerId: accountId });
       socket.emit(
         'seatTable',
@@ -207,14 +245,25 @@ export default function DominoRoyalLobby() {
           avatar,
           mode: 'online',
           token: stake.token,
+          variant: gameType,
+          matchMeta: {
+            variant: gameType,
+            mode: 'online',
+            token: stake.token
+          },
           game: gameType,
           points: gameType === 'points' ? Number(targetPoints) : 0
         },
         (res = {}) => {
           if (!res.success || !res.tableId) {
-            alert('Unable to join Domino online table. Please try again.');
+            setMatching(false);
+            setMatchError(`Unable to join Domino online table${res.error ? ` (${res.error})` : ''}. Your stake was refunded.`);
+            try {
+              addTransaction(tgId, stake.amount, 'refund', { game: 'domino', accountId });
+            } catch {}
             return;
           }
+          setMatchError('');
           socket.emit('confirmReady', { accountId, tableId: res.tableId });
         }
       );
@@ -235,6 +284,7 @@ export default function DominoRoyalLobby() {
     if (mode !== 'online') return undefined;
 
     const handleGameStart = ({ tableId, players, stake: onlineStake }) => {
+      setMatching(false);
       const accountId = ensureAccountId().catch(() => '');
       Promise.resolve(accountId).then((resolvedAccountId) => {
         const seat = Array.isArray(players)
@@ -551,12 +601,20 @@ export default function DominoRoyalLobby() {
           </div>
         </div>
 
+        {mode === 'online' && (matching || matchError) && (
+          <div className="rounded-2xl border border-cyan-300/20 bg-cyan-500/10 p-3 text-sm text-cyan-50">
+            {matching
+              ? 'Matching Domino Royal table… keep this screen open until all players connect.'
+              : matchError}
+          </div>
+        )}
+
         <button
           onClick={startGame}
-          disabled={mode === 'local' && flags.length !== flagPickerCount}
+          disabled={matching || (mode === 'local' && flags.length !== flagPickerCount)}
           className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
         >
-          START
+          {matching ? 'MATCHING…' : 'START'}
         </button>
 
         <FlagPickerModal


### PR DESCRIPTION
### Motivation

- Bring Domino Royal online: ensure players who join from the lobby can rejoin the same runtime table and keep game state synchronized across clients.  
- Fix gaps in the lobby → runtime contract so the Domino runtime can accept a `tableId`/`accountId` and resume authoritative state without changing local vs-AI behavior.  

### Description

- Added backend runtime state and socket handlers: introduced a per-table `dominoRoyalStates` store and two socket handlers `joinGameTable` and `dominoRoyalState` that validate seat membership, enforce `init`/turn/host rules, persist a sequence number and broadcast `dominoRoyalState` to the table room.  
- Extended lobby matchmaking/payloads: allowed 2/3/4 player `domino-royal` matchmaking in the online policy and pass `matchMeta`/socket info when navigating into the runtime so the client can connect to the correct socket.  
- Improved lobby UX/network robustness: lobby now attempts to (re)connect/register the socket before calling `seatTable`, displays matching/progress/errors in the UI, refunds stake on connection/join failures, and disables the Start button while matching.  
- Added client runtime sync: the Domino runtime now optionally connects to Socket.IO when `mode=online` and `tableId` is present, can `joinGameTable`, apply serialized game state from host, ignore out-of-order updates using a sequence number, and emit `dominoRoyalState` for `init/draw/turn/finish` actions so all runtime clients remain synced (serialization + apply logic included).  
- Tests and small infra: added an integration test `test/dominoRoyalOnlineFlow.test.js` that verifies lobby seating → `gameStart` → runtime `joinGameTable` → `dominoRoyalState` broadcast and updated server-side game policy code.  

### Testing

- Ran `node --check webapp/public/domino-royal-game.js` and `node --check bot/server.js` with no syntax errors.  
- Linted the modified lobby component with `npm --prefix webapp run lint -- src/pages/Games/DominoRoyalLobby.jsx` with no errors.  
- Executed Jest suites: `test/onlineGamePolicy.test.js` and the new `test/dominoRoyalOnlineFlow.test.js`, both passed.  
- Performed a production build `npm --prefix webapp run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252b691fbc8329b68d3f0113427dd7)