### PR TITLE
Fix Pool Royale cue forward stroke

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24901,13 +24901,14 @@ const shotPowerRef = useRef(0);
             const safeHoldDuration = Math.max(0, holdDuration ?? 45);
             const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
             const resolvedIdlePos = idlePos ?? impactPos ?? stroke.contactPos ?? pullPos;
+            const desiredContactPos = stroke.contactPos ?? impactPos ?? resolvedIdlePos ?? pullPos;
             const normalizedStroke = ensureCueStrokeForwardMotion({
               pullPos: pullPos ?? resolvedIdlePos,
-              impactPos: resolvedIdlePos ?? pullPos,
+              impactPos: desiredContactPos ?? resolvedIdlePos ?? pullPos,
               fallbackDirection: tmpCueStrokeB.set(Math.sin(baseRotationY ?? 0), 0, Math.cos(baseRotationY ?? 0))
             });
             const resolvedPullPos = normalizedStroke.pullPos ?? pullPos ?? resolvedIdlePos;
-            const resolvedContactPos = resolvedIdlePos ?? stroke.contactPos ?? impactPos ?? pullPos;
+            const resolvedContactPos = normalizedStroke.impactPos ?? desiredContactPos ?? resolvedIdlePos ?? pullPos;
             const strikeProgress = THREE.MathUtils.clamp(
               elapsed / Math.max(safeStrikeDuration, 1e-6),
               0,
@@ -24941,7 +24942,7 @@ const shotPowerRef = useRef(0);
             if (recoverT < 1) {
               cueStick.position.lerpVectors(
                 resolvedContactPos,
-                resolvedIdlePos ?? impactPos ?? pullPos,
+                resolvedIdlePos ?? pullPos ?? impactPos,
                 easeInOutCubic(recoverT)
               );
               cueAnimating = true;
@@ -29573,7 +29574,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29674,16 +29674,31 @@ const shotPowerRef = useRef(0);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = 0;
           const startTime = performance.now();
-          const impactPos = idlePos.clone();
-          const contactAdvance = 0; // push forward only to the original idle pose where the slider pull began
+          // Match Snooker Royal: after the slider pullback, drive the tip forward
+          // through the original address gap so the cue visibly pushes into the cue ball.
+          const impactPush = THREE.MathUtils.clamp(
+            CUE_TIP_GAP - BALL_R * 0.9,
+            BALL_R * 0.16,
+            BALL_R * 0.38
+          );
+          const impactPos = buildCuePosition(-impactPush);
+          const contactAdvance = impactPush;
           shotImpactPayload.contactAdvance = contactAdvance;
-          const contactPos = impactPos
-            .clone()
-            .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
+          const contactPos = impactPos.clone();
+          const forwardDir = tmpCueStrokeA.copy(impactPos).sub(releaseStartPos);
+          if (forwardDir.lengthSq() > 1e-8) {
+            forwardDir.normalize();
+          } else {
+            forwardDir.copy(dir);
+          }
+          const followDistance = THREE.MathUtils.lerp(
+            BALL_R * 0.26,
+            BALL_R * 0.72,
+            clampedPower
+          );
           const followPos = contactPos
             .clone()
-            .addScaledVector(dir, followDistance);
+            .addScaledVector(forwardDir, followDistance);
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =


### PR DESCRIPTION
### Motivation
- Pool Royale's visible cue animation was not matching SnookerRoyal: the cue sometimes did not visibly push forward and physics could be applied before the forward animation reached impact, reducing visual clarity.

### Description
- Use the intended contact/impact point for forward-only strokes by preferring an explicit contact position when resolving forward motion and pass that to `ensureCueStrokeForwardMotion` so the cue drives to the actual contact point instead of snapping to the idle pose (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Defer applying shot physics until the animated stroke reaches its impact threshold by removing the early `applyShotAtImpact` invocation and relying on the stroke's `onImpact`/`shotApplied` logic to trigger impact when `strikeProgress` crosses the threshold.
- Match Snooker Royal visual behavior for slider-triggered releases by computing an `impactPush`, building an `impactPos` via `buildCuePosition(-impactPush)`, setting `contactAdvance` accordingly, and adding a power-scaled forward/follow direction so the cue tip visibly pushes through the address gap and produces a readable follow-through and replay stroke.
- Minor recover/lerp ordering tweaks to ensure the cue recovers toward the appropriate positions after impact.

### Testing
- Ran `npm --prefix webapp run lint -- src/pages/Games/PoolRoyale.jsx` and it completed without errors.
- Ran `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28687085f88329995cafcf0c390d45)