### PR TITLE
Tune Pool Royale table and shot feel

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1174,7 +1174,7 @@ const TABLE_FOOTPRINT_SCALE = 0.82; // reduce the table footprint ~18% while kee
 const BASE_FOOTPRINT_SHRINK = 0.82; // shrink the table base footprint by 18% without changing overall height
 const SIZE_REDUCTION = 0.7;
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
-const TABLE_DISPLAY_SCALE = 0.86; // make the table read just a bit larger in portrait while preserving proportions
+const TABLE_DISPLAY_SCALE = 0.88; // make the table read a touch larger in portrait while preserving proportions
 const WORLD_SCALE = 0.85 * GLOBAL_SIZE_FACTOR * 0.7 * TABLE_DISPLAY_SCALE;
 const TOUCH_UI_SCALE = SIZE_REDUCTION;
 const POINTER_UI_SCALE = 1;
@@ -1312,7 +1312,7 @@ const REPLAY_CAMERA_START_DELAY_MS = 0;
   const TABLE_SCALE = TABLE_BASE_SCALE * TABLE_REDUCTION * TABLE_WIDTH_SCALE;
   const TABLE_LENGTH_SCALE = 0.8;
   const TABLE_SURFACE_REFERENCE = 1.12; // baseline expansion before the wider table adjustment
-  const TABLE_SURFACE_EXPANSION = 1.29; // make the table footprint just a bit bigger while keeping the portrait proportions stable
+  const TABLE_SURFACE_EXPANSION = 1.33; // make the table footprint a touch bigger while keeping the portrait proportions stable
   const TABLE_SURFACE_COMPENSATION = TABLE_SURFACE_EXPANSION / TABLE_SURFACE_REFERENCE;
   const TABLE = {
     W: 72 * TABLE_SCALE * TABLE_FOOTPRINT_SCALE * OFFICIAL_TABLE_SCALE * TABLE_SURFACE_EXPANSION,
@@ -1427,7 +1427,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
     'Pool table inner ratio must match the official 2:1 target after scaling.'
   );
 const MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION;
-const BALL_SIZE_SCALE = 1.04; // make balls just a bit bigger while every helper stays tied to BALL_R/BALL_DIAMETER
+const BALL_SIZE_SCALE = 1.07; // make balls a touch bigger while every helper stays tied to BALL_R/BALL_DIAMETER
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1552,14 +1552,14 @@ if (BALL_SHADOW_MATERIAL) {
 // Match the snooker build so pace and rebound energy stay consistent between modes.
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
-  restitution: 0.972,
+  restitution: 0.982,
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
   maxTipOffsetRatio: 0.9
 });
 const PHYSICS_BASE_STEP = 1 / 60;
-const FRICTION = 0.9956;
+const FRICTION = 0.9961;
 const DEFAULT_CUSHION_RESTITUTION = PHYSICS_PROFILE.restitution;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const BALL_MASS = 0.17;
@@ -1570,7 +1570,7 @@ const SPIN_KINETIC_FRICTION = 0.22;
 const SPIN_ROLL_DAMPING = 0.1;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const ROLLING_RESISTANCE = 0.0104;
+const ROLLING_RESISTANCE = 0.0098;
 const BALL_BALL_FRICTION = 0.105;
 const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
 const BALL_COLLISION_SLOP = BALL_R * 0.001; // tighter tolerance so visible ball overlap is corrected faster
@@ -1617,7 +1617,7 @@ const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
   0,
   SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.04
 );
-const CUSHION_CUT_RESTITUTION_SCALE = 1.01; // make cut-angle rebounds just a bit more lively without adding excess speed
+const CUSHION_CUT_RESTITUTION_SCALE = 1.02; // make cut-angle rebounds a touch livelier without adding excess speed
 const CUSHION_CUT_FRICTION_SCALE = 0.99; // reduce cut-line grab slightly so added bounce reads naturally
 const SIDE_POCKET_DEPTH_LIMIT =
   SIDE_POCKET_RADIUS * 1.6 * POCKET_VISUAL_EXPANSION; // align side-pocket rail limits with the visible mouth depth
@@ -1855,7 +1855,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.5; // preserve legacy cue response before the final mobile comfort trim
-const SHOT_GLOBAL_POWER_SCALE = 0.83; // add a little more Pool Royale shot power while keeping the selected shot-power curve
+const SHOT_GLOBAL_POWER_SCALE = 0.88; // add a touch more Pool Royale shot power while keeping the selected shot-power curve
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *

--- a/webapp/src/pages/Games/poolRoyaleShotState.js
+++ b/webapp/src/pages/Games/poolRoyaleShotState.js
@@ -22,7 +22,7 @@ export const resolveCommittedShot = ({
 export const resolvePoolRoyaleShotPowerScale = (power) => {
   const clampedPower = THREE.MathUtils.clamp(Number.isFinite(power) ? power : 0, 0, 1);
   const highEndT = THREE.MathUtils.clamp((clampedPower - 0.6) / 0.4, 0, 1);
-  const highEndBoost = highEndT * highEndT * 0.55;
+  const highEndBoost = highEndT * highEndT * 0.62;
   return clampedPower * (1 + highEndBoost);
 };
 


### PR DESCRIPTION
### Motivation
- Improve the Pool Royale tactile and visual feel by making the table and balls appear a bit larger on portrait phones, and by making shots and rebounds feel slightly snappier and more powerful.
- Keep all visual helpers and physics helpers tied to the shared ball radius/diameter constants so visual sizing changes remain consistent across systems.

### Description
- Increased portrait presentation and playable surface by bumping `TABLE_DISPLAY_SCALE` and `TABLE_SURFACE_EXPANSION` in `webapp/src/pages/Games/PoolRoyale.jsx` so the table reads larger on mobile screens.
- Enlarged balls by raising `BALL_SIZE_SCALE` so `BALL_DIAMETER` / `BALL_R` drive all geometry and helper math consistently in `PoolRoyale.jsx`.
- Tuned physics constants in `PoolRoyale.jsx` to make motion livelier: increased `restitution`, slightly raised `FRICTION`, lowered `ROLLING_RESISTANCE`, and increased `CUSHION_CUT_RESTITUTION_SCALE` for bouncier cushion rebounds.
- Increased shot power by bumping `SHOT_GLOBAL_POWER_SCALE` and adjusted the high-end power curve in `webapp/src/pages/Games/poolRoyaleShotState.js` by increasing the high-end boost multiplier so high-power slider values produce a stronger launch.

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.
- Playwright browser dependencies were installed (`npx playwright install` / `install-deps`) but a headless WebGL screenshot attempt timed out/failed in this environment due to runtime browser/GL constraints, so visual verification via automated screenshot did not complete.
- No unit tests were modified or run as part of this change; basic source checks passed during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a279cca95508329a88e5a2910669b8d)