### PR TITLE
Align Pool Royale Showood table mapping

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -57,7 +57,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     useOriginalLayoutSurfaces: true,
     useProceduralBaseWithExternal: false,
     hideOriginalBaseAndLegsForProceduralBase: false,
-    keepGeneratedPocketDropHardware: true,
+    keepGeneratedPocketDropHardware: false,
     usePoolRoyaleFinish: true,
     useReferenceShowoodMapping: true,
     usePoolRoyaleFinishRoles: ['cloth', 'cushion', 'wood'],

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1311,9 +1311,7 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   const TABLE_WIDTH_SCALE = 1.25;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
-  const TABLE_SURFACE_REFERENCE = 1.12; // baseline expansion before the wider table adjustment
-  const TABLE_SURFACE_EXPANSION = 1.25; // widen/lengthen the table footprint by ~12% while keeping pockets/balls unchanged
-  const TABLE_SURFACE_COMPENSATION = TABLE_SURFACE_EXPANSION / TABLE_SURFACE_REFERENCE;
+  const TABLE_SURFACE_EXPANSION = 1.25; // widen/lengthen the visual table footprint while the game mapping stays locked to the Showood 7 ft playfield
   const TABLE = {
     W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * OFFICIAL_TABLE_SCALE * TABLE_SURFACE_EXPANSION,
     H:
@@ -1426,7 +1424,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     Math.abs(CURRENT_RATIO - TARGET_RATIO) < 1e-4,
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
-const MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION;
+const MM_TO_UNITS = innerLong / WIDTH_REF; // map game physics directly to the native Showood 7 ft GLB playfield size
 const BALL_SIZE_SCALE = 1; // official WPA/WEPF 57.15 mm balls; every helper stays tied to BALL_R/BALL_DIAMETER
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;


### PR DESCRIPTION
### Motivation
- Remove the procedurally generated pocket drop hardware (thin chrome holder rails, leather straps, and hex net) when the Showood 7 ft GLB is used so the GLB’s native pocket visuals are authoritative. 
- Ensure the game physics and playfield mapping use the actual Showood 7 ft GLB playfield size so pockets, balls and collisions align exactly with the model.

### Description
- Disabled generated pocket-drop hardware for the Showood GLB by setting `keepGeneratedPocketDropHardware` to `false` in `webapp/src/config/poolRoyaleTableModels.js`, which prevents the procedural net/strap/holder assembly from being kept visible when mounting the GLB table.
- Changed the millimeter→world-unit mapping in `webapp/src/pages/Games/PoolRoyale.jsx` so `MM_TO_UNITS` is computed as `innerLong / WIDTH_REF` (direct mapping to the Showood playfield) instead of dividing by the previous surface-compensation factor, locking physics to the GLB native playfield.

### Testing
- Ran ESLint: `npm run lint -- src/pages/Games/PoolRoyale.jsx src/config/poolRoyaleTableModels.js`, which completed without errors.
- Production build: `npm run build` completed successfully and produced the app `dist` artifacts.
- Smoke preview: launched a portrait Playwright preview of `/games/poolroyale?tableModel=showood-seven-foot` and captured a screenshot to verify the Showood GLB mounted and procedural pocket hardware is no longer visible; the screenshot was produced (noting console network warnings from external services during the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a253e1f642c8329a151ae00bb09ef63)