### PR TITLE
Improve battle royale weapon grip aiming

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -39,13 +39,16 @@ namespace TonPlaygram.Gameplay.Weapons
     public sealed class WeaponGripPoseProfile
     {
         [Tooltip("Visible right-hand grip socket offset for this weapon, in muzzle/local aim space.")]
-        public Vector3 rightGripBackOffset = new Vector3(0f, 0f, -0.12f);
+        public Vector3 rightGripBackOffset = new Vector3(0.035f, -0.055f, -0.22f);
 
         [Tooltip("Visible left/support-hand grip socket offset for this weapon, in muzzle/local aim space.")]
-        public Vector3 leftGripBackOffset = new Vector3(-0.06f, 0f, -0.06f);
+        public Vector3 leftGripBackOffset = new Vector3(-0.045f, -0.045f, -0.12f);
 
         [Tooltip("Extra rotation applied to both visible grip sockets after aiming at the token.")]
         public Vector3 gripEulerOffset;
+
+        [Tooltip("How strongly the support/left hand rotates inward to meet the weapon barrel. 0 keeps both hands parallel; 1 aims the support hand directly at the muzzle.")]
+        [Range(0f, 1f)] public float supportHandTowardMuzzle = 0.55f;
 
         [Tooltip("Animator that owns the imported weapon or FPS-rig animation states for this specific weapon.")]
         public Animator animator;
@@ -602,29 +605,50 @@ namespace TonPlaygram.Gameplay.Weapons
             }
 
             WeaponGripPoseProfile gripPose = _activeWeapon != null ? _activeWeapon.gripPose : null;
-            Quaternion aimRotation = Quaternion.LookRotation(shotDirection, Vector3.up);
+            Vector3 aimDirection = shotDirection.normalized;
+            Quaternion aimRotation = Quaternion.LookRotation(aimDirection, Vector3.up);
             Quaternion gripRotation = aimRotation * (gripPose != null ? gripPose.GripRotationOffset : Quaternion.identity);
 
             if (rightHandGrip != null)
             {
-                Vector3 rightOffset = gripPose != null ? gripPose.rightGripBackOffset : new Vector3(0f, 0f, -0.12f);
+                Vector3 rightOffset = gripPose != null ? gripPose.rightGripBackOffset : new Vector3(0.035f, -0.055f, -0.22f);
                 rightHandGrip.position = muzzle.position + aimRotation * rightOffset;
                 rightHandGrip.rotation = gripRotation;
             }
 
             if (leftHandGrip != null)
             {
-                Vector3 leftOffset = gripPose != null ? gripPose.leftGripBackOffset : new Vector3(-0.06f, 0f, -0.06f);
+                Vector3 leftOffset = gripPose != null ? gripPose.leftGripBackOffset : new Vector3(-0.045f, -0.045f, -0.12f);
                 leftHandGrip.position = muzzle.position + aimRotation * leftOffset;
-                leftHandGrip.rotation = gripRotation;
+                leftHandGrip.rotation = ResolveSupportHandGripRotation(gripRotation, leftHandGrip.position, aimDirection, gripPose);
             }
 
             if (humanHandRetargeter != null)
             {
+                humanHandRetargeter.SetRuntimeAimDirection(aimDirection, muzzle);
                 humanHandRetargeter.SnapToMappedPose();
             }
 
-            RotateHeldWeaponMuzzleToAim(shotDirection);
+            RotateHeldWeaponMuzzleToAim(aimDirection);
+        }
+
+        private Quaternion ResolveSupportHandGripRotation(Quaternion baseGripRotation, Vector3 supportHandPosition, Vector3 aimDirection, WeaponGripPoseProfile gripPose)
+        {
+            float blend = gripPose != null ? Mathf.Clamp01(gripPose.supportHandTowardMuzzle) : 0.55f;
+            if (blend <= 0.001f || muzzle == null)
+            {
+                return baseGripRotation;
+            }
+
+            Vector3 towardMuzzle = muzzle.position - supportHandPosition;
+            if (towardMuzzle.sqrMagnitude <= 0.00001f)
+            {
+                return baseGripRotation;
+            }
+
+            Quaternion supportGrip = Quaternion.LookRotation(Vector3.Slerp(aimDirection, towardMuzzle.normalized, blend), Vector3.up)
+                * (gripPose != null ? gripPose.GripRotationOffset : Quaternion.identity);
+            return supportGrip;
         }
 
         private void AimHeldWeaponAtTarget()
@@ -825,6 +849,7 @@ namespace TonPlaygram.Gameplay.Weapons
             MaintainStaticPresentationAnchors();
             if (humanHandRetargeter != null)
             {
+                humanHandRetargeter.SetRuntimeAimDirection(_lastAimDirection, muzzle);
                 humanHandRetargeter.SnapToMappedPose();
             }
 

