### PR TITLE
Align Snake dice and weapons with Ludo Battle Royal

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -18,6 +18,7 @@ export default function DiceRoller({
   renderVisual = true,
   placeholder = null,
   diceWrapperClassName = 'flex space-x-4 items-center justify-center',
+  rollDurationMs = 1050,
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -78,7 +79,7 @@ export default function DiceRoller({
     };
 
     const tick = 50; // ms between face changes
-    const iterations = 20; // ~1 second of rolling
+    const iterations = Math.max(1, Math.round(rollDurationMs / tick)); // Ludo-compatible configurable roll cadence
     let count = 0;
 
     const id = setInterval(() => {

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -905,7 +905,15 @@ const SNAKE_CAPTURE_WEAPON_SFX_ID_MAP = Object.freeze({
   'slot-17-mrtk-gun-glb': 'glockSidearmAttack',
   'slot-18-fps-gun-gltf': 'shotgunBlastAttack'
 });
-const resolveSnakeCaptureWeaponSfxId = (weaponType) => SNAKE_CAPTURE_WEAPON_SFX_ID_MAP[weaponType] || weaponType || 'missileJavelin';
+const resolveSnakeCaptureWeaponAnimationId = (weaponType) => {
+  const rawWeaponType = typeof weaponType === 'string' ? weaponType.trim() : '';
+  const catalogOption = SNAKE_CAPTURE_WEAPON_OPTION_BY_ID[rawWeaponType] || null;
+  return catalogOption?.ludoCaptureAnimationId || SNAKE_CAPTURE_WEAPON_KIND_MAP[rawWeaponType] || rawWeaponType || 'missileJavelin';
+};
+const resolveSnakeCaptureWeaponSfxId = (weaponType) => {
+  const animationId = resolveSnakeCaptureWeaponAnimationId(weaponType);
+  return SNAKE_CAPTURE_WEAPON_SFX_ID_MAP[weaponType] || SNAKE_CAPTURE_WEAPON_SFX_ID_MAP[animationId] || animationId || 'missileJavelin';
+};
 const WEAPON_TABLE_PARKING_ROTATION_BY_POSE = Object.freeze({
   // Portrait screen: top/bottom player weapons lie flat left-to-right on the tabletop.
   horizontal: Object.freeze({ yaw: 0, preferAxis: 'x' }),
@@ -972,7 +980,9 @@ function applyFlatTableWeaponParkingPose(object, parkingPose = 'horizontal') {
 }
 
 function normalizeSnakeCaptureWeaponKind(weaponType = 'fighter') {
-  return SNAKE_CAPTURE_WEAPON_KIND_MAP[weaponType] || weaponType || 'fighter';
+  const animationId = resolveSnakeCaptureWeaponAnimationId(weaponType);
+  const mapped = SNAKE_CAPTURE_WEAPON_KIND_MAP[animationId] || animationId || weaponType || 'fighter';
+  return SNAKE_CAPTURE_WEAPON_KIND_MAP[mapped] || mapped;
 }
 
 function pullPointTowardCenter(point, amount = TILE_EDGE_INSET) {

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -1,15 +1,15 @@
-import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
-import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
-import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
-import { SNAKE_CAPTURE_WEAPON_OPTIONS } from './snakeWeaponCatalog.js';
+import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js'
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js'
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js'
+import { SNAKE_CAPTURE_WEAPON_OPTIONS } from './snakeWeaponCatalog.js'
 
 const mapLabels = (options) =>
   Object.freeze(
     options.reduce((acc, option) => {
-      acc[option.id] = option.label;
-      return acc;
+      acc[option.id] = option.label
+      return acc
     }, {})
-  );
+  )
 
 const SNAKE_TABLE_FINISH_OPTIONS = Object.freeze([
   { id: 'peelingPaintWeathered', label: 'Wood Peeling Paint Weathered' },
@@ -17,7 +17,7 @@ const SNAKE_TABLE_FINISH_OPTIONS = Object.freeze([
   { id: 'woodTable001', label: 'Wood Table 001' },
   { id: 'darkWood', label: 'Dark Wood' },
   { id: 'rosewoodVeneer01', label: 'Rosewood Veneer 01' }
-]);
+])
 
 const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'pawn', label: 'Pawn Token' },
@@ -26,7 +26,7 @@ const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'rook', label: 'Rook Token' },
   { id: 'queen', label: 'Queen Token' },
   { id: 'king', label: 'King Token' }
-]);
+])
 
 export const SNAKE_PAWN_HEAD_OPTIONS = Object.freeze([
   { id: 'current', label: 'Current' },
@@ -34,7 +34,7 @@ export const SNAKE_PAWN_HEAD_OPTIONS = Object.freeze([
   { id: 'headSapphire', label: 'Sapphire' },
   { id: 'headChrome', label: 'Chrome' },
   { id: 'headGold', label: 'Gold' }
-]);
+])
 
 export const SNAKE_TOKEN_COLOR_OPTIONS = Object.freeze([
   { id: 'marble', label: 'Marble', color: '#f8fafc' },
@@ -46,7 +46,7 @@ export const SNAKE_TOKEN_COLOR_OPTIONS = Object.freeze([
   { id: 'amethyst', label: 'Amethyst', color: '#8b5cf6' },
   { id: 'cinderBlaze', label: 'Cinder Blaze', color: '#ff6b35' },
   { id: 'arcticDrift', label: 'Arctic Drift', color: '#bcd7ff' }
-]);
+])
 
 const SNAKE_TABLE_FINISH_THUMBNAILS = Object.freeze({
   peelingPaintWeathered: polyHavenThumb('wood_peeling_paint_weathered'),
@@ -54,7 +54,7 @@ const SNAKE_TABLE_FINISH_THUMBNAILS = Object.freeze({
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
   rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
-});
+})
 
 const SNAKE_THEME_THUMBNAILS = Object.freeze({
   arenaTheme: {
@@ -97,7 +97,7 @@ const SNAKE_THEME_THUMBNAILS = Object.freeze({
     supportTruck: swatchThumbnail(['#f97316', '#7c2d12', '#fdba74']),
     drone: swatchThumbnail(['#60a5fa', '#1d4ed8', '#bfdbfe'])
   }
-});
+})
 
 export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   arenaTheme: ['nebulaAtrium'],
@@ -109,17 +109,13 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
   headStyle: [SNAKE_PAWN_HEAD_OPTIONS[0].id],
   tokenShape: [SNAKE_TOKEN_SHAPE_OPTIONS[0].id],
-  captureWeapon: [
-    SNAKE_CAPTURE_WEAPON_OPTIONS[0].id,
-    'fighterJetAttack',
-    'helicopterAttack',
-    'droneAttack',
-    'supportTruckAttack'
-  ],
+  // Snake & Ladder uses the full Ludo Battle Royal weapon rack by default so
+  // every Ludo capture animation/sound/camera profile is available in inventory.
+  captureWeapon: SNAKE_CAPTURE_WEAPON_OPTIONS.map((option) => option.id),
   tables: [MURLAN_TABLE_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
   environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
-});
+})
 
 export const SNAKE_OPTION_LABELS = Object.freeze({
   arenaTheme: Object.freeze({
@@ -156,11 +152,11 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
   stools: mapLabels(MURLAN_STOOL_THEMES),
   environmentHdri: Object.freeze(
     POOL_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => {
-      acc[variant.id] = `${variant.name} HDRI`;
-      return acc;
+      acc[variant.id] = `${variant.name} HDRI`
+      return acc
     }, {})
   )
-});
+})
 
 export const SNAKE_STORE_ITEMS = [
   ...SNAKE_CAPTURE_WEAPON_OPTIONS.filter((option, idx) => idx > 0).map((option, idx) => ({
@@ -359,7 +355,7 @@ export const SNAKE_STORE_ITEMS = [
     thumbnail: variant.thumbnail,
     previewShape: 'table'
   }))
-);
+)
 
 export const SNAKE_DEFAULT_LOADOUT = [
   { type: 'arenaTheme', optionId: 'nebulaAtrium', label: 'Nebula Atrium Arena' },
@@ -391,4 +387,4 @@ export const SNAKE_DEFAULT_LOADOUT = [
     optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
     label: `${POOL_ROYALE_HDRI_VARIANTS[0].name} HDRI`
   }
-];
+]

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -13,7 +13,8 @@ const polyPizzaWeapon = (id, label, uuid, colors, extra = {}) => ({
   creator: extra.creator || undefined,
   license: extra.license || 'CC0 / Poly Pizza source page',
   modelScale: extra.modelScale,
-  ...Object.fromEntries(Object.entries(extra).filter(([key]) => !['thumbnail', 'source', 'creator', 'license', 'modelScale'].includes(key))),
+  ludoCaptureAnimationId: extra.ludoCaptureAnimationId,
+  ...Object.fromEntries(Object.entries(extra).filter(([key]) => !['thumbnail', 'source', 'creator', 'license', 'modelScale', 'ludoCaptureAnimationId'].includes(key))),
   fallbackThumbnail: weaponSilhouetteThumbnail(colors)
 })
 
