### PR TITLE
Pool Royale: lock cue aim during power charge and drive cue stroke from slider

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18039,6 +18039,7 @@ const shotPowerRef = useRef(0);
   const preShotTopViewLockRef = useRef(false);
   const sidePocketAimRef = useRef(false);
   const aimDirRef = useRef(new THREE.Vector2(0, 1));
+  const cueChargeAimLockRef = useRef(null);
   const playerOffsetRef = useRef(0);
   const orbitFocusRef = useRef({
     target: new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0),
@@ -18162,10 +18163,16 @@ const shotPowerRef = useRef(0);
     dot.style.backgroundColor = magnitude > 0.01 ? '#facc15' : '#dc2626';
     dot.dataset.blocked = showBlocked ? '1' : '0';
   }, []);
-  const captureCueStickAnchor = useCallback(() => {
+  const captureCueStickAnchor = useCallback(({ lockAim = false } = {}) => {
     const cueBall = cueRef.current;
     if (!cueBall?.pos) return;
     cueStickAnchorRef.current.set(cueBall.pos.x, CUE_Y, cueBall.pos.y);
+    if (lockAim) {
+      const lockedAim = aimDirRef.current?.clone?.() ?? new THREE.Vector2(0, 1);
+      if (lockedAim.lengthSq() < 1e-6) lockedAim.set(0, 1);
+      else lockedAim.normalize();
+      cueChargeAimLockRef.current = lockedAim;
+    }
   }, []);
   const cueRef = useRef(null);
   const ballsRef = useRef([]);
@@ -24856,6 +24863,7 @@ const shotPowerRef = useRef(0);
               cueAnimating = false;
               cuePullCurrentRef.current = 0;
               cuePullTargetRef.current = 0;
+              cueChargeAimLockRef.current = null;
               pendingImpactRef.current = null;
             }
             return false;
@@ -24864,6 +24872,7 @@ const shotPowerRef = useRef(0);
             cueStick.visible = false;
             cueAnimating = false;
             cueStrokeStateRef.current = null;
+            cueChargeAimLockRef.current = null;
             pendingImpactRef.current = null;
             syncCueShadow();
             return false;
@@ -24944,6 +24953,7 @@ const shotPowerRef = useRef(0);
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
+            cueChargeAimLockRef.current = null;
             cueStrokeStateRef.current = null;
             pendingImpactRef.current = null;
             if (cameraRef.current && sphRef.current) {
@@ -25044,6 +25054,7 @@ const shotPowerRef = useRef(0);
           cuePullCurrentRef.current = 0;
           cuePullTargetRef.current = 0;
           cueStrokeStateRef.current = null;
+          cueChargeAimLockRef.current = null;
           pendingImpactRef.current = null;
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29597,8 +29608,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
-
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
             topViewLockedRef.current = false;
@@ -29699,12 +29708,20 @@ const shotPowerRef = useRef(0);
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
-          const contactAdvance = 0; // stop the cue exactly where the slider pull started, matching Snooker Royal
+          const contactAdvance = THREE.MathUtils.lerp(
+            BALL_R * 0.42,
+            BALL_R * 0.9,
+            clampedPower
+          );
           shotImpactPayload.contactAdvance = contactAdvance;
           const contactPos = impactPos
             .clone()
             .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
+          const followDistance = THREE.MathUtils.lerp(
+            CUE_FOLLOW_THROUGH_MIN,
+            CUE_FOLLOW_THROUGH_MAX,
+            clampedPower
+          );
           const followPos = contactPos
             .clone()
             .addScaledVector(dir, followDistance);
@@ -33142,6 +33159,13 @@ const shotPowerRef = useRef(0);
             }
           }
         }
+        const chargeAimLock = cueChargeAimLockRef.current;
+        if (
+          chargeAimLock?.lengthSq?.() > 1e-6 &&
+          (Boolean(sliderInstanceRef.current?.dragging) || shooting || cueAnimating)
+        ) {
+          aimDir.copy(chargeAimLock).normalize();
+        }
         const appliedSpin = applySpinConstraints(aimDir, true);
         const aimPreviewSpin = resolveAimPreviewSpin(appliedSpin);
         const liftStrength = normalizeCueLift(resolveUserCueLift());
@@ -35674,10 +35698,14 @@ const shotPowerRef = useRef(0);
       labels: true,
       onChange: (v) => applyPower(v / 100),
       onStart: () => {
-        captureCueStickAnchor();
+        captureCueStickAnchor({ lockAim: true });
       },
       onCommit: (value) => {
         const committedPower = clampPower(value / 100, 0);
+        const lockedAim = cueChargeAimLockRef.current;
+        if (lockedAim?.lengthSq?.() > 1e-6) {
+          aimDirRef.current.copy(lockedAim).normalize();
+        }
         shotPowerRef.current = committedPower;
         powerRef.current = committedPower;
         fireRef.current?.(committedPower);


### PR DESCRIPTION
### Motivation
- Ensure the visual cue stick preserves the same standing-camera orientation while the player is pulling power so the pull/push motion reads consistently on mobile portrait screens.
- Make the visible cue stroke and the applied physics impulse come from the same source (slider → pull distance → strike) so replay and live shots match and the cue visibly pushes through on release.

### Description
- Add a `cueChargeAimLockRef` and extend `captureCueStickAnchor` to optionally `lockAim`, so the aim direction can be captured and reused during slider drag (`onStart`) and release (`onCommit`) via the new code path calling `captureCueStickAnchor({ lockAim: true })` and copying the locked aim into `aimDirRef` when committing the shot.
- Prevent the shot impulse from being applied immediately on slider release by removing the direct `applyShotAtImpact(...)` call and instead preparing `shotImpactPayload` and letting the cue-stroke animation call `onImpact` when the stroke reaches the armed/hit timing.
- Compute and apply a dynamic visual contact advance and follow-through: set `shotImpactPayload.contactAdvance` using `THREE.MathUtils.lerp(BALL_R * 0.42, BALL_R * 0.9, clampedPower)` and set `followDistance` via `THREE.MathUtils.lerp(CUE_FOLLOW_THROUGH_MIN, CUE_FOLLOW_THROUGH_MAX, clampedPower)` so the cue visibly pushes forward after release in proportion to power.
- Clear the locked aim at appropriate cleanup points (stroke end and animation-disabled paths) and use the lock to override `aimDir` while the slider is dragging or during the shot animation to keep orientation stable.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully (Vite build, assets emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d16b12083298ebd8ff7faee9c5e)