### PR TITLE
Restore Ludo table weapon parking

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -361,10 +361,6 @@ const FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS = Object.freeze([
   Object.freeze({ side: -0.012, inward: 0.052 }), // top
   Object.freeze({ side: -0.008, inward: 0.004 }) // left
 ]);
-const FIREARM_RACK_DICE_SIDE_OFFSET = 0.102;
-const FIREARM_RACK_DICE_INWARD_OFFSET = 0.018;
-const FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA = 0.036;
-const FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA = 0.012;
 const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
   0: 2,
   2: 0
@@ -8632,50 +8628,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return kingToken.getWorldPosition(new THREE.Vector3());
   }, []);
 
-  const resolveFirearmRackDicePose = useCallback((playerIndex, captureAnimationId = null) => {
-    const arena = arenaRef.current;
-    const dice = diceRef.current;
-    const boardGroup = arena?.boardGroup;
-    if (!arena?.boardLookTarget || !dice?.userData || !boardGroup?.localToWorld) return null;
-    const railPositions = Array.isArray(dice.userData.railPositions) ? dice.userData.railPositions : [];
-    const layouts = Array.isArray(dice.userData.tokenRails) ? dice.userData.tokenRails : [];
-    const railLocal = railPositions[playerIndex]?.clone?.();
-    const layout = layouts[playerIndex];
-    if (!railLocal || !layout?.forward?.clone || !layout?.right?.clone) return null;
-
-    const railWorld = railLocal.clone();
-    boardGroup.localToWorld(railWorld);
-    railWorld.y = arena.tableInfo?.surfaceY ?? railWorld.y;
-
-    const forwardWorld = layout.forward.clone().setY(0);
-    const rightWorld = layout.right.clone().setY(0);
-    if (forwardWorld.lengthSq() < 1e-6 || rightWorld.lengthSq() < 1e-6) return null;
-    forwardWorld.normalize().transformDirection(boardGroup.matrixWorld).setY(0);
-    rightWorld.normalize().transformDirection(boardGroup.matrixWorld).setY(0);
-    if (forwardWorld.lengthSq() < 1e-6 || rightWorld.lengthSq() < 1e-6) return null;
-    forwardWorld.normalize();
-    rightWorld.normalize();
-
-    const isLargeFirearm = LARGE_RACK_FIREARM_IDS.has(captureAnimationId);
-    const sideOffset = FIREARM_RACK_DICE_SIDE_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA : 0);
-    const inwardOffset = FIREARM_RACK_DICE_INWARD_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA : 0);
-    const position = railWorld
-      .clone()
-      .addScaledVector(rightWorld, sideOffset)
-      .addScaledVector(forwardWorld, -inwardOffset);
-    position.y = (arena.tableInfo?.surfaceY ?? position.y) + 0.002;
-    return { position, aimTarget: railWorld.clone().addScaledVector(forwardWorld, -0.22) };
-  }, []);
-
   const resolveCaptureParkingAnchors = useCallback((playerIndex, vehicleType = 'fighter') => {
     const arena = arenaRef.current;
     if (!arena?.seatAnchors?.length || !arena.boardLookTarget) return null;
     const anchor = arena.seatAnchors[playerIndex];
     if (!anchor) return null;
-    if (vehicleType === 'firearmRack') {
-      const dicePose = resolveFirearmRackDicePose(playerIndex);
-      if (dicePose?.position?.isVector3) return dicePose.position;
-    }
     const seatPos = anchor.getWorldPosition(new THREE.Vector3());
     const kingPos = getKingTokenPositionForPlayer(playerIndex) ?? seatPos;
     const inward = arena.boardLookTarget.clone().sub(kingPos).setY(0).normalize();
@@ -8697,7 +8654,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       .addScaledVector(inward, -outwardOffset);
     park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.002;
     return park;
-  }, [getKingTokenPositionForPlayer, resolveFirearmRackDicePose]);
+  }, [getKingTokenPositionForPlayer]);
 
   const resolvePlayerLabel = useCallback(
     (playerIndex) => players[playerIndex]?.name || COLOR_NAMES[playerIndex] || `Player ${playerIndex + 1}`,
@@ -8728,25 +8685,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           ? FIREARM_RACK_PARKING_TUNING.large
           : FIREARM_RACK_PARKING_TUNING.small);
       const seatAdjustment = FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS[playerIndex] || FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS[0];
-      const dicePose = resolveFirearmRackDicePose(playerIndex, captureAnimationId);
-      const basePosition = dicePose?.position?.isVector3
-        ? dicePose.position.clone()
-        : kingPos
-            .clone()
-            .addScaledVector(rightSide, rackTuning.side + seatAdjustment.side)
-            .addScaledVector(inward, rackTuning.inward + seatAdjustment.inward)
-            .addScaledVector(inward, -rackTuning.outward);
+      const basePosition = kingPos
+        .clone()
+        .addScaledVector(rightSide, rackTuning.side + seatAdjustment.side)
+        .addScaledVector(inward, rackTuning.inward + seatAdjustment.inward)
+        .addScaledVector(inward, -rackTuning.outward);
       entry.weaponRack.position.copy(basePosition);
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       const firearmAimTarget =
-        dicePose?.aimTarget?.isVector3
-          ? dicePose.aimTarget
-          : resolveFirearmRackAimTarget(
-              arena,
-              playerIndex,
-              getKingTokenPositionForPlayer
-            ) ?? arena.boardLookTarget;
+        resolveFirearmRackAimTarget(
+          arena,
+          playerIndex,
+          getKingTokenPositionForPlayer
+        ) ?? arena.boardLookTarget;
       orientFirearmRackTowardBoardCenter(entry.weaponRack, firearmAimTarget);
       orientWeaponHolderTowardBoardCenter(entry, firearmAimTarget);
     };
@@ -8795,7 +8747,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
       }
     });
-  }, [aiLoadoutByPlayer, getKingTokenPositionForPlayer, resolveFirearmRackDicePose]);
+  }, [aiLoadoutByPlayer, getKingTokenPositionForPlayer]);
 
   const rebuildParkedCaptureVehicles = useCallback(async () => {
     const arena = arenaRef.current;


### PR DESCRIPTION
### Motivation
- Revert recent dice-anchored firearm parking so parked capture weapons return to the table-side/king-token parking layout that matched the May baseline. 

### Description
- Remove the dice-specific firearm rack offsets (`FIREARM_RACK_DICE_*`) and the `resolveFirearmRackDicePose` helper. 
- Restore `resolveCaptureParkingAnchors` to compute park positions relative to the king-token/table anchors instead of dice rail anchors. 
- Adjust weapon-rack refresh logic to use the king-token-relative base position and `resolveFirearmRackAimTarget` as the aim target. 
- Preserve existing May-9 firearm tuning maps and seat adjustments so legacy weapon sizing/poses remain unchanged. 

### Testing
- Ran `npm --prefix webapp run build` and the webapp production build completed successfully. 
- Ran `npx playwright install chromium` to fetch browsers and the installation succeeded. 
- Attempted a Playwright mobile screenshot to validate parking on a phone viewport but the headless browser could not launch due to a missing system library (`libatk-1.0.so.0`), so the visual snapshot step failed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28f9e8ebb883299c681aa22e2e0d82)