### PR TITLE
Snooker Royal: remove human character, tighten standing camera, and show cue when camera lowers

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -5609,7 +5609,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.132; // pull the standing camera closer so the table fills more of portrait screens
+const STANDING_VIEW_DISTANCE_SCALE = 0.12; // pull the standing camera a bit closer so the table fills more of portrait screens
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -19816,7 +19816,8 @@ const powerRef = useRef(hud.power);
           const zoomProfile = resolveCameraZoomProfile(aspect);
           const standingRadiusRaw = fitRadius(
             camera,
-            Math.max(m * zoomProfile.margin, 1e-4)
+            Math.max(m * zoomProfile.margin, 1e-4),
+            STANDING_VIEW_DISTANCE_SCALE
           );
           const cueBase = clampOrbitRadius(BREAK_VIEW.radius);
           const playerRadiusBase = Math.max(standingRadiusRaw, cueBase);
@@ -22269,9 +22270,7 @@ const powerRef = useRef(hud.power);
       // thin side already faces the cue ball so no extra rotation
       cueStick.visible = false;
       table.add(cueStick);
-      const snookerRoyalHuman = addHuman(table, renderer, (status) => {
-        if (status) console.debug(status);
-      });
+      // Snooker Royal no longer renders the ReadyPlayer human character; keep the cue-stick controller unchanged.
       const snookerCuePoseController = createSnookerRoyalCuePoseController();
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
@@ -23608,11 +23607,12 @@ const powerRef = useRef(hud.power);
           const cueBallY = cue?.pos ? CUE_Y : BALL_CENTER_Y;
           const cameraHeightAboveCue =
             (cameraForCueVisibility?.position?.y ?? cueBallY) - cueBallY;
-          const isStandingCueView =
+          const isFullyStandingCueView =
             !shooting &&
             !cueAnimating &&
+            (cameraBlendRef.current ?? 1) >= 0.995 &&
             cameraHeightAboveCue > BALL_R * 3.4;
-          cueStick.visible = !isStandingCueView;
+          cueStick.visible = !isFullyStandingCueView;
           cueStick.position.copy(idlePos);
           const startTime = performance.now();
           const pullEndTime = startTime + pullbackDuration;
@@ -23720,8 +23720,10 @@ const powerRef = useRef(hud.power);
               const releaseCueBallY = cue?.pos ? CUE_Y : BALL_CENTER_Y;
               const releaseHeightAboveCue =
                 (releaseCamera?.position?.y ?? releaseCueBallY) - releaseCueBallY;
-              const standingReleaseView = releaseHeightAboveCue > BALL_R * 3.4;
-              cueStick.visible = !standingReleaseView;
+              const fullyStandingReleaseView =
+                (cameraBlendRef.current ?? 1) >= 0.995 &&
+                releaseHeightAboveCue > BALL_R * 3.4;
+              cueStick.visible = !fullyStandingReleaseView;
               cueAnimating = false;
               cuePullCurrentRef.current = 0;
               cuePullTargetRef.current = 0;
@@ -26791,7 +26793,7 @@ const powerRef = useRef(hud.power);
             power: (shooting || cueAnimating) ? lastShotPower : (powerRef.current ?? activeAiPlan?.power ?? 0),
             shooting,
             cueAnimating,
-            tableCueVisible: Boolean(cueStick.visible && (cameraBlendRef.current ?? 1) <= 0.55),
+            tableCueVisible: Boolean(cueStick.visible && (cameraBlendRef.current ?? 1) < 0.995),
             spinInput: activeAiPlan?.spin ?? spinRef.current ?? { x: 0, y: 0 }
           });
         } catch (error) {
@@ -26799,72 +26801,7 @@ const powerRef = useRef(hud.power);
           console.warn('Snooker Royal cue pose disabled after update error', error);
         }
 
