### PR TITLE
Add helicopter capture animation, shared vehicle models, and store preview

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -468,7 +468,7 @@ export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   headStyle: ['current'],
   humanCharacter: [CHESS_HUMAN_CHARACTER_OPTIONS[0]?.id],
   environmentHdri: [DEFAULT_HDRI_ID],
-  captureAnimation: [CAPTURE_ANIMATION_OPTIONS[0]?.id, 'ukrainianDroneAttack']
+  captureAnimation: [CAPTURE_ANIMATION_OPTIONS[0]?.id, 'ukrainianDroneAttack', 'helicopterAttack']
 });
 
 export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
@@ -815,21 +815,29 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     type: 'captureAnimation',
     optionId: option.id,
     name: option.label,
-    price: option.id === 'ukrainianDroneAttack' ? 0 : 900 + idx * 110,
+    price: option.id === 'ukrainianDroneAttack' || option.id === 'helicopterAttack' ? 0 : 900 + idx * 110,
     description:
       option.id === 'ukrainianDroneAttack'
         ? 'Exact srcejon Ukrainian drone.glb inventory weapon with original texture preflight, direct-loader fallbacks, and a straight-down no-smoke missile drop.'
-        : option.description || 'Ludo Battle Royal weapon animation pack adapted for Chess Battle Royal.',
+        : option.id === 'helicopterAttack'
+          ? 'Same srcejon helicopter.glb used by Snake & Ladder, with Chess Battle Royal flyover and missile timing.'
+          : option.description || 'Ludo Battle Royal weapon animation pack adapted for Chess Battle Royal.',
     thumbnail: option.thumbnail,
-    swatches: option.id === 'ukrainianDroneAttack' ? ['#020617', '#2563eb', '#facc15'] : undefined,
-    previewShape: option.id === 'ukrainianDroneAttack' ? 'ukrainian-drone' : undefined,
+    swatches: option.id === 'ukrainianDroneAttack' ? ['#020617', '#2563eb', '#facc15'] : option.id === 'helicopterAttack' ? ['#5f6871', '#848f99', '#a5b1ba'] : undefined,
+    previewShape: option.id === 'ukrainianDroneAttack' ? 'ukrainian-drone' : option.id === 'helicopterAttack' ? 'helicopter' : undefined,
     modelUrls: option.id === 'ukrainianDroneAttack'
       ? [
           'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
           'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
           'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
         ]