--- a/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
+++ b/Assets/Scripts/Gameplay/Weapons/FpsGunHumanHandRetargeter.cs
@@ -83,7 +83,9 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Transform weaponRoot;
         [SerializeField] private Transform originalFpsRightGrip;
         [SerializeField] private Transform humanRightGrip;
+        [SerializeField] private Transform weaponMuzzle;
         [SerializeField] private bool keepWeaponOnHumanRightGrip = true;
+        [SerializeField] private bool forceMuzzleTowardRuntimeAim = true;
         [SerializeField] private Vector3 weaponGripPositionOffset;
         [SerializeField] private Vector3 weaponGripEulerOffset;
 
@@ -92,6 +94,8 @@ namespace TonPlaygram.Gameplay.Weapons
         private Quaternion _originalGripToWeaponRotation = Quaternion.identity;
         private Vector3 _originalGripToWeaponPosition;
         private bool _hasOriginalGripToWeapon;
+        private Vector3 _runtimeAimDirection = Vector3.forward;
+        private bool _hasRuntimeAimDirection;
 
         private void Awake()
         {
@@ -111,6 +115,23 @@ namespace TonPlaygram.Gameplay.Weapons
                 return;
 
             SnapToMappedPose();
+        }
+
+        public void SetRuntimeAimDirection(Vector3 worldAimDirection, Transform runtimeMuzzle = null)
+        {
+            if (runtimeMuzzle != null)
+            {
+                weaponMuzzle = runtimeMuzzle;
+            }
+
+            if (worldAimDirection.sqrMagnitude <= 0.00001f)
+            {
+                _hasRuntimeAimDirection = false;
+                return;
+            }
+
+            _runtimeAimDirection = worldAimDirection.normalized;
+            _hasRuntimeAimDirection = true;
         }
 
         [ContextMenu("Snap Human Hands To FPS Gun Rig")]
@@ -187,11 +208,23 @@ namespace TonPlaygram.Gameplay.Weapons
             {
                 weaponRoot.rotation = humanRightGrip.rotation * _originalGripToWeaponRotation * _weaponGripRotationOffset;
                 weaponRoot.position = humanRightGrip.position + (humanRightGrip.rotation * (_originalGripToWeaponPosition + weaponGripPositionOffset));
+                AimWeaponMuzzleTowardRuntimeTarget();
                 return;
             }
 
             weaponRoot.position = humanRightGrip.TransformPoint(weaponGripPositionOffset);
             weaponRoot.rotation = humanRightGrip.rotation * _weaponGripRotationOffset;
+
+            AimWeaponMuzzleTowardRuntimeTarget();
+        }
+
+        private void AimWeaponMuzzleTowardRuntimeTarget()
+        {
+            if (!forceMuzzleTowardRuntimeAim || !_hasRuntimeAimDirection || weaponRoot == null || weaponMuzzle == null)
+                return;
+
+            Quaternion delta = Quaternion.FromToRotation(weaponMuzzle.forward, _runtimeAimDirection);
+            weaponRoot.rotation = delta * weaponRoot.rotation;
         }
 
         private void AddExtraOriginalHandRenderers()


### PR DESCRIPTION
### Motivation

- Make two-hand weapon poses look more realistic by repositioning visible grip sockets and orienting the support hand toward the barrel rather than leaving it parallel.
- Ensure the visible weapon muzzle stays pointed at runtime targets even when using FPS-authored hand animation retargeting.

### Description

- Adjusted default visible grip offsets in `WeaponGripPoseProfile` (`rightGripBackOffset` and `leftGripBackOffset`) to better match a natural two-hand hold.
- Added a `supportHandTowardMuzzle` blend and `ResolveSupportHandGripRotation` logic in `BattleRoyaleWeaponDirector` so the support/left hand rotates inward toward the muzzle based on runtime aim direction, and switched `RefreshWeaponPose` to use a normalized `aimDirection` consistently.
- Passed runtime aim information into `FpsGunHumanHandRetargeter` by adding `SetRuntimeAimDirection`, `weaponMuzzle`, and `forceMuzzleTowardRuntimeAim` support in `FpsGunHumanHandRetargeter`, and applied a final muzzle-facing correction after snapping the weapon to the mapped human grip.

### Testing

- Ran a brace-balance verification script over the modified C# files (`python3` check) which succeeded.
- Ran `git diff --check` for basic whitespace/merge issues which reported no errors.
- Attempted to run a local Unity/C# compilation environment check but `dotnet`/Unity toolchain was not available in this environment so a full compile was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27ce8c24448329a86c2e439c2e123d)