### PR TITLE
Make Pool Royale cue release push forward and stop at original pull depth

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -28820,8 +28820,8 @@ const shotPowerRef = useRef(0);
         const strikeDuration = THREE.MathUtils.lerp(128, 92, p);
         const holdDuration = THREE.MathUtils.lerp(40, 68, p);
         return {
-          // Rebuilt cue stroke: slider pull maps directly to cue pullback,
-          // then release performs a single forward punch through the cue ball.
+          // Snooker Royal-style live stroke: slider pull maps directly to cue pullback,
+          // then release performs one forward push back to the original cue-start pose.
           motion: 'classic',
           pullRatio: p,
           pullSmoothing: 1,
@@ -28830,7 +28830,7 @@ const shotPowerRef = useRef(0);
           pullbackDuration,
           recoverDuration: 0,
           impactThreshold: 0.86,
-          forwardOnly: false,
+          forwardOnly: true,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
         };
@@ -29739,7 +29739,9 @@ const shotPowerRef = useRef(0);
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
               strikeImpactThreshold: 0.9,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
-              forwardOnly: false,
+              // Match Snooker Royal's release: push from the pulled pose and
+              // stop exactly at the cue's original idle/contact pose.
+              forwardOnly: Boolean(strokeProfile.forwardOnly),
               onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,


### PR DESCRIPTION
### Motivation
- Align Pool Royale live cue animation with the Snooker Royal behavior so the cue pushes forward on release from the pulled pose and stops at the original pull/start contact pose instead of remaining pulled-back.

### Description
- Change the Pool Royale stroke profile to a forward-only release and add a short comment documenting the Snooker-style behavior in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Ensure the cue stroke state honors the profile by setting `forwardOnly` from the resolved `strokeProfile` and keep `releaseStartsFromCurrentPull` so the forward motion begins exactly from the computed pulled pose.

### Testing
- Ran the unit suite for the cue stroke timeline with `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js`, which passed (4 tests, 1 suite).
- Built the webapp with `npm --prefix webapp run build`, which completed successfully and produced the production bundles. 
- Started the dev server with `npm --prefix webapp run dev` to smoke-check runtime behavior; server came up and served the Pool Royale page.
- Installed Playwright and required system deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) and performed a headless smoke screenshot of the Pool Royale page (saved to `/tmp/pool-royale-cue-stroke.png`) to verify the visual cue stroke; the screenshot run completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2697d41fe4832998833eec8197898c)