### PR TITLE
Fix Murlan character loading fallbacks

### DIFF
--- a/test/murlanCharacterThemes.test.js
+++ b/test/murlanCharacterThemes.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { MURLAN_CHARACTER_THEMES } from '../webapp/src/config/murlanCharacterThemes.js';
+
+const sketchfabLocalCharacterThemes = MURLAN_CHARACTER_THEMES.filter(
+  (theme) => theme?.sourceFormat === 'sketchfab-converted-gltf'
+);
+
+test('Murlan Sketchfab characters have reliable fallback model URLs', () => {
+  assert(sketchfabLocalCharacterThemes.length >= 7);
+
+  for (const theme of sketchfabLocalCharacterThemes) {
+    assert(theme.url?.startsWith('/models/murlan/'), `${theme.id} should use a local install path first`);
+    assert(
+      Array.isArray(theme.fallbackModelUrls) && theme.fallbackModelUrls.some((url) => url.startsWith('https://')),
+      `${theme.id} should include at least one remote GLB fallback so the seat never stays empty`
+    );
+    assert.equal(theme.requiresAttribution, true, `${theme.id} must retain attribution metadata`);
+  }
+});
+
+test('Murlan Ready Player Me variants keep non-RPM fallback GLBs', () => {
+  const rpmVariants = MURLAN_CHARACTER_THEMES.filter((theme) => theme.id.startsWith('rpm-') && theme.id !== 'rpm-current');
+  assert.equal(rpmVariants.length, 3);
+
+  for (const theme of rpmVariants) {
+    assert(
+      theme.fallbackModelUrls?.some((url) => !url.includes('readyplayer.me')),
+      `${theme.id} should recover when Ready Player Me returns a transient 503`
+    );
+  }
+});
+
+test('Murlan fetch script knows every installable Sketchfab character', async () => {
+  const script = await readFile(new URL('../webapp/scripts/fetch-murlan-agent47.mjs', import.meta.url), 'utf8');
+
+  for (const theme of sketchfabLocalCharacterThemes) {
+    const assetId = theme.url.split('/models/murlan/')[1]?.split('/')[0];
+    assert(assetId, `${theme.id} should have a local asset directory`);
+    assert(script.includes(`targetDir: 'public/models/murlan/${assetId}'`), `${assetId} should be installable with fetch:murlan-characters`);
+    assert(script.includes(theme.sketchfabUid), `${theme.id} Sketchfab UID should be present in the fetch script`);
+  }
+});

--- a/webapp/scripts/fetch-murlan-agent47.mjs
+++ b/webapp/scripts/fetch-murlan-agent47.mjs
@@ -60,6 +60,22 @@ const SKETCHFAB_CHARACTERS = Object.freeze({
       'https://sketchfab.com/3d-models/casual-confidence-bff76010d9534241ae6c96a4a46a7959',
     targetDir: 'public/models/murlan/casual-confidence',
     targetFileName: TARGET_FILE_NAME
+  },
+  'generic-scanned-man': {
+    label: 'Generic Scanned Man',
+    uid: '9b4527d4bc524c31bed48054f0c04b71',
+    sourceUrl:
+      'https://sketchfab.com/3d-models/generic-man-9b4527d4bc524c31bed48054f0c04b71',
+    targetDir: 'public/models/murlan/generic-scanned-man',
+    targetFileName: TARGET_FILE_NAME
+  },
+  'rigged-scan-male': {
+    label: 'Rigged Scan Male',
+    uid: 'cc7e4596bcd145208a6992c757854c07',
+    sourceUrl:
+      'https://sketchfab.com/3d-models/rigged-t-pose-human-male-w-50-face-blendshapes-cc7e4596bcd145208a6992c757854c07',
+    targetDir: 'public/models/murlan/rigged-scan-male',
+    targetFileName: TARGET_FILE_NAME
   }
 });
 
@@ -112,6 +128,7 @@ Usage:
   SKETCHFAB_TOKEN=<token> npm run fetch:murlan-characters -- --asset suede-gentleman
   npm run fetch:murlan-agent47 -- --from /path/to/authentic-sketchfab-gltf.zip
   npm run fetch:murlan-characters -- --asset casual-confidence --from /path/to/extracted-gltf-folder
