### PR TITLE
Fix Domino Royal lobby matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -479,6 +479,9 @@ const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
+const defaultGameStartGraceMs = Number(process.env.GAME_START_GRACE_MS) || 1000;
+const dominoRoyalStartGraceMs =
+  Number(process.env.DOMINO_ROYAL_START_GRACE_MS) || 5000;
 
 function isRateLimited(socket, key, cooldownMs) {
   const now = Date.now();
@@ -1283,7 +1286,8 @@ function maybeStartGame(table) {
         players: table.players,
         currentTurn: table.currentTurn,
         stake: table.stake,
-        meta: table.meta
+        meta: table.meta,
+        connectGraceMs: table.gameType === 'domino-royal' ? dominoRoyalStartGraceMs : defaultGameStartGraceMs
       });
       tableSeats.delete(table.id);
       const key = `${table.gameType}-${table.maxPlayers}`;
@@ -1296,7 +1300,7 @@ function maybeStartGame(table) {
         dominoRoyalStates.set(table.id, { state: null, action: null, ts: Date.now() });
       }
       table.startTimeout = null;
-    }, 1000);
+    }, table.gameType === 'domino-royal' ? dominoRoyalStartGraceMs : defaultGameStartGraceMs);
   }
 }
 

--- a/bot/tests/lobbyMatchmaking.test.js
+++ b/bot/tests/lobbyMatchmaking.test.js
@@ -61,3 +61,52 @@ test('keeps quick and private lobby table buckets separate', () => {
   assert.equal(quickKey, sameQuickKey);
   assert.notEqual(quickKey, privateKey);
 });
+
+test('requires Domino Royal quick matches to share stake seats and criteria', () => {
+  const base = {
+    gameType: 'domino-royal',
+    stake: 100,
+    maxPlayers: 4,
+    matchMeta: { mode: 'online', token: 'TPC', variant: 'points', targetPoints: 51 }
+  };
+
+  const sameCriteria = buildLobbyMatchKey({
+    ...base,
+    matchMeta: { mode: 'ONLINE', token: 'tpc', variant: ' Points ', targetPoints: '51' }
+  });
+
+  assert.equal(buildLobbyMatchKey(base), sameCriteria);
+  assert.notEqual(buildLobbyMatchKey(base), buildLobbyMatchKey({ ...base, stake: 250 }));
+  assert.notEqual(buildLobbyMatchKey(base), buildLobbyMatchKey({ ...base, maxPlayers: 3 }));
+  assert.notEqual(
+    buildLobbyMatchKey(base),
+    buildLobbyMatchKey({ ...base, matchMeta: { ...base.matchMeta, targetPoints: 101 } })
+  );
+});
+
+test('requires Domino Royal mode token and variant on legacy compatibility checks', () => {
+  assert.equal(
+    isMatchMetaCompatible(
+      { mode: 'online', token: 'tpc', variant: 'single', targetPoints: '0' },
+      { mode: 'online', token: 'tpc', variant: 'single', targetPoints: '0' },
+      'domino-royal'
+    ),
+    true
+  );
+  assert.equal(
+    isMatchMetaCompatible(
+      { mode: 'online', token: 'tpc', variant: 'single', targetPoints: '0' },
+      { mode: 'online', token: 'tpc', targetPoints: '0' },
+      'domino-royal'
+    ),
+    false
+  );
+  assert.equal(
+    isMatchMetaCompatible(
+      { mode: 'online', token: 'tpc', variant: 'single', targetPoints: '0' },
+      { mode: 'online', token: 'ton', variant: 'single', targetPoints: '0' },
+      'domino-royal'
+    ),
+    false
+  );
+});

--- a/bot/utils/lobbyMatchmaking.js
+++ b/bot/utils/lobbyMatchmaking.js
@@ -1,5 +1,8 @@
 const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'targetPoints', 'tableSize', 'ballSet', 'token'];
 const STRICT_MATCH_META_KEYS = new Set(['mode', 'token', 'targetPoints']);
