### PR TITLE
Match Pool Royale cue release to Snooker Royal (push forward then recover)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -28828,7 +28828,7 @@ const shotPowerRef = useRef(0);
           strikeDuration,
           holdDuration,
           pullbackDuration,
-          recoverDuration: 0,
+          recoverDuration: 95,
           impactThreshold: 0.86,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
@@ -29605,13 +29605,22 @@ const shotPowerRef = useRef(0);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
-          const impactPos = idlePos.clone();
-          const contactAdvance = 0; // stop the cue exactly where the slider pull started, matching Snooker Royal
-          shotImpactPayload.contactAdvance = contactAdvance;
-          const contactPos = impactPos
-            .clone()
-            .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
+          // Match Snooker Royal's visible release: the cue drives forward past
+          // its address point, then recovers to the exact idle/address position
+          // where the pull started instead of staying at the pulled-back depth.
+          const impactPush = THREE.MathUtils.clamp(
+            CUE_TIP_GAP - BALL_R * 0.9,
+            BALL_R * 0.16,
+            BALL_R * 0.38
+          );
+          const impactPos = buildCuePosition(-impactPush);
+          shotImpactPayload.contactAdvance = impactPush;
+          const contactPos = impactPos.clone();
+          const followDistance = THREE.MathUtils.lerp(
+            BALL_R * 0.26,
+            BALL_R * 0.72,
+            clampedPower
+          );
           const followPos = contactPos
             .clone()
             .addScaledVector(dir, followDistance);


### PR DESCRIPTION
### Motivation
- The Pool Royale cue stayed visually pulled after release; the goal is to have the cue push forward on release and then return to the original address position, matching the visual behavior in Snooker Royal.

### Description
- Updated the cue stroke profile in `webapp/src/pages/Games/PoolRoyale.jsx` to include a short recovery window by setting `recoverDuration` to `95` in `resolveCueStrokeProfile`.
- Reworked the live-fire release sequence so the cue now performs a forward push past the address point and then recovers back to the idle/address pose by computing an `impactPush` and using `buildCuePosition(-impactPush)` for the visible impact position.
- Set `shotImpactPayload.contactAdvance` to the computed `impactPush` and compute a `followDistance` that scales with `clampedPower` so the visible follow/recover motion matches power.
- Kept the change localized to `webapp/src/pages/Games/PoolRoyale.jsx` and preserved existing stroke timing profiles and camera hold logic while altering only the visual release/recover behavior.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Installed and ran browser tooling via `npx playwright install chromium` and `npx playwright install-deps chromium` to satisfy Playwright prerequisites; the missing-system-libraries failure was resolved by the latter step.
- Started the dev server (`npm --prefix webapp run dev`) and performed a Playwright smoke screenshot of `http://127.0.0.1:5173/games/poolroyale`, which saved to `/tmp/pool-royale-cue-forward-check.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2697d41fe4832998833eec8197898c)