### PR TITLE
Align weapon animation orientation, adjust camera framing, and restore parked weapons

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -361,10 +361,6 @@ const FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS = Object.freeze([
   Object.freeze({ side: -0.012, inward: 0.052 }), // top
   Object.freeze({ side: -0.008, inward: 0.004 }) // left
 ]);
-const FIREARM_RACK_DICE_SIDE_OFFSET = 0.102;
-const FIREARM_RACK_DICE_INWARD_OFFSET = 0.018;
-const FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA = 0.036;
-const FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA = 0.012;
 const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
   0: 2,
   2: 0
@@ -1190,6 +1186,9 @@ const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
 const FIREARM_UNIFIED_DIRECTION_ROTATION =
   FIREARM_HAND_ATTACH_TUNING.assaultRifleAttack?.rotation ||
   FIREARM_HAND_ATTACH_TUNING.default.rotation;
+const FIREARM_ANIMATION_ORIENTATION_ROTATION =
+  FIREARM_HAND_ATTACH_TUNING.smgBurstAttack?.rotation ||
+  FIREARM_UNIFIED_DIRECTION_ROTATION;
 const FIREARM_ATTACH_WORLD_SCALE_BOOST = 1.18;
 const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   // Keep glock as the grip-size baseline and upscale all other firearms so
@@ -1992,7 +1991,9 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
   const weapon = modelTemplate.clone(true);
   const readyGripOffset = new THREE.Vector3(...(tuning.gripOffset || tuning.position || FIREARM_HAND_ATTACH_TUNING.default.position));
   weapon.position.copy(readyGripOffset);
-  weapon.rotation.set(...(tuning.rotation || FIREARM_UNIFIED_DIRECTION_ROTATION));
+  // Use the SMG burst hand pose as the shared visual orientation baseline so
+  // every firearm points/twists the same way during capture animations.
+  weapon.rotation.set(...FIREARM_ANIMATION_ORIENTATION_ROTATION);
   const attachScaleMultiplier = FIREARM_ATTACH_SCALE_MULTIPLIER[captureAnimationId] ?? 1;
   const scaleBoost =
     FIREARM_ATTACH_WORLD_SCALE_BOOST * attachScaleMultiplier;
@@ -2039,7 +2040,9 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
     twoHanded,
     gripProfile,
     muzzleForward: new THREE.Vector3(...(FIREARM_MUZZLE_FORWARD_BY_ID[captureAnimationId] || FIREARM_MUZZLE_FORWARD_BY_ID.default)),
-    aimRollRad: FIREARM_AIM_ROLL_BY_PROFILE[gripProfile] ?? FIREARM_AIM_ROLL_BY_PROFILE.default,
+    // Keep the final aim roll matched to SMG burst too; this avoids each
+    // weapon profile twisting to a different visual orientation mid-animation.
+    aimRollRad: FIREARM_AIM_ROLL_BY_PROFILE.smg ?? FIREARM_AIM_ROLL_BY_PROFILE.default,
     release: () => {
       const mixer = weapon.userData?.captureWeaponMixer;
       if (mixer && weaponMixers?.delete) {
@@ -4375,11 +4378,11 @@ const SEATED_HELPER_FACE_CAMERA_UP = 0.146 * MODEL_SCALE;
 const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.072 * MODEL_SCALE;
 // The bottom-seat gameplay camera is intentionally raised and pushed farther toward the table so
 // portrait players see over the local avatar and closer into the Ludo board/action area.
-const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.31 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.335 * MODEL_SCALE;
 // Lift the human player's locked first-person camera higher so portrait gameplay has a clearer
-// over-the-shoulder view of the dice, tokens, and board instead of sitting too low near the face.
-const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.66 * MODEL_SCALE;
-const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.32 * MODEL_SCALE;
+// over-the-table view of the dice, tokens, and board while staying only slightly closer.
+const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.72 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.37 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 9;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.34;
 const SEATED_CONTACT_DICE_Y_OFFSET = 0.005;
@@ -4458,9 +4461,9 @@ const LUDO_CAMERA_PHI_MAX = 1.14;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.18;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.26;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 2.3;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 2.34;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.98;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.2;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.28;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.9;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT = 0.42 * MODEL_SCALE;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_LANDSCAPE = 0.2 * MODEL_SCALE;
@@ -4475,7 +4478,7 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT,
   forwardOffset: PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT,
   heightOffset: PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT,
-  targetLift: 0.06 * MODEL_SCALE
+  targetLift: 0.03 * MODEL_SCALE
 });
 const CAMERA_EXTRA_PULLBACK = 0.1;
 const CAMERA_EXTRA_LIFT = 0.2;