+  npm run fetch:murlan-characters -- --asset generic-scanned-man
   npm run fetch:murlan-characters -- --asset red-hibiscus-hair --validate-only
 
 Assets:

--- a/webapp/src/config/murlanCharacterThemes.js
+++ b/webapp/src/config/murlanCharacterThemes.js
@@ -1,4 +1,9 @@
-import { khronosThumb } from './storeThumbnails.js';
+import { khronosThumb, swatchThumbnail } from './storeThumbnails.js';
+
+const MURLAN_READY_PLAYER_ME_FALLBACK_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const MURLAN_XBOT_FALLBACK_URL = 'https://threejs.org/examples/models/gltf/Xbot.glb';
+const MURLAN_VIETNAM_HUMAN_FALLBACK_URL = 'https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb';
+const MURLAN_AI_TEACHER_FALLBACK_URL = 'https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb';
 
 export const MURLAN_CHARACTER_THEMES = Object.freeze([
   {
@@ -37,6 +42,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
       'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
       'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
     ],
+    fallbackModelUrls: [MURLAN_READY_PLAYER_ME_FALLBACK_URL, MURLAN_VIETNAM_HUMAN_FALLBACK_URL],
     thumbnail: khronosThumb('ReadyPlayerMe67d411'),
     scale: 1.0,
     seatOffsetY: -0.84,
@@ -64,6 +70,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
       'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
       'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
     ],
+    fallbackModelUrls: [MURLAN_AI_TEACHER_FALLBACK_URL, MURLAN_READY_PLAYER_ME_FALLBACK_URL],
     thumbnail: khronosThumb('ReadyPlayerMe67f433'),
     scale: 1.0,
     seatOffsetY: -0.84,
@@ -91,6 +98,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
       'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
       'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
     ],
+    fallbackModelUrls: [MURLAN_XBOT_FALLBACK_URL, MURLAN_READY_PLAYER_ME_FALLBACK_URL],
     thumbnail: khronosThumb('ReadyPlayerMe67e1b5'),
     scale: 1.0,
     seatOffsetY: -0.84,
@@ -202,6 +210,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     description: 'Sketchfab rigged Mixamo-style character loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/agent-47-rigged-face-morphs/scene.gltf',
     modelUrls: ['/models/murlan/agent-47-rigged-face-morphs/scene.gltf'],
+    fallbackModelUrls: [MURLAN_READY_PLAYER_ME_FALLBACK_URL, MURLAN_XBOT_FALLBACK_URL],
     sourceUrl: 'https://sketchfab.com/3d-models/agent-47-riggedface-morphs-1680cad927304bb687d6a9ad5b9dd98a',
     sketchfabUid: '1680cad927304bb687d6a9ad5b9dd98a',
     sourceFormat: 'sketchfab-converted-gltf',
@@ -231,6 +240,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     description: 'Sketchfab human portrait loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/leather-jacket-portrait/scene.gltf',
     modelUrls: ['/models/murlan/leather-jacket-portrait/scene.gltf'],
+    fallbackModelUrls: [MURLAN_AI_TEACHER_FALLBACK_URL, MURLAN_READY_PLAYER_ME_FALLBACK_URL],
     sourceUrl: 'https://sketchfab.com/3d-models/leather-jacket-portrait-e4b6a08211c746fe932e0d5041d28812',
     sketchfabUid: 'e4b6a08211c746fe932e0d5041d28812',
     sourceFormat: 'sketchfab-converted-gltf',
@@ -260,6 +270,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     description: 'Sketchfab seated gentleman character loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/seated-gentleman-suede-jacket/scene.gltf',
     modelUrls: ['/models/murlan/seated-gentleman-suede-jacket/scene.gltf'],
+    fallbackModelUrls: [MURLAN_VIETNAM_HUMAN_FALLBACK_URL, MURLAN_READY_PLAYER_ME_FALLBACK_URL],
     sourceUrl: 'https://sketchfab.com/3d-models/seated-gentleman-in-suede-jacket-8b1101c090d4454caf9f311b3c008946',
     sketchfabUid: '8b1101c090d4454caf9f311b3c008946',
     sourceFormat: 'sketchfab-converted-gltf',
