### PR TITLE
Align Snooker Royal human & cue pose with provided reference (increase human scale + cue endpoint parity)

### DIFF
--- a/test/snookerRoyalCharacterCuePose.test.js
+++ b/test/snookerRoyalCharacterCuePose.test.js
@@ -1,0 +1,21 @@
+/* global describe, test */
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+describe('Snooker Royal character and cue parity', () => {
+  test('scales the ReadyPlayer human to be about 30% taller than the cue stick', async () => {
+    const source = await readFile('webapp/src/pages/Games/SnookerRoyal.jsx', 'utf8')
+
+    assert.match(source, /cueLength:\s*1\.78 \* SNOOKER_CUE_POSE_SCALE,/)
+    assert.match(source, /humanScale:\s*1\.3 \* 1\.78 \* SNOOKER_CUE_POSE_SCALE,/)
+  })
+
+  test('uses SnookerRoyalProvided cue endpoint math for aiming, spin, bridge, and pull', async () => {
+    const source = await readFile('webapp/src/pages/Games/SnookerRoyal.jsx', 'utf8')
+
+    assert.match(source, /const bridgeHandTarget = cueBallWorld\.clone\(\)\s*\.addScaledVector\(aimForward, -CFG\.bridgeHandBackFromBall\)\s*\.addScaledVector\(aimSide, CFG\.bridgeHandSide\)\s*\.setY\(CFG\.tableTopY \+ CFG\.bridgePalmTableLift\);/s)
+    assert.match(source, /const bridgeCuePoint = bridgeHandTarget\.clone\(\)\s*\.addScaledVector\(aimForward, CFG\.bridgeVGrooveForward\)\s*\.addScaledVector\(aimSide, CFG\.bridgeVGrooveSide\)\s*\.add\(new THREE\.Vector3\(0, CFG\.bridgeCueLift, 0\)\);/s)
+    assert.match(source, /const providedCueTip = cueBallWorld\.clone\(\)\s*\.addScaledVector\(aimForward, -\(CFG\.ballR \+ gap\)\)\s*\.addScaledVector\(aimSide, \(spinOffset\.x \?\? 0\) \* CFG\.ballR \* 0\.52\)\s*\.add\(new THREE\.Vector3\(0, \(spinOffset\.y \?\? 0\) \* CFG\.ballR \* 0\.44, 0\)\);/s)
+    assert.match(source, /const providedCueBack = bridgeCuePoint\.clone\(\)\.addScaledVector\(aimForward, -\(CFG\.cueLength - CFG\.bridgeDist - CFG\.ballR - gap\)\)\.add\(new THREE\.Vector3\(0, 0\.024 \* CFG\.scale, 0\)\);/)
+  })
+})

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1719,7 +1719,7 @@ const CFG = {
   poseLambda: 9,
   moveLambda: 5.6,
   rotLambda: 8.5,
-  humanScale: 1.2 * 1.78 * SNOOKER_CUE_POSE_SCALE,
+  humanScale: 1.3 * 1.78 * SNOOKER_CUE_POSE_SCALE,
   humanVisualYawFix: Math.PI,
   stanceWidth: 0.52 * SNOOKER_CUE_POSE_SCALE,
   bridgePalmTableLift: 0.006 * SNOOKER_CUE_POSE_SCALE,
@@ -2078,7 +2078,8 @@ function createSnookerRoyalCuePoseController() {
   return {
     disabled: false,
     strikeClock: 0,
-    strikeLock: null
+    strikeLock: null,
+    didHit: false
   };
 }
 
@@ -2097,78 +2098,67 @@ function cuePoseEaseOutCubic(t) {
   return 1 - Math.pow(1 - t, 3);
 }
 
-function cuePoseLerp(a, b, t) {
-  return a + (b - a) * t;
-}
 
 function updateSnookerRoyalCuePose(controller, dt, options) {
   if (!controller || controller.disabled) return;
   const {
     cue,
     cueStick,
-    cueLen,
     aimDir,
     visible,
     power = 0,
+    spinInput = { x: 0, y: 0 },
     shooting = false,
     cueAnimating = false,
     tableCueVisible = false
   } = options || {};
   const cuePos = cue?.pos;
-  if (!cueStick || !cueLen || !cuePos || !cue?.active || !visible) return;
+  if (!cueStick || !cuePos || !cue?.active || !visible) return;
 
   controller.strikeClock = shooting || cueAnimating
     ? (controller.strikeClock || 0) + Math.max(0, dt || 0)
     : 0;
 
+  const cueBallWorld = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
   const aimForward = new THREE.Vector3(aimDir?.x ?? 0, 0, aimDir?.y ?? 1);
   if (aimForward.lengthSq() < 1e-8) aimForward.set(0, 0, 1);
   aimForward.normalize();
+  const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
   const activePower = THREE.MathUtils.clamp(power ?? 0, 0, 1);
-  const liveCueBallWorld = new THREE.Vector3(cuePos.x, CUE_Y, cuePos.y);
-  const strikeActive = Boolean(shooting || cueAnimating);
-  if (strikeActive && !controller.strikeLock) {
-    controller.strikeLock = {
-      cueBallWorld: liveCueBallWorld.clone(),
-      aimForward: aimForward.clone(),
-      power: activePower
-    };
-  } else if (!strikeActive) {
-    controller.strikeLock = null;
-  }
-  const lockedStrike = strikeActive ? controller.strikeLock : null;
-  const cueBallWorld = lockedStrike?.cueBallWorld?.clone?.() ?? liveCueBallWorld;
-  if (lockedStrike?.aimForward?.lengthSq?.() > 1e-8) {
-    aimForward.copy(lockedStrike.aimForward).normalize();
-  }
 
-  const bridgeCuePoint = cueBallWorld.clone()
-    .addScaledVector(aimForward, -(SNOOKER_CUE_BRIDGE_DIST + BALL_R))
-    .setY(BALL_CENTER_Y + 0.018 * SNOOKER_CUE_POSE_SCALE);
-  const pull = SNOOKER_CUE_PULL_RANGE * cuePoseEaseOutCubic(activePower);
+  const humanRootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward);
+  const bridgeHandTarget = cueBallWorld.clone()
+    .addScaledVector(aimForward, -CFG.bridgeHandBackFromBall)
+    .addScaledVector(aimSide, CFG.bridgeHandSide)
+    .setY(CFG.tableTopY + CFG.bridgePalmTableLift);
+  const bridgeCuePoint = bridgeHandTarget.clone()
+    .addScaledVector(aimForward, CFG.bridgeVGrooveForward)
+    .addScaledVector(aimSide, CFG.bridgeVGrooveSide)
+    .add(new THREE.Vector3(0, CFG.bridgeCueLift, 0));
+  const pull = CFG.pullRange * easeOutCubic(activePower);
   const practiceStroke = !shooting && !cueAnimating && activePower > 0.02
-    ? Math.sin(performance.now() * 0.012) * 0.035 * SNOOKER_CUE_POSE_SCALE * (0.25 + activePower * 0.75)
+    ? Math.sin(performance.now() * 0.012) * 0.035 * CFG.scale * (0.25 + activePower * 0.75)
     : 0;
-  const strikeNorm = THREE.MathUtils.clamp((controller.strikeClock || 0) / 0.12, 0, 1);
-  let providedGap = SNOOKER_CUE_IDLE_GAP;
-  if (activePower > 0.02 && !shooting && !cueAnimating) providedGap += pull + practiceStroke;
+  const strikeNorm = clamp01((controller.strikeClock || 0) / CFG.strikeTime);
+  let gap = CFG.idleGap;
+  const spinOffset = mapSpinForPhysics(spinInput);
+  if (activePower > 0.02 && !shooting && !cueAnimating) gap += pull + practiceStroke;
   if (shooting || cueAnimating) {
-    const contactPushT = THREE.MathUtils.clamp((strikeNorm - 0.86) / 0.14, 0, 1);
-    const contactGap = cuePoseLerp(
-      SNOOKER_CUE_CONTACT_GAP,
-      SNOOKER_CUE_FOLLOW_GAP,
-      cuePoseEaseOutCubic(contactPushT)
-    );
-    providedGap = cuePoseLerp(
-      SNOOKER_CUE_IDLE_GAP + pull,
-      contactGap,
-      cuePoseEaseOutCubic(strikeNorm)
-    );
+    const strikeMotionNorm = controller.didHit ? 0.88 : strikeNorm;
+    gap = lerp(CFG.idleGap + pull, CFG.contactGap, easeOutCubic(strikeMotionNorm));
+    if (!controller.didHit && strikeNorm > 0.88) {
+      controller.didHit = true;
+    }
+  } else {
+    controller.didHit = false;
   }
-  const providedCueTip = cueBallWorld.clone().addScaledVector(aimForward, -(BALL_R + providedGap));
-  const providedCueBack = providedCueTip.clone()
-    .addScaledVector(aimForward, -cueLen)
-    .setY(bridgeCuePoint.y + 0.006 * SNOOKER_CUE_POSE_SCALE);
+  const providedCueTip = cueBallWorld.clone()
+    .addScaledVector(aimForward, -(CFG.ballR + gap))
+    .addScaledVector(aimSide, (spinOffset.x ?? 0) * CFG.ballR * 0.52)
+    .add(new THREE.Vector3(0, (spinOffset.y ?? 0) * CFG.ballR * 0.44, 0));
+  const providedCueBack = bridgeCuePoint.clone().addScaledVector(aimForward, -(CFG.cueLength - CFG.bridgeDist - CFG.ballR - gap)).add(new THREE.Vector3(0, 0.024 * CFG.scale, 0));
+  cueStick.userData.providedHumanRootTarget = humanRootTarget.clone();
+  cueStick.userData.providedBridgeHandTarget = bridgeHandTarget.clone();
   applyProvidedCueEndpointPose(cueStick, providedCueBack, providedCueTip);
   cueStick.visible = Boolean(tableCueVisible || activePower > 0.02 || shooting || cueAnimating);
 }
