### PR TITLE
Refine Pool Royale pocket and cue visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -416,6 +416,8 @@ const resolveTextureAnisotropy = (fallback = 1) =>
   Math.max(rendererAnisotropyCap, Number.isFinite(fallback) ? fallback : 1);
 
 const POCKET_NET_LINE_THICKNESS_SCALE = 4.8;
+const POOL_ROYALE_RENDER_POCKET_DROP_HARDWARE = false;
+const POOL_ROYALE_RENDER_POTTED_HOLDER_BALLS = false;
 
 const createPocketNetTexture = (size = 256, repeat = POCKET_NET_HEX_REPEAT) => {
   if (typeof document === 'undefined') return null;
@@ -9331,18 +9333,22 @@ export function Table3D(
 
   const markingsGroup = new THREE.Group();
   const markingMat = new THREE.MeshBasicMaterial({
-    color: resolvedTableOptions?.tableModel?.useReferenceShowoodMapping ? 0xffffff : palette.markings,
+    color: 0xffffff,
     transparent: true,
-    opacity: resolvedTableOptions?.tableModel?.useReferenceShowoodMapping ? 0.98 : 0.94,
+    opacity: 1,
     side: THREE.DoubleSide,
-    depthWrite: false
+    depthWrite: false,
+    depthTest: false
   });
+  markingMat.polygonOffset = true;
+  markingMat.polygonOffsetFactor = -4;
+  markingMat.polygonOffsetUnits = -4;
   const externalMarkingLift =
     usesExternalTableModel && Number.isFinite(resolvedTableOptions?.tableModel?.markingVisualLift)
       ? Math.max(0, resolvedTableOptions.tableModel.markingVisualLift)
       : 0;
-  const markingHeight = clothPlaneLocal - CLOTH_DROP + MICRO_EPS * 2 + externalMarkingLift;
-  const lineThickness = Math.max(BALL_R * 0.1, 0.1);
+  const markingHeight = clothPlaneLocal + Math.max(MICRO_EPS * 8, BALL_R * 0.018) + externalMarkingLift;
+  const lineThickness = Math.max(BALL_R * 0.22, 0.014);
   const baulkLineLength = PLAY_W - SIDE_RAIL_INNER_THICKNESS * 0.4;
   const baulkLineGeom = new THREE.PlaneGeometry(baulkLineLength, lineThickness);
   const baulkLine = new THREE.Mesh(baulkLineGeom, markingMat);
@@ -9353,7 +9359,7 @@ export function Table3D(
   markingsGroup.add(baulkLine);
 
   const dArc = null;
-  const spotRadius = BALL_R * 0.34;
+  const spotRadius = BALL_R * 0.46;
   const spotMeshes = [];
   const addSpot = (x, z) => {
     const spotGeo = new THREE.CircleGeometry(spotRadius, 40);
@@ -9370,7 +9376,7 @@ export function Table3D(
   const penaltySpot = addSpot(0, (topCushionZ + 0) / 2);
   markingsGroup.traverse((child) => {
     if (child.isMesh) {
-      child.renderOrder = cloth.renderOrder + 1;
+      child.renderOrder = cloth.renderOrder + 12;
       child.castShadow = false;
       child.receiveShadow = false;
     }
@@ -9531,6 +9537,14 @@ export function Table3D(
     pocket.userData.externalTablePocketDropHardware = true;
     table.add(pocket);
     pocketMeshes.push(pocket);
+    if (!POOL_ROYALE_RENDER_POCKET_DROP_HARDWARE) {
+      table.userData.pocketHolderAnchors[index] = {
+        pocketId,
+        ringAnchor: null
+      };
+      return;
+    }
+
     const fieldCutRadius = resolvePocketFieldCutRadius(index);
     const pocketGuideRingRadius = fieldCutRadius;
     const net = new THREE.Mesh(resolvePocketNetGeometry(index), pocketNetMaterial);
@@ -29544,7 +29558,10 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
+          const shouldDeferShotUntilCueImpact = Boolean(ENABLE_CUE_STROKE_ANIMATION && cueStick);
+          if (!shouldDeferShotUntilCueImpact) {
+            applyShotAtImpact(shotImpactPayload);
+          }
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29587,7 +29604,7 @@ const shotPowerRef = useRef(0);
             Math.max(CUE_PULL_MIN_VISUAL, maxPull)
           );
           const pullTarget = pullRange * strokeProfile.pullRatio;
-          const pulledNow = cuePullCurrentRef.current ?? pullTarget;
+          const pulledNow = Math.max(cuePullCurrentRef.current ?? 0, pullTarget);
           const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
           const visualPull = applyVisualPullCompensation(startPull, dir);
           shotImpactPayload.pullDistance = visualPull;
@@ -34919,7 +34936,7 @@ const shotPowerRef = useRef(0);
                 );
               const restY =
                 railRunStart.y - POCKET_HOLDER_REST_DROP - tiltDrop;
-              if (!isCueBall) {
+              if (!isCueBall && POOL_ROYALE_RENDER_POTTED_HOLDER_BALLS) {
                 const dropEntry = {
                   start: dropStart,
                   fromY: BALL_CENTER_Y,
@@ -34956,6 +34973,10 @@ const shotPowerRef = useRef(0);
                 pocketDropRef.current.set(b.id, dropEntry);
               } else {
                 removePocketDropEntry(b.id);
+                if (b.mesh) {
+                  b.mesh.visible = false;
+                  b.mesh.scale.set(1, 1, 1);
+                }
               }
               const mappedColor = toBallColorId(b.id);
               const colorId =


### PR DESCRIPTION
### Motivation
- Remove decorative pocket drop hardware (nets, chrome rings, holder rails and leather strap) and avoid rendering balls on pocket holders while keeping procedural pocket bowls and physics unchanged. 
- Make white table markings (baulk line and penalty spot) reliably visible on the cloth surface in portrait/mobile views. 
- Ensure the cue stick visibly pushes forward from the player’s chosen pull and returns to the original idle/contact pose when a shot fires. 

### Description
- Added two feature flags `POOL_ROYALE_RENDER_POCKET_DROP_HARDWARE` and `POOL_ROYALE_RENDER_POTTED_HOLDER_BALLS` and short-circuited pocket-holder setup when pocket hardware rendering is disabled so nets, chrome rings, holder rails and leather straps are not created. 
- Hid potted-holder visuals by gating pocket drop entries with `POOL_ROYALE_RENDER_POTTED_HOLDER_BALLS` and setting potted ball meshes invisible when holder rendering is off. 
- Strengthened table markings by forcing a white `markingMat` (`color: 0xffffff`), disabling `depthTest`, raising `polygonOffset` and `renderOrder`, increasing `markingHeight` and `spotRadius` so the baulk line and penalty spot remain visible above the cloth. 
- Adjusted shot/cue logic to defer immediate physics application when an animated cue is present (`ENABLE_CUE_STROKE_ANIMATION && cueStick`) so `applyShotAtImpact` runs at cue impact time, and preserved slider pull by clamping `pulledNow = Math.max(cuePullCurrentRef.current ?? 0, pullTarget)` so the cue pushes forward from the recorded pull back to the idle/contact position. 

### Testing
- Ran unit tests `test/poolRoyaleCueStrokeTimeline.test.js` and `test/poolRoyaleShotState.test.js` with `npm test` and both test suites passed. 
- Executed a TypeScript build with `npm run build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a282ef3153c8329b0a8d157a5e4cdcf)