+const GAME_STRICT_MATCH_META_KEYS = {
+  'domino-royal': new Set(['mode', 'token', 'variant', 'targetPoints'])
+};
 
 export function normalizeTableSizeMeta(value = '') {
   const normalized = String(value || '').trim().toLowerCase();
@@ -43,10 +46,11 @@ export function normalizeMatchMeta(rawMeta = {}) {
   const normalized = {};
   MATCH_META_KEYS.forEach((key) => {
     const value = rawMeta[key];
-    if (typeof value === 'string' && value.trim()) {
-      const normalizedValue = normalizeMatchMetaValue(key, value);
-      if (normalizedValue) normalized[key] = normalizedValue;
-    }
+    if (value == null) return;
+    const rawValue = String(value).trim();
+    if (!rawValue) return;
+    const normalizedValue = normalizeMatchMetaValue(key, rawValue);
+    if (normalizedValue) normalized[key] = normalizedValue;
   });
   return normalized;
 }
@@ -64,9 +68,12 @@ export function isMatchMetaCompatible(existing = {}, requested = {}, gameType = 
     return existingVariant === requestedVariant;
   }
 
+  const gameStrictKeys = GAME_STRICT_MATCH_META_KEYS[normalizedGameType];
+  const strictKeys = gameStrictKeys || STRICT_MATCH_META_KEYS;
   const allKeys = new Set([
     ...Object.keys(existing || {}),
-    ...Object.keys(requested || {})
+    ...Object.keys(requested || {}),
+    ...(gameStrictKeys || [])
   ]);
   for (const key of allKeys) {
     if (key === 'preferredSide') {
@@ -79,7 +86,7 @@ export function isMatchMetaCompatible(existing = {}, requested = {}, gameType = 
     if (!existingValue || !requestedValue) {
       // Core lobby criteria must match exactly. This prevents Chess Battle
       // Royal players with different tokens/modes from being seated together.
-      if (STRICT_MATCH_META_KEYS.has(key)) return false;
+      if (strictKeys.has(key)) return false;
       // Treat non-core missing keys as wildcards so players can still pair when
       // one client sends less detailed lobby metadata (for example tableSize).
       continue;

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -47,6 +47,35 @@ const GAME_TYPE_OPTIONS = [
   }
 ];
 const TARGET_POINTS_OPTIONS = [51, 101];
+const DOMINO_MATCH_TIMEOUT_MS = 120000;
+const DOMINO_SOCKET_CONNECT_TIMEOUT_MS = 10000;
+
+function ensureDominoSocketReady(timeoutMs = DOMINO_SOCKET_CONNECT_TIMEOUT_MS) {
+  if (socket.connected) return Promise.resolve(true);
+  try {
+    socket.connect?.();
+  } catch {
+    return Promise.resolve(false);
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.off?.('connect', onConnect);
+      socket.off?.('connect_error', onError);
+      socket.off?.('error', onError);
+      resolve(Boolean(ok));
+    };
+    const onConnect = () => finish(true);
+    const onError = () => finish(false);
+    const timer = setTimeout(() => finish(socket.connected), timeoutMs);
+    socket.once?.('connect', onConnect);
+    socket.once?.('connect_error', onError);
+    socket.once?.('error', onError);
+  });
+}
 
 export default function DominoRoyalLobby() {
   const navigate = useNavigate();
@@ -68,6 +97,7 @@ export default function DominoRoyalLobby() {
   const [queueStatus, setQueueStatus] = useState('');
   const [queueError, setQueueError] = useState('');
   const queuedTableIdRef = useRef('');
+  const queueTimeoutRef = useRef(null);
   const onlineStakeDebitedRef = useRef(false);
   const startBet = stake.amount / 100;
   const readiness = getOnlineReadiness('domino-royal');
@@ -199,7 +229,24 @@ export default function DominoRoyalLobby() {
       setQueueError('');
       setQueueStatus('Connecting to Domino Royal lobby…');
       onlineStakeDebitedRef.current = false;
+      const socketReady = await ensureDominoSocketReady();
+      if (!socketReady) {
+        setQueueError('Unable to connect to Domino Royal lobby. Please try again.');
+        setQueueStatus('');
+        return;
+      }
       socket.emit('register', { playerId: accountId });
+      if (queueTimeoutRef.current) clearTimeout(queueTimeoutRef.current);
+      queueTimeoutRef.current = setTimeout(() => {
+        const tableId = queuedTableIdRef.current;
+        if (tableId) {
+          socket.emit('leaveLobby', { accountId, tableId });
+        }
+        queuedTableIdRef.current = '';
+        setQueuedTableId('');
+        setQueueStatus('');
+        setQueueError('Matchmaking is taking longer than expected. Please try again with the same stake and player count.');
+      }, DOMINO_MATCH_TIMEOUT_MS);
       socket.emit(
         'seatTable',
         {
@@ -216,13 +263,17 @@ export default function DominoRoyalLobby() {
           matchMeta: {
             mode: 'online',
             variant: gameType,
-            targetPoints: gameType === 'points' ? String(targetPoints) : '',
+            targetPoints: String(gameType === 'points' ? targetPoints : 0),
             token: stake.token
           }
         },
         (res = {}) => {
           if (!res.success || !res.tableId) {
             const message = `Unable to join Domino online table (${res.error || 'try_again'}).`;
+            if (queueTimeoutRef.current) {
+              clearTimeout(queueTimeoutRef.current);
+              queueTimeoutRef.current = null;
+            }
             setQueueError(message);
             setQueueStatus('');
             return;
@@ -257,7 +308,7 @@ export default function DominoRoyalLobby() {
       );
     };
 
-    const handleGameStart = ({ tableId, players, stake: onlineStake, meta }) => {
+    const handleGameStart = ({ tableId, players, stake: onlineStake, meta, connectGraceMs }) => {
       if (!tableId || tableId !== queuedTableIdRef.current) return;
       const accountId = ensureAccountId().catch(() => '');
       Promise.resolve(accountId).then((resolvedAccountId) => {
@@ -289,9 +340,14 @@ export default function DominoRoyalLobby() {
             })
           );
         } catch {}
+        if (queueTimeoutRef.current) {
+          clearTimeout(queueTimeoutRef.current);
+          queueTimeoutRef.current = null;
+        }
         queuedTableIdRef.current = '';
         setQueuedTableId('');
-        setQueueStatus('Starting online match…');
+        const graceSeconds = Math.max(1, Math.round((Number(connectGraceMs) || 0) / 1000));
+        setQueueStatus(`Starting online match… players had ${graceSeconds}s to connect.`);
         launchGame({
           accountId: resolvedAccountId,
           tgId: getTelegramId(),
@@ -309,9 +365,14 @@ export default function DominoRoyalLobby() {
     return () => {
       socket.off('lobbyUpdate', handleLobbyUpdate);
       socket.off('gameStart', handleGameStart);
+      if (queueTimeoutRef.current) {
+        clearTimeout(queueTimeoutRef.current);
+        queueTimeoutRef.current = null;
+      }
       if (queuedTableIdRef.current) {
+        const tableId = queuedTableIdRef.current;
         ensureAccountId()
-          .then((accountId) => socket.emit('leaveLobby', { accountId, tableId: queuedTableIdRef.current }))
+          .then((accountId) => socket.emit('leaveLobby', { accountId, tableId }))
           .catch(() => {});
       }
     };


### PR DESCRIPTION
### Motivation
- Ensure Domino Royal online players only match when their lobby criteria truly match (same stake, player count, token/mode, variant and target points) and give matched players extra time to connect before starting the game. 

### Description
- Tighten match-key and compatibility logic in `bot/utils/lobbyMatchmaking.js` by normalizing numeric/string metadata and adding a Domino-specific strict key set (`mode`, `token`, `variant`, `targetPoints`) so `buildLobbyMatchKey` and `isMatchMetaCompatible` treat `targetPoints` as a core criterion for Domino Royal. 
- Add configurable start-grace timeouts in `bot/server.js` (`GAME_START_GRACE_MS` and `DOMINO_ROYAL_START_GRACE_MS`) and include `connectGraceMs` in the `gameStart` payload so clients know how long to allow peers to connect. 
- Harden the Domino Royal lobby UI in `webapp/src/pages/Games/DominoRoyalLobby.jsx` by verifying socket connection (`ensureDominoSocketReady`), adding a matchmaking timeout/cleanup (`queueTimeoutRef`), ensuring `targetPoints` is serialized consistently, and using the server-supplied `connectGraceMs` to update user messaging. 
- Add unit tests in `bot/tests/lobbyMatchmaking.test.js` to assert Domino Royal quick-match key behavior and legacy compatibility checks. 

### Testing
- Ran unit tests with `node --test bot/tests/lobbyMatchmaking.test.js` and full bot test suite with `npm --prefix bot test`; all tests passed. 
- Performed static checks with `node --check bot/server.js` and `node --check bot/utils/lobbyMatchmaking.js`; no syntax errors. 
- Linted the Domino lobby page with `npm --prefix webapp run lint -- src/pages/Games/DominoRoyalLobby.jsx`; lint passed. 
- Built the webapp with `npm --prefix webapp run build`; production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a253c091b9083298ed3011453566bbe)