### PR TITLE
Fix Pool Royale cue stroke follow-through

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24901,13 +24901,15 @@ const shotPowerRef = useRef(0);
             const safeHoldDuration = Math.max(0, holdDuration ?? 45);
             const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
             const resolvedIdlePos = idlePos ?? impactPos ?? stroke.contactPos ?? pullPos;
+            const resolvedImpactPos = impactPos ?? stroke.contactPos ?? resolvedIdlePos ?? pullPos;
             const normalizedStroke = ensureCueStrokeForwardMotion({
               pullPos: pullPos ?? resolvedIdlePos,
-              impactPos: resolvedIdlePos ?? pullPos,
+              impactPos: resolvedImpactPos ?? resolvedIdlePos ?? pullPos,
               fallbackDirection: tmpCueStrokeB.set(Math.sin(baseRotationY ?? 0), 0, Math.cos(baseRotationY ?? 0))
             });
             const resolvedPullPos = normalizedStroke.pullPos ?? pullPos ?? resolvedIdlePos;
-            const resolvedContactPos = resolvedIdlePos ?? stroke.contactPos ?? impactPos ?? pullPos;
+            const resolvedContactPos = stroke.contactPos ?? resolvedImpactPos ?? resolvedIdlePos ?? pullPos;
+            const resolvedFollowPos = followPos ?? resolvedContactPos;
             const strikeProgress = THREE.MathUtils.clamp(
               elapsed / Math.max(safeStrikeDuration, 1e-6),
               0,
@@ -24928,7 +24930,22 @@ const shotPowerRef = useRef(0);
               stroke.onImpact?.();
             }
 
+            if (elapsed < safeStrikeDuration) {
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
             if (elapsed < safeStrikeDuration + safeHoldDuration) {
+              const holdT = THREE.MathUtils.clamp(
+                (elapsed - safeStrikeDuration) / Math.max(safeHoldDuration, 1e-6),
+                0,
+                1
+              );
+              cueStick.position.lerpVectors(
+                resolvedContactPos,
+                resolvedFollowPos,
+                easeInOutCubic(holdT)
+              );
               cueAnimating = true;
               syncCueShadow();
               return true;
@@ -24940,7 +24957,7 @@ const shotPowerRef = useRef(0);
             );
             if (recoverT < 1) {
               cueStick.position.lerpVectors(
-                resolvedContactPos,
+                resolvedFollowPos,
                 resolvedIdlePos ?? impactPos ?? pullPos,
                 easeInOutCubic(recoverT)
               );
@@ -28890,7 +28907,7 @@ const shotPowerRef = useRef(0);
         const holdDuration = THREE.MathUtils.lerp(40, 68, p);
         return {
           // Snooker Royal-style live stroke: slider pull maps directly to cue pullback,
-          // then release performs one forward push back to the original cue-start pose.
+          // then release performs one forward push through cue-ball contact.
           motion: 'classic',
           pullRatio: p,
           pullSmoothing: 1,
@@ -29674,16 +29691,31 @@ const shotPowerRef = useRef(0);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = 0;
           const startTime = performance.now();
-          const impactPos = idlePos.clone();
-          const contactAdvance = 0; // push forward only to the original idle pose where the slider pull began
-          shotImpactPayload.contactAdvance = contactAdvance;
-          const contactPos = impactPos
-            .clone()
-            .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
+          // Match Snooker Royal's visible strike: after releasing from the pulled
+          // position, drive the tip past the original address gap so it reads as
+          // a forward push into the cue ball on portrait mobile screens.
+          const impactPush = THREE.MathUtils.clamp(
+            CUE_TIP_GAP - BALL_R * 0.9,
+            BALL_R * 0.16,
+            BALL_R * 0.38
+          );
+          const impactPos = buildCuePosition(-impactPush);
+          shotImpactPayload.contactAdvance = impactPush;
+          const contactPos = impactPos.clone();
+          const followDir = impactPos.clone().sub(releaseStartPos);
+          if (followDir.lengthSq() > 1e-8) {
+            followDir.normalize();
+          } else {
+            followDir.copy(dir);
+          }
+          const followDistance = THREE.MathUtils.lerp(
+            CUE_FOLLOW_THROUGH_MIN,
+            CUE_FOLLOW_THROUGH_MAX,
+            clampedPower
+          );
           const followPos = contactPos
             .clone()
-            .addScaledVector(dir, followDistance);
+            .addScaledVector(followDir, followDistance);
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =
@@ -29808,8 +29840,8 @@ const shotPowerRef = useRef(0);
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
               strikeImpactThreshold: 0.9,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
-              // Match Snooker Royal's release: push from the pulled pose and
-              // stop exactly at the cue's original idle/contact pose.
+              // Match Snooker Royal's release: push from the pulled pose
+              // through cue-ball contact, then hold the forward follow-through.
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,


### PR DESCRIPTION
### Motivation
- The Pool Royale cue remained visually pulled back after firing and did not show a forward push/follow-through like Snooker, making shots read weak and inconsistent with cue-ball power.
- The goal was to match Snooker Royal’s visible forward motion while preserving the existing impulse applied to the cue ball so shot power is unaffected.

### Description
- Updated the forward-only cue stroke logic in `webapp/src/pages/Games/PoolRoyale.jsx` to resolve an explicit impact position and a `resolvedFollowPos`, and to drive the tip from the pulled pose through the contact point instead of stopping at the pulled/contact pose. (`resolvedImpactPos`, `resolvedContactPos`, `resolvedFollowPos`).
- Added a power-scaled visible impact advance (`impactPush`) and follow-through vector so strong shots visibly push the cue further forward; this value is written into the shot payload as `shotImpactPayload.contactAdvance` so physics/launch remain consistent.
- Adjusted the forward-only timeline to separate the strike window and the follow/hold window so the cue visibly advances during the strike and then holds into follow-through before recovering.
- Kept the existing cue-ball launch path (`applyShotAtImpact`) unchanged so the cue velocity/spin calculation still controls actual cue-ball `vel`/`spin` and `omega` application.

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js`, all tests passed (4/4).
- Built the web app: `npm --prefix webapp run build`, build completed successfully and assets were produced.
- Installed Playwright and system deps: `npx playwright install chromium` and `npx playwright install-deps chromium` completed successfully.
- Attempted a Playwright smoke render and screenshot of `/games/poolroyale?mode=training`; a screenshot was saved to `/tmp/pool-royale-cue-stroke.png` but the page logged several runtime/network errors (local asset/TonConnect fetch / cert issues), so visual QA beyond the smoke shot was impeded by local runtime connectivity issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28eab547388329a188696ddceff2a7)