### PR TITLE
Align Snake dice and weapons with Ludo Battle Royal

### DIFF
--- a/webapp/public/pwa/app-build.js
+++ b/webapp/public/pwa/app-build.js
@@ -1,1 +1,1 @@
-self.__TONPLAYGRAM_APP_BUILD__ = "d992be4";
+self.__TONPLAYGRAM_APP_BUILD__ = "ee3462b";

--- a/webapp/public/version.json
+++ b/webapp/public/version.json
@@ -1,4 +1,4 @@
 {
-  "build": "d992be4",
-  "generatedAt": "2026-06-07T03:14:48.068Z"
+  "build": "ee3462b",
+  "generatedAt": "2026-06-09T11:31:48.555Z"
 }

--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -63,22 +63,12 @@ export default function DiceRoller({
     setRolling(true);
     onRollStart && onRollStart();
 
-    const rand = () => {
-      if (window.crypto?.getRandomValues) {
-        const arr = new Uint32Array(1);
-        const maxUnbiased = Math.floor(0x100000000 / 6) * 6;
-        let value = 0;
-        do {
-          window.crypto.getRandomValues(arr);
-          value = arr[0];
-        } while (value >= maxUnbiased);
-        return (value % 6) + 1;
-      }
-      return Math.floor(Math.random() * 6) + 1;
-    };
+    // Match Ludo Battle Royal's spinDice result source exactly: one Math.random()
+    // face selection per die after the same 1100ms roll window.
+    const rand = () => Math.floor(Math.random() * 6) + 1;
 
-    const tick = 50; // ms between face changes
-    const iterations = 20; // ~1 second of rolling
+    const tick = 55; // 20 ticks = Ludo's 1100ms AUTO_ROLL_DURATION_MS
+    const iterations = 20;
     let count = 0;
 
     const id = setInterval(() => {

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -267,9 +267,10 @@ const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
 // Keep Snake dice motion aligned with Ludo Battle Royal's frame-synced single-arc spinDice roll.
 const DICE_ROLL_DURATION = 1100;
-const DICE_SETTLE_DURATION = 220;
-const DICE_RESULT_HOLD_DURATION = 720;
-const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.78;
+const DICE_SETTLE_DURATION = 0;
+const DICE_RESULT_HOLD_DURATION = 1500;
+// Ludo Battle Royal spinDice uses an absolute 0.06 tabletop bounce.
+const DICE_BOUNCE_HEIGHT = 0.06;
 const DICE_THROW_LANDING_MARGIN = TILE_SIZE * 1.8;
 const DICE_THROW_START_EXTRA = TILE_SIZE * 3.6;
 const DICE_THROW_HEIGHT = DICE_SIZE * 0.78;

--- a/webapp/src/config/buildInfo.js
+++ b/webapp/src/config/buildInfo.js
@@ -1,2 +1,2 @@
-export const APP_BUILD = "d992be4";
-export const APP_BUILD_GENERATED_AT = "2026-06-07T03:14:48.068Z";
+export const APP_BUILD = "ee3462b";
+export const APP_BUILD_GENERATED_AT = "2026-06-09T11:31:48.555Z";

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -1,12 +1,42 @@
 import { CAPTURE_ANIMATION_OPTIONS } from './ludoBattleOptions.js'
 import { swatchThumbnail, weaponSilhouetteThumbnail } from './storeThumbnails.js'
 
+const SNAKE_LEGACY_WEAPON_ID_TO_LUDO_ANIMATION_ID = Object.freeze({
+  'poly-shotgun-01': 'polyShotgun01Attack',
+  'poly-assault-rifle-01': 'polyAssaultRifle01Attack',
+  'poly-pistol-01': 'polyPistol01Attack',
+  'poly-revolver-01': 'polyRevolver01Attack',
+  'poly-sawed-off-01': 'polySawedOff01Attack',
+  'poly-revolver-02': 'polyRevolver02Attack',
+  'poly-shotgun-02': 'polyShotgun02Attack',
+  'poly-shotgun-03': 'polyShotgun03Attack',
+  'poly-smg-01': 'polySmg01Attack',
+  'poly-robot-large-gun-01': 'polyRobotLargeGunAttack',
+  'poly-robot-flying-gun-01': 'polyRobotFlyingGunAttack',
+  'poly-bazooka-01': 'polyBazooka01Attack',
+  'poly-grenade-launcher-01': 'polyGrenadeLauncher01Attack',
+  'poly-dynamite-bomb-01': 'polyDynamiteBomb01Attack',
+  'poly-molotov-01': 'polyMolotov01Attack',
+  'poly-gas-tank-01': 'polyGasTank01Attack',
+  'poly-hand-grenade-01': 'polyHandGrenade01Attack',
+  'poly-tank-01': 'polyTank01Attack',
+  'slot-10-ak47-gltf': 'ak47VolleyAttack',
+  'slot-11-krsv-gltf': 'krsvBurstAttack',
+  'slot-12-smith-gltf': 'smithSidearmAttack',
+  'slot-13-mosin-gltf': 'mosinMarksmanAttack',
+  'slot-14-uzi-gltf': 'uziSprayAttack',
+  'slot-15-sigsauer-gltf': 'sigsauerTacticalAttack',
+  'slot-16-awp-glb': 'sniperShotAttack',
+  'slot-18-fps-gun-gltf': 'fpsGunAttack'
+})
+
 const polyGlb = (uuid) => `https://static.poly.pizza/${uuid}.glb`
 const polyWebp = (uuid) => `https://static.poly.pizza/${uuid}.webp`
 
 const polyPizzaWeapon = (id, label, uuid, colors, extra = {}) => ({
   id,
   label,
+  ludoAnimationId: extra.ludoAnimationId || SNAKE_LEGACY_WEAPON_ID_TO_LUDO_ANIMATION_ID[id],
   thumbnail: extra.thumbnail || polyWebp(uuid),
   urls: [polyGlb(uuid)],
   source: extra.source || 'Poly Pizza',
@@ -37,6 +67,7 @@ const gunifyModelUrls = (modelName) => {
 const gunifyWeapon = (id, label, modelName, colors, extra = {}) => ({
   id,
   label,
+  ludoAnimationId: extra.ludoAnimationId || SNAKE_LEGACY_WEAPON_ID_TO_LUDO_ANIMATION_ID[id],
   thumbnail: weaponSilhouetteThumbnail(colors),
   urls: gunifyModelUrls(modelName),
   modelName,
@@ -67,6 +98,26 @@ const ludoVehicleWeapon = (id, vehicleKind, fallbackLabel, fallbackThumbnail, ex
   vehicleKind,
   ...extra
 })
+
+const LUDO_CAPTURE_OPTION_MAP = Object.freeze(
+  CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option
+    return acc
+  }, {})
+)
+
+const ludoCaptureWeapon = (id, colors, extra = {}) => {
+  const option = LUDO_CAPTURE_OPTION_MAP[id] || {}
+  return {
+    id,
+    label: option.label || extra.label || id,
+    description: option.description || extra.description || 'Ludo Battle Royal capture weapon animation and sound setup.',
+    thumbnail: option.thumbnail || weaponSilhouetteThumbnail(colors),
+    source: 'Ludo Battle Royal',
+    ludoAnimationId: id,
+    ...extra
+  }
+}
 
 export const UKRAINIAN_DRONE_GLB_URLS = Object.freeze([
   'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
@@ -103,6 +154,7 @@ export const SNAKE_FPS_GUN_MODEL_CONFIG = Object.freeze({
 })
 
 export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
+  ludoCaptureWeapon('missileJavelin', ['#1d4ed8', '#0f172a', '#93c5fd'], { vehicleKind: 'javelin' }),
   {
     id: 'ukrainianDroneAttack',
     label: 'Ukrainian Drone',
@@ -136,6 +188,15 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
     source: 'Ludo Battle Royal',
     vehicleKind: 'supportTruck'
   },
+  ludoCaptureWeapon('fpsGunAttack', ['#f59e0b', '#111827', '#fde68a'], { urls: SNAKE_FPS_GUN_MODEL_CONFIG.urls, modelScale: SNAKE_FPS_GUN_MODEL_CONFIG.ludoModelScale }),
+  ludoCaptureWeapon('glockSidearmAttack', ['#475569', '#111827', '#e5e7eb']),
+  ludoCaptureWeapon('assaultRifleAttack', ['#334155', '#111827', '#94a3b8']),
+  ludoCaptureWeapon('grenadeBlastAttack', ['#166534', '#111827', '#f97316']),
+  ludoCaptureWeapon('shotgunBlastAttack', ['#64748b', '#1e293b', '#f8fafc']),
+  ludoCaptureWeapon('sniperShotAttack', ['#1e293b', '#0f172a', '#f8fafc'], { urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }),
+  ludoCaptureWeapon('smgBurstAttack', ['#374151', '#030712', '#d1d5db']),
+  ludoCaptureWeapon('compactCarbineAttack', ['#334155', '#020617', '#bfdbfe']),
+  ludoCaptureWeapon('marksmanDmrAttack', ['#92400e', '#1f2937', '#fcd34d']),
   polyPizzaWeapon('poly-shotgun-01', 'Quaternius Shotgun', '032e6589-3188-41bc-b92b-e25528344275', ['#64748b', '#1e293b', '#f8fafc'], { creator: 'Quaternius', modelScale: 1 }),
   polyPizzaWeapon('poly-assault-rifle-01', 'Quaternius Assault Rifle', 'b3e6be61-0299-4866-a227-58f5f3fe610b', ['#334155', '#0f172a', '#94a3b8'], { creator: 'Quaternius', modelScale: 1.02 }),
   polyPizzaWeapon('poly-pistol-01', 'Quaternius Pistol', '3b53f0fe-f86e-451c-816d-6ab9bd265cdc', ['#6b7280', '#111827', '#e5e7eb'], { creator: 'Quaternius', modelScale: 0.6 }),
@@ -178,6 +239,24 @@ export const SNAKE_CAPTURE_WEAPON_ALIAS_MAP = Object.freeze({
   supporttruck: 'supportTruckAttack',
   supporttruckattack: 'supportTruckAttack',
   truck: 'supportTruckAttack',
+  javelin: 'missileJavelin',
+  missile: 'missileJavelin',
+  missilejavelin: 'missileJavelin',
+  fpsgun: 'fpsGunAttack',
+  fpsgunattack: 'fpsGunAttack',
+  glock: 'glockSidearmAttack',
+  glocksidearmattack: 'glockSidearmAttack',
+  assaultrifle: 'assaultRifleAttack',
+  assaultrifleattack: 'assaultRifleAttack',
+  grenadeblast: 'grenadeBlastAttack',
+  grenadeblastattack: 'grenadeBlastAttack',
+  shotgun: 'shotgunBlastAttack',
+  shotgunblastattack: 'shotgunBlastAttack',
+  sniper: 'sniperShotAttack',
+  snipershotattack: 'sniperShotAttack',
+  smgburstattack: 'smgBurstAttack',
+  compactcarbineattack: 'compactCarbineAttack',
+  marksmandmrattack: 'marksmanDmrAttack',
   polyrobotlargegunattack: 'poly-robot-large-gun-01',
   polyrobotflyinggunattack: 'poly-robot-flying-gun-01',
   polybazooka01attack: 'poly-bazooka-01',

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -189,10 +189,9 @@ const TURN_TIME = 15;
 const AI_ROLL_DELAY_MS = 1300;
 const AI_EXTRA_ROLL_DELAY_MS = 850;
 const TURN_ADVANCE_AFTER_DICE_MS = 0;
-const DICE_RESULT_HOLD_MS = 2000;
-// Match the 3D Ludo/Pool dice: a server-authoritative value should only
-// replace the rolling face after the physical throw has had time to land.
-const DICE_BOARD_ROLL_REVEAL_DELAY_MS = 930;
+const DICE_RESULT_HOLD_MS = 1500;
+// Ludo Battle Royal resolves the face only after the full 1100ms spinDice throw.
+const DICE_BOARD_ROLL_REVEAL_DELAY_MS = 1100;
 const DICE_SFX_MIN_INTERVAL_MS = 850;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
@@ -825,14 +824,17 @@ const CAPTURE_WEAPON_OPTIONS = Object.freeze(
   SNAKE_CAPTURE_WEAPON_OPTIONS.map((option) => ({
     id: option.id,
     label: option.label,
-    thumbnail: option.thumbnail
+    thumbnail: option.thumbnail,
+    ludoAnimationId: option.ludoAnimationId
   }))
 );
 
 const resolveCaptureWeaponOptionById = (weaponId) => {
   const resolvedId = resolveSnakeCaptureWeaponId(weaponId);
   if (!resolvedId) return null;
-  return CAPTURE_WEAPON_OPTIONS.find((option) => option.id === resolvedId) || null;
+  return (
+    CAPTURE_WEAPON_OPTIONS.find((option) => option.id === resolvedId || option.ludoAnimationId === resolvedId) || null
+  );
 };
 
 const SNAKE_SKIN_OPTIONS = Object.freeze([
@@ -1811,7 +1813,8 @@ export default function SnakeAndLadder() {
       if (idx !== mover && p === cell) victims.push(idx);
     });
     if (victims.length && cell > 0) {
-      const selectedWeapon = resolvedAppearance?.captureWeapon?.id || 'drone';
+      const selectedWeaponOption = resolvedAppearance?.captureWeapon;
+      const selectedWeapon = selectedWeaponOption?.ludoAnimationId || selectedWeaponOption?.id || 'drone';
       const aiWeapon = aiWeaponLoadout[mover - 1];
       const weaponType = mover === 0 ? selectedWeapon : (aiWeapon || selectedWeapon || 'drone');
       setBurning((b) => [...new Set([...b, ...victims])]);


### PR DESCRIPTION
### Motivation
- Make Snake & Ladder dice feel and behave identically to Ludo Battle Royal by matching roll timing, reveal and settle behavior. 
- Ensure Snake has full parity with Ludo capture weapons so inventory, animations, SFX and weapon resolution use the same authored Ludo definitions.

### Description
- Matched dice flow by updating `DiceRoller.jsx` to use a single `Math.random()` face source and 20 ticks @ 55ms (1100ms total), and adjusted board-side timing constants in `SnakeBoard3D.jsx` and `SnakeAndLadder.jsx` (`DICE_ROLL_DURATION`, `DICE_SETTLE_DURATION`, `DICE_BOUNCE_HEIGHT`, `DICE_BOARD_ROLL_REVEAL_DELAY_MS`, and result hold durations). 
- Added Ludo-aligned capture weapon entries and helpers in `webapp/src/config/snakeWeaponCatalog.js` including `ludoCaptureWeapon`, `LUDO_CAPTURE_OPTION_MAP`, legacy ID→Ludo animation mappings, and alias mappings so legacy Snake IDs map to Ludo animation IDs. 
- Propagated `ludoAnimationId` through the catalog into `CAPTURE_WEAPON_OPTIONS` and updated resolution and selection logic in `webapp/src/pages/Games/SnakeAndLadder.jsx` so selected/owned legacy weapons resolve by either Snake ID or the Ludo animation ID and capture flows use the Ludo animation/sfx tuning. 
- Minor build metadata updates from the production build output; affected files include `DiceRoller.jsx`, `SnakeBoard3D.jsx`, `snakeWeaponCatalog.js`, `SnakeAndLadder.jsx`, and generated `public`/`buildInfo` artifacts. 

### Testing
- Ran `npm run lint -- --quiet` which completed without errors. 
- Verified coverage of Ludo capture weapons by running a Node check that confirmed all `CAPTURE_ANIMATION_OPTIONS` are represented in Snake inventory. 
- Built the app with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f880b9d483299c6a56fbd5e5bc92)