### PR TITLE
Tune cue stroke visuals: larger balls and forward cue follow-through

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1425,7 +1425,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF; // map game physics directly to the native Showood 7 ft GLB playfield size
-const BALL_SIZE_SCALE = 1; // official WPA/WEPF 57.15 mm balls; every helper stays tied to BALL_R/BALL_DIAMETER
+const BALL_SIZE_SCALE = 1.06; // slightly larger portrait-screen balls; every helper stays tied to BALL_R/BALL_DIAMETER
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -24914,7 +24914,8 @@ const shotPowerRef = useRef(0);
             strikeDuration,
             holdDuration,
             recoverDuration,
-            animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE
+            animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE,
+            hitArmRatio: stroke.strikeImpactThreshold ?? 0.86
           });
           cueStick.visible = true;
           cueAnimating = !sample.done;
@@ -29543,7 +29544,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29645,12 +29645,16 @@ const shotPowerRef = useRef(0);
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
-          const contactAdvance = 0; // stop the cue exactly where the slider pull started, matching Snooker Royal
+          // After the pull slider is released, show the stick itself driving
+          // visually inward/forward into the cue ball instead of relying on the
+          // camera motion to imply impact. Keep the follow-through short so the
+          // tip never appears to chase the moving cue ball across the table.
+          const contactAdvance = Math.min(BALL_R * 0.62, CUE_TIP_GAP + BALL_R * 0.38);
           shotImpactPayload.contactAdvance = contactAdvance;
           const contactPos = impactPos
             .clone()
             .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
+          const followDistance = BALL_R * 0.28;
           const followPos = contactPos
             .clone()
             .addScaledVector(dir, followDistance);
@@ -29776,7 +29780,7 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: strokeProfile.impactThreshold ?? 0.86,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
               forwardOnly: false,
               onImpact: () => applyShotImpactOnce(),


### PR DESCRIPTION
### Motivation
- Improve visual clarity on portrait mobile: make balls slightly larger so they read better on small screens and ensure the cue stick visibly pushes forward during a shot so the player sees the stick drive into the cue ball rather than only camera motion implying it.
- Make impact timing consistent with the visible cue stroke so the physics impulse happens when the animated cue reach indicates contact (important for perceived responsiveness).

### Description
- Increased global ball scale by bumping `BALL_SIZE_SCALE` from `1` to `1.06` so `BALL_DIAMETER`/`BALL_R` and all dependent helpers grow proportionally (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Deferred applying the impact to the cue ball until the cue stroke timeline indicates the hit (removed immediate `applyShotAtImpact` on slider release and instead apply on timeline `hitArmed`).
- Wire the stroke sampler to use a configurable hit-arm threshold by passing `hitArmRatio` into `sampleCueStrokeTimeline` (uses `stroke.strikeImpactThreshold` when available) so the shot is applied when the animation reaches the armed point.
- Add a short visible cue-stick forward travel: compute a small `contactAdvance` and `followDistance` (both scaled from `BALL_R`) and store `contactPos` / `followPos` in the cue stroke state so the cue visibly drives forward into the ball before the physics impulse is applied.
- Use stroke profile `impactThreshold` for stored `strikeImpactThreshold` instead of a hardcoded value so different stroke profiles can control the exact hit timing.

### Testing
- Ran a production build with `npm run build` (Vite) which completed successfully and produced the app bundles.
- Installed Playwright and OS deps with `npx playwright install chromium` and `npx playwright install-deps chromium` to enable headless browser testing, which completed successfully.
- Launched the dev server with `npm run dev -- --host 127.0.0.1 --port 4173` and exercised a Playwright mobile screenshot flow that navigated to `/games/poolroyale?mode=ai&type=regular`; the screenshot step succeeded (headless browser run completed and produced an output image).
- No automated unit tests were changed; the above build + headless render checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a254f7ed50483298e259ed70128d9aa)