### PR TITLE
Restore Ludo table weapon parking and adjust camera framing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -361,10 +361,6 @@ const FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS = Object.freeze([
   Object.freeze({ side: -0.012, inward: 0.052 }), // top
   Object.freeze({ side: -0.008, inward: 0.004 }) // left
 ]);
-const FIREARM_RACK_DICE_SIDE_OFFSET = 0.102;
-const FIREARM_RACK_DICE_INWARD_OFFSET = 0.018;
-const FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA = 0.036;
-const FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA = 0.012;
 const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
   0: 2,
   2: 0
@@ -4375,11 +4371,11 @@ const SEATED_HELPER_FACE_CAMERA_UP = 0.146 * MODEL_SCALE;
 const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.072 * MODEL_SCALE;
 // The bottom-seat gameplay camera is intentionally raised and pushed farther toward the table so
 // portrait players see over the local avatar and closer into the Ludo board/action area.
-const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.31 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.335 * MODEL_SCALE;
 // Lift the human player's locked first-person camera higher so portrait gameplay has a clearer
 // over-the-shoulder view of the dice, tokens, and board instead of sitting too low near the face.
-const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.66 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.32 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.72 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.36 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 9;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.34;
 const SEATED_CONTACT_DICE_Y_OFFSET = 0.005;
@@ -4458,10 +4454,10 @@ const LUDO_CAMERA_PHI_MAX = 1.14;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.18;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.26;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 2.3;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.98;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.2;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.9;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 2.36;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 1.02;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.28;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.94;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT = 0.42 * MODEL_SCALE;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_LANDSCAPE = 0.2 * MODEL_SCALE;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -0.02 * 3.22 * ARENA_SCALE;
@@ -5798,11 +5794,13 @@ const CAM = {
   phiMin: LUDO_CAMERA_PHI_MIN,
   phiMax: LUDO_CAMERA_PHI_MAX
 };
-const CAMERA_2D_DISTANCE_FACTOR = 1.08;
-const CAMERA_2D_MAX_DISTANCE_FACTOR = 1.32;
+const CAMERA_2D_DISTANCE_FACTOR = 2.56;
+const CAMERA_2D_MIN_DISTANCE_FACTOR = 1.2;
+const CAMERA_2D_MAX_DISTANCE_FACTOR = 4.7;
+const CAMERA_2D_TOPDOWN_POLAR = THREE.MathUtils.degToRad(2);
 const CAMERA_3D_VERTICAL_DROP = 0;
 const CAMERA_3D_HEIGHT_BOOST = 0.26 * MODEL_SCALE;
