### PR TITLE
Add Sketchfab 'Eastern Carbine Rifle' capture weapon to Chess Battle Royal

### DIFF
--- a/webapp/config/sketchfab-assets.json
+++ b/webapp/config/sketchfab-assets.json
@@ -1,3 +1,18 @@
 {
-  "assets": []
+  "assets": [
+    {
+      "id": "eastern-carbine-rifle",
+      "label": "Eastern Carbine Rifle",
+      "uid": "3b06ac94c2f9475b962afdc06e16ddcf",
+      "sourceUrl": "https://skfb.ly/pKGIA",
+      "modelPageUrl": "https://sketchfab.com/3d-models/eastern-carbine-rifle-3b06ac94c2f9475b962afdc06e16ddcf",
+      "format": "gltf",
+      "targetDir": "public/models/sketchfab/eastern-carbine-rifle",
+      "targetFileName": "scene.gltf",
+      "license": "CC BY 4.0",
+      "creator": "Dezryelle",
+      "attribution": "Eastern Carbine Rifle by Dezryelle on Sketchfab, CC BY 4.0",
+      "notes": "Runtime glTF for Chess Battle Royal Eastern Carbine Rifle. Install with SKETCHFAB_TOKEN or --from; do not commit downloaded binaries."
+    }
+  ]
 }

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -10,6 +10,33 @@ import { swatchThumbnail } from './storeThumbnails.js';
 
 const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id;
 
+const EASTERN_CARBINE_SKETCHFAB_THUMBNAIL =
+  'https://media.sketchfab.com/models/3b06ac94c2f9475b962afdc06e16ddcf/thumbnails/5e445b35a1b74a79ae1a0a3f41cab344/a8f4b97044e3409e8d57b3f025ee9c7d.jpeg';
+const EASTERN_CARBINE_SKETCHFAB_MODEL_URL =
+  '/models/sketchfab/eastern-carbine-rifle/scene.gltf';
+
+export const CHESS_EASTERN_CARBINE_CAPTURE_OPTION = Object.freeze({
+  id: 'easternCarbineRifleAttack',
+  label: 'Eastern Carbine Rifle',
+  description:
+    'Dezryelle Sketchfab eastern_carbine_rifle adapted as a Chess Battle Royal capture weapon with low-poly carbine proportions.',
+  thumbnail: EASTERN_CARBINE_SKETCHFAB_THUMBNAIL,
+  modelUrls: [EASTERN_CARBINE_SKETCHFAB_MODEL_URL],
+  modelPageUrl:
+    'https://sketchfab.com/3d-models/eastern-carbine-rifle-3b06ac94c2f9475b962afdc06e16ddcf',
+  sourceUrl: 'https://skfb.ly/pKGIA',
+  source: 'Sketchfab',
+  author: 'Dezryelle',
+  license: 'CC Attribution 4.0'
+});
+
+export const CHESS_EASTERN_CARBINE_MODEL_URLS = CHESS_EASTERN_CARBINE_CAPTURE_OPTION.modelUrls;
+
+export const CHESS_CAPTURE_ANIMATION_OPTIONS = Object.freeze([
+  ...CAPTURE_ANIMATION_OPTIONS,
+  CHESS_EASTERN_CARBINE_CAPTURE_OPTION
+]);
+
 const CHESS_HUMAN_CHARACTER_SOURCE = Object.freeze({
   source: 'open-source',
   license: 'CC0',
@@ -534,7 +561,7 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
     }, {})
   ),
   captureAnimation: Object.freeze(
-    CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
+    CHESS_CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.label;
       return acc;
     }, {})
@@ -580,7 +607,7 @@ export const CHESS_BATTLE_OPTION_THUMBNAILS = Object.freeze({
     }, {})
   ),
   captureAnimation: Object.freeze(
-    CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
+    CHESS_CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.thumbnail;
       return acc;
     }, {})
@@ -810,7 +837,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     description: 'Unlocks an additional pawn head glass preset.',
     thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.headStyle.headGold
   },