@@ -5798,8 +5801,11 @@ const CAM = {
   phiMin: LUDO_CAMERA_PHI_MIN,
   phiMax: LUDO_CAMERA_PHI_MAX
 };
-const CAMERA_2D_DISTANCE_FACTOR = 1.08;
-const CAMERA_2D_MAX_DISTANCE_FACTOR = 1.32;
+const CAMERA_2D_TOPDOWN_MIN_POLAR = THREE.MathUtils.degToRad(2);
+const CAMERA_2D_TOPDOWN_MAX_POLAR = THREE.MathUtils.degToRad(18);
+const CAMERA_2D_DISTANCE_FACTOR = 2.56;
+const CAMERA_2D_MIN_DISTANCE_FACTOR = 1.2;
+const CAMERA_2D_MAX_DISTANCE_FACTOR = 4.7;
 const CAMERA_3D_VERTICAL_DROP = 0;
 const CAMERA_3D_HEIGHT_BOOST = 0.26 * MODEL_SCALE;
 const CAMERA_LOOKDOWN_TARGET_OFFSET = 0.062 * MODEL_SCALE;
@@ -8492,7 +8498,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const boardLookTarget = boardLookTargetRef.current;
     if (!camera || !controls || !boardLookTarget) return;
 
-    const topDownPolar = 0.001;
     if (nextIs2d) {
       if (!saved3dCameraStateRef.current) {
         saved3dCameraStateRef.current = {
@@ -8513,19 +8518,27 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       cancelCameraViewAnimation();
       cameraTurnStateRef.current.activePriority = -Infinity;
       cameraTurnStateRef.current.followObject = null;
-      const max2dDistance = CAM.maxR * CAMERA_2D_MAX_DISTANCE_FACTOR;
-      const topDownDistance = clamp(CAM.maxR * CAMERA_2D_DISTANCE_FACTOR, CAM.minR, max2dDistance);
-      camera.position.set(boardLookTarget.x, boardLookTarget.y + topDownDistance, boardLookTarget.z + 0.001);
-      controls.target.copy(boardLookTarget);
+      const topDownTarget = boardLookTarget.clone();
+      topDownTarget.y = arenaRef.current?.tableInfo?.surfaceY ?? boardLookTarget.y;
+      const min2dDistance = CAMERA_BASE_RADIUS * CAMERA_2D_MIN_DISTANCE_FACTOR;
+      const max2dDistance = CAMERA_BASE_RADIUS * CAMERA_2D_MAX_DISTANCE_FACTOR;
+      const topDownDistance = clamp(CAMERA_BASE_RADIUS * CAMERA_2D_DISTANCE_FACTOR, min2dDistance, max2dDistance);
+      const topDownOffset = new THREE.Vector3(0, topDownDistance, 0.0001);
+      const spherical = new THREE.Spherical().setFromVector3(topDownOffset);
+      spherical.radius = topDownDistance;
+      spherical.phi = clamp(spherical.phi, CAMERA_2D_TOPDOWN_MIN_POLAR, CAMERA_2D_TOPDOWN_MAX_POLAR);
+      camera.position.copy(topDownTarget).add(new THREE.Vector3().setFromSpherical(spherical));
+      controls.target.copy(topDownTarget);
       controls.enableRotate = false;
       controls.enablePan = false;
       controls.enableZoom = false;
-      controls.minPolarAngle = topDownPolar;
-      controls.maxPolarAngle = topDownPolar;
-      controls.minAzimuthAngle = -Infinity;
-      controls.maxAzimuthAngle = Infinity;
-      controls.minDistance = topDownDistance;
-      controls.maxDistance = topDownDistance;
+      controls.minPolarAngle = CAMERA_2D_TOPDOWN_MIN_POLAR;
+      controls.maxPolarAngle = CAMERA_2D_TOPDOWN_MAX_POLAR;
+      const lockedAzimuth = controls.getAzimuthalAngle();
+      controls.minAzimuthAngle = lockedAzimuth;
+      controls.maxAzimuthAngle = lockedAzimuth;
+      controls.minDistance = min2dDistance;
+      controls.maxDistance = max2dDistance;
     } else {
       const saved = saved3dCameraStateRef.current;
       controls.enableRotate = false;
@@ -8615,50 +8628,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return kingToken.getWorldPosition(new THREE.Vector3());
   }, []);
 
-  const resolveFirearmRackDicePose = useCallback((playerIndex, captureAnimationId = null) => {
-    const arena = arenaRef.current;
-    const dice = diceRef.current;
-    const boardGroup = arena?.boardGroup;
-    if (!arena?.boardLookTarget || !dice?.userData || !boardGroup?.localToWorld) return null;
-    const railPositions = Array.isArray(dice.userData.railPositions) ? dice.userData.railPositions : [];
-    const layouts = Array.isArray(dice.userData.tokenRails) ? dice.userData.tokenRails : [];
-    const railLocal = railPositions[playerIndex]?.clone?.();
-    const layout = layouts[playerIndex];
-    if (!railLocal || !layout?.forward?.clone || !layout?.right?.clone) return null;
-
-    const railWorld = railLocal.clone();
-    boardGroup.localToWorld(railWorld);
-    railWorld.y = arena.tableInfo?.surfaceY ?? railWorld.y;
-
-    const forwardWorld = layout.forward.clone().setY(0);
-    const rightWorld = layout.right.clone().setY(0);
-    if (forwardWorld.lengthSq() < 1e-6 || rightWorld.lengthSq() < 1e-6) return null;
-    forwardWorld.normalize().transformDirection(boardGroup.matrixWorld).setY(0);
-    rightWorld.normalize().transformDirection(boardGroup.matrixWorld).setY(0);
-    if (forwardWorld.lengthSq() < 1e-6 || rightWorld.lengthSq() < 1e-6) return null;
-    forwardWorld.normalize();
-    rightWorld.normalize();
-
-    const isLargeFirearm = LARGE_RACK_FIREARM_IDS.has(captureAnimationId);
-    const sideOffset = FIREARM_RACK_DICE_SIDE_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA : 0);
-    const inwardOffset = FIREARM_RACK_DICE_INWARD_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA : 0);
-    const position = railWorld
-      .clone()
-      .addScaledVector(rightWorld, sideOffset)
-      .addScaledVector(forwardWorld, -inwardOffset);
-    position.y = (arena.tableInfo?.surfaceY ?? position.y) + 0.002;
-    return { position, aimTarget: railWorld.clone().addScaledVector(forwardWorld, -0.22) };
-  }, []);
-
   const resolveCaptureParkingAnchors = useCallback((playerIndex, vehicleType = 'fighter') => {
     const arena = arenaRef.current;
     if (!arena?.seatAnchors?.length || !arena.boardLookTarget) return null;
     const anchor = arena.seatAnchors[playerIndex];
     if (!anchor) return null;
-    if (vehicleType === 'firearmRack') {
-      const dicePose = resolveFirearmRackDicePose(playerIndex);
-      if (dicePose?.position?.isVector3) return dicePose.position;
-    }
     const seatPos = anchor.getWorldPosition(new THREE.Vector3());
     const kingPos = getKingTokenPositionForPlayer(playerIndex) ?? seatPos;
     const inward = arena.boardLookTarget.clone().sub(kingPos).setY(0).normalize();
@@ -8680,7 +8654,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       .addScaledVector(inward, -outwardOffset);
     park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.002;
     return park;
-  }, [getKingTokenPositionForPlayer, resolveFirearmRackDicePose]);
+  }, [getKingTokenPositionForPlayer]);
 
   const resolvePlayerLabel = useCallback(
     (playerIndex) => players[playerIndex]?.name || COLOR_NAMES[playerIndex] || `Player ${playerIndex + 1}`,
@@ -8711,25 +8685,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           ? FIREARM_RACK_PARKING_TUNING.large
           : FIREARM_RACK_PARKING_TUNING.small);
       const seatAdjustment = FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS[playerIndex] || FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS[0];