@@ -26761,6 +26751,9 @@ const powerRef = useRef(hud.power);
               : activeAiPlan?.aimDir || aimDir,
             visible: Boolean(cue?.active),
             power: (shooting || cueAnimating) ? lastShotPower : (powerRef.current ?? activeAiPlan?.power ?? 0),
+            spinInput: showingRemoteAim
+              ? remoteAimState?.spin || spinRef.current
+              : activeAiPlan?.spin || spinRef.current,
             shooting,
             cueAnimating,
             tableCueVisible: Boolean(cueStick.visible && (cameraBlendRef.current ?? 1) <= 0.55)
@@ -26787,8 +26780,8 @@ const powerRef = useRef(hud.power);
           );
           if (cueBallWorld && cue?.active) {
             const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
-            const humanRootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward);
-            const bridgeHandTarget = cueBallWorld.clone()
+            const humanRootTarget = cueStick.userData.providedHumanRootTarget?.clone?.() ?? chooseHumanEdgePosition(cueBallWorld, aimForward);
+            const bridgeHandTarget = cueStick.userData.providedBridgeHandTarget?.clone?.() ?? cueBallWorld.clone()
               .addScaledVector(aimForward, -CFG.bridgeHandBackFromBall)
               .addScaledVector(aimSide, CFG.bridgeHandSide)
               .setY(CFG.tableTopY + CFG.bridgePalmTableLift);


