### PR TITLE
Lock cue aim during power pull + delay impulse to cue-stroke impact (Pool Royale)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18039,6 +18039,7 @@ const shotPowerRef = useRef(0);
   const preShotTopViewLockRef = useRef(false);
   const sidePocketAimRef = useRef(false);
   const aimDirRef = useRef(new THREE.Vector2(0, 1));
+  const sliderLockedAimDirRef = useRef(null);
   const playerOffsetRef = useRef(0);
   const orbitFocusRef = useRef({
     target: new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0),
@@ -18166,6 +18167,10 @@ const shotPowerRef = useRef(0);
     const cueBall = cueRef.current;
     if (!cueBall?.pos) return;
     cueStickAnchorRef.current.set(cueBall.pos.x, CUE_Y, cueBall.pos.y);
+    const lockedAim = aimDirRef.current?.clone?.() ?? new THREE.Vector2(0, 1);
+    if (lockedAim.lengthSq() < 1e-6) lockedAim.set(0, 1);
+    else lockedAim.normalize();
+    sliderLockedAimDirRef.current = lockedAim;
   }, []);
   const cueRef = useRef(null);
   const ballsRef = useRef([]);
@@ -29291,7 +29296,7 @@ const shotPowerRef = useRef(0);
         pottedIds.clear();
         firstHit = null;
         clearInterval(timerRef.current);
-        const aimDir = aimDirRef.current.clone();
+        const aimDir = (sliderLockedAimDirRef.current ?? aimDirRef.current).clone();
         if (aimDir.lengthSq() < 1e-6) {
           aimDir.set(0, 1);
         } else {
@@ -29597,7 +29602,9 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
+          if (!ENABLE_CUE_STROKE_ANIMATION) {
+            applyShotAtImpact(shotImpactPayload);
+          }
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -33563,12 +33570,17 @@ const shotPowerRef = useRef(0);
               (isAiTurn && !aiPullReady),
             smoothingOverride: pullProfile.pullSmoothing
           });
-          const visualPull = applyVisualPullCompensation(pull, dir);
+          const cueStickDir = sliderLockedAimDirRef.current?.clone?.() ?? dir.clone();
+          if (cueStickDir.lengthSq() > 1e-6) cueStickDir.normalize();
+          else cueStickDir.copy(dir);
+          const cueStickPerp = new THREE.Vector3(-cueStickDir.z, 0, cueStickDir.x);
+          if (cueStickPerp.lengthSq() > 1e-8) cueStickPerp.normalize();
+          const visualPull = applyVisualPullCompensation(pull, cueStickDir);
           const { side, vert, hasSpin } = computeSpinOffsets(appliedSpin, ranges);
-          const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
+          const spinWorld = new THREE.Vector3(cueStickPerp.x * side, vert, cueStickPerp.z * side);
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(
-            dir,
+            cueStickDir,
             pull,
             null,
             spinWorld
@@ -33578,7 +33590,7 @@ const shotPowerRef = useRef(0);
           const tiltAmount = hasSpin ? Math.max(0, appliedSpin.y || 0) : 0;
           const liftTilt = resolveUserCueLift();
           const extraTilt = MAX_BACKSPIN_TILT * tiltAmount + liftTilt;
-          cueStick.rotation.y = Math.atan2(dir.x, dir.z) + Math.PI;
+          cueStick.rotation.y = Math.atan2(cueStickDir.x, cueStickDir.z) + Math.PI;
           applyCueButtTilt(
             cueStick,
             extraTilt + obstructionTilt + obstructionTiltFromLift
@@ -33586,7 +33598,7 @@ const shotPowerRef = useRef(0);
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          const tipTarget = resolveCueTipTarget(dir, visualPull, spinWorld);
+          const tipTarget = resolveCueTipTarget(cueStickDir, visualPull, spinWorld);
           applyCueObstructionLift(tipTarget, obstructionLift);
           applyCueStickTransform(tipTarget);
           clampCueButtAboveCushion(tipTarget);
@@ -35684,12 +35696,14 @@ const shotPowerRef = useRef(0);
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);
+          sliderLockedAimDirRef.current = null;
         });
       }
     });
     sliderInstanceRef.current = slider;
     applySliderLock();
     return () => {
+      sliderLockedAimDirRef.current = null;
       sliderInstanceRef.current = null;
       slider.destroy();
     };
@@ -35704,6 +35718,7 @@ const shotPowerRef = useRef(0);
     shotPowerRef.current = 0;
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;
+    sliderLockedAimDirRef.current = null;
   }, [applyPower, hud.over, hud.turn, shotActive]);
 
   const isPlayerTurn = hud.turn === 0;


### PR DESCRIPTION
### Motivation
- Ensure the visual cue stick keeps the same orientation the player set while dragging the power slider (standing/cue view), and that release looks like a physical push before the ball moves. 
- Make the visible pull/push on the cue match the recorded stroke used by replay/physics so replay and live shots look identical.

### Description
- Add a `sliderLockedAimDirRef` that captures `aimDirRef` on slider `onStart` and is used while pulling to keep the cue stick orientation locked to the standing-camera aim. 
- Apply the locked direction to pull visuals, obstruction checks, spin offsets, butt rotation, tip target computation, and cue transform by using `cueStickDir` instead of ad-hoc `dir` where the slider lock is present. 
- Delay applying the cue-ball impulse (`applyShotAtImpact`) when `ENABLE_CUE_STROKE_ANIMATION` is enabled so the physical impulse is applied at the stroke impact/strike phase rather than immediately on slider release. 
- Clear `sliderLockedAimDirRef` on slider reset/cleanup/commit so later interactions use live aim again and avoid stale locks.

### Testing
- Ran `npm --prefix webapp run build` to produce a production build and the build completed successfully (Vite chunk-size warnings are unchanged). 
- Installed browsers and deps via `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully. 
- Launched the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0` and it started successfully. 
- Performed a Playwright smoke screenshot test of `/games/poolroyale` (mobile portrait viewport) and the screenshot completed and was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d16b12083298ebd8ff7faee9c5e)