### PR TITLE
Fix Chess Battle Royal lobby alias matchmaking

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -26,14 +26,21 @@ const GAME_ONLINE_POLICY = Object.freeze({
 });
 
 const GAME_TYPE_ALIASES = Object.freeze({
+  chessbattle: 'chess',
   chessbattleroyal: 'chess',
-  checkersbattleroyal: 'checkers'
+  chessbattleroyale: 'chess',
+  checkersbattle: 'checkers',
+  checkersbattleroyal: 'checkers',
+  checkersbattleroyale: 'checkers'
 });
 
 export function normalizeOnlineGameType(gameType) {
   const normalized = String(gameType || '').trim().toLowerCase();
   if (!normalized) return '';
-  return GAME_TYPE_ALIASES[normalized] || normalized;
+  if (GAME_TYPE_ALIASES[normalized]) return GAME_TYPE_ALIASES[normalized];
+
+  const compact = normalized.replace(/[^a-z0-9]+/g, '');
+  return GAME_TYPE_ALIASES[compact] || normalized;
 }
 
 function sanitizeMetaValue(value) {

--- a/bot/server.js
+++ b/bot/server.js
@@ -714,13 +714,14 @@ function resolveSeatIdentityFromTableId(tableId, fallbackGameType, fallbackMaxPl
   }
 
   const [prefix, capStr] = String(tableId).split('-');
+  const normalizedPrefix = normalizeOnlineGameType(prefix);
   const parsedCap = Number(capStr);
 
   // Some joins use invite/table ids that are opaque (UUID-like) and not in
   // "<game>-<capacity>-..." form. In those cases, keep the explicit payload
   // gameType/maxPlayers instead of inferring invalid values from the table id.
   if (
-    !GAME_ONLINE_POLICY[prefix] ||
+    !GAME_ONLINE_POLICY[normalizedPrefix] ||
     !Number.isFinite(parsedCap) ||
     parsedCap <= 0
   ) {
@@ -731,7 +732,7 @@ function resolveSeatIdentityFromTableId(tableId, fallbackGameType, fallbackMaxPl
   }
 
   return {
-    gameType: normalizeOnlineGameType(prefix),
+    gameType: normalizedPrefix,
     maxPlayers: parsedCap
   };
 }
@@ -1014,7 +1015,8 @@ function updateChessState(tableId, nextState = {}) {
 }
 
 function normalizeSidePreference(pref) {
-  return pref === 'white' || pref === 'black' ? pref : 'auto';
+  const normalized = String(pref || '').trim().toLowerCase();
+  return normalized === 'white' || normalized === 'black' ? normalized : 'auto';
 }
 
 function assignCheckersSides(players = []) {

--- a/test/chessLobbyAliasCriteriaMatchmaking.test.js
+++ b/test/chessLobbyAliasCriteriaMatchmaking.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test(
+  'chess battle royal aliases with the same criteria seat players at one table',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3221',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const s1 = io('http://localhost:3221', { auth: { token: apiToken } });
+    const s2 = io('http://localhost:3221', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve))
+      ]);
+
+      const register = (socket, playerId) =>
+        new Promise((resolve) => socket.emit('register', { playerId }, resolve));
+      await Promise.all([
+        register(s1, 'chess-alias-a'),
+        register(s2, 'chess-alias-b')
+      ]);
+
+      const seat = (socket, payload) =>
+        new Promise((resolve) => socket.emit('seatTable', payload, resolve));
+
+      const firstSeat = await seat(s1, {
+        accountId: 'chess-alias-a',
+        gameType: 'Chess Battle Royal',
+        stake: '100.00',
+        maxPlayers: 2,
+        mode: 'Online',
+        token: 'TPC',
+        preferredSide: 'WHITE'
+      });
+      const secondSeat = await seat(s2, {
+        accountId: 'chess-alias-b',
+        gameType: 'chess-battle-royale',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'tpc',
+        preferredSide: 'black'
+      });
+
+      assert.equal(firstSeat.success, true);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, firstSeat.tableId);
+      assert.equal(secondSeat.players.length, 2);
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      server.kill();
+    }
+  }
+);

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -64,7 +64,10 @@ describe('online game policy', () => {
 
   test('normalizes battle royal aliases to shared lobby game types', () => {
     expect(normalizeOnlineGameType('chessbattleroyal')).toBe('chess');
+    expect(normalizeOnlineGameType('Chess Battle Royal')).toBe('chess');
+    expect(normalizeOnlineGameType('chess-battle-royale')).toBe('chess');
     expect(normalizeOnlineGameType('checkersbattleroyal')).toBe('checkers');
+    expect(normalizeOnlineGameType('Checkers Battle Royal')).toBe('checkers');
     expect(normalizeOnlineGameType('poolroyale')).toBe('poolroyale');
   });
 


### PR DESCRIPTION
### Motivation
- Players using different spellings/aliases for Chess/Checkers Battle Royal were not always routed into the same matchmaking queue and private/table-id parsing could let alias-prefixed IDs escape policy checks.
- Side preferences were treated inconsistently when provided in mixed case which could affect seat assignment and side selection.

### Description
- Normalize Battle Royal aliases in `normalizeOnlineGameType` by adding common alias variants and compacting input (strip non-alphanumerics) so spaced/hyphenated/`royale` variants map to the same canonical game (`bot/config/onlineGamePolicy.js`).
- Use the normalized table-id prefix when deriving seat identity in `resolveSeatIdentityFromTableId` so alias-prefixed `tableId` values are validated against `GAME_ONLINE_POLICY` correctly (`bot/server.js`).
- Make `normalizeSidePreference` case-insensitive and return normalized `white`/`black`/`auto` values to ensure consistent side handling (`bot/server.js`).
- Add a regression test `test/chessLobbyAliasCriteriaMatchmaking.test.js` and extend `test/onlineGamePolicy.test.js` to cover spaced/hyphenated Battle Royal aliases and verify two alias variants with the same match criteria are seated at the same table.

### Testing
- Ran targeted suites with `npm test -- --runInBand` including `test/onlineGamePolicy.test.js`, `test/chessLobbyAliasCriteriaMatchmaking.test.js`, `test/chessLobbyStaleTableIdMatchmaking.test.js`, `test/chessLobbyPrivateCodeIsolation.test.js`, `test/chessLobbyPreferredSideMatchmaking.test.js`, and `test/chessOnlineMoveValidation.test.js`.
- All test suites passed: `Test Suites: 6 passed, 6 total` and `Tests: 11 passed, 11 total` in the final run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2538a1c0948329a434b1ef37e4dcac)