### PR TITLE
Fix Domino Royal online socket sync

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -18,7 +18,7 @@ const GAME_ONLINE_POLICY = Object.freeze({
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
   checkersbattleroyal: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
-  'domino-royal': { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
+  'domino-royal': { maxPlayers: [2, 3, 4], allowMatchMeta: ['variant', 'targetPoints', 'mode', 'token'] },
   ludobattleroyal: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   texasholdem: { maxPlayers: [2, 6], allowMatchMeta: ['mode', 'token'] },
   airhockey: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },

--- a/bot/server.js
+++ b/bot/server.js
@@ -440,13 +440,14 @@ const lobbyTables = {};
 const tableMap = new Map();
 const poolStates = new Map();
 const snookerStates = new Map();
+const dominoRoyalStates = new Map();
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
 
-const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token'];
+const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'targetPoints', 'tableSize', 'ballSet', 'token'];
 
 function normalizeTableSizeMeta(value = '') {
   const normalized = String(value || '').trim().toLowerCase();
@@ -1327,6 +1328,8 @@ function maybeStartGame(table) {
       );
       if (table.gameType === 'poolroyale') {
         poolStates.set(table.id, { state: null, hud: null, layout: null, ts: Date.now() });
+      } else if (table.gameType === 'domino-royal') {
+        dominoRoyalStates.set(table.id, { state: null, action: null, ts: Date.now() });
       }
       table.startTimeout = null;
     }, 1000);