-      : undefined
+      : option.id === 'helicopterAttack'
+        ? [
+            'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/helicopter.glb',
+            'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/helicopter.glb',
+            'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/helicopter.glb'
+          ]
+        : undefined
   })),
   ...CHESS_HUMAN_CHARACTER_OPTIONS.filter((option) =>
     CHESS_STORE_HUMAN_CHARACTER_IDS.includes(option.id)

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -183,27 +183,20 @@ const CAPTURE_EXPLOSION_SCALE = 0.132; // smaller capture explosion
 const CAPTURE_EDGE_PATH_FACTOR = 0.52;
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+const SNAKE_SHARED_CAPTURE_VEHICLE_MODEL_HOSTS = Object.freeze([
+  'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main',
+  'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main',
+  'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main'
+]);
+const snakeSharedCaptureVehicleUrls = (fileName) =>
+  SNAKE_SHARED_CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${fileName}`);
 const CAPTURE_MODEL_URLS = Object.freeze({
-  drone: [
-    'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
-    'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
-    'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
-  ],
-  helicopter: [
-    'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/helicopter.glb',
-    'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/helicopter.glb',
-    'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/helicopter.glb'
-  ],
-  fighter: [
-    'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/f15.glb',
-    'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/f15.glb',
-    'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/f15.glb'
-  ],
-  truck: [
-    'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/fire_truck.glb',
-    'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/fire_truck.glb',
-    'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/fire_truck.glb'
-  ]
+  drone: snakeSharedCaptureVehicleUrls('drone.glb'),
+  // Keep the Chess Battle Royal jet and helicopter on the exact same source
+  // models as Snake & Ladder so portrait players see the familiar aircraft.
+  helicopter: snakeSharedCaptureVehicleUrls('helicopter.glb'),
+  fighter: snakeSharedCaptureVehicleUrls('f15.glb'),
+  truck: snakeSharedCaptureVehicleUrls('fire_truck.glb')
 });
 
 const GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID = Object.freeze({
@@ -11638,15 +11631,49 @@ function Chess3D({
           addFxSphere(root, 0.1 + i * 0.024, [-1.05 - i * 0.18, 0, 0], '#8b949b', 1, 0, true, 0.26 - i * 0.03)
         );
       }
-      return {
+      const fx = {
         root,
         topRotor,
         tailRotor,
         topRotorAxis: new THREE.Vector3(0, 1, 0),
         tailRotorAxis: new THREE.Vector3(1, 0, 0),
+        rotorNodes: [topRotor, tailRotor],
         exhaustClouds,
         missileHardpoints: [new THREE.Vector3(0.14, -0.17, -0.27), new THREE.Vector3(0.14, -0.17, 0.27)]
       };
+      // Match Snake & Ladder behavior: show a fallback immediately, then swap
+      // only the helicopter to the shared srcejon helicopter.glb when it loads.
+      void loadCaptureUnitTemplate('helicopter', 5.2).then(() => {
+        if (!root.parent || root.userData?.loadedSnakeSharedHelicopter) return;
+        const loadedModel = cloneCaptureUnitTemplate('helicopter');
+        if (!loadedModel) return;
+        loadedModel.rotation.set(0, 0, 0);
+        const loadedTailRotor = findCaptureRotor(loadedModel, 'tail');
+        let loadedTopRotor = findCaptureRotor(loadedModel, 'main');
+        const loadedRotorNodes = [];
+        loadedModel.traverse((node) => {
+          if (!node?.isObject3D) return;
+          const name = `${node.name || ''}`.toLowerCase();
+          if (/rotor|propell|blade|fan/.test(name)) loadedRotorNodes.push(node);
+          if (!loadedTopRotor && node?.isMesh && !isDescendantOf(node, loadedTailRotor) && /rotor|propell|blade|fan/.test(name)) {
+            loadedTopRotor = node;
+          }
+        });
+        applyMilitaryHelicopterLook(loadedModel, loadedTopRotor, loadedTailRotor, getCaptureToneSeed('helicopter'));
+        const overlayChildren = root.children.filter((child) => child?.geometry?.type === 'CircleGeometry');
+        root.clear();
+        root.add(loadedModel);
+        overlayChildren.forEach((child) => root.add(child));
+        root.userData.loadedSnakeSharedHelicopter = true;
+        fx.topRotor = loadedTopRotor;
+        fx.tailRotor = loadedTailRotor;
+        fx.rotorNodes = loadedRotorNodes;
+        fx.topRotorAxis = new THREE.Vector3(0, 1, 0);
+        fx.tailRotorAxis = inferRotorSpinAxis(loadedTailRotor, 'x');
+        fx.exhaustClouds = [];
+        fx.missileHardpoints = findAirMissileHardpoints(loadedModel, 'helicopter');
+      }).catch(() => {});
+      return fx;
     };
     const createFxJet = () => {
       const model = cloneCaptureUnitTemplate('fighter');
@@ -11728,7 +11755,44 @@ function Chess3D({
       const exhaustClouds = createJetExhaustClouds(root, 8, [exhaustAnchor.x, exhaustAnchor.y, exhaustAnchor.z], 0.26);
       const missileHardpoints = [leftStore.position.clone(), rightStore.position.clone()];
       setJetExhaustVisible({ exhaustClouds }, false);
-      return { root, cockpit, leftStore, rightStore, exhaustClouds, exhaustAnchor, missileHardpoints };
+      const fx = { root, cockpit, leftStore, rightStore, exhaustClouds, exhaustAnchor, missileHardpoints };
+      // Match Snake & Ladder behavior: show a fallback immediately, then swap
+      // only the jet to the shared srcejon f15.glb when it loads.
+      void loadCaptureUnitTemplate('fighter', 5.8).then(() => {
+        if (!root.parent || root.userData?.loadedSnakeSharedJet) return;
+        const loadedModel = cloneCaptureUnitTemplate('fighter');
+        if (!loadedModel) return;
+        loadedModel.rotation.set(0, 0, 0);
+        loadedModel.traverse((node) => {
+          if (!node?.isMesh) return;
+          const name = `${node.name || ''}`.toLowerCase();
+          if (!/cockpit|canopy|glass|window/.test(name)) return;
+          ensureIsolatedMaterial(node);
+          const mats = Array.isArray(node.material) ? node.material : [node.material];
+          mats.forEach((mat) => {
+            if (!mat) return;
+            mat.color?.set?.('#050608');
+            mat.emissive?.set?.('#000000');
+            mat.metalness = Math.max(0.08, Number.isFinite(mat.metalness) ? mat.metalness * 0.35 : 0.12);
+            mat.roughness = Math.max(0.18, Number.isFinite(mat.roughness) ? mat.roughness * 0.6 : 0.28);
+          });
+        });
+        const loadedExhaustAnchor = findJetExhaustAnchor(loadedModel).lerp(new THREE.Vector3(-1.95, -0.02, 0), 0.25);
+        const overlayChildren = root.children.filter((child) => child?.geometry?.type === 'CircleGeometry');
+        root.clear();
+        root.add(loadedModel);
+        overlayChildren.forEach((child) => root.add(child));
+        const loadedExhaustClouds = createJetExhaustClouds(root, 8, [loadedExhaustAnchor.x, loadedExhaustAnchor.y, loadedExhaustAnchor.z], 0.24);
+        setJetExhaustVisible({ exhaustClouds: loadedExhaustClouds }, false);
+        root.userData.loadedSnakeSharedJet = true;
+        fx.cockpit = loadedModel.getObjectByName('cockpit') || loadedModel.getObjectByName('Cockpit') || loadedModel;
+        fx.leftStore = null;
+        fx.rightStore = null;
+        fx.exhaustClouds = loadedExhaustClouds;
+        fx.exhaustAnchor = loadedExhaustAnchor;
+        fx.missileHardpoints = findAirMissileHardpoints(loadedModel, 'jet');
+      }).catch(() => {});
+      return fx;
     };
     const createFxSupportTruck = () => {
       const root = new THREE.Group();

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1001,6 +1001,7 @@ const PREVIEW_LABELS = {
   table: 'Table surface',
   puck: 'Rink gear',
   'token-stack': 'Token stack',
+  helicopter: 'Helicopter model',
   default: '3D sample'
 };
 
@@ -3855,6 +3856,30 @@ export default function Store() {
                 fill={accent}
                 opacity="0.15"
               />
+            </g>
+          );
+        case 'helicopter':
+          return (
+            <g filter={`url(#${shadowId})`}>
+              <ellipse cx="80" cy="78" rx="44" ry="8" fill="rgba(0,0,0,0.36)" />
+              <rect x="42" y="45" width="58" height="18" rx="9" fill={`url(#${gradientId})`} />
+              <path
+                d="M94 49h34c5 0 8 4 8 8v2h-42Z"
+                fill={`url(#${shineId})`}
+                opacity="0.92"
+              />
+              <path
+                d="M48 49 25 42v8l24 7Z"
+                fill={secondary}
+                opacity="0.86"
+              />
+              <rect x="75" y="28" width="5" height="18" rx="2" fill={accent} opacity="0.78" />
+              <rect x="31" y="25" width="98" height="5" rx="2.5" fill={accent} opacity="0.82" />
+              <rect x="72" y="17" width="5" height="22" rx="2.5" fill={accent} opacity="0.34" transform="rotate(90 74.5 28)" />
+              <rect x="50" y="66" width="52" height="4" rx="2" fill={accent} opacity="0.66" />
+              <rect x="55" y="62" width="4" height="10" rx="2" fill={accent} opacity="0.5" />
+              <rect x="94" y="62" width="4" height="10" rx="2" fill={accent} opacity="0.5" />
+              <circle cx="128" cy="56" r="8" fill="none" stroke={accent} strokeWidth="3" opacity="0.74" />
             </g>
           );
         case 'puck':


### PR DESCRIPTION
### Motivation
- Add a new helicopter capture animation option and include it in default unlocks and store offerings for Chess Battle Royal. 
- Reuse the same external vehicle GLB assets used by Snake & Ladder to ensure consistent aircraft visuals across games. 
- Provide a store preview/icon for the helicopter model so it appears correctly in the storefront. 

### Description
- Added `helicopterAttack` to `CHESS_BATTLE_DEFAULT_UNLOCKS` and included it as a zero-price `captureAnimation` store item with swatches, preview shape, and remote `helicopter.glb` asset references in `webapp/src/config/chessBattleInventoryConfig.js`. 
- Introduced `SNAKE_SHARED_CAPTURE_VEHICLE_MODEL_HOSTS` and `snakeSharedCaptureVehicleUrls()` and refactored `CAPTURE_MODEL_URLS` to use the shared host list so drone/fighter/helicopter/truck models are loaded from the same external sources in `webapp/src/pages/Games/ChessBattleRoyal.jsx`. 
- Updated the in-scene FX creators to return mutable `fx` objects and added runtime swap logic to load and replace the fallback jet and helicopter models with the shared Snake & Ladder GLBs once they are available, preserving overlays and adjusting rotor/exhaust/missile hardpoints. 
- Added a `helicopter` label and a vector SVG preview case in the store renderer at `webapp/src/pages/Store.jsx` so the helicopter item has a proper storefront thumbnail. 

### Testing
- Ran the project test suite with `yarn test` which completed successfully. 
- Performed a production build with `yarn build` which completed without errors. 
- Confirmed linting via `yarn lint` passed with no introduced issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26970fb3788329874c09a7f2bbb05b)