### PR TITLE
Tune Pool Royale: slightly larger table, bigger/faster balls, bouncier cushions and more power

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1312,7 +1312,7 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
   const TABLE_SURFACE_REFERENCE = 1.12; // baseline expansion before the wider table adjustment
-  const TABLE_SURFACE_EXPANSION = 1.25; // widen/lengthen the table footprint by ~12% while keeping pockets/balls unchanged
+  const TABLE_SURFACE_EXPANSION = 1.29; // make the table footprint just a bit bigger while keeping the portrait proportions stable
   const TABLE_SURFACE_COMPENSATION = TABLE_SURFACE_EXPANSION / TABLE_SURFACE_REFERENCE;
   const TABLE = {
     W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * OFFICIAL_TABLE_SCALE * TABLE_SURFACE_EXPANSION,
@@ -1427,7 +1427,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
 const MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION;
-const BALL_SIZE_SCALE = 1; // official WPA/WEPF 57.15 mm balls; every helper stays tied to BALL_R/BALL_DIAMETER
+const BALL_SIZE_SCALE = 1.04; // make balls just a bit bigger while every helper stays tied to BALL_R/BALL_DIAMETER
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1552,14 +1552,14 @@ if (BALL_SHADOW_MATERIAL) {
 // Match the snooker build so pace and rebound energy stay consistent between modes.
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
-  restitution: 0.96,
+  restitution: 0.972,
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
   maxTipOffsetRatio: 0.9
 });
 const PHYSICS_BASE_STEP = 1 / 60;
-const FRICTION = 0.9951;
+const FRICTION = 0.9956;
 const DEFAULT_CUSHION_RESTITUTION = PHYSICS_PROFILE.restitution;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const BALL_MASS = 0.17;
@@ -1570,7 +1570,7 @@ const SPIN_KINETIC_FRICTION = 0.22;
 const SPIN_ROLL_DAMPING = 0.1;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const ROLLING_RESISTANCE = 0.011;
+const ROLLING_RESISTANCE = 0.0104;
 const BALL_BALL_FRICTION = 0.105;
 const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
 const BALL_COLLISION_SLOP = BALL_R * 0.001; // tighter tolerance so visible ball overlap is corrected faster
@@ -1617,8 +1617,8 @@ const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
   0,
   SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.04
 );
-const CUSHION_CUT_RESTITUTION_SCALE = 0.99; // keep cut-angle rebounds lively without adding excess speed
-const CUSHION_CUT_FRICTION_SCALE = 1.02; // reduce cut-line grab slightly so added bounce reads naturally
+const CUSHION_CUT_RESTITUTION_SCALE = 1.01; // make cut-angle rebounds just a bit more lively without adding excess speed
+const CUSHION_CUT_FRICTION_SCALE = 0.99; // reduce cut-line grab slightly so added bounce reads naturally
 const SIDE_POCKET_DEPTH_LIMIT =
   SIDE_POCKET_RADIUS * 1.6 * POCKET_VISUAL_EXPANSION; // align side-pocket rail limits with the visible mouth depth
 let SIDE_POCKET_SPAN =
@@ -1855,7 +1855,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.5; // preserve legacy cue response before the final mobile comfort trim
-const SHOT_GLOBAL_POWER_SCALE = 0.78; // add a small Pool Royale shot pace bump while keeping the selected shot-power curve
+const SHOT_GLOBAL_POWER_SCALE = 0.83; // add a little more Pool Royale shot power while keeping the selected shot-power curve
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *


### PR DESCRIPTION
### Motivation
- Improve the feel and presentation of Pool Royal on portrait phones by making the table read slightly larger and giving shots more presence. 
- Make balls slightly larger and increase roll / momentum so shots feel snappier and more arcade-forward. 
- Increase cushion liveliness and adjust friction/rolling resistances so rebound behavior matches the requested "more bounce" and perceived power.

### Description
- Adjusted table footprint scaling via `TABLE_SURFACE_EXPANSION` to `1.29` and related compensation so the playfield reads a bit larger in portrait (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Increased ball size by changing `BALL_SIZE_SCALE` from `1` to `1.04`, which updates `BALL_DIAMETER` / `BALL_R` and all ball-tied helpers. 
- Tuned physics constants: raised `PHYSICS_PROFILE.restitution` to `0.972`, increased `FRICTION` to `0.9956`, reduced `ROLLING_RESISTANCE` to `0.0104`, and made cushion cut rebounds livelier by changing `CUSHION_CUT_RESTITUTION_SCALE` to `1.01` and `CUSHION_CUT_FRICTION_SCALE` to `0.99`. 
- Bumped global shot feel by increasing `SHOT_GLOBAL_POWER_SCALE` from `0.78` to `0.83` so released shots carry a bit more speed while preserving the existing slider curve.

### Testing
- Ran linter: `npm run lint -- src/pages/Games/PoolRoyale.jsx` and it completed without errors. (success)
- Built the webapp: `npm run build` and production build completed successfully. (success)
- Started dev server and captured a portrait screenshot using Playwright to verify visual framing: `npx playwright screenshot --viewport-size=390,844 http://127.0.0.1:5173/games/poolroyale /tmp/pool-royale-physics-tuning.png` after installing Playwright deps; screenshot run completed. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26d0ea30648329aaabd2fd5f2da4a7)