### PR TITLE
Add ReadyPlayer GLTF human avatar and procedural pose system to SnookerRoyal

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1693,6 +1693,387 @@ const SNOOKER_CUE_FOLLOW_GAP = -CUE_TIP_RADIUS * 0.62; // tiny post-impact compr
 const SNOOKER_CUE_PULL_RANGE = 0.42 * SNOOKER_CUE_POSE_SCALE;
 const SNOOKER_CUE_BRIDGE_DIST = 0.28 * SNOOKER_CUE_POSE_SCALE;
 
+
+const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const UP = new THREE.Vector3(0, 1, 0);
+const Y_AXIS = UP;
+const BASIS_MAT = new THREE.Matrix4();
+const SNOOKER_ROYAL_HUMAN_TABLE_TOP_Y = BALL_CENTER_Y - BALL_R;
+const SNOOKER_ROYAL_HUMAN_GROUND_Y = FLOOR_Y - TABLE_Y;
+const CFG = {
+  scale: SNOOKER_CUE_POSE_SCALE,
+  tableTopY: SNOOKER_ROYAL_HUMAN_TABLE_TOP_Y,
+  groundY: SNOOKER_ROYAL_HUMAN_GROUND_Y,
+  tableW: PLAY_W,
+  tableL: PLAY_H,
+  ballR: BALL_R,
+  idleGap: SNOOKER_CUE_IDLE_GAP,
+  contactGap: SNOOKER_CUE_CONTACT_GAP,
+  pullRange: SNOOKER_CUE_PULL_RANGE,
+  strikeTime: 0.12,
+  holdTime: 0.05,
+  cueLength: 1.78 * SNOOKER_CUE_POSE_SCALE,
+  bridgeDist: SNOOKER_CUE_BRIDGE_DIST,
+  edgeMargin: 0.5 * SNOOKER_CUE_POSE_SCALE,
+  desiredShootDistance: 0.82 * SNOOKER_CUE_POSE_SCALE,
+  poseLambda: 9,
+  moveLambda: 5.6,
+  rotLambda: 8.5,
+  humanScale: 1.2 * 1.78 * SNOOKER_CUE_POSE_SCALE,
+  humanVisualYawFix: Math.PI,
+  stanceWidth: 0.52 * SNOOKER_CUE_POSE_SCALE,
+  bridgePalmTableLift: 0.006 * SNOOKER_CUE_POSE_SCALE,
+  bridgeCueLift: 0.018 * SNOOKER_CUE_POSE_SCALE,
+  bridgeHandBackFromBall: 0.235 * SNOOKER_CUE_POSE_SCALE,
+  bridgeHandSide: -0.115 * SNOOKER_CUE_POSE_SCALE,
+  bridgeVGrooveForward: 0.026 * SNOOKER_CUE_POSE_SCALE,
+  bridgeVGrooveSide: -0.032 * SNOOKER_CUE_POSE_SCALE,
+  bridgePalmUnderCueDrop: 0.052 * SNOOKER_CUE_POSE_SCALE,
+  chinToCueHeight: 0.11 * SNOOKER_CUE_POSE_SCALE,
+  footGroundY: 0.035 * SNOOKER_CUE_POSE_SCALE,
+  footLockStrength: 1,
+  kneeBendShot: 0.16 * SNOOKER_CUE_POSE_SCALE,
+  rightElbowShotRise: 0.18 * SNOOKER_CUE_POSE_SCALE,
+  rightElbowShotSide: -0.46 * SNOOKER_CUE_POSE_SCALE,
+  rightElbowShotBack: -0.78 * SNOOKER_CUE_POSE_SCALE,
+  rightForearmOutward: 0.36 * SNOOKER_CUE_POSE_SCALE,
+  rightForearmBack: 0.44 * SNOOKER_CUE_POSE_SCALE,
+  rightForearmDown: 0.48 * SNOOKER_CUE_POSE_SCALE,
+  rightForearmLength: 0.34 * SNOOKER_CUE_POSE_SCALE,
+  rightStrokePull: 0.30 * SNOOKER_CUE_POSE_SCALE,
+  rightStrokePush: 0.24 * SNOOKER_CUE_POSE_SCALE,
+  rightHandShotLift: -0.30 * SNOOKER_CUE_POSE_SCALE,
+  shootCueGripFromBack: 0.58 * SNOOKER_CUE_POSE_SCALE,
+  idleRightHandY: 0.8 * SNOOKER_CUE_POSE_SCALE,
+  idleRightHandX: 0.31 * SNOOKER_CUE_POSE_SCALE,
+  idleRightHandZ: -0.015 * SNOOKER_CUE_POSE_SCALE,
+  idleCueGripFromBack: 0.24 * SNOOKER_CUE_POSE_SCALE,
+  idleCueDir: new THREE.Vector3(0.055, 0.965, -0.13),
+  rightHandRollIdle: -2.2,
+  rightHandRollShoot: -2.05,
+  rightHandDownPose: 0.42,
+  rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(SNOOKER_CUE_POSE_SCALE)
+};
+const clamp01 = (v) => clamp(v, 0, 1);
+const lerp = (a, b, t) => a + (b - a) * t;
+const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+const easeInOut = (t) => t * t * (3 - 2 * t);
+const dampScalar = (current, target, lambda, dt) => THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+const dampVector = (current, target, lambda, dt) => current.lerp(target, 1 - Math.exp(-lambda * dt));
+const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
+const cleanName = (name) => name.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+function makeBasisQuaternion(side, up, forward) {
+  BASIS_MAT.makeBasis(side.clone().normalize(), up.clone().normalize(), forward.clone().normalize());
+  return new THREE.Quaternion().setFromRotationMatrix(BASIS_MAT);
+}
+
+function enableShadow(obj) {
+  if (!obj) return obj;
+  obj.castShadow = true;
+  obj.receiveShadow = true;
+  obj.frustumCulled = false;
+  return obj;
+}
+
+function cuePoseFromGrip(grip, dir, gripFromBack, length = CFG.cueLength) {
+  const n = dir.clone().normalize();
+  return { back: grip.clone().addScaledVector(n, -gripFromBack), tip: grip.clone().addScaledVector(n, length - gripFromBack) };
+}
+
+function createUniversalGLTFLoader(renderer) {
+  const manager = new THREE.LoadingManager();
+  const loader = new GLTFLoader(manager);
+  loader.setCrossOrigin('anonymous');
+  const draco = new DRACOLoader(manager);
+  draco.setDecoderPath(DRACO_DECODER_PATH);
+  loader.setDRACOLoader(draco);
+  const ktx2 = new KTX2Loader(manager);
+  ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  ktx2.detectSupport(renderer);
+  loader.setKTX2Loader(ktx2);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+  return { loader, dispose: () => { draco.dispose(); ktx2.dispose(); } };
+}
+function findBone(all, aliases) {
+  const list = all.map((bone) => ({ bone, name: cleanName(bone.name) }));
+  const names = aliases.map(cleanName);
+  for (const alias of names) {
+    const exact = list.find((x) => x.name === alias || x.name.endsWith(alias));
+    if (exact) return exact.bone;
+  }
+  for (const alias of names) {
+    const loose = list.find((x) => x.name.includes(alias));
+    if (loose) return loose.bone;
+  }
+  return undefined;
+}
+function buildAvatarBones(model) {
+  const all = [];
+  model.traverse((obj) => { if (obj.isBone) all.push(obj); });
+  const f = (...names) => findBone(all, names);
+  return {
+    hips: f('hips', 'pelvis', 'mixamorigHips'), spine: f('spine', 'spine01', 'mixamorigSpine'), chest: f('spine2', 'chest', 'upperchest', 'mixamorigSpine2', 'mixamorigSpine1'), neck: f('neck', 'mixamorigNeck'), head: f('head', 'mixamorigHead'),
+    leftUpperArm: f('leftupperarm', 'leftarm', 'upperarml', 'mixamorigLeftArm'), leftLowerArm: f('leftforearm', 'leftlowerarm', 'forearml', 'mixamorigLeftForeArm'), leftHand: f('lefthand', 'handl', 'mixamorigLeftHand'),
+    rightUpperArm: f('rightupperarm', 'rightarm', 'upperarmr', 'mixamorigRightArm'), rightLowerArm: f('rightforearm', 'rightlowerarm', 'forearmr', 'mixamorigRightForeArm'), rightHand: f('righthand', 'handr', 'mixamorigRightHand'),
+    leftUpperLeg: f('leftupleg', 'leftupperleg', 'leftthigh', 'mixamorigLeftUpLeg'), leftLowerLeg: f('leftleg', 'leftlowerleg', 'leftcalf', 'mixamorigLeftLeg'), leftFoot: f('leftfoot', 'footl', 'mixamorigLeftFoot'),
+    rightUpperLeg: f('rightupleg', 'rightupperleg', 'rightthigh', 'mixamorigRightUpLeg'), rightLowerLeg: f('rightleg', 'rightlowerleg', 'rightcalf', 'mixamorigRightLeg'), rightFoot: f('rightfoot', 'footr', 'mixamorigRightFoot')
+  };
+}
+function collectFingerBones(hand) {
+  const out = [];
+  hand?.traverse((obj) => {
+    if (!obj.isBone || obj === hand) return;
+    const n = cleanName(obj.name);
+    if (['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((s) => n.includes(s))) out.push(obj);
+  });
+  return out;
+}
+function normalizeHuman(model) {
+  model.rotation.set(0, CFG.humanVisualYawFix, 0);
+  model.position.set(0, 0, 0);
+  model.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const height = Math.max(box.max.y - box.min.y, 0.0001);
+  model.scale.multiplyScalar(CFG.humanScale / height);
+  model.updateMatrixWorld(true);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.set(-center.x, -scaledBox.min.y, -center.z);
+}
+function addHuman(scene, renderer, setStatus) {
+  const human = { root: new THREE.Group(), modelRoot: new THREE.Group(), model: null, bones: {}, leftFingers: [], rightFingers: [], restQuats: new Map(), activeGlb: false, poseT: 0, walkT: 0, yaw: 0, breathT: 0, settleT: 0, strikeRoot: new THREE.Vector3(), strikeYaw: 0, strikeClock: 0 };
+  human.root.visible = false;
+  human.modelRoot.visible = false;
+  scene.add(human.root, human.modelRoot);
+  const { loader } = createUniversalGLTFLoader(renderer);
+  setStatus('Loading ReadyPlayer GLTF human…');
+  loader.load(HUMAN_URL, (gltf) => {
+    const model = gltf.scene;
+    normalizeHuman(model);
+    model.traverse((obj) => {
+      if (!obj.isMesh) return;
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+      obj.frustumCulled = false;
+      const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+      mats.forEach((m) => { if (m.map) { m.map.colorSpace = THREE.SRGBColorSpace; m.map.flipY = false; m.map.needsUpdate = true; } m.needsUpdate = true; });
+    });
+    human.bones = buildAvatarBones(model);
+    human.leftFingers = collectFingerBones(human.bones.leftHand);
+    human.rightFingers = collectFingerBones(human.bones.rightHand);
+    [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((bone) => bone && human.restQuats.set(bone, bone.quaternion.clone()));
+    human.activeGlb = Boolean(human.bones.hips && human.bones.spine && human.bones.head && human.bones.rightUpperArm && human.bones.rightLowerArm && human.bones.rightHand);
+    human.model = model;
+    human.modelRoot.add(model);
+    human.modelRoot.visible = human.activeGlb;
+    setStatus(human.activeGlb ? 'ReadyPlayer GLTF human active' : 'ReadyPlayer loaded but skeleton aliases incomplete');
+  }, undefined, () => setStatus('ReadyPlayer GLTF human failed'));
+  return human;
+}
+function setBoneWorldQuaternion(bone, q) {
+  if (!bone || !q) return;
+  const parentQ = new THREE.Quaternion();
+  bone.parent?.getWorldQuaternion(parentQ);
+  bone.quaternion.copy(parentQ.invert().multiply(q));
+  bone.updateMatrixWorld(true);
+}
+function firstBoneChild(bone) { return bone?.children.find((child) => child.isBone); }
+function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) {
+  if (!bone || strength <= 0) return;
+  const bonePos = bone.getWorldPosition(new THREE.Vector3());
+  const childPos = firstBoneChild(bone)?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25 * CFG.scale);
+  const current = childPos.sub(bonePos).normalize();
+  const desired = target.clone().sub(bonePos);
+  if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return;
+  const delta = new THREE.Quaternion().slerpQuaternions(new THREE.Quaternion(), new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()), clamp01(strength));
+  setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+function twistBone(bone, axis, amount) {
+  if (!bone || Math.abs(amount) < 1e-5) return;
+  setBoneWorldQuaternion(bone, new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount).multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+}
+function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) {
+  for (let i = 0; i < 4; i += 1) {
+    rotateBoneToward(upper, elbow, upperStrength, pole);
+    rotateBoneToward(lower, hand, lowerStrength, pole);
+  }
+}
+function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) {
+  if (!bone || strength <= 0) return;
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength)));
+}
+function cueSocketOffsetWorld(side, up, forward, roll, socketLocal = CFG.rightHandCueSocketLocal) {
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  return socketLocal.clone().applyQuaternion(q);
+}
+function poseFingers(fingers, mode, weight) {
+  const w = clamp01(weight);
+  fingers.forEach((finger, i) => {
+    const n = cleanName(finger.name);
+    const thumb = n.includes('thumb'), index = n.includes('index'), middle = n.includes('middle'), ring = n.includes('ring'), pinky = n.includes('pinky') || n.includes('little');
+    const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal'));
+    const mid = n.includes('2') || n.includes('intermediate');
+    const tip = n.includes('3') || n.includes('distal');
+    if (mode === 'idle') { finger.rotation.x += 0.018 * w; finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1); return; }
+    if (mode === 'grip') {
+      if (thumb) { finger.rotation.x += 0.48 * w; finger.rotation.y += -0.82 * w; finger.rotation.z += 0.54 * w; return; }
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0;
+      finger.rotation.x += curl * w;
+      finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w;
+      finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w;
+      return;
+    }
+    // Open snooker bridge: stable fingertips on the cloth with the thumb pressed
+    // into the index knuckle to form a precise V-groove for the cue to ride through.
+    if (thumb) { finger.rotation.x += -0.12 * w; finger.rotation.y += 1.1 * w; finger.rotation.z += -1.08 * w; }
+    else if (index) { finger.rotation.x += (base ? 0.18 : mid ? 0.28 : 0.18) * w; finger.rotation.y += -0.58 * w; finger.rotation.z += -0.5 * w; }
+    else if (middle) { finger.rotation.x += (base ? 0.12 : mid ? 0.24 : 0.16) * w; finger.rotation.y += -0.18 * w; finger.rotation.z += -0.16 * w; }
+    else if (ring || pinky) { finger.rotation.x += (base ? (ring ? 0.06 : 0.04) : mid ? (ring ? 0.14 : 0.12) : tip ? (ring ? 0.1 : 0.08) : 0.08) * w; finger.rotation.y += (ring ? 0.14 : 0.28) * w; finger.rotation.z += (ring ? 0.24 : 0.42) * w; }
+  });
+}
+function driveHuman(human, frame) {
+  if (!human.activeGlb || !human.model) return;
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(frame.rootWorld);
+  human.modelRoot.rotation.y = human.yaw;
+  human.modelRoot.updateMatrixWorld(true);
+  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
+  human.modelRoot.updateMatrixWorld(true);
+  const b = human.bones;
+  const ik = easeInOut(clamp01(frame.t));
+  const idle = 1 - ik;
+  const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
+  const standingCueDir = CFG.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
+  if (frame.walkAmount * idle > 0.001) {
+    const s = Math.sin(human.walkT * 6.2), c = Math.cos(human.walkT * 6.2), w = frame.walkAmount * idle;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+  }
+  if (ik >= 0.025) {
+    rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
+    twistBone(b.hips, frame.side, -0.045 * ik);
+    twistBone(b.spine, frame.side, -0.2 * ik);
+    rotateBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
+    rotateBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
+    twistBone(b.chest, frame.side, -0.32 * ik);
+    rotateBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
+    setBoneWorldQuaternion(b.head, b.head ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)), 0.74 * ik) : shotQ);
+    human.modelRoot.updateMatrixWorld(true);
+  }
+  const rightGrip = frame.rightHandWorld.clone();
+  const rightIdleElbow = rightGrip.clone().addScaledVector(UP, 0.04 * CFG.scale + 0.14 * CFG.scale * ik).addScaledVector(frame.side, -0.2 * CFG.scale).addScaledVector(frame.forward, -0.03 * CFG.scale * idle);
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.32).addScaledVector(frame.forward, -0.55).normalize(), 0.9 + 0.1 * ik, 1);
+  const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
+  const standingHandUp = UP.clone().multiplyScalar(-1).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
+  setHandBasis(b.rightHand, standingHandSide, standingHandUp, ik >= 0.025 ? cueDir : standingCueDir, ik >= 0.025 ? CFG.rightHandRollShoot : CFG.rightHandRollIdle, 1);
+  poseFingers(human.rightFingers, 'grip', 0.95);
+  if (ik < 0.025) { poseFingers(human.leftFingers, 'idle', 1); return; }
+  aimTwoBone(b.leftUpperArm, b.leftLowerArm, frame.leftElbow, frame.leftHandWorld, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(), 0.98 * ik, ik);
+  setHandBasis(b.leftHand, frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.52).normalize(), UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward, -0.28).addScaledVector(frame.side, -0.16).normalize(), cueDir, -0.68 * ik, ik);
+  poseFingers(human.leftFingers, 'bridge', ik);
+  aimTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(UP, 0.18).normalize(), 0.9 * ik, ik);
+  aimTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), 0.9 * ik, ik);
+}
+function chooseHumanEdgePosition(cueBallWorld, aimForward) {
+  const desired = cueBallWorld.clone().addScaledVector(aimForward, -CFG.desiredShootDistance);
+  desired.y = CFG.groundY;
+  const xEdge = CFG.tableW / 2 + CFG.edgeMargin;
+  const zEdge = CFG.tableL / 2 + CFG.edgeMargin;
+  const candidates = [new THREE.Vector3(-xEdge, CFG.groundY, clamp(desired.z, -zEdge, zEdge)), new THREE.Vector3(xEdge, CFG.groundY, clamp(desired.z, -zEdge, zEdge)), new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), CFG.groundY, -zEdge), new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), CFG.groundY, zEdge)];
+  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+}
+function constrainHumanPerimeterStep(current, target) {
+  const xEdge = CFG.tableW / 2 + CFG.edgeMargin;
+  const zEdge = CFG.tableL / 2 + CFG.edgeMargin;
+  const project = (point) => {
+    const dx = Math.abs(Math.abs(point.x) - xEdge);
+    const dz = Math.abs(Math.abs(point.z) - zEdge);
+    if (dx < dz) return new THREE.Vector3(Math.sign(point.x || target.x || 1) * xEdge, CFG.groundY, clamp(point.z, -zEdge, zEdge));
+    return new THREE.Vector3(clamp(point.x, -xEdge, xEdge), CFG.groundY, Math.sign(point.z || target.z || 1) * zEdge);
+  };
+  const cur = current.lengthSq() > 1e-6 ? project(current) : project(target);
+  const goal = project(target);
+  const curOnX = Math.abs(Math.abs(cur.x) - xEdge) < Math.abs(Math.abs(cur.z) - zEdge);
+  const goalOnX = Math.abs(Math.abs(goal.x) - xEdge) < Math.abs(Math.abs(goal.z) - zEdge);
+  if (curOnX === goalOnX && (curOnX ? Math.sign(cur.x) === Math.sign(goal.x) : Math.sign(cur.z) === Math.sign(goal.z))) return goal;
+  return curOnX
+    ? new THREE.Vector3(cur.x, CFG.groundY, Math.sign(goal.z || cur.z || 1) * zEdge)
+    : new THREE.Vector3(Math.sign(goal.x || cur.x || 1) * xEdge, CFG.groundY, cur.z);
+}
+
+function updateHumanPose(human, dt, state, rootTarget, aimForward, bridgeTarget, idleRight, idleLeft, cueBack, cueTip, power) {
+  human.poseT = dampScalar(human.poseT, state === 'idle' ? 0 : 1, CFG.poseLambda, dt);
+  human.breathT += dt * (state === 'idle' ? 1.05 : 0.5);
+  human.settleT = dampScalar(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
+  if (state === 'striking') {
+    if (human.strikeClock === 0) { human.strikeRoot.copy(human.root.position.lengthSq() > 0.001 ? human.root.position : rootTarget); human.strikeYaw = human.yaw; }
+    human.strikeClock += dt;
+  } else human.strikeClock = 0;
+  const rootGoal = state === 'striking' ? human.strikeRoot : constrainHumanPerimeterStep(human.root.position, rootTarget);
+  dampVector(human.root.position, rootGoal, state === 'striking' ? 12 : CFG.moveLambda, dt);
+  const moveAmountRaw = human.root.position.distanceTo(rootGoal);
+  human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10 / CFG.scale));
+  human.yaw = dampScalar(human.yaw, state === 'striking' ? human.strikeYaw : yawFromForward(aimForward), CFG.rotLambda, dt);
+  const t = easeInOut(human.poseT), idle = 1 - t;
+  const breath = Math.sin(human.breathT * Math.PI * 2) * ((0.006 + idle * 0.004) * CFG.scale);
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12 / CFG.scale);
+  const walkAmount = clamp01(moveAmountRaw * 18 / CFG.scale) * idle;
+  const dragStroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75) : 0;
+  const strikeFollow = state === 'striking' ? Math.sin(clamp01(human.strikeClock / (CFG.strikeTime + CFG.holdTime)) * Math.PI) : 0;
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
+  const powerLean = power * t;
+  const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow) * CFG.scale);
+  rootWorld.y = CFG.groundY;
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) * CFG.scale + breath, (lerp(0.02, -0.16, t) - 0.014 * powerLean) * CFG.scale));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) * CFG.scale + breath, (lerp(0.02, -0.42, t) - 0.024 * powerLean) * CFG.scale));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) * CFG.scale + breath, (lerp(0.02, -0.61, t) - 0.028 * powerLean) * CFG.scale));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) * CFG.scale + breath - CFG.chinToCueHeight * 0.16 * t, (lerp(0.04, -0.72, t) - 0.028 * powerLean) * CFG.scale));
+  const leftShoulder = local(new THREE.Vector3(-0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.46, t) - 0.018 * human.settleT) * CFG.scale));
+  const rightShoulder = local(new THREE.Vector3(0.23 * CFG.scale, lerp(1.58, 1.36, t) * CFG.scale + breath, (lerp(0, -0.34, t) - 0.018 * human.settleT) * CFG.scale));
+  const leftHip = local(new THREE.Vector3(-0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
+  const rightHip = local(new THREE.Vector3(0.13 * CFG.scale, 0.92 * CFG.scale, 0.02 * CFG.scale));
+  const leftFoot = local(new THREE.Vector3(-0.13 * CFG.scale, CFG.footGroundY, 0.03 * CFG.scale + walk * 0.018 * CFG.scale).lerp(new THREE.Vector3(-CFG.stanceWidth * 0.42, CFG.footGroundY, -0.34 * CFG.scale), t));
+  const rightFoot = local(new THREE.Vector3(0.13 * CFG.scale, CFG.footGroundY, -0.03 * CFG.scale - walk * 0.018 * CFG.scale).lerp(new THREE.Vector3(CFG.stanceWidth * 0.5, CFG.footGroundY, 0.34 * CFG.scale), t));
+  const bridgePalmTarget = bridgeTarget.clone()
+    .addScaledVector(forward, -0.006 * CFG.scale * t)
+    .addScaledVector(side, -0.012 * CFG.scale * t)
+    .setY(CFG.tableTopY + CFG.bridgePalmTableLift)
+    .addScaledVector(UP, -CFG.bridgePalmUnderCueDrop * t)
+    .addScaledVector(UP, -0.01 * CFG.scale * human.settleT);
+  const leftHand = idleLeft.clone().lerp(bridgePalmTarget, t);
+  const cueDirForHand = cueTip.clone().sub(cueBack).normalize();
+  const handIk = easeInOut(clamp01(t));
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = UP.clone().multiplyScalar(-1).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
+  const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04 * CFG.scale, CFG.rightElbowShotRise, t)).addScaledVector(side, lerp(-0.18 * CFG.scale, CFG.rightElbowShotSide, t)).addScaledVector(forward, lerp(-0.04 * CFG.scale, CFG.rightElbowShotBack, t));
+  const forearmStroke = (state === 'dragging' ? -CFG.rightStrokePull * easeOutCubic(power) : 0) + (state === 'striking' ? CFG.rightStrokePush * strikeFollow : 0) + (state === 'dragging' ? dragStroke * 0.035 * CFG.scale : 0);
+  const forearmBase = lockedRightElbow.clone().addScaledVector(side, CFG.rightForearmOutward * t).addScaledVector(UP, -CFG.rightForearmDown * t).addScaledVector(UP, CFG.rightHandShotLift * t).addScaledVector(forward, -CFG.rightForearmBack * t).addScaledVector(cueDirForHand, CFG.rightForearmLength);
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
+  const idleWristTarget = idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, CFG.rightHandRollIdle));
+  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(CFG.rightHandRollIdle, CFG.rightHandRollShoot - CFG.rightHandDownPose, handIk)));
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * CFG.scale * t).addScaledVector(side, -0.044 * CFG.scale * t).addScaledVector(forward, 0.065 * CFG.scale * t);
+  const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2 * CFG.scale, CFG.kneeBendShot, t)).addScaledVector(forward, 0.04 * CFG.scale * t).addScaledVector(side, -0.012 * CFG.scale * t);
+  const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2 * CFG.scale, CFG.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * CFG.scale * t).addScaledVector(side, 0.014 * CFG.scale * t);
+  driveHuman(human, { t, stroke: forearmStroke / CFG.scale, follow: strikeFollow, walkAmount, forward, side, up: UP, rootWorld, torsoCenterWorld: torso, chestCenterWorld: chest, neckWorld: neck, headCenterWorld: head, leftElbow, rightElbow: lockedRightElbow, leftHandWorld: leftHand, rightHandWorld: rightHand, leftKnee, rightKnee, leftFootWorld: leftFoot, rightFootWorld: rightFoot, cueBackWorld: cueBack, cueTipWorld: cueTip });
+}
+
 function createSnookerRoyalCuePoseController() {
   return {
     disabled: false,
@@ -1708,6 +2089,8 @@ function applyProvidedCueEndpointPose(cueStick, cueBack, cueTip) {
   const buttDir = cueBack.clone().sub(cueTip).normalize();
   cueStick.position.copy(cueBack).add(cueTip).multiplyScalar(0.5);
   cueStick.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), buttDir);
+  cueStick.userData.providedCueBack = cueBack.clone();
+  cueStick.userData.providedCueTip = cueTip.clone();
 }
 
 function cuePoseEaseOutCubic(t) {
@@ -5203,14 +5586,14 @@ const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.1; // match Pool Royale standing-view
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.54);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0108; // bring the player's standing/cue camera closer to the table
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0096; // bring the player's standing/cue camera closer to the table
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.145; // pull the standing camera closer so the table fills more of portrait screens
+const STANDING_VIEW_DISTANCE_SCALE = 0.132; // pull the standing camera closer so the table fills more of portrait screens
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -21549,7 +21932,7 @@ const powerRef = useRef(hud.power);
 
       // Cue stick behind cueball
       const SCALE = BALL_R / 0.0525;
