### PR TITLE
Add Sketchfab Eastern Carbine capture weapon and Sketchfab glTF texture support

### DIFF
--- a/webapp/config/sketchfab-assets.json
+++ b/webapp/config/sketchfab-assets.json
@@ -1,3 +1,18 @@
 {
-  "assets": []
+  "assets": [
+    {
+      "id": "eastern-carbine-rifle",
+      "label": "Eastern Carbine Rifle",
+      "uid": "3b06ac94c2f9475b962afdc06e16ddcf",
+      "sourceUrl": "https://skfb.ly/pKGIA",
+      "modelPageUrl": "https://sketchfab.com/3d-models/eastern-carbine-rifle-3b06ac94c2f9475b962afdc06e16ddcf",
+      "format": "gltf",
+      "targetDir": "public/models/sketchfab/eastern-carbine-rifle",
+      "targetFileName": "scene.gltf",
+      "license": "CC BY 4.0",
+      "creator": "Dezryelle",
+      "attribution": "Eastern Carbine Rifle by Dezryelle on Sketchfab, CC BY 4.0",
+      "notes": "Runtime glTF for Chess Battle Royal Eastern Carbine Rifle. Install with SKETCHFAB_TOKEN or --from; do not commit downloaded binaries."
+    }
+  ]
 }

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -10,6 +10,34 @@ import { swatchThumbnail } from './storeThumbnails.js';
 
 const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id;
 
+const EASTERN_CARBINE_SKETCHFAB_THUMBNAIL =
+  'https://media.sketchfab.com/models/3b06ac94c2f9475b962afdc06e16ddcf/thumbnails/5e445b35a1b74a79ae1a0a3f41cab344/a8f4b97044e3409e8d57b3f025ee9c7d.jpeg';
+const EASTERN_CARBINE_SKETCHFAB_MODEL_URL =
+  '/models/sketchfab/eastern-carbine-rifle/scene.gltf';
+
+export const CHESS_EASTERN_CARBINE_CAPTURE_OPTION = Object.freeze({
+  id: 'easternCarbineRifleAttack',
+  label: 'Eastern Carbine Rifle',
+  description:
+    'Dezryelle Sketchfab eastern_carbine_rifle adapted as a Chess Battle Royal capture weapon with low-poly carbine proportions.',
+  thumbnail: EASTERN_CARBINE_SKETCHFAB_THUMBNAIL,
+  modelUrls: [EASTERN_CARBINE_SKETCHFAB_MODEL_URL],
+  texturePolicy: 'sketchfabOriginalGltf',
+  modelPageUrl:
+    'https://sketchfab.com/3d-models/eastern-carbine-rifle-3b06ac94c2f9475b962afdc06e16ddcf',
+  sourceUrl: 'https://skfb.ly/pKGIA',
+  source: 'Sketchfab',
+  author: 'Dezryelle',
+  license: 'CC Attribution 4.0'
+});
+
+export const CHESS_EASTERN_CARBINE_MODEL_URLS = CHESS_EASTERN_CARBINE_CAPTURE_OPTION.modelUrls;
+
+export const CHESS_CAPTURE_ANIMATION_OPTIONS = Object.freeze([
+  ...CAPTURE_ANIMATION_OPTIONS,
+  CHESS_EASTERN_CARBINE_CAPTURE_OPTION
+]);
+
 const CHESS_HUMAN_CHARACTER_SOURCE = Object.freeze({
   source: 'open-source',
   license: 'CC0',
@@ -534,7 +562,7 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
     }, {})
   ),
   captureAnimation: Object.freeze(
-    CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
+    CHESS_CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.label;
       return acc;
     }, {})
@@ -580,7 +608,7 @@ export const CHESS_BATTLE_OPTION_THUMBNAILS = Object.freeze({
     }, {})
   ),
   captureAnimation: Object.freeze(
-    CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
+    CHESS_CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.thumbnail;
       return acc;
     }, {})
@@ -810,7 +838,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     description: 'Unlocks an additional pawn head glass preset.',
     thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.headStyle.headGold
   },