-      const dicePose = resolveFirearmRackDicePose(playerIndex, captureAnimationId);
-      const basePosition = dicePose?.position?.isVector3
-        ? dicePose.position.clone()
-        : kingPos
-            .clone()
-            .addScaledVector(rightSide, rackTuning.side + seatAdjustment.side)
-            .addScaledVector(inward, rackTuning.inward + seatAdjustment.inward)
-            .addScaledVector(inward, -rackTuning.outward);
+      const basePosition = kingPos
+        .clone()
+        .addScaledVector(rightSide, rackTuning.side + seatAdjustment.side)
+        .addScaledVector(inward, rackTuning.inward + seatAdjustment.inward)
+        .addScaledVector(inward, -rackTuning.outward);
       entry.weaponRack.position.copy(basePosition);
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       const firearmAimTarget =
-        dicePose?.aimTarget?.isVector3
-          ? dicePose.aimTarget
-          : resolveFirearmRackAimTarget(
-              arena,
-              playerIndex,
-              getKingTokenPositionForPlayer
-            ) ?? arena.boardLookTarget;
+        resolveFirearmRackAimTarget(
+          arena,
+          playerIndex,
+          getKingTokenPositionForPlayer
+        ) ?? arena.boardLookTarget;
       orientFirearmRackTowardBoardCenter(entry.weaponRack, firearmAimTarget);
       orientWeaponHolderTowardBoardCenter(entry, firearmAimTarget);
     };
