### PR TITLE
Refine cue-stroke timing/impact and adjust ball sizing for clearer mobile visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1425,7 +1425,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF; // map game physics directly to the native Showood 7 ft GLB playfield size
-const BALL_SIZE_SCALE = 1; // official WPA/WEPF 57.15 mm balls; every helper stays tied to BALL_R/BALL_DIAMETER
+const BALL_SIZE_SCALE = 1.045; // slightly enlarged for clearer mobile portrait play; every helper stays tied to BALL_R/BALL_DIAMETER
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -6337,14 +6337,16 @@ const RANDOM_BREAK_REVEAL_DELAY_MS = 360;
 const RANDOM_BREAK_RESULT_PAUSE_MS = 480;
 const REPLAY_CUE_MIN_PULLBACK_MS = 220; // guarantee a readable pullback in replay/broadcast clips
 const REPLAY_CUE_MIN_RELEASE_MS = 180; // keep forward stroke visible while still feeling fast
-const MIN_VISIBLE_CUE_PUSH_DISTANCE = BALL_R * 0.12;
+const MIN_VISIBLE_CUE_PUSH_DISTANCE = BALL_R * 0.42;
 const REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS = 220;
 const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.82;
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 140; // hold broadcast cue angle a bit longer so forward push reads clearly
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
 const LIVE_CUE_FORWARD_DURATION_MS = 140;
-const LIVE_CUE_IMPACT_HOLD_MS = 90;
+const LIVE_CUE_IMPACT_HOLD_MS = 120;
+const LIVE_CUE_CONTACT_ADVANCE = BALL_R * 0.62;
+const LIVE_CUE_FOLLOW_THROUGH = BALL_R * 0.28;
 const CAMERA_SWITCH_MIN_HOLD_MS = 70; // cut mandatory lock further so rail-overhead camera switches in noticeably earlier
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
 const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
@@ -24914,7 +24916,8 @@ const shotPowerRef = useRef(0);
             strikeDuration,
             holdDuration,
             recoverDuration,
-            animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE
+            animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE,
+            hitArmRatio: strikeImpactThreshold ?? 0.88
           });
           cueStick.visible = true;
           cueAnimating = !sample.done;
@@ -29543,7 +29546,9 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
+          // Do not apply the physics impulse immediately on slider release.
+          // The cue stroke owns impact timing so players first see the cue stick
+          // drive forward from the pulled-back pose, then the ball/camera reacts.
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29645,17 +29650,30 @@ const shotPowerRef = useRef(0);
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
-          const contactAdvance = 0; // stop the cue exactly where the slider pull started, matching Snooker Royal
+          const contactAdvance = THREE.MathUtils.lerp(
+            LIVE_CUE_CONTACT_ADVANCE * 0.72,
+            LIVE_CUE_CONTACT_ADVANCE,
+            clampedPower
+          );
           shotImpactPayload.contactAdvance = contactAdvance;
           const contactPos = impactPos
             .clone()
             .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
+          const followDistance = THREE.MathUtils.lerp(
+            LIVE_CUE_FOLLOW_THROUGH * 0.55,
+            LIVE_CUE_FOLLOW_THROUGH,
+            clampedPower
+          );
           const followPos = contactPos
             .clone()
             .addScaledVector(dir, followDistance);
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
+          const impactThreshold = THREE.MathUtils.clamp(
+            strokeProfile.impactThreshold ?? 0.88,
+            0.05,
+            0.995
+          );
           const forwardPreviewHold =
             startTime +
             Math.max(
@@ -29735,6 +29753,7 @@ const shotPowerRef = useRef(0);
           const applyShotImpactOnce = () => {
             if (shotImpactApplied) return;
             shotImpactApplied = true;
+            pendingImpactRef.current = null;
             applyShotAtImpact(shotImpactPayload);
           };
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
@@ -29776,13 +29795,21 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: impactThreshold,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
               forwardOnly: false,
               onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true
+            };
+            pendingImpactRef.current = {
+              time: startTime + strikeDuration * impactThreshold,
+              apply: () => {
+                const activeStroke = cueStrokeStateRef.current;
+                if (activeStroke) activeStroke.shotApplied = true;
+                applyShotImpactOnce();
+              }
             };
           } else {
             applyShotImpactOnce();
@@ -35119,8 +35146,15 @@ const shotPowerRef = useRef(0);
             const any = balls.some(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
+            const cueStrokePendingImpact = Boolean(
+              ENABLE_CUE_STROKE_ANIMATION &&
+                cueStrokeStateRef.current &&
+                !cueStrokeStateRef.current.shotApplied
+            );
             if (!any) {
-              resolve();
+              if (!cueStrokePendingImpact) {
+                resolve();
+              }
             } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
               console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');
               balls.forEach((ball) => {


### PR DESCRIPTION
### Motivation
- Improve the visual fidelity of live cue strokes by separating cue stick animation from physics application so players see the cue drive forward before the ball and camera react.
- Make the playfield objects clearer on mobile portrait by slightly enlarging balls and nudge related timing/thresholds to match the new visuals.

### Description
- Increased ball rendering scale via `BALL_SIZE_SCALE = 1.045` so `BALL_DIAMETER`, `BALL_R`, and related values map to a slightly larger ball on mobile portrait.
- Raised the minimum visible forward cue push distance by updating `MIN_VISIBLE_CUE_PUSH_DISTANCE` to `BALL_R * 0.42` and adjusted `LIVE_CUE_IMPACT_HOLD_MS` to `120` ms for a more readable impact hold.
- Added `LIVE_CUE_CONTACT_ADVANCE` and `LIVE_CUE_FOLLOW_THROUGH` constants and compute `contactAdvance` and `followDistance` per-shot using `THREE.MathUtils.lerp(..., clampedPower)` so impact position and visual follow-through scale with shot power.
- Delay actual physics impulse application: stop calling `applyShotAtImpact` immediately on slider release and instead create a timed pending impact (`pendingImpactRef`) and set `strikeImpactThreshold` from a per-stroke `impactThreshold` (clamped) so the cue stroke animation owns the impact timing and then invokes `applyShotAtImpact` via `applyShotImpactOnce`/`pendingImpactRef.apply`.
- Expose `hitArmRatio` into the cue stroke sampler call via `sampleCueStrokeTimeline(..., hitArmRatio: strikeImpactThreshold ?? 0.88)` so timed sampling respects the stroke's impact threshold.
- Prevent frame-resolve until the pending cue-stroke impact has been applied by checking `cueStrokePendingImpact` before resolving a shot simulation.

### Testing
- Ran the project's linting and unit test suite (`yarn lint` and `yarn test`) and they completed successfully with no regressions detected.
- Executed a local smoke test of the live shot flow and replay/cue-stroke animation to validate that the visual cue push precedes ball physics and that pending impacts apply correctly, which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a254f7ed50483298e259ed70128d9aa)