### PR TITLE
Enable Domino Royal online lobby + authoritative table sync

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -18,7 +18,7 @@ const GAME_ONLINE_POLICY = Object.freeze({
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
   checkersbattleroyal: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
-  'domino-royal': { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
+  'domino-royal': { maxPlayers: [2, 3, 4], allowMatchMeta: ['variant', 'mode', 'token', 'game', 'points'] },
   ludobattleroyal: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   texasholdem: { maxPlayers: [2, 6], allowMatchMeta: ['mode', 'token'] },
   airhockey: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },

--- a/bot/server.js
+++ b/bot/server.js
@@ -440,13 +440,14 @@ const lobbyTables = {};
 const tableMap = new Map();
 const poolStates = new Map();
 const snookerStates = new Map();
+const dominoStates = new Map();
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
 
-const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token'];
+const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token', 'game', 'points'];
 
 function normalizeTableSizeMeta(value = '') {
   const normalized = String(value || '').trim().toLowerCase();
@@ -1328,6 +1329,9 @@ function maybeStartGame(table) {
       if (table.gameType === 'poolroyale') {
         poolStates.set(table.id, { state: null, hud: null, layout: null, ts: Date.now() });
       }
+      if (table.gameType === 'domino-royal') {
+        dominoStates.set(table.id, { state: null, seq: 0, ts: Date.now() });
+      }
       table.startTimeout = null;
     }, 1000);
   }
@@ -1363,6 +1367,9 @@ function unseatTableSocket(accountId, tableId, socketId) {
       if (table.gameType === 'checkers') {
         checkersRealtimeStore.clearState(tableId);
         checkersMatchSessions.delete(tableId);
+      }
+      if (table.gameType === 'domino-royal') {
+        dominoStates.delete(tableId);
       }
       tableMap.delete(tableId);
       const key = `${table.gameType}-${table.maxPlayers}`;
@@ -2009,7 +2016,9 @@ io.on('connection', (socket) => {
         playType,
         tableSize,
         ballSet,
-        token
+        token,
+        game,
+        points
       } = payload;
       const resolvedVariant = payloadMatchMeta.variant ?? variant;
       const resolvedMode = payloadMatchMeta.mode ?? mode;
@@ -2017,6 +2026,8 @@ io.on('connection', (socket) => {
       const resolvedTableSize = payloadMatchMeta.tableSize ?? tableSize;
       const resolvedBallSet = payloadMatchMeta.ballSet ?? ballSet;
       const resolvedToken = payloadMatchMeta.token ?? token;
+      const resolvedGame = payloadMatchMeta.game ?? game;
+      const resolvedPoints = payloadMatchMeta.points ?? points;
       const resolvedPreferredSide =
         payloadMatchMeta.preferredSide ?? preferredSide;
       const resolvedAccountId = resolveTpcIdentity(payload);
@@ -2050,6 +2061,8 @@ io.on('connection', (socket) => {
           tableSize: resolvedTableSize,
           ballSet: resolvedBallSet,
           token: resolvedToken,
+          game: resolvedGame,
+          points: resolvedPoints,
           preferredSide: resolvedPreferredSide
         }
       });
@@ -2063,7 +2076,9 @@ io.on('connection', (socket) => {
         playType: validation.safeMatchMeta.playType,
         tableSize: validation.safeMatchMeta.tableSize,
         ballSet: validation.safeMatchMeta.ballSet,
-        token: validation.safeMatchMeta.token
+        token: validation.safeMatchMeta.token,
+        game: validation.safeMatchMeta.game,
+        points: validation.safeMatchMeta.points
       };
 
       let table;
@@ -2232,6 +2247,75 @@ io.on('connection', (socket) => {
     if (!tableId) return;
     const state = getChessState(tableId);
     socket.emit('chessState', { tableId, ...state });
+  });
+
+
+  socket.on('joinDominoRoom', async ({ tableId, accountId } = {}) => {
+    if (!tableId) return;
+    if (accountId && !ensureRegistered(socket, accountId)) return;
+    socket.join(tableId);
+    if (accountId) {
+      await registerConnection({
+        userId: String(accountId),
+        roomId: tableId,
+        socketId: socket.id
+      });
+    }
+    const cached = dominoStates.get(tableId);
+    if (cached?.state) {
+      socket.emit('dominoState', {
+        tableId,
+        state: cached.state,
+        seq: cached.seq || 0,
+        updatedAt: cached.ts
+      });
+    }
+  });
+
+  socket.on('dominoSyncRequest', ({ tableId } = {}) => {
+    if (!tableId) return;
+    const cached = dominoStates.get(tableId);
+    if (cached?.state) {
+      socket.emit('dominoState', {
+        tableId,
+        state: cached.state,
+        seq: cached.seq || 0,
+        updatedAt: cached.ts
+      });
+    }
+  });
+
+  socket.on('dominoState', ({ tableId, state, seq } = {}, cb) => {
+    if (!tableId || !state || typeof state !== 'object') {
+      cb && cb({ success: false, error: 'invalid_payload' });
+      return;
+    }
+    const playerId = String(socket.data?.playerId || '');
+    if (!playerId) {
+      cb && cb({ success: false, error: 'register_required' });
+      return;
+    }
+    const table = tableMap.get(tableId);
+    if (table && !table.players.some((player) => String(player.id) === playerId)) {
+      cb && cb({ success: false, error: 'seat_required' });
+      return;
+    }
+    const cached = dominoStates.get(tableId) || { seq: 0 };
+    const nextSeq = Number.isFinite(Number(seq)) ? Number(seq) : (Number(cached.seq) || 0) + 1;
+    if (Number(cached.seq) && nextSeq <= Number(cached.seq)) {
+      cb && cb({ success: false, error: 'stale_state', seq: cached.seq });
+      return;
+    }
+    const payload = {
+      tableId,
+      state,
+      seq: nextSeq,
+      updatedAt: Date.now(),
+      playerId
+    };
+    dominoStates.set(tableId, { state, seq: nextSeq, ts: payload.updatedAt });
+    socket.to(tableId).emit('dominoState', payload);
+    cb && cb({ success: true, seq: nextSeq });
   });
 
   socket.on('joinPoolTable', async ({ tableId, accountId }) => {

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -68,6 +68,27 @@ describe('online game policy', () => {
     expect(normalizeOnlineGameType('poolroyale')).toBe('poolroyale');
   });
 
+
+  test('accepts Domino Royal online tables for 2, 3, and 4 players with rule metadata', () => {
+    for (const maxPlayers of [2, 3, 4]) {
+      const result = validateSeatTableRequest({
+        gameType: 'domino-royal',
+        stake: 100,
+        maxPlayers,
+        matchMeta: { mode: 'online', token: 'TPC', game: 'points', points: '101' }
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.normalizedMaxPlayers).toBe(maxPlayers);
+      expect(result.safeMatchMeta).toEqual({
+        mode: 'online',
+        token: 'TPC',
+        game: 'points',
+        points: '101'
+      });
+    }
+  });
+
   test('buildReadinessSnapshot returns all policy games with security checks', () => {
     const snapshot = buildReadinessSnapshot();
     expect(Object.keys(snapshot).sort()).toEqual(Object.keys(GAME_ONLINE_POLICY).sort());

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1106,11 +1106,14 @@ function normalizeAvatarSource(src = '') {
 
 const entryMode = (urlParams.get('entry') || '').toLowerCase();
 const gameMode = (urlParams.get('mode') || 'local').toLowerCase();
+const isOnlineMatch = gameMode === 'online';
 const isVsAiMatch = gameMode === 'local';
 const shouldRunHallwayEntry = !USE_MINIMAL_STAGE && entryMode === 'hallway';
 const shouldShowSeatLabel = shouldRunHallwayEntry;
 
 const accountId = (urlParams.get('accountId') || '').trim();
+const onlineTableId = (urlParams.get('tableId') || '').trim();
+const DOMINO_ONLINE_SESSION_PREFIX = 'dominoRoyalOnlineSession:';
 const telegramId = (
   urlParams.get('tgId') ||
   urlParams.get('telegramId') ||
@@ -1203,6 +1206,9 @@ function pickFlagForSeat(index = 0) {
 }
 
 function getSeatUsernames(count = N) {
+  if (isOnlineMatch && onlinePlayers.length) {
+    return Array.from({ length: Math.max(1, count) }, (_, idx) => onlinePlayers[idx]?.name || DEFAULT_SEAT_NAMES[idx] || `Player ${idx + 1}`);
+  }
   const avatars = buildSeatAvatarSources(count);
   return avatars.map((avatar, idx) => {
     if (idx === HUMAN_SEAT_INDEX && seatAvatarUsername) {
@@ -6171,6 +6177,9 @@ function isAvatarUrl(str = '') {
 
 function buildSeatAvatarSources(count = N) {
   const total = Math.max(1, count);
+  if (isOnlineMatch && onlinePlayers.length) {
+    return Array.from({ length: total }, (_, idx) => onlinePlayers[idx]?.avatar || pickFlagForSeat(idx));
+  }
   return Array.from({ length: total }, (_, idx) => {
     if (idx === HUMAN_SEAT_INDEX) {
       const preferred =
@@ -9095,6 +9104,211 @@ let cpuMoveTimeout = null;
 let pendingTurnAdvanceTimeout = null;
 const activeHandMeshes = new Set();
 
+let onlineSocket = null;
+let onlineStateSeq = 0;
+let onlineReady = !isOnlineMatch;
+let onlinePlayers = [];
+let onlineBootstrapStarted = false;
+let applyingOnlineState = false;
+
+function readOnlineSession() {
+  if (!isOnlineMatch || !onlineTableId) return null;
+  try {
+    const raw = window.sessionStorage?.getItem(`${DOMINO_ONLINE_SESSION_PREFIX}${onlineTableId}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (error) {
+    console.warn('Unable to read Domino online lobby session', error);
+    return null;
+  }
+}
+
+function normalizeOnlinePlayers() {
+  const session = readOnlineSession();
+  const sessionPlayers = Array.isArray(session?.players) ? session.players : [];
+  onlinePlayers = sessionPlayers
+    .slice(0, N)
+    .map((player, index) => ({
+      id: String(player?.id || player?.accountId || `seat-${index}`),
+      name: String(player?.name || player?.username || `Player ${index + 1}`),
+      avatar: normalizeAvatarSource(String(player?.avatar || ''))
+    }));
+  if (onlinePlayers.length) {
+    N = Math.max(2, Math.min(4, onlinePlayers.length));
+  }
+  const seatIndex = onlinePlayers.findIndex((player) => String(player.id) === String(accountId));
+  human = seatIndex >= 0 ? seatIndex : 0;
+}
+
+function isOnlineHost() {
+  if (!isOnlineMatch) return false;
+  if (!onlinePlayers.length) return true;
+  return String(onlinePlayers[0]?.id || '') === String(accountId || onlinePlayers[0]?.id || '');
+}
+
+function stripTile(tile) {
+  const canon = canonTile(tile);
+  return canon ? { a: canon.a, b: canon.b } : null;
+}
+
+function serializeOnlineState(reason = 'sync') {
+  return {
+    version: 1,
+    reason,
+    seq: onlineStateSeq,
+    N,
+    humanSeat: human,
+    current,
+    flipDir,
+    gameFinished,
+    winnerIndex,
+    revealAllHands,
+    statusPrefix,
+    ends: ends ? JSON.parse(JSON.stringify(ends)) : null,
+    chain: chain.map((segment) => ({
+      tile: stripTile(segment.tile),
+      x: segment.x,
+      z: segment.z,
+      rot: segment.rot,
+      double: !!segment.double,
+      endSide: segment.endSide || null
+    })),
+    boneyard: boneyard.map(stripTile).filter(Boolean),
+    players: players.map((player, index) => ({
+      id: onlinePlayers[index]?.id || player.id || index,
+      name: onlinePlayers[index]?.name || `Player ${index + 1}`,
+      avatar: onlinePlayers[index]?.avatar || '',
+      hand: (player.hand || []).map(stripTile).filter(Boolean)
+    })),
+    racePenaltyTotals,
+    raceDisqualifiedPlayers,
+    raceRoundNumber,
+    lastHandWinnerIndex,
+    updatedAt: Date.now()
+  };
+}
+
+function applyOnlineStateSnapshot(state = {}) {
+  if (!state || typeof state !== 'object') return;
+  applyingOnlineState = true;
+  try {
+    clearMarkers();
+    clearExistingDominoMeshes();
+    selectedTile = null;
+    clearSelectedHighlight();
+    if (cpuMoveTimeout) {
+      clearTimeout(cpuMoveTimeout);
+      cpuMoveTimeout = null;
+    }
+    if (pendingTurnAdvanceTimeout) {
+      clearTimeout(pendingTurnAdvanceTimeout);
+      pendingTurnAdvanceTimeout = null;
+    }
+    N = Math.max(2, Math.min(4, Number(state.N) || N));
+    current = Math.max(0, Math.min(N - 1, Number(state.current) || 0));
+    flipDir = !!state.flipDir;
+    gameFinished = !!state.gameFinished;
+    winnerIndex = Number.isInteger(state.winnerIndex) ? state.winnerIndex : null;
+    revealAllHands = !!state.revealAllHands;
+    ends = state.ends ? JSON.parse(JSON.stringify(state.ends)) : null;
+    chain = Array.isArray(state.chain)
+      ? state.chain.map((segment) => ({
+          tile: stripTile(segment.tile),
+          x: Number(segment.x) || 0,
+          z: Number(segment.z) || 0,
+          rot: Number(segment.rot) || 0,
+          double: !!segment.double,
+          endSide: segment.endSide || null
+        })).filter((segment) => segment.tile)
+      : [];
+    boneyard = Array.isArray(state.boneyard) ? state.boneyard.map(stripTile).filter(Boolean) : [];
+    players = Array.isArray(state.players)
+      ? state.players.slice(0, N).map((player, index) => ({
+          id: player?.id || onlinePlayers[index]?.id || index,
+          hand: Array.isArray(player?.hand) ? player.hand.map(stripTile).filter(Boolean) : []
+        }))
+      : players;
+    while (players.length < N) players.push({ id: players.length, hand: [] });
+    onlinePlayers = players.map((player, index) => ({
+      id: String(player.id || onlinePlayers[index]?.id || `seat-${index}`),
+      name: state.players?.[index]?.name || onlinePlayers[index]?.name || `Player ${index + 1}`,
+      avatar: normalizeAvatarSource(state.players?.[index]?.avatar || onlinePlayers[index]?.avatar || '')
+    }));
+    racePenaltyTotals = Array.isArray(state.racePenaltyTotals) ? state.racePenaltyTotals : racePenaltyTotals;
+    raceDisqualifiedPlayers = Array.isArray(state.raceDisqualifiedPlayers) ? state.raceDisqualifiedPlayers : raceDisqualifiedPlayers;
+    raceRoundNumber = Number(state.raceRoundNumber) || raceRoundNumber;
+    lastHandWinnerIndex = Number.isInteger(state.lastHandWinnerIndex) ? state.lastHandWinnerIndex : lastHandWinnerIndex;
+    usedTileKeys.clear();
+    chain.forEach((segment) => {
+      const key = tileKey(segment.tile);
+      if (key) usedTileKeys.add(key);
+    });
+    renderBoneyardStack();
+    renderHands();
+    renderChain();
+    refreshSeatAvatars();
+    refreshAllDominoCharacterRacks();
+    if (gameFinished && winnerIndex !== null) showWinnerHighlight(winnerIndex);
+    updateInteractivity();
+  } finally {
+    applyingOnlineState = false;
+  }
+}
+
+function emitOnlineState(reason = 'sync') {
+  if (!isOnlineMatch || !onlineSocket || !onlineTableId || applyingOnlineState) return;
+  onlineStateSeq += 1;
+  const state = serializeOnlineState(reason);
+  onlineSocket.emit('dominoState', { tableId: onlineTableId, state, seq: onlineStateSeq }, (response = {}) => {
+    if (response?.seq && Number(response.seq) > onlineStateSeq) {
+      onlineStateSeq = Number(response.seq);
+    }
+  });
+}
+
+async function connectOnlineDominoSocket() {
+  if (!isOnlineMatch) return null;
+  normalizeOnlinePlayers();
+  if (!onlineTableId || !accountId) {
+    revealStatus('Online table is missing. Return to lobby and join again.');
+    return null;
+  }
+  if (onlineSocket) return onlineSocket;
+  const { io } = await import('/socket.io/socket.io.esm.min.js');
+  onlineSocket = io(window.location.origin, {
+    transports: ['websocket', 'polling'],
+    auth: { accountId },
+    reconnectionAttempts: 8,
+    reconnectionDelay: 500,
+    timeout: 20000
+  });
+  onlineSocket.on('connect', () => {
+    onlineSocket.emit('register', { playerId: accountId });
+    onlineSocket.emit('joinDominoRoom', { tableId: onlineTableId, accountId });
+    onlineSocket.emit('dominoSyncRequest', { tableId: onlineTableId });
+    if (!onlineBootstrapStarted && isOnlineHost()) {
+      onlineBootstrapStarted = true;
+      startGame();
+      emitOnlineState('initial');
+    }
+  });
+  onlineSocket.on('dominoState', ({ tableId, state, seq } = {}) => {
+    if (String(tableId || '') !== String(onlineTableId)) return;
+    const incomingSeq = Number(seq || state?.seq || 0);
+    if (incomingSeq && incomingSeq <= onlineStateSeq) return;
+    onlineStateSeq = incomingSeq || onlineStateSeq + 1;
+    onlineReady = true;
+    applyOnlineStateSnapshot(state);
+  });
+  onlineSocket.on('connect_error', (error) => {
+    console.warn('Domino online socket connection failed', error);
+    revealStatus('Connecting to Domino online table…');
+  });
+  return onlineSocket;
+}
+
+
 function tileKey(tile) {
   const ct = canonTile(tile);
   return ct ? `${ct.a}|${ct.b}` : '';
@@ -10105,6 +10319,10 @@ function startGame({ resetRace = true } = {}) {
   renderChain();
   current = (starter - 1 + N) % N;
   updateInteractivity();
+  if (isOnlineMatch) {
+    emitOnlineState('start');
+    return;
+  }
   if (current !== human) {
     scheduleCpuPlay();
   }
@@ -10664,6 +10882,7 @@ renderer.domElement.addEventListener('pointerdown', (ev) => {
     selectedTile = null;
     clearMarkers();
     renderHands();
+    emitOnlineState('place');
     scheduleTurnAdvanceAfterPlacement(playedPlacement?.segment);
     return;
   }
@@ -10794,6 +11013,7 @@ if (btnDraw) {
   renderHands();
   if (drewTile) {
     SFX.drawTile();
+    emitOnlineState('draw');
   }
   });
 }
@@ -10803,6 +11023,7 @@ if (btnPass) {
     clearMarkers();
     selectedTile = null;
     SFX.pass();
+    emitOnlineState('pass');
     schedulePassTurnAdvance(human);
   }
   });
@@ -10811,6 +11032,13 @@ if (btnPass) {
 async function bootstrapDominoRoyal() {
   try {
     await loadHumanProfileFromApi();
+    if (isOnlineMatch) {
+      setControlEnabled(false);
+      revealStatus('Connecting to Domino online table…');
+      await connectOnlineDominoSocket();
+      setControlEnabled(true);
+      return;
+    }
     startGame();
     setControlEnabled(true);
   } catch (error) {
@@ -11007,7 +11235,8 @@ function updateInteractivity() {
     renderChain();
     return;
   }
-  setStatus(`Turn: Player ${current + 1}`);
+  const turnName = getSeatUsernames(N)[current] || `Player ${current + 1}`;
+  setStatus(isOnlineMatch ? `Online turn: ${turnName}` : `Turn: Player ${current + 1}`);
   clearAllPassBubbles();
   renderHands();
   renderChain();
@@ -11033,6 +11262,10 @@ function nextTurn() {
   }
   updateInteractivity();
   if (gameFinished) {
+    return;
+  }
+  if (isOnlineMatch) {
+    emitOnlineState('turn');
     return;
   }
   if (current !== human) {
@@ -11837,6 +12070,13 @@ function shutdownDominoRoyal(reason = 'unknown') {
     selfVideoObserver?.disconnect?.();
     selfVideoObserver = null;
     anchoredSelfVideoElement = null;
+    if (onlineSocket) {
+      try {
+        onlineSocket.emit('leaveLobby', { tableId: onlineTableId, accountId });
+        onlineSocket.disconnect();
+      } catch {}
+      onlineSocket = null;
+    }
     controls.enabled = false;
     scene.visible = false;
     if (seatOverlay?.parentNode) {

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -27,6 +27,7 @@ const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 const DOMINO_PLAYER_FLAG_KEY = 'dominoRoyalPlayerFlag';
 const DOMINO_AI_FLAG_KEY = 'dominoRoyalAiFlag';
+const DOMINO_ONLINE_SESSION_PREFIX = 'dominoRoyalOnlineSession:';
 
 const PLAYER_OPTIONS = [2, 3, 4];
 const HUMAN_ICON_FALLBACK = '🧑‍🤝‍🧑';
@@ -208,7 +209,13 @@ export default function DominoRoyalLobby() {
           mode: 'online',
           token: stake.token,
           game: gameType,
-          points: gameType === 'points' ? Number(targetPoints) : 0
+          points: gameType === 'points' ? Number(targetPoints) : 0,
+          matchMeta: {
+            mode: 'online',
+            token: stake.token,
+            game: gameType,
+            points: gameType === 'points' ? String(targetPoints) : '0'
+          }
         },
         (res = {}) => {
           if (!res.success || !res.tableId) {
@@ -245,6 +252,25 @@ export default function DominoRoyalLobby() {
           : null;
         const token = stake.token || onlineStake?.token || 'TPC';
         const amount = Number(onlineStake?.amount || stake.amount || 0);
+        try {
+          window.sessionStorage?.setItem(
+            `${DOMINO_ONLINE_SESSION_PREFIX}${tableId}`,
+            JSON.stringify({
+              tableId,
+              players: Array.isArray(players) ? players : [],
+              currentTurn: players?.[0]?.id || '',
+              stake: onlineStake || null,
+              meta: {
+                mode: 'online',
+                token,
+                game: gameType,
+                points: gameType === 'points' ? String(targetPoints) : '0'
+              },
+              accountId: resolvedAccountId,
+              savedAt: Date.now()
+            })
+          );
+        } catch {}
         launchGame({
           accountId: resolvedAccountId,
           tgId: getTelegramId(),


### PR DESCRIPTION
### Motivation
- Allow Domino Royal to run as a proper online game mode (2/3/4 players) with matchmaking partitioned by game variant (single vs points) so lobby pairing doesn't mix different rule sets.
- Provide authoritative, seated-player-only state sync for Domino matches so connected clients can join/reconnect to the same table and keep game simulation consistent.

### Description
- Extend `GAME_ONLINE_POLICY` to support `domino-royal` for 2/3/4 players and accept `game`/`points` metadata for rule partitioning. (`bot/config/onlineGamePolicy.js`)
- Add an in-memory `dominoStates` store and socket handlers on the backend for `joinDominoRoom`, `dominoSyncRequest`, and `dominoState` with seat validation and monotonic sequence checks to relay authoritative table state to seated clients. (`bot/server.js`)
- Ensure `seatTable` accepts and validates `matchMeta.game` and `matchMeta.points` so Domino lobby requests include rule metadata during matchmaking. (`bot/server.js`)
- Persist the matched lobby session in `sessionStorage` in the lobby UI and include `matchMeta` when calling `seatTable`, so the arena client can hydrate online sessions after joining. (`webapp/src/pages/Games/DominoRoyalLobby.jsx`)
- Wire the Domino arena runtime to support online mode: read saved lobby session, open a socket (`joinDominoRoom`/`dominoSyncRequest`), hydrate cached state, and emit `dominoState` for `start`, `place`, `draw`, `pass`, and `turn` actions while preserving the existing local vs-AI flow. (`webapp/public/domino-royal-game.js`)
- Add a test case verifying Domino policy accepts 2/3/4 player online table requests with `game`/`points` metadata. (`test/onlineGamePolicy.test.js`)

### Testing
- Ran `node --check bot/server.js` and `node --check webapp/public/domino-royal-game.js` with no syntax errors reported. (passed)
- Ran `npm test -- --runInBand test/onlineGamePolicy.test.js` which executed the updated policy tests; the suite passed (6 tests, 1 suite). (passed)
- Built the client with `npm --prefix webapp run build`; Vite completed and production assets were generated. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252b691fbc8329b68d3f0113427dd7)