### PR TITLE
Add CDN VALID avatar fallbacks and include VALID human characters for Murlan

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -107,11 +107,34 @@ describe('cross-game inventory alignment', () => {
     expectedSketchfabCharacters.forEach(([id, modelUrl, license]) => {
       const theme = MURLAN_CHARACTER_THEMES.find((entry) => entry.id === id);
       expect(theme).toBeTruthy();
-      expect(theme.modelUrls).toEqual([modelUrl]);
+      expect(theme.modelUrls[0]).toBe(modelUrl);
+      expect(theme.modelUrls.some((url) => url.includes('cdn.jsdelivr.net/gh/c-frame/valid-avatars-glb'))).toBe(true);
       expect(theme.sourceUrl).toContain('sketchfab.com/3d-models/');
       expect(theme.license).toContain(license);
       expect(theme.sourceFormat).toBe('sketchfab-converted-gltf');
       expect(theme.installCheck).toBe('gltf-json');
+      expect(MURLAN_ROYALE_STORE_ITEMS.some((item) => item.type === 'characters' && item.optionId === theme.id)).toBe(true);
+      expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.characters).toContain(theme.id);
+    });
+  });
+
+
+  test('murlan includes online VALID human avatar fallbacks and store entries', () => {
+    const validCharacters = [
+      'valid-aian-business-human',
+      'valid-black-casual-human',
+      'valid-asian-casual-human'
+    ];
+
+    validCharacters.forEach((id) => {
+      const theme = MURLAN_CHARACTER_THEMES.find((entry) => entry.id === id);
+      expect(theme).toBeTruthy();
+      expect(theme.sourceUrl).toBe('https://github.com/c-frame/valid-avatars-glb');
+      expect(theme.license).toContain('MIT');
+      expect(theme.sourceFormat).toBe('valid-avatar-glb');
+      expect(theme.modelUrls).toEqual([theme.url]);
+      expect(theme.url).toMatch(/^https:\/\/cdn\.jsdelivr\.net\/gh\/c-frame\/valid-avatars-glb@c539a28\/avatars\/.+\.glb$/);
+      expect(theme.thumbnail).toMatch(/^https:\/\/cdn\.jsdelivr\.net\/gh\/c-frame\/valid-avatars-glb@c539a28\/images\/.+\.jpg$/);
       expect(MURLAN_ROYALE_STORE_ITEMS.some((item) => item.type === 'characters' && item.optionId === theme.id)).toBe(true);
       expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.characters).toContain(theme.id);
     });

--- a/webapp/src/config/murlanCharacterThemes.js
+++ b/webapp/src/config/murlanCharacterThemes.js
@@ -1,5 +1,9 @@
 import { khronosThumb } from './storeThumbnails.js';
 
+const VALID_AVATAR_BASE_URL = 'https://cdn.jsdelivr.net/gh/c-frame/valid-avatars-glb@c539a28';
+const validAvatarModel = (path) => `${VALID_AVATAR_BASE_URL}/avatars/${path}.glb`;
+const validAvatarThumb = (path) => `${VALID_AVATAR_BASE_URL}/images/${path}.jpg`;
+
 export const MURLAN_CHARACTER_THEMES = Object.freeze([
   {
     id: 'rpm-current',
@@ -35,7 +39,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     modelUrls: [
       'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
       'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
-      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      validAvatarModel('AIAN/AIAN_M_1_Busi')
     ],
     thumbnail: khronosThumb('ReadyPlayerMe67d411'),
     scale: 1.0,
@@ -62,7 +67,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     modelUrls: [
       'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
       'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
-      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      validAvatarModel('Black/Black_F_1_Casual')
     ],
     thumbnail: khronosThumb('ReadyPlayerMe67f433'),
     scale: 1.0,
@@ -89,7 +95,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     modelUrls: [
       'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
       'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
-      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      validAvatarModel('Asian/Asian_M_2_Casual')
     ],
     thumbnail: khronosThumb('ReadyPlayerMe67e1b5'),
     scale: 1.0,
@@ -193,6 +200,82 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     eyeColor: 0x334d5f,
     skinTone: 0xd09a73
   },
+
+  {
+    id: 'valid-aian-business-human',
+    label: 'VALID AIAN Business',
+    source: 'c-frame/valid-avatars-glb VALID converted glTF avatar library',
+    license: 'MIT; open-source VALID avatar library',
+    price: 600,
+    description: 'Open-source VALID business human avatar served as GLB through jsDelivr for reliable WebGL loading on mobile.',
+    url: validAvatarModel('AIAN/AIAN_M_1_Busi'),
+    modelUrls: [validAvatarModel('AIAN/AIAN_M_1_Busi')],
+    sourceUrl: 'https://github.com/c-frame/valid-avatars-glb',
+    thumbnail: validAvatarThumb('AIAN/AIAN_M_1_Busi'),
+    sourceFormat: 'valid-avatar-glb',
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04,
+    clothCombo: 'casinoCheck',
+    hairColor: 0x1a120d,
+    eyeColor: 0x4a3528,
+    skinTone: 0xb9815c
+  },
+  {
+    id: 'valid-black-casual-human',
+    label: 'VALID Black Casual',
+    source: 'c-frame/valid-avatars-glb VALID converted glTF avatar library',
+    license: 'MIT; open-source VALID avatar library',
+    price: 620,
+    description: 'Open-source VALID casual human avatar added as a free-to-load realistic 3D WebGL character option.',
+    url: validAvatarModel('Black/Black_F_1_Casual'),
+    modelUrls: [validAvatarModel('Black/Black_F_1_Casual')],
+    sourceUrl: 'https://github.com/c-frame/valid-avatars-glb',
+    thumbnail: validAvatarThumb('Black/Black_F_1_Casual'),
+    sourceFormat: 'valid-avatar-glb',
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04,
+    clothCombo: 'softFleece',
+    hairColor: 0x140f0c,
+    eyeColor: 0x30241c,
+    skinTone: 0x8b5a3d
+  },
+  {
+    id: 'valid-asian-casual-human',
+    label: 'VALID Asian Casual',
+    source: 'c-frame/valid-avatars-glb VALID converted glTF avatar library',
+    license: 'MIT; open-source VALID avatar library',
+    price: 640,
+    description: 'Open-source VALID casual human avatar with a direct GLB URL and CORS-friendly CDN delivery.',
+    url: validAvatarModel('Asian/Asian_M_2_Casual'),
+    modelUrls: [validAvatarModel('Asian/Asian_M_2_Casual')],
+    sourceUrl: 'https://github.com/c-frame/valid-avatars-glb',
+    thumbnail: validAvatarThumb('Asian/Asian_M_2_Casual'),
+    sourceFormat: 'valid-avatar-glb',
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04,
+    clothCombo: 'linenStreet',
+    hairColor: 0x19110c,
+    eyeColor: 0x463126,
+    skinTone: 0xc9926f
+  },
   {
     id: 'sketchfab-agent-47',
     label: 'Agent 47',
@@ -201,7 +284,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     price: 760,
     description: 'Sketchfab rigged Mixamo-style character loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/agent-47-rigged-face-morphs/scene.gltf',
-    modelUrls: ['/models/murlan/agent-47-rigged-face-morphs/scene.gltf'],
+    modelUrls: ['/models/murlan/agent-47-rigged-face-morphs/scene.gltf', validAvatarModel('White/White_M_2_Busi')],
     sourceUrl: 'https://sketchfab.com/3d-models/agent-47-riggedface-morphs-1680cad927304bb687d6a9ad5b9dd98a',
     sketchfabUid: '1680cad927304bb687d6a9ad5b9dd98a',
     sourceFormat: 'sketchfab-converted-gltf',
@@ -230,7 +313,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     price: 780,
     description: 'Sketchfab human portrait loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/leather-jacket-portrait/scene.gltf',
-    modelUrls: ['/models/murlan/leather-jacket-portrait/scene.gltf'],
+    modelUrls: ['/models/murlan/leather-jacket-portrait/scene.gltf', validAvatarModel('Hispanic/Hispanic_M_1_Casual')],
     sourceUrl: 'https://sketchfab.com/3d-models/leather-jacket-portrait-e4b6a08211c746fe932e0d5041d28812',
     sketchfabUid: 'e4b6a08211c746fe932e0d5041d28812',
     sourceFormat: 'sketchfab-converted-gltf',
@@ -259,7 +342,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     price: 820,
     description: 'Sketchfab seated gentleman character loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/seated-gentleman-suede-jacket/scene.gltf',
-    modelUrls: ['/models/murlan/seated-gentleman-suede-jacket/scene.gltf'],
+    modelUrls: ['/models/murlan/seated-gentleman-suede-jacket/scene.gltf', validAvatarModel('White/White_M_1_Busi')],
     sourceUrl: 'https://sketchfab.com/3d-models/seated-gentleman-in-suede-jacket-8b1101c090d4454caf9f311b3c008946',
     sketchfabUid: '8b1101c090d4454caf9f311b3c008946',
     sourceFormat: 'sketchfab-converted-gltf',
@@ -288,7 +371,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     price: 840,
     description: 'Sketchfab hibiscus portrait character loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/red-hibiscus-in-the-hair/scene.gltf',
-    modelUrls: ['/models/murlan/red-hibiscus-in-the-hair/scene.gltf'],
+    modelUrls: ['/models/murlan/red-hibiscus-in-the-hair/scene.gltf', validAvatarModel('NHPI/NHPI_M_1_Casual')],
     sourceUrl: 'https://sketchfab.com/3d-models/red-hibiscus-in-the-hair-dc65f86920814a4296f930e7d85ab314',
     sketchfabUid: 'dc65f86920814a4296f930e7d85ab314',
     sourceFormat: 'sketchfab-converted-gltf',
@@ -317,7 +400,7 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     price: 860,
     description: 'Sketchfab casual human character loaded from the converted glTF package and prepared for Murlan Royale seating. Converted glTF folder is installed locally outside git with npm run fetch:murlan-characters.',
     url: '/models/murlan/casual-confidence/scene.gltf',
-    modelUrls: ['/models/murlan/casual-confidence/scene.gltf'],
+    modelUrls: ['/models/murlan/casual-confidence/scene.gltf', validAvatarModel('Black/Black_M_2_Casual')],
     sourceUrl: 'https://sketchfab.com/3d-models/casual-confidence-bff76010d9534241ae6c96a4a46a7959',
     sketchfabUid: 'bff76010d9534241ae6c96a4a46a7959',
     sourceFormat: 'sketchfab-converted-gltf',

--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -27,7 +27,7 @@ const DEFAULT_MURLAN_SHARED_IDS = Object.freeze({
 
 
 const DEFAULT_UNLOCKED_CHARACTER_IDS = Object.freeze(
-  MURLAN_CHARACTER_THEMES.filter((theme, index) => index === 0 || theme?.sourceUrl?.includes('sketchfab.com/3d-models/'))
+  MURLAN_CHARACTER_THEMES.filter((theme, index) => index === 0 || theme?.sourceUrl?.includes('sketchfab.com/3d-models/') || theme?.sourceFormat === 'valid-avatar-glb')
     .map((theme) => theme.id)
     .filter(Boolean)
 );

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2281,7 +2281,7 @@ function fitCharacterModelForSeat(characterRoot, characterTheme = null) {
   const size = bounds.getSize(new THREE.Vector3());
   const currentHeight = size.y;
   const shouldNormalize = Boolean(
-    characterTheme?.sourceFormat === 'sketchfab-converted-gltf' ||
+    ['sketchfab-converted-gltf', 'valid-avatar-glb'].includes(characterTheme?.sourceFormat) ||
     characterTheme?.normalizeForSeat ||
     currentHeight < 0.35 ||
     currentHeight > 2.4
@@ -2296,7 +2296,7 @@ function fitCharacterModelForSeat(characterRoot, characterTheme = null) {
 }
 
 function shouldPreserveOriginalCharacterMaterials(characterTheme) {
-  return Boolean(characterTheme?.sourceFormat === 'sketchfab-converted-gltf' || characterTheme?.preserveOriginalMaterials);
+  return Boolean(['sketchfab-converted-gltf', 'valid-avatar-glb'].includes(characterTheme?.sourceFormat) || characterTheme?.preserveOriginalMaterials);
 }
 
 function normalizeOriginalCharacterTexture(texture, { isColor = false, maxAnisotropy = 8 } = {}) {


### PR DESCRIPTION
### Motivation
- Ensure every Murlan human character has a reachable runtime GLB URL so seated characters reliably load on mobile/portrait, even when local Sketchfab packages or upstream avatar endpoints fail. 
- Add openly-licensed, realistic GLB avatars to diversify the roster with CDN-served options that are CORS-friendly and fast for WebGL consumption. 

### Description
- Added CDN-backed VALID avatar helpers and three new VALID character themes (`valid-aian-business-human`, `valid-black-casual-human`, `valid-asian-casual-human`) with `url`/`modelUrls` pointing to `https://cdn.jsdelivr.net/gh/c-frame/valid-avatars-glb@...` and `thumbnail` helpers in `webapp/src/config/murlanCharacterThemes.js`.
- Added CDN fallbacks into existing Ready Player Me and Sketchfab theme `modelUrls` so each theme has at least one reachable public GLB entry; implemented `VALID_AVATAR_BASE_URL` + helper functions for consistent CDN URLs.
- Included VALID source format support: updated character fit/material logic in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so `valid-avatar-glb` is treated like `sketchfab-converted-gltf` for normalization and material preservation.
- Included VALID themes in default unlocks and store items by updating `webapp/src/config/murlanInventoryConfig.js` to include `valid-avatar-glb` themes when computing defaults and store lists.
- Expanded `test/inventoryCrossGameConfig.test.js` to assert presence/shape of VALID fallbacks and adjusted the Sketchfab assertions to accept the added fallback chain.
- Added local test helpers: Playwright routing during CI-run to serve downloaded VALID GLBs from `/tmp/murlan-valid/` for deterministic browser checks and produced a portrait screenshot at `artifacts/murlan-valid-character-portrait.png`.

### Testing
- Ran the focused inventory assertion suite: `npm test -- --runInBand test/inventoryCrossGameConfig.test.js -t "murlan includes"` and the Murlan character assertions passed (2 targeted tests passed, others skipped as expected). ✅
- Performed full inventory test file: `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` — Murlan-related tests passed, but two preexisting unrelated tests in the same file (Ludo capture-weapon material opacity and Snake capture weapon unlocks) still fail; these failures are not caused by the Murlan changes. ⚠️
- Performed reachability check for each Murlan character model chains (local Sketchfab paths + CDN fallbacks) and confirmed at least one reachable URL for all 17 configured characters. ✅
- Captured an automated portrait screenshot using Playwright with CDN fallbacks routed to local GLB files; screenshot saved at `artifacts/murlan-valid-character-portrait.png` and produced zero character-load warnings. ✅
- Completed a production build of the webapp: `npm run build` and the build succeeded. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27a35767788329aac0e7d85627657e)