@@ -1363,6 +1366,9 @@ function unseatTableSocket(accountId, tableId, socketId) {
       if (table.gameType === 'checkers') {
         checkersRealtimeStore.clearState(tableId);
         checkersMatchSessions.delete(tableId);
+      }
+      if (table.gameType === 'domino-royal') {
+        dominoRoyalStates.delete(tableId);
       }
       tableMap.delete(tableId);
       const key = `${table.gameType}-${table.maxPlayers}`;
@@ -2009,7 +2015,9 @@ io.on('connection', (socket) => {
         playType,
         tableSize,
         ballSet,
-        token
+        token,
+        targetPoints,
+        points
       } = payload;
       const resolvedVariant = payloadMatchMeta.variant ?? variant;
       const resolvedMode = payloadMatchMeta.mode ?? mode;
@@ -2017,6 +2025,7 @@ io.on('connection', (socket) => {
       const resolvedTableSize = payloadMatchMeta.tableSize ?? tableSize;
       const resolvedBallSet = payloadMatchMeta.ballSet ?? ballSet;
       const resolvedToken = payloadMatchMeta.token ?? token;
+      const resolvedTargetPoints = payloadMatchMeta.targetPoints ?? targetPoints ?? points;
       const resolvedPreferredSide =
         payloadMatchMeta.preferredSide ?? preferredSide;
       const resolvedAccountId = resolveTpcIdentity(payload);
@@ -2050,6 +2059,7 @@ io.on('connection', (socket) => {
           tableSize: resolvedTableSize,
           ballSet: resolvedBallSet,
           token: resolvedToken,
+          targetPoints: resolvedTargetPoints,
           preferredSide: resolvedPreferredSide
         }
       });
@@ -2063,7 +2073,8 @@ io.on('connection', (socket) => {
         playType: validation.safeMatchMeta.playType,
         tableSize: validation.safeMatchMeta.tableSize,
         ballSet: validation.safeMatchMeta.ballSet,
-        token: validation.safeMatchMeta.token
+        token: validation.safeMatchMeta.token,
+        targetPoints: validation.safeMatchMeta.targetPoints
       };
 
       let table;
@@ -2232,6 +2243,59 @@ io.on('connection', (socket) => {
     if (!tableId) return;
     const state = getChessState(tableId);
     socket.emit('chessState', { tableId, ...state });
+  });
+
+
+  socket.on('joinDominoRoyalTable', async ({ tableId, accountId } = {}) => {
+    if (!tableId) return;
+    if (accountId && !ensureRegistered(socket, accountId)) return;
+    socket.join(tableId);
+    if (accountId) {
+      await registerConnection({
+        userId: String(accountId),
+        roomId: tableId,
+        socketId: socket.id
+      });
+    }
+    const cached = dominoRoyalStates.get(tableId);
+    if (cached?.state) {
+      socket.emit('dominoRoyalState', {
+        tableId,
+        state: cached.state,
+        action: cached.action || null,
+        updatedAt: cached.ts
+      });
+    }
+  });
+
+  socket.on('dominoRoyalSyncRequest', ({ tableId } = {}) => {
+    if (!tableId) return;
+    const cached = dominoRoyalStates.get(tableId);
+    if (cached?.state) {
+      socket.emit('dominoRoyalState', {
+        tableId,
+        state: cached.state,
+        action: cached.action || null,
+        updatedAt: cached.ts
+      });
+    }
+  });
+
+  socket.on('dominoRoyalState', ({ tableId, state, action } = {}) => {
+    if (!tableId || !state || typeof state !== 'object') return;
+    if (!socket.rooms.has(tableId)) return;
+    const payload = {
+      tableId,
+      state,
+      action: action || null,
+      updatedAt: Date.now()
+    };
+    dominoRoyalStates.set(tableId, {
+      state,
+      action: payload.action,
+      ts: payload.updatedAt
+    });
+    socket.to(tableId).emit('dominoRoyalState', payload);
   });
 
   socket.on('joinPoolTable', async ({ tableId, accountId }) => {

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -11,6 +11,23 @@ import { clone as cloneSkeleton } from '/vendor/three/examples/jsm/utils/Skeleto
 import './flag-emojis.js';
 
 const urlParams = new URLSearchParams(window.location.search);
+const DOMINO_ONLINE_MODE = (urlParams.get('mode') || '').toLowerCase() === 'online';
+const DOMINO_ONLINE_TABLE_ID = urlParams.get('tableId') || urlParams.get('table') || '';
+const DOMINO_ONLINE_ACCOUNT_ID = urlParams.get('accountId') || '';
+const DOMINO_ONLINE_SOCKET = typeof window !== 'undefined' ? window.__DOMINO_ROYAL_SOCKET__ : null;
+const DOMINO_ONLINE_MATCH = (() => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage?.getItem('dominoRoyalOnlineMatch');
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+})();
+let dominoOnlineStateSeq = 0;
+let dominoApplyingRemoteState = false;
+let dominoOnlineHasState = false;
+let dominoOnlineStateHandler = null;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
 const FRAME_RATE_STORAGE_KEY = 'dominoRoyalFrameRate';
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
@@ -1203,6 +1220,13 @@ function pickFlagForSeat(index = 0) {
 }
 
 function getSeatUsernames(count = N) {
+  if (DOMINO_ONLINE_MODE && Array.isArray(DOMINO_ONLINE_MATCH?.players) && DOMINO_ONLINE_MATCH.players.length) {
+    return Array.from({ length: count }, (_, idx) => {
+      const player = DOMINO_ONLINE_MATCH.players[idx];
+      if (idx === human && seatAvatarUsername) return seatAvatarUsername;
+      return player?.name || DEFAULT_SEAT_NAMES[idx] || `Player ${idx + 1}`;
+    });
+  }
   const avatars = buildSeatAvatarSources(count);
   return avatars.map((avatar, idx) => {
     if (idx === HUMAN_SEAT_INDEX && seatAvatarUsername) {
@@ -6171,6 +6195,13 @@ function isAvatarUrl(str = '') {
 
 function buildSeatAvatarSources(count = N) {
   const total = Math.max(1, count);
+  if (DOMINO_ONLINE_MODE && Array.isArray(DOMINO_ONLINE_MATCH?.players) && DOMINO_ONLINE_MATCH.players.length) {
+    return Array.from({ length: total }, (_, idx) => {
+      const player = DOMINO_ONLINE_MATCH.players[idx];
+      if (idx === human) return normalizeAvatarSource(seatAvatarPhoto) || player?.avatar || lobbyAvatarFallback || pickFlagForSeat(idx);
+      return player?.avatar || pickFlagForSeat(idx);
+    });
+  }
   return Array.from({ length: total }, (_, idx) => {
     if (idx === HUMAN_SEAT_INDEX) {
       const preferred =
@@ -9215,6 +9246,17 @@ const isPointsRace =
 if (requestedPlayers >= 2 && requestedPlayers <= 4) {
   N = requestedPlayers;
 }
+if (DOMINO_ONLINE_MODE && Array.isArray(DOMINO_ONLINE_MATCH?.players)) {
+  const onlineSeatIndex = DOMINO_ONLINE_MATCH.players.findIndex(
+    (player) => String(player?.id || '') === String(DOMINO_ONLINE_ACCOUNT_ID || DOMINO_ONLINE_MATCH?.accountId || '')
+  );
+  if (onlineSeatIndex >= 0) {
+    human = onlineSeatIndex;
+  }
+  if (DOMINO_ONLINE_MATCH.players.length >= 2 && DOMINO_ONLINE_MATCH.players.length <= 4) {
+    N = DOMINO_ONLINE_MATCH.players.length;
+  }
+}
 const stakeAmount = Number.parseInt(urlParams.get('amount') || '', 10);
 const stakeToken = urlParams.get('token') || 'TPC';
 if (Number.isFinite(stakeAmount) && stakeAmount > 0) {
@@ -10105,7 +10147,9 @@ function startGame({ resetRace = true } = {}) {
   renderChain();
   current = (starter - 1 + N) % N;
   updateInteractivity();
-  if (current !== human) {
+  if (DOMINO_ONLINE_MODE) {
+    emitDominoOnlineState('initial');
+  } else if (current !== human) {
     scheduleCpuPlay();
   }
 }
@@ -10660,6 +10704,7 @@ renderer.domElement.addEventListener('pointerdown', (ev) => {
       }
       playedPlacement = placement;
       runDominoCharacterAction(human, 'PLAY');
+      emitDominoOnlineState('play');
     }
     selectedTile = null;
     clearMarkers();
@@ -10794,6 +10839,7 @@ if (btnDraw) {
   renderHands();
   if (drewTile) {
     SFX.drawTile();
+    emitDominoOnlineState('draw');
   }
   });
 }
@@ -10808,11 +10854,154 @@ if (btnPass) {
   });
 }
 
+
+function stripRuntimeTile(tile) {
+  const clean = canonTile(tile) || tile;
+  if (!clean || typeof clean.a !== 'number' || typeof clean.b !== 'number') return null;
+  return { a: clean.a, b: clean.b };
+}
+
+function serializeDominoSegment(segment) {
+  if (!segment?.tile) return null;
+  const tile = stripRuntimeTile(segment.tile);
+  if (!tile) return null;
+  return {
+    tile,
+    x: Number(segment.x) || 0,
+    z: Number(segment.z) || 0,
+    rot: Number(segment.rot) || 0,
+    double: Boolean(segment.double)
+  };
+}
+
+function buildDominoOnlineState() {
+  return {
+    seq: ++dominoOnlineStateSeq,
+    players: players.map((player, idx) => ({
+      id: player?.id ?? idx,
+      hand: Array.isArray(player?.hand) ? player.hand.map(stripRuntimeTile).filter(Boolean) : []
+    })),
+    boneyard: Array.isArray(boneyard) ? boneyard.map(stripRuntimeTile).filter(Boolean) : [],
+    chain: Array.isArray(chain) ? chain.map(serializeDominoSegment).filter(Boolean) : [],
+    ends,
+    current,
+    humanCount: N,
+    gameFinished,
+    winnerIndex,
+    revealAllHands,
+    racePenaltyTotals,
+    raceDisqualifiedPlayers,
+    raceRoundNumber,
+    lastHandWinnerIndex
+  };
+}
+
+function emitDominoOnlineState(action = 'sync') {
+  if (!DOMINO_ONLINE_MODE || dominoApplyingRemoteState || !DOMINO_ONLINE_SOCKET || !DOMINO_ONLINE_TABLE_ID) {
+    return;
+  }
+  DOMINO_ONLINE_SOCKET.emit('dominoRoyalState', {
+    tableId: DOMINO_ONLINE_TABLE_ID,
+    action: { type: action, accountId: DOMINO_ONLINE_ACCOUNT_ID, seat: human },
+    state: buildDominoOnlineState()
+  });
+}
+
+function hydrateRuntimeTile(tile) {
+  const clean = stripRuntimeTile(tile);
+  return clean ? { ...clean } : null;
+}
+
+function applyDominoOnlineState(remoteState = {}) {
+  if (!remoteState || typeof remoteState !== 'object') return;
+  const incomingSeq = Number(remoteState.seq) || 0;
+  if (incomingSeq && incomingSeq < dominoOnlineStateSeq) return;
+  dominoApplyingRemoteState = true;
+  dominoOnlineStateSeq = Math.max(dominoOnlineStateSeq, incomingSeq);
+  clearMarkers();
+  clearSelectedHighlight();
+  clearExistingDominoMeshes();
+  selectedTile = null;
+  N = Math.max(2, Math.min(4, Number(remoteState.humanCount) || N || 4));
+  players = Array.from({ length: N }, (_, idx) => {
+    const source = Array.isArray(remoteState.players) ? remoteState.players[idx] : null;
+    return {
+      id: source?.id ?? idx,
+      hand: Array.isArray(source?.hand) ? source.hand.map(hydrateRuntimeTile).filter(Boolean) : []
+    };
+  });
+  boneyard = Array.isArray(remoteState.boneyard) ? remoteState.boneyard.map(hydrateRuntimeTile).filter(Boolean) : [];
+  chain = Array.isArray(remoteState.chain)
+    ? remoteState.chain.map((segment) => ({
+        tile: hydrateRuntimeTile(segment.tile),
+        x: Number(segment.x) || 0,
+        z: Number(segment.z) || 0,
+        rot: Number(segment.rot) || 0,
+        double: Boolean(segment.double)
+      })).filter((segment) => segment.tile)
+    : [];
+  usedTileKeys.clear();
+  chain.forEach((segment) => usedTileKeys.add(tileKey(segment.tile)));
+  ends = remoteState.ends || null;
+  current = Number.isInteger(remoteState.current) ? remoteState.current : current;
+  gameFinished = Boolean(remoteState.gameFinished);
+  winnerIndex = Number.isInteger(remoteState.winnerIndex) ? remoteState.winnerIndex : null;
+  revealAllHands = Boolean(remoteState.revealAllHands);
+  racePenaltyTotals = Array.isArray(remoteState.racePenaltyTotals) ? remoteState.racePenaltyTotals : racePenaltyTotals;
+  raceDisqualifiedPlayers = Array.isArray(remoteState.raceDisqualifiedPlayers) ? remoteState.raceDisqualifiedPlayers : raceDisqualifiedPlayers;
+  raceRoundNumber = Number(remoteState.raceRoundNumber) || raceRoundNumber;
+  lastHandWinnerIndex = Number.isInteger(remoteState.lastHandWinnerIndex) ? remoteState.lastHandWinnerIndex : null;
+  dominoOnlineHasState = true;
+  refreshSeatAvatars();
+  rebuildDominoCharactersForChairs();
+  renderBoneyardStack();
+  renderHands();
+  renderChain();
+  updateInteractivity();
+  if (gameFinished) {
+    showWinnerOverlay({ winner: winnerIndex, reason: winnerIndex === human ? 'You won!' : 'Online match finished' });
+  }
+  dominoApplyingRemoteState = false;
+}
+
+function connectDominoOnlineTable() {
+  if (!DOMINO_ONLINE_MODE || !DOMINO_ONLINE_SOCKET || !DOMINO_ONLINE_TABLE_ID) return;
+  DOMINO_ONLINE_SOCKET.emit('joinDominoRoyalTable', {
+    tableId: DOMINO_ONLINE_TABLE_ID,
+    accountId: DOMINO_ONLINE_ACCOUNT_ID
+  });
+  if (dominoOnlineStateHandler) {
+    DOMINO_ONLINE_SOCKET.off?.('dominoRoyalState', dominoOnlineStateHandler);
+  }
+  dominoOnlineStateHandler = ({ tableId, state } = {}) => {
+    if (tableId !== DOMINO_ONLINE_TABLE_ID || !state) return;
+    applyDominoOnlineState(state);
+  };
+  DOMINO_ONLINE_SOCKET.on('dominoRoyalState', dominoOnlineStateHandler);
+  DOMINO_ONLINE_SOCKET.emit('dominoRoyalSyncRequest', { tableId: DOMINO_ONLINE_TABLE_ID });
+}
+
 async function bootstrapDominoRoyal() {
   try {
     await loadHumanProfileFromApi();
-    startGame();
-    setControlEnabled(true);
+    if (DOMINO_ONLINE_MODE) {
+      connectDominoOnlineTable();
+      if (human === 0) {
+        startGame();
+        setControlEnabled(true);
+      } else {
+        players = Array.from({ length: N }, (_, i) => ({ id: i, hand: [] }));
+        refreshSeatAvatars();
+        rebuildDominoCharactersForChairs();
+        renderHands();
+        renderChain();
+        setStatus('Waiting for host sync…');
+        setControlEnabled(true);
+      }
+    } else {
+      startGame();
+      setControlEnabled(true);
+    }
   } catch (error) {
     console.error('Domino Royal failed to start', error);
     revealStatus('Unable to start match. Please reload.');
@@ -10849,6 +11038,7 @@ function blockedAndWinner() {
 }
 
 function scheduleCpuPlay(delay = CPU_PLAY_DELAY) {
+  if (DOMINO_ONLINE_MODE) return;
   if (cpuMoveTimeout) {
     clearTimeout(cpuMoveTimeout);
     cpuMoveTimeout = null;
@@ -10879,6 +11069,7 @@ function scheduleTurnAdvanceAfterPlacement(segment, delayMs = TURN_ADVANCE_AFTER
     pendingTurnAdvanceTimeout = null;
     if (!gameFinished) {
       nextTurn();
+      emitDominoOnlineState('turn-advance');
     }
   }, safeDelay);
 }
@@ -10934,6 +11125,7 @@ function finishGame({ winner = null, reason = '', revealAll = false } = {}) {
     SFX.drawGame();
   }
   showWinnerOverlay({ winner: winnerIndex, reason });
+  emitDominoOnlineState('finish');
 }
 
 
@@ -11035,7 +11227,8 @@ function nextTurn() {
   if (gameFinished) {
     return;
   }
-  if (current !== human) {
+  emitDominoOnlineState('turn');
+  if (!DOMINO_ONLINE_MODE && current !== human) {
     scheduleCpuPlay();
   }
 }
@@ -11365,6 +11558,7 @@ function schedulePassTurnAdvance(
     pendingTurnAdvanceTimeout = null;
     if (!gameFinished) {
       nextTurn();
+      emitDominoOnlineState('pass');
     }
   }, safeDelay);
 }
@@ -11852,6 +12046,10 @@ function shutdownDominoRoyal(reason = 'unknown') {
     }
   } catch (error) {
     console.warn('Domino Royal shutdown failed', reason, error);
+  }
+  if (DOMINO_ONLINE_SOCKET && dominoOnlineStateHandler) {
+    DOMINO_ONLINE_SOCKET.off?.('dominoRoyalState', dominoOnlineStateHandler);
+    dominoOnlineStateHandler = null;
   }
 }
 

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
 
 import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
+import { socket } from '../../utils/socket.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-30-murlan-arm-hand-gesture-v65';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-06-07-online-sync-v66';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',
@@ -38,6 +39,7 @@ export default function DominoRoyalArena() {
     }
 
     window.__DOMINO_ROYAL_ENABLE_SEATED_HUMANS = true;
+    window.__DOMINO_ROYAL_SOCKET__ = socket;
     const characterPreconnectLinks = DOMINO_CHARACTER_PRECONNECT_URLS.map((href) => {
       const link = document.createElement('link');
       link.rel = 'preconnect';
@@ -74,6 +76,7 @@ export default function DominoRoyalArena() {
       script.remove();
       characterPreconnectLinks.forEach((link) => link.remove());
       delete window.__DOMINO_ROYAL_ENABLE_SEATED_HUMANS;
+      delete window.__DOMINO_ROYAL_SOCKET__;
       if (appRoot) {
         appRoot.replaceChildren();
       }

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import RoomSelector from '../../components/RoomSelector.jsx';
@@ -64,6 +64,11 @@ export default function DominoRoyalLobby() {
   const [flagsManuallySelected, setFlagsManuallySelected] = useState(false);
   const [dominoPlayerFlag, setDominoPlayerFlag] = useState(null);
   const [dominoAiFlag, setDominoAiFlag] = useState(null);
+  const [queuedTableId, setQueuedTableId] = useState('');
+  const [queueStatus, setQueueStatus] = useState('');
+  const [queueError, setQueueError] = useState('');
+  const queuedTableIdRef = useRef('');
+  const onlineStakeDebitedRef = useRef(false);
   const startBet = stake.amount / 100;
   const readiness = getOnlineReadiness('domino-royal');
 
@@ -187,14 +192,13 @@ export default function DominoRoyalLobby() {
           alert('Insufficient balance');
           return;
         }
-        await addTransaction(tgId, -stake.amount, 'stake', {
-          game: 'domino',
-          accountId
-        });
       }
     } catch {}
 
     if (mode === 'online' && accountId) {
+      setQueueError('');
+      setQueueStatus('Connecting to Domino Royal lobby…');
+      onlineStakeDebitedRef.current = false;
       socket.emit('register', { playerId: accountId });
       socket.emit(
         'seatTable',
@@ -207,14 +211,26 @@ export default function DominoRoyalLobby() {
           avatar,
           mode: 'online',
           token: stake.token,
-          game: gameType,
-          points: gameType === 'points' ? Number(targetPoints) : 0
+          variant: gameType,
+          targetPoints: gameType === 'points' ? Number(targetPoints) : 0,
+          matchMeta: {
+            mode: 'online',
+            variant: gameType,
+            targetPoints: gameType === 'points' ? String(targetPoints) : '',
+            token: stake.token
+          }
         },
         (res = {}) => {
           if (!res.success || !res.tableId) {
-            alert('Unable to join Domino online table. Please try again.');
+            const message = `Unable to join Domino online table (${res.error || 'try_again'}).`;
+            setQueueError(message);
+            setQueueStatus('');
             return;
           }
+          queuedTableIdRef.current = res.tableId;
+          setQueuedTableId(res.tableId);
+          const seated = Array.isArray(res.players) ? res.players.length : 1;
+          setQueueStatus(`Table ${res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players ready`);
           socket.emit('confirmReady', { accountId, tableId: res.tableId });
         }
       );
@@ -234,7 +250,15 @@ export default function DominoRoyalLobby() {
   useEffect(() => {
     if (mode !== 'online') return undefined;
 
-    const handleGameStart = ({ tableId, players, stake: onlineStake }) => {
+    const handleLobbyUpdate = ({ tableId, players: lobbyPlayers = [], ready = [] } = {}) => {
+      if (!tableId || tableId !== queuedTableIdRef.current) return;
+      setQueueStatus(
+        `Table ${String(tableId).slice(0, 8)} • ${lobbyPlayers.length}/${totalPlayers} players connected • ${ready.length}/${totalPlayers} ready`
+      );
+    };
+
+    const handleGameStart = ({ tableId, players, stake: onlineStake, meta }) => {
+      if (!tableId || tableId !== queuedTableIdRef.current) return;
       const accountId = ensureAccountId().catch(() => '');
       Promise.resolve(accountId).then((resolvedAccountId) => {
         const seat = Array.isArray(players)
@@ -245,6 +269,29 @@ export default function DominoRoyalLobby() {
           : null;
         const token = stake.token || onlineStake?.token || 'TPC';
         const amount = Number(onlineStake?.amount || stake.amount || 0);
+        if (!onlineStakeDebitedRef.current && amount > 0) {
+          onlineStakeDebitedRef.current = true;
+          addTransaction(getTelegramId(), -amount, 'stake', {
+            game: 'domino',
+            accountId: resolvedAccountId,
+            tableId
+          }).catch(() => {});
+        }
+        try {
+          window.sessionStorage?.setItem(
+            'dominoRoyalOnlineMatch',
+            JSON.stringify({
+              tableId,
+              accountId: resolvedAccountId,
+              players: Array.isArray(players) ? players : [],
+              meta: meta || {},
+              startedAt: Date.now()
+            })
+          );
+        } catch {}
+        queuedTableIdRef.current = '';
+        setQueuedTableId('');
+        setQueueStatus('Starting online match…');
         launchGame({
           accountId: resolvedAccountId,
           tgId: getTelegramId(),
@@ -257,9 +304,16 @@ export default function DominoRoyalLobby() {
       });
     };
 
+    socket.on('lobbyUpdate', handleLobbyUpdate);
     socket.on('gameStart', handleGameStart);
     return () => {
+      socket.off('lobbyUpdate', handleLobbyUpdate);
       socket.off('gameStart', handleGameStart);
+      if (queuedTableIdRef.current) {
+        ensureAccountId()
+          .then((accountId) => socket.emit('leaveLobby', { accountId, tableId: queuedTableIdRef.current }))
+          .catch(() => {});
+      }
     };
   }, [mode, stake.token, stake.amount, totalPlayers, avatar, flags, gameType, targetPoints]);
 
@@ -551,12 +605,18 @@ export default function DominoRoyalLobby() {
           </div>
         </div>
 
+        {mode === 'online' && (queueStatus || queueError) && (
+          <div className={`rounded-2xl border px-4 py-3 text-sm ${queueError ? 'border-red-400/40 bg-red-500/10 text-red-100' : 'border-sky-400/30 bg-sky-500/10 text-sky-100'}`}>
+            {queueError || queueStatus}
+          </div>
+        )}
+
         <button
           onClick={startGame}
-          disabled={mode === 'local' && flags.length !== flagPickerCount}
+          disabled={(mode === 'local' && flags.length !== flagPickerCount) || Boolean(queuedTableId)}
           className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
         >
-          START
+          {mode === 'online' && queuedTableId ? 'WAITING FOR PLAYERS…' : 'START'}
         </button>
 
         <FlagPickerModal


### PR DESCRIPTION
### Motivation
- Make Domino Royal online-ready by wiring lobby <-> runtime socket flow, ensuring players can seat/join from the lobby and the arena stays in sync for 2–4 player matches and points-race games. 

### Description
- Update online policy to allow Domino Royal 2/3/4 player tables and include `targetPoints` in allowed match meta for points-race matchmaking (`bot/config/onlineGamePolicy.js`).
- Add server-side cached table state and Socket.IO relay for Domino Royal (`dominoRoyalStates`) plus handlers: `joinDominoRoyalTable`, `dominoRoyalSyncRequest`, and `dominoRoyalState`, and ensure emitted state is only forwarded to sockets in the table room (`bot/server.js`).
- Extend `seatTable` validation to accept `targetPoints` and pass it through matchmaking and table meta (`bot/server.js`).
- Lobby changes to track queue state and present status to players, register/seat with the backend including matchMeta, confirm ready, persist roster payload for the arena, and defer stake debit until the authoritative `gameStart` (`webapp/src/pages/Games/DominoRoyalLobby.jsx`).
- Arena wiring: inject the shared `socket` client into the Domino runtime and bump the Domino script version so the arena loads the online-sync code (`webapp/src/pages/Games/DominoRoyalArena.jsx`).
- Large runtime additions to `domino-royal-game.js`: detect online mode/table/account, join the authoritative room, request sync, build/emit full game snapshots (`players`, `boneyard`, `chain`, `ends`, `current`, etc.), apply remote snapshots to hydrate runtime state, and disable CPU/AI automation when in online mode; emit events on key player actions (`play`, `draw`, `pass`, `turn`, `finish`) so the authoritative server can relay state to other viewers/players (`webapp/public/domino-royal-game.js`).

### Testing
- Built the webapp: `npm --prefix webapp run build` (succeeded, production bundle produced).
- Static checks: `node --check bot/server.js`, `node --check bot/config/onlineGamePolicy.js`, and `node --check webapp/public/domino-royal-game.js` (all succeeded).
- Ran repository checks: `git diff --check` (no issues).
- Playwright screenshot attempt to verify lobby UI failed due to missing native Chromium system library (`libatk-1.0.so.0`) in the container, so headless browser smoke capture could not complete (environment limitation, not code failure).

If you want, I can: add finer-grained server-side validation for incoming domino state, reduce the runtime snapshot size, or add a small e2e smoke test that runs in CI with headless browsers that have required native deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252b691fbc8329b68d3f0113427dd7)