### PR TITLE
Align Pool Royale shooter stance and cue logic with SnookerRoyalProvided (human ~1.8m, cue/bridge parity)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1950,8 +1950,9 @@ const CUE_PULL_RETURN_PUSH = 1.22; // accelerate the forward cue drive so push-t
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.9; // keep low-power shots visibly pushing through the cue ball
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so powerful shots visibly punch forward
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
+const HUMAN_PLAYER_HEIGHT_METERS = 1.8; // normalize the shooter to a realistic 1.8 m human before portrait scaling.
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.96; // fallback body/table proportion when cue dimensions are unavailable
-const HUMAN_PLAYER_HEIGHT_RATIO_TO_CUE = 1.46; // make the shooter visibly bigger in portrait while staying proportional to the live cue stick
+const HUMAN_PLAYER_HEIGHT_RATIO_TO_CUE = 1.3; // keep the human about 30% taller than the live cue stick
 const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/Soldier.glb';
 const buildPoolRoyaleHumanUrls = (theme) => {
   const urls = [];
@@ -1974,7 +1975,7 @@ const POOL_ROYALE_VERIFIED_HUMAN_FALLBACK_URLS = Object.freeze(
 const POOL_ROYALE_PRIMARY_HUMAN_FALLBACKS_BY_ID = POOL_ROYALE_HUMAN_URLS_BY_ID;
 const DEFAULT_POOL_ROYALE_HUMAN_CHARACTER_ID = POOL_ROYALE_HUMAN_CHARACTER_OPTIONS[0]?.id ?? 'rpm-current';
 const POOL_ROYALE_HUMAN_CHARACTER_STORAGE_KEY = 'poolHumanCharacter';
-const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.12; // final visual upscale for the grounded Pool/Snooker Royale shooter
+const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.18; // final visual upscale for the grounded Pool/Snooker Royale shooter
 const POOL_ROYALE_LOUNGE_TABLE_RADIUS = BALL_R * 24; // match Murlan Royale's default octagon table proportions at pool-side scale.
 const POOL_ROYALE_LOUNGE_TABLE_HEIGHT = BALL_R * 16.5;
 const POOL_ROYALE_LOUNGE_CHAIR_SPAN = BALL_R * 64; // oversized portrait-readable chairs matching Murlan's default dining-chair asset.
@@ -1990,23 +1991,26 @@ const HUMAN_PLAYER_REACT_LEAN = 0.12;
 const HUMAN_POSE_LAMBDA = 9.0;
 const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
-const HUMAN_EDGE_MARGIN = 1.86; // push the shooter farther outward so the avatar stays clear of the table edge in portrait
-const HUMAN_DESIRED_SHOOT_DISTANCE = 2.08; // keep the shooter much farther back on the cue-butt side like a real pool stance
+const HUMAN_EDGE_MARGIN = 0.5 * WORLD_SCALE; // SnookerRoyalProvided edge margin, scaled to Pool Royale world units
+const HUMAN_DESIRED_SHOOT_DISTANCE = 0.82 * WORLD_SCALE; // SnookerRoyalProvided cue-butt-side shooter distance
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.96; // enter shooting pose immediately when the portrait cue camera starts lowering
-const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 4.55; // widen the perimeter walk ring so feet never step onto the table mesh
-const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
 const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.032; // lower the low cue camera close to cloth height for portrait aiming
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 2.34; // move the low cue camera closer toward the table while staying behind the bridge hand
 const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 0.22; // preserve subtle right-eye bias without exposing too much of the avatar body
 const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
 const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
-const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.34; // set the bridge farther behind the cue ball to match real pool hand placement
-const HUMAN_BRIDGE_HAND_SIDE = -0.008; // match Bilardo Shqip bridge hand lateral placement
-const HUMAN_BRIDGE_CUE_LIFT = 0.018; // flatten the cue closer to the cloth like the reference shooting photos
+const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.235 * WORLD_SCALE; // SnookerRoyalProvided bridge-hand distance behind the cue ball
+const HUMAN_BRIDGE_HAND_SIDE = -0.115 * WORLD_SCALE; // SnookerRoyalProvided lateral bridge-hand placement
+const HUMAN_BRIDGE_V_GROOVE_FORWARD = 0.026 * WORLD_SCALE; // SnookerRoyalProvided bridge V-groove forward offset
+const HUMAN_BRIDGE_V_GROOVE_SIDE = -0.032 * WORLD_SCALE; // SnookerRoyalProvided bridge V-groove side offset
+const HUMAN_BRIDGE_CUE_LIFT = 0.018 * WORLD_SCALE; // SnookerRoyalProvided cue lift above the bridge
 const HUMAN_GRIP_RATIO = 0.9; // anchor right-hand grip much closer to the cue butt so the hand no longer drifts toward the tip
-const HUMAN_CUE_LENGTH = 1.46; // match Bilardo Shqip cue length used for hand/cue alignment
-const HUMAN_BRIDGE_DIST = 0.24; // match Bilardo Shqip bridge-to-tip section used by cue placement
+const HUMAN_CUE_LENGTH = 1.78 * WORLD_SCALE; // SnookerRoyalProvided cue length for hand/cue alignment
+const HUMAN_BRIDGE_DIST = 0.28 * WORLD_SCALE; // SnookerRoyalProvided bridge-to-tip section used by cue placement
+const HUMAN_IDLE_GAP = 0.012 * WORLD_SCALE; // SnookerRoyalProvided idle cue-tip gap
+const HUMAN_CONTACT_GAP = 0.0012 * WORLD_SCALE; // SnookerRoyalProvided strike contact gap
+const HUMAN_PULL_RANGE = 0.42 * WORLD_SCALE; // SnookerRoyalProvided pull range
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
 const CUE_STRIKE_DURATION_MS = 260;
@@ -26483,10 +26487,13 @@ const shotPowerRef = useRef(0);
         rigGroup.rotation.y = facingY;
 
         const liveCueLength = 1.5 * (BALL_R / 0.0525) * CUE_LENGTH_MULTIPLIER;
-        const humanHeight = Number.isFinite(liveCueLength) && liveCueLength > 0
+        const oneMeterWorld = BALL_D_REF > 0 ? (BALL_DIAMETER / BALL_D_REF) * 1000 : WORLD_SCALE;
+        const requestedHumanHeight = HUMAN_PLAYER_HEIGHT_METERS * oneMeterWorld;
+        const cueRatioHumanHeight = Number.isFinite(liveCueLength) && liveCueLength > 0
           ? liveCueLength * HUMAN_PLAYER_HEIGHT_RATIO_TO_CUE
           : TABLE.H * HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE;
-        const scale = (humanHeight / 1.82) * POOL_ROYALE_HUMAN_SCALE_MULTIPLIER * (template?.userData?.poolShooterScaleMultiplier ?? 1);
+        const humanHeight = Math.max(requestedHumanHeight, cueRatioHumanHeight) * POOL_ROYALE_HUMAN_SCALE_MULTIPLIER;
+        const scale = (humanHeight / 1.82) * (template?.userData?.poolShooterScaleMultiplier ?? 1);
         const skinMat = new THREE.MeshStandardMaterial({ color: 0xe4bf9d, roughness: 0.82 });
         const bridgeHand = createBridgeHandGroup(skinMat);
         const gripHand = createGripHandGroup(skinMat);
@@ -26823,13 +26830,13 @@ const shotPowerRef = useRef(0);
         ));
         startRoot.x = THREE.MathUtils.clamp(
           startRoot.x,
-          -(TABLE.W / 2 + HUMAN_WALK_RING_MARGIN),
-          TABLE.W / 2 + HUMAN_WALK_RING_MARGIN
+          -(TABLE.W / 2 + HUMAN_EDGE_MARGIN),
+          TABLE.W / 2 + HUMAN_EDGE_MARGIN
         );
         startRoot.z = THREE.MathUtils.clamp(
           startRoot.z,
-          -(TABLE.H / 2 + HUMAN_WALK_RING_MARGIN),
-          TABLE.H / 2 + HUMAN_WALK_RING_MARGIN
+          -(TABLE.H / 2 + HUMAN_EDGE_MARGIN),
+          TABLE.H / 2 + HUMAN_EDGE_MARGIN
         );
         const facingY = Math.atan2(-startAim.x, -startAim.y);
         const selectedHumanTemplate = await ensureSelectedHumanTemplate(activeHumanCharacterRef.current);
