### PR TITLE
Stabilize Pool Royale cue orientation and defer shot impact to slider release

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -17258,6 +17258,7 @@ function PoolRoyaleGame({
     seatedBySeat: { A: true, B: true }
   });
   const activeHumanCueViewRef = useRef(null);
+  const standingCuePoseRef = useRef(null);
   const activeHumanCharacterRef = useRef(activeHumanCharacterOption);
   useEffect(() => {
     activeHumanCharacterRef.current = activeHumanCharacterOption;
@@ -22365,8 +22366,11 @@ const shotPowerRef = useRef(0);
           const cueBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
           const cueBias = 1 - cueBlend;
           if (cueBias <= HUMAN_EYE_CAMERA_MIN_BLEND) return null;
-          const cuePose = activeHumanCueViewRef.current;
-          if (!cuePose?.cueBack || !cuePose?.bridgeTarget || !cuePose?.aimForward || !cuePose?.side) {
+          // Keep cue-camera framing tied to the same table-space cue pose used by
+          // the standing camera.  The animated character can move independently,
+          // but the player always sees the cue stick with one stable orientation.
+          const cuePose = standingCuePoseRef.current ?? activeHumanCueViewRef.current;
+          if (!cuePose?.cueBack || !cuePose?.aimForward || !cuePose?.side) {
             return null;
           }
           const eyePos = cuePose.cueBack
@@ -29597,7 +29601,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -33590,6 +33593,12 @@ const shotPowerRef = useRef(0);
           applyCueObstructionLift(tipTarget, obstructionLift);
           applyCueStickTransform(tipTarget);
           clampCueButtAboveCushion(tipTarget);
+          standingCuePoseRef.current = {
+            cueBack: TMP_VEC3_BUTT.clone(),
+            cueTip: tipTarget.clone(),
+            aimForward: dir.clone(),
+            side: perp.clone()
+          };
           let visibleChalkIndex = null;
           const chalkMeta = table.userData?.chalkMeta;
           if (chalkMeta) {
@@ -34043,6 +34052,7 @@ const shotPowerRef = useRef(0);
           cueAfterPower.visible = false;
           impactRing.visible = false;
           computeCuePull(0, CUE_PULL_BASE);
+          standingCuePoseRef.current = null;
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }


### PR DESCRIPTION
### Motivation
- Players expect the cue stick to keep the same visual orientation when the camera drops into the cue/standing view and to visibly push forward when the power slider is released. These changes align the cue visuals and timing with the slider interaction.

### Description
- Added a new `standingCuePoseRef` in `webapp/src/pages/Games/PoolRoyale.jsx` to cache a stable table-space cue pose used by the standing/eye camera. 
- Updated `resolveActiveHumanEyePose` to prefer the cached `standingCuePoseRef` so the cue-camera framing keeps the same orientation as standing mode (`standingCuePoseRef` falls back to `activeHumanCueViewRef` when needed). 
- Captured the live standing cue pose (back, tip, aim forward and side vectors) while computing tip/ butt transforms during live aim updates and cleared it when the cue is hidden. 
- Deferred applying the physics shot impact: removed the immediate `applyShotAtImpact` call at the moment of slider commit so the shot is applied from the cue-stroke animation's `onImpact` callback (ensuring the cue visibly pushes forward on slider release before the shot is applied). 

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` — all tests passed. 
- Verified a production build: `npm --prefix webapp run build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d16b12083298ebd8ff7faee9c5e)