### PR TITLE
Restore Ludo firearm rack table parking and add regression test

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -266,6 +266,19 @@ describe('cross-game inventory alignment', () => {
     expect(source).toContain('}, DICE_RESULT_CAMERA_HOLD_MS);');
   });
 
+  test('ludo battle royal parks firearm racks on dice rail table slots', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('const FIREARM_RACK_DICE_SIDE_OFFSET = 0.102');
+    expect(source).toContain('const FIREARM_RACK_DICE_INWARD_OFFSET = 0.018');
+    expect(source).toContain('const resolveFirearmRackDicePose = useCallback');
+    expect(source).toContain('dice.userData.railPositions');
+    expect(source).toContain('dice.userData.tokenRails');
+    expect(source).toContain("if (vehicleType === 'firearmRack')");
+    expect(source).toContain('const dicePose = resolveFirearmRackDicePose(playerIndex, captureAnimationId);');
+    expect(source).toContain('dicePose?.aimTarget?.isVector3');
+  });
+
   test('ludo battle royal preserves source-authored materials for non-Gunify weapons', async () => {
     const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
 

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -361,6 +361,13 @@ const FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS = Object.freeze([
   Object.freeze({ side: -0.012, inward: 0.052 }), // top
   Object.freeze({ side: -0.008, inward: 0.004 }) // left
 ]);
+// Legacy tabletop parking: keep firearms on the same dice/token rail slots used by
+// Snake & Ladder so portrait players see the weapons parked on the table instead
+// of drifting back to the seated hands or token center.
+const FIREARM_RACK_DICE_SIDE_OFFSET = 0.102;
+const FIREARM_RACK_DICE_INWARD_OFFSET = 0.018;
+const FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA = 0.036;
+const FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA = 0.012;
 const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
   0: 2,
   2: 0
@@ -8628,11 +8635,50 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return kingToken.getWorldPosition(new THREE.Vector3());
   }, []);
 
+  const resolveFirearmRackDicePose = useCallback((playerIndex, captureAnimationId = null) => {
+    const arena = arenaRef.current;
+    const dice = diceRef.current;
+    const boardGroup = arena?.boardGroup;
+    if (!arena?.boardLookTarget || !dice?.userData || !boardGroup?.localToWorld) return null;
+    const railPositions = Array.isArray(dice.userData.railPositions) ? dice.userData.railPositions : [];
+    const layouts = Array.isArray(dice.userData.tokenRails) ? dice.userData.tokenRails : [];
+    const railLocal = railPositions[playerIndex]?.clone?.();
+    const layout = layouts[playerIndex];
+    if (!railLocal || !layout?.forward?.clone || !layout?.right?.clone) return null;
+
+    const railWorld = railLocal.clone();
+    boardGroup.localToWorld(railWorld);
+    railWorld.y = arena.tableInfo?.surfaceY ?? railWorld.y;
+
+    const forwardWorld = layout.forward.clone().setY(0);
+    const rightWorld = layout.right.clone().setY(0);
+    if (forwardWorld.lengthSq() < 1e-6 || rightWorld.lengthSq() < 1e-6) return null;
+    forwardWorld.normalize().transformDirection(boardGroup.matrixWorld).setY(0);
+    rightWorld.normalize().transformDirection(boardGroup.matrixWorld).setY(0);
+    if (forwardWorld.lengthSq() < 1e-6 || rightWorld.lengthSq() < 1e-6) return null;
+    forwardWorld.normalize();
+    rightWorld.normalize();
+
+    const isLargeFirearm = LARGE_RACK_FIREARM_IDS.has(captureAnimationId);
+    const sideOffset = FIREARM_RACK_DICE_SIDE_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA : 0);
+    const inwardOffset = FIREARM_RACK_DICE_INWARD_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA : 0);
+    const position = railWorld
+      .clone()
+      .addScaledVector(rightWorld, sideOffset)
+      .addScaledVector(forwardWorld, -inwardOffset);
+    position.y = (arena.tableInfo?.surfaceY ?? position.y) + 0.002;
+    return { position, aimTarget: railWorld.clone().addScaledVector(forwardWorld, -0.22) };
+  }, []);
+
   const resolveCaptureParkingAnchors = useCallback((playerIndex, vehicleType = 'fighter') => {
     const arena = arenaRef.current;
     if (!arena?.seatAnchors?.length || !arena.boardLookTarget) return null;
     const anchor = arena.seatAnchors[playerIndex];
     if (!anchor) return null;
+    if (vehicleType === 'firearmRack') {
+      const dicePose = resolveFirearmRackDicePose(playerIndex);
+      if (dicePose?.position?.isVector3) return dicePose.position;
+    }
     const seatPos = anchor.getWorldPosition(new THREE.Vector3());
     const kingPos = getKingTokenPositionForPlayer(playerIndex) ?? seatPos;
     const inward = arena.boardLookTarget.clone().sub(kingPos).setY(0).normalize();
@@ -8654,7 +8700,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       .addScaledVector(inward, -outwardOffset);
     park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.002;
     return park;
-  }, [getKingTokenPositionForPlayer]);
+  }, [getKingTokenPositionForPlayer, resolveFirearmRackDicePose]);
 
   const resolvePlayerLabel = useCallback(
     (playerIndex) => players[playerIndex]?.name || COLOR_NAMES[playerIndex] || `Player ${playerIndex + 1}`,
@@ -8685,20 +8731,25 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           ? FIREARM_RACK_PARKING_TUNING.large
           : FIREARM_RACK_PARKING_TUNING.small);
       const seatAdjustment = FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS[playerIndex] || FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS[0];