@@ -8778,7 +8747,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
       }
     });
-  }, [aiLoadoutByPlayer, getKingTokenPositionForPlayer, resolveFirearmRackDicePose]);
+  }, [aiLoadoutByPlayer, getKingTokenPositionForPlayer]);
 
   const rebuildParkedCaptureVehicles = useCallback(async () => {
     const arena = arenaRef.current;


### PR DESCRIPTION
### Motivation
- Ensure all weapon capture animations share the same visual orientation as the SMG burst so weapons don't twist differently during animations.  
- Improve portrait camera framing by moving it slightly higher and a bit closer to the table for clearer over-table gameplay.  
- Restore parked weapons to the table/king-token anchors so parked firearms are visible again as in the May 9 snapshot.  
- Stabilize 2D/top-down framing so the table remains well-centered and at predictable polar/distance bounds.

### Description
- Added a shared orientation baseline `FIREARM_ANIMATION_ORIENTATION_ROTATION` (derived from `smgBurstAttack`) and apply it when attaching weapons to the right hand so all weapons use the SMG burst hand pose during capture animations (`attachFirearmToRightHand`).
- Force a consistent aim roll by using the SMG aim roll for final aim (`aimRollRad: FIREARM_AIM_ROLL_BY_PROFILE.smg`) to avoid per-weapon roll drift mid-animation.
- Raised and tightened portrait camera tuning values (`SEATED_FACE_CAMERA_GAMEPLAY_FORWARD`, `SEATED_FACE_CAMERA_GAMEPLAY_UP`, `SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN`, `PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT`, `PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT`, and portrait `targetLift`) to sit slightly higher and a touch closer to the table.
- Restored parked firearm placement to use king-token/table anchors (removed the fallback dice-rail pose) and preserved May 9 display/parking tuning (`MAY_9_TABLE_FIREARM_DISPLAY_TUNING_BY_ID` / `MAY_9_TABLE_FIREARM_PARKING_TUNING_BY_ID`) so parked weapons appear on the table as before.
- Improved top-down/2D camera handling by adding explicit polar and distance bounds (`CAMERA_2D_TOPDOWN_MIN_POLAR`, `CAMERA_2D_TOPDOWN_MAX_POLAR`, `CAMERA_2D_MIN_DISTANCE_FACTOR`, `CAMERA_2D_MAX_DISTANCE_FACTOR`) and computing a spherical camera placement to keep the board framed consistently.

### Testing
- Ran lint on the modified file with `npm --prefix webapp run lint -- src/pages/Games/LudoBattleRoyal.jsx` and it completed successfully.  
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.  
- Installed Playwright browser dependencies (`npx playwright install-deps chromium`) and executed a Playwright mobile smoke screenshot of `/games/ludobattleroyal?players=4&ai=3`; the screenshot run completed but the local preview environment logged external model/texture network and certificate fetch failures so some remote assets did not load (environment-limited failure, not code errors).  
- No automated unit tests were modified; only lint/build/smoke preview were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a284c57f3d083298944ac3a3079d640)