@@ -289,6 +300,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     description: 'Sketchfab hibiscus portrait character loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/red-hibiscus-in-the-hair/scene.gltf',
     modelUrls: ['/models/murlan/red-hibiscus-in-the-hair/scene.gltf'],
+    fallbackModelUrls: [MURLAN_AI_TEACHER_FALLBACK_URL, MURLAN_READY_PLAYER_ME_FALLBACK_URL],
     sourceUrl: 'https://sketchfab.com/3d-models/red-hibiscus-in-the-hair-dc65f86920814a4296f930e7d85ab314',
     sketchfabUid: 'dc65f86920814a4296f930e7d85ab314',
     sourceFormat: 'sketchfab-converted-gltf',
@@ -318,6 +330,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     description: 'Sketchfab casual human character loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/casual-confidence/scene.gltf',
     modelUrls: ['/models/murlan/casual-confidence/scene.gltf'],
+    fallbackModelUrls: [MURLAN_VIETNAM_HUMAN_FALLBACK_URL, MURLAN_READY_PLAYER_ME_FALLBACK_URL],
     sourceUrl: 'https://sketchfab.com/3d-models/casual-confidence-bff76010d9534241ae6c96a4a46a7959',
     sketchfabUid: 'bff76010d9534241ae6c96a4a46a7959',
     sourceFormat: 'sketchfab-converted-gltf',
@@ -337,6 +350,66 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     hairColor: 0x21150f,
     eyeColor: 0x4a5d6a,
     skinTone: 0xc98f68