@@ -26880,7 +26887,9 @@ const shotPowerRef = useRef(0);
         const aimDir2 = aimDirRef.current;
         const hasAim = cueBall?.pos && aimDir2 && Number.isFinite(aimDir2.x) && Number.isFinite(aimDir2.y) && aimDir2.lengthSq?.() > 1e-6;
         const normalizedAim = hasAim ? aimDir2.clone().normalize() : new THREE.Vector2(0, -1);
-        const cueWorld = hasAim ? new THREE.Vector3(cueBall.pos.x, floorY, cueBall.pos.y) : new THREE.Vector3(0, floorY, 0);
+        const cueWorld = hasAim
+          ? new THREE.Vector3(cueBall.pos.x, TABLE_Y + TABLE.THICK + BALL_R, cueBall.pos.y)
+          : new THREE.Vector3(0, TABLE_Y + TABLE.THICK + BALL_R, 0);
 
         const chooseEdgeTarget = (forward2) => {
           const desired = cueWorld.clone().add(new THREE.Vector3(
@@ -26900,10 +26909,10 @@ const shotPowerRef = useRef(0);
             candidate.distanceToSquared(desired) < best.distanceToSquared(desired) ? candidate : best
           );
         };
-        const walkHalfX = TABLE.W / 2 + HUMAN_WALK_RING_MARGIN;
-        const walkHalfZ = TABLE.H / 2 + HUMAN_WALK_RING_MARGIN;
-        const blockerHalfX = TABLE.W / 2 + HUMAN_TABLE_BLOCKER_MARGIN;
-        const blockerHalfZ = TABLE.H / 2 + HUMAN_TABLE_BLOCKER_MARGIN;
+        const walkHalfX = TABLE.W / 2 + HUMAN_EDGE_MARGIN;
+        const walkHalfZ = TABLE.H / 2 + HUMAN_EDGE_MARGIN;
+        const blockerHalfX = TABLE.W / 2 + HUMAN_EDGE_MARGIN;
+        const blockerHalfZ = TABLE.H / 2 + HUMAN_EDGE_MARGIN;
         const clampToWalkPerimeter = (point) => {
           const px = Number.isFinite(point?.x) ? point.x : 0;
           const pz = Number.isFinite(point?.z) ? point.z : 0;
@@ -27022,10 +27031,7 @@ const shotPowerRef = useRef(0);
           const targetPose = mode === 'idle' ? 0 : 1;
           anim.poseT = THREE.MathUtils.lerp(anim.poseT ?? 0, targetPose, 1 - Math.exp(-HUMAN_POSE_LAMBDA * dtSeconds));
 
-          const seatBiasX = anim.seat === 'A' ? -TABLE.W * 0.19 : TABLE.W * 0.19;
-          const seatBiasZ = anim.seat === 'A' ? -TABLE.H * 0.72 : TABLE.H * 0.72;
-          const seatTarget = desiredRoot.clone().lerp(new THREE.Vector3(seatBiasX, floorY, seatBiasZ), 0.42);
-          const perimeterTarget = clampToWalkPerimeter(seatTarget);
+          const perimeterTarget = clampToWalkPerimeter(desiredRoot);
           if (!anim.rootTarget) anim.rootTarget = perimeterTarget.clone();
           anim.rootTarget.copy(perimeterTarget);
           if (!Number.isFinite(anim.walkPerimeterT)) {
@@ -27072,10 +27078,11 @@ const shotPowerRef = useRef(0);
             .clone()
             .addScaledVector(aimForward, -HUMAN_BRIDGE_HAND_BACK_FROM_BALL)
             .addScaledVector(side, HUMAN_BRIDGE_HAND_SIDE)
-            .setY(TABLE_Y + TABLE.THICK + BALL_R * 0.7);
+            .setY(TABLE_Y + TABLE.THICK + 0.006 * WORLD_SCALE);
           const bridgeCuePoint = bridgeHandTarget
             .clone()
-            .addScaledVector(aimForward, 0.01)
+            .addScaledVector(aimForward, HUMAN_BRIDGE_V_GROOVE_FORWARD)
+            .addScaledVector(side, HUMAN_BRIDGE_V_GROOVE_SIDE)
             .add(new THREE.Vector3(0, HUMAN_BRIDGE_CUE_LIFT, 0));
 
           const humanShotState =
@@ -27083,10 +27090,10 @@ const shotPowerRef = useRef(0);
           const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
           const strikingPower = Math.max(0, Math.min(1, shotPowerRef.current ?? draggingPower));
           const activePower = humanShotState === 'dragging' ? draggingPower : strikingPower;
-          const pull = BALL_R * 7.6 * (1 - Math.pow(1 - activePower, 3));
+          const pull = HUMAN_PULL_RANGE * easeOutCubic(activePower);
           const practiceStroke =
             humanShotState === 'dragging'
-              ? Math.sin(nowMs * 0.012) * BALL_R * 0.65 * (0.25 + activePower * 0.75)
+              ? Math.sin(nowMs * 0.012) * 0.035 * WORLD_SCALE * (0.25 + activePower * 0.75)
               : 0;
           const strikeTotalMs = Math.max(
             1,
@@ -27097,30 +27104,21 @@ const shotPowerRef = useRef(0);
             humanShotState === 'striking'
               ? THREE.MathUtils.clamp(shotAge / strikeTotalMs, 0, 1)
               : 0;
-          const strikePush = humanShotState === 'striking'
-            ? Math.sin(strikeNorm * Math.PI) * BALL_R * 1.25 * (0.35 + activePower * 0.65)
-            : 0;
-          let cueBallGap = BALL_R * 1.22;
-          if (humanShotState === 'dragging') {
-            cueBallGap += pull + practiceStroke;
-          } else if (humanShotState === 'striking') {
-            cueBallGap = Math.max(
-              BALL_R * 1.05,
-              THREE.MathUtils.lerp(
-                BALL_R * (1.22 + (pull / BALL_R)),
-                BALL_R * 1.22,
-                1 - Math.pow(1 - strikeNorm, 3)
-              ) - strikePush
-            );
+          let cueBallGap = HUMAN_IDLE_GAP;
+          const spinOffset = mapSpinForPhysics(spinRef.current);
+          if (humanShotState === 'dragging') cueBallGap += pull + practiceStroke;
+          if (humanShotState === 'striking') {
+            cueBallGap = THREE.MathUtils.lerp(HUMAN_IDLE_GAP + pull, HUMAN_CONTACT_GAP, easeOutCubic(strikeNorm));
           }
           const cueTipShoot = cueWorld
             .clone()
-            .addScaledVector(aimForward, -cueBallGap)
-            .setY(bridgeHandTarget.y + HUMAN_BRIDGE_CUE_LIFT - 0.004);
+            .addScaledVector(aimForward, -(BALL_R + cueBallGap))
+            .addScaledVector(side, (spinOffset.x ?? 0) * BALL_R * 0.52)
+            .add(new THREE.Vector3(0, (spinOffset.y ?? 0) * BALL_R * 0.44, 0));
           const cueBackShoot = bridgeCuePoint
             .clone()
             .addScaledVector(aimForward, -(HUMAN_CUE_LENGTH - HUMAN_BRIDGE_DIST - BALL_R - cueBallGap))
-            .add(new THREE.Vector3(0, 0.028 * scale, 0));
+            .add(new THREE.Vector3(0, 0.024 * WORLD_SCALE, 0));
           if (isShooter && (mode === 'aim' || mode === 'strike')) {
             setCueStickFromHumanCuePose?.(cueBackShoot, cueTipShoot);
             activeHumanCueViewRef.current = {


### PR DESCRIPTION
### Motivation
- Make the Pool Royale human shooter visually larger (~1.8 m target; ~30% taller than cue) and ensure the aiming/ cue placement matches the proven SnookerRoyalProvided behavior for consistent portrait UX.
- Reuse the snooker-proven bridge/ cue/back/ tip math and perimeter placement so hand poses, aiming line, and cue visuals are identical to the Snooker reference.

### Description
- Normalize human sizing: add `HUMAN_PLAYER_HEIGHT_METERS = 1.8` and compute a requested world height, then choose the max between that and a cue-derived minimum; increase `POOL_ROYALE_HUMAN_SCALE_MULTIPLIER` for final visual scaling. (human sizing logic in `createPlayerCharacterRig` and avatar fit path).
- Replace several shooter constants with Snooker-style values: edge margin, desired shoot distance, bridge back/side/V-groove offsets, cue length, bridge distance, idle/contact gaps, and pull range; scale these into Pool Royale world units using `WORLD_SCALE`.
- Move cue world Y to be anchored to table top (`TABLE_Y + TABLE.THICK + BALL_R`) so bridge/cue pose aligns with Snooker reference and include spin-offset in cue tip calculation; update cue back/tip and cue-ball gap logic to use the new constants and pull model.
- Replace seat-biased seatTarget placement with direct cue-ball/aim-line perimeter placement so the human stands at the same edge position logic as SnookerRoyalProvided; update walk/perimeter clamp logic to use the new edge margin.

### Testing
- Ran lint: `npm --prefix webapp run lint -- --quiet src/pages/Games/PoolRoyale.jsx` — succeeded.
- Built the webapp: `npm --prefix webapp run build` — production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257c2c14b48329a6f3d8c3a903df2e)