-  ...CAPTURE_ANIMATION_OPTIONS.slice(1).map((option, idx) => ({
+  ...CHESS_CAPTURE_ANIMATION_OPTIONS.slice(1).map((option, idx) => ({
     id: `chess-capture-animation-${option.id}`,
     type: 'captureAnimation',
     optionId: option.id,
@@ -819,9 +847,15 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     description:
       option.id === 'ukrainianDroneAttack'
         ? 'Exact srcejon Ukrainian drone.glb inventory weapon with original texture preflight, direct-loader fallbacks, and a straight-down no-smoke missile drop.'
-        : option.description || 'Ludo Battle Royal weapon animation pack adapted for Chess Battle Royal.',
+        : option.id === CHESS_EASTERN_CARBINE_CAPTURE_OPTION.id
+          ? 'Sketchfab eastern_carbine_rifle by Dezryelle (CC BY 4.0), adapted as a low-poly Chess Battle Royal capture rifle from https://skfb.ly/pKGIA.'
+          : option.description || 'Ludo Battle Royal weapon animation pack adapted for Chess Battle Royal.',
     thumbnail: option.thumbnail,
-    swatches: option.id === 'ukrainianDroneAttack' ? ['#020617', '#2563eb', '#facc15'] : undefined,
+    swatches: option.id === 'ukrainianDroneAttack'
+      ? ['#020617', '#2563eb', '#facc15']
+      : option.id === CHESS_EASTERN_CARBINE_CAPTURE_OPTION.id
+        ? ['#1f2937', '#6b4f35', '#cbd5e1']
+        : undefined,
     previewShape: option.id === 'ukrainianDroneAttack' ? 'ukrainian-drone' : undefined,
     modelUrls: option.id === 'ukrainianDroneAttack'
       ? [
@@ -829,7 +863,12 @@ export const CHESS_BATTLE_STORE_ITEMS = [
           'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
           'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
         ]
-      : undefined
+      : option.modelUrls,
+    sourceUrl: option.sourceUrl,
+    texturePolicy: option.texturePolicy,
+    modelPageUrl: option.modelPageUrl,
+    author: option.author,
+    license: option.license
   })),
   ...CHESS_HUMAN_CHARACTER_OPTIONS.filter((option) =>
     CHESS_STORE_HUMAN_CHARACTER_IDS.includes(option.id)

--- a/webapp/src/config/ludoWeaponDirectorBridge.js
+++ b/webapp/src/config/ludoWeaponDirectorBridge.js
@@ -12,6 +12,7 @@ export const LUDO_WEAPON_DIRECTOR_BRIDGE = Object.freeze({
     smgBurstAttack: 'SMG',
     polySmg01Attack: 'SMG',
     assaultRifleAttack: 'Rifle',
+    easternCarbineRifleAttack: 'Rifle',
     ak47VolleyAttack: 'Rifle',
     fpsGunAttack: 'Rifle',
     compactCarbineAttack: 'Rifle',

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -49,7 +49,10 @@ import {
   CHESS_BATTLE_TABLE_OPTIONS,
   CHESS_BATTLE_OPTION_THUMBNAILS,
   CHESS_TABLE_FINISH_OPTIONS,
-  CHESS_HUMAN_CHARACTER_OPTIONS
+  CHESS_HUMAN_CHARACTER_OPTIONS,
+  CHESS_CAPTURE_ANIMATION_OPTIONS,
+  CHESS_EASTERN_CARBINE_CAPTURE_OPTION,
+  CHESS_EASTERN_CARBINE_MODEL_URLS
 } from '../../config/chessBattleInventoryConfig.js';
 import {
   chessBattleAccountId,
@@ -73,7 +76,6 @@ import {
   loadExactUkrainianDroneModel
 } from '../../utils/ukrainianDroneModel.js';
 import { giftSounds } from '../../utils/giftSounds.js';
-import { CAPTURE_ANIMATION_OPTIONS } from '../../config/ludoBattleOptions.js';
 import { LUDO_WEAPON_DIRECTOR_BRIDGE } from '../../config/ludoWeaponDirectorBridge.js';
 import { SNAKE_FPS_GUN_MODEL_CONFIG } from '../../config/snakeWeaponCatalog.js';
 
@@ -223,7 +225,7 @@ const getParkedWeaponKindForAnimationId = (animationId) => {
 const isCaptureAnimationVisibleOnParkedKind = (animationId, parkedKind) =>
   getParkedWeaponKindForAnimationId(animationId) === parkedKind;
 const FIREARM_CAPTURE_ANIMATION_IDS = new Set(
-  CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter((id) => !GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[id])
+  CHESS_CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter((id) => !GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[id])
 );
 
 const resolveFirearmTypeForAnimationId = (captureAnimationId) =>
@@ -306,6 +308,52 @@ function applyGunifyWeaponTexturePolicy(material) {
   material.needsUpdate = true;
 }
 
+
+function configureLoaderResourcePath(loader, candidateUrl) {
+  try {
+    const basePath = new URL('.', candidateUrl, window.location.href).href;
+    loader.setPath?.(basePath);
+    loader.setResourcePath?.(basePath);
+    return basePath;
+  } catch {
+    const basePath = `${candidateUrl}`.replace(/[^/]*(?:[?#].*)?$/i, '');
+    loader.setPath?.(basePath);
+    loader.setResourcePath?.(basePath);
+    return basePath;
+  }
+}
+
+function applySketchfabOriginalGltfTexturePolicy(material) {
+  if (!material) return;
+  [
+    'map',
+    'emissiveMap',
+    'normalMap',
+    'roughnessMap',
+    'metalnessMap',
+    'aoMap',
+    'alphaMap',
+    'bumpMap',
+    'displacementMap',
+    'lightMap'
+  ].forEach((textureKey) => {
+    const texture = material[textureKey];
+    if (!texture) return;
+    if (textureKey === 'map' || textureKey === 'emissiveMap') applySRGBColorSpace(texture);
+    // GLTFLoader already sets glTF texture orientation. Re-asserting false keeps
+    // installed Sketchfab sibling images visually identical instead of vertically
+    // flipped on portrait WebGL previews.
+    texture.flipY = false;
+    texture.anisotropy = Math.max(texture.anisotropy || 1, 8);
+    texture.needsUpdate = true;
+  });
+  material.userData = {
+    ...(material.userData || {}),
+    sourceTexturePolicy: 'sketchfabOriginalGltf'
+  };
+  material.needsUpdate = true;
+}
+
 function preserveChessCaptureWeaponSourceMaterial(material, texturePolicy = 'preserveSource') {
   if (!material) return;
   material.userData = {
@@ -316,6 +364,17 @@ function preserveChessCaptureWeaponSourceMaterial(material, texturePolicy = 'pre
 }
 
 const CHESS_CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
+  easternCarbineRifleAttack: {
+    label: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.label,
+    urls: [...CHESS_EASTERN_CARBINE_MODEL_URLS],
+    source: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.source,
+    author: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.author,
+    license: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.license,
+    sourceUrl: CHESS_EASTERN_CARBINE_CAPTURE_OPTION.sourceUrl,
+    scale: 0.215,
+    texturePolicy: 'sketchfabOriginalGltf',
+    requireExactModel: true
+  },
   fpsGunAttack: {
     label: 'FPS Gun',
     urls: [...SNAKE_FPS_GUN_MODEL_CONFIG.urls],
@@ -446,7 +505,8 @@ const CHESS_LARGE_FIREARM_IDS = new Set([
   'polyRobotFlyingGunAttack',
   'polyBazooka01Attack',
   'polyGrenadeLauncher01Attack',
-  'polyTank01Attack'
+  'polyTank01Attack',
+  'easternCarbineRifleAttack'
 ]);
 const CHESS_FIREARM_MAGAZINE_SHOTS_BY_ID = Object.freeze({
   fpsGunAttack: 24,
@@ -482,7 +542,8 @@ const CHESS_FIREARM_MAGAZINE_SHOTS_BY_ID = Object.freeze({
   polyMolotov01Attack: 1,
   polyGasTank01Attack: 1,
   polyHandGrenade01Attack: 1,
-  polyTank01Attack: 1
+  polyTank01Attack: 1,
+  easternCarbineRifleAttack: 20
 });
 const CHESS_GRENADE_SHORT_MISSILE_IDS = new Set([
   'grenadeBlastAttack',
@@ -523,7 +584,8 @@ const CHESS_FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   polyMolotov01Attack: 0.92,
   polyGasTank01Attack: 1.28,
   polyHandGrenade01Attack: 0.48,
-  polyTank01Attack: 2.3
+  polyTank01Attack: 2.3,
+  easternCarbineRifleAttack: 2.15
 });
 const CHESS_FIREARM_FLAT_ROTATION = Object.freeze([-Math.PI * 0.5, -Math.PI * 0.02, 0]);
 const CHESS_FIREARM_AIM_ROTATION = Object.freeze([0, -Math.PI * 0.5, 0]); // keep weapon front/muzzle pointed visually toward the board target.
@@ -559,7 +621,8 @@ const CHESS_FIREARM_HANDHELD_SCALE_MULTIPLIER_BY_ID = Object.freeze({
   polyMolotov01Attack: 0.9,
   polyGasTank01Attack: 1.0,
   polyHandGrenade01Attack: 0.95,
-  polyTank01Attack: 1.2
+  polyTank01Attack: 1.2,
+  easternCarbineRifleAttack: 1.24
 });
 const CHESS_FIREARM_MUZZLE_YAW_CORRECTION_BY_ID = Object.freeze({
   ak47VolleyAttack: Math.PI,
@@ -584,6 +647,7 @@ const CHESS_FIREARM_HAND_ATTACH_TUNING = Object.freeze({
   uziSprayAttack: { muzzleOffset: [0, 0.014, 0.215] },
   smgBurstAttack: { muzzleOffset: [0, 0.014, 0.22] },
   assaultRifleAttack: { muzzleOffset: [0, 0.014, 0.244] },
+  easternCarbineRifleAttack: { muzzleOffset: [0, 0.014, 0.248] },
   ak47VolleyAttack: { muzzleOffset: [0, 0.014, 0.256] },
   krsvBurstAttack: { muzzleOffset: [0, 0.014, 0.249] },
   smithSidearmAttack: { muzzleOffset: [0, 0.012, 0.194] },
@@ -2481,6 +2545,7 @@ const FIREARM_CAPTURE_SHOT_SOUND_URL_BY_ID = Object.freeze({
   uziSprayAttack: 'https://cdn.freesound.org/previews/171/171104_2437358-lq.mp3',
   smgBurstAttack: 'https://cdn.freesound.org/previews/171/171104_2437358-lq.mp3',
   assaultRifleAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
+  easternCarbineRifleAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
   ak47VolleyAttack: 'https://cdn.freesound.org/previews/212/212968_4048940-lq.mp3',
   sniperShotAttack: 'https://cdn.freesound.org/previews/533/533981_11861866-lq.mp3',
   shotgunBlastAttack: 'https://cdn.freesound.org/previews/456/456035_5121236-lq.mp3',
@@ -2547,6 +2612,7 @@ const CHESS_FIREARM_CALIBER_BY_ANIMATION_ID = Object.freeze({
   marksmanDmrAttack: Object.freeze({ caliberLabel: '7.62×51mm DMR round', projectileKind: 'marksman-round', bulletRadius: 0.0042, bulletLength: 0.052, shellRadius: 0.0032, shellLength: 0.024, bulletSpeed: 0.292 }),
   polyRobotLargeGunAttack: Object.freeze({ caliberLabel: 'heavy robot rifle round', projectileKind: 'rifle-round', bulletRadius: 0.0042, bulletLength: 0.047, shellRadius: 0.0032, shellLength: 0.024, bulletSpeed: 0.255 }),
   polyRobotFlyingGunAttack: Object.freeze({ caliberLabel: 'drone SMG micro-round', projectileKind: 'smg-round', bulletRadius: 0.003, bulletLength: 0.026, shellRadius: 0.0021, shellLength: 0.012, bulletSpeed: 0.235 }),
+  easternCarbineRifleAttack: Object.freeze({ caliberLabel: '7.62×39mm carbine round', projectileKind: 'rifle-round', bulletRadius: 0.0039, bulletLength: 0.043, shellRadius: 0.003, shellLength: 0.022, bulletSpeed: 0.27 }),
   grenadeBlastAttack: Object.freeze({ caliberLabel: 'hand grenade blast', projectileKind: 'explosive-warhead', bulletRadius: 0.0064, bulletLength: 0.046, shellRadius: 0.0046, shellLength: 0.03, bulletSpeed: 0.14 }),
   polyBazooka01Attack: Object.freeze({ caliberLabel: 'RPG rocket', projectileKind: 'explosive-warhead', bulletRadius: 0.0075, bulletLength: 0.068, shellRadius: 0.0054, shellLength: 0.036, bulletSpeed: 0.12 }),
   polyGrenadeLauncher01Attack: Object.freeze({ caliberLabel: '40mm launcher grenade', projectileKind: 'explosive-warhead', bulletRadius: 0.0068, bulletLength: 0.049, shellRadius: 0.005, shellLength: 0.032, bulletSpeed: 0.135 }),
@@ -3497,7 +3563,7 @@ const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.22; // keep truck as prominent as t
 const SIDE_PARKED_FIREARM_DISPLAY_SIZE_RATIO = 1.22; // scale parked firearm swaps to match the larger vehicles occupying each pad
 
 function chooseRandomCaptureAnimationId(kind, fallbackId) {
-  const pool = CAPTURE_ANIMATION_OPTIONS
+  const pool = CHESS_CAPTURE_ANIMATION_OPTIONS
     .map((option) => option?.id)
     .filter((id) => {
       if (!id) return false;
@@ -4497,6 +4563,8 @@ function fitObjectToTargetSize(object, targetSize = 0.12) {
   object.updateMatrixWorld?.(true);
 }
 
+
+
 function prepareChessCaptureWeaponClone(template, captureAnimationId, { flat = true, targetSize = null } = {}) {
   const clone = cloneSkinned(template);
   clone.traverse((node) => {
@@ -4540,11 +4608,11 @@ function prepareChessCaptureWeaponClone(template, captureAnimationId, { flat = t
 
 async function loadChessCaptureWeaponModel(captureAnimationId) {
   const config = CHESS_CAPTURE_WEAPON_MODEL_CONFIG[captureAnimationId];
-  const candidateUrls = Array.isArray(config?.urls) ? config.urls.filter(Boolean) : [];
-  if (!candidateUrls.length) return null;
   if (CHESS_CAPTURE_WEAPON_MODEL_CACHE.has(captureAnimationId)) {
     return CHESS_CAPTURE_WEAPON_MODEL_CACHE.get(captureAnimationId);
   }
+  const candidateUrls = Array.isArray(config?.urls) ? config.urls.filter(Boolean) : [];
+  if (!candidateUrls.length) return null;
   const withLoadTimeout = async (promise) =>
     Promise.race([
       promise,
@@ -4561,6 +4629,7 @@ async function loadChessCaptureWeaponModel(captureAnimationId) {
       const candidateUrl = candidateUrls[i];
       try {
         // eslint-disable-next-line no-await-in-loop
+        if (config?.texturePolicy !== 'gunifyPbr') configureLoaderResourcePath(loader, candidateUrl);
         loadedRoot = assignLoadedGltf(
           config?.texturePolicy === 'gunifyPbr'
             ? await withLoadTimeout(loadGunifyOriginalGltf(loader, candidateUrl))
@@ -4613,6 +4682,10 @@ async function loadChessCaptureWeaponModel(captureAnimationId) {
       const materials = Array.isArray(node.material) ? node.material : [node.material];
       materials.forEach((material) => {
         if (!material) return;
+        if (config?.texturePolicy === 'sketchfabOriginalGltf') {
+          applySketchfabOriginalGltfTexturePolicy(material);
+          return;
+        }
         if (textureOverride && !material.map) material.map = textureOverride;
         if (material.map) applySRGBColorSpace(material.map);
         if (material.emissiveMap) applySRGBColorSpace(material.emissiveMap);
@@ -4633,6 +4706,7 @@ async function loadChessCaptureWeaponModel(captureAnimationId) {
   const resolved = await promise;
   if (resolved) return resolved;
   CHESS_CAPTURE_WEAPON_MODEL_FAILURE.add(captureAnimationId);
+  if (config?.requireExactModel) return null;
   const fallbackId = Array.from(FIREARM_CAPTURE_ANIMATION_IDS).find(
     (id) => id !== captureAnimationId && !CHESS_CAPTURE_WEAPON_MODEL_FAILURE.has(id) && CHESS_CAPTURE_WEAPON_MODEL_CONFIG[id]
   );
@@ -8785,7 +8859,7 @@ function Chess3D({
   );
   const selectedCaptureAnimationId = useMemo(() => {
     const owned = chessInventory?.captureAnimation;
-    return (Array.isArray(owned) && owned[0]) || CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
+    return (Array.isArray(owned) && owned[0]) || CHESS_CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
   }, [chessInventory]);
   const selectedCaptureKind = useMemo(() => {
     if (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId)) return 'firearm';
@@ -8802,13 +8876,14 @@ function Chess3D({
   const ownedCaptureAnimations = useMemo(
     () =>
       (chessInventory?.captureAnimation || [])
-        .map((optionId) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
+        .map((optionId) => CHESS_CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
         .filter(Boolean),
     [chessInventory]
   );
   const QUICK_SWAP_WEAPON_IDS = useMemo(
     () =>
       [
+        'easternCarbineRifleAttack',
         'ukrainianDroneAttack',
         'droneAttack',
         'polyShotgun01Attack',

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -402,6 +402,7 @@ const CHESS_TYPE_LABELS = {
   sideColor: 'Piece Colors',
   boardTheme: 'Board Themes',
   headStyle: 'Pawn Heads',
+  captureAnimation: 'Weapons',
   environmentHdri: 'HDR Environments'
 };
 const CHECKERS_BATTLE_TYPE_LABELS = {


### PR DESCRIPTION
### Motivation
- Add a Sketchfab-sourced weapon model to Chess Battle Royal and ensure its materials/textures are preserved when loaded as an original Sketchfab glTF asset.
- Wire the new weapon into inventory, store, UI, weapon handling, and load/preview pipelines so the Eastern Carbine functions like other capture weapons.

### Description
- Add a Sketchfab asset manifest entry in `webapp/config/sketchfab-assets.json` for the Eastern Carbine Rifle and introduce `CHESS_EASTERN_CARBINE_CAPTURE_OPTION` with model URL and thumbnail in `chessBattleInventoryConfig.js` and include it in `CHESS_CAPTURE_ANIMATION_OPTIONS`.
- Add a `sketchfabOriginalGltf` texture policy and implement `configureLoaderResourcePath` and `applySketchfabOriginalGltfTexturePolicy` in `ChessBattleRoyal.jsx` so Sketchfab GLTF textures keep correct orientation, sRGB handling, anisotropy, and metadata tags when loaded.
- Register the new capture weapon in `CHESS_CAPTURE_WEAPON_MODEL_CONFIG` with `requireExactModel`, add the id to large firearm sets and various firearm tuning maps (magazine shots, rack size, hand scale, muzzle offsets, projectile calibers) and add mapping to `LUDO_WEAPON_DIRECTOR_BRIDGE` and quick-swap lists.
- Propagate capture-option metadata (e.g. `modelUrls`, `texturePolicy`, `sourceUrl`, `modelPageUrl`, `author`, `license`) into store item generation and load-time fallback behavior, and make the loader treat `requireExactModel` items as non-fallback when the exact model fails.

### Testing
- Ran unit test suite with `npm test` and all tests completed successfully.
- Ran linting with `npm run lint` and no lint errors were reported.
- Performed a production build with `npm run build` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26630c44f48329bfe8f0eccc999c03)