@@ -45,8 +46,8 @@ const gunifyWeapon = (id, label, modelName, colors, extra = {}) => ({
   ...extra
 })
 
-
 const LUDO_CAPTURE_WEAPON_IDS = Object.freeze([
+  'missileJavelin',
   'fighterJetAttack',
   'helicopterAttack',
   'droneAttack'
@@ -65,8 +66,37 @@ const ludoVehicleWeapon = (id, vehicleKind, fallbackLabel, fallbackThumbnail, ex
   thumbnail: LUDO_CAPTURE_OPTION_BY_ID[id]?.thumbnail || fallbackThumbnail,
   source: 'Ludo Battle Royal',
   vehicleKind,
+  ludoCaptureAnimationId: id,
   ...extra
 })
+
+const ludoCaptureWeapon = (id, colors, extra = {}) => {
+  const option = LUDO_CAPTURE_OPTION_BY_ID[id] || CAPTURE_ANIMATION_OPTIONS.find((entry) => entry.id === id)
+  return {
+    id,
+    label: option?.label || extra.label || id,
+    description: option?.description || extra.description,
+    thumbnail: option?.thumbnail || extra.thumbnail || weaponSilhouetteThumbnail(colors),
+    source: 'Ludo Battle Royal',
+    ludoCaptureAnimationId: id,
+    ...extra
+  }
+}
+
+const SNAKE_DIRECT_LUDO_WEAPON_IDS = new Set([
+  'droneAttack',
+  'ukrainianDroneAttack',
+  'fighterJetAttack',
+  'helicopterAttack'
+])
+
+const LUDO_CAPTURE_WEAPON_PROXY_OPTIONS = Object.freeze(
+  CAPTURE_ANIMATION_OPTIONS.filter((option) => !SNAKE_DIRECT_LUDO_WEAPON_IDS.has(option.id)).map((option) =>
+    ludoCaptureWeapon(option.id, ['#334155', '#0f172a', '#e2e8f0'], {
+      ludoProxyOnly: true
+    })
+  )
+)
 
 export const UKRAINIAN_DRONE_GLB_URLS = Object.freeze([
   'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
@@ -99,7 +129,8 @@ export const SNAKE_FPS_GUN_MODEL_CONFIG = Object.freeze({
   // May 9 05:00 baseline used by Ludo Battle Royal for the same FPS gun asset.
   ludoModelScale: 0.24,
   ludoRackSizeMultiplier: 2.2,
-  ludoHandScaleMultiplier: 3.2
+  ludoHandScaleMultiplier: 3.2,
+  ludoCaptureAnimationId: 'fpsGunAttack'
 })
 
 export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
@@ -108,8 +139,10 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
     label: 'Ukrainian Drone',
     thumbnail: swatchThumbnail(['#60a5fa', '#facc15', '#1d4ed8']),
     urls: UKRAINIAN_DRONE_GLB_URLS,
-    vehicleKind: 'ukrainianDrone'
+    vehicleKind: 'ukrainianDrone',
+    ludoCaptureAnimationId: 'ukrainianDroneAttack'
   },
+  ...LUDO_CAPTURE_WEAPON_PROXY_OPTIONS,
   ludoVehicleWeapon(
     'fighterJetAttack',
     'fighter',
@@ -134,7 +167,8 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
     description: 'Ludo Battle Royal support truck parked with the same capture-vehicle inventory set.',
     thumbnail: swatchThumbnail(['#f97316', '#7c2d12', '#fdba74']),
     source: 'Ludo Battle Royal',
-    vehicleKind: 'supportTruck'
+    vehicleKind: 'supportTruck',
+    ludoCaptureAnimationId: 'missileJavelin'
   },
   polyPizzaWeapon('poly-shotgun-01', 'Quaternius Shotgun', '032e6589-3188-41bc-b92b-e25528344275', ['#64748b', '#1e293b', '#f8fafc'], { creator: 'Quaternius', modelScale: 1 }),
   polyPizzaWeapon('poly-assault-rifle-01', 'Quaternius Assault Rifle', 'b3e6be61-0299-4866-a227-58f5f3fe610b', ['#334155', '#0f172a', '#94a3b8'], { creator: 'Quaternius', modelScale: 1.02 }),
@@ -154,13 +188,14 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   polyPizzaWeapon('poly-gas-tank-01', 'Quaternius Gas Tank', '9c4d2ac5-114b-4da2-a26a-8049e2b1ba04', ['#b91c1c', '#111827', '#e5e7eb'], { creator: 'Quaternius', modelScale: 0.62 }),
   polyPizzaWeapon('poly-hand-grenade-01', 'CreativeTrio Hand Grenade', '03fa7f5b-4df5-45d6-86fb-87e8590f28d7', ['#3f6212', '#111827', '#a3e635'], { creator: 'CreativeTrio', modelScale: 0.36 }),
   polyPizzaWeapon('poly-tank-01', 'Quaternius Battle Tank', '58c387b2-636f-49dc-a900-13b0852717d6', ['#334155', '#111827', '#94a3b8'], { creator: 'Quaternius', modelScale: 0.7 }),
-  gunifyWeapon('slot-10-ak47-gltf', 'AK47 GLTF', 'AK47', ['#7f1d1d', '#111827', '#f59e0b'], { ludoCaptureScale: 0.24 }),
-  gunifyWeapon('slot-11-krsv-gltf', 'KRSV GLTF', 'KRSV', ['#1d4ed8', '#0f172a', '#bfdbfe'], { ludoCaptureScale: 0.24 }),
-  gunifyWeapon('slot-12-smith-gltf', 'Smith GLTF', 'Smith', ['#6b7280', '#0f172a', '#f8fafc'], { ludoCaptureScale: 0.13 }),
-  gunifyWeapon('slot-13-mosin-gltf', 'Mosin GLTF', 'Mosin', ['#92400e', '#1f2937', '#fcd34d'], { ludoCaptureScale: 0.5125 }),
-  gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e', '#111827', '#99f6e4'], { ludoCaptureScale: 0.2 }),
-  gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155', '#020617', '#f1f5f9'], { ludoCaptureScale: 0.13 }),
-  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
+  gunifyWeapon('slot-10-ak47-gltf', 'AK47 GLTF', 'AK47', ['#7f1d1d', '#111827', '#f59e0b'], { ludoCaptureScale: 0.24, ludoCaptureAnimationId: 'ak47VolleyAttack' }),
+  gunifyWeapon('slot-11-krsv-gltf', 'KRSV GLTF', 'KRSV', ['#1d4ed8', '#0f172a', '#bfdbfe'], { ludoCaptureScale: 0.24, ludoCaptureAnimationId: 'krsvBurstAttack' }),
+  gunifyWeapon('slot-12-smith-gltf', 'Smith GLTF', 'Smith', ['#6b7280', '#0f172a', '#f8fafc'], { ludoCaptureScale: 0.13, ludoCaptureAnimationId: 'smithSidearmAttack' }),
+  gunifyWeapon('slot-13-mosin-gltf', 'Mosin GLTF', 'Mosin', ['#92400e', '#1f2937', '#fcd34d'], { ludoCaptureScale: 0.5125, ludoCaptureAnimationId: 'mosinMarksmanAttack' }),
+  gunifyWeapon('slot-14-uzi-gltf', 'Uzi GLTF', 'Uzi', ['#0f766e', '#111827', '#99f6e4'], { ludoCaptureScale: 0.2, ludoCaptureAnimationId: 'uziSprayAttack' }),
+  gunifyWeapon('slot-15-sigsauer-gltf', 'SigSauer GLTF', 'SigSauer', ['#334155', '#020617', '#f1f5f9'], { ludoCaptureScale: 0.13, ludoCaptureAnimationId: 'sigsauerTacticalAttack' }),
+  { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw], ludoCaptureAnimationId: 'sniperShotAttack' },
+  { id: 'slot-17-mrtk-gun-glb', label: 'MRTK Glock Sidearm GLB', thumbnail: weaponSilhouetteThumbnail(['#111827', '#475569', '#e5e7eb']), urls: [SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkRaw, SNAKE_KNOWN_WORKING_GLB.mrtkMaster], ludoCaptureAnimationId: 'glockSidearmAttack' },
   SNAKE_FPS_GUN_MODEL_CONFIG
 ])
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -192,7 +192,10 @@ const TURN_ADVANCE_AFTER_DICE_MS = 0;
 const DICE_RESULT_HOLD_MS = 2000;
 // Match the 3D Ludo/Pool dice: a server-authoritative value should only
 // replace the rolling face after the physical throw has had time to land.