-      const cueLen = 1.5 * SCALE * CUE_LENGTH_MULTIPLIER;
+      const cueLen = CFG.cueLength;
       const cueStick = new THREE.Group();
       const cueBody = new THREE.Group();
       cueStick.add(cueBody);
@@ -21858,6 +22241,9 @@ const powerRef = useRef(hud.power);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
+      const snookerRoyalHuman = addHuman(table, renderer, (status) => {
+        if (status) console.debug(status);
+      });
       const snookerCuePoseController = createSnookerRoyalCuePoseController();
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
@@ -26382,6 +26768,73 @@ const powerRef = useRef(hud.power);
         } catch (error) {
           snookerCuePoseController.disabled = true;
           console.warn('Snooker Royal cue pose disabled after update error', error);
+        }
+
+        try {
+          const cueBallWorld = cue?.pos
+            ? new THREE.Vector3(cue.pos.x, CUE_Y, cue.pos.y)
+            : null;
+          const activeAimDir = showingRemoteAim
+            ? new THREE.Vector2(remoteAimState?.dir?.x ?? 0, remoteAimState?.dir?.y ?? 1)
+            : activeAiPlan?.aimDir || aimDir;
+          const aimForward = new THREE.Vector3(activeAimDir?.x ?? 0, 0, activeAimDir?.y ?? 1);
+          if (aimForward.lengthSq() < 1e-8) aimForward.set(0, 0, 1);
+          aimForward.normalize();
+          const activePower = THREE.MathUtils.clamp(
+            (shooting || cueAnimating) ? lastShotPower : (powerRef.current ?? activeAiPlan?.power ?? 0),
+            0,
+            1
+          );
+          if (cueBallWorld && cue?.active) {
+            const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+            const humanRootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward);
+            const bridgeHandTarget = cueBallWorld.clone()
+              .addScaledVector(aimForward, -CFG.bridgeHandBackFromBall)
+              .addScaledVector(aimSide, CFG.bridgeHandSide)
+              .setY(CFG.tableTopY + CFG.bridgePalmTableLift);
+            const standingYaw = yawFromForward(aimForward);
+            const idleRightHandTarget = humanRootTarget.clone().add(
+              new THREE.Vector3(CFG.idleRightHandX, CFG.idleRightHandY, CFG.idleRightHandZ)
+                .applyAxisAngle(Y_AXIS, standingYaw)
+            );
+            const idleLeftHandTarget = humanRootTarget.clone().add(
+              new THREE.Vector3(-0.18 * CFG.scale, 1.08 * CFG.scale, 0.03 * CFG.scale)
+                .applyAxisAngle(Y_AXIS, standingYaw)
+            );
+            const idleDir = CFG.idleCueDir.clone().applyAxisAngle(Y_AXIS, standingYaw).normalize();
+            const idleCue = cuePoseFromGrip(idleRightHandTarget, idleDir, CFG.idleCueGripFromBack, CFG.cueLength);
+            const providedCueBack = cueStick.userData.providedCueBack?.clone?.() ?? idleCue.back;
+            const providedCueTip = cueStick.userData.providedCueTip?.clone?.() ?? idleCue.tip;
+            const visualState = shooting || cueAnimating
+              ? 'striking'
+              : activePower > 0.02
+                ? 'dragging'
+                : cueStick.visible
+                  ? 'aiming'
+                  : 'idle';
+            const activeCueBack = visualState === 'idle' ? idleCue.back : providedCueBack;
+            const activeCueTip = visualState === 'idle' ? idleCue.tip : providedCueTip;
+            updateHumanPose(
+              snookerRoyalHuman,
+              deltaSeconds,
+              visualState,
+              humanRootTarget,
+              aimForward,
+              bridgeHandTarget,
+              idleRightHandTarget,
+              idleLeftHandTarget,
+              activeCueBack,
+              activeCueTip,
+              activePower
+            );
+          } else {
+            snookerRoyalHuman.root.visible = false;
+            snookerRoyalHuman.modelRoot.visible = false;
+          }
+        } catch (error) {
+          snookerRoyalHuman.root.visible = false;
+          snookerRoyalHuman.modelRoot.visible = false;
+          console.warn('Snooker Royal ReadyPlayer human pose skipped', error);
         }
 
         if (!shouldSlowAim) {


### PR DESCRIPTION
### Motivation
- Add a ReadyPlayer GLTF human avatar and procedural IK/finger posing so a human figure can be shown lining up and striking snooker shots for improved visual realism. 
- Drive the avatar from the same cue endpoints used by the cue stick so poses match user/AI aim and power states. 
- Keep the feature robust by gracefully falling back and disabling on load/pose errors.

### Description
- Introduces a new human avatar subsystem with constants and configuration in `CFG`, helper math utilities, and IK/pose functions (`buildAvatarBones`, `collectFingerBones`, `normalizeHuman`, `addHuman`, `driveHuman`, `updateHumanPose`, `aimTwoBone`, `poseFingers`, etc.).
- Adds GLTF loader plumbing via `createUniversalGLTFLoader` and loads a ReadyPlayer model from `HUMAN_URL`, mapping bones and preparing rest quaternions for procedural animation.
- Integrates avatar updates into the existing snooker loop by calling `addHuman(...)` when the cue stick is created, capturing provided cue endpoints in `applyProvidedCueEndpointPose` (`userData.providedCueBack`/`providedCueTip`), and computing a visual state (`idle/aiming/dragging/striking`) to feed into `updateHumanPose` each frame.
- Makes smaller related adjustments to cue/camera constants (uses `CFG.cueLength` for `cueLen`, tweaks `PLAYER_CAMERA_DISTANCE_FACTOR` and `STANDING_VIEW_DISTANCE_SCALE`) and wraps avatar pose updates in try/catch so failures disable/hide the human model without breaking the main loop.

### Testing
- Ran project lint and automated unit tests via `yarn lint` and `yarn test`; the suite completed successfully. 
- Performed a production build via `yarn build` which succeeded without compile errors. 
- The new runtime human loading/pose code is wrapped in error handlers so failed GLTF loads or pose errors do not break the main runtime (no automated failures observed during build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2558d3a804832996ff3506082b08ec)