### PR TITLE
Fix Pool Royale cue stroke release and aiming visual

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -29504,7 +29504,10 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
+          // Apply the physics impulse from the cue-stroke impact callback, not
+          // immediately on slider release. This keeps the visible Pool Royale
+          // cue push-forward aligned with the moment the stick returns to the
+          // original address point instead of leaving the cue visually pulled.
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -33063,6 +33066,9 @@ const shotPowerRef = useRef(0);
         if (isAiTurn) {
           autoPlaceAiCueBall();
         }
+        const cueStrokeVisualActive = Boolean(
+          ENABLE_CUE_STROKE_ANIMATION && (cueStrokeStateRef.current || cueAnimating)
+        );
         const canShowCue =
           allStopped(balls) &&
           cue?.active &&
@@ -33070,6 +33076,8 @@ const shotPowerRef = useRef(0);
           !(inHandPlacementModeRef.current) &&
           (!(currentHud?.inHand) || cueBallPlacedFromHandRef.current) &&
           !remoteShotActive &&
+          !shooting &&
+          !cueStrokeVisualActive &&
           (isPlayerTurn || previewingAiShot || aiCueViewActive);
         if (
           cue?.pos &&


### PR DESCRIPTION
### Motivation
- Players reported the Pool Royale cue appearing to stay pulled after release because the physics impulse was applied immediately on slider release instead of at the visible impact moment.  
- The aiming cue renderer could override the active cue-stroke animation and leave the stick visually stuck; this change keeps visual stroke and physics aligned so the cue pushes forward then returns to its original address.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` the shot impulse is no longer applied immediately from the slider release path and is instead applied by the cue-stroke impact callback (preserving the visible pull → forward push → settle sequence).  
- Added a guard (`cueStrokeVisualActive`) and updated the `canShowCue` conditions to prevent the regular aiming cue renderer from rendering while a cue-stroke animation or shot is active, avoiding visual conflicts with the forward stroke.  
- The change is localized to the Pool Royale cue-stroke and aiming code paths to retain existing behavior elsewhere.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.  
- Ran `npm --prefix webapp run lint -- src/pages/Games/PoolRoyale.jsx` and ESLint reported no errors.  
- Installed Playwright browsers with `npx playwright install chromium` and `npx playwright install-deps chromium` successfully, and ran a Playwright smoke test that loaded `/games/poolroyale` and saved a screenshot to `/tmp/poolroyale-cue-stroke.png` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2697d41fe4832998833eec8197898c)