### PR TITLE
Fix chess lobby socket matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -146,27 +146,55 @@ const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
   .map((o) => o.trim())
 
   .filter(Boolean);
+const defaultDevOrigins = [
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+  'http://localhost:4173',
+  'http://127.0.0.1:4173'
+];
+const effectiveAllowedOrigins = allowedOrigins.length
+  ? allowedOrigins
+  : process.env.NODE_ENV === 'production'
+    ? []
+    : defaultDevOrigins;
+
+function isAllowedCorsOrigin(origin) {
+  if (!origin) return true;
+  if (effectiveAllowedOrigins.includes(origin)) return true;
+  if (process.env.NODE_ENV !== 'production') {
+    try {
+      const { hostname } = new URL(origin);
+      return hostname === 'localhost' || hostname === '127.0.0.1';
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function resolveCorsOrigin(origin, callback) {
+  if (isAllowedCorsOrigin(origin)) {
+    return callback(null, true);
+  }
+  if (effectiveAllowedOrigins.length === 0) {
+    return callback(null, false);
+  }
+  return callback(new Error('Not allowed by CORS'));
+}
 
 const rateLimitWindowMs =
   Number(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
 
 const rateLimitMax = Number(process.env.RATE_LIMIT_MAX) || 100;
 const app = express();
-const corsOptions = allowedOrigins.length
-  ? {
-    origin(origin, callback) {
-      if (!origin || allowedOrigins.includes(origin)) {
-        return callback(null, true);
-      }
-      return callback(new Error('Not allowed by CORS'));
-    }
-  }
-  : { origin: false };
+const corsOptions = {
+  origin: resolveCorsOrigin
+};
 app.use(cors(corsOptions));
 const httpServer = http.createServer(app);
 const io = initSocket(httpServer, {
   cors: {
-    origin: allowedOrigins.length ? allowedOrigins : false,
+    origin: resolveCorsOrigin,
     methods: ['GET', 'POST']
   },
   transports: ['websocket', 'polling'],

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -305,7 +305,13 @@ export default function ChessBattleRoyalLobby() {
   const [matchError, setMatchError] = useState('');
   const preferredSide = 'auto';
   const pendingTableRef = useRef('');
-  const lobbyHandlersRef = useRef({ gameStart: null, lobbyUpdate: null });
+  const lobbyHandlersRef = useRef({
+    gameStart: null,
+    lobbyUpdate: null,
+    connectError: null,
+    disconnect: null,
+    errorMessage: null
+  });
   const cleanupRef = useRef(() => {});
   const matchmakingTimeoutRef = useRef(null);
   const spinIntervalRef = useRef(null);
@@ -481,13 +487,28 @@ export default function ChessBattleRoyalLobby() {
       clearTimeout(matchmakingTimeoutRef.current);
       matchmakingTimeoutRef.current = null;
     }
-    const { gameStart, lobbyUpdate } = lobbyHandlersRef.current;
+    const {
+      gameStart,
+      lobbyUpdate,
+      connectError,
+      disconnect,
+      errorMessage
+    } = lobbyHandlersRef.current;
     if (gameStart) {
       socket.off('gameStart', gameStart);
       socket.off('gameStarted', gameStart);
     }
     if (lobbyUpdate) socket.off('lobbyUpdate', lobbyUpdate);
-    lobbyHandlersRef.current = { gameStart: null, lobbyUpdate: null };
+    if (connectError) socket.off('connect_error', connectError);
+    if (disconnect) socket.off('disconnect', disconnect);
+    if (errorMessage) socket.off('errorMessage', errorMessage);
+    lobbyHandlersRef.current = {
+      gameStart: null,
+      lobbyUpdate: null,
+      connectError: null,
+      disconnect: null,
+      errorMessage: null
+    };
     if (!skipLeave && pendingTableRef.current && (account || accountId)) {
       socket.emit('leaveLobby', {
         accountId: account || accountId,
@@ -638,15 +659,37 @@ export default function ChessBattleRoyalLobby() {
       });
     };
 
+    const handleConnectError = () => {
+      setMatchStatus('Lobby connection failed. Reconnecting…');
+    };
+
+    const handleDisconnect = () => {
+      if (pendingTableRef.current) {
+        setMatchStatus('Connection dropped. Reconnecting to lobby…');
+      }
+    };
+
+    const handleErrorMessage = (error) => {
+      if (!pendingTableRef.current) return;
+      const message = resolveSeatErrorMessage(error);
+      setMatchError(message);
+    };
+
     cleanupRef.current = () =>
       cleanupLobby({ account: trackedAccountId, skipRefReset: true });
 
     socket.on('gameStart', handleGameStart);
     socket.on('gameStarted', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
+    socket.on('connect_error', handleConnectError);
+    socket.on('disconnect', handleDisconnect);
+    socket.on('errorMessage', handleErrorMessage);
     lobbyHandlersRef.current = {
       gameStart: handleGameStart,
-      lobbyUpdate: handleLobbyUpdate
+      lobbyUpdate: handleLobbyUpdate,
+      connectError: handleConnectError,
+      disconnect: handleDisconnect,
+      errorMessage: handleErrorMessage
     };
 
     const matchTimeout = window.setTimeout(async () => {

--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -141,10 +141,15 @@ export function refreshSocketAuthIdentity(patch = {}, { reconnect = false } = {}
     ...base,
     ...patch
   };
-  if (!isSameIdentity(socket.auth, nextAuth)) {
+  const changed = !isSameIdentity(socket.auth, nextAuth);
+  if (changed) {
     socket.auth = nextAuth;
-    if (reconnect && socket.connected) {
+  }
+  if (reconnect) {
+    if (socket.connected && changed) {
       socket.disconnect();
+      socket.connect();
+    } else if (!socket.connected) {
       socket.connect();
     }
   }


### PR DESCRIPTION
### Motivation
- Improve reliability of online chess matchmaking by allowing local dev clients to connect, ensuring client auth updates re-establish socket sessions, and surfacing socket errors/reconnect state in the lobby UI.
- Prevent listener leaks in the Chess Battle Royal lobby so repeated matchmaking attempts don't accumulate handlers or miss connection errors.

### Description
- Add a CORS resolver in `bot/server.js` that permits common local Vite preview/dev origins when `ALLOWED_ORIGINS` is not configured and uses the same resolver for Socket.IO (`resolveCorsOrigin`, `effectiveAllowedOrigins`).
- Update socket identity refresh in `webapp/src/utils/socket.js` so `refreshSocketAuthIdentity` will reconnect disconnected sockets and avoid unnecessary disconnect/connect when no auth changed (preserves identity change detection and reconnect behavior).
- Add connection/error listeners and robust cleanup in `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` so the lobby registers `connect_error`, `disconnect`, and `errorMessage` handlers, updates `matchStatus`/`matchError`, and removes those handlers on cleanup to avoid leaks.
- Changes touch `bot/server.js`, `webapp/src/utils/socket.js`, and `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` to wire CORS, auth-reconnect, and lobby socket failure handling together.

### Testing
- Built the project with `npm run build` successfully.
- Ran the chess-related test suites with `npm test -- --runInBand test/chessLobbyPreferredSideMatchmaking.test.js test/chessLobbyStaleTableIdMatchmaking.test.js test/chessOnlineMoveValidation.test.js` and all tests passed (3 suites, 4 tests total).
- Verified behavior in unit tests that `seatTable`, `confirmReady`, `gameStart`, `chessMove` and lobby matchmaking flows operate without regressions under the updated CORS/auth/reconnect logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2534248f308329b906efa799e8d774)