### PR TITLE
PoolRoyale: enlarge balls, tune live-cue timing, and defer physics impact to cue animation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1425,7 +1425,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF; // map game physics directly to the native Showood 7 ft GLB playfield size
-const BALL_SIZE_SCALE = 1; // official WPA/WEPF 57.15 mm balls; every helper stays tied to BALL_R/BALL_DIAMETER
+const BALL_SIZE_SCALE = 1.045; // slightly enlarged for clearer mobile portrait play; every helper stays tied to BALL_R/BALL_DIAMETER
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -6337,14 +6337,16 @@ const RANDOM_BREAK_REVEAL_DELAY_MS = 360;
 const RANDOM_BREAK_RESULT_PAUSE_MS = 480;
 const REPLAY_CUE_MIN_PULLBACK_MS = 220; // guarantee a readable pullback in replay/broadcast clips
 const REPLAY_CUE_MIN_RELEASE_MS = 180; // keep forward stroke visible while still feeling fast
-const MIN_VISIBLE_CUE_PUSH_DISTANCE = BALL_R * 0.12;
+const MIN_VISIBLE_CUE_PUSH_DISTANCE = BALL_R * 0.42;
 const REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS = 220;
 const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.82;
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 140; // hold broadcast cue angle a bit longer so forward push reads clearly
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
 const LIVE_CUE_FORWARD_DURATION_MS = 140;
-const LIVE_CUE_IMPACT_HOLD_MS = 90;
+const LIVE_CUE_IMPACT_HOLD_MS = 120;
+const LIVE_CUE_CONTACT_ADVANCE = BALL_R * 0.62;
+const LIVE_CUE_FOLLOW_THROUGH = BALL_R * 0.28;
 const CAMERA_SWITCH_MIN_HOLD_MS = 70; // cut mandatory lock further so rail-overhead camera switches in noticeably earlier
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
 const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
@@ -24862,6 +24864,7 @@ const shotPowerRef = useRef(0);
             const impactThreshold = THREE.MathUtils.clamp(strikeImpactThreshold ?? 0.88, 0.05, 0.995);
             if (!stroke.shotApplied && strikeProgress >= impactThreshold) {
               stroke.shotApplied = true;
+              pendingImpactRef.current = null;
               stroke.onImpact?.();
             }
 
@@ -24914,12 +24917,14 @@ const shotPowerRef = useRef(0);
             strikeDuration,
             holdDuration,
             recoverDuration,
-            animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE
+            animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE,
+            hitArmRatio: strikeImpactThreshold ?? 0.88
           });
           cueStick.visible = true;
           cueAnimating = !sample.done;
           if (!stroke.shotApplied && sample.hitArmed) {
             stroke.shotApplied = true;
+            pendingImpactRef.current = null;
             stroke.onImpact?.();
           }
           if (sample.phase === 'pullback') {
@@ -29543,7 +29548,9 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
+          // Do not apply the physics impulse immediately on slider release.
+          // The cue stroke owns impact timing so players first see the cue stick
+          // drive forward from the pulled-back pose, then the ball/camera reacts.
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29645,17 +29652,30 @@ const shotPowerRef = useRef(0);
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
-          const contactAdvance = 0; // stop the cue exactly where the slider pull started, matching Snooker Royal
+          const contactAdvance = THREE.MathUtils.lerp(
+            LIVE_CUE_CONTACT_ADVANCE * 0.72,
+            LIVE_CUE_CONTACT_ADVANCE,
+            clampedPower
+          );
           shotImpactPayload.contactAdvance = contactAdvance;
           const contactPos = impactPos
             .clone()
             .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
+          const followDistance = THREE.MathUtils.lerp(
+            LIVE_CUE_FOLLOW_THROUGH * 0.55,
+            LIVE_CUE_FOLLOW_THROUGH,
+            clampedPower
+          );
           const followPos = contactPos
             .clone()
             .addScaledVector(dir, followDistance);
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
+          const strokeImpactThreshold = THREE.MathUtils.clamp(
+            strokeProfile.impactThreshold ?? 0.88,
+            0.05,
+            0.98
+          );
           const forwardPreviewHold =
             startTime +
             Math.max(
@@ -29735,7 +29755,12 @@ const shotPowerRef = useRef(0);
           const applyShotImpactOnce = () => {
             if (shotImpactApplied) return;
             shotImpactApplied = true;
+            pendingImpactRef.current = null;
             applyShotAtImpact(shotImpactPayload);
+          };
+          pendingImpactRef.current = {
+            time: startTime + strikeDuration * strokeImpactThreshold,
+            apply: applyShotImpactOnce
           };
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
             const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
@@ -29776,7 +29801,7 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: strokeImpactThreshold,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
               forwardOnly: false,
               onImpact: () => applyShotImpactOnce(),


### PR DESCRIPTION
### Motivation
- Improve visual clarity on mobile portrait by slightly enlarging balls and making the cue push visibly larger. 
- Make the live cue animation drive the actual physics impact so players always see the cue push before the ball/camera reacts. 
- Adjust timing/hold values so the forward stroke reads more clearly across power levels.

### Description
- Increase `BALL_SIZE_SCALE` from `1` to `1.045` to enlarge balls for mobile portrait visibility. 
- Increase `MIN_VISIBLE_CUE_PUSH_DISTANCE` and `LIVE_CUE_IMPACT_HOLD_MS`, and add `LIVE_CUE_CONTACT_ADVANCE` and `LIVE_CUE_FOLLOW_THROUGH` constants to widen visible cue push and hold timing. 
- Compute `contactAdvance` and `followDistance` as power-scaled lerps from the new live-cue constants and store them on the `shotImpactPayload`. 
- Stop applying physics immediately on slider release and instead schedule the impact via `pendingImpactRef.current` (with `time` and `apply`), so the cue stroke animation owns impact timing. 
- Pass `hitArmRatio`/`strokeImpactThreshold` to `sampleCueStrokeTimeline` and thread the clamped `strokeImpactThreshold` into the cue stroke state so animation/sample logic and scheduled impact remain consistent. 
- Clear `pendingImpactRef.current` when an impact is applied to avoid double applications.

### Testing
- Ran lint (`yarn lint`) against the changed files and fixed issues; lint succeeded. 
- Ran unit tests (`yarn test`) for the webapp package; all tests passed. 
- Built the webapp (`yarn build`) to verify bundles and runtime initialization; build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a254f7ed50483298e259ed70128d9aa)