### PR TITLE
Improve Snake & Ladder dice roll motion

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -3654,7 +3654,8 @@ function createDiceRollAnimation(
   {
     basePositions,
     baseY,
-    startPositions = []
+    startPositions = [],
+    bouncePoints = []
   }
 ) {
   const start = performance.now();
@@ -3664,6 +3665,13 @@ function createDiceRollAnimation(
       1.35 + Math.random() * 0.65,
       1.05 + Math.random() * 0.75
     )
+  );
+  const tumbleAxes = diceArray.map(() =>
+    new THREE.Vector3(
+      (Math.random() - 0.5) * 0.9,
+      0.55 + Math.random() * 0.5,
+      0.75 + Math.random() * 0.7
+    ).normalize()
   );
   const wobbleVectors = diceArray.map(
     () => new THREE.Vector3((Math.random() - 0.5) * 0.16, 0, (Math.random() - 0.5) * 0.16)
@@ -3680,18 +3688,35 @@ function createDiceRollAnimation(
         if (!base) return;
         const startPos = startPositions[index] ?? base;
         const endPos = new THREE.Vector3(base.x, baseY, base.z);
-        const position = startPos.clone().lerp(endPos, eased);
+        const bouncePoint = bouncePoints[index]
+          ? new THREE.Vector3(bouncePoints[index].x, baseY, bouncePoints[index].z)
+          : startPos.clone().lerp(endPos, 0.72).setY(baseY);
+        const firstLeg = eased < 0.58;
+        const legT = firstLeg ? eased / 0.58 : (eased - 0.58) / 0.42;
+        const legEase = firstLeg ? easeOutCubic(legT) : legT * legT * (3 - 2 * legT);
+        const position = firstLeg
+          ? startPos.clone().lerp(bouncePoint, legEase)
+          : bouncePoint.clone().lerp(endPos, legEase);
+        const arcHeight = firstLeg
+          ? DICE_BOUNCE_HEIGHT * 1.1 * Math.sin(Math.min(1, legT) * Math.PI)
+          : DICE_BOUNCE_HEIGHT * 0.24 * Math.sin(Math.min(1, legT) * Math.PI) * (1 - legT * 0.35);
+        const contactHop = Math.max(0, Math.sin((eased * 5.5 + index * 0.35) * Math.PI))
+          * DICE_SIZE
+          * 0.055
+          * (1 - eased);
         const wobbleStrength = Math.sin(eased * Math.PI);
         position.addScaledVector(wobbleVectors[index], wobbleStrength * 0.45);
-        const bounce = Math.sin(Math.min(1, eased * 1.25) * Math.PI) * DICE_BOUNCE_HEIGHT * (1 - eased * 0.45);
-        position.y = THREE.MathUtils.lerp(startPos.y, endPos.y, eased) + bounce;
+        position.y = THREE.MathUtils.lerp(startPos.y, baseY, eased) + arcHeight + contactHop;
         die.position.copy(position);
 
-        // Same spin cadence as Ludo Battle Royal's spinDice helper.
+        // Same spin cadence as Ludo Battle Royal's spinDice helper, with an
+        // added distance-based tumble axis so the cube travels across the cloth
+        // instead of vibrating in place.
         const spinFactor = 1 - eased * 0.28;
         die.rotation.x += spinVectors[index].x * spinFactor * 0.22;
         die.rotation.y += spinVectors[index].y * spinFactor * 0.22;
         die.rotation.z += spinVectors[index].z * spinFactor * 0.22;
+        die.rotateOnWorldAxis(tumbleAxes[index], (firstLeg ? 0.18 : 0.1) * spinFactor);
       });
       if (t >= 1) {
         diceArray.forEach((die, index) => {


### PR DESCRIPTION
### Motivation
- Make Snake & Ladder dice visually match the natural roll/arc behavior used by Ludo Battle Royal so throws feel like a physical roll rather than a local shake. 

### Description
- Updated `createDiceRollAnimation` in `webapp/src/components/SnakeBoard3D.jsx` to accept and use `bouncePoints` and `startPositions` so dice follow a two‑leg arc (start → bounce → settle) instead of linear lerp. 
- Added per‑die `tumbleAxes`, an arc height / contact hop, and a two‑phase easing blend so dice travel, bounce, and then settle with a natural tumble across the cloth while preserving the Ludo spin cadence. 
- Kept final face application via `die.userData.setValue` / `setDiceOrientation` and left existing timing constants unchanged (`DICE_ROLL_DURATION`, etc.).

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx --no-ignore --no-warn-ignored` and it passed.
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.
- Ran the inventory cross‑game test `npm test -- --runInBand test/inventoryCrossGameConfig.test.js`; several unrelated inventory alignment assertions failed (preexisting expectations between Ludo/Chess/Snake configs) and are not caused by this dice animation change. 
- Attempted an automated Playwright screenshot to preview the mobile (portrait) dice; browser launch failed in CI due to missing system library (`libatk-1.0.so.0`) after installing Playwright, so visual screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28246c83008329b653bbde5c152e5c)