-  ...CAPTURE_ANIMATION_OPTIONS.slice(1).map((option, idx) => ({
+  ...CHESS_CAPTURE_ANIMATION_OPTIONS.slice(1).map((option, idx) => ({
     id: `chess-capture-animation-${option.id}`,
     type: 'captureAnimation',
     optionId: option.id,
@@ -819,9 +846,15 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     description:
       option.id === 'ukrainianDroneAttack'
         ? 'Exact srcejon Ukrainian drone.glb inventory weapon with original texture preflight, direct-loader fallbacks, and a straight-down no-smoke missile drop.'
-        : option.description || 'Ludo Battle Royal weapon animation pack adapted for Chess Battle Royal.',
+        : option.id === CHESS_EASTERN_CARBINE_CAPTURE_OPTION.id
+          ? 'Sketchfab eastern_carbine_rifle by Dezryelle (CC BY 4.0), adapted as a low-poly Chess Battle Royal capture rifle from https://skfb.ly/pKGIA.'
+          : option.description || 'Ludo Battle Royal weapon animation pack adapted for Chess Battle Royal.',
     thumbnail: option.thumbnail,
-    swatches: option.id === 'ukrainianDroneAttack' ? ['#020617', '#2563eb', '#facc15'] : undefined,
+    swatches: option.id === 'ukrainianDroneAttack'
+      ? ['#020617', '#2563eb', '#facc15']
+      : option.id === CHESS_EASTERN_CARBINE_CAPTURE_OPTION.id
+        ? ['#1f2937', '#6b4f35', '#cbd5e1']
+        : undefined,
     previewShape: option.id === 'ukrainianDroneAttack' ? 'ukrainian-drone' : undefined,
     modelUrls: option.id === 'ukrainianDroneAttack'
       ? [
@@ -829,7 +862,11 @@ export const CHESS_BATTLE_STORE_ITEMS = [
           'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
           'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
         ]
-      : undefined
+      : option.modelUrls,
+    sourceUrl: option.sourceUrl,
+    modelPageUrl: option.modelPageUrl,
+    author: option.author,
+    license: option.license
   })),
   ...CHESS_HUMAN_CHARACTER_OPTIONS.filter((option) =>
     CHESS_STORE_HUMAN_CHARACTER_IDS.includes(option.id)

--- a/webapp/src/config/ludoWeaponDirectorBridge.js
+++ b/webapp/src/config/ludoWeaponDirectorBridge.js
@@ -12,6 +12,7 @@ export const LUDO_WEAPON_DIRECTOR_BRIDGE = Object.freeze({
     smgBurstAttack: 'SMG',
     polySmg01Attack: 'SMG',
     assaultRifleAttack: 'Rifle',
+    easternCarbineRifleAttack: 'Rifle',
     ak47VolleyAttack: 'Rifle',
     fpsGunAttack: 'Rifle',
     compactCarbineAttack: 'Rifle',

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -49,7 +49,10 @@ import {
   CHESS_BATTLE_TABLE_OPTIONS,
   CHESS_BATTLE_OPTION_THUMBNAILS,
   CHESS_TABLE_FINISH_OPTIONS,
-  CHESS_HUMAN_CHARACTER_OPTIONS
+  CHESS_HUMAN_CHARACTER_OPTIONS,
+  CHESS_CAPTURE_ANIMATION_OPTIONS,
+  CHESS_EASTERN_CARBINE_CAPTURE_OPTION,
+  CHESS_EASTERN_CARBINE_MODEL_URLS
 } from '../../config/chessBattleInventoryConfig.js';
 import {
   chessBattleAccountId,
@@ -73,7 +76,6 @@ import {
   loadExactUkrainianDroneModel
 } from '../../utils/ukrainianDroneModel.js';
 import { giftSounds } from '../../utils/giftSounds.js';
-import { CAPTURE_ANIMATION_OPTIONS } from '../../config/ludoBattleOptions.js';
 import { LUDO_WEAPON_DIRECTOR_BRIDGE } from '../../config/ludoWeaponDirectorBridge.js';
 import { SNAKE_FPS_GUN_MODEL_CONFIG } from '../../config/snakeWeaponCatalog.js';
 
@@ -223,7 +225,7 @@ const getParkedWeaponKindForAnimationId = (animationId) => {
 const isCaptureAnimationVisibleOnParkedKind = (animationId, parkedKind) =>
   getParkedWeaponKindForAnimationId(animationId) === parkedKind;
 const FIREARM_CAPTURE_ANIMATION_IDS = new Set(
-  CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter((id) => !GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[id])
+  CHESS_CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter((id) => !GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[id])
 );
 
 const resolveFirearmTypeForAnimationId = (captureAnimationId) =>
@@ -316,6 +318,16 @@ function preserveChessCaptureWeaponSourceMaterial(material, texturePolicy = 'pre
 }
 
 const CHESS_CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
+  easternCarbineRifleAttack: {
+    label: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.label,
+    urls: [...CHESS_EASTERN_CARBINE_MODEL_URLS],
+    source: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.source,
+    author: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.author,
+    license: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.license,
+    sourceUrl: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.sourceUrl,
+    scale: 0.215,
+    requireExactModel: true
+  },
   fpsGunAttack: {
     label: 'FPS Gun',
     urls: [...SNAKE_FPS_GUN_MODEL_CONFIG.urls],
@@ -446,7 +458,8 @@ const CHESS_LARGE_FIREARM_IDS = new Set([
   'polyRobotFlyingGunAttack',
   'polyBazooka01Attack',
   'polyGrenadeLauncher01Attack',
-  'polyTank01Attack'
+  'polyTank01Attack',
+  'easternCarbineRifleAttack'
 ]);
 const CHESS_FIREARM_MAGAZINE_SHOTS_BY_ID = Object.freeze({
   fpsGunAttack: 24,
@@ -482,7 +495,8 @@ const CHESS_FIREARM_MAGAZINE_SHOTS_BY_ID = Object.freeze({
   polyMolotov01Attack: 1,
   polyGasTank01Attack: 1,
   polyHandGrenade01Attack: 1,
-  polyTank01Attack: 1
+  polyTank01Attack: 1,
+  easternCarbineRifleAttack: 20
 });
 const CHESS_GRENADE_SHORT_MISSILE_IDS = new Set([
   'grenadeBlastAttack',
@@ -523,7 +537,8 @@ const CHESS_FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   polyMolotov01Attack: 0.92,
   polyGasTank01Attack: 1.28,
   polyHandGrenade01Attack: 0.48,
-  polyTank01Attack: 2.3
+  polyTank01Attack: 2.3,
+  easternCarbineRifleAttack: 2.15
 });
 const CHESS_FIREARM_FLAT_ROTATION = Object.freeze([-Math.PI * 0.5, -Math.PI * 0.02, 0]);
 const CHESS_FIREARM_AIM_ROTATION = Object.freeze([0, -Math.PI * 0.5, 0]); // keep weapon front/muzzle pointed visually toward the board target.
@@ -559,7 +574,8 @@ const CHESS_FIREARM_HANDHELD_SCALE_MULTIPLIER_BY_ID = Object.freeze({
   polyMolotov01Attack: 0.9,
   polyGasTank01Attack: 1.0,
   polyHandGrenade01Attack: 0.95,
-  polyTank01Attack: 1.2
+  polyTank01Attack: 1.2,
+  easternCarbineRifleAttack: 1.24
 });
 const CHESS_FIREARM_MUZZLE_YAW_CORRECTION_BY_ID = Object.freeze({
   ak47VolleyAttack: Math.PI,
@@ -584,6 +600,7 @@ const CHESS_FIREARM_HAND_ATTACH_TUNING = Object.freeze({
   uziSprayAttack: { muzzleOffset: [0, 0.014, 0.215] },
   smgBurstAttack: { muzzleOffset: [0, 0.014, 0.22] },
   assaultRifleAttack: { muzzleOffset: [0, 0.014, 0.244] },
+  easternCarbineRifleAttack: { muzzleOffset: [0, 0.014, 0.248] },
   ak47VolleyAttack: { muzzleOffset: [0, 0.014, 0.256] },
   krsvBurstAttack: { muzzleOffset: [0, 0.014, 0.249] },
   smithSidearmAttack: { muzzleOffset: [0, 0.012, 0.194] },
@@ -2481,6 +2498,7 @@ const FIREARM_CAPTURE_SHOT_SOUND_URL_BY_ID = Object.freeze({
   uziSprayAttack: 'https://cdn.freesound.org/previews/171/171104_2437358-lq.mp3',
   smgBurstAttack: 'https://cdn.freesound.org/previews/171/171104_2437358-lq.mp3',
   assaultRifleAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
+  easternCarbineRifleAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
   ak47VolleyAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
   sniperShotAttack: 'https://cdn.freesound.org/previews/533/533981_11861866-lq.mp3',
   shotgunBlastAttack: 'https://cdn.freesound.org/previews/456/456035_5121236-lq.mp3',
@@ -2547,6 +2565,7 @@ const CHESS_FIREARM_CALIBER_BY_ANIMATION_ID = Object.freeze({
   marksmanDmrAttack: Object.freeze({ caliberLabel: '7.62×51mm DMR round', projectileKind: 'marksman-round', bulletRadius: 0.0042, bulletLength: 0.052, shellRadius: 0.0032, shellLength: 0.024, bulletSpeed: 0.292 }),
   polyRobotLargeGunAttack: Object.freeze({ caliberLabel: 'heavy robot rifle round', projectileKind: 'rifle-round', bulletRadius: 0.0042, bulletLength: 0.047, shellRadius: 0.0032, shellLength: 0.024, bulletSpeed: 0.255 }),
   polyRobotFlyingGunAttack: Object.freeze({ caliberLabel: 'drone SMG micro-round', projectileKind: 'smg-round', bulletRadius: 0.003, bulletLength: 0.026, shellRadius: 0.0021, shellLength: 0.012, bulletSpeed: 0.235 }),
+  easternCarbineRifleAttack: Object.freeze({ caliberLabel: '7.62×39mm carbine round', projectileKind: 'rifle-round', bulletRadius: 0.0039, bulletLength: 0.043, shellRadius: 0.003, shellLength: 0.022, bulletSpeed: 0.27 }),
   grenadeBlastAttack: Object.freeze({ caliberLabel: 'hand grenade blast', projectileKind: 'explosive-warhead', bulletRadius: 0.0064, bulletLength: 0.046, shellRadius: 0.0046, shellLength: 0.03, bulletSpeed: 0.14 }),
   polyBazooka01Attack: Object.freeze({ caliberLabel: 'RPG rocket', projectileKind: 'explosive-warhead', bulletRadius: 0.0075, bulletLength: 0.068, shellRadius: 0.0054, shellLength: 0.036, bulletSpeed: 0.12 }),
   polyGrenadeLauncher01Attack: Object.freeze({ caliberLabel: '40mm launcher grenade', projectileKind: 'explosive-warhead', bulletRadius: 0.0068, bulletLength: 0.049, shellRadius: 0.005, shellLength: 0.032, bulletSpeed: 0.135 }),
@@ -3497,7 +3516,7 @@ const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.22; // keep truck as prominent as t
 const SIDE_PARKED_FIREARM_DISPLAY_SIZE_RATIO = 1.22; // scale parked firearm swaps to match the larger vehicles occupying each pad
 
 function chooseRandomCaptureAnimationId(kind, fallbackId) {
-  const pool = CAPTURE_ANIMATION_OPTIONS
+  const pool = CHESS_CAPTURE_ANIMATION_OPTIONS
     .map((option) => option?.id)
     .filter((id) => {
       if (!id) return false;
@@ -4497,6 +4516,8 @@ function fitObjectToTargetSize(object, targetSize = 0.12) {
   object.updateMatrixWorld?.(true);
 }
 
+
+
 function prepareChessCaptureWeaponClone(template, captureAnimationId, { flat = true, targetSize = null } = {}) {
   const clone = cloneSkinned(template);
   clone.traverse((node) => {
@@ -4540,11 +4561,11 @@ function prepareChessCaptureWeaponClone(template, captureAnimationId, { flat = t
 
 async function loadChessCaptureWeaponModel(captureAnimationId) {
   const config = CHESS_CAPTURE_WEAPON_MODEL_CONFIG[captureAnimationId];
-  const candidateUrls = Array.isArray(config?.urls) ? config.urls.filter(Boolean) : [];
-  if (!candidateUrls.length) return null;
   if (CHESS_CAPTURE_WEAPON_MODEL_CACHE.has(captureAnimationId)) {
     return CHESS_CAPTURE_WEAPON_MODEL_CACHE.get(captureAnimationId);
   }
+  const candidateUrls = Array.isArray(config?.urls) ? config.urls.filter(Boolean) : [];
+  if (!candidateUrls.length) return null;
   const withLoadTimeout = async (promise) =>
     Promise.race([
       promise,
@@ -4633,6 +4654,7 @@ async function loadChessCaptureWeaponModel(captureAnimationId) {
   const resolved = await promise;
   if (resolved) return resolved;
   CHESS_CAPTURE_WEAPON_MODEL_FAILURE.add(captureAnimationId);
+  if (config?.requireExactModel) return null;
   const fallbackId = Array.from(FIREARM_CAPTURE_ANIMATION_IDS).find(
     (id) => id !== captureAnimationId && !CHESS_CAPTURE_WEAPON_MODEL_FAILURE.has(id) && CHESS_CAPTURE_WEAPON_MODEL_CONFIG[id]
   );
@@ -8785,7 +8807,7 @@ function Chess3D({
   );
   const selectedCaptureAnimationId = useMemo(() => {
     const owned = chessInventory?.captureAnimation;
-    return (Array.isArray(owned) && owned[0]) || CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
+    return (Array.isArray(owned) && owned[0]) || CHESS_CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
   }, [chessInventory]);
   const selectedCaptureKind = useMemo(() => {
     if (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId)) return 'firearm';
@@ -8802,13 +8824,14 @@ function Chess3D({
   const ownedCaptureAnimations = useMemo(
     () =>
       (chessInventory?.captureAnimation || [])
-        .map((optionId) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
+        .map((optionId) => CHESS_CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
         .filter(Boolean),
     [chessInventory]
   );
   const QUICK_SWAP_WEAPON_IDS = useMemo(
     () =>
       [
+        'easternCarbineRifleAttack',
         'ukrainianDroneAttack',
         'droneAttack',
         'polyShotgun01Attack',

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -402,6 +402,7 @@ const CHESS_TYPE_LABELS = {
   sideColor: 'Piece Colors',
   boardTheme: 'Board Themes',
   headStyle: 'Pawn Heads',
+  captureAnimation: 'Weapons',
   environmentHdri: 'HDR Environments'
 };
 const CHECKERS_BATTLE_TYPE_LABELS = {


### PR DESCRIPTION
### Motivation
- Add a new Sketchfab-sourced capture weapon (Eastern Carbine Rifle by Dezryelle, CC BY 4.0) to the Chess Battle Royal inventory so players can select and use it as a capture animation/weapon.
- Ensure the weapon is treated as a first-class capture model with source metadata, exact-model loading semantics, and tuned scale/hold/visual parameters to match existing firearms.

### Description
- Added a Sketchfab asset entry in `webapp/config/sketchfab-assets.json` for the Eastern Carbine Rifle including `sourceUrl`, `modelPageUrl`, `targetDir`, `targetFileName`, `license`, and attribution notes.
- Introduced `CHESS_EASTERN_CARBINE_CAPTURE_OPTION` and `CHESS_EASTERN_CARBINE_MODEL_URLS` in `chessBattleInventoryConfig.js`, and added the option into `CHESS_CAPTURE_ANIMATION_OPTIONS` so it appears in capture animation option lists and thumbnails.
- Integrated the new capture id `easternCarbineRifleAttack` across gameplay/config surfaces: added weapon mapping in `ludoWeaponDirectorBridge`, added a `CHESS_CAPTURE_WEAPON_MODEL_CONFIG` entry with `requireExactModel` and scale, and updated apparel/visual tuning (large firearm set, magazine shots, rack size multiplier, handheld scale, muzzle offset, audio source mapping, and caliber profile).
- Updated store and UI code to include the new capture animation in store item generation, quick-swap lists, and replaced usages of the shared `CAPTURE_ANIMATION_OPTIONS` with `CHESS_CAPTURE_ANIMATION_OPTIONS` in relevant Chess pages so the new option is selectable and populated with source/author/license/modelUrl metadata.

### Testing
- Ran the webapp unit test suite with `npm test` and the linter with `npm run lint`, and both completed without failures.
- Performed a dev build and smoke test with `npm run build` and a local start, confirming the Chess Battle Royal page loads and the capture animation options list includes the Eastern Carbine Rifle.
- Exercised model loading paths for capture weapons in a local session to confirm fallback logic and `requireExactModel` behavior; loading returned either the exact model or a valid fallback and did not cause runtime exceptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26630c44f48329bfe8f0eccc999c03)