### PR TITLE
Domino Royal: add lobby connect-grace and stricter matchmaking readiness

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -477,6 +477,8 @@ const dominoRoyalStates = new Map();
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
+const lobbyStartDelayMs = Number(process.env.LOBBY_START_DELAY_MS) || 1000;
+const dominoLobbyConnectGraceMs = Number(process.env.DOMINO_LOBBY_CONNECT_GRACE_MS) || 3500;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
 
@@ -1237,14 +1239,50 @@ async function seatTableSocket(
   return table;
 }
 
-function maybeStartGame(table) {
-  if (
+function hasAllPlayersReady(table) {
+  return (
+    table &&
     table.players.length === table.maxPlayers &&
     table.ready &&
-    table.ready.size === table.maxPlayers
-  ) {
+    table.ready.size === table.maxPlayers &&
+    table.players.every((player) => table.ready.has(String(player.id)))
+  );
+}
+
+function getLobbyStartDelayMs(table) {
+  if (table?.gameType === 'domino-royal') {
+    return Math.max(1000, dominoLobbyConnectGraceMs);
+  }
+  return Math.max(0, lobbyStartDelayMs);
+}
+
+function maybeStartGame(table) {
+  if (hasAllPlayersReady(table)) {
     if (table.startTimeout) return;
+    const startDelayMs = getLobbyStartDelayMs(table);
+    table.startAt = Date.now() + startDelayMs;
+    io.to(table.id).emit('lobbyUpdate', {
+      tableId: table.id,
+      players: table.players,
+      currentTurn: table.currentTurn,
+      ready: Array.from(table.ready),
+      meta: table.meta,
+      startAt: table.startAt,
+      startDelayMs
+    });
     table.startTimeout = setTimeout(() => {
+      if (!hasAllPlayersReady(table)) {
+        table.startTimeout = null;
+        table.startAt = null;
+        io.to(table.id).emit('lobbyUpdate', {
+          tableId: table.id,
+          players: table.players,
+          currentTurn: table.currentTurn,
+          ready: Array.from(table.ready || []),
+          meta: table.meta
+        });
+        return;
+      }
       console.log(`Table ${table.id} confirmed by all players. Starting game.`);
       if (table.gameType === 'poolroyale') {
         const randomStarter = table.players[Math.floor(Math.random() * table.players.length)];
@@ -1283,7 +1321,8 @@ function maybeStartGame(table) {
         players: table.players,
         currentTurn: table.currentTurn,
         stake: table.stake,
-        meta: table.meta
+        meta: table.meta,
+        startAt: table.startAt || Date.now()
       });
       tableSeats.delete(table.id);
       const key = `${table.gameType}-${table.maxPlayers}`;
@@ -1296,7 +1335,8 @@ function maybeStartGame(table) {
         dominoRoyalStates.set(table.id, { state: null, action: null, ts: Date.now() });
       }
       table.startTimeout = null;
-    }, 1000);
+      table.startAt = null;
+    }, startDelayMs);
   }
 }
 
@@ -1314,6 +1354,11 @@ function unseatTableSocket(accountId, tableId, socketId) {
   }
   const table = tableMap.get(tableId);
   if (table) {
+    if (table.startTimeout) {
+      clearTimeout(table.startTimeout);
+      table.startTimeout = null;
+      table.startAt = null;
+    }
     if (accountId)
       table.players = table.players.filter((p) => p.id !== accountId);
     else if (socketId)

--- a/test/dominoRoyalMatchmaking.test.js
+++ b/test/dominoRoyalMatchmaking.test.js
@@ -1,0 +1,151 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+function connectSocket(port) {
+  return io(`http://localhost:${port}`, { auth: { token: apiToken } });
+}
+
+function register(socket, playerId) {
+  return new Promise((resolve) => {
+    socket.emit('register', { playerId }, resolve);
+  });
+}
+
+function seat(socket, payload) {
+  return new Promise((resolve) => {
+    socket.emit('seatTable', payload, resolve);
+  });
+}
+
+const dominoPayload = (accountId, overrides = {}) => ({
+  accountId,
+  gameType: 'domino-royal',
+  stake: 100,
+  maxPlayers: 2,
+  mode: 'online',
+  token: 'TPC',
+  variant: 'single',
+  matchMeta: {
+    mode: 'online',
+    token: 'TPC',
+    variant: 'single'
+  },
+  ...overrides
+});
+
+test(
+  'Domino Royal only matches players with the same stake, player count, and game criteria',
+  { concurrency: false, timeout: 30000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const port = '3211';
+    const env = {
+      ...process.env,
+      PORT: port,
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1',
+      DOMINO_LOBBY_CONNECT_GRACE_MS: '1000'
+    };
+    const server = await startServer(env);
+    const sockets = ['a', 'b', 'c', 'd', 'e'].map(() => connectSocket(port));
+
+    try {
+      await Promise.all(
+        sockets.map(
+          (socket) => new Promise((resolve) => socket.on('connect', resolve))
+        )
+      );
+      await Promise.all(
+        sockets.map((socket, index) => register(socket, `domino-${index}`))
+      );
+
+      const first = await seat(sockets[0], dominoPayload('domino-0'));
+      const differentStake = await seat(
+        sockets[1],
+        dominoPayload('domino-1', { stake: 200 })
+      );
+      const differentPlayers = await seat(
+        sockets[2],
+        dominoPayload('domino-2', { maxPlayers: 3 })
+      );
+      const differentVariant = await seat(
+        sockets[3],
+        dominoPayload('domino-3', {
+          variant: 'points',
+          targetPoints: 101,
+          matchMeta: {
+            mode: 'online',
+            token: 'TPC',
+            variant: 'points',
+            targetPoints: '101'
+          }
+        })
+      );
+      const matching = await seat(sockets[4], dominoPayload('domino-4'));
+
+      assert.equal(first.success, true);
+      assert.equal(differentStake.success, true);
+      assert.equal(differentPlayers.success, true);
+      assert.equal(differentVariant.success, true);
+      assert.equal(matching.success, true);
+      assert.equal(matching.tableId, first.tableId);
+      assert.notEqual(differentStake.tableId, first.tableId);
+      assert.notEqual(differentPlayers.tableId, first.tableId);
+      assert.notEqual(differentVariant.tableId, first.tableId);
+
+      const readyAt = Date.now();
+      const gameStartPromise = new Promise((resolve) =>
+        sockets[0].once('gameStart', (payload) =>
+          resolve({ payload, elapsedMs: Date.now() - readyAt })
+        )
+      );
+      sockets[0].emit('confirmReady', {
+        accountId: 'domino-0',
+        tableId: first.tableId
+      });
+      sockets[4].emit('confirmReady', {
+        accountId: 'domino-4',
+        tableId: first.tableId
+      });
+
+      const { payload: started, elapsedMs } = await gameStartPromise;
+      assert.ok(
+        elapsedMs >= 900,
+        `expected connect grace before start, got ${elapsedMs}ms`
+      );
+      assert.equal(started.tableId, first.tableId);
+      assert.equal(started.players.length, 2);
+      assert.equal(started.stake, 100);
+      assert.equal(started.meta.variant, 'single');
+    } finally {
+      sockets.forEach((socket) => socket.disconnect());
+      server.kill();
+    }
+  }
+);

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -230,7 +230,9 @@ export default function DominoRoyalLobby() {
           queuedTableIdRef.current = res.tableId;
           setQueuedTableId(res.tableId);
           const seated = Array.isArray(res.players) ? res.players.length : 1;
-          setQueueStatus(`Table ${res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players ready`);
+          setQueueStatus(
+            `Table ${res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players connected • matching same stake and player count`
+          );
           socket.emit('confirmReady', { accountId, tableId: res.tableId });
         }
       );
@@ -250,10 +252,28 @@ export default function DominoRoyalLobby() {
   useEffect(() => {
     if (mode !== 'online') return undefined;
 
-    const handleLobbyUpdate = ({ tableId, players: lobbyPlayers = [], ready = [] } = {}) => {
+    const handleLobbyUpdate = ({
+      tableId,
+      players: lobbyPlayers = [],
+      ready = [],
+      startAt,
+      startDelayMs
+    } = {}) => {
       if (!tableId || tableId !== queuedTableIdRef.current) return;
+      const allReady =
+        lobbyPlayers.length === totalPlayers && ready.length === totalPlayers;
+      const connectGraceSeconds = Math.max(
+        1,
+        Math.ceil(Number(startDelayMs || 0) / 1000)
+      );
+      const startCountdownSeconds = startAt
+        ? Math.max(1, Math.ceil((Number(startAt) - Date.now()) / 1000))
+        : connectGraceSeconds;
+      const suffix = allReady
+        ? ` • starting in ${startCountdownSeconds}s so every player can connect`
+        : '';
       setQueueStatus(
-        `Table ${String(tableId).slice(0, 8)} • ${lobbyPlayers.length}/${totalPlayers} players connected • ${ready.length}/${totalPlayers} ready`
+        `Table ${String(tableId).slice(0, 8)} • ${lobbyPlayers.length}/${totalPlayers} players connected • ${ready.length}/${totalPlayers} ready${suffix}`
       );
     };
 


### PR DESCRIPTION
### Motivation
- Prevent Domino Royal matches from starting before all matched players have time to connect while keeping matchmaking partitioned by core criteria (stake, player count, variant). 

### Description
- Add configurable lobby timing and grace values (`DOMINO_LOBBY_CONNECT_GRACE_MS`, `LOBBY_START_DELAY_MS`) and expose them via `getLobbyStartDelayMs` in the server. (changed: `bot/server.js`).
- Require full server-side readiness with `hasAllPlayersReady` before scheduling a start and re-check readiness at the end of the delay; cancel start and emit `lobbyUpdate` if players drop during the grace window. (changed: `bot/server.js` — `maybeStartGame`, `unseatTableSocket`).
- Include `startAt` and `startDelayMs` in lobby updates and `gameStart` payloads so clients can show a countdown. (changed: `bot/server.js`).
- Surface clearer lobby UI/status in the Domino Royal lobby to indicate matching by stake/player-count and display connect-grace countdown when all players are ready. (changed: `webapp/src/pages/Games/DominoRoyalLobby.jsx`).
- Add an integration test `test/dominoRoyalMatchmaking.test.js` that verifies players with different stakes/player counts/variants are partitioned and that the connect-grace delay is respected before `gameStart`. (new file: `test/dominoRoyalMatchmaking.test.js`).

### Testing
- Ran integration and unit checks: `node --test test/dominoRoyalMatchmaking.test.js bot/tests/lobbyMatchmaking.test.js`, and the Domino Royal matchmaking test passed. 
- Ran policy suite: `npx jest test/onlineGamePolicy.test.js --runInBand`, and all tests passed. 
- Ran TypeScript build: `npm run build`, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a253c091b9083298ed3011453566bbe)