-      const basePosition = kingPos
-        .clone()
-        .addScaledVector(rightSide, rackTuning.side + seatAdjustment.side)
-        .addScaledVector(inward, rackTuning.inward + seatAdjustment.inward)
-        .addScaledVector(inward, -rackTuning.outward);
+      const dicePose = resolveFirearmRackDicePose(playerIndex, captureAnimationId);
+      const basePosition = dicePose?.position?.isVector3
+        ? dicePose.position.clone()
+        : kingPos
+            .clone()
+            .addScaledVector(rightSide, rackTuning.side + seatAdjustment.side)
+            .addScaledVector(inward, rackTuning.inward + seatAdjustment.inward)
+            .addScaledVector(inward, -rackTuning.outward);
       entry.weaponRack.position.copy(basePosition);
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       const firearmAimTarget =
-        resolveFirearmRackAimTarget(
-          arena,
-          playerIndex,
-          getKingTokenPositionForPlayer
-        ) ?? arena.boardLookTarget;
+        dicePose?.aimTarget?.isVector3
+          ? dicePose.aimTarget
+          : resolveFirearmRackAimTarget(
+              arena,
+              playerIndex,
+              getKingTokenPositionForPlayer
+            ) ?? arena.boardLookTarget;
       orientFirearmRackTowardBoardCenter(entry.weaponRack, firearmAimTarget);
       orientWeaponHolderTowardBoardCenter(entry, firearmAimTarget);
     };
@@ -8747,7 +8798,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
       }
     });
-  }, [aiLoadoutByPlayer, getKingTokenPositionForPlayer]);
+  }, [aiLoadoutByPlayer, getKingTokenPositionForPlayer, resolveFirearmRackDicePose]);
 
   const rebuildParkedCaptureVehicles = useCallback(async () => {
     const arena = arenaRef.current;


### PR DESCRIPTION
### Motivation
- Parked firearms in Ludo Battle Royal were drifting from the tabletop slots back toward seated hands/token centers in portrait view, diverging from the intended Snake & Ladder / legacy tabletop presentation.
- Restore the legacy dice/token-rail parking so selected firearm racks sit on the table in the same visual slots used by the dice/token rails.

### Description
- Reintroduced legacy tabletop parking offsets (`FIREARM_RACK_DICE_SIDE_OFFSET`, `FIREARM_RACK_DICE_INWARD_OFFSET`, and long-gun extras). 
- Added `resolveFirearmRackDicePose` (a `useCallback`) to compute dice-rail-derived world `position` and `aimTarget` using `dice.userData.railPositions` and `dice.userData.tokenRails` when available.
- Updated `resolveCaptureParkingAnchors` to return the dice-rail pose for `vehicleType === 'firearmRack'` (king-relative fallback preserved).
- Updated parked-rack refresh logic (`updateParkedCaptureVehicleVisibility` / rack placement) to prefer the dice-derived position/aim target and to fall back to the previous king-relative rack tuning when rail data is unavailable.
- Added a focused regression test `ludo battle royal parks firearm racks on dice rail table slots` to `test/inventoryCrossGameConfig.test.js` that asserts presence of the new offsets and dice-rail pose logic.

### Testing
- Ran the focused regression test with `npm test -- --runInBand test/inventoryCrossGameConfig.test.js -t "ludo battle royal parks firearm racks"` and it passed.
- Ran the entire `test/inventoryCrossGameConfig.test.js` file and observed unrelated pre-existing expectations failing elsewhere in the file; the new parking test still passes inside the suite.
- Executed local automated checks (`jest` for the targeted test and related assertions); the parking change and added test behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e696ba948329af7f59c05771dc9a)