### PR DESCRIPTION
### Motivation
- Make the ReadyPlayer human in Snooker Royal appear ~30% taller than the cue stick and make the human aiming/bridge/cue visuals use the exact endpoint math and pose logic from the provided reference so visuals and IK stay identical to the source implementation.

### Description
- Increased the human scale in `CFG` so the ReadyPlayer human uses `humanScale: 1.3 * 1.78 * SNOOKER_CUE_POSE_SCALE` (approx. 30% taller vs cue). 
- Reworked `updateSnookerRoyalCuePose` to match the provided file: compute `humanRootTarget`, `bridgeHandTarget`, `bridgeCuePoint`, pull/gap (strike timing and contact), spin offsets and compute `providedCueTip` / `providedCueBack`, then call `applyProvidedCueEndpointPose` so the cue endpoints match the provided behaviour.
- Persist provided targets on the cue stick (`cueStick.userData.providedHumanRootTarget` / `providedBridgeHandTarget`) and feed them back into the human IK update so hands/body remain locked to the same cue pose when available.
- Added `didHit` state to the cue pose controller to reproduce provided strike interpolation, included `spinInput` propagation into cue pose updates, removed the controller reliance on external `cueLen` where unnecessary, and updated calls to `updateSnookerRoyalCuePose` accordingly.
- Added a regression test `test/snookerRoyalCharacterCuePose.test.js` asserting the human scale and the presence of the provided cue endpoint math snippets.

### Testing
- Ran `npm test -- --runInBand test/snookerRoyalCharacterCuePose.test.js` and the new test suite passed. 
- Ran project linting with `npm --prefix webapp run lint -- src/pages/Games/SnookerRoyal.jsx` and `npx eslint --no-ignore --no-warn-ignored test/snookerRoyalCharacterCuePose.test.js`, both completed successfully (no blocking errors). 
- Built the webapp with `npm --prefix webapp run build`, which produced a successful production build. 
- Attempted an automated portrait preview via Playwright to capture a screenshot of `/games/snookerroyale`, but the headless WebGL scene timed out while rendering; other automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257c5371e8832991186f04fdb87a48)