-const CAMERA_LOOKDOWN_TARGET_OFFSET = 0.062 * MODEL_SCALE;
+const CAMERA_LOOKDOWN_TARGET_OFFSET = 0.082 * MODEL_SCALE;
 const TRACK_COORDS = Object.freeze([
   [6, 1],
   [6, 2],
@@ -8492,7 +8490,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const boardLookTarget = boardLookTargetRef.current;
     if (!camera || !controls || !boardLookTarget) return;
 
-    const topDownPolar = 0.001;
+    const topDownPolar = CAMERA_2D_TOPDOWN_POLAR;
     if (nextIs2d) {
       if (!saved3dCameraStateRef.current) {
         saved3dCameraStateRef.current = {
@@ -8513,9 +8511,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       cancelCameraViewAnimation();
       cameraTurnStateRef.current.activePriority = -Infinity;
       cameraTurnStateRef.current.followObject = null;
-      const max2dDistance = CAM.maxR * CAMERA_2D_MAX_DISTANCE_FACTOR;
-      const topDownDistance = clamp(CAM.maxR * CAMERA_2D_DISTANCE_FACTOR, CAM.minR, max2dDistance);
-      camera.position.set(boardLookTarget.x, boardLookTarget.y + topDownDistance, boardLookTarget.z + 0.001);
+      const min2dDistance = CAMERA_BASE_RADIUS * CAMERA_2D_MIN_DISTANCE_FACTOR;
+      const max2dDistance = CAMERA_BASE_RADIUS * CAMERA_2D_MAX_DISTANCE_FACTOR;
+      const topDownDistance = clamp(CAMERA_BASE_RADIUS * CAMERA_2D_DISTANCE_FACTOR, min2dDistance, max2dDistance);
+      const topDownOffset = new THREE.Vector3().setFromSpherical(new THREE.Spherical(topDownDistance, topDownPolar, 0));
+      camera.position.copy(boardLookTarget).add(topDownOffset);
       controls.target.copy(boardLookTarget);
       controls.enableRotate = false;
       controls.enablePan = false;
@@ -8524,8 +8524,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       controls.maxPolarAngle = topDownPolar;
       controls.minAzimuthAngle = -Infinity;
       controls.maxAzimuthAngle = Infinity;
-      controls.minDistance = topDownDistance;
-      controls.maxDistance = topDownDistance;
+      controls.minDistance = min2dDistance;
+      controls.maxDistance = max2dDistance;
     } else {
       const saved = saved3dCameraStateRef.current;
       controls.enableRotate = false;
@@ -8615,51 +8615,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return kingToken.getWorldPosition(new THREE.Vector3());
   }, []);
 
-  const resolveFirearmRackDicePose = useCallback((playerIndex, captureAnimationId = null) => {
-    const arena = arenaRef.current;
-    const dice = diceRef.current;
-    const boardGroup = arena?.boardGroup;
-    if (!arena?.boardLookTarget || !dice?.userData || !boardGroup?.localToWorld) return null;
-    const railPositions = Array.isArray(dice.userData.railPositions) ? dice.userData.railPositions : [];
-    const layouts = Array.isArray(dice.userData.tokenRails) ? dice.userData.tokenRails : [];
-    const railLocal = railPositions[playerIndex]?.clone?.();
-    const layout = layouts[playerIndex];
-    if (!railLocal || !layout?.forward?.clone || !layout?.right?.clone) return null;
-
-    const railWorld = railLocal.clone();
-    boardGroup.localToWorld(railWorld);
-    railWorld.y = arena.tableInfo?.surfaceY ?? railWorld.y;
-
-    const forwardWorld = layout.forward.clone().setY(0);
-    const rightWorld = layout.right.clone().setY(0);
-    if (forwardWorld.lengthSq() < 1e-6 || rightWorld.lengthSq() < 1e-6) return null;
-    forwardWorld.normalize().transformDirection(boardGroup.matrixWorld).setY(0);
-    rightWorld.normalize().transformDirection(boardGroup.matrixWorld).setY(0);
-    if (forwardWorld.lengthSq() < 1e-6 || rightWorld.lengthSq() < 1e-6) return null;
-    forwardWorld.normalize();
-    rightWorld.normalize();
-
-    const isLargeFirearm = LARGE_RACK_FIREARM_IDS.has(captureAnimationId);
-    const sideOffset = FIREARM_RACK_DICE_SIDE_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA : 0);
-    const inwardOffset = FIREARM_RACK_DICE_INWARD_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA : 0);
-    const position = railWorld
-      .clone()
-      .addScaledVector(rightWorld, sideOffset)
-      .addScaledVector(forwardWorld, -inwardOffset);
-    position.y = (arena.tableInfo?.surfaceY ?? position.y) + 0.002;
-    return { position, aimTarget: railWorld.clone().addScaledVector(forwardWorld, -0.22) };
-  }, []);
-
   const resolveCaptureParkingAnchors = useCallback((playerIndex, vehicleType = 'fighter') => {
     const arena = arenaRef.current;
     if (!arena?.seatAnchors?.length || !arena.boardLookTarget) return null;
     const anchor = arena.seatAnchors[playerIndex];
     if (!anchor) return null;
-    if (vehicleType === 'firearmRack') {
-      const dicePose = resolveFirearmRackDicePose(playerIndex);
-      if (dicePose?.position?.isVector3) return dicePose.position;
-    }
     const seatPos = anchor.getWorldPosition(new THREE.Vector3());
+    // Park table weapons from the player's king/token anchor, matching the legacy tabletop
+    // layout instead of drifting them into the dice roll slot.
     const kingPos = getKingTokenPositionForPlayer(playerIndex) ?? seatPos;
     const inward = arena.boardLookTarget.clone().sub(kingPos).setY(0).normalize();
     if (inward.lengthSq() < 1e-6) return null;
@@ -8680,7 +8643,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       .addScaledVector(inward, -outwardOffset);
     park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.002;
     return park;
-  }, [getKingTokenPositionForPlayer, resolveFirearmRackDicePose]);
+  }, [getKingTokenPositionForPlayer]);
 
   const resolvePlayerLabel = useCallback(
     (playerIndex) => players[playerIndex]?.name || COLOR_NAMES[playerIndex] || `Player ${playerIndex + 1}`,
@@ -8711,25 +8674,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           ? FIREARM_RACK_PARKING_TUNING.large
           : FIREARM_RACK_PARKING_TUNING.small);
       const seatAdjustment = FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS[playerIndex] || FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS[0];