-        try {
-          const cueBallWorld = cue?.pos
-            ? new THREE.Vector3(cue.pos.x, CUE_Y, cue.pos.y)
-            : null;
-          const activeAimDir = showingRemoteAim
-            ? new THREE.Vector2(remoteAimState?.dir?.x ?? 0, remoteAimState?.dir?.y ?? 1)
-            : activeAiPlan?.aimDir || aimDir;
-          const aimForward = new THREE.Vector3(activeAimDir?.x ?? 0, 0, activeAimDir?.y ?? 1);
-          if (aimForward.lengthSq() < 1e-8) aimForward.set(0, 0, 1);
-          aimForward.normalize();
-          const activePower = THREE.MathUtils.clamp(
-            (shooting || cueAnimating) ? lastShotPower : (powerRef.current ?? activeAiPlan?.power ?? 0),
-            0,
-            1
-          );
-          if (cueBallWorld && cue?.active) {
-            const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
-            const humanRootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward);
-            const bridgeHandTarget = cueBallWorld.clone()
-              .addScaledVector(aimForward, -CFG.bridgeHandBackFromBall)
-              .addScaledVector(aimSide, CFG.bridgeHandSide)
-              .setY(CFG.tableTopY + CFG.bridgePalmTableLift);
-            const standingYaw = yawFromForward(aimForward);
-            const idleRightHandTarget = humanRootTarget.clone().add(
-              new THREE.Vector3(CFG.idleRightHandX, CFG.idleRightHandY, CFG.idleRightHandZ)
-                .applyAxisAngle(Y_AXIS, standingYaw)
-            );
-            const idleLeftHandTarget = humanRootTarget.clone().add(
-              new THREE.Vector3(-0.18 * CFG.scale, 1.08 * CFG.scale, 0.03 * CFG.scale)
-                .applyAxisAngle(Y_AXIS, standingYaw)
-            );
-            const idleDir = CFG.idleCueDir.clone().applyAxisAngle(Y_AXIS, standingYaw).normalize();
-            const idleCue = cuePoseFromGrip(idleRightHandTarget, idleDir, CFG.idleCueGripFromBack, CFG.cueLength);
-            const providedCueBack = cueStick.userData.providedCueBack?.clone?.() ?? idleCue.back;
-            const providedCueTip = cueStick.userData.providedCueTip?.clone?.() ?? idleCue.tip;
-            const visualState = shooting || cueAnimating
-              ? 'striking'
-              : activePower > 0.02
-                ? 'dragging'
-                : cueStick.visible
-                  ? 'aiming'
-                  : 'idle';
-            const activeCueBack = visualState === 'idle' ? idleCue.back : providedCueBack;
-            const activeCueTip = visualState === 'idle' ? idleCue.tip : providedCueTip;
-            updateHumanPose(
-              snookerRoyalHuman,
-              deltaSeconds,
-              visualState,
-              humanRootTarget,
-              aimForward,
-              bridgeHandTarget,
-              idleRightHandTarget,
-              idleLeftHandTarget,
-              activeCueBack,
-              activeCueTip,
-              activePower
-            );
-          } else {
-            snookerRoyalHuman.root.visible = false;
-            snookerRoyalHuman.modelRoot.visible = false;
-          }
-        } catch (error) {
-          snookerRoyalHuman.root.visible = false;
-          snookerRoyalHuman.modelRoot.visible = false;
-          console.warn('Snooker Royal ReadyPlayer human pose skipped', error);
-        }
+        // Human character pose update removed by request; cue-stick pose logic remains active above.
 
         if (!shouldSlowAim) {
           const precisionArea = chalkAreaRef.current;


### PR DESCRIPTION
### Motivation
- Reduce scene complexity by removing the ReadyPlayer human character while preserving the existing cue logic and pose controller for visual fidelity. 
- Improve portrait mobile framing by pulling the standing camera a bit closer to the table so the playfield fills more of the screen. 
- Make the cue stick appear reliably when the camera is lowered even slightly so players always see the cue when expected. 

### Description
- Removed ReadyPlayer human load/instance and per-frame human pose update paths from `webapp/src/pages/Games/SnookerRoyal.jsx` while leaving the cue pose controller (`createSnookerRoyalCuePoseController` / `updateSnookerRoyalCuePose`) intact. 
- Tuned standing camera fit behavior by changing `STANDING_VIEW_DISTANCE_SCALE` from `0.132` to `0.12` and passing that scale into `fitRadius` via the `fit` function so refit/resizes use the closer standing distance. 
- Changed cue visibility logic to hide the cue only for a fully standing camera view (checks `(cameraBlendRef.current ?? 1) >= 0.995`) instead of the previous rule, so lowering the camera even slightly makes the cue visible. Also updated the `tableCueVisible` flag used when driving cue pose. 
- Replaced the human creation call with a short comment and retained all cue construction / styling and cue gallery code paths. All edits are contained in `webapp/src/pages/Games/SnookerRoyal.jsx`.

### Testing
- Ran lint: `npm --prefix webapp run lint -- src/pages/Games/SnookerRoyal.jsx` — succeeded. 
- Production build: `npm --prefix webapp run build` — succeeded (Vite build completed). 
- Attempted an automated mobile portrait preview using Playwright after launching the Vite dev server; Playwright browser binaries were installed but headless screenshot capture timed out / experienced environment network/graphics constraints (dependency installation and `playwright install-deps` were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d9bf2188329822b571fd736915a)