+  },
+  {
+    id: 'sketchfab-generic-scanned-man',
+    label: 'Generic Scanned Man',
+    source: 'Sketchfab: Generic Man by Scanlab Photogrammetry Inc.',
+    license: 'CC BY 4.0; attribution required; commercial use allowed',
+    price: 880,
+    description: 'Realistic 3D-scanned human compiled from photogrammetry scans. Install the converted glTF with npm run fetch:murlan-characters -- --asset generic-scanned-man; reliable GLB fallbacks keep this slot visible before the scan pack is installed.',
+    url: '/models/murlan/generic-scanned-man/scene.gltf',
+    modelUrls: ['/models/murlan/generic-scanned-man/scene.gltf'],
+    fallbackModelUrls: [MURLAN_VIETNAM_HUMAN_FALLBACK_URL, MURLAN_READY_PLAYER_ME_FALLBACK_URL],
+    sourceUrl: 'https://sketchfab.com/3d-models/generic-man-9b4527d4bc524c31bed48054f0c04b71',
+    sketchfabUid: '9b4527d4bc524c31bed48054f0c04b71',
+    sourceFormat: 'sketchfab-converted-gltf',
+    installCheck: 'gltf-json',
+    thumbnail: swatchThumbnail(['#2b211c', '#8b6f5a', '#f0c49a']),
+    requiresAttribution: true,
+    nonCommercialOnly: false,
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04,
+    clothCombo: 'linenStreet',
+    hairColor: 0x17100c,
+    eyeColor: 0x4b5563,
+    skinTone: 0xcb9874
+  },
+  {
+    id: 'sketchfab-rigged-scan-male',
+    label: 'Rigged Scan Male',
+    source: 'Sketchfab: Rigged T-Pose Human Male by Mike Alger',
+    license: 'CC BY 4.0; attribution required; commercial use allowed',
+    price: 900,
+    description: 'Optimized rigged scan created from a real person scan for game/avatar use. Install with npm run fetch:murlan-characters -- --asset rigged-scan-male; reliable GLB fallbacks keep this slot visible before the scan pack is installed.',
+    url: '/models/murlan/rigged-scan-male/scene.gltf',
+    modelUrls: ['/models/murlan/rigged-scan-male/scene.gltf'],
+    fallbackModelUrls: [MURLAN_XBOT_FALLBACK_URL, MURLAN_READY_PLAYER_ME_FALLBACK_URL],
+    sourceUrl: 'https://sketchfab.com/3d-models/rigged-t-pose-human-male-w-50-face-blendshapes-cc7e4596bcd145208a6992c757854c07',
+    sketchfabUid: 'cc7e4596bcd145208a6992c757854c07',
+    sourceFormat: 'sketchfab-converted-gltf',
+    installCheck: 'gltf-json',
+    thumbnail: swatchThumbnail(['#111827', '#475569', '#d7a37b']),
+    requiresAttribution: true,
+    nonCommercialOnly: false,
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04,
+    clothCombo: 'casinoCheck',
+    hairColor: 0x20140e,
+    eyeColor: 0x465a66,
+    skinTone: 0xc7926e
   },
   {
     id: 'threejs-xbot-human',

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -236,7 +236,7 @@ function resolveLoadedSeatCharacterTheme({
   if (isSelectedHumanSeat && seatTheme?.id === selectedTheme?.id) {
     console.warn('Selected Murlan character model is unavailable; not substituting another character', {
       characterId: seatTheme?.id,
-      modelUrls: seatTheme?.modelUrls || (seatTheme?.url ? [seatTheme.url] : [])
+      modelUrls: uniqueCharacterModelUrls(seatTheme)
     });
     return null;
   }
@@ -2161,12 +2161,18 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0, renderer = 
 
 const CHARACTER_MODEL_CACHE = new Map();
 
-async function loadCharacterModel(theme, renderer = null) {
-  const urls = Array.isArray(theme?.modelUrls) && theme.modelUrls.length
+function uniqueCharacterModelUrls(theme) {
+  const primaryUrls = Array.isArray(theme?.modelUrls) && theme.modelUrls.length
     ? theme.modelUrls
     : theme?.url
       ? [theme.url]
       : [];
+  const fallbackUrls = Array.isArray(theme?.fallbackModelUrls) ? theme.fallbackModelUrls : [];
+  return [...new Set([...primaryUrls, ...fallbackUrls].filter((url) => typeof url === 'string' && url.trim()))];
+}
+
+async function loadCharacterModel(theme, renderer = null) {
+  const urls = uniqueCharacterModelUrls(theme);
   if (!urls.length) throw new Error('Missing character model URL');
   const cacheKey = `${theme.id || urls[0]}::${urls.join('|')}`;
   if (CHARACTER_MODEL_CACHE.has(cacheKey)) {


### PR DESCRIPTION
### Motivation
- Some Murlan human characters could fail to load when locally-installed Sketchfab glTF packs were not present or when remote Ready Player Me endpoints returned transient errors, leaving empty seats in the arena. 
- The goal was to make character loading robust by adding reliable remote GLB fallbacks and to expand available realistic scanned human options with installable Sketchfab entries.

### Description
- Add remote fallback constants and `fallbackModelUrls` to many `MURLAN_CHARACTER_THEMES` entries and wire them into the theme data so each sketchfab/local character has at least one remote GLB fallback. 
- Add two new Sketchfab scanned-human character slots (`sketchfab-generic-scanned-man`, `sketchfab-rigged-scan-male`) with attribution metadata, `url`/`modelUrls`, `fallbackModelUrls`, and fetch/install hooks. 
- Update the character loader to merge `modelUrls` and `fallbackModelUrls` via `uniqueCharacterModelUrls()` and attempt each URL in order in `loadCharacterModel()` before failing, and surface the merged candidate list in warnings (`resolveLoadedSeatCharacterTheme`).
- Extend `webapp/scripts/fetch-murlan-agent47.mjs` so the new Sketchfab assets are installable with the existing `npm run fetch:murlan-characters` workflow. 
- Add `test/murlanCharacterThemes.test.js` to validate that sketchfab-installed themes include local `url` paths, include at least one remote fallback GLB, require attribution, and are present in the fetch script; also add thumbnail helpers imports and small thumbnail fallbacks.

### Testing
- Ran the unit checks with `node --test test/murlanCharacterThemes.test.js` and all subtests passed. 
- Built the webapp with `npm --prefix webapp run build` and a production build completed successfully. 
- Performed an automated portrait/webview smoke check using Playwright to load the Murlan scene and capture canvas output; a canvas screenshot was saved to `artifacts/murlan-character-portrait-canvas.png` (used to verify characters render without leaving empty seats).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27a35767788329aac0e7d85627657e)