### PR TITLE
Fix Pool Royale cue aim stability

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6736,6 +6736,15 @@ const computeCueViewVector = (cueBall, camera) => {
   return TMP_VEC2_VIEW.clone().normalize();
 };
 
+const resolveAimDirectionFromOrbitTheta = (theta, fallback = null) => {
+  if (!Number.isFinite(theta)) {
+    const safeFallback = fallback?.clone?.() ?? new THREE.Vector2(0, 1);
+    if (safeFallback.lengthSq() < 1e-8) safeFallback.set(0, 1);
+    return safeFallback.normalize();
+  }
+  return new THREE.Vector2(-Math.sin(theta), -Math.cos(theta)).normalize();
+};
+
 const clampSpinToVisibleHemisphere = (spinInput, aimDir, cueBall, camera) => {
   if (!spinInput || !aimDir || !cueBall || !camera) return spinInput;
   const viewVec = computeCueViewVector(cueBall, camera);
@@ -28323,7 +28332,6 @@ const shotPowerRef = useRef(0);
       };
 
       const aimDir = aimDirRef.current;
-      const camFwd = new THREE.Vector3();
       const shotSph = new THREE.Spherical();
       const tmpAim = new THREE.Vector2();
 
@@ -33054,15 +33062,11 @@ const shotPowerRef = useRef(0);
           if (fallbackAim.lengthSq() < 1e-6) fallbackAim.set(0, 1);
           tmpAim.copy(fallbackAim.normalize());
         } else {
-          camera.getWorldDirection(camFwd);
-          tmpAim.set(camFwd.x, camFwd.z);
-          if (tmpAim.lengthSq() < 1e-6) {
-            const fallbackAim = aimDirRef.current.clone();
-            if (fallbackAim.lengthSq() < 1e-6) fallbackAim.set(0, 1);
-            tmpAim.copy(fallbackAim.normalize());
-          } else {
-            tmpAim.normalize();
-          }
+          // Keep the table-space cue line locked to the standing orbit theta. The
+          // low human-eye/cue camera can slide beside the stick for portrait aiming,
+          // so deriving aim from the live camera direction can make the cue appear
+          // to jump or flip sides while the player only lowers the camera.
+          tmpAim.copy(resolveAimDirectionFromOrbitTheta(sph.theta, aimDirRef.current));
         }
         const cameraBlend = THREE.MathUtils.clamp(
           cameraBlendRef.current ?? 1,


### PR DESCRIPTION
### Motivation
- Prevent the cue stick from flipping sides or jumping visually when the player lowers the portrait camera by keeping the table-space cue aim stable relative to the standing orbit.
- Ensure the visible cue line and slider-driven pull/release start from the same table-space direction as the standing view so pull gestures remain consistent across camera blends.

### Description
- Add `resolveAimDirectionFromOrbitTheta` to derive a stable table-space aim vector from the orbit `theta` with a safe fallback to the existing `aimDir` when needed.
- Replace the previous live-camera-derived aim sampling with a table-space aim computed from the standing orbit `sph.theta` in the main aiming loop so lowering the camera no longer flips the cue direction.
- Remove an unused `camFwd` temporary and tidy related aim-selection logic in `webapp/src/pages/Games/PoolRoyale.jsx` and add a short explanatory comment about the change.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully.
- Installed Playwright and browser dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium`, both completed successfully.
- Launched the dev server and exercised a headless Playwright screenshot of `/games/poolroyale` to smoke-check the change; Playwright screenshots in this headless/WebGL environment were flaky (timeouts/black frames) but the runtime build/dev server ran without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a266ce363c08329bcca945acde35e95)