### PR TITLE
Adjust Murlan Royale portrait camera angle

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3148,7 +3148,7 @@ const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({
   landscape: 0.62
 });
 const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({
-  portrait: 2.22,
+  portrait: 2.14,
   landscape: 0.96
 });
 const CAMERA_LOOK_VERTICAL_ALLOWANCE = Object.freeze({
@@ -3156,7 +3156,7 @@ const CAMERA_LOOK_VERTICAL_ALLOWANCE = Object.freeze({
   landscape: { up: THREE.MathUtils.degToRad(7), down: THREE.MathUtils.degToRad(4) }
 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
-const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
+const CAMERA_FOCUS_CENTER_LIFT = 0.145 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.36 * MODEL_SCALE;
 const CAMERA_SCREEN_DOWN_SHIFT = Object.freeze({
   portrait: 0.19 * MODEL_SCALE,


### PR DESCRIPTION
### Motivation
- Tweak the portrait camera framing for the Murlan Royale arena so the camera sits slightly lower and the focal look is a bit higher, improving the visual composition on phone portrait screens.

### Description
- Lowered the portrait seated camera elevation by changing `CAMERA_SEATED_ELEVATION_OFFSETS.portrait` from `2.22` to `2.14` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Raised the camera focus so the view looks slightly more upward by increasing `CAMERA_FOCUS_CENTER_LIFT` from `0.1 * MODEL_SCALE` to `0.145 * MODEL_SCALE` in the same file.

### Testing
- Ran lint on the modified file with `npm --prefix webapp run lint -- src/pages/Games/MurlanRoyaleArena.jsx` (passed).
- Built the webapp with `npm --prefix webapp run build` (production build completed successfully).
- Installed Playwright browsers with `npx playwright install chromium` (download completed), and attempted an automated Playwright screenshot run, but Chromium could not be launched in this environment due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28542349308329bfddd514343904f0)