### PR TITLE
Refine live cue-stroke timing and visuals; slightly enlarge balls for mobile

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1425,7 +1425,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
 const MM_TO_UNITS = innerLong / WIDTH_REF; // map game physics directly to the native Showood 7 ft GLB playfield size
-const BALL_SIZE_SCALE = 1; // official WPA/WEPF 57.15 mm balls; every helper stays tied to BALL_R/BALL_DIAMETER
+const BALL_SIZE_SCALE = 1.045; // slightly enlarged for clearer mobile portrait play; every helper stays tied to BALL_R/BALL_DIAMETER
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -6337,14 +6337,16 @@ const RANDOM_BREAK_REVEAL_DELAY_MS = 360;
 const RANDOM_BREAK_RESULT_PAUSE_MS = 480;
 const REPLAY_CUE_MIN_PULLBACK_MS = 220; // guarantee a readable pullback in replay/broadcast clips
 const REPLAY_CUE_MIN_RELEASE_MS = 180; // keep forward stroke visible while still feeling fast
-const MIN_VISIBLE_CUE_PUSH_DISTANCE = BALL_R * 0.12;
+const MIN_VISIBLE_CUE_PUSH_DISTANCE = BALL_R * 0.42;
 const REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS = 220;
 const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.82;
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 140; // hold broadcast cue angle a bit longer so forward push reads clearly
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
 const LIVE_CUE_FORWARD_DURATION_MS = 140;
-const LIVE_CUE_IMPACT_HOLD_MS = 90;
+const LIVE_CUE_IMPACT_HOLD_MS = 120;
+const LIVE_CUE_CONTACT_ADVANCE = BALL_R * 0.62;
+const LIVE_CUE_FOLLOW_THROUGH = BALL_R * 0.28;
 const CAMERA_SWITCH_MIN_HOLD_MS = 70; // cut mandatory lock further so rail-overhead camera switches in noticeably earlier
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
 const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
@@ -24914,7 +24916,8 @@ const shotPowerRef = useRef(0);
             strikeDuration,
             holdDuration,
             recoverDuration,
-            animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE
+            animationStyle: stroke.animationStyle ?? cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE,
+            hitArmRatio: stroke.strikeImpactThreshold ?? 0.88
           });
           cueStick.visible = true;
           cueAnimating = !sample.done;
@@ -29543,7 +29546,9 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
+          // Do not apply the physics impulse immediately on slider release.
+          // The cue stroke owns impact timing so players first see the cue stick
+          // drive forward from the pulled-back pose, then the ball/camera reacts.
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29645,12 +29650,20 @@ const shotPowerRef = useRef(0);
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
-          const contactAdvance = 0; // stop the cue exactly where the slider pull started, matching Snooker Royal
+          const contactAdvance = THREE.MathUtils.lerp(
+            LIVE_CUE_CONTACT_ADVANCE * 0.72,
+            LIVE_CUE_CONTACT_ADVANCE,
+            clampedPower
+          );
           shotImpactPayload.contactAdvance = contactAdvance;
           const contactPos = impactPos
             .clone()
             .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
+          const followDistance = THREE.MathUtils.lerp(
+            LIVE_CUE_FOLLOW_THROUGH * 0.55,
+            LIVE_CUE_FOLLOW_THROUGH,
+            clampedPower
+          );
           const followPos = contactPos
             .clone()
             .addScaledVector(dir, followDistance);
@@ -29776,7 +29789,7 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: strokeProfile.impactThreshold ?? 0.88,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
               forwardOnly: false,
               onImpact: () => applyShotImpactOnce(),
@@ -33102,7 +33115,11 @@ const shotPowerRef = useRef(0);
         if (isAiTurn) {
           autoPlaceAiCueBall();
         }
+        const liveCueStrokeActive =
+          ENABLE_CUE_STROKE_ANIMATION && Boolean(cueStrokeStateRef.current);
         const canShowCue =
+          !shooting &&
+          !liveCueStrokeActive &&
           allStopped(balls) &&
           cue?.active &&
           !(currentHud?.over) &&
@@ -35116,9 +35133,13 @@ const shotPowerRef = useRef(0);
             recordReplayFrame(now);
           }
           if (shooting) {
-            const any = balls.some(
-              (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
-            );
+            const pendingCueImpact =
+              ENABLE_CUE_STROKE_ANIMATION &&
+              cueStrokeStateRef.current &&
+              !cueStrokeStateRef.current.shotApplied;
+            const any =
+              pendingCueImpact ||
+              balls.some((b) => b.active && b.vel.length() * frameScale >= STOP_EPS);
             if (!any) {
               resolve();
             } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {


### PR DESCRIPTION
### Motivation
- Improve the synchronization between cue stick animation and physics so the ball and camera react only when the visible cue contacts the cue ball. 
- Make live/sticky cue-forward motion and hold behavior clearer on player shots and replays by tuning contact/follow-through distances and timing. 
- Increase on-screen ball size slightly to improve clarity in mobile portrait play. 

### Description
- Adjusted ball scale by changing `BALL_SIZE_SCALE` from `1` to `1.045`, and recomputed `BALL_DIAMETER`, `BALL_R`, and related values. 
- Introduced `LIVE_CUE_CONTACT_ADVANCE` and `LIVE_CUE_FOLLOW_THROUGH`, increased `MIN_VISIBLE_CUE_PUSH_DISTANCE`, and bumped `LIVE_CUE_IMPACT_HOLD_MS` to refine visible cue motion and impact hold. 
- Defer applying the physics impulse until the cue stroke's impact timing by removing the immediate `applyShotAtImpact` call, adding `hitArmRatio` to `sampleCueStrokeTimeline`, computing `contactAdvance` and `followDistance` as power-dependent lerps, and using `applyShotImpactOnce()` as the stroke's `onImpact` handler; also make `strikeImpactThreshold` read from `strokeProfile.impactThreshold ?? 0.88`. 
- Add gating so the cue is hidden while a live cue stroke is active (`liveCueStrokeActive`) and make the shot-resolve loop treat a pending cue impact as activity so the frame loop doesn't prematurely resolve the shot. 

### Testing
- Ran the automated test suite with `yarn test` and all tests passed. 
- Ran lint checks with `yarn lint` and no new lint errors were reported. 
- Executed a local development build (`yarn build`) as an automated CI-style check and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a254f7ed50483298e259ed70128d9aa)