-const DICE_BOARD_ROLL_REVEAL_DELAY_MS = 930;
+// Match Ludo Battle Royal's AUTO_ROLL_DURATION_MS so the server/local result
+// appears only after the full one-arc dice throw has completed.
+const LUDO_MATCHED_DICE_ROLL_DURATION_MS = 1100;
+const DICE_BOARD_ROLL_REVEAL_DELAY_MS = LUDO_MATCHED_DICE_ROLL_DURATION_MS;
 const DICE_SFX_MIN_INTERVAL_MS = 850;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
@@ -4261,6 +4264,7 @@ export default function SnakeAndLadder() {
             showButton={false}
             muted
             fixedSoundVolume={1}
+            rollDurationMs={LUDO_MATCHED_DICE_ROLL_DURATION_MS}
           />
         </div>
       )}
@@ -4272,6 +4276,7 @@ export default function SnakeAndLadder() {
               showButton={false}
               muted
               fixedSoundVolume={1}
+              rollDurationMs={LUDO_MATCHED_DICE_ROLL_DURATION_MS}
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder gameplay match the Ludo Battle Royal experience by using the same dice roll timing and cadence and by ensuring the Snake weapon inventory, animations, camera and SFX resolution use the same Ludo profiles.

### Description
- Dice timing: add `LUDO_MATCHED_DICE_ROLL_DURATION_MS = 1100` and use it to set the board reveal delay, and pass a new `rollDurationMs` prop into `DiceRoller` so roll cadence matches Ludo (`webapp/src/pages/Games/SnakeAndLadder.jsx`, `webapp/src/components/DiceRoller.jsx`).
- Weapon catalog: expand `SNAKE_CAPTURE_WEAPON_OPTIONS` with Ludo proxy entries and attach `ludoCaptureAnimationId` to catalog entries (including Gunify / AWP / FPS / MRTK mappings) so Snake can surface the full Ludo capture rack (`webapp/src/config/snakeWeaponCatalog.js`).
- Inventory defaults: unlock the full Ludo-aligned Snake weapon catalog by default by setting `captureWeapon` to `SNAKE_CAPTURE_WEAPON_OPTIONS.map((option) => option.id)` (`webapp/src/config/snakeInventoryConfig.js`).
- Capture resolution: route capture animation / SFX / kind resolution through the catalog `ludoCaptureAnimationId`, and update `normalizeSnakeCaptureWeaponKind` / SFX resolution to prefer the Ludo animation id so behavior, sounds and camera tuning match Ludo (`webapp/src/components/SnakeBoard3D.jsx`).

### Testing
- Ran linter: `npm --prefix webapp run lint -- src/components/DiceRoller.jsx src/components/SnakeBoard3D.jsx src/config/snakeInventoryConfig.js src/config/snakeWeaponCatalog.js src/pages/Games/SnakeAndLadder.jsx` and fixed/style-cleaned issues (succeeded).
- Built frontend: `npm --prefix webapp run build` and validated the production build artifacts (succeeded).
- Playwright: executed `npx playwright install chromium` (succeeded), attempted a headless portrait screenshot of `/games/snake?ai=1` via `vite preview` but Chromium failed to launch in the container due to a missing system library (`libatk-1.0.so.0`), so automated screenshot validation could not complete (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f880b9d483299c6a56fbd5e5bc92)