-      const dicePose = resolveFirearmRackDicePose(playerIndex, captureAnimationId);
-      const basePosition = dicePose?.position?.isVector3
-        ? dicePose.position.clone()
-        : kingPos
-            .clone()
-            .addScaledVector(rightSide, rackTuning.side + seatAdjustment.side)
-            .addScaledVector(inward, rackTuning.inward + seatAdjustment.inward)
-            .addScaledVector(inward, -rackTuning.outward);
+      // Keep refreshed firearms parked by the player token/king, as they were in the
+      // legacy tabletop layout, rather than snapping to the dice roll target.
+      const basePosition = kingPos
+        .clone()
+        .addScaledVector(rightSide, rackTuning.side + seatAdjustment.side)
+        .addScaledVector(inward, rackTuning.inward + seatAdjustment.inward)
+        .addScaledVector(inward, -rackTuning.outward);
       entry.weaponRack.position.copy(basePosition);
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       const firearmAimTarget =
-        dicePose?.aimTarget?.isVector3
-          ? dicePose.aimTarget
-          : resolveFirearmRackAimTarget(
-              arena,
-              playerIndex,
-              getKingTokenPositionForPlayer
-            ) ?? arena.boardLookTarget;
+        resolveFirearmRackAimTarget(
+          arena,
+          playerIndex,
+          getKingTokenPositionForPlayer
+        ) ?? arena.boardLookTarget;
       orientFirearmRackTowardBoardCenter(entry.weaponRack, firearmAimTarget);
       orientWeaponHolderTowardBoardCenter(entry, firearmAimTarget);
     };
@@ -8778,7 +8738,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
       }
     });
-  }, [aiLoadoutByPlayer, getKingTokenPositionForPlayer, resolveFirearmRackDicePose]);
+  }, [aiLoadoutByPlayer, getKingTokenPositionForPlayer]);
 
   const rebuildParkedCaptureVehicles = useCallback(async () => {
     const arena = arenaRef.current;


### PR DESCRIPTION
### Motivation

- Parked Ludo weapons were drifting into the dice-slot anchors instead of sitting on the tabletop beside the player token, so restore legacy table/token parking so parked firearms appear visually where expected.  
- The portrait gameplay camera needed to be slightly higher, a bit closer to the table, and pitched more downward to match the intended phone portrait framing.  
- The 2D (top-down) camera mode should behave like Snake & Ladder’s overhead view for consistent straight-down framing on mobile.

### Description

- Restored table/token parking by removing dice-slot anchoring for firearm racks and reverting rack placement to use the player king/token anchor (`resolveCaptureParkingAnchors` updated to base on `getKingTokenPositionForPlayer`).  
- Removed the `resolveFirearmRackDicePose` usage and related dice-offset constants so parked weapon racks no longer snap to the dice rail/layout.  
- Adjusted camera tuning constants for tighter portrait framing by updating `SEATED_FACE_CAMERA_GAMEPLAY_FORWARD`, `SEATED_FACE_CAMERA_GAMEPLAY_UP`, `SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN`, `PLAYER_VIEW_CAMERA_FORWARD_OFFSET_*`, and `PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_*`.  
- Reworked the 2D top-down behavior: added `CAMERA_2D_MIN_DISTANCE_FACTOR`, `CAMERA_2D_MAX_DISTANCE_FACTOR`, and `CAMERA_2D_TOPDOWN_POLAR`, and changed `applyCameraViewMode` to compute a spherical top-down offset and range clamping so the Ludo 2D view matches the Snake & Ladder overhead framing.

### Testing

- Ran lint for the modified file with `npm --prefix webapp run lint -- src/pages/Games/LudoBattleRoyal.jsx` and it completed successfully.  
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.  
- Attempted an automated Playwright screenshot to validate the portrait camera visually, but the headless browser failed to launch due to a missing native library (`libatk-1.0.so.0`) in the environment so no screenshot was captured; installing Playwright browsers completed successfully but the environment lacks required OS deps for headless Chromium here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283738b2dc832994c66fba094a74b6)