### PR TITLE
Adjust Showood GLB horizontal fit + increase cushion bounce

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -31,6 +31,7 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1.04,
+    horizontalFitScale: 1.065,
     upperFrameHeightScale: 1,
     cornerRimHeightScale: 1,
     trimCornerRimsToTopRailBottom: false,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1560,7 +1560,9 @@ const PHYSICS_PROFILE = Object.freeze({
 });
 const PHYSICS_BASE_STEP = 1 / 60;
 const FRICTION = 0.9962;
-const DEFAULT_CUSHION_RESTITUTION = PHYSICS_PROFILE.restitution;
+// Cushions use a slightly higher restitution than ball-ball impacts so rail
+// rebounds feel livelier without making direct ball collisions over-energetic.
+const DEFAULT_CUSHION_RESTITUTION = 0.992;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const BALL_MASS = 0.17;
 const BALL_INERTIA = (2 / 5) * BALL_MASS * BALL_R * BALL_R;
@@ -13681,6 +13683,7 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
   const widthScale = dims.targetWidth / modelWidth;
   const lengthScale = dims.targetLength / modelLength;
   const fitScaleMultiplier = tableModel?.fitScale ?? 1;
+  const horizontalFitScaleMultiplier = tableModel?.horizontalFitScale ?? fitScaleMultiplier;
   if (tableModel?.fitStrategy === 'exact') {
     const exactXScale = Math.max(MICRO_EPS, dims.targetWidth / Math.max(MICRO_EPS, footprintSize.x));
     const exactZScale = Math.max(MICRO_EPS, dims.targetLength / Math.max(MICRO_EPS, footprintSize.z));
@@ -13701,16 +13704,20 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
         (tableModel?.fitHeightScale ?? 1)
       : Math.sqrt(exactXScale * exactZScale);
     model.scale.set(
-      model.scale.x * exactXScale * fitScaleMultiplier,
+      model.scale.x * exactXScale * horizontalFitScaleMultiplier,
       model.scale.y * exactYScale * fitScaleMultiplier,
-      model.scale.z * exactZScale * fitScaleMultiplier
+      model.scale.z * exactZScale * horizontalFitScaleMultiplier
     );
   } else {
     const baseFitScale =
       tableModel?.fitStrategy === 'contain'
         ? Math.min(widthScale, lengthScale)
         : Math.max(widthScale, lengthScale);
-    model.scale.multiplyScalar(baseFitScale * fitScaleMultiplier);
+    model.scale.set(
+      model.scale.x * baseFitScale * horizontalFitScaleMultiplier,
+      model.scale.y * baseFitScale * fitScaleMultiplier,
+      model.scale.z * baseFitScale * horizontalFitScaleMultiplier
+    );
   }
   model.updateMatrixWorld(true);
 


### PR DESCRIPTION
### Motivation
- Make the Showood GLB table read slightly larger on-screen in width/length while preserving its native vertical height for consistent pocket/cushion alignment.
- Make cushions feel livelier by increasing cushion restitution so rail rebounds are a bit bouncier without changing ball-ball collision restitution.

### Description
- Add a new `horizontalFitScale` option to the Showood table model config so horizontal-only scaling can be applied to external GLB assets (`webapp/src/config/poolRoyaleTableModels.js`).
- Apply the horizontal-only multiplier during external GLTF fitting so `scale.x` and `scale.z` use the horizontal scale while `scale.y` preserves the vertical fit behavior for both `exact` and fallback fit strategies (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Raise the default cushion restitution to `0.992` so cushions are slightly more bouncy while keeping `PHYSICS_PROFILE.restitution` for ball-ball collisions unchanged (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran `npm run lint -- --max-warnings=0` and it completed with no lint errors.
- Ran `npm run build` and the production build completed successfully.
- Installed Playwright and system deps with `npx playwright install chromium` and `npx playwright install-deps chromium` and then used a headless Playwright mobile check to load `/games/poolroyale?mode=practice&tableModel=showood-seven-foot` and save a screenshot at `/tmp/pool-royale-showood-check.png`, which completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27b8c2f1908329aa7b2dddf687d3f1)