### PR TITLE
Fix chess lobby stale-seat matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -472,6 +472,7 @@ const dominoRoyalStates = new Map();
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
+const lobbySeatTtlMs = Number(process.env.LOBBY_SEAT_TTL_MS) || 60_000;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
 
@@ -668,6 +669,8 @@ function getAvailableTable(
   const normalizedMeta = normalizeMatchMeta(matchMeta);
   const key = `${gameType}-${maxPlayers}`;
   if (!lobbyTables[key]) lobbyTables[key] = [];
+  cleanupSeats();
+  reconcileOpenLobbyTables(key);
   if (forcedTableId) {
     const isHostedTable = isReservedHostedTableId(forcedTableId, gameType, maxPlayers);
     const existing = tableMap.get(forcedTableId);
@@ -736,13 +739,70 @@ function resolveSeatIdentityFromTableId(tableId, fallbackGameType, fallbackMaxPl
   };
 }
 
+function pruneLobbyTableSeats(tableId) {
+  const table = tableMap.get(tableId);
+  if (!table) return;
+  const key = `${table.gameType}-${table.maxPlayers}`;
+  if (!(lobbyTables[key] || []).some((entry) => entry.id === tableId)) return;
+
+  const seats = tableSeats.get(tableId);
+  const liveSeatIds = new Set(
+    Array.from(seats?.keys() || []).map((pid) => String(pid))
+  );
+
+  table.players = (table.players || []).filter((player) =>
+    liveSeatIds.has(String(player.id))
+  );
+
+  if (table.ready) {
+    for (const pid of Array.from(table.ready)) {
+      if (!liveSeatIds.has(String(pid))) table.ready.delete(pid);
+    }
+  }
+
+  if (table.players.length === 0) {
+    tableSeats.delete(tableId);
+    tableMap.delete(tableId);
+    lobbyTables[key] = (lobbyTables[key] || []).filter(
+      (entry) => entry.id !== tableId
+    );
+    return;
+  }
+
+  if (!table.currentTurn || !liveSeatIds.has(String(table.currentTurn))) {
+    table.currentTurn = table.players[0]?.id || null;
+  }
+}
+
 function cleanupSeats() {
   const now = Date.now();
+  const touchedTables = new Set();
   for (const [tableId, players] of tableSeats) {
+    let changed = false;
     for (const [pid, info] of players) {
-      if (now - info.ts > 60_000) players.delete(pid);
+      if (now - info.ts > lobbySeatTtlMs) {
+        players.delete(pid);
+        changed = true;
+      }
     }
-    if (players.size === 0) tableSeats.delete(tableId);
+    if (players.size === 0) {
+      tableSeats.delete(tableId);
+      changed = true;
+    }
+    if (changed) touchedTables.add(tableId);
+  }
+
+  for (const tableId of touchedTables) {
+    pruneLobbyTableSeats(tableId);
+  }
+}
+
+function reconcileOpenLobbyTables(key) {
+  const tables = key
+    ? [...(lobbyTables[key] || [])]
+    : Object.values(lobbyTables).flatMap((entries) => entries || []);
+  for (const table of tables) {
+    pruneLobbyTableSeats(table.id);
   }
 }
 

--- a/test/chessLobbyExpiredSeatMatchmaking.test.js
+++ b/test/chessLobbyExpiredSeatMatchmaking.test.js
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+const register = (socket, playerId) =>
+  new Promise((resolve) => {
+    socket.emit('register', { playerId }, resolve);
+  });
+
+const seat = (socket, payload) =>
+  new Promise((resolve) => {
+    socket.emit('seatTable', payload, resolve);
+  });
+
+test(
+  'chess quick matchmaking prunes expired lobby seats before matching same criteria players',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3216',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1',
+      LOBBY_SEAT_TTL_MS: '100'
+    };
+    const server = await startServer(env);
+    const stale = io('http://localhost:3216', { auth: { token: apiToken } });
+    const freshA = io('http://localhost:3216', { auth: { token: apiToken } });
+    const freshB = io('http://localhost:3216', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => stale.on('connect', resolve)),
+        new Promise((resolve) => freshA.on('connect', resolve)),
+        new Promise((resolve) => freshB.on('connect', resolve))
+      ]);
+
+      await Promise.all([
+        register(stale, 'chess-expired-stale'),
+        register(freshA, 'chess-expired-a'),
+        register(freshB, 'chess-expired-b')
+      ]);
+
+      const sharedPayload = {
+        gameType: 'chess',
+        stake: 250,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC'
+      };
+
+      const staleSeat = await seat(stale, {
+        ...sharedPayload,
+        accountId: 'chess-expired-stale'
+      });
+      assert.equal(staleSeat.success, true);
+      assert.equal(staleSeat.players.length, 1);
+
+      await delay(180);
+
+      const firstFreshSeat = await seat(freshA, {
+        ...sharedPayload,
+        accountId: 'chess-expired-a'
+      });
+      const secondFreshSeat = await seat(freshB, {
+        ...sharedPayload,
+        accountId: 'chess-expired-b'
+      });
+
+      assert.equal(firstFreshSeat.success, true);
+      assert.equal(secondFreshSeat.success, true);
+      assert.notEqual(firstFreshSeat.tableId, staleSeat.tableId);
+      assert.equal(secondFreshSeat.tableId, firstFreshSeat.tableId);
+      assert.deepEqual(
+        secondFreshSeat.players.map((player) => player.id).sort(),
+        ['chess-expired-a', 'chess-expired-b']
+      );
+    } finally {
+      stale.disconnect();
+      freshA.disconnect();
+      freshB.disconnect();
+      server.kill();
+    }
+  }
+);


### PR DESCRIPTION
### Motivation
- Quick matchmaking could be blocked by stale/orphaned lobby seats, preventing fresh players with identical criteria from being seated together; this change ensures expired seats are pruned before selecting an available table.
- Make TTL configurable for deterministic test coverage and to allow runtime tuning via `LOBBY_SEAT_TTL_MS`.

### Description
- Add a configurable lobby seat TTL `lobbySeatTtlMs` (env `LOBBY_SEAT_TTL_MS`, default 60000ms) and use it in `cleanupSeats` to expire stale seats instead of a hard-coded 60s.
- Introduce `pruneLobbyTableSeats(tableId)` which reconciles a table's `players` and `ready` sets against live seats, removes empty tables from `lobbyTables`/`tableMap`, and fixes `currentTurn` if needed.
- Run `cleanupSeats()` and `reconcileOpenLobbyTables(key)` at the start of `getAvailableTable()` so expired/orphaned seats are pruned before choosing or creating a lobby table.
- Add `test/chessLobbyExpiredSeatMatchmaking.test.js` to reproduce the stale-seat failure mode and verify two fresh players with the same matchmaking criteria are matched onto the same table after pruning.

### Testing
- Ran `node --check bot/server.js` and verified no syntax errors (success).
- Ran the new regression test with `node --test test/chessLobbyExpiredSeatMatchmaking.test.js` (passed).
- Re-ran related chess lobby tests with `node --test test/chessLobbyPreferredSideMatchmaking.test.js test/chessLobbyStaleTableIdMatchmaking.test.js test/chessLobbyPrivateCodeIsolation.test.js test/chessLobbyExpiredSeatMatchmaking.test.js` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2538a1c0948329a434b1ef37e4dcac)