### PR TITLE
Restore Real Bowling and Tennis games

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/CharacterWalk8Dir.cs
+++ b/Assets/Scripts/Gameplay/Tennis/CharacterWalk8Dir.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [RequireComponent(typeof(CharacterController))]
+    public class CharacterWalk8Dir : MonoBehaviour
+    {
+        [SerializeField] private float walkSpeed = 4.5f;
+        [SerializeField] private Transform cameraForwardSource;
+        [SerializeField] private Animator animator;
+
+        private CharacterController _controller;
+
+        private void Awake() => _controller = GetComponent<CharacterController>();
+
+        private void Update()
+        {
+            float x = Input.GetAxis("Horizontal");
+            float y = Input.GetAxis("Vertical");
+
+            Vector3 forward = cameraForwardSource != null ? cameraForwardSource.forward : Vector3.forward;
+            Vector3 right = cameraForwardSource != null ? cameraForwardSource.right : Vector3.right;
+            forward.y = 0f;
+            right.y = 0f;
+            forward.Normalize();
+            right.Normalize();
+
+            Vector3 move = (right * x + forward * y);
+            if (move.sqrMagnitude > 1f) move.Normalize();
+
+            _controller.Move(move * (walkSpeed * Time.deltaTime));
+
+            if (animator != null)
+            {
+                animator.SetFloat("MoveX", x);
+                animator.SetFloat("MoveY", y);
+                animator.SetFloat("Speed", move.magnitude);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/README.md
+++ b/Assets/Scripts/Gameplay/Tennis/README.md
@@ -1,0 +1,24 @@
+# Tennis gameplay upgrade notes
+
+This folder adds modular tennis systems:
+
+- `TennisShotTuning`: keeps shots at a calmer match-power pace and supports flat/power/topspin/curve variants.
+- `TennisCourtScaler`: scales the court/net larger than the players and moves the camera back to keep the bigger court framed.
+- `TennisAudioController`: trigger shot and bounce SFX.
+- `TennisAIOpponent`: faster AI reaction, mixed shot variants, and capped match-power shot selection.
+- `CharacterWalk8Dir`: 8-direction walk movement (forward/backward/sideways).
+
+## Free/open-source sound effect sources
+
+1. Kenney assets (CC0): https://kenney.nl/assets
+2. Sonniss GDC free packs: https://sonniss.com/gameaudiogdc
+
+Import chosen WAV/OGG files into Unity and assign them to `shotClip` and `ballBounceClip`.
+
+
+## Replay flow (TV-style VAR)
+
+- Add `TennisReplayDirector` in the tennis scene and connect `ReplayBroadcastGate`.
+- Call `OnDecisivePoint(...)` for match-point / winner moments and `OnFoul(...)` for fouls.
+- Wire `menuSkipReplayButton` (menu-level skip) and `replaySkipIconButton` (overlay skip icon).
+- Optional: assign `replayOverlay` CanvasGroup to show replay UI while active.

--- a/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    public class TennisAIOpponent : MonoBehaviour
+    {
+        [SerializeField] private TennisShotTuning shotTuning;
+        [SerializeField] private Rigidbody ballBody;
+        [SerializeField] private Transform hitTarget;
+        [SerializeField, Min(0.01f)] private float reactionTime = 0.1f;
+        [SerializeField, Min(0f)] private float anticipationTime = 0.14f;
+        [SerializeField, Min(0.01f)] private float minReactionTime = 0.05f;
+        [SerializeField, Min(0.1f)] private float minShotPower01 = 0.45f;
+        [SerializeField, Min(0.1f)] private float maxShotPower01 = 0.82f;
+
+        private float _nextHitTime;
+
+        private void Update()
+        {
+            if (shotTuning == null || ballBody == null || hitTarget == null) return;
+            if (Time.time < _nextHitTime) return;
+
+            bool ballComingToAi = ballBody.velocity.z > 0f;
+            float predictedBallZ = ballBody.position.z + (ballBody.velocity.z * anticipationTime);
+            if (ballComingToAi && predictedBallZ > transform.position.z)
+            {
+                float speed = ballBody.velocity.magnitude;
+                float adaptiveReaction = Mathf.Max(minReactionTime, reactionTime - (speed * 0.003f));
+                _nextHitTime = Time.time + adaptiveReaction;
+                ShootAdaptive();
+            }
+        }
+
+        private void ShootAdaptive()
+        {
+            Vector3 aim = (hitTarget.position - ballBody.position).normalized;
+            float power = Random.Range(minShotPower01, maxShotPower01);
+            ShotVariant variant = (ShotVariant)Random.Range(0, 5);
+            shotTuning.ApplyShot(ballBody, aim, power, variant);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisAudioController.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisAudioController.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [RequireComponent(typeof(AudioSource))]
+    public class TennisAudioController : MonoBehaviour
+    {
+        [Header("Assign imported clips from open-source packs")]
+        [Tooltip("Recommended source: Kenney UI Audio + Impact Sounds (CC0): https://kenney.nl/assets")]
+        public AudioClip shotClip;
+        [Tooltip("Recommended source: Sonniss GDC free packs (license in pack): https://sonniss.com/gameaudiogdc")]
+        public AudioClip ballBounceClip;
+
+        [SerializeField, Range(0f, 1f)] private float shotVolume = 0.9f;
+        [SerializeField, Range(0f, 1f)] private float bounceVolume = 0.75f;
+
+        private AudioSource _audio;
+
+        private void Awake() => _audio = GetComponent<AudioSource>();
+
+        public void PlayShot()
+        {
+            if (shotClip != null) _audio.PlayOneShot(shotClip, shotVolume);
+        }
+
+        public void PlayBounce()
+        {
+            if (ballBounceClip != null) _audio.PlayOneShot(ballBounceClip, bounceVolume);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
@@ -1,0 +1,105 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    public class TennisCourtScaler : MonoBehaviour
+    {
+        [SerializeField] private Transform courtRoot;
+        [SerializeField] private Transform[] characterRoots;
+        [SerializeField] private Transform[] racketRoots;
+        [SerializeField] private Transform ballRoot;
+        [SerializeField] private Transform netRoot;
+        [SerializeField] private Camera targetCamera;
+        [SerializeField] private Transform framingPivot;
+        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 2.45f;
+        [SerializeField, Min(0.1f)] private float courtScaleMultiplier = 3.2f;
+        [SerializeField, Min(1f)] private float framingDistanceScale = 2.65f;
+
+        private bool _initialized;
+        private Vector3 _initialCourtScale;
+        private Vector3[] _initialCharacterScales;
+        private Vector3[] _initialRacketScales;
+        private Vector3 _initialBallScale;
+        private Vector3 _initialNetScale;
+        private Vector3 _initialCameraPosition;
+
+        private void Start()
+        {
+            ApplyScaleAndFraming();
+        }
+
+        [ContextMenu("Apply Scale + Camera Framing")]
+        public void ApplyScaleAndFraming()
+        {
+            EnsureInitialized();
+
+            SetScaled(courtRoot, _initialCourtScale, courtScaleMultiplier);
+            SetScaled(ballRoot, _initialBallScale, worldScaleMultiplier);
+            SetScaled(netRoot, _initialNetScale, courtScaleMultiplier);
+            SetScaledArray(characterRoots, _initialCharacterScales);
+            SetScaledArray(racketRoots, _initialRacketScales);
+
+            ApplyCameraFraming();
+        }
+
+        private void EnsureInitialized()
+        {
+            if (_initialized) return;
+            _initialized = true;
+
+            _initialCourtScale = courtRoot != null ? courtRoot.localScale : Vector3.one;
+            _initialBallScale = ballRoot != null ? ballRoot.localScale : Vector3.one;
+            _initialNetScale = netRoot != null ? netRoot.localScale : Vector3.one;
+
+            _initialCharacterScales = CaptureScales(characterRoots);
+            _initialRacketScales = CaptureScales(racketRoots);
+
+            if (targetCamera != null)
+            {
+                _initialCameraPosition = targetCamera.transform.position;
+            }
+        }
+
+        private void ApplyCameraFraming()
+        {
+            if (targetCamera == null) return;
+
+            if (framingPivot == null)
+            {
+                targetCamera.transform.position = _initialCameraPosition * framingDistanceScale;
+                return;
+            }
+
+            Vector3 offset = _initialCameraPosition - framingPivot.position;
+            targetCamera.transform.position = framingPivot.position + (offset * framingDistanceScale);
+        }
+
+        private Vector3[] CaptureScales(Transform[] roots)
+        {
+            if (roots == null) return null;
+
+            var scales = new Vector3[roots.Length];
+            for (int i = 0; i < roots.Length; i++)
+            {
+                scales[i] = roots[i] != null ? roots[i].localScale : Vector3.one;
+            }
+
+            return scales;
+        }
+
+        private void SetScaledArray(Transform[] roots, Vector3[] baseScales)
+        {
+            if (roots == null || baseScales == null) return;
+            for (int i = 0; i < roots.Length && i < baseScales.Length; i++)
+            {
+                SetScaled(roots[i], baseScales[i], worldScaleMultiplier);
+            }
+        }
+
+        private void SetScaled(Transform target, Vector3 baseScale, float scaleMultiplier)
+        {
+            if (target == null) return;
+            target.localScale = baseScale * scaleMultiplier;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisReplayDirector.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisReplayDirector.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using Aiming.Gameplay.Broadcast;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    /// <summary>
+    /// Lightweight TV-style replay trigger for decisive points/fouls with global skip controls.
+    /// Hook this from gameplay events: OnDecisivePoint / OnFoul.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class TennisReplayDirector : MonoBehaviour
+    {
+        [Header("Replay Dependencies")]
+        [SerializeField] private ReplayBroadcastGate replayGate;
+
+        [Header("Replay Timing")]
+        [SerializeField, Min(0.2f)] private float replayDurationSeconds = 3f;
+        [SerializeField] private bool pauseGameplayDuringReplay = true;
+
+        [Header("Skip Controls")]
+        [SerializeField] private Button menuSkipReplayButton;
+        [SerializeField] private Button replaySkipIconButton;
+        [SerializeField] private CanvasGroup replayOverlay;
+
+        private Coroutine replayRoutine;
+        private bool isReplayActive;
+        private float previousTimeScale = 1f;
+
+        public bool IsReplayActive => isReplayActive;
+
+        private void Awake()
+        {
+            if (menuSkipReplayButton != null)
+                menuSkipReplayButton.onClick.AddListener(SkipReplay);
+            if (replaySkipIconButton != null)
+                replaySkipIconButton.onClick.AddListener(SkipReplay);
+
+            SetReplayOverlayVisible(false);
+        }
+
+        private void OnDestroy()
+        {
+            if (menuSkipReplayButton != null)
+                menuSkipReplayButton.onClick.RemoveListener(SkipReplay);
+            if (replaySkipIconButton != null)
+                replaySkipIconButton.onClick.RemoveListener(SkipReplay);
+        }
+
+        public void OnDecisivePoint(string pointId, Vector3 ballPosition, Vector3 shotDirection, float powerNormalized)
+        {
+            RequestReplay(pointId, ballPosition, shotDirection, powerNormalized, replayOnPoint: true, replayOnFoul: false);
+        }
+
+        public void OnFoul(string foulId, Vector3 ballPosition, Vector3 shotDirection, float powerNormalized)
+        {
+            RequestReplay(foulId, ballPosition, shotDirection, powerNormalized, replayOnPoint: false, replayOnFoul: true);
+        }
+
+        public void SkipReplay()
+        {
+            if (!isReplayActive) return;
+            EndReplay();
+        }
+
+        private void RequestReplay(string shotId, Vector3 ballPosition, Vector3 shotDirection, float powerNormalized, bool replayOnPoint, bool replayOnFoul)
+        {
+            if (replayGate == null) return;
+
+            var payload = new ReplayBroadcastPayload
+            {
+                shotId = shotId,
+                cueBallPosition = ballPosition,
+                cueDirection = shotDirection,
+                powerNormalized = Mathf.Clamp01(powerNormalized),
+                replayOnPottedBall = replayOnPoint,
+                replayOnFoul = replayOnFoul
+            };
+
+            if (!replayGate.TryBroadcastReplay(payload)) return;
+
+            if (replayRoutine != null)
+                StopCoroutine(replayRoutine);
+
+            replayRoutine = StartCoroutine(ReplayRoutine());
+        }
+
+        private IEnumerator ReplayRoutine()
+        {
+            isReplayActive = true;
+            SetReplayOverlayVisible(true);
+
+            if (pauseGameplayDuringReplay)
+            {
+                previousTimeScale = Time.timeScale;
+                Time.timeScale = 0f;
+            }
+
+            yield return new WaitForSecondsRealtime(replayDurationSeconds);
+
+            EndReplay();
+        }
+
+        private void EndReplay()
+        {
+            if (replayRoutine != null)
+            {
+                StopCoroutine(replayRoutine);
+                replayRoutine = null;
+            }
+
+            if (pauseGameplayDuringReplay)
+                Time.timeScale = previousTimeScale;
+
+            isReplayActive = false;
+            SetReplayOverlayVisible(false);
+        }
+
+        private void SetReplayOverlayVisible(bool visible)
+        {
+            if (replayOverlay == null) return;
+            replayOverlay.alpha = visible ? 1f : 0f;
+            replayOverlay.interactable = visible;
+            replayOverlay.blocksRaycasts = visible;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [DisallowMultipleComponent]
+    public class TennisShotTuning : MonoBehaviour
+    {
+        [Header("Power")]
+        [Min(1f)] public float baseShotPower = 14.25f;
+        [Range(0.1f, 1f)] public float maxMatchPower01 = 0.68f;
+        [Range(0f, 2f)] public float topspin = 0.35f;
+        [Range(0f, 2f)] public float sidespin = 0.2f;
+        [Range(0f, 2f)] public float curvePower = 0.5f;
+
+        public void ApplyShot(Rigidbody ballBody, Vector3 aimDirection, float normalizedPower, ShotVariant variant)
+        {
+            if (ballBody == null) return;
+
+            var dir = aimDirection.sqrMagnitude > 0.0001f ? aimDirection.normalized : transform.forward;
+            float matchPower = Mathf.Clamp(normalizedPower, 0f, maxMatchPower01);
+            float power = baseShotPower * matchPower;
+
+            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.02f : 1f;
+            float finalPower = power * variantPowerMultiplier;
+
+            ballBody.AddForce(dir * finalPower, ForceMode.Impulse);
+
+            Vector3 right = Vector3.Cross(Vector3.up, dir).normalized;
+            float side = variant == ShotVariant.CurveLeft ? -1f : variant == ShotVariant.CurveRight ? 1f : 0f;
+            float spinY = (variant == ShotVariant.Topspin ? topspin : 0.15f) * finalPower;
+
+            ballBody.AddTorque((Vector3.right * spinY) + (right * side * sidespin * finalPower), ForceMode.Impulse);
+            if (Mathf.Abs(side) > 0f)
+            {
+                ballBody.AddForce(right * side * curvePower * matchPower, ForceMode.Impulse);
+            }
+        }
+    }
+
+    public enum ShotVariant
+    {
+        Flat,
+        Power,
+        Topspin,
+        CurveLeft,
+        CurveRight
+    }
+}

--- a/frontend/src/table-tennis/AIController.ts
+++ b/frontend/src/table-tennis/AIController.ts
@@ -1,0 +1,92 @@
+import * as THREE from 'three';
+import { BallPhysics } from './BallPhysics';
+import { GAME_CONFIG, ShotCommand, ShotType, TABLE_BOUNDS } from './gameConfig';
+
+const BASE_TABLE_WIDTH = 61.651044 * 0.045;
+const BASE_TABLE_LENGTH = 90.4215312 * 0.045;
+const TABLE_AI_REACH_MAX_Z = TABLE_BOUNDS.minZ + GAME_CONFIG.table.length * (0.34 / BASE_TABLE_LENGTH);
+const TABLE_AI_REACH_MIN_Z = GAME_CONFIG.ai.z - GAME_CONFIG.table.length * (0.27 / BASE_TABLE_LENGTH);
+
+export class AIController {
+  readonly targetX = { value: 0 };
+  currentShot: ShotType = 'forehand drive';
+  private reactionTimer = 0;
+  private committedLanding: THREE.Vector3 | null = null;
+  private readonly shotCommand: ShotCommand = { aimX: 0, power: 0.76, lift: 0.42, curve: 0, spin: 0.34 };
+  private bounceReadyTimer = 0;
+
+  constructor(private root: THREE.Group, private hand: THREE.Object3D, private paddle: THREE.Object3D) {}
+
+  update(dt: number, ball: BallPhysics) {
+    this.bounceReadyTimer = Math.max(0, this.bounceReadyTimer - dt);
+    const cfg = GAME_CONFIG.ai.difficulty;
+    this.reactionTimer -= dt;
+    if (this.reactionTimer <= 0) {
+      this.committedLanding = ball.predictLandingPoint('ai');
+      if (this.committedLanding) {
+        const noise = (1 - cfg.accuracy) * THREE.MathUtils.randFloatSpread(GAME_CONFIG.table.width * (0.38 / BASE_TABLE_WIDTH));
+        this.targetX.value = THREE.MathUtils.clamp(this.committedLanding.x + noise, GAME_CONFIG.ai.minX, GAME_CONFIG.ai.maxX);
+        this.prepareShotCommand(ball);
+      }
+      const speedRead = THREE.MathUtils.clamp(ball.velocity.length() / 7, 0, 0.055);
+      this.reactionTimer = Math.max(0.045, cfg.reactionTime - speedRead);
+    }
+
+    if (ball.bounces.ai === 1 && ball.lastTouch !== 'ai' && ball.velocity.y > 0 && this.canReach(ball.position)) {
+      this.bounceReadyTimer = 0.085;
+    }
+
+    this.root.position.x = THREE.MathUtils.damp(this.root.position.x, this.targetX.value, cfg.moveSpeed, dt);
+    this.root.position.z = GAME_CONFIG.ai.z;
+    this.currentShot = ball.position.x > this.root.position.x ? 'forehand drive' : 'backhand drive';
+    const yaw = THREE.MathUtils.clamp((ball.position.x - this.root.position.x) * 0.4, -0.5, 0.5);
+    this.root.rotation.y = Math.PI + yaw;
+    this.hand.position.set(this.currentShot === 'forehand drive' ? -0.16 : 0.16, 0.92, -0.28);
+    this.paddle.position.set(0, -0.02, -0.12);
+    this.paddle.rotation.set(-0.25, 0, this.currentShot === 'forehand drive' ? -0.16 : 0.16);
+  }
+
+  private prepareShotCommand(ball: BallPhysics) {
+    const pressure = THREE.MathUtils.clamp(ball.velocity.length() / 6, 0, 1);
+    const openCourtAim = THREE.MathUtils.clamp(-this.root.position.x / (GAME_CONFIG.table.width * 0.5), -0.82, 0.82);
+    this.shotCommand.aimX = THREE.MathUtils.clamp(openCourtAim + THREE.MathUtils.randFloatSpread(0.34), -1, 1);
+    this.shotCommand.power = THREE.MathUtils.clamp(0.68 + pressure * 0.24 + THREE.MathUtils.randFloatSpread(0.08), 0.62, 0.95);
+    this.shotCommand.lift = THREE.MathUtils.clamp(0.34 + pressure * 0.18 + THREE.MathUtils.randFloatSpread(0.1), 0.26, 0.66);
+    this.shotCommand.curve = THREE.MathUtils.clamp(THREE.MathUtils.randFloatSpread(0.34), -0.5, 0.5);
+    this.shotCommand.spin = THREE.MathUtils.clamp(0.28 + pressure * 0.28, 0.22, 0.72);
+  }
+
+  canReach(ballPosition: THREE.Vector3) {
+    return (
+      Math.abs(ballPosition.x - this.root.position.x) <= GAME_CONFIG.ai.maxReach &&
+      ballPosition.z < TABLE_AI_REACH_MAX_Z &&
+      ballPosition.z > TABLE_AI_REACH_MIN_Z
+    );
+  }
+
+  shouldMiss() {
+    return Math.random() < GAME_CONFIG.ai.difficulty.mistakeChance;
+  }
+
+  getShotCommand() {
+    return this.shotCommand;
+  }
+
+  getPaddleWorldPosition() {
+    return this.paddle.getWorldPosition(new THREE.Vector3());
+  }
+
+  getPaddleForward() {
+    return new THREE.Vector3(0, 0, 1).applyQuaternion(this.paddle.getWorldQuaternion(new THREE.Quaternion())).normalize();
+  }
+
+  shouldStrikeAfterBounce(ball: BallPhysics) {
+    if (ball.bounces.ai !== 1 || ball.lastTouch === 'ai') return false;
+    const risingAfterBounce = ball.velocity.y >= -0.08;
+    const headingToPlayerSide = ball.position.z < -0.02;
+    return this.bounceReadyTimer > 0 && risingAfterBounce && headingToPlayerSide && this.canReach(ball.position);
+  }
+}
+
+
+

--- a/frontend/src/table-tennis/BallPhysics.ts
+++ b/frontend/src/table-tennis/BallPhysics.ts
@@ -1,0 +1,197 @@
+import * as THREE from 'three';
+import { GAME_CONFIG, NET_BOUNDS, Side, TABLE_BOUNDS } from './gameConfig';
+
+export type BallStateName =
+  | 'idle'
+  | 'serve'
+  | 'flying'
+  | 'tableBouncePlayer'
+  | 'tableBounceAI'
+  | 'paddleHitPlayer'
+  | 'paddleHitAI'
+  | 'netHit'
+  | 'out'
+  | 'pointEnded';
+
+export interface BallSnapshot {
+  position: THREE.Vector3;
+  velocity: THREE.Vector3;
+  spin: THREE.Vector3;
+  state: BallStateName;
+  bounces: Record<Side, number>;
+  lastTouch: Side | null;
+}
+
+export interface BallEvent {
+  type: 'bounce' | 'net' | 'out';
+  side?: Side;
+  position: THREE.Vector3;
+  state: BallStateName;
+}
+
+const tmp = new THREE.Vector3();
+const INITIAL_SERVE_X_RATIO = 0.16 / 1.55;
+const INITIAL_SERVE_Z_RATIO = 1.08 / 2.74;
+const INITIAL_OUT_X_MARGIN_RATIO = 0.44 / 1.55;
+const INITIAL_OUT_Z_MARGIN_RATIO = 1 / 2.74;
+
+export class BallPhysics {
+  readonly position = new THREE.Vector3();
+  readonly velocity = new THREE.Vector3();
+  readonly spin = new THREE.Vector3();
+  state: BallStateName = 'idle';
+  lastTouch: Side | null = null;
+  bounces: Record<Side, number> = { player: 0, ai: 0 };
+  private accumulator = 0;
+
+  resetForServe(server: Side) {
+    this.position.set(
+      server === 'player' ? -GAME_CONFIG.table.width * INITIAL_SERVE_X_RATIO : GAME_CONFIG.table.width * INITIAL_SERVE_X_RATIO,
+      GAME_CONFIG.table.topY + GAME_CONFIG.serveHeight,
+      server === 'player' ? GAME_CONFIG.table.length * INITIAL_SERVE_Z_RATIO : -GAME_CONFIG.table.length * INITIAL_SERVE_Z_RATIO,
+    );
+    this.velocity.set(0, 0, 0);
+    this.spin.set(0, 0, 0);
+    this.lastTouch = server;
+    this.bounces = { player: 0, ai: 0 };
+    this.state = 'serve';
+    this.accumulator = 0;
+  }
+
+  serve(server: Side) {
+    this.resetBouncesAfterHit(server);
+    this.velocity.set(server === 'player' ? 0.08 : -0.08, 1.25, server === 'player' ? -GAME_CONFIG.serveForwardPower : GAME_CONFIG.serveForwardPower);
+    this.spin.set(server === 'player' ? 0.2 : -0.2, 0, server === 'player' ? -1.2 : 1.2);
+    this.state = 'flying';
+  }
+
+  applyPaddleHit(side: Side, velocity: THREE.Vector3, spin: THREE.Vector3) {
+    this.velocity.copy(velocity);
+    this.spin.copy(spin);
+    this.lastTouch = side;
+    this.resetBouncesAfterHit(side);
+    this.state = side === 'player' ? 'paddleHitPlayer' : 'paddleHitAI';
+  }
+
+  update(deltaSeconds: number): BallEvent[] {
+    const events: BallEvent[] = [];
+    this.accumulator += Math.min(deltaSeconds, 0.05);
+    while (this.accumulator >= GAME_CONFIG.fixedDt) {
+      events.push(...this.step(GAME_CONFIG.fixedDt));
+      this.accumulator -= GAME_CONFIG.fixedDt;
+    }
+    return events;
+  }
+
+  private step(dt: number): BallEvent[] {
+    if (this.state === 'idle' || this.state === 'serve' || this.state === 'pointEnded') return [];
+
+    const events: BallEvent[] = [];
+    const previous = this.position.clone();
+    const acceleration = tmp.set(this.spin.z * GAME_CONFIG.spinCurve, GAME_CONFIG.gravity, -this.spin.x * GAME_CONFIG.spinCurve);
+    this.velocity.addScaledVector(acceleration, dt);
+    this.velocity.multiplyScalar(1 - GAME_CONFIG.drag * dt);
+    this.position.addScaledVector(this.velocity, dt);
+
+    const tableEvent = this.resolveTableCollision(previous);
+    if (tableEvent) events.push(tableEvent);
+
+    const netEvent = this.resolveNetCollision(previous);
+    if (netEvent) events.push(netEvent);
+
+    if (this.isClearlyOut()) {
+      this.state = 'out';
+      events.push({ type: 'out', position: this.position.clone(), state: this.state });
+    } else if (this.state !== 'netHit' && this.state !== 'out') {
+      this.state = 'flying';
+    }
+
+    return events;
+  }
+
+  private resolveTableCollision(previous: THREE.Vector3): BallEvent | null {
+    const top = GAME_CONFIG.table.topY + GAME_CONFIG.ballRadius;
+    const crossedTop = previous.y >= top && this.position.y <= top;
+    if (!crossedTop || this.velocity.y >= 0) return null;
+
+    const t = (previous.y - top) / Math.max(previous.y - this.position.y, 0.0001);
+    const xAtImpact = THREE.MathUtils.lerp(previous.x, this.position.x, t);
+    const zAtImpact = THREE.MathUtils.lerp(previous.z, this.position.z, t);
+    const inside = xAtImpact >= TABLE_BOUNDS.minX && xAtImpact <= TABLE_BOUNDS.maxX && zAtImpact >= TABLE_BOUNDS.minZ && zAtImpact <= TABLE_BOUNDS.maxZ;
+    if (!inside) return null;
+
+    this.position.set(xAtImpact, top, zAtImpact);
+    this.velocity.y = Math.abs(this.velocity.y) * 0.88;
+    this.velocity.x += this.spin.z * 0.018;
+    this.velocity.z -= this.spin.x * 0.018;
+    this.spin.multiplyScalar(0.84);
+
+    const side: Side = zAtImpact > 0 ? 'player' : 'ai';
+    this.bounces[side] += 1;
+    this.state = side === 'player' ? 'tableBouncePlayer' : 'tableBounceAI';
+    return { type: 'bounce', side, position: this.position.clone(), state: this.state };
+  }
+
+  private resolveNetCollision(previous: THREE.Vector3): BallEvent | null {
+    const radius = GAME_CONFIG.ballRadius;
+    const crossesNet = (previous.z - NET_BOUNDS.minZ) * (this.position.z - NET_BOUNDS.minZ) <= 0 || (previous.z - NET_BOUNDS.maxZ) * (this.position.z - NET_BOUNDS.maxZ) <= 0;
+    const insideX = this.position.x + radius >= NET_BOUNDS.minX && this.position.x - radius <= NET_BOUNDS.maxX;
+    const insideY = this.position.y - radius <= NET_BOUNDS.maxY && this.position.y + radius >= NET_BOUNDS.minY;
+    const insideZ = this.position.z + radius >= NET_BOUNDS.minZ && this.position.z - radius <= NET_BOUNDS.maxZ;
+    if (!crossesNet || !insideX || !insideY || !insideZ) return null;
+
+    this.position.z = previous.z > 0 ? NET_BOUNDS.maxZ + radius : NET_BOUNDS.minZ - radius;
+    this.velocity.z *= -0.42;
+    this.velocity.y = Math.max(this.velocity.y, 0.35);
+    this.spin.multiplyScalar(0.55);
+    this.state = 'netHit';
+    return { type: 'net', position: this.position.clone(), state: this.state };
+  }
+
+  private isClearlyOut() {
+    const xMargin = GAME_CONFIG.table.width * INITIAL_OUT_X_MARGIN_RATIO;
+    const zMargin = GAME_CONFIG.table.length * INITIAL_OUT_Z_MARGIN_RATIO;
+    const verticalMargin = GAME_CONFIG.table.topY * (0.42 / 0.76);
+    return this.position.y < GAME_CONFIG.table.topY - verticalMargin || Math.abs(this.position.x) > TABLE_BOUNDS.maxX + xMargin || Math.abs(this.position.z) > TABLE_BOUNDS.maxZ + zMargin;
+  }
+
+  private resetBouncesAfterHit(side: Side) {
+    this.lastTouch = side;
+    this.bounces = { player: 0, ai: 0 };
+  }
+
+  predictLandingPoint(targetSide?: Side): THREE.Vector3 | null {
+    const simPos = this.position.clone();
+    const simVel = this.velocity.clone();
+    const simSpin = this.spin.clone();
+    const top = GAME_CONFIG.table.topY + GAME_CONFIG.ballRadius;
+
+    for (let i = 0; i < 240; i += 1) {
+      const prev = simPos.clone();
+      simVel.addScaledVector(new THREE.Vector3(simSpin.z * GAME_CONFIG.spinCurve, GAME_CONFIG.gravity, -simSpin.x * GAME_CONFIG.spinCurve), GAME_CONFIG.fixedDt);
+      simVel.multiplyScalar(1 - GAME_CONFIG.drag * GAME_CONFIG.fixedDt);
+      simPos.addScaledVector(simVel, GAME_CONFIG.fixedDt);
+      if (prev.y >= top && simPos.y <= top && simVel.y < 0) {
+        const t = (prev.y - top) / Math.max(prev.y - simPos.y, 0.0001);
+        const x = THREE.MathUtils.lerp(prev.x, simPos.x, t);
+        const z = THREE.MathUtils.lerp(prev.z, simPos.z, t);
+        const side: Side = z > 0 ? 'player' : 'ai';
+        if (x >= TABLE_BOUNDS.minX && x <= TABLE_BOUNDS.maxX && z >= TABLE_BOUNDS.minZ && z <= TABLE_BOUNDS.maxZ && (!targetSide || side === targetSide)) {
+          return new THREE.Vector3(x, top, z);
+        }
+      }
+    }
+    return null;
+  }
+
+  snapshot(): BallSnapshot {
+    return {
+      position: this.position.clone(),
+      velocity: this.velocity.clone(),
+      spin: this.spin.clone(),
+      state: this.state,
+      bounces: { ...this.bounces },
+      lastTouch: this.lastTouch,
+    };
+  }
+}

--- a/frontend/src/table-tennis/CameraController.ts
+++ b/frontend/src/table-tennis/CameraController.ts
@@ -1,0 +1,21 @@
+import * as THREE from 'three';
+import { GAME_CONFIG } from './gameConfig';
+
+export class CameraController {
+  private desired = new THREE.Vector3();
+  private target = new THREE.Vector3();
+
+  constructor(private camera: THREE.PerspectiveCamera) {
+    this.camera.position.copy(GAME_CONFIG.camera.position);
+  }
+
+  update(dt: number, ballPosition: THREE.Vector3, playerPosition: THREE.Vector3) {
+    const nearPlayer = ballPosition.z > GAME_CONFIG.table.length * 0.21;
+    const lateralClamp = GAME_CONFIG.table.width * 0.115;
+    const lateralOffset = nearPlayer ? THREE.MathUtils.clamp((ballPosition.x - playerPosition.x) * 0.55, -lateralClamp, lateralClamp) : 0;
+    this.desired.set(lateralOffset, GAME_CONFIG.camera.position.y + (nearPlayer ? GAME_CONFIG.table.topY * 0.237 : 0), GAME_CONFIG.camera.position.z);
+    this.target.set(ballPosition.x * 0.14, GAME_CONFIG.camera.target.y + ballPosition.y * 0.08, GAME_CONFIG.camera.target.z);
+    this.camera.position.lerp(this.desired, 1 - Math.exp(-GAME_CONFIG.camera.damping * dt));
+    this.camera.lookAt(this.target);
+  }
+}

--- a/frontend/src/table-tennis/GameManager.ts
+++ b/frontend/src/table-tennis/GameManager.ts
@@ -1,0 +1,418 @@
+import * as THREE from 'three';
+import { AIController } from './AIController';
+import { BallPhysics } from './BallPhysics';
+import { CameraController } from './CameraController';
+import { GAME_CONFIG, ShotCommand, ShotType } from './gameConfig';
+import { PaddleHitDetector } from './PaddleHitDetector';
+import { PlayerController } from './PlayerController';
+import { ReplayManager } from './ReplayManager';
+import { ScoreManager } from './ScoreManager';
+
+export interface GameHudState {
+  playerScore: number;
+  aiScore: number;
+  server: string;
+  lastShot: string;
+  lastReason: string;
+  replaying: boolean;
+  debug: {
+    ballState: string;
+    bounces: string;
+    hitValidity: string;
+    predictedLanding: string;
+  };
+}
+
+export class GameManager {
+  readonly scene = new THREE.Scene();
+  readonly camera: THREE.PerspectiveCamera;
+  readonly renderer: THREE.WebGLRenderer;
+  readonly ball = new BallPhysics();
+  readonly score = new ScoreManager();
+  readonly replay = new ReplayManager();
+  private readonly hitDetector = new PaddleHitDetector();
+  private readonly cameraController: CameraController;
+  private readonly player: PlayerController;
+  private readonly ai: AIController;
+  private readonly clock = new THREE.Clock();
+  private readonly ballMesh: THREE.Mesh;
+  private readonly predictedMarker: THREE.Mesh;
+  private animationId = 0;
+  private rallyTime = 0;
+  private pointResetTimer = 0;
+  private lastShot = '';
+  private lastHitValidity = 'waiting';
+  private onHud?: (hud: GameHudState) => void;
+
+  constructor(private mount: HTMLElement) {
+    this.camera = new THREE.PerspectiveCamera(48, mount.clientWidth / mount.clientHeight, 0.1, 100);
+    this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.setSize(mount.clientWidth, mount.clientHeight);
+    this.renderer.shadowMap.enabled = true;
+    this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    mount.appendChild(this.renderer.domElement);
+
+    this.scene.background = new THREE.Color('#07162e');
+    this.scene.fog = new THREE.Fog('#07162e', 5.5, 9.5);
+    this.cameraController = new CameraController(this.camera);
+    this.createLights();
+    this.createTable();
+    const playerVisuals = this.createAvatar('player');
+    const aiVisuals = this.createAvatar('ai');
+    this.player = new PlayerController(playerVisuals);
+    this.ai = new AIController(aiVisuals.root, aiVisuals.hand, aiVisuals.paddle);
+    this.ballMesh = this.createBall();
+    this.predictedMarker = this.createPredictionMarker();
+    this.resetPoint();
+  }
+
+  start(onHud: (hud: GameHudState) => void) {
+    this.onHud = onHud;
+    this.clock.start();
+    const loop = () => {
+      this.animationId = requestAnimationFrame(loop);
+      this.update(Math.min(this.clock.getDelta(), 0.05));
+    };
+    loop();
+  }
+
+  dispose() {
+    cancelAnimationFrame(this.animationId);
+    this.renderer.dispose();
+    this.mount.removeChild(this.renderer.domElement);
+  }
+
+  setPointer(_normalizedX: number) {
+    // Player movement is auto-tracked now; pointer movement is reserved for swipe shooting.
+  }
+
+  shootSwipe(start: { x: number; y: number }, end: { x: number; y: number }, durationMs: number) {
+    if (this.replay.isReplaying) return;
+    this.player.queueShot(this.buildShotCommandFromSwipe(start, end, durationMs));
+  }
+
+  replayLastRally() {
+    this.replay.beginReplay();
+  }
+
+  resetMatch() {
+    this.score.resetMatch();
+    this.resetPoint();
+  }
+
+  private update(dt: number) {
+    if (this.replay.isReplaying) {
+      const replayBall = this.replay.update(dt);
+      if (replayBall) this.ballMesh.position.copy(replayBall);
+      this.cameraController.update(dt, this.ballMesh.position, new THREE.Vector3(0, 0, GAME_CONFIG.player.z));
+      this.renderer.render(this.scene, this.camera);
+      this.emitHud();
+      return;
+    }
+
+    this.rallyTime += dt;
+    this.player.update(dt, this.ball.position, this.ball.predictLandingPoint('player'));
+    this.ai.update(dt, this.ball);
+
+    if (this.ball.state === 'serve') this.ball.serve(this.score.state.server);
+    const events = this.ball.update(dt);
+    events.filter((event) => event.type === 'bounce').forEach((event) => this.replay.recordBounce(this.rallyTime, event.side, event.position));
+
+    this.tryPlayerHit();
+    this.tryAiHit();
+
+    const pointWinner = this.score.evaluate(events, this.ball);
+    if (pointWinner) {
+      this.replay.recordScore(this.rallyTime, pointWinner, { player: this.score.state.player, ai: this.score.state.ai }, this.score.state.lastReason);
+      this.pointResetTimer = 1.35;
+    }
+
+    if (this.ball.state === 'pointEnded') {
+      this.pointResetTimer -= dt;
+      if (this.pointResetTimer <= 0 && !this.score.state.winner) this.resetPoint();
+    }
+
+    this.ballMesh.position.copy(this.ball.position);
+    this.updatePredictionMarker();
+    this.replay.recordBall(this.rallyTime, this.ball.position, this.ball.state);
+    this.cameraController.update(dt, this.ball.position, new THREE.Vector3(this.playerPositionX(), 0, GAME_CONFIG.player.z));
+    this.renderer.render(this.scene, this.camera);
+    this.emitHud();
+  }
+
+  private tryPlayerHit() {
+    if (this.ball.lastTouch === 'player' || this.ball.bounces.player < 1 || this.ball.bounces.player > 1) return;
+    const result = this.hitDetector.detect({
+      side: 'player',
+      paddlePosition: this.player.getPaddleWorldPosition(),
+      paddleForward: this.player.getPaddleForward(),
+      ballPosition: this.ball.position,
+      ballVelocity: this.ball.velocity,
+      ballSpin: this.ball.spin,
+      requestedShot: this.player.currentShot,
+      shotCommand: this.player.peekShotCommand(),
+    });
+    this.lastHitValidity = result.valid ? 'valid player hit' : result.reason ?? 'invalid';
+    if (result.valid && result.velocity && result.spin && result.shotType) {
+      this.player.consumeShotCommand();
+      this.ball.applyPaddleHit('player', result.velocity, result.spin);
+      this.player.triggerHit();
+      this.lastShot = result.shotType;
+      this.replay.recordHit(this.rallyTime, 'player', result.shotType, this.ball.position);
+    }
+  }
+
+  private tryAiHit() {
+    if (!this.ai.shouldStrikeAfterBounce(this.ball) || this.ai.shouldMiss()) return;
+    const shot = this.ai.currentShot as ShotType;
+    const result = this.hitDetector.detect({
+      side: 'ai',
+      paddlePosition: this.ai.getPaddleWorldPosition(),
+      paddleForward: this.ai.getPaddleForward(),
+      ballPosition: this.ball.position,
+      ballVelocity: this.ball.velocity,
+      ballSpin: this.ball.spin,
+      requestedShot: shot,
+      shotCommand: this.ai.getShotCommand(),
+      accuracy: GAME_CONFIG.ai.difficulty.accuracy,
+      powerScale: GAME_CONFIG.ai.difficulty.shotPower,
+    });
+    this.lastHitValidity = result.valid ? 'valid AI hit' : result.reason ?? 'invalid';
+    if (result.valid && result.velocity && result.spin && result.shotType) {
+      this.ball.applyPaddleHit('ai', result.velocity, result.spin);
+      this.lastShot = result.shotType;
+      this.replay.recordHit(this.rallyTime, 'ai', result.shotType, this.ball.position);
+    }
+  }
+
+
+  private buildShotCommandFromSwipe(start: { x: number; y: number }, end: { x: number; y: number }, durationMs: number): ShotCommand {
+    const dx = end.x - start.x;
+    const dy = start.y - end.y;
+    const distance = Math.hypot(dx, dy);
+    const safeDistance = Math.max(distance, 0.001);
+    const horizontalIntent = THREE.MathUtils.clamp(dx / safeDistance, -1, 1);
+    const verticalIntent = THREE.MathUtils.clamp(dy / safeDistance, -1, 1);
+    const swipeDuration = Math.max(durationMs / 1000, 0.05);
+    const swipeSpeed = distance / swipeDuration;
+    const speedPower = THREE.MathUtils.clamp(swipeSpeed / 3.4, 0, 1);
+    const distancePower = THREE.MathUtils.clamp(distance / 1.05, 0, 1);
+
+    // Keep portrait-screen intuition: swipe visually right => aim right, swipe left => aim left.
+    const aimX = THREE.MathUtils.clamp(horizontalIntent * 0.86 + end.x * 0.12 + dx * 0.18, -1, 1);
+    const power = THREE.MathUtils.clamp(distancePower * 0.52 + speedPower * 0.48, 0.16, 1);
+    const lift = THREE.MathUtils.clamp(0.18 + Math.max(verticalIntent, -0.3) * 0.62 + dy * 0.14, 0, 1);
+    const curve = THREE.MathUtils.clamp(horizontalIntent * 0.72 + dx * 0.22, -1, 1);
+    const spin = THREE.MathUtils.clamp(verticalIntent * 0.66 + dy * 0.22 + power * 0.18 - Math.abs(curve) * 0.05, -1, 1);
+
+    return { aimX, power, lift, curve, spin };
+  }
+
+  private resetPoint() {
+    this.rallyTime = 0;
+    this.lastShot = '';
+    this.lastHitValidity = 'waiting';
+    this.replay.startRecording();
+    this.ball.resetForServe(this.score.state.server);
+  }
+
+  private emitHud() {
+    const landing = this.ball.predictLandingPoint();
+    this.onHud?.({
+      playerScore: this.score.state.player,
+      aiScore: this.score.state.ai,
+      server: this.score.state.server === 'player' ? 'YOU' : 'AI',
+      lastShot: this.lastShot,
+      lastReason: this.score.state.lastReason,
+      replaying: this.replay.isReplaying,
+      debug: {
+        ballState: this.ball.state,
+        bounces: `P:${this.ball.bounces.player} AI:${this.ball.bounces.ai}`,
+        hitValidity: this.lastHitValidity,
+        predictedLanding: landing ? `${landing.x.toFixed(2)}, ${landing.z.toFixed(2)}` : 'none',
+      },
+    });
+  }
+
+  private playerPositionX() {
+    return this.player.getPaddleWorldPosition().x;
+  }
+
+  private updatePredictionMarker() {
+    const landing = this.ball.predictLandingPoint();
+    this.predictedMarker.visible = Boolean(landing);
+    if (landing) this.predictedMarker.position.set(landing.x, GAME_CONFIG.table.topY + 0.006, landing.z);
+  }
+
+  private createLights() {
+    this.scene.add(new THREE.HemisphereLight('#dbeafe', '#0f172a', 1.15));
+    const key = new THREE.DirectionalLight('#ffffff', 2.25);
+    key.position.set(2.8, 5.2, 3.4);
+    key.castShadow = true;
+    key.shadow.mapSize.set(1024, 1024);
+    key.shadow.camera.near = 0.5;
+    key.shadow.camera.far = 12;
+    this.scene.add(key);
+  }
+
+  private createTable() {
+    const table = new THREE.Group();
+    const top = new THREE.Mesh(
+      new THREE.BoxGeometry(GAME_CONFIG.table.width, GAME_CONFIG.table.thickness, GAME_CONFIG.table.length),
+      new THREE.MeshStandardMaterial({ color: GAME_CONFIG.table.color, roughness: 0.58, metalness: 0.05 }),
+    );
+    top.position.y = GAME_CONFIG.table.topY - GAME_CONFIG.table.thickness / 2;
+    top.receiveShadow = true;
+    table.add(top);
+
+    const lineMat = new THREE.MeshBasicMaterial({ color: GAME_CONFIG.table.lineColor });
+    const centerLineThickness = GAME_CONFIG.table.width * (0.012 / (61.651044 * 0.045));
+    const edgeLineThickness = GAME_CONFIG.table.width * (0.016 / (61.651044 * 0.045));
+    const edgeInset = GAME_CONFIG.table.width * (0.01 / (61.651044 * 0.045));
+    const addLine = (w: number, l: number, x: number, z: number) => {
+      const line = new THREE.Mesh(new THREE.BoxGeometry(w, 0.006, l), lineMat);
+      line.position.set(x, GAME_CONFIG.table.topY + 0.004, z);
+      table.add(line);
+    };
+    addLine(GAME_CONFIG.table.width, centerLineThickness, 0, 0);
+    addLine(centerLineThickness, GAME_CONFIG.table.length, 0, 0);
+    addLine(GAME_CONFIG.table.width, edgeLineThickness, 0, GAME_CONFIG.table.length / 2 - edgeInset);
+    addLine(GAME_CONFIG.table.width, edgeLineThickness, 0, -GAME_CONFIG.table.length / 2 + edgeInset);
+    addLine(edgeLineThickness, GAME_CONFIG.table.length, GAME_CONFIG.table.width / 2 - edgeInset, 0);
+    addLine(edgeLineThickness, GAME_CONFIG.table.length, -GAME_CONFIG.table.width / 2 + edgeInset, 0);
+
+    const net = this.createNet();
+    table.add(net);
+
+    const floor = new THREE.Mesh(
+      new THREE.PlaneGeometry(GAME_CONFIG.table.width + 4.4, GAME_CONFIG.table.length + 5.3),
+      new THREE.ShadowMaterial({ opacity: 0.24 }),
+    );
+    floor.rotation.x = -Math.PI / 2;
+    floor.receiveShadow = true;
+    this.scene.add(floor, table);
+  }
+
+  private createNet() {
+    const netGroup = new THREE.Group();
+    const netWidth = GAME_CONFIG.table.width + GAME_CONFIG.net.overhang * 2;
+    const netHeight = GAME_CONFIG.net.height;
+    const netTexture = this.createHexNetTexture();
+    const netMaterial = new THREE.MeshBasicMaterial({
+      map: netTexture,
+      transparent: true,
+      opacity: 0.92,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+    const netPanel = new THREE.Mesh(new THREE.PlaneGeometry(netWidth, netHeight), netMaterial);
+    netPanel.position.y = GAME_CONFIG.table.topY + netHeight / 2;
+    netPanel.rotation.y = Math.PI;
+    netPanel.castShadow = true;
+    netGroup.add(netPanel);
+
+    const stripeMaterial = new THREE.MeshStandardMaterial({ color: '#f8fafc', roughness: 0.42, metalness: 0.02 });
+    const stripeHeight = 0.018;
+    const stripeDepth = GAME_CONFIG.net.thickness * 1.35;
+    const topStripe = new THREE.Mesh(new THREE.BoxGeometry(netWidth, stripeHeight, stripeDepth), stripeMaterial);
+    topStripe.position.y = GAME_CONFIG.table.topY + netHeight - stripeHeight / 2;
+    topStripe.castShadow = true;
+    const bottomStripe = topStripe.clone();
+    bottomStripe.position.y = GAME_CONFIG.table.topY + stripeHeight / 2;
+    netGroup.add(topStripe, bottomStripe);
+
+    return netGroup;
+  }
+
+  private createHexNetTexture() {
+    const canvas = document.createElement('canvas');
+    canvas.width = 512;
+    canvas.height = 96;
+    const context = canvas.getContext('2d');
+    if (!context) return new THREE.CanvasTexture(canvas);
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.strokeStyle = 'rgba(219, 234, 254, 0.92)';
+    context.lineWidth = 3;
+    context.lineCap = 'round';
+    context.lineJoin = 'round';
+
+    const radius = 14;
+    const hexWidth = Math.sqrt(3) * radius;
+    const verticalStep = radius * 1.5;
+    for (let y = radius; y < canvas.height + radius; y += verticalStep) {
+      const row = Math.round((y - radius) / verticalStep);
+      const xOffset = row % 2 === 0 ? radius : radius + hexWidth / 2;
+      for (let x = -hexWidth; x < canvas.width + hexWidth; x += hexWidth) {
+        this.drawHexagon(context, x + xOffset, y, radius);
+      }
+    }
+
+    return new THREE.CanvasTexture(canvas);
+  }
+
+  private drawHexagon(context: CanvasRenderingContext2D, centerX: number, centerY: number, radius: number) {
+    context.beginPath();
+    for (let i = 0; i < 6; i += 1) {
+      const angle = Math.PI / 6 + (Math.PI / 3) * i;
+      const x = centerX + Math.cos(angle) * radius;
+      const y = centerY + Math.sin(angle) * radius;
+      if (i === 0) context.moveTo(x, y);
+      else context.lineTo(x, y);
+    }
+    context.closePath();
+    context.stroke();
+  }
+
+  private createAvatar(side: 'player' | 'ai') {
+    const root = new THREE.Group();
+    root.position.set(0, 0, side === 'player' ? GAME_CONFIG.player.z : GAME_CONFIG.ai.z);
+    root.rotation.y = side === 'player' ? 0 : Math.PI;
+    const avatarScale = side === 'player' ? GAME_CONFIG.player.avatarScale : GAME_CONFIG.ai.avatarScale;
+    root.scale.setScalar(avatarScale);
+    const material = new THREE.MeshStandardMaterial({ color: '#f1f5f9', roughness: 0.72, metalness: 0.02 });
+    const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.18, 0.44, 5, 12), material);
+    torso.position.y = 0.72;
+    torso.castShadow = true;
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.15, 20, 16), material);
+    head.position.y = 1.16;
+    head.castShadow = true;
+    const hand = new THREE.Group();
+    const arm = new THREE.Mesh(new THREE.CapsuleGeometry(0.045, 0.34, 4, 8), material);
+    arm.rotation.x = Math.PI / 2;
+    arm.castShadow = true;
+    hand.add(arm);
+    const paddle = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.13, 0.13, 0.018, 32),
+      new THREE.MeshStandardMaterial({ color: '#d72638', roughness: 0.48 }),
+    );
+    paddle.rotation.x = Math.PI / 2;
+    paddle.castShadow = true;
+    hand.add(paddle);
+    root.add(torso, head, hand);
+    this.scene.add(root);
+    return { root, torso, head, hand, paddle };
+  }
+
+  private createBall() {
+    const ball = new THREE.Mesh(
+      new THREE.SphereGeometry(GAME_CONFIG.ballRadius, 24, 18),
+      new THREE.MeshStandardMaterial({ color: '#fff8b5', emissive: '#facc15', emissiveIntensity: 0.22, roughness: 0.36 }),
+    );
+    ball.castShadow = true;
+    this.scene.add(ball);
+    return ball;
+  }
+
+  private createPredictionMarker() {
+    const marker = new THREE.Mesh(
+      new THREE.RingGeometry(GAME_CONFIG.ballRadius * 1.45, GAME_CONFIG.ballRadius * 1.94, 32),
+      new THREE.MeshBasicMaterial({ color: '#fef08a', transparent: true, opacity: 0.65, side: THREE.DoubleSide }),
+    );
+    marker.rotation.x = -Math.PI / 2;
+    marker.visible = false;
+    this.scene.add(marker);
+    return marker;
+  }
+}

--- a/frontend/src/table-tennis/PaddleHitDetector.ts
+++ b/frontend/src/table-tennis/PaddleHitDetector.ts
@@ -1,0 +1,83 @@
+import * as THREE from 'three';
+import { GAME_CONFIG, ShotCommand, ShotType, Side, TABLE_BOUNDS } from './gameConfig';
+
+export interface PaddleHitInput {
+  side: Side;
+  paddlePosition: THREE.Vector3;
+  paddleForward: THREE.Vector3;
+  ballPosition: THREE.Vector3;
+  ballVelocity: THREE.Vector3;
+  ballSpin: THREE.Vector3;
+  requestedShot: ShotType;
+  shotCommand?: ShotCommand;
+  accuracy?: number;
+  powerScale?: number;
+}
+
+export interface PaddleHitResult {
+  valid: boolean;
+  shotType?: ShotType;
+  velocity?: THREE.Vector3;
+  spin?: THREE.Vector3;
+  reason?: string;
+}
+
+const shotProfiles: Record<ShotType, { lift: number; speed: number; spin: number; arc: number }> = {
+  'forehand drive': { lift: 1.68, speed: GAME_CONFIG.paddle.drivePower, spin: 2.35, arc: 0.16 },
+  'backhand drive': { lift: 1.58, speed: GAME_CONFIG.paddle.drivePower * 0.96, spin: 2.05, arc: 0.12 },
+  push: { lift: 1.12, speed: GAME_CONFIG.paddle.pushPower, spin: -1.85, arc: 0.2 },
+  'brush/topspin': { lift: 1.78, speed: GAME_CONFIG.paddle.drivePower * 0.98, spin: GAME_CONFIG.paddle.spin, arc: 0.05 },
+  lob: { lift: 2.85, speed: GAME_CONFIG.paddle.lobPower, spin: 0.75, arc: 0.46 },
+  'swerve power': { lift: 1.62, speed: GAME_CONFIG.paddle.drivePower * GAME_CONFIG.paddle.powerShotMultiplier, spin: GAME_CONFIG.paddle.spin * 0.9, arc: 0.08 },
+};
+
+const DEFAULT_COMMAND: ShotCommand = { aimX: 0, power: 0.58, lift: 0.45, curve: 0, spin: 0.25 };
+
+export class PaddleHitDetector {
+  detect(input: PaddleHitInput): PaddleHitResult {
+    const distance = input.paddlePosition.distanceTo(input.ballPosition);
+    if (distance > GAME_CONFIG.paddle.hitRadius) return { valid: false, reason: 'outside hit radius' };
+
+    const incoming = input.ballVelocity.clone().normalize();
+    const facingDot = input.paddleForward.clone().normalize().dot(incoming.clone().multiplyScalar(-1));
+    if (facingDot < GAME_CONFIG.paddle.minFacingDot) return { valid: false, reason: 'paddle face angle' };
+
+    const ballComingToPaddle = input.side === 'player' ? input.ballVelocity.z > 0.4 : input.ballVelocity.z < -0.4;
+    if (!ballComingToPaddle) return { valid: false, reason: 'ball moving away' };
+
+    const command = input.shotCommand ?? DEFAULT_COMMAND;
+    const profile = shotProfiles[input.requestedShot];
+    const screenAim = input.side === 'player' ? command.aimX : -command.aimX;
+    const edgeInset = GAME_CONFIG.table.width * 0.055;
+    const targetXBase = THREE.MathUtils.lerp(TABLE_BOUNDS.minX + edgeInset, TABLE_BOUNDS.maxX - edgeInset, (screenAim + 1) / 2);
+    const accuracy = input.accuracy ?? GAME_CONFIG.paddle.accuracy;
+    const error = (1 - accuracy) * GAME_CONFIG.table.width * THREE.MathUtils.lerp(0.16, 0.07, command.power);
+    const targetX = THREE.MathUtils.clamp(
+      targetXBase + THREE.MathUtils.randFloatSpread(error),
+      TABLE_BOUNDS.minX + edgeInset,
+      TABLE_BOUNDS.maxX - edgeInset,
+    );
+    const nearZ = input.side === 'player' ? TABLE_BOUNDS.minZ * 0.28 : TABLE_BOUNDS.maxZ * 0.28;
+    const deepZ = input.side === 'player' ? TABLE_BOUNDS.minZ * 0.84 : TABLE_BOUNDS.maxZ * 0.84;
+    const depthPower = THREE.MathUtils.clamp(command.power * 0.82 + (1 - command.lift) * 0.18, 0, 1);
+    const targetZBase = THREE.MathUtils.lerp(nearZ, deepZ, depthPower);
+    const targetZ = targetZBase + THREE.MathUtils.randFloatSpread((1 - accuracy) * GAME_CONFIG.table.length * 0.06);
+    const target = new THREE.Vector3(
+      targetX,
+      GAME_CONFIG.table.topY + profile.arc + command.lift * 0.32,
+      THREE.MathUtils.clamp(targetZ, Math.min(nearZ, deepZ), Math.max(nearZ, deepZ)),
+    );
+    const direction = target.sub(input.ballPosition).normalize();
+    const commandPower = THREE.MathUtils.lerp(0.72, 1.28, command.power);
+    const power = profile.speed * commandPower * (input.powerScale ?? 1);
+    const velocity = direction.multiplyScalar(power);
+    const minLift = input.requestedShot === 'lob' ? 2.18 : THREE.MathUtils.lerp(0.9, 1.24, command.lift);
+    velocity.y = Math.max(velocity.y + profile.lift + command.lift * 0.58, minLift);
+
+    const sideSign = input.side === 'player' ? -1 : 1;
+    const topOrBackSpin = profile.spin + command.spin * GAME_CONFIG.paddle.spin;
+    const sideSpin = command.curve * GAME_CONFIG.paddle.sideSpin;
+    const spin = new THREE.Vector3(topOrBackSpin * sideSign, 0, sideSpin * sideSign - input.paddleForward.x * 1.1);
+    return { valid: true, shotType: input.requestedShot, velocity, spin };
+  }
+}

--- a/frontend/src/table-tennis/PlayerController.ts
+++ b/frontend/src/table-tennis/PlayerController.ts
@@ -1,0 +1,112 @@
+import * as THREE from 'three';
+import { GAME_CONFIG, ShotCommand, ShotType } from './gameConfig';
+
+export interface PlayerVisuals {
+  root: THREE.Group;
+  torso: THREE.Object3D;
+  head: THREE.Object3D;
+  hand: THREE.Object3D;
+  paddle: THREE.Object3D;
+}
+
+const DEFAULT_SHOT: ShotCommand = { aimX: 0, power: 0.58, lift: 0.45, curve: 0, spin: 0.25 };
+
+export class PlayerController {
+  readonly targetX = { value: 0 };
+  currentShot: ShotType = 'forehand drive';
+  isRecovering = false;
+  private recoveryTimer = 0;
+  private queuedShot: ShotCommand | null = null;
+  private queuedShotAge = 0;
+  private readonly maxQueuedShotAge = 1.6;
+
+  constructor(private visuals: PlayerVisuals) {}
+
+  queueShot(command: ShotCommand) {
+    this.queuedShot = {
+      aimX: THREE.MathUtils.clamp(command.aimX, -1, 1),
+      power: THREE.MathUtils.clamp(command.power, 0, 1),
+      lift: THREE.MathUtils.clamp(command.lift, 0, 1),
+      curve: THREE.MathUtils.clamp(command.curve, -1, 1),
+      spin: THREE.MathUtils.clamp(command.spin, -1, 1),
+    };
+    this.queuedShotAge = 0;
+  }
+
+  peekShotCommand(): ShotCommand {
+    return this.queuedShot ?? DEFAULT_SHOT;
+  }
+
+  consumeShotCommand(): ShotCommand {
+    const shot = this.peekShotCommand();
+    this.queuedShot = null;
+    return shot;
+  }
+
+  update(dt: number, ballPosition: THREE.Vector3, predictedLanding: THREE.Vector3 | null) {
+    if (this.queuedShot) {
+      this.queuedShotAge += dt;
+      if (this.queuedShotAge > this.maxQueuedShotAge) this.queuedShot = null;
+    }
+
+    const root = this.visuals.root;
+    const isIncoming = ballPosition.z > 0.12;
+    const trackX = predictedLanding && predictedLanding.z > 0
+      ? predictedLanding.x
+      : ballPosition.x + THREE.MathUtils.clamp(ballPosition.x - root.position.x, -GAME_CONFIG.player.autoTrackLead, GAME_CONFIG.player.autoTrackLead);
+    this.targetX.value = THREE.MathUtils.clamp(isIncoming ? trackX : ballPosition.x * 0.42, GAME_CONFIG.player.minX, GAME_CONFIG.player.maxX);
+    root.position.x = THREE.MathUtils.damp(root.position.x, this.targetX.value, GAME_CONFIG.player.moveSpeed, dt);
+    root.position.x = THREE.MathUtils.clamp(root.position.x, GAME_CONFIG.player.minX, GAME_CONFIG.player.maxX);
+    root.position.z = GAME_CONFIG.player.z;
+
+    const command = this.peekShotCommand();
+    const acrossBody = ballPosition.x < root.position.x - 0.05;
+    this.currentShot = this.chooseShotVariant(ballPosition, acrossBody, command);
+
+    const lookYaw = THREE.MathUtils.clamp((ballPosition.x - root.position.x) * 0.45 + command.curve * 0.1, -0.52, 0.52);
+    this.visuals.torso.rotation.y = THREE.MathUtils.damp(this.visuals.torso.rotation.y, lookYaw, 9, dt);
+    this.visuals.head.rotation.y = THREE.MathUtils.damp(this.visuals.head.rotation.y, lookYaw * 0.8, 10, dt);
+
+    if (this.isRecovering) {
+      this.recoveryTimer -= dt;
+      if (this.recoveryTimer <= 0) this.isRecovering = false;
+    }
+    this.updatePaddleAttachment(dt, ballPosition, command);
+  }
+
+  triggerHit() {
+    this.isRecovering = true;
+    this.recoveryTimer = GAME_CONFIG.player.recoveryTime;
+  }
+
+  getPaddleWorldPosition() {
+    return this.visuals.paddle.getWorldPosition(new THREE.Vector3());
+  }
+
+  getPaddleForward() {
+    return new THREE.Vector3(0, 0, -1).applyQuaternion(this.visuals.paddle.getWorldQuaternion(new THREE.Quaternion())).normalize();
+  }
+
+  private chooseShotVariant(ballPosition: THREE.Vector3, acrossBody: boolean, command: ShotCommand): ShotType {
+    if (command.power > 0.82 && Math.abs(command.curve) > 0.34) return 'swerve power';
+    if (command.lift > 0.76 || ballPosition.y > GAME_CONFIG.table.topY + 0.55) return 'lob';
+    if (command.power < 0.34 || ballPosition.y < GAME_CONFIG.table.topY + 0.18) return 'push';
+    if (command.spin > 0.45 || Math.abs(command.curve) > 0.22) return 'brush/topspin';
+    return acrossBody ? 'backhand drive' : 'forehand drive';
+  }
+
+  private updatePaddleAttachment(dt: number, ballPosition: THREE.Vector3, command: ShotCommand) {
+    const hand = this.visuals.hand;
+    const paddle = this.visuals.paddle;
+    const side = this.currentShot === 'backhand drive' ? -1 : 1;
+    const reach = this.isRecovering
+      ? GAME_CONFIG.player.reach * 0.7
+      : THREE.MathUtils.clamp((GAME_CONFIG.player.z - ballPosition.z) * 0.28, 0.12, GAME_CONFIG.player.reach);
+    const powerLoad = THREE.MathUtils.lerp(-0.08, -0.2, command.power);
+    hand.position.set((0.16 + Math.abs(command.curve) * 0.05) * side, 0.92 + command.lift * 0.08, powerLoad - reach);
+    hand.rotation.y = THREE.MathUtils.damp(hand.rotation.y, side * (0.22 + Math.abs(command.curve) * 0.28), 12, dt);
+    hand.rotation.x = THREE.MathUtils.damp(hand.rotation.x, this.isRecovering ? -0.48 : -0.16 - command.lift * 0.24, 12, dt);
+    paddle.position.set(0, -0.02, -0.12);
+    paddle.rotation.set(-0.25 - command.lift * 0.18, command.curve * 0.22, side * (0.12 + command.power * 0.1));
+  }
+}

--- a/frontend/src/table-tennis/ReplayManager.ts
+++ b/frontend/src/table-tennis/ReplayManager.ts
@@ -1,0 +1,73 @@
+import * as THREE from 'three';
+import { BallStateName } from './BallPhysics';
+import { ShotType, Side } from './gameConfig';
+
+export type ReplayEvent =
+  | { type: 'ball'; time: number; position: THREE.Vector3; state: BallStateName }
+  | { type: 'hit'; time: number; side: Side; shotType: ShotType; position: THREE.Vector3 }
+  | { type: 'bounce'; time: number; side?: Side; position: THREE.Vector3 }
+  | { type: 'score'; time: number; winner: Side; score: { player: number; ai: number }; reason: string };
+
+export class ReplayManager {
+  events: ReplayEvent[] = [];
+  isReplaying = false;
+  private replayTime = 0;
+  private duration = 0;
+
+  startRecording() {
+    this.events = [];
+    this.isReplaying = false;
+    this.replayTime = 0;
+    this.duration = 0;
+  }
+
+  recordBall(time: number, position: THREE.Vector3, state: BallStateName) {
+    if (this.isReplaying) return;
+    this.events.push({ type: 'ball', time, position: position.clone(), state });
+    this.duration = Math.max(this.duration, time);
+  }
+
+  recordHit(time: number, side: Side, shotType: ShotType, position: THREE.Vector3) {
+    this.events.push({ type: 'hit', time, side, shotType, position: position.clone() });
+  }
+
+  recordBounce(time: number, side: Side | undefined, position: THREE.Vector3) {
+    this.events.push({ type: 'bounce', time, side, position: position.clone() });
+  }
+
+  recordScore(time: number, winner: Side, score: { player: number; ai: number }, reason: string) {
+    this.events.push({ type: 'score', time, winner, score: { ...score }, reason });
+  }
+
+  beginReplay() {
+    if (this.events.length < 2) return false;
+    this.isReplaying = true;
+    this.replayTime = 0;
+    return true;
+  }
+
+  update(dt: number) {
+    if (!this.isReplaying) return null;
+    this.replayTime += dt * 0.42;
+    if (this.replayTime >= this.duration) {
+      this.isReplaying = false;
+      return null;
+    }
+    return this.sampleBall(this.replayTime);
+  }
+
+  private sampleBall(time: number) {
+    const balls = this.events.filter((event): event is Extract<ReplayEvent, { type: 'ball' }> => event.type === 'ball');
+    let prev = balls[0];
+    let next = balls[balls.length - 1];
+    for (let i = 1; i < balls.length; i += 1) {
+      if (balls[i].time >= time) {
+        next = balls[i];
+        prev = balls[i - 1];
+        break;
+      }
+    }
+    const t = next.time === prev.time ? 0 : (time - prev.time) / (next.time - prev.time);
+    return prev.position.clone().lerp(next.position, THREE.MathUtils.clamp(t, 0, 1));
+  }
+}

--- a/frontend/src/table-tennis/ScoreManager.ts
+++ b/frontend/src/table-tennis/ScoreManager.ts
@@ -1,0 +1,67 @@
+import { BallEvent, BallPhysics } from './BallPhysics';
+import { GAME_CONFIG, Side } from './gameConfig';
+
+export interface ScoreState {
+  player: number;
+  ai: number;
+  server: Side;
+  winner: Side | null;
+  lastReason: string;
+}
+
+export class ScoreManager {
+  state: ScoreState = { player: 0, ai: 0, server: 'player', winner: null, lastReason: 'Serve' };
+  private ralliesSinceServeSwitch = 0;
+
+  evaluate(events: BallEvent[], ball: BallPhysics): Side | null {
+    if (ball.state === 'pointEnded') return null;
+    let winner: Side | null = null;
+    let reason = '';
+
+    if (events.some((event) => event.type === 'net')) {
+      winner = ball.lastTouch === 'player' ? 'ai' : 'player';
+      reason = 'net fault';
+    } else if (ball.bounces.player > 1) {
+      winner = 'ai';
+      reason = 'double bounce on player side';
+    } else if (ball.bounces.ai > 1) {
+      winner = 'player';
+      reason = 'double bounce on AI side';
+    } else if (events.some((event) => event.type === 'out')) {
+      winner = this.scoreOutOrMiss(ball);
+      reason = 'missed return / out';
+    }
+
+    if (!winner) return null;
+    this.awardPoint(winner, reason);
+    ball.state = 'pointEnded';
+    return winner;
+  }
+
+  private scoreOutOrMiss(ball: BallPhysics): Side {
+    if (ball.lastTouch === 'player') {
+      return ball.bounces.ai === 0 ? 'ai' : 'player';
+    }
+    return ball.bounces.player === 0 ? 'player' : 'ai';
+  }
+
+  private awardPoint(winner: Side, reason: string) {
+    this.state[winner] += 1;
+    this.ralliesSinceServeSwitch += 1;
+    const serveInterval = this.state.player >= 10 && this.state.ai >= 10 ? 1 : 2;
+    if (this.ralliesSinceServeSwitch >= serveInterval) {
+      this.state.server = this.state.server === 'player' ? 'ai' : 'player';
+      this.ralliesSinceServeSwitch = 0;
+    }
+    this.state.lastReason = reason;
+    const leading = this.state.player > this.state.ai ? 'player' : 'ai';
+    const high = Math.max(this.state.player, this.state.ai);
+    const gap = Math.abs(this.state.player - this.state.ai);
+    this.state.winner = high >= GAME_CONFIG.score.gamePoint && gap >= GAME_CONFIG.score.winBy ? leading : null;
+  }
+
+  resetMatch() {
+    this.state = { player: 0, ai: 0, server: 'player', winner: null, lastReason: 'Serve' };
+    this.ralliesSinceServeSwitch = 0;
+  }
+}

--- a/frontend/src/table-tennis/UIOverlay.tsx
+++ b/frontend/src/table-tennis/UIOverlay.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react';
+import { GameHudState, GameManager } from './GameManager';
+import './tableTennis.css';
+
+const initialHud: GameHudState = {
+  playerScore: 0,
+  aiScore: 0,
+  server: 'YOU',
+  lastShot: '',
+  lastReason: 'Serve',
+  replaying: false,
+  debug: { ballState: 'idle', bounces: 'P:0 AI:0', hitValidity: 'waiting', predictedLanding: 'none' },
+};
+
+export function UIOverlay() {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const managerRef = useRef<GameManager | null>(null);
+  const [hud, setHud] = useState(initialHud);
+  const [debug, setDebug] = useState(false);
+  const swipeStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
+
+  useEffect(() => {
+    if (!mountRef.current) return undefined;
+    const manager = new GameManager(mountRef.current);
+    managerRef.current = manager;
+    manager.start(setHud);
+
+    const onResize = () => {
+      const mount = mountRef.current;
+      if (!mount || !managerRef.current) return;
+      managerRef.current.camera.aspect = mount.clientWidth / mount.clientHeight;
+      managerRef.current.camera.updateProjectionMatrix();
+      managerRef.current.renderer.setSize(mount.clientWidth, mount.clientHeight);
+    };
+
+    const normalizePointer = (event: PointerEvent) => {
+      const bounds = mountRef.current?.getBoundingClientRect();
+      if (!bounds) return null;
+      return {
+        x: ((event.clientX - bounds.left) / bounds.width) * 2 - 1,
+        y: ((event.clientY - bounds.top) / bounds.height) * 2 - 1,
+      };
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      const point = normalizePointer(event);
+      if (!point) return;
+      manager.setPointer(point.x);
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      const point = normalizePointer(event);
+      if (!point) return;
+      swipeStartRef.current = { ...point, time: performance.now() };
+      manager.renderer.domElement.setPointerCapture(event.pointerId);
+    };
+
+    const onPointerUp = (event: PointerEvent) => {
+      const point = normalizePointer(event);
+      const start = swipeStartRef.current;
+      swipeStartRef.current = null;
+      if (!point || !start) return;
+      manager.shootSwipe({ x: start.x, y: start.y }, point, performance.now() - start.time);
+      if (manager.renderer.domElement.hasPointerCapture(event.pointerId)) {
+        manager.renderer.domElement.releasePointerCapture(event.pointerId);
+      }
+    };
+
+    window.addEventListener('resize', onResize);
+    manager.renderer.domElement.addEventListener('pointermove', onPointerMove);
+    manager.renderer.domElement.addEventListener('pointerdown', onPointerDown);
+    manager.renderer.domElement.addEventListener('pointerup', onPointerUp);
+    manager.renderer.domElement.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      manager.renderer.domElement.removeEventListener('pointermove', onPointerMove);
+      manager.renderer.domElement.removeEventListener('pointerdown', onPointerDown);
+      manager.renderer.domElement.removeEventListener('pointerup', onPointerUp);
+      manager.renderer.domElement.removeEventListener('pointercancel', onPointerUp);
+      manager.dispose();
+      managerRef.current = null;
+    };
+  }, []);
+
+  return (
+    <main className="tt-shell">
+      <div className="tt-phone-frame">
+        <div ref={mountRef} className="tt-canvas" />
+        <section className="tt-score-panel" aria-label="Score">
+          <div>
+            <span className="tt-name">YOU</span>
+            <strong>{hud.playerScore}</strong>
+          </div>
+          <div className="tt-serve">SERVE: {hud.server}</div>
+          <div>
+            <span className="tt-name">AI</span>
+            <strong>{hud.aiScore}</strong>
+          </div>
+        </section>
+
+        {hud.lastShot && !hud.replaying ? <div className="tt-shot-label">{hud.lastShot}</div> : null}
+        <div className="tt-swipe-hint">Swipe to shoot · aim sideways · flick up for lift · bend for curve</div>
+        {hud.replaying ? <div className="tt-replay-banner">VAR Replay: slow motion review</div> : null}
+
+        <section className="tt-controls">
+          <button type="button" onClick={() => managerRef.current?.replayLastRally()}>Replay</button>
+          <button type="button" onClick={() => managerRef.current?.resetMatch()}>Reset</button>
+          <button type="button" onClick={() => setDebug((value) => !value)}>{debug ? 'Hide debug' : 'Debug'}</button>
+        </section>
+
+        {debug ? (
+          <aside className="tt-debug">
+            <span>state: {hud.debug.ballState}</span>
+            <span>bounces: {hud.debug.bounces}</span>
+            <span>hit: {hud.debug.hitValidity}</span>
+            <span>landing: {hud.debug.predictedLanding}</span>
+            <span>last point: {hud.lastReason}</span>
+          </aside>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/table-tennis/gameConfig.ts
+++ b/frontend/src/table-tennis/gameConfig.ts
@@ -1,0 +1,123 @@
+import * as THREE from 'three';
+
+export type Side = 'player' | 'ai';
+export type ShotType = 'forehand drive' | 'backhand drive' | 'push' | 'brush/topspin' | 'lob' | 'swerve power';
+
+export interface ShotCommand {
+  /** -1 aims to the left sideline, +1 aims to the right sideline from the striker's screen perspective. */
+  aimX: number;
+  /** 0 is a soft touch, 1 is the strongest drive. */
+  power: number;
+  /** 0 is a flat/low shot, 1 is a higher clearance arc. */
+  lift: number;
+  /** -1 bends left, +1 bends right with side spin. */
+  curve: number;
+  /** -1 slices/backspins, +1 brushes heavy topspin. */
+  spin: number;
+}
+
+export interface DifficultyConfig {
+  reactionTime: number;
+  moveSpeed: number;
+  accuracy: number;
+  shotPower: number;
+  mistakeChance: number;
+}
+
+// Pool Royale exports its current 7ft outer table footprint as 61.651044 × 90.4215312
+// world units. Table Tennis uses the same width:length ratio and scaled-down footprint so
+// it occupies the same HDRI placement/orientation while staying in this game's meter-sized scene.
+const POOL_ROYALE_TABLE_WIDTH = 61.651044;
+const POOL_ROYALE_TABLE_LENGTH = 90.4215312;
+const POOL_ROYALE_TO_TABLE_TENNIS_BASE_SCALE = 0.045;
+const TABLE_TENNIS_SIZE_MULTIPLIER = 1.58;
+const POOL_ROYALE_TO_TABLE_TENNIS_SCALE = POOL_ROYALE_TO_TABLE_TENNIS_BASE_SCALE * TABLE_TENNIS_SIZE_MULTIPLIER;
+const TABLE_WIDTH = POOL_ROYALE_TABLE_WIDTH * POOL_ROYALE_TO_TABLE_TENNIS_SCALE;
+const TABLE_LENGTH = POOL_ROYALE_TABLE_LENGTH * POOL_ROYALE_TO_TABLE_TENNIS_SCALE;
+const TABLE_LENGTH_SCALE = TABLE_LENGTH / 2.74;
+const TABLE_WIDTH_SCALE = TABLE_WIDTH / 1.55;
+
+export const GAME_CONFIG = {
+  fixedDt: 1 / 120,
+  gravity: -9.8,
+  drag: 0.09,
+  spinCurve: 0.08,
+  ballRadius: 0.062 * TABLE_TENNIS_SIZE_MULTIPLIER,
+  serveHeight: 0.38 * TABLE_TENNIS_SIZE_MULTIPLIER,
+  serveForwardPower: 2.9 * TABLE_LENGTH_SCALE,
+  table: {
+    width: TABLE_WIDTH,
+    length: TABLE_LENGTH,
+    topY: 0.76 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    thickness: 0.09 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    color: '#1266c3',
+    lineColor: '#e8f4ff',
+  },
+  net: {
+    height: 0.2 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    thickness: 0.03 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    overhang: 0.13 * TABLE_TENNIS_SIZE_MULTIPLIER,
+  },
+  player: {
+    z: TABLE_LENGTH / 2 + 0.84 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    minX: -TABLE_WIDTH / 2 - 0.12 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    maxX: TABLE_WIDTH / 2 + 0.12 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    safeZ: TABLE_LENGTH / 2 + 0.68 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    moveSpeed: 2.55 * TABLE_WIDTH_SCALE,
+    reach: 0.48 * TABLE_WIDTH_SCALE,
+    autoTrackLead: 0.34 * TABLE_WIDTH_SCALE,
+    recoveryTime: 0.28,
+    avatarScale: 1.62 * TABLE_TENNIS_SIZE_MULTIPLIER,
+  },
+  ai: {
+    z: -TABLE_LENGTH / 2 - 0.84 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    minX: -TABLE_WIDTH / 2 - 0.12 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    maxX: TABLE_WIDTH / 2 + 0.12 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    maxReach: 0.58 * TABLE_WIDTH_SCALE,
+    avatarScale: 1.62 * TABLE_TENNIS_SIZE_MULTIPLIER,
+    difficulty: {
+      reactionTime: 0.1,
+      moveSpeed: 3.05 * TABLE_WIDTH_SCALE,
+      accuracy: 0.94,
+      shotPower: 1.18,
+      mistakeChance: 0.035,
+    } satisfies DifficultyConfig,
+  },
+  paddle: {
+    hitRadius: 0.18 * TABLE_WIDTH_SCALE,
+    timingWindow: 0.15,
+    minFacingDot: 0.22,
+    drivePower: 3.35 * TABLE_LENGTH_SCALE,
+    pushPower: 2.55 * TABLE_LENGTH_SCALE,
+    lobPower: 2.65 * TABLE_LENGTH_SCALE,
+    powerShotMultiplier: 1.18,
+    spin: 3.6,
+    sideSpin: 4.2,
+    accuracy: 0.985,
+  },
+  camera: {
+    position: new THREE.Vector3(0, 2.7 * TABLE_TENNIS_SIZE_MULTIPLIER, 6.1 * TABLE_TENNIS_SIZE_MULTIPLIER),
+    target: new THREE.Vector3(0, 1.02 * TABLE_TENNIS_SIZE_MULTIPLIER, 0.18 * TABLE_TENNIS_SIZE_MULTIPLIER),
+    damping: 8,
+  },
+  score: {
+    gamePoint: 11,
+    winBy: 2,
+  },
+} as const;
+
+export const TABLE_BOUNDS = {
+  minX: -GAME_CONFIG.table.width / 2,
+  maxX: GAME_CONFIG.table.width / 2,
+  minZ: -GAME_CONFIG.table.length / 2,
+  maxZ: GAME_CONFIG.table.length / 2,
+};
+
+export const NET_BOUNDS = {
+  minX: -GAME_CONFIG.table.width / 2 - GAME_CONFIG.net.overhang,
+  maxX: GAME_CONFIG.table.width / 2 + GAME_CONFIG.net.overhang,
+  minY: GAME_CONFIG.table.topY,
+  maxY: GAME_CONFIG.table.topY + GAME_CONFIG.net.height,
+  minZ: -GAME_CONFIG.net.thickness / 2,
+  maxZ: GAME_CONFIG.net.thickness / 2,
+};

--- a/frontend/src/table-tennis/tableTennis.css
+++ b/frontend/src/table-tennis/tableTennis.css
@@ -1,0 +1,148 @@
+.tt-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, #123466, #020617 72%);
+  color: white;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  overflow: hidden;
+}
+
+.tt-phone-frame {
+  position: relative;
+  width: min(100vw, 430px);
+  height: 100vh;
+  max-height: 932px;
+  overflow: hidden;
+  background: #07162e;
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45);
+}
+
+.tt-canvas,
+.tt-canvas canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  touch-action: none;
+}
+
+.tt-score-panel {
+  position: absolute;
+  top: max(14px, env(safe-area-inset-top));
+  left: 16px;
+  right: 16px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 20px;
+  background: rgba(3, 7, 18, 0.56);
+  backdrop-filter: blur(14px);
+}
+
+.tt-score-panel > div:not(.tt-serve) {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tt-score-panel strong {
+  font-size: clamp(24px, 7vw, 36px);
+  line-height: 1;
+}
+
+.tt-name,
+.tt-serve {
+  color: #bfdbfe;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.tt-serve {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.35);
+  white-space: nowrap;
+}
+
+.tt-shot-label,
+.tt-replay-banner {
+  position: absolute;
+  left: 50%;
+  top: 102px;
+  transform: translateX(-50%);
+  padding: 9px 14px;
+  border-radius: 999px;
+  background: rgba(250, 204, 21, 0.92);
+  color: #111827;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  box-shadow: 0 10px 30px rgba(250, 204, 21, 0.25);
+}
+
+.tt-replay-banner {
+  background: rgba(37, 99, 235, 0.92);
+  color: white;
+}
+
+.tt-controls {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: max(18px, env(safe-area-inset-bottom));
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.tt-controls button {
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 14px;
+  color: white;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(12px);
+  font-weight: 800;
+}
+
+.tt-debug {
+  position: absolute;
+  right: 12px;
+  bottom: 76px;
+  display: grid;
+  gap: 3px;
+  padding: 10px;
+  max-width: 230px;
+  border-radius: 14px;
+  color: #dbeafe;
+  background: rgba(2, 6, 23, 0.7);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+}
+
+.tt-swipe-hint {
+  position: absolute;
+  left: 50%;
+  bottom: max(74px, calc(env(safe-area-inset-bottom) + 74px));
+  width: min(calc(100% - 32px), 360px);
+  transform: translateX(-50%);
+  padding: 10px 13px;
+  border: 1px solid rgba(125, 211, 252, 0.2);
+  border-radius: 999px;
+  background: rgba(8, 47, 73, 0.48);
+  color: #dff7ff;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-align: center;
+  text-shadow: 0 1px 10px rgba(14, 165, 233, 0.38);
+  backdrop-filter: blur(12px);
+  pointer-events: none;
+}

--- a/test/bowlingTenPinRules.test.js
+++ b/test/bowlingTenPinRules.test.js
@@ -1,0 +1,87 @@
+import {
+  addTenPinRoll,
+  frameComplete,
+  getLegalTenPinMax,
+  recomputePlayerTotals
+} from '../webapp/src/pages/Games/bowlingTenPinRules.js';
+
+const makePlayer = () => ({
+  name: 'P1',
+  total: 0,
+  frames: Array.from({ length: 10 }, () => ({ rolls: [], cumulative: null }))
+});
+
+const rollMany = (player, rolls) =>
+  rolls.map((pins) => addTenPinRoll(player, pins));
+
+describe('official ten-pin bowling rules', () => {
+  test('scores a perfect game as 300 with 10th-frame bonus strikes', () => {
+    const player = makePlayer();
+    const decisions = rollMany(player, Array(12).fill(10));
+
+    expect(player.total).toBe(300);
+    expect(player.frames[9].rolls).toEqual([10, 10, 10]);
+    expect(decisions.at(-1).gameFinished).toBe(true);
+  });
+
+  test('scores spare bonuses and keeps cumulative frames pending until bonus roll arrives', () => {
+    const player = makePlayer();
+    addTenPinRoll(player, 5);
+    addTenPinRoll(player, 5);
+
+    expect(player.frames[0].cumulative).toBeNull();
+
+    addTenPinRoll(player, 3);
+    addTenPinRoll(player, 4);
+
+    expect(player.frames[0].cumulative).toBe(13);
+    expect(player.frames[1].cumulative).toBe(20);
+    expect(player.total).toBe(20);
+  });
+
+  test('limits legal pinfall to the standing rack in normal frames and 10th-frame partial racks', () => {
+    const player = makePlayer();
+    addTenPinRoll(player, 8);
+    addTenPinRoll(player, 8);
+
+    expect(player.frames[0].rolls).toEqual([8, 2]);
+
+    player.frames[9].rolls = [10, 7];
+    expect(getLegalTenPinMax(player.frames[9], 9, 2)).toBe(3);
+  });
+
+  test('keeps open 10th frames to two rolls and strike/spare 10th frames to three rolls', () => {
+    const open = { rolls: [4, 5], cumulative: null };
+    const strikeBonus = { rolls: [10, 4], cumulative: null };
+    const spareBonus = { rolls: [4, 6], cumulative: null };
+
+    expect(frameComplete(open, 9)).toBe(true);
+    expect(frameComplete(strikeBonus, 9)).toBe(false);
+    expect(frameComplete(spareBonus, 9)).toBe(false);
+
+    strikeBonus.rolls.push(3);
+    spareBonus.rolls.push(8);
+    expect(frameComplete(strikeBonus, 9)).toBe(true);
+    expect(frameComplete(spareBonus, 9)).toBe(true);
+  });
+
+  test('counts foul rolls as delivered balls with zero scored pinfall', () => {
+    const player = makePlayer();
+    const decision = addTenPinRoll(player, 8, { foul: true });
+    addTenPinRoll(player, 5);
+
+    expect(decision.foul).toBe(true);
+    expect(decision.knocked).toBe(0);
+    expect(player.frames[0].rolls).toEqual([0, 5]);
+    expect(player.frames[0].cumulative).toBe(5);
+  });
+
+  test('scores all nines as 90 open-frame game', () => {
+    const player = makePlayer();
+    player.frames.forEach((frame) => frame.rolls.push(9, 0));
+    recomputePlayerTotals(player);
+
+    expect(player.total).toBe(90);
+    expect(player.frames[9].cumulative).toBe(90);
+  });
+});

--- a/webapp/public/assets/icons/table-tennis-icon.svg
+++ b/webapp/public/assets/icons/table-tennis-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Table tennis icon">
+  <rect width="128" height="128" rx="24" fill="#0b1220"/>
+  <text x="64" y="84" text-anchor="middle" font-size="72">🏓</text>
+</svg>

--- a/webapp/public/assets/icons/tennis-icon.svg
+++ b/webapp/public/assets/icons/tennis-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><rect width="256" height="256" rx="48" fill="#0c1b2a"/><text x="128" y="152" text-anchor="middle" font-size="96">🎾</text></svg>

--- a/webapp/public/assets/icons/tennis-royal.svg
+++ b/webapp/public/assets/icons/tennis-royal.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="675" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#052e16"/>
+      <stop offset="1" stop-color="#0f766e"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" rx="44" fill="url(#bg)"/>
+  <circle cx="600" cy="338" r="170" fill="#d9f84a"/>
+  <path d="M480 210c70 30 115 80 140 128 25 48 30 105 8 170" stroke="white" stroke-opacity="0.95" stroke-width="24" stroke-linecap="round"/>
+  <path d="M720 210c-70 30-115 80-140 128-25 48-30 105-8 170" stroke="white" stroke-opacity="0.95" stroke-width="24" stroke-linecap="round"/>
+  <text x="600" y="585" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="76" font-weight="700">Tennis Royal 🎾</text>
+</svg>

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -100,6 +100,12 @@ const SnookerRoyal = React.lazy(() => import('./pages/Games/SnookerRoyal.jsx'));
 const SnookerRoyalLobby = React.lazy(
   () => import('./pages/Games/SnookerRoyalLobby.jsx')
 );
+const Tennis = React.lazy(() => import('./pages/Games/Tennis.tsx'));
+const TennisLobby = React.lazy(() => import('./pages/Games/TennisLobby.jsx'));
+const BowlingRealistic = React.lazy(
+  () => import('./pages/Games/BowlingRealistic.tsx')
+);
+const BowlingLobby = React.lazy(() => import('./pages/Games/BowlingLobby.jsx'));
 const ShootingRange = React.lazy(
   () => import('./pages/Games/ShootingRange.tsx')
 );
@@ -420,6 +426,24 @@ export default function App() {
                 element={
                   <GameLiveAvatarOverlay gameSlug="snookerroyale">
                     <SnookerRoyal />
+                  </GameLiveAvatarOverlay>
+                }
+              />
+              <Route path="/games/tennis/lobby" element={<TennisLobby />} />
+              <Route
+                path="/games/tennis"
+                element={
+                  <GameLiveAvatarOverlay gameSlug="tennis">
+                    <Tennis />
+                  </GameLiveAvatarOverlay>
+                }
+              />
+              <Route path="/games/bowling/lobby" element={<BowlingLobby />} />
+              <Route
+                path="/games/bowling"
+                element={
+                  <GameLiveAvatarOverlay gameSlug="bowling">
+                    <BowlingRealistic />
                   </GameLiveAvatarOverlay>
                 }
               />

--- a/webapp/src/config/bowlingInventoryConfig.js
+++ b/webapp/src/config/bowlingInventoryConfig.js
@@ -1,0 +1,248 @@
+import {
+  POOL_ROYALE_HDRI_VARIANTS,
+  POOL_ROYALE_STORE_ITEMS,
+} from './poolRoyaleInventoryConfig.js';
+import { swatchThumbnail } from './storeThumbnails.js';
+
+const DEFAULT_BOWLING_CHARACTER_SOURCE = Object.freeze({
+  source: 'Domino Royal human character set',
+  license: 'original game avatar catalog'
+});
+
+export const BOWLING_DOMINO_CLOTH_MATERIALS = Object.freeze({
+  denim: {
+    source: 'Poly Haven denim_fabric 1k glTF CC0',
+    color: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/denim_fabric/denim_fabric_diff_1k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/denim_fabric/denim_fabric_nor_gl_1k.jpg',
+    roughness: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/denim_fabric/denim_fabric_rough_1k.jpg',
+    tint: 0x314d86
+  },
+  check: {
+    source: 'Poly Haven gingham_check 1k glTF CC0',
+    color: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/gingham_check/gingham_check_diff_1k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/gingham_check/gingham_check_nor_gl_1k.jpg',
+    roughness: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/gingham_check/gingham_check_rough_1k.jpg',
+    tint: 0x9f3651
+  },
+  hessian: {
+    source: 'Poly Haven hessian_230 1k glTF CC0',
+    color: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/hessian_230/hessian_230_diff_1k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/hessian_230/hessian_230_nor_gl_1k.jpg',
+    roughness: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/hessian_230/hessian_230_rough_1k.jpg',
+    tint: 0xa27445
+  },
+  floral: {
+    source: 'Poly Haven floral_jacquard 1k glTF CC0',
+    color: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/floral_jacquard/floral_jacquard_diff_1k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/floral_jacquard/floral_jacquard_nor_gl_1k.jpg',
+    roughness: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/floral_jacquard/floral_jacquard_rough_1k.jpg',
+    tint: 0x6d3f7f
+  },
+  fleece: {
+    source: 'Poly Haven knitted_fleece 1k glTF CC0',
+    color: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/knitted_fleece/knitted_fleece_diff_1k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/knitted_fleece/knitted_fleece_nor_gl_1k.jpg',
+    roughness: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/knitted_fleece/knitted_fleece_rough_1k.jpg',
+    tint: 0x4b5563
+  },
+  picnic: {
+    source: 'Poly Haven fabric_pattern_07 1k glTF CC0',
+    color: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/fabric_pattern_07/fabric_pattern_07_col_1_1k.jpg',
+    normal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/fabric_pattern_07/fabric_pattern_07_nor_gl_1k.jpg',
+    roughness: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/fabric_pattern_07/fabric_pattern_07_rough_1k.jpg',
+    tint: 0xc44f42
+  }
+});
+
+export const BOWLING_DOMINO_CHARACTER_TEXTURES = Object.freeze({
+  royalDenim: {
+    upper: { material: 'denim', tint: 0x2f5f9f, repeat: 4.2 },
+    lower: { material: 'hessian', tint: 0x9b6b3f, repeat: 3.4 },
+    accent: { material: 'fleece', tint: 0xd8dee9, repeat: 5.0 },
+    hairColor: 0x24150f,
+    eyeColor: 0x2f5d7c,
+    skinTone: 0xd9a27d
+  },
+  casinoCheck: {
+    upper: { material: 'check', tint: 0xb7375d, repeat: 3.8 },
+    lower: { material: 'denim', tint: 0x243e70, repeat: 4.4 },
+    accent: { material: 'hessian', tint: 0xf4d7a1, repeat: 3.2 },
+    hairColor: 0x14100c,
+    eyeColor: 0x5a3d2b,
+    skinTone: 0xc78f68
+  },
+  linenStreet: {
+    upper: { material: 'hessian', tint: 0xb68452, repeat: 3.6 },
+    lower: { material: 'fleece', tint: 0x374151, repeat: 5.2 },
+    accent: { material: 'denim', tint: 0x4a6fa4, repeat: 4.0 },
+    hairColor: 0x2c1b12,
+    eyeColor: 0x406a45,
+    skinTone: 0xe0b18d
+  },
+  jacquardNight: {
+    upper: { material: 'floral', tint: 0x7c3f88, repeat: 3.2 },
+    lower: { material: 'denim', tint: 0x1f335f, repeat: 4.5 },
+    accent: { material: 'check', tint: 0xe3c16f, repeat: 4.0 },
+    hairColor: 0x3a2418,
+    eyeColor: 0x364f7d,
+    skinTone: 0xb87957
+  },
+  softFleece: {
+    upper: { material: 'fleece', tint: 0x556070, repeat: 5.3 },
+    lower: { material: 'hessian', tint: 0x8b633f, repeat: 3.7 },
+    accent: { material: 'floral', tint: 0xb88ab8, repeat: 3.0 },
+    hairColor: 0x120d0a,
+    eyeColor: 0x33271e,
+    skinTone: 0xd39a72
+  },
+  patternedRed: {
+    upper: { material: 'picnic', tint: 0xc44f42, repeat: 3.4 },
+    lower: { material: 'denim', tint: 0x263f73, repeat: 4.7 },
+    accent: { material: 'fleece', tint: 0xf1f5f9, repeat: 5.0 },
+    hairColor: 0x231915,
+    eyeColor: 0x3d5f73,
+    skinTone: 0xc88b64
+  },
+  mixedDenim: {
+    upper: { material: 'denim', tint: 0x3b6ea8, repeat: 4.0 },
+    lower: { material: 'check', tint: 0x4f6f93, repeat: 4.2 },
+    accent: { material: 'hessian', tint: 0xd6a35f, repeat: 3.2 },
+    hairColor: 0x0f0b08,
+    eyeColor: 0x4c3425,
+    skinTone: 0xe3b08b
+  }
+});
+
+export const BOWLING_HUMAN_CHARACTER_OPTIONS = Object.freeze([
+  {
+    id: 'rpm-current-domino',
+    label: 'Current Avatar',
+    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'],
+    thumbnail: swatchThumbnail(['#2f6f8a', '#1e293b', '#b48d6b']),
+    accent: '#ff7a2f',
+    clothCombo: 'royalDenim',
+    ...DEFAULT_BOWLING_CHARACTER_SOURCE
+  },
+  {
+    id: 'rpm-67d411-domino',
+    label: 'Casino Rival',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    thumbnail: swatchThumbnail(['#b7375d', '#243e70', '#f4d7a1']),
+    accent: '#b7375d',
+    clothCombo: 'casinoCheck',
+    ...DEFAULT_BOWLING_CHARACTER_SOURCE
+  },
+  {
+    id: 'rpm-67f433-domino',
+    label: 'Linen Pro',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    thumbnail: swatchThumbnail(['#b68452', '#374151', '#4a6fa4']),
+    accent: '#b68452',
+    clothCombo: 'linenStreet',
+    ...DEFAULT_BOWLING_CHARACTER_SOURCE
+  },
+  {
+    id: 'rpm-67e1b5-domino',
+    label: 'Jacquard Ace',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    thumbnail: swatchThumbnail(['#7c3f88', '#1f335f', '#e3c16f']),
+    accent: '#7c3f88',
+    clothCombo: 'jacquardNight',
+    ...DEFAULT_BOWLING_CHARACTER_SOURCE
+  },
+  {
+    id: 'webgl-vietnam-human-domino',
+    label: 'Street Champ',
+    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb'],
+    thumbnail: swatchThumbnail(['#556070', '#8b633f', '#b88ab8']),
+    accent: '#556070',
+    clothCombo: 'softFleece',
+    ...DEFAULT_BOWLING_CHARACTER_SOURCE
+  },
+  {
+    id: 'webgl-ai-teacher-domino',
+    label: 'Pattern Coach',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb'],
+    thumbnail: swatchThumbnail(['#c44f42', '#263f73', '#f1f5f9']),
+    accent: '#c44f42',
+    clothCombo: 'patternedRed',
+    ...DEFAULT_BOWLING_CHARACTER_SOURCE
+  },
+  {
+    id: 'webgl-ai-teacher-1-domino',
+    label: 'Denim Striker',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb'],
+    thumbnail: swatchThumbnail(['#3b6ea8', '#4f6f93', '#d6a35f']),
+    accent: '#3b6ea8',
+    clothCombo: 'mixedDenim',
+    ...DEFAULT_BOWLING_CHARACTER_SOURCE
+  }
+]);
+
+const reduceLabels = (options) =>
+  options.reduce((acc, option) => {
+    acc[option.id] = option.label;
+    return acc;
+  }, {});
+
+export const BOWLING_HDRI_VARIANTS = Object.freeze(
+  POOL_ROYALE_HDRI_VARIANTS.map((variant, index) => ({
+    ...variant,
+    id: variant.id,
+    name: variant.name,
+    description: variant.description || 'Shared Pool Royale HDRI for bowling.',
+    sourceUrl: variant.sourceUrl,
+    hdriUrl: variant.hdriUrl,
+    thumbnailUrl: variant.thumbnailUrl || variant.thumbnail,
+    priceCoins: index === 0 ? 0 : variant.priceCoins ?? variant.price ?? 450,
+    rarity: index === 0 ? 'common' : 'rare',
+  }))
+);
+
+export const BOWLING_OPTION_LABELS = Object.freeze({
+  environmentHdri: Object.freeze(reduceLabels(BOWLING_HDRI_VARIANTS.map((variant) => ({ id: variant.id, label: `${variant.name} HDRI` })))),
+  tableFinish: 'Bowling Table Finish',
+  chromeColor: 'Bowling Chrome Plates',
+  humanCharacter: Object.freeze(reduceLabels(BOWLING_HUMAN_CHARACTER_OPTIONS)),
+});
+
+export const BOWLING_DEFAULT_LOADOUT = Object.freeze({
+  environmentHdri: BOWLING_HDRI_VARIANTS[0]?.id,
+  humanCharacter: BOWLING_HUMAN_CHARACTER_OPTIONS[0]?.id,
+});
+
+const poolVisualStoreItems = POOL_ROYALE_STORE_ITEMS.filter((item) =>
+  ['environmentHdri', 'tableFinish', 'chromeColor'].includes(item.type)
+);
+
+export const BOWLING_STORE_ITEMS = Object.freeze([
+  ...poolVisualStoreItems.map((item) => ({
+    ...item,
+    id: `bowling-${item.id}`,
+    game: 'bowling',
+    featured: item.type === 'environmentHdri' ? item.optionId === BOWLING_DEFAULT_LOADOUT.environmentHdri : !!item.featured,
+  })),
+  ...BOWLING_HUMAN_CHARACTER_OPTIONS.slice(1).map((option, index) => ({
+    id: `bowling-human-character-${option.id}`,
+    type: 'humanCharacter',
+    optionId: option.id,
+    game: 'bowling',
+    name: option.label,
+    price: 1200 + index * 90,
+    description: 'Domino Royal human avatar adapted for Real Bowling player and AI bowlers.',
+    thumbnail: option.thumbnail,
+    featured: index < 2,
+  }))
+]);

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -23,6 +23,7 @@ export const gameThumbnails = {
   fourinrowroyale: '/assets/icons/four-in-row-royale.svg',
   tavullbattleroyal: '/assets/icons/Backgammonroyallogo.png',
   ludobattleroyal: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png',
+  tennis: '/assets/icons/tennis-icon.svg',
   shootingrange: '/assets/icons/shooting-range.svg',
 };
 

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -1,5 +1,20 @@
 const gamesCatalog = [
   {
+    name: 'Real Bowling',
+    route: '/games/bowling/lobby',
+    slug: 'bowling',
+    image: '/assets/icons/air-hockey.svg',
+    description: 'Portrait-friendly 3D bowling with swipe aim and power.'
+  },
+
+  {
+    name: 'Tennis',
+    route: '/games/tennis/lobby',
+    slug: 'tennis',
+    image: '/assets/icons/tennis-icon.svg',
+    description: '3D tennis rally with swipe controls and physics.'
+  },
+  {
     name: "Texas Hold'em",
     route: '/games/texasholdem/lobby',
     slug: 'texasholdem',

--- a/webapp/src/pages/Games/BowlingLobby.jsx
+++ b/webapp/src/pages/Games/BowlingLobby.jsx
@@ -1,0 +1,321 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
+import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import RoomSelector from '../../components/RoomSelector.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { getLobbyIcon } from '../../config/gameAssets.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { addTransaction, getAccountBalance } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { socket } from '../../utils/socket.js';
+import {
+  ensureAccountId,
+  getTelegramId,
+  getTelegramPhotoUrl,
+  getTelegramUsername
+} from '../../utils/telegram.js';
+
+const PLAYER_OPTIONS = [1, 2, 3, 4, 5];
+const BOWLING_PLAYER_FLAG_KEY = 'bowlingPlayerFlag';
+const BOWLING_FLAGS_KEY = 'bowlingFlags';
+
+export default function BowlingLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [mode, setMode] = useState('local');
+  const [playerCount, setPlayerCount] = useState(2);
+  const [avatar, setAvatar] = useState('');
+  const [flags, setFlags] = useState([]);
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const startBet = stake.amount / 100;
+  const flagPickerCount = playerCount;
+
+  const flagSummary = useMemo(
+    () =>
+      flags.length ? flags.map((f) => FLAG_EMOJIS[f] || '').join(' ') : '🌐',
+    [flags]
+  );
+
+  useEffect(() => {
+    try {
+      setAvatar(loadAvatar() || getTelegramPhotoUrl());
+      const storedFlags = JSON.parse(
+        window.localStorage?.getItem(BOWLING_FLAGS_KEY) || '[]'
+      );
+      if (Array.isArray(storedFlags)) setFlags(storedFlags.slice(0, 5));
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    import('./BowlingRealistic.tsx').catch(() => {});
+  }, []);
+
+  const saveFlags = (nextFlags) => {
+    const safeFlags = (nextFlags || []).slice(0, flagPickerCount);
+    setFlags(safeFlags);
+    try {
+      window.localStorage?.setItem(
+        BOWLING_FLAGS_KEY,
+        JSON.stringify(safeFlags)
+      );
+      const firstFlag = FLAG_EMOJIS[safeFlags[0]];
+      if (firstFlag)
+        window.localStorage?.setItem(BOWLING_PLAYER_FLAG_KEY, firstFlag);
+    } catch {}
+  };
+
+  const launchGame = ({ accountId = '', tgId = '', tableId = '' } = {}) => {
+    const params = new URLSearchParams();
+    params.set('mode', mode);
+    params.set('players', String(playerCount));
+    params.set('avatars', 'flags');
+    if (flags.length)
+      params.set('flags', flags.slice(0, flagPickerCount).join(','));
+    if (avatar) params.set('avatar', avatar);
+    if (mode === 'online') {
+      params.set('token', stake.token);
+      params.set('amount', String(stake.amount));
+    }
+    const username = getTelegramUsername();
+    if (username) params.set('username', username);
+    if (tgId) params.set('tgId', tgId);
+    if (accountId) params.set('accountId', accountId);
+    if (tableId) params.set('tableId', tableId);
+    const initData = window.Telegram?.WebApp?.initData;
+    if (initData) params.set('init', encodeURIComponent(initData));
+    navigate(`/games/bowling?${params.toString()}`);
+  };
+
+  const startGame = async () => {
+    let accountId = '';
+    let tgId = '';
+    try {
+      accountId = await ensureAccountId();
+      tgId = getTelegramId();
+      if (mode === 'online') {
+        const balRes = await getAccountBalance(accountId);
+        if ((balRes.balance || 0) < stake.amount) {
+          alert('Insufficient balance');
+          return;
+        }
+        await addTransaction(tgId, -stake.amount, 'stake', {
+          game: 'bowling',
+          accountId
+        });
+      }
+    } catch {}
+
+    if (mode === 'online' && accountId) {
+      socket.emit('register', { playerId: accountId });
+      socket.emit(
+        'seatTable',
+        {
+          accountId,
+          gameType: 'bowling',
+          stake: Number(stake.amount) || 0,
+          maxPlayers: playerCount,
+          playerName: getTelegramUsername() || 'Player',
+          avatar,
+          mode: 'online',
+          token: stake.token
+        },
+        (res = {}) => {
+          if (!res.success || !res.tableId) {
+            alert('Unable to join Bowling online table. Please try again.');
+            return;
+          }
+          socket.emit('confirmReady', { accountId, tableId: res.tableId });
+          launchGame({ accountId, tgId, tableId: res.tableId });
+        }
+      );
+      return;
+    }
+
+    launchGame({ accountId, tgId });
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <GameLobbyHeader
+          slug="bowling"
+          title="Real Bowling Lobby"
+          badge="1 lane · 1 Murlan table"
+          description="Choose 1–5 bowlers, world-flag avatars, and online or AI play."
+        />
+
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">
+            Player Profile
+          </p>
+          <div className="mt-3 flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border border-white/15 bg-white/5 text-2xl">
+              {flags.length ? (
+                FLAG_EMOJIS[flags[0]] || '🌐'
+              ) : avatar ? (
+                <img
+                  src={avatar}
+                  alt="Your avatar"
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                '🌐'
+              )}
+            </div>
+            <div className="text-sm text-white/80">
+              <p className="font-semibold">Seat ready</p>
+              <p className="text-xs text-white/50">Flags: {flagSummary}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowFlagPicker(true)}
+            className="mt-3 w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-left text-sm text-white/80 transition hover:border-white/30"
+          >
+            <div className="text-[11px] uppercase tracking-wide text-white/50">
+              World Flag Avatars
+            </div>
+            <div className="flex items-center gap-2 text-base font-semibold">
+              <span className="text-lg">{flagSummary}</span>
+              <span>
+                {flags.length
+                  ? 'Custom flags selected'
+                  : 'Auto-pick global flags'}
+              </span>
+            </div>
+          </button>
+        </div>
+
+        {mode === 'local' ? (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <h3 className="font-semibold text-white">AI Match</h3>
+            <p className="text-xs text-white/60">
+              Local games fill every extra chair with AI bowlers for free.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
+            <h3 className="font-semibold text-white">Online Stake</h3>
+            <RoomSelector
+              selected={stake}
+              onSelect={setStake}
+              tokens={['TPC']}
+            />
+            <p className="text-center text-xs text-white/60">
+              Start bet: {startBet.toLocaleString('en-US')} TPC • Table stake:{' '}
+              {stake.amount.toLocaleString('en-US')} TPC
+            </p>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Match Mode</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+              Online / AI
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              {
+                id: 'local',
+                label: 'Vs AI',
+                desc: 'Instant 1–5 player table',
+                icon: '🤖'
+              },
+              {
+                id: 'online',
+                label: 'Online',
+                desc: 'Hosted matchmaking',
+                icon: '⚔️'
+              }
+            ].map(({ id, label, desc, icon }) => {
+              const active = mode === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setMode(id)}
+                  className={`lobby-option-card ${
+                    active
+                      ? 'lobby-option-card-active'
+                      : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-indigo-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('bowling', `mode-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Bowlers / Chairs</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+              1–5
+            </span>
+          </div>
+          <div className="grid grid-cols-5 gap-2">
+            {PLAYER_OPTIONS.map((count) => (
+              <button
+                key={count}
+                type="button"
+                onClick={() => {
+                  setPlayerCount(count);
+                  if (flags.length > count) saveFlags(flags.slice(0, count));
+                }}
+                className={`rounded-2xl border px-3 py-3 text-center font-black transition ${
+                  playerCount === count
+                    ? 'border-cyan-300 bg-cyan-300 text-slate-950'
+                    : 'border-white/10 bg-white/5 text-white hover:border-white/30'
+                }`}
+              >
+                {count}
+              </button>
+            ))}
+          </div>
+          <p className="text-center text-xs text-white/60">
+            The arena renders one bowling lane, one Murlan table, and exactly{' '}
+            {playerCount} chair{playerCount === 1 ? '' : 's'}.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={startGame}
+          className="w-full rounded-2xl bg-gradient-to-r from-cyan-300 via-sky-400 to-indigo-400 px-4 py-4 text-base font-black uppercase tracking-[0.24em] text-slate-950 shadow-lg shadow-cyan-500/20"
+        >
+          Start Bowling
+        </button>
+      </div>
+
+      <FlagPickerModal
+        open={showFlagPicker}
+        onClose={() => setShowFlagPicker(false)}
+        count={flagPickerCount}
+        selected={flags}
+        onSave={saveFlags}
+      />
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -1,0 +1,5983 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import {
+  BOWLING_DOMINO_CHARACTER_TEXTURES,
+  BOWLING_DOMINO_CLOTH_MATERIALS,
+  BOWLING_HDRI_VARIANTS,
+  BOWLING_HUMAN_CHARACTER_OPTIONS
+} from '../../config/bowlingInventoryConfig.js';
+import {
+  POOL_ROYALE_DEFAULT_UNLOCKS,
+  POOL_ROYALE_OPTION_LABELS,
+  POOL_ROYALE_STORE_ITEMS
+} from '../../config/poolRoyaleInventoryConfig.js';
+import { getCachedPoolRoyalInventory } from '../../utils/poolRoyalInventory.js';
+import { createMurlanStyleTable } from '../../utils/murlanTable.js';
+import { mapSpinForPhysics } from './poolRoyaleSpinUtils.js';
+import {
+  OFFICIAL_TEN_PIN_RULE_SUMMARY,
+  addTenPinRoll as addOfficialTenPinRoll,
+  clampTenPinRoll,
+  playerFinished as officialTenPinPlayerFinished
+} from './bowlingTenPinRules.js';
+
+type PlayerAction =
+  | 'idle'
+  | 'seated'
+  | 'standingUp'
+  | 'approach'
+  | 'throw'
+  | 'recover'
+  | 'celebrate'
+  | 'toSeat'
+  | 'toRack'
+  | 'pickBall'
+  | 'toApproach'
+  | 'replay';
+type BallReturnState = 'idle' | 'toPit' | 'hidden' | 'returning';
+type PinResetPhase = 'idle' | 'lowering' | 'sweeping' | 'lifting';
+type GraphicsQuality = 'performance' | 'balanced' | 'ultra';
+type BowlingFpsOption = 'auto' | '60' | '90' | '120';
+type BallSelectionMode = 'manual' | 'random';
+
+type HudState = {
+  power: number;
+  status: string;
+  compliment: string;
+  activePlayer: number;
+  p1: number;
+  p2: number;
+  frame: number;
+  roll: number;
+  rule: string;
+  lane: string;
+};
+
+type ThrowIntent = {
+  power: number;
+  releaseX: number;
+  targetX: number;
+  hook: number;
+  speed: number;
+  spin: { x: number; y: number };
+};
+
+type ControlState = {
+  active: boolean;
+  pointerId: number | null;
+  startX: number;
+  startY: number;
+  lastX: number;
+  lastY: number;
+  intent: ThrowIntent | null;
+};
+
+type CameraLookState = {
+  active: boolean;
+  pointerId: number | null;
+  startX: number;
+  startY: number;
+  yaw: number;
+  pitch: number;
+  targetYaw: number;
+  targetPitch: number;
+};
+
+type BowlingFrame = { rolls: number[]; cumulative: number | null };
+type RollDecision = {
+  frameIndex: number;
+  rollIndex: number;
+  frameEnded: boolean;
+  resetPins: boolean;
+  gameFinished: boolean;
+  knocked: number;
+  foul?: boolean;
+};
+type ScorePlayer = { name: string; frames: BowlingFrame[]; total: number };
+
+type HumanRig = {
+  root: THREE.Group;
+  modelRoot: THREE.Group;
+  fallback: THREE.Group;
+  shadow: THREE.Mesh;
+  model: THREE.Object3D | null;
+  pos: THREE.Vector3;
+  yaw: number;
+  targetYaw: number;
+  yawVelocity: number;
+  action: PlayerAction;
+  approachT: number;
+  throwT: number;
+  recoverT: number;
+  celebrateT: number;
+  celebrateVariant: "armsUp" | "fistPump" | "sideWave";
+  celebrateNext: boolean;
+  returnWalkT: number;
+  pickT: number;
+  walkCycle: number;
+  approachFrom: THREE.Vector3;
+  approachTo: THREE.Vector3;
+  seatPos: THREE.Vector3;
+  seatYaw: number;
+  standPos: THREE.Vector3;
+  seatT: number;
+};
+
+type BallVariant = {
+  label: string;
+  radius: number;
+  massFactor: number;
+  colors: [string, string, string];
+};
+type HumanCharacterOption = {
+  id: string;
+  label: string;
+  modelUrls: string[];
+  thumbnail?: string;
+  accent?: string;
+  clothCombo?: string;
+};
+
+type BallState = {
+  mesh: THREE.Mesh;
+  pos: THREE.Vector3;
+  vel: THREE.Vector3;
+  held: boolean;
+  rolling: boolean;
+  laneCenter: number;
+  inGutter: boolean;
+  hook: number;
+  spin: THREE.Vector2;
+  returnState: BallReturnState;
+  returnT: number;
+  variant: BallVariant;
+};
+
+type PinState = {
+  root: THREE.Group;
+  start: THREE.Vector3;
+  pos: THREE.Vector3;
+  vel: THREE.Vector3;
+  tilt: number;
+  tiltDir: THREE.Vector3;
+  angularVel: number;
+  standing: boolean;
+  knocked: boolean;
+};
+
+const HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const DEFAULT_HUMAN_CHARACTER_ID =
+  BOWLING_HUMAN_CHARACTER_OPTIONS[0]?.id || 'rpm-current-domino';
+const HUMAN_CHARACTER_OPTIONS =
+  BOWLING_HUMAN_CHARACTER_OPTIONS as HumanCharacterOption[];
+const HUMAN_INITIAL_SCALE = 1.34;
+const HDRI_OPTIONS = BOWLING_HDRI_VARIANTS.map((h) => ({
+  id: h.id,
+  name: h.name,
+  thumb: h.thumbnailUrl || h.thumbnail,
+  hdriUrl: h.hdriUrl,
+  assetId: h.assetId,
+  assetUrls: h.assetUrls,
+  preferredResolutions: h.preferredResolutions,
+  rotationY: h.rotationY,
+  cameraHeightM: h.cameraHeightM,
+  arenaScale: h.arenaScale
+}));
+const DEFAULT_HDRI_ID = HDRI_OPTIONS[0]?.id || 'studio_small_09';
+const TABLE_FINISH_ITEMS = POOL_ROYALE_STORE_ITEMS.filter(
+  (item) => item.type === 'tableFinish'
+);
+const CHROME_ITEMS = POOL_ROYALE_STORE_ITEMS.filter(
+  (item) => item.type === 'chromeColor'
+);
+const PORTRAIT_CAMERA_SIDE_OFFSET = 0.42;
+const PORTRAIT_CAMERA_HEIGHT_OFFSET = 0.18;
+const BOWLING_CAMERA_PULLBACK = 0.5;
+const BOWLING_HUMAN_SHOT_BROADCAST_PULLBACK = 1.15;
+const BOWLING_CAMERA_WIDER_FOV_BOOST = 1.5;
+const BOWLING_HDRI_WALL_ALIGNMENT_Y = 0;
+const BOWLING_GRAPHICS_PROFILES: Record<
+  GraphicsQuality,
+  {
+    maxPixelRatio: number;
+    targetFps: number;
+    shadowMapSize: number;
+  }
+> = {
+  performance: {
+    maxPixelRatio: 1.15,
+    targetFps: 60,
+    shadowMapSize: 1024
+  },
+  balanced: {
+    maxPixelRatio: 1.65,
+    targetFps: 90,
+    shadowMapSize: 1536
+  },
+  ultra: {
+    maxPixelRatio: 2.2,
+    targetFps: 120,
+    shadowMapSize: 2048
+  }
+};
+const BOWLING_FPS_OPTIONS: {
+  id: BowlingFpsOption;
+  label: string;
+  fps: number | null;
+}[] = [
+  { id: 'auto', label: 'Auto', fps: null },
+  { id: '60', label: '60 FPS', fps: 60 },
+  { id: '90', label: '90 FPS', fps: 90 },
+  { id: '120', label: '120 FPS', fps: 120 }
+];
+const BALL_VARIANTS: BallVariant[] = [
+  {
+    label: '10',
+    radius: 0.165,
+    massFactor: 0.92,
+    colors: ['#93c5fd', '#2563eb', '#0b1b4a']
+  },
+  {
+    label: '12',
+    radius: 0.176,
+    massFactor: 1.0,
+    colors: ['#fda4af', '#e11d48', '#4a0416']
+  },
+  {
+    label: '14',
+    radius: 0.188,
+    massFactor: 1.08,
+    colors: ['#fde68a', '#f59e0b', '#4a2900']
+  },
+  {
+    label: '16',
+    radius: 0.2,
+    massFactor: 1.16,
+    colors: ['#a7f3d0', '#059669', '#032d22']
+  }
+];
+const OAK_BASE =
+  'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/oak_veneer_01/';
+const OAK = {
+  diff: `${OAK_BASE}oak_veneer_01_diff_2k.jpg`,
+  rough: `${OAK_BASE}oak_veneer_01_rough_2k.jpg`,
+  normal: `${OAK_BASE}oak_veneer_01_nor_gl_2k.jpg`
+};
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+const STRIKE_DANCE_LINES = [
+  'Perfect strike!',
+  'Unstoppable!',
+  'Ten down, wow!',
+  'Pure power!'
+];
+const RESULT_COMPLIMENTS = {
+  strike: [
+    'STRIKE! Beautiful release.',
+    'Clean pocket hit!',
+    'That was elite timing.'
+  ],
+  spare: ['Great spare conversion!', 'Clutch second ball!'],
+  open: ['Nice try—adjust and fire again.', 'Good pace, keep rhythm.']
+} as const;
+
+// Keep the full bowling field grounded on the HDRI floor in portrait view.
+const BOWLING_HDRI_GROUND_SNAP_DROP = 0;
+
+const CFG = {
+  laneY: -1.5 - BOWLING_HDRI_GROUND_SNAP_DROP,
+  laneHalfW: 1.36,
+  gutterHalfW: 1.72,
+  laneCenterOffset: 1.82,
+  playerStartZ: 7.62,
+  rackEdgeX: 2.78,
+  rackStopZ: 6.96,
+  approachStopZ: 4.98,
+  foulZ: 4.55,
+  arrowsZ: 0.78,
+  pinDeckZ: -16.2,
+  backStopZ: -18.8,
+  ballR: 0.18,
+  pinR: 0.17,
+  pinToppleThreshold: 0.58,
+  pinSpotSpacing: 0.56,
+  approachDuration: 0.72,
+  throwDuration: 1.02,
+  replayDuration: 3.2,
+  recoverDuration: 0.28,
+  celebrateDuration: 1.85,
+  seatWalkDuration: 1.25,
+  standDuration: 0.5,
+  returnWalkDuration: 1.44,
+  pickDuration: 0.58,
+  releaseT: 0.62
+};
+
+const clamp = (v: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(hi, v));
+const clamp01 = (v: number) => clamp(v, 0, 1);
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+const easeInOut = (t: number) => t * t * (3 - 2 * t);
+const HDRI_RES_LADDER = ['8k', '4k', '2k', '1k'] as const;
+const CELEBRATION_VARIANTS = ['armsUp', 'fistPump', 'sideWave'] as const;
+const BOWLING_SFX = {
+  throw: 'https://cdn.pixabay.com/download/audio/2022/03/15/audio_c8f4f5f572.mp3?filename=bowling-ball-roll-6891.mp3',
+  strike: 'https://cdn.pixabay.com/download/audio/2022/03/24/audio_1710eb2548.mp3?filename=small-crowd-cheer-6713.mp3',
+  spare: 'https://cdn.pixabay.com/download/audio/2022/03/10/audio_e325dc0d53.mp3?filename=success-fanfare-trumpets-6185.mp3'
+} as const;
+
+const BOWLING_RULE_SUMMARY = OFFICIAL_TEN_PIN_RULE_SUMMARY;
+const SHOOTING_ZONE_DEPTH = 3.55;
+const SHOOTING_ZONE_SIDE_PAD = 0.42;
+const BOWLING_APPROACH_STEP_LENGTH = 0.72;
+const BOWLING_APPROACH_STEP_COUNT = 4;
+const SHOOTING_READY_Z =
+  CFG.foulZ + BOWLING_APPROACH_STEP_LENGTH * BOWLING_APPROACH_STEP_COUNT;
+const LANE_BOARD_COUNT = 39;
+const BOARD_WIDTH = (CFG.laneHalfW * 2) / LANE_BOARD_COUNT;
+const BOWLING_MURLAN_CHAIR_URLS = [
+  'https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/dining_chair_02/dining_chair_02_1k.gltf',
+  'https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/dining_chair_02/dining_chair_02_2k.gltf',
+  'https://dl.polyhaven.org/file/ph-assets/Models/gltf/4k/dining_chair_02/dining_chair_02_4k.gltf'
+];
+const LANE_CENTERS = [0] as const;
+const laneCenterForPlayer = (_playerIndex: number) => LANE_CENTERS[0];
+const isAtShootingLine = (pos: THREE.Vector3, laneCenter: number) =>
+  pos.z <= CFG.foulZ + SHOOTING_ZONE_DEPTH &&
+  pos.z >= CFG.foulZ + BOWLING_SHOOTING_ZONE_MIN_CLEARANCE &&
+  Math.abs(pos.x - laneCenter) <= CFG.laneHalfW + SHOOTING_ZONE_SIDE_PAD;
+const BOWLING_LOUNGE_CENTER = new THREE.Vector3(-4.42, CFG.laneY, 8.28);
+const BOWLING_RETURN_SIDE_X = 2.72;
+const BOWLING_RETURN_Z = 6.38;
+const BOWLING_RACK_SIDE_X = 3.42;
+const BOWLING_RACK_Z = 7.34;
+const BOWLING_RACK_SIDE_SIGN = Math.sign(BOWLING_RACK_SIDE_X) || 1;
+const BOWLING_RETURN_SIDE_SIGN = Math.sign(BOWLING_RETURN_SIDE_X) || 1;
+const bowlingRackPickupX = () =>
+  BOWLING_RACK_SIDE_X - BOWLING_RACK_SIDE_SIGN * 0.62;
+const BOWLING_RELEASE_FOUL_CLEARANCE = 0.42;
+const BOWLING_SHOOTING_ZONE_MIN_CLEARANCE = 0.32;
+const BOWLING_TABLE_CENTERS = [
+  new THREE.Vector3(-4.42, CFG.laneY, 8.18)
+] as const;
+type NavigationObstacle = { x: number; z: number; rx: number; rz: number };
+const HUMAN_NAV_OBSTACLES: NavigationObstacle[] = [
+  ...BOWLING_TABLE_CENTERS.map((center) => ({
+    x: center.x,
+    z: center.z,
+    rx: 1.46,
+    rz: 1.1
+  })),
+  { x: BOWLING_RETURN_SIDE_X, z: BOWLING_RETURN_Z, rx: 0.82, rz: 1.5 },
+  { x: BOWLING_RACK_SIDE_X, z: BOWLING_RACK_Z, rx: 0.9, rz: 0.7 }
+];
+const HUMAN_CLEARANCE = 0.34;
+const PLAYER_READY_POINT = new THREE.Vector3(
+  laneCenterForPlayer(0),
+  CFG.laneY,
+  SHOOTING_READY_Z
+);
+function yawTowardPoint(from: THREE.Vector3, to: THREE.Vector3) {
+  return Math.atan2(to.x - from.x, to.z - from.z);
+}
+function makeLoungeSeat(x: number, z: number) {
+  const pos = new THREE.Vector3(x, CFG.laneY, z);
+  return { pos, yaw: yawTowardPoint(pos, BOWLING_TABLE_CENTERS[0]) };
+}
+const BOWLING_LOUNGE_CHAIRS = [
+  makeLoungeSeat(-5.45, 7.28),
+  makeLoungeSeat(-3.38, 7.22),
+  makeLoungeSeat(-5.62, 8.72),
+  makeLoungeSeat(-3.18, 8.82),
+  makeLoungeSeat(-4.42, 9.52)
+] as { pos: THREE.Vector3; yaw: number }[];
+const PLAYER_SEATS = BOWLING_LOUNGE_CHAIRS.map((chair, index) => ({
+  pos: chair.pos.clone(),
+  yaw: chair.yaw,
+  stand: new THREE.Vector3(
+    clamp((index - 1.5) * 0.16, -0.34, 0.34),
+    CFG.laneY,
+    SHOOTING_READY_Z + Math.min(index, 3) * 0.08
+  )
+}));
+
+function keepHumanInBowlingWalkableArea(
+  pos: THREE.Vector3,
+  preferredSide = -1
+) {
+  // Keep bowlers off ball returns, furniture, lane caps, and other props with a light-weight ellipse navmesh.
+  pos.z = clamp(pos.z, CFG.foulZ + 0.2, 9.82);
+  const maxLoungeX = 5.9;
+  const minLoungeX = -6.25;
+  pos.x = clamp(pos.x, minLoungeX, maxLoungeX);
+  for (let pass = 0; pass < 2; pass++) {
+    for (const obstacle of HUMAN_NAV_OBSTACLES) {
+      const rx = obstacle.rx + HUMAN_CLEARANCE;
+      const rz = obstacle.rz + HUMAN_CLEARANCE;
+      const dx = pos.x - obstacle.x;
+      const dz = pos.z - obstacle.z;
+      const dist = (dx * dx) / (rx * rx) + (dz * dz) / (rz * rz);
+      if (dist >= 1) continue;
+      const angle = Math.atan2(dz / rz, dx / rx);
+      pos.x = obstacle.x + Math.cos(angle || preferredSide * Math.PI) * rx;
+      pos.z = obstacle.z + Math.sin(angle || -0.35) * rz;
+    }
+  }
+  if (Math.abs(pos.x) < CFG.gutterHalfW + 0.58 && pos.z < CFG.foulZ + 1.2) {
+    pos.z = CFG.foulZ + 1.2;
+  }
+  pos.y = CFG.laneY;
+  return pos;
+}
+
+function returnPickupPointForRig(rig: HumanRig) {
+  return new THREE.Vector3(bowlingRackPickupX(), CFG.laneY, BOWLING_RACK_Z);
+}
+
+function shootingReadyPointForRig(rig: HumanRig, laneCenter = 0) {
+  return new THREE.Vector3(
+    laneCenter + clamp(rig.standPos.x - laneCenter, -0.18, 0.18),
+    CFG.laneY,
+    SHOOTING_READY_Z
+  );
+}
+
+function bowlingReleaseFootPoint(laneCenter = 0) {
+  // Right-handed bowling finish: the left slide foot plants just behind the
+  // foul line while the right foot trails behind it, matching a legal release.
+  return new THREE.Vector3(
+    laneCenter - 0.16,
+    CFG.laneY,
+    CFG.foulZ + BOWLING_RELEASE_FOUL_CLEARANCE
+  );
+}
+
+function keepPlayersSeparated(rigs: HumanRig[], minDistance = 0.58) {
+  for (let i = 0; i < rigs.length; i++) {
+    for (let j = i + 1; j < rigs.length; j++) {
+      const a = rigs[i].pos;
+      const b = rigs[j].pos;
+      const dx = b.x - a.x;
+      const dz = b.z - a.z;
+      const d = Math.hypot(dx, dz);
+      if (d <= 0.0001 || d >= minDistance) continue;
+      const push = (minDistance - d) * 0.5;
+      const nx = dx / d;
+      const nz = dz / d;
+      a.x -= nx * push;
+      a.z -= nz * push;
+      b.x += nx * push;
+      b.z += nz * push;
+      keepHumanInBowlingWalkableArea(a, -1);
+      keepHumanInBowlingWalkableArea(b, 1);
+      syncHuman(rigs[i]);
+      syncHuman(rigs[j]);
+    }
+  }
+}
+
+function makeEmptyPlayers(count = 2): ScorePlayer[] {
+  const safeCount = clamp(Math.round(Number(count) || 2), 1, 5);
+  const makeFrames = () =>
+    Array.from({ length: 10 }, () => ({
+      rolls: [] as number[],
+      cumulative: null
+    }));
+  return Array.from({ length: safeCount }, (_, i) => ({
+    name: i === 0 ? 'PLAYER 1' : `PLAYER ${i + 1} AI`,
+    frames: makeFrames(),
+    total: 0
+  }));
+}
+
+function clonePlayers(players: ScorePlayer[]) {
+  return players.map((p) => ({
+    ...p,
+    frames: p.frames.map((f) => ({
+      rolls: [...f.rolls],
+      cumulative: f.cumulative
+    }))
+  }));
+}
+
+function frameComplete(frame: BowlingFrame, index: number) {
+  const r = frame.rolls;
+  if (index < 9) return r[0] === 10 || r.length >= 2;
+  if (r.length < 2) return false;
+  if (r[0] === 10 || r[0] + r[1] === 10) return r.length >= 3;
+  return r.length >= 2;
+}
+
+function currentFrameIndex(player: ScorePlayer) {
+  const idx = player.frames.findIndex((f, i) => !frameComplete(f, i));
+  return idx === -1 ? 9 : idx;
+}
+
+function playerFinished(player: ScorePlayer) {
+  return player.frames.every((f, i) => frameComplete(f, i));
+}
+
+function nextUnfinishedPlayerIndex(
+  players: ScorePlayer[],
+  currentIndex: number
+) {
+  if (players.every((p) => officialTenPinPlayerFinished(p)))
+    return currentIndex;
+  for (let offset = 1; offset <= players.length; offset++) {
+    const idx = (currentIndex + offset) % players.length;
+    if (!officialTenPinPlayerFinished(players[idx])) return idx;
+  }
+  return currentIndex;
+}
+
+function recomputePlayerTotals(player: ScorePlayer) {
+  const flat = player.frames.flatMap((f) => f.rolls);
+  let rollIndex = 0;
+  let running = 0;
+
+  for (let frame = 0; frame < 10; frame++) {
+    const out = player.frames[frame];
+    out.cumulative = null;
+
+    if (frame < 9) {
+      const a = flat[rollIndex];
+      if (a == null) break;
+      if (a === 10) {
+        const b = flat[rollIndex + 1];
+        const c = flat[rollIndex + 2];
+        if (b == null || c == null) break;
+        running += 10 + b + c;
+        out.cumulative = running;
+        rollIndex += 1;
+      } else {
+        const b = flat[rollIndex + 1];
+        if (b == null) break;
+        const base = a + b;
+        if (base === 10) {
+          const c = flat[rollIndex + 2];
+          if (c == null) break;
+          running += 10 + c;
+        } else running += base;
+        out.cumulative = running;
+        rollIndex += 2;
+      }
+    } else {
+      if (!frameComplete(out, frame)) break;
+      running += out.rolls.reduce((s, v) => s + v, 0);
+      out.cumulative = running;
+    }
+  }
+
+  player.total = running;
+}
+
+function addRollToPlayer(
+  player: ScorePlayer,
+  knocked: number,
+  foul = false
+): RollDecision {
+  const decision = addOfficialTenPinRoll(player, knocked, {
+    foul
+  }) as RollDecision;
+  return {
+    ...decision,
+    knocked:
+      decision.knocked ??
+      clampTenPinRoll(
+        player.frames[decision.frameIndex],
+        decision.frameIndex,
+        decision.rollIndex,
+        foul ? 0 : knocked
+      ),
+    foul
+  };
+}
+
+function shouldResetPinsForNextRoll(
+  frame: BowlingFrame,
+  frameIndex: number,
+  rollIndex: number,
+  knocked: number,
+  frameEnded: boolean
+) {
+  if (frameEnded) return true;
+  if (frameIndex < 9) return knocked === 10;
+  if (rollIndex === 0) return knocked === 10;
+  if (rollIndex === 1)
+    return frame.rolls[0] === 10 || frame.rolls[0] + frame.rolls[1] === 10;
+  return false;
+}
+
+function describeRollResult(
+  player: ScorePlayer,
+  result: RollDecision,
+  knocked: number
+) {
+  if (result.foul) {
+    return {
+      isStrike: false,
+      isSpare: false,
+      rule: 'Foul: delivered ball counts, pinfall scores 0, rack follows frame state',
+      lane: 'Foul line crossed · official score is 0 for this roll'
+    };
+  }
+  const frame = player.frames[result.frameIndex];
+  const isStrike =
+    knocked === 10 && (result.rollIndex === 0 || result.frameIndex === 9);
+  const isSpare =
+    !isStrike &&
+    result.rollIndex > 0 &&
+    frame.rolls[result.rollIndex - 1] + knocked === 10;
+  const pocket =
+    knocked >= 8
+      ? 'Pocket hit'
+      : knocked >= 5
+        ? 'Brooklyn leaves'
+        : 'Light hit';
+  return {
+    isStrike,
+    isSpare,
+    rule: isStrike
+      ? 'Strike: rack resets and next two rolls are bonuses'
+      : isSpare
+        ? 'Spare: next roll scores as bonus'
+        : result.frameEnded
+          ? 'Open frame: switch players'
+          : 'Second ball: convert the spare',
+    lane: `${pocket} · ${Math.max(0, 10 - knocked)} pin${10 - knocked === 1 ? '' : 's'} left`
+  };
+}
+
+function standingPinsCount(pins: PinState[]) {
+  return pins.filter(
+    (p) => p.root.visible && p.standing && p.tilt < CFG.pinToppleThreshold
+  ).length;
+}
+
+function enableShadow(obj: THREE.Object3D) {
+  obj.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (mesh.isMesh) {
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      mesh.frustumCulled = false;
+    }
+  });
+  return obj;
+}
+
+function setTexRepeat(tex: THREE.Texture, rx: number, ry: number) {
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(rx, ry);
+  tex.anisotropy = 8;
+}
+
+function loadOakMaterial(
+  loader: THREE.TextureLoader,
+  repeatX: number,
+  repeatY: number
+) {
+  const diff = loader.load(OAK.diff);
+  const rough = loader.load(OAK.rough);
+  const normal = loader.load(OAK.normal);
+  diff.colorSpace = THREE.SRGBColorSpace;
+  setTexRepeat(diff, repeatX, repeatY);
+  setTexRepeat(rough, repeatX, repeatY);
+  setTexRepeat(normal, repeatX, repeatY);
+  return new THREE.MeshPhysicalMaterial({
+    map: diff,
+    roughnessMap: rough,
+    normalMap: normal,
+    roughness: 0.28,
+    metalness: 0.012,
+    clearcoat: 0.72,
+    clearcoatRoughness: 0.12,
+    reflectivity: 0.62
+  });
+}
+
+function makeFallbackWoodMaterial() {
+  const c = document.createElement('canvas');
+  c.width = 512;
+  c.height = 512;
+  const ctx = c.getContext('2d')!;
+  ctx.fillStyle = '#d3a365';
+  ctx.fillRect(0, 0, 512, 512);
+  for (let i = 0; i < 90; i++) {
+    ctx.fillStyle = i % 2 ? 'rgba(110,65,28,0.12)' : 'rgba(255,255,255,0.07)';
+    ctx.fillRect(0, Math.random() * 512, 512, 1 + Math.random() * 3);
+  }
+  const tex = new THREE.CanvasTexture(c);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(1.1, 8.2);
+  return new THREE.MeshPhysicalMaterial({
+    map: tex,
+    roughness: 0.3,
+    metalness: 0.012,
+    clearcoat: 0.68,
+    clearcoatRoughness: 0.13,
+    reflectivity: 0.58
+  });
+}
+
+function normalizeHuman(model: THREE.Object3D, targetHeight: number) {
+  model.rotation.set(0, 0, 0);
+  model.position.set(0, 0, 0);
+  model.scale.setScalar(1);
+  model.updateMatrixWorld(true);
+  let box = new THREE.Box3().setFromObject(model);
+  const h = Math.max(0.001, box.max.y - box.min.y);
+  model.scale.setScalar(targetHeight / h);
+  model.updateMatrixWorld(true);
+  box = new THREE.Box3().setFromObject(model);
+  const center = box.getCenter(new THREE.Vector3());
+  model.position.add(new THREE.Vector3(-center.x, -box.min.y, -center.z));
+}
+
+function makeFallbackHuman(_color: number) {
+  // GLTF-only humans: keep an empty placeholder so animation code has a stable root,
+  // but never render procedural capsule/body parts while remote characters load.
+  const g = new THREE.Group();
+  g.visible = false;
+  return g;
+}
+
+function parseHexColor(value: string | undefined, fallback: number) {
+  if (!value) return fallback;
+  const normalized = value.replace('#', '');
+  const parsed = Number.parseInt(normalized, 16);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function getCharacterById(id: string | undefined) {
+  return (
+    HUMAN_CHARACTER_OPTIONS.find((option) => option.id === id) ||
+    HUMAN_CHARACTER_OPTIONS[0]
+  );
+}
+
+function pickRandomAiCharacter(playerCharacterId: string) {
+  const pool = HUMAN_CHARACTER_OPTIONS.filter(
+    (option) => option.id !== playerCharacterId
+  );
+  return (
+    pool[Math.floor(Math.random() * pool.length)] || HUMAN_CHARACTER_OPTIONS[0]
+  );
+}
+
+const dominoHumanTextureLoader = new THREE.TextureLoader();
+const dominoHumanTextureCache = new Map<string, THREE.Texture>();
+
+function loadDominoHumanTexture(
+  url: string | undefined,
+  isColor = false,
+  repeat = 3
+) {
+  if (!url) return null;
+  const key = `${url}|${isColor ? 'srgb' : 'linear'}|${repeat}`;
+  const cached = dominoHumanTextureCache.get(key);
+  if (cached) return cached;
+  const tex = dominoHumanTextureLoader.load(url);
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(repeat, repeat);
+  if (isColor) tex.colorSpace = THREE.SRGBColorSpace;
+  tex.anisotropy = 8;
+  dominoHumanTextureCache.set(key, tex);
+  return tex;
+}
+
+function isNearlyWhiteMaterial(mat: any) {
+  if (!mat?.color) return false;
+  return (
+    mat.color.r > 0.82 && mat.color.g > 0.82 && mat.color.b > 0.82 && !mat.map
+  );
+}
+
+function isLowSaturationLightMaterial(mat: any) {
+  if (!mat?.color || mat.map) return false;
+  const max = Math.max(mat.color.r, mat.color.g, mat.color.b);
+  const min = Math.min(mat.color.r, mat.color.g, mat.color.b);
+  return max > 0.72 && max - min < 0.18;
+}
+
+function classifyDominoHumanSurface(obj: THREE.Object3D, mat: any) {
+  const name = `${obj?.name || ''} ${mat?.name || ''}`.toLowerCase();
+  if (/eye|iris|pupil|cornea|wolf3d_eyes/.test(name)) return 'eye';
+  if (
+    /hair|brow|beard|mustache|moustache|lash|wolf3d_hair|wolf3d_beard|wolf3d_eyebrow/.test(
+      name
+    )
+  )
+    return 'hair';
+  if (/teeth|tooth|tongue|mouth|gum/.test(name)) return 'mouth';
+  if (/shoe|boot|sole|sneaker|footwear|wolf3d_outfit_footwear/.test(name))
+    return 'shoe';
+  if (
+    /skin|head|face|neck|hand|finger|wolf3d_head|wolf3d_body|bodymesh/.test(
+      name
+    ) &&
+    !/outfit|shirt|pants|trouser|shoe|sock|cloth|jacket|hood|dress|skirt|uniform|suit/.test(
+      name
+    )
+  )
+    return 'skin';
+  if (
+    /shirt|top|torso|chest|jacket|hood|dress|skirt|sleeve|upper|outfit_top|wolf3d_outfit_top/.test(
+      name
+    )
+  )
+    return 'upperCloth';
+  if (
+    /pants|trouser|jean|short|legging|bottom|outfit_bottom|wolf3d_outfit_bottom/.test(
+      name
+    )
+  )
+    return 'lowerCloth';
+  if (/tie|scarf|belt|strap|bag|hat|cap|glove|sock|accessory|accent/.test(name))
+    return 'accentCloth';
+  if (/cloth|clothing|uniform|outfit|suit/.test(name)) return 'upperCloth';
+  if (
+    isNearlyWhiteMaterial(mat) &&
+    /torso|chest|spine|pelvis|hip|leg|arm|body|mesh/.test(name)
+  )
+    return 'upperCloth';
+  return 'other';
+}
+
+function resolveDominoCloth(
+  character: HumanCharacterOption,
+  slot: 'upper' | 'lower' | 'accent'
+) {
+  const combo =
+    (BOWLING_DOMINO_CHARACTER_TEXTURES as any)[
+      character?.clothCombo || 'royalDenim'
+    ] || (BOWLING_DOMINO_CHARACTER_TEXTURES as any).royalDenim;
+  const slotConfig = combo?.[slot] || combo?.upper || { material: 'denim' };
+  const material =
+    (BOWLING_DOMINO_CLOTH_MATERIALS as any)[slotConfig.material] ||
+    (BOWLING_DOMINO_CLOTH_MATERIALS as any).denim;
+  return {
+    ...material,
+    tint: slotConfig.tint ?? material.tint ?? 0xffffff,
+    repeat: slotConfig.repeat ?? 3.5
+  };
+}
+
+function applyDominoClothMaterial(mat: any, cloth: any) {
+  mat.map = loadDominoHumanTexture(cloth.color, true, cloth.repeat);
+  mat.normalMap = loadDominoHumanTexture(cloth.normal, false, cloth.repeat);
+  mat.roughnessMap = loadDominoHumanTexture(
+    cloth.roughness,
+    false,
+    cloth.repeat
+  );
+  mat.color = new THREE.Color(cloth.tint ?? 0xffffff);
+  mat.normalScale = new THREE.Vector2(0.28, 0.28);
+  mat.roughness = 0.86;
+  mat.metalness = 0.015;
+}
+
+function enhanceBowlingHumanLikeDomino(
+  model: THREE.Object3D,
+  character: HumanCharacterOption
+) {
+  const combo =
+    (BOWLING_DOMINO_CHARACTER_TEXTURES as any)[
+      character?.clothCombo || 'royalDenim'
+    ] || (BOWLING_DOMINO_CHARACTER_TEXTURES as any).royalDenim;
+  const clothSlots: Record<string, any> = {
+    upperCloth: resolveDominoCloth(character, 'upper'),
+    lowerCloth: resolveDominoCloth(character, 'lower'),
+    accentCloth: resolveDominoCloth(character, 'accent')
+  };
+  const skinColor = new THREE.Color(combo.skinTone ?? 0xd2a07c);
+  const hairColor = new THREE.Color(combo.hairColor ?? 0x21150f);
+  const eyeColor = new THREE.Color(combo.eyeColor ?? 0x3f5f75);
+  model.traverse((obj: any) => {
+    if (!obj?.isMesh) return;
+    const sourceMaterials = Array.isArray(obj.material)
+      ? obj.material
+      : [obj.material];
+    const enhanced = sourceMaterials.map((sourceMat: any) => {
+      if (!sourceMat) return sourceMat;
+      const mat = sourceMat.clone
+        ? sourceMat.clone()
+        : new THREE.MeshStandardMaterial();
+      const surface = classifyDominoHumanSurface(obj, mat);
+      if (clothSlots[surface])
+        applyDominoClothMaterial(mat, clothSlots[surface]);
+      else if (surface === 'hair') {
+        mat.map = null;
+        mat.color = hairColor.clone();
+        mat.roughness = 0.56;
+        mat.metalness = 0.02;
+        mat.envMapIntensity = 0.28;
+      } else if (surface === 'eye') {
+        mat.map = null;
+        mat.color = eyeColor.clone();
+        mat.roughness = 0.18;
+        mat.metalness = 0;
+        mat.envMapIntensity = 1.1;
+      } else if (surface === 'skin') {
+        if (isLowSaturationLightMaterial(mat)) mat.color = skinColor.clone();
+        mat.roughness = Math.min(mat.roughness ?? 0.62, 0.62);
+        mat.metalness = 0;
+      } else if (surface === 'shoe') {
+        if (isLowSaturationLightMaterial(mat))
+          mat.color = new THREE.Color(0x111827);
+        mat.roughness = 0.78;
+        mat.metalness = 0.02;
+      } else if (surface === 'mouth') {
+        if (isNearlyWhiteMaterial(mat)) mat.color = new THREE.Color(0xf8fafc);
+        mat.roughness = 0.32;
+        mat.metalness = 0;
+      } else if (isNearlyWhiteMaterial(mat)) {
+        mat.color = skinColor.clone();
+        mat.roughness = 0.58;
+        mat.metalness = 0;
+      }
+      mat.needsUpdate = true;
+      return mat;
+    });
+    obj.material = Array.isArray(obj.material) ? enhanced : enhanced[0];
+  });
+}
+
+function addHuman(
+  scene: THREE.Scene,
+  start: THREE.Vector3,
+  character: HumanCharacterOption,
+  seatPos = start.clone(),
+  seatYaw = 0
+): HumanRig {
+  const root = new THREE.Group();
+  const modelRoot = new THREE.Group();
+  const fallback = makeFallbackHuman(
+    parseHexColor(character?.accent, 0xff7a2f)
+  );
+  const shadow = new THREE.Mesh(
+    new THREE.CircleGeometry(0.34, 32),
+    new THREE.MeshBasicMaterial({
+      color: 0x000000,
+      transparent: true,
+      opacity: 0.18,
+      depthWrite: false
+    })
+  );
+  shadow.rotation.x = -Math.PI / 2;
+  modelRoot.position.copy(start);
+  fallback.visible = false;
+  modelRoot.add(fallback);
+  shadow.position.set(start.x, CFG.laneY + 0.01, start.z);
+  scene.add(root, modelRoot, shadow);
+
+  const rig: HumanRig = {
+    root,
+    modelRoot,
+    fallback,
+    shadow,
+    model: null,
+    pos: start.clone(),
+    yaw: 0,
+    targetYaw: 0,
+    yawVelocity: 0,
+    action: 'idle',
+    approachT: 0,
+    throwT: 0,
+    recoverT: 0,
+    celebrateT: 0,
+    celebrateVariant: CELEBRATION_VARIANTS[Math.floor(Math.random() * CELEBRATION_VARIANTS.length)],
+    celebrateNext: false,
+    returnWalkT: 0,
+    pickT: 0,
+    walkCycle: 0,
+    approachFrom: start.clone(),
+    approachTo: start.clone(),
+    seatPos: seatPos.clone(),
+    seatYaw,
+    standPos: start.clone(),
+    seatT: 0
+  };
+
+  loadHumanCharacter(rig, character);
+
+  return rig;
+}
+
+function loadHumanCharacter(
+  rig: HumanRig,
+  character: HumanCharacterOption | undefined
+) {
+  const selected = character || HUMAN_CHARACTER_OPTIONS[0];
+  const urls = selected?.modelUrls?.length ? selected.modelUrls : [HUMAN_URL];
+  const loader = new GLTFLoader().setCrossOrigin('anonymous');
+  if (rig.model) {
+    rig.modelRoot.remove(rig.model);
+    rig.model = null;
+  }
+  rig.fallback.visible = false;
+  let cancelled = false;
+  const tryLoad = (index: number) => {
+    if (cancelled) return;
+    if (index >= urls.length) {
+      rig.fallback.visible = false;
+      return;
+    }
+    loader.load(
+      urls[index],
+      (gltf) => {
+        if (cancelled) return;
+        const model = gltf.scene;
+        normalizeHuman(model, 1.82);
+        model.scale.multiplyScalar(HUMAN_INITIAL_SCALE);
+        enhanceBowlingHumanLikeDomino(model, selected);
+        lockHumanToLaneGround(model);
+        enableShadow(model);
+        captureBowlingHumanDefaultPose(model);
+        if (rig.model) rig.modelRoot.remove(rig.model);
+        rig.model = model;
+        rig.fallback.visible = false;
+        rig.modelRoot.add(model);
+      },
+      undefined,
+      () => tryLoad(index + 1)
+    );
+  };
+  tryLoad(0);
+  return () => {
+    cancelled = true;
+  };
+}
+
+function lockHumanToLaneGround(model: THREE.Object3D) {
+  model.updateMatrixWorld(true);
+  const bounds = new THREE.Box3().setFromObject(model);
+  const groundOffset = CFG.laneY - bounds.min.y;
+  model.position.y += groundOffset;
+}
+
+function syncHuman(rig: HumanRig) {
+  rig.modelRoot.position.copy(rig.pos);
+  rig.modelRoot.rotation.y = rig.yaw;
+  rig.shadow.position.set(rig.pos.x, CFG.laneY + 0.01, rig.pos.z);
+}
+
+function smoothFacing(rig: HumanRig, nextPos: THREE.Vector3, dt: number) {
+  const move = nextPos.clone().sub(rig.pos);
+  if (move.lengthSq() > 0.0005) rig.targetYaw = Math.atan2(move.x, move.z);
+  let delta = rig.targetYaw - rig.yaw;
+  while (delta > Math.PI) delta -= Math.PI * 2;
+  while (delta < -Math.PI) delta += Math.PI * 2;
+  const yawStep = delta * (1 - Math.pow(0.0025, dt));
+  rig.yaw += yawStep;
+  rig.yawVelocity = yawStep / Math.max(0.0001, dt);
+}
+
+function applyHumanWalkMotion(
+  rig: HumanRig,
+  stride: number,
+  turnScale = 0.003,
+  lateralScale = 1
+) {
+  if (!rig.model) return;
+  // Soldier.glb-style walk: slower planted cadence, opposite arm/leg swing,
+  // visible hip roll, and restrained root drift so every Bowling character
+  // shares the same Goal Rush locomotion feel instead of skating.
+  captureBowlingHumanDefaultPose(rig.model);
+  resetBowlingHumanBonePose(rig.model);
+  const phase = rig.walkCycle;
+  const step = Math.sin(phase);
+  const counter = Math.sin(phase + Math.PI);
+  const footfall = Math.abs(step);
+  const turnLean = clamp(rig.yawVelocity * turnScale, -0.1, 0.1);
+  const deg = THREE.MathUtils.degToRad;
+  rig.model.position.y = footfall * stride * 0.115;
+  rig.model.position.x = Math.sin(phase * 0.5) * stride * 0.035 * lateralScale;
+  rig.model.rotation.x = 0.012 + counter * stride * 0.045;
+  rig.model.rotation.y = step * stride * 0.18;
+  rig.model.rotation.z = step * stride * 0.105 - turnLean;
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'hips'),
+    0,
+    step * stride * 0.08,
+    -step * stride * 0.09
+  );
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'spine'),
+    deg(2.5),
+    -step * stride * 0.035,
+    step * stride * 0.045
+  );
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'leftUpperArm'),
+    -counter * stride * 1.35,
+    0,
+    deg(-5)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'rightUpperArm'),
+    -step * stride * 1.35,
+    0,
+    deg(5)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'leftForeArm'),
+    Math.max(0, step) * stride * 0.42,
+    0,
+    0
+  );
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'rightForeArm'),
+    Math.max(0, counter) * stride * 0.42,
+    0,
+    0
+  );
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'leftThigh'),
+    step * stride * 1.05,
+    0,
+    deg(1.5)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'rightThigh'),
+    counter * stride * 1.05,
+    0,
+    deg(-1.5)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'leftCalf'),
+    Math.max(0, -step) * stride * 0.74,
+    0,
+    0
+  );
+  applyRotationOffset(
+    bowlingPoseBone(rig.model, 'rightCalf'),
+    Math.max(0, -counter) * stride * 0.74,
+    0,
+    0
+  );
+}
+
+function findRightHand(modelRoot: THREE.Object3D | null) {
+  if (!modelRoot) return null;
+  let hand: THREE.Object3D | null = null;
+  modelRoot.traverse((obj) => {
+    const n = obj.name.toLowerCase();
+    if (
+      !hand &&
+      (n.includes('righthand') ||
+        n.includes('hand_r') ||
+        n.includes('right_hand'))
+    )
+      hand = obj;
+  });
+  return hand;
+}
+
+function findBoneByHints(root: THREE.Object3D | null, hints: string[] = []) {
+  if (!root) return null;
+  const normalizedHints = hints.map((hint) => hint.toLowerCase());
+  let found: THREE.Object3D | null = null;
+  root.traverse((obj) => {
+    if (found) return;
+    const normalized = obj.name.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (
+      normalizedHints.some((hint) =>
+        normalized.includes(hint.replace(/[^a-z0-9]/g, ''))
+      )
+    ) {
+      found = obj;
+    }
+  });
+  return found;
+}
+
+function captureBowlingHumanDefaultPose(model: THREE.Object3D) {
+  if (model.userData.bowlingDefaultPose) return;
+  const bones = [
+    'hips',
+    'spine',
+    'head',
+    'leftUpperArm',
+    'leftForeArm',
+    'leftHand',
+    'rightUpperArm',
+    'rightForeArm',
+    'rightHand',
+    'leftThigh',
+    'leftCalf',
+    'rightThigh',
+    'rightCalf'
+  ] as const;
+  const pose: Record<string, THREE.Euler> = {};
+  for (const key of bones) {
+    const bone = bowlingPoseBone(model, key);
+    if (bone) pose[key] = bone.rotation.clone();
+  }
+  model.userData.bowlingDefaultPose = pose;
+}
+
+function bowlingPoseBone(model: THREE.Object3D, key: string) {
+  const hints: Record<string, string[]> = {
+    hips: ['hips', 'pelvis', 'pelvisjoint', 'hip_joint'],
+    spine: ['spine', 'chest', 'torso'],
+    head: ['head', 'neck', 'headjoint', 'head_joint'],
+    leftUpperArm: [
+      'leftarm',
+      'arm.l',
+      'l_upperarm',
+      'leftshoulder',
+      'armjointl',
+      'shoulderl'
+    ],
+    leftForeArm: [
+      'leftforearm',
+      'l_forearm',
+      'leftlowerarm',
+      'forearml',
+      'elbowl'
+    ],
+    leftHand: ['lefthand', 'hand.l', 'l_hand', 'handjointl'],
+    rightUpperArm: [
+      'rightarm',
+      'arm.r',
+      'r_upperarm',
+      'rightshoulder',
+      'armjointr',
+      'shoulderr'
+    ],
+    rightForeArm: [
+      'rightforearm',
+      'r_forearm',
+      'rightlowerarm',
+      'forearmr',
+      'elbowr'
+    ],
+    rightHand: ['righthand', 'hand.r', 'r_hand', 'handjointr'],
+    leftThigh: ['leftupleg', 'leftthigh', 'l_thigh', 'legjointl1'],
+    leftCalf: ['leftleg', 'leftcalf', 'l_calf', 'legjointl2'],
+    rightThigh: ['rightupleg', 'rightthigh', 'r_thigh', 'legjointr1'],
+    rightCalf: ['rightleg', 'rightcalf', 'r_calf', 'legjointr2']
+  };
+  return findBoneByHints(model, hints[key] || []);
+}
+
+function resetBowlingHumanBonePose(model: THREE.Object3D | null) {
+  const pose = model?.userData?.bowlingDefaultPose as
+    | Record<string, THREE.Euler>
+    | undefined;
+  if (!model || !pose) return;
+  Object.entries(pose).forEach(([key, rotation]) => {
+    const bone = bowlingPoseBone(model, key);
+    if (bone) bone.rotation.copy(rotation);
+  });
+}
+
+function applyRotationOffset(bone: THREE.Object3D | null, x = 0, y = 0, z = 0) {
+  if (!bone) return;
+  bone.rotation.x += x;
+  bone.rotation.y += y;
+  bone.rotation.z += z;
+}
+
+function applyMurlanSeatedBonePose(model: THREE.Object3D | null) {
+  if (!model) return;
+  captureBowlingHumanDefaultPose(model);
+  resetBowlingHumanBonePose(model);
+  const deg = THREE.MathUtils.degToRad;
+  applyRotationOffset(bowlingPoseBone(model, 'hips'), deg(-9), 0, 0);
+  applyRotationOffset(bowlingPoseBone(model, 'spine'), deg(-3), 0, 0);
+  applyRotationOffset(bowlingPoseBone(model, 'head'), deg(2), 0, 0);
+  applyRotationOffset(
+    bowlingPoseBone(model, 'leftUpperArm'),
+    deg(-44),
+    deg(-11),
+    deg(-8)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'leftForeArm'),
+    deg(62),
+    deg(-7),
+    deg(-7)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'leftHand'),
+    deg(22),
+    deg(-10),
+    deg(-9)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightUpperArm'),
+    deg(-46),
+    deg(11),
+    deg(8)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightForeArm'),
+    deg(62),
+    deg(7),
+    deg(7)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightHand'),
+    deg(24),
+    deg(10),
+    deg(9)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'leftThigh'),
+    deg(-90.5),
+    deg(9.2),
+    deg(2.9)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightThigh'),
+    deg(-90.5),
+    deg(1.7),
+    deg(-1.1)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'leftCalf'),
+    deg(-95.1),
+    deg(1.1),
+    deg(0.6)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightCalf'),
+    deg(-95.1),
+    deg(-1.1),
+    deg(-0.6)
+  );
+}
+
+function applyBowlingDeliveryPose(model: THREE.Object3D | null, t: number) {
+  if (!model) return;
+  captureBowlingHumanDefaultPose(model);
+  resetBowlingHumanBonePose(model);
+  const deg = THREE.MathUtils.degToRad;
+  const windup = clamp01(t / 0.32);
+  const drive = clamp01((t - 0.26) / (CFG.releaseT - 0.26));
+  const follow = clamp01((t - CFG.releaseT) / (1 - CFG.releaseT));
+  const releaseSnap = Math.exp(-Math.pow((t - CFG.releaseT) / 0.075, 2));
+  const leftPlant = easeInOut(clamp01(t / CFG.releaseT));
+  const rightTrailSettle = easeOutCubic(follow);
+
+  applyRotationOffset(
+    bowlingPoseBone(model, 'hips'),
+    deg(lerp(0, 13, leftPlant) - follow * 4),
+    deg(lerp(-4, 12, drive) - follow * 5),
+    deg(lerp(2, -9, drive) + follow * 12)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'spine'),
+    deg(lerp(2, 20, leftPlant) + releaseSnap * 4 - follow * 7),
+    deg(lerp(-8, 14, drive) - follow * 8),
+    deg(lerp(4, -16, drive) + follow * 19)
+  );
+  applyRotationOffset(bowlingPoseBone(model, 'head'), deg(-3), deg(-4), deg(4));
+
+  // Four-step right-handed release: the left arm stays slightly out/back for
+  // balance while the right hand carries the ball into a pendulum backswing,
+  // then drives forward beside the planted left slide foot.
+  applyRotationOffset(
+    bowlingPoseBone(model, 'leftUpperArm'),
+    deg(lerp(-12, -34, leftPlant) + follow * 6),
+    deg(lerp(-8, -18, leftPlant)),
+    deg(lerp(-6, -31, leftPlant) + follow * 6)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'leftForeArm'),
+    deg(lerp(8, 24, leftPlant)),
+    deg(-8),
+    deg(-10)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightUpperArm'),
+    deg(lerp(6, -78, windup) + lerp(0, 136, drive) + follow * 42),
+    deg(lerp(3, -10, windup) + follow * 6),
+    deg(lerp(3, 14, drive) + follow * 12)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightForeArm'),
+    deg(lerp(6, -24, windup) + lerp(0, 82, drive) + follow * 32),
+    deg(4),
+    deg(lerp(-4, 8, drive))
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightHand'),
+    deg(lerp(4, -22, drive) + follow * 20),
+    deg(4),
+    deg(lerp(-8, 14, drive))
+  );
+
+  // Left foot plants at the foul line and the right foot stays back on the floor for balance.
+  applyRotationOffset(
+    bowlingPoseBone(model, 'leftThigh'),
+    deg(lerp(3, -29, leftPlant)),
+    deg(lerp(0, -6, leftPlant)),
+    deg(lerp(0, -4, leftPlant))
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'leftCalf'),
+    deg(lerp(0, 18, leftPlant)),
+    0,
+    deg(1)
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightThigh'),
+    deg(lerp(-5, 24, leftPlant) - rightTrailSettle * 4),
+    deg(lerp(0, 10, leftPlant)),
+    deg(lerp(0, 16, leftPlant))
+  );
+  applyRotationOffset(
+    bowlingPoseBone(model, 'rightCalf'),
+    deg(lerp(0, -22, leftPlant) - rightTrailSettle * 3),
+    deg(1.5),
+    deg(6)
+  );
+}
+
+function applyStandingPose(rig: HumanRig) {
+  rig.modelRoot.visible = true;
+  rig.shadow.visible = true;
+  if (rig.model) {
+    resetBowlingHumanBonePose(rig.model);
+    rig.model.position.set(0.02, 0, 0.02);
+    rig.model.rotation.set(0.03, 0.02, -0.025);
+  }
+  rig.shadow.scale.set(0.82, 0.64, 1);
+}
+
+function applySeatedPose(rig: HumanRig) {
+  rig.modelRoot.visible = true;
+  rig.shadow.visible = true;
+  rig.pos.copy(rig.seatPos);
+  rig.yaw = rig.seatYaw;
+  rig.targetYaw = rig.seatYaw;
+  rig.action = 'seated';
+  if (rig.model) {
+    applyMurlanSeatedBonePose(rig.model);
+    rig.model.position.set(0, -0.5, -0.1);
+    rig.model.rotation.set(-0.18, 0, 0.02);
+  }
+  syncHuman(rig);
+  rig.shadow.scale.set(0.92, 0.72, 1);
+}
+
+function standRigForTurn(rig: HumanRig) {
+  rig.action = 'standingUp';
+  rig.seatT = 0.001;
+  rig.approachT = 0;
+  rig.throwT = 0;
+  rig.recoverT = 0;
+  rig.returnWalkT = 0;
+  rig.walkCycle = 0;
+  rig.approachFrom.copy(rig.seatPos);
+  rig.approachTo.copy(rig.standPos);
+}
+
+function seatRigAfterTurn(rig: HumanRig) {
+  rig.action = 'toSeat';
+  rig.seatT = 0.001;
+  rig.returnWalkT = 0;
+  rig.approachFrom.copy(rig.pos);
+  rig.approachTo.copy(rig.seatPos);
+}
+
+function loadFirstAvailableGltf(
+  urls: string[],
+  onLoad: (gltf: any) => void,
+  onError?: () => void
+) {
+  const loader = new GLTFLoader().setCrossOrigin('anonymous');
+  const tryLoad = (index: number) => {
+    if (index >= urls.length) {
+      onError?.();
+      return;
+    }
+    loader.load(urls[index], onLoad, undefined, () => tryLoad(index + 1));
+  };
+  tryLoad(0);
+}
+
+function animateFallbackHuman(
+  rig: HumanRig,
+  mode: 'walk' | 'bowl' | 'seat' | 'celebrate' | 'idle',
+  t: number
+) {
+  const leftArm = rig.fallback.getObjectByName('leftArm') as
+    | THREE.Object3D
+    | undefined;
+  const rightArm = rig.fallback.getObjectByName('rightArm') as
+    | THREE.Object3D
+    | undefined;
+  const leftLeg = rig.fallback.getObjectByName('leftLeg') as
+    | THREE.Object3D
+    | undefined;
+  const rightLeg = rig.fallback.getObjectByName('rightLeg') as
+    | THREE.Object3D
+    | undefined;
+  const torso = rig.fallback.getObjectByName('torso') as
+    | THREE.Object3D
+    | undefined;
+  const reset = () => {
+    if (leftArm) leftArm.rotation.set(0, 0, 0.22);
+    if (rightArm) rightArm.rotation.set(0, 0, -0.18);
+    if (leftLeg) leftLeg.rotation.set(0, 0, 0);
+    if (rightLeg) rightLeg.rotation.set(0, 0, 0);
+    if (torso) torso.rotation.set(0, 0, 0);
+  };
+  reset();
+  if (mode === 'walk') {
+    const s = Math.sin(t);
+    if (leftArm) leftArm.rotation.x = -s * 0.52;
+    if (rightArm) rightArm.rotation.x = s * 0.52;
+    if (leftLeg) leftLeg.rotation.x = s * 0.38;
+    if (rightLeg) rightLeg.rotation.x = -s * 0.38;
+  } else if (mode === 'bowl') {
+    const k = clamp01(t);
+    if (rightArm)
+      rightArm.rotation.x =
+        k < CFG.releaseT
+          ? lerp(-0.35, -1.9, k / CFG.releaseT)
+          : lerp(-1.9, 0.9, (k - CFG.releaseT) / (1 - CFG.releaseT));
+    if (leftArm) leftArm.rotation.x = lerp(0.35, -0.45, k);
+    if (leftLeg) leftLeg.rotation.x = lerp(0.1, -0.58, k);
+    if (rightLeg) rightLeg.rotation.x = lerp(-0.1, 0.46, k);
+    if (torso) torso.rotation.x = lerp(0, 0.22, Math.sin(k * Math.PI));
+  } else if (mode === 'seat') {
+    if (leftLeg) leftLeg.rotation.x = -0.95;
+    if (rightLeg) rightLeg.rotation.x = -0.95;
+    if (torso) torso.rotation.x = -0.12;
+  } else if (mode === 'celebrate') {
+    const wave = Math.sin(t * 8);
+    if (rig.celebrateVariant === 'fistPump') {
+      if (rightArm) rightArm.rotation.x = -1.95 + wave * 0.35;
+      if (leftArm) leftArm.rotation.x = -0.45 + wave * 0.08;
+      if (torso) torso.rotation.z = wave * 0.12;
+    } else if (rig.celebrateVariant === 'sideWave') {
+      if (leftArm) leftArm.rotation.x = -1.35 + wave * 0.22;
+      if (rightArm) rightArm.rotation.x = -1.35 - wave * 0.22;
+      if (leftArm) leftArm.rotation.z = 0.75;
+      if (rightArm) rightArm.rotation.z = -0.75;
+      if (torso) torso.rotation.y = wave * 0.1;
+    } else {
+      if (leftArm) leftArm.rotation.x = -1.9 + wave * 0.18;
+      if (rightArm) rightArm.rotation.x = -1.8 - wave * 0.18;
+      if (torso) torso.rotation.z = wave * 0.06;
+    }
+  }
+}
+
+function getHeldBallWorldPosition(rig: HumanRig) {
+  const handNode = findRightHand(rig.model) as THREE.Object3D | null;
+  const handAnchor = handNode
+    ? handNode.getWorldPosition(new THREE.Vector3())
+    : null;
+  let local = new THREE.Vector3(0.36, 0.7, 0.16);
+  if (rig.action === 'approach') {
+    const s = Math.sin(rig.walkCycle);
+    local = new THREE.Vector3(0.4, 0.7 + Math.abs(s) * 0.04, 0.16 + s * 0.08);
+  } else if (rig.action === 'throw') {
+    const t = clamp01(rig.throwT);
+    if (t < 0.3) {
+      const k = easeInOut(t / 0.3);
+      local = new THREE.Vector3(
+        lerp(0.34, 0.5, k),
+        lerp(0.88, 0.58, k),
+        lerp(0.14, 0.96, k)
+      );
+    } else if (t < CFG.releaseT) {
+      const k = easeInOut((t - 0.3) / (CFG.releaseT - 0.3));
+      local = new THREE.Vector3(
+        lerp(0.5, 0.16, k),
+        lerp(0.58, 0.32, k),
+        lerp(0.96, -0.7, k)
+      );
+    } else {
+      const k = easeOutCubic((t - CFG.releaseT) / (1 - CFG.releaseT));
+      local = new THREE.Vector3(
+        lerp(0.16, 0.08, k),
+        lerp(0.32, 1.46, k),
+        lerp(-0.7, -0.36, k)
+      );
+    }
+  } else if (rig.action === 'recover') {
+    const k = clamp01(rig.recoverT);
+    local = new THREE.Vector3(0.24, lerp(1.18, 0.96, k), lerp(0.44, 0.18, k));
+  } else if (rig.action === 'pickBall' || rig.action === 'toRack') {
+    const pickLift =
+      rig.action === 'pickBall' ? easeInOut(clamp01(rig.pickT)) : 0;
+    local = new THREE.Vector3(
+      0.3,
+      lerp(0.46, 0.88, pickLift),
+      lerp(0.24, 0.08, pickLift)
+    );
+  }
+  const fallbackWorld = local.applyAxisAngle(UP, rig.yaw).add(rig.pos);
+  if (!handAnchor) return fallbackWorld;
+  return handAnchor.add(
+    new THREE.Vector3(0.02, -0.075, 0.015).applyAxisAngle(UP, rig.yaw)
+  );
+}
+
+function makeBallTexture(colors: [string, string, string]) {
+  const c = document.createElement('canvas');
+  c.width = 1024;
+  c.height = 1024;
+  const ctx = c.getContext('2d')!;
+  const grad = ctx.createRadialGradient(320, 260, 30, 512, 512, 560);
+  grad.addColorStop(0, colors[0]);
+  grad.addColorStop(0.44, colors[1]);
+  grad.addColorStop(1, colors[2]);
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, 1024, 1024);
+  ctx.globalAlpha = 0.13;
+  for (let i = 0; i < 110; i++) {
+    ctx.fillStyle = i % 2 === 0 ? '#ffffff' : colors[1];
+    ctx.beginPath();
+    ctx.arc(
+      Math.random() * 1024,
+      Math.random() * 1024,
+      14 + Math.random() * 70,
+      0,
+      Math.PI * 2
+    );
+    ctx.fill();
+  }
+  ctx.globalAlpha = 0.18;
+  for (let i = 0; i < 38; i++) {
+    ctx.strokeStyle = i % 2 ? colors[0] : 'rgba(0,0,0,0.8)';
+    ctx.lineWidth = 8 + Math.random() * 18;
+    ctx.beginPath();
+    ctx.moveTo(Math.random() * 1024, Math.random() * 1024);
+    for (let j = 0; j < 5; j++)
+      ctx.lineTo(Math.random() * 1024, Math.random() * 1024);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = 'rgba(0,0,0,0.55)';
+  ctx.beginPath();
+  ctx.arc(420, 380, 28, 0, Math.PI * 2);
+  ctx.arc(495, 430, 28, 0, Math.PI * 2);
+  ctx.arc(395, 492, 26, 0, Math.PI * 2);
+  ctx.fill();
+  const tex = new THREE.CanvasTexture(c);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+function makeBallMaterial(colors: [string, string, string]) {
+  return new THREE.MeshPhysicalMaterial({
+    map: makeBallTexture(colors),
+    roughness: 0.08,
+    metalness: 0.01,
+    clearcoat: 1,
+    clearcoatRoughness: 0.03,
+    reflectivity: 1,
+    envMapIntensity: 1.4
+  });
+}
+
+function createActiveBall(
+  variant: BallVariant,
+  laneCenter = laneCenterForPlayer(0)
+) {
+  const mesh = new THREE.Mesh(
+    new THREE.SphereGeometry(variant.radius, 80, 64),
+    makeBallMaterial(variant.colors)
+  );
+  enableShadow(mesh);
+  const pos = new THREE.Vector3(laneCenter, CFG.laneY + 0.52, 6.34);
+  mesh.position.copy(pos);
+  mesh.visible = false;
+  return {
+    mesh,
+    pos,
+    vel: new THREE.Vector3(),
+    held: false,
+    rolling: false,
+    laneCenter,
+    inGutter: false,
+    hook: 0,
+    spin: new THREE.Vector2(),
+    returnState: 'idle',
+    returnT: 0,
+    variant
+  } as BallState;
+}
+
+function createShootingLineGuides(scene: THREE.Scene) {
+  const guideMat = new THREE.MeshBasicMaterial({
+    color: 0x38bdf8,
+    transparent: true,
+    opacity: 0.16,
+    depthWrite: false
+  });
+  const edgeMat = new THREE.MeshBasicMaterial({
+    color: 0x7dd3fc,
+    transparent: true,
+    opacity: 0.62,
+    depthWrite: false
+  });
+  for (const laneCenter of LANE_CENTERS) {
+    const zone = new THREE.Mesh(
+      new THREE.PlaneGeometry(
+        (CFG.laneHalfW + SHOOTING_ZONE_SIDE_PAD) * 2,
+        SHOOTING_ZONE_DEPTH
+      ),
+      guideMat.clone()
+    );
+    zone.rotation.x = -Math.PI / 2;
+    zone.position.set(
+      laneCenter,
+      CFG.laneY + 0.018,
+      CFG.foulZ + SHOOTING_ZONE_DEPTH * 0.5 + 0.18
+    );
+    scene.add(zone);
+
+    const border = new THREE.LineSegments(
+      new THREE.EdgesGeometry(
+        new THREE.PlaneGeometry(
+          (CFG.laneHalfW + SHOOTING_ZONE_SIDE_PAD) * 2,
+          SHOOTING_ZONE_DEPTH
+        )
+      ),
+      edgeMat.clone()
+    );
+    border.rotation.x = -Math.PI / 2;
+    border.position.copy(zone.position).add(new THREE.Vector3(0, 0.006, 0));
+    scene.add(border);
+  }
+}
+
+function createPinMesh() {
+  const root = new THREE.Group();
+  const white = new THREE.MeshPhysicalMaterial({
+    color: 0xf8f5ef,
+    roughness: 0.2,
+    clearcoat: 1,
+    clearcoatRoughness: 0.08
+  });
+  const red = new THREE.MeshPhysicalMaterial({
+    color: 0xcc2b2b,
+    roughness: 0.22,
+    clearcoat: 1,
+    clearcoatRoughness: 0.1
+  });
+  const points = [
+    new THREE.Vector2(0.045, 0),
+    new THREE.Vector2(0.09, 0.06),
+    new THREE.Vector2(0.085, 0.2),
+    new THREE.Vector2(0.16, 0.36),
+    new THREE.Vector2(0.14, 0.5),
+    new THREE.Vector2(0.068, 0.62),
+    new THREE.Vector2(0.076, 0.7),
+    new THREE.Vector2(0.038, 0.74),
+    new THREE.Vector2(0, 0.74)
+  ];
+  root.add(new THREE.Mesh(new THREE.LatheGeometry(points, 42), white));
+  const stripe = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.082, 0.072, 0.035, 40),
+    red
+  );
+  stripe.position.y = 0.615;
+  root.add(stripe);
+  enableShadow(root);
+  return root;
+}
+
+function createPins(scene: THREE.Scene, laneCenter = 0) {
+  const pins: PinState[] = [];
+  const s = CFG.pinSpotSpacing;
+  const positions = [
+    [0, 0],
+    [-s * 0.57, -s],
+    [s * 0.57, -s],
+    [-s * 1.14, -s * 2],
+    [0, -s * 2],
+    [s * 1.14, -s * 2],
+    [-s * 1.71, -s * 3],
+    [-s * 0.57, -s * 3],
+    [s * 0.57, -s * 3],
+    [s * 1.71, -s * 3]
+  ];
+  for (const [x, dz] of positions) {
+    const root = createPinMesh();
+    const start = new THREE.Vector3(
+      laneCenter + x,
+      CFG.laneY + 0.006,
+      CFG.pinDeckZ + dz
+    );
+    root.position.copy(start);
+    scene.add(root);
+    pins.push({
+      root,
+      start: start.clone(),
+      pos: start.clone(),
+      vel: new THREE.Vector3(),
+      tilt: 0,
+      tiltDir: new THREE.Vector3(0, 0, -1),
+      angularVel: 0,
+      standing: true,
+      knocked: false
+    });
+  }
+  return pins;
+}
+
+function resetPins(pins: PinState[]) {
+  for (const pin of pins) {
+    pin.pos.copy(pin.start);
+    pin.vel.set(0, 0, 0);
+    pin.tilt = 0;
+    pin.tiltDir.set(0, 0, -1);
+    pin.angularVel = 0;
+    pin.standing = true;
+    pin.knocked = false;
+    pin.root.visible = true;
+    pin.root.position.copy(pin.pos);
+    pin.root.rotation.set(0, 0, 0);
+  }
+}
+
+function clearFallenPins(pins: PinState[]) {
+  for (const pin of pins) {
+    const fallen =
+      !pin.standing || pin.tilt >= CFG.pinToppleThreshold || pin.knocked;
+    if (!fallen) continue;
+    pin.root.visible = false;
+    pin.vel.set(0, 0, 0);
+    pin.angularVel = 0;
+  }
+}
+
+function isFallenPin(pin: PinState) {
+  return (
+    !pin.root.visible ||
+    !pin.standing ||
+    pin.tilt >= CFG.pinToppleThreshold ||
+    pin.knocked
+  );
+}
+
+function makePinResetState(): PinResetState {
+  return {
+    phase: 'idle',
+    t: 0,
+    fallenPins: [],
+    standingPins: [],
+    removed: false
+  };
+}
+
+function beginPinReset(
+  state: PinResetState,
+  pins: PinState[],
+  decor: BowlingArenaDecor
+) {
+  if (state.phase !== 'idle') return;
+  state.phase = 'lowering';
+  state.t = 0;
+  state.removed = false;
+  state.fallenPins = pins.filter(isFallenPin);
+  state.standingPins = pins.filter((pin) => !isFallenPin(pin));
+  decor.resetMachine.visible = true;
+  const sourcePin = state.standingPins[0] || state.fallenPins[0];
+  const resetCenter = sourcePin
+    ? laneCenterForPlayer(sourcePin.start.x > 0 ? 1 : 0)
+    : 0;
+  decor.resetMachine.position.x = resetCenter;
+  decor.resetMachine.position.y = CFG.laneY + 1.16;
+  decor.resetMachine.position.z = CFG.pinDeckZ - 0.82;
+  for (const pin of pins) {
+    pin.vel.set(0, 0, 0);
+    pin.angularVel = 0;
+    if (!state.fallenPins.includes(pin)) {
+      pin.standing = true;
+      pin.knocked = false;
+      pin.tilt = 0;
+      pin.pos.copy(pin.start);
+      pin.root.visible = true;
+      pin.root.rotation.set(0, 0, 0);
+    }
+  }
+}
+
+function updatePinReset(
+  state: PinResetState,
+  decor: BowlingArenaDecor,
+  dt: number
+) {
+  if (state.phase === 'idle') return null;
+  state.t = clamp01(state.t + dt / 1.9);
+  state.phase =
+    state.t < 0.34 ? 'lowering' : state.t < 0.76 ? 'sweeping' : 'lifting';
+  const lower =
+    state.t < 0.34
+      ? easeInOut(state.t / 0.34)
+      : state.t > 0.76
+        ? 1 - easeInOut((state.t - 0.76) / 0.24)
+        : 1;
+  const sweep = clamp01((state.t - 0.34) / 0.34);
+  const lift =
+    state.t < 0.48
+      ? 0
+      : state.t < 0.76
+        ? Math.sin(((state.t - 0.48) / 0.28) * Math.PI) * 0.14
+        : 0;
+  decor.resetMachine.position.y = CFG.laneY + lerp(1.16, 0.43, lower);
+  decor.resetMachine.position.z = CFG.pinDeckZ - 0.92 + sweep * 1.12;
+
+  for (const pin of state.standingPins) {
+    pin.pos.copy(pin.start);
+    pin.pos.y = pin.start.y + lift;
+    pin.root.visible = true;
+    pin.root.position.copy(pin.pos);
+    pin.root.rotation.set(0, 0, 0);
+  }
+
+  for (const pin of state.fallenPins) {
+    if (!pin.root.visible) continue;
+    const carry = clamp01((state.t - 0.38) / 0.26);
+    pin.root.position.z = pin.pos.z - carry * 1.55;
+    pin.root.position.y = Math.max(CFG.laneY + 0.02, pin.pos.y - carry * 0.1);
+  }
+
+  if (!state.removed && state.t >= 0.64) {
+    clearFallenPins(state.fallenPins);
+    state.removed = true;
+  }
+
+  if (state.t >= 1) {
+    const standing = state.standingPins.length;
+    for (const pin of state.standingPins) {
+      pin.pos.copy(pin.start);
+      pin.root.position.copy(pin.pos);
+      pin.root.rotation.set(0, 0, 0);
+    }
+    state.phase = 'idle';
+    state.t = 0;
+    state.fallenPins = [];
+    state.standingPins = [];
+    state.removed = false;
+    decor.resetMachine.visible = false;
+    return standing;
+  }
+  return null;
+}
+
+type BowlingArenaDecor = {
+  returnBalls: THREE.Mesh[];
+  scoreboardPanels: THREE.Mesh[];
+  pinfallPanels: THREE.Mesh[];
+  crowdPulseLights: THREE.PointLight[];
+  resetMachine: THREE.Group;
+  rackPickupBalls: THREE.Mesh[];
+};
+
+type PinResetState = {
+  phase: PinResetPhase;
+  t: number;
+  fallenPins: PinState[];
+  standingPins: PinState[];
+  removed: boolean;
+};
+
+type BowlingCrowdMember = {
+  rig: HumanRig;
+  behavior:
+    | 'talking'
+    | 'clapping'
+    | 'phone'
+    | 'drinking'
+    | 'spectating'
+    | 'celebrating';
+  phase: number;
+  baseYaw: number;
+  seated: boolean;
+};
+
+function makeCanvasTextMaterial(
+  text: string,
+  options: {
+    width?: number;
+    height?: number;
+    bg?: string;
+    fg?: string;
+    accent?: string;
+  } = {}
+) {
+  const width = options.width || 512;
+  const height = options.height || 160;
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d')!;
+  const bg = options.bg || 'rgba(3, 7, 18, 0.92)';
+  const fg = options.fg || '#f8fafc';
+  const accent = options.accent || '#38bdf8';
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, width, height);
+  const grad = ctx.createLinearGradient(0, 0, width, 0);
+  grad.addColorStop(0, 'rgba(56,189,248,0.8)');
+  grad.addColorStop(0.5, 'rgba(244,114,182,0.85)');
+  grad.addColorStop(1, 'rgba(250,204,21,0.75)');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, width, 10);
+  ctx.fillRect(0, height - 10, width, 10);
+  ctx.fillStyle = accent;
+  ctx.font = `900 ${Math.round(height * 0.22)}px system-ui, sans-serif`;
+  ctx.fillText('TON PLAYGRAM', 28, Math.round(height * 0.36));
+  ctx.fillStyle = fg;
+  ctx.font = `900 ${Math.round(height * 0.36)}px system-ui, sans-serif`;
+  ctx.fillText(text, 28, Math.round(height * 0.76));
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return new THREE.MeshBasicMaterial({
+    map: tex,
+    transparent: true,
+    toneMapped: false
+  });
+}
+
+function setBoardCanvasText(
+  panel: THREE.Mesh,
+  text: string,
+  options: {
+    width?: number;
+    height?: number;
+    bg?: string;
+    fg?: string;
+    accent?: string;
+  } = {}
+) {
+  const previous = panel.material as THREE.Material | THREE.Material[];
+  panel.material = makeCanvasTextMaterial(text, options);
+  if (Array.isArray(previous)) previous.forEach((mat) => mat.dispose());
+  else previous?.dispose?.();
+}
+
+function updatePinfallBoards(
+  decor: BowlingArenaDecor,
+  laneIndex: number,
+  knocked: number,
+  afterStanding: number,
+  label: string
+) {
+  const text = knocked === 10 ? `${label} STRIKE` : `${label} ${knocked} DOWN`;
+  decor.pinfallPanels.forEach((panel, index) => {
+    const active = index === laneIndex;
+    const message = active
+      ? `${text} · ${afterStanding} LEFT`
+      : `LANE ${index + 1} READY`;
+    setBoardCanvasText(panel, message, {
+      width: 1024,
+      height: 256,
+      bg: active ? 'rgba(1,6,14,0.98)' : 'rgba(2,6,12,0.9)',
+      fg: active ? '#f8fafc' : '#cbd5e1',
+      accent: active ? '#facc15' : index === 0 ? '#38bdf8' : '#f97316'
+    });
+    panel.userData.flashUntil = performance.now() + 1800;
+    panel.userData.baseScale = active ? 1.08 : 1;
+  });
+}
+
+function makeDrink(mat: THREE.Material) {
+  const g = new THREE.Group();
+  const cup = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.055, 0.045, 0.16, 16),
+    mat
+  );
+  cup.position.y = 0.08;
+  g.add(cup);
+  const straw = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.008, 0.008, 0.2, 8),
+    new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.45 })
+  );
+  straw.position.set(0.025, 0.21, 0.01);
+  straw.rotation.z = 0.25;
+  g.add(straw);
+  return g;
+}
+
+function makePickupPromptSprite() {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 192;
+  const ctx = canvas.getContext('2d')!;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const grad = ctx.createLinearGradient(0, 0, 512, 192);
+  grad.addColorStop(0, 'rgba(6,11,21,0.92)');
+  grad.addColorStop(1, 'rgba(14,165,233,0.76)');
+  ctx.fillStyle = grad;
+  ctx.strokeStyle = 'rgba(255,255,255,0.7)';
+  ctx.lineWidth = 6;
+  const r = 44;
+  ctx.beginPath();
+  ctx.moveTo(r, 10);
+  ctx.lineTo(512 - r, 10);
+  ctx.quadraticCurveTo(502, 10, 502, r);
+  ctx.lineTo(502, 192 - r);
+  ctx.quadraticCurveTo(502, 182, 512 - r, 182);
+  ctx.lineTo(r, 182);
+  ctx.quadraticCurveTo(10, 182, 10, 192 - r);
+  ctx.lineTo(10, r);
+  ctx.quadraticCurveTo(10, 10, r, 10);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = '#ffffff';
+  ctx.font =
+    '900 54px system-ui, -apple-system, BlinkMacSystemFont, sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText('PICK UP', 256, 78);
+  ctx.font =
+    '800 26px system-ui, -apple-system, BlinkMacSystemFont, sans-serif';
+  ctx.fillStyle = '#dff7ff';
+  ctx.fillText('tap a ball weight', 256, 128);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  const sprite = new THREE.Sprite(
+    new THREE.SpriteMaterial({
+      map: texture,
+      transparent: true,
+      opacity: 0.95,
+      depthTest: false
+    })
+  );
+  sprite.scale.set(1.26, 0.47, 1);
+  sprite.position.set(0, CFG.laneY + 1.52, 7.42);
+  sprite.visible = false;
+  sprite.renderOrder = 80;
+  return sprite;
+}
+
+function makeBowlingBallRack(
+  variants: BallVariant[],
+  matFactory: (colors: [string, string, string]) => THREE.MeshPhysicalMaterial,
+  pickupBalls?: THREE.Mesh[]
+) {
+  const rack = new THREE.Group();
+  const railMat = new THREE.MeshPhysicalMaterial({
+    color: 0x07090d,
+    roughness: 0.88,
+    metalness: 0.18,
+    clearcoat: 0.16,
+    clearcoatRoughness: 0.62
+  });
+  const rubberMat = new THREE.MeshStandardMaterial({
+    color: 0x020305,
+    roughness: 0.96,
+    metalness: 0.02
+  });
+  const railGeom = new THREE.CylinderGeometry(0.045, 0.045, 1.86, 24);
+  for (const [y, z] of [
+    [0.34, -0.34],
+    [0.58, 0.08]
+  ]) {
+    const rail = new THREE.Mesh(railGeom, railMat);
+    rail.rotation.z = Math.PI / 2;
+    rail.position.set(0, y as number, z as number);
+    rack.add(rail);
+  }
+  for (const [x, z] of [
+    [-0.98, -0.16],
+    [0.98, -0.16]
+  ]) {
+    const side = new THREE.Mesh(
+      new THREE.CapsuleGeometry(0.045, 0.64, 8, 18),
+      railMat
+    );
+    side.position.set(x as number, 0.36, z as number);
+    rack.add(side);
+  }
+  for (const [x, z] of [
+    [-0.84, -0.48],
+    [0.84, -0.48],
+    [-0.84, 0.2],
+    [0.84, 0.2]
+  ]) {
+    const leg = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.035, 0.045, 0.56, 18),
+      railMat
+    );
+    leg.position.set(x as number, 0.28, z as number);
+    rack.add(leg);
+    const foot = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.11, 0.11, 0.02, 24),
+      rubberMat
+    );
+    foot.position.set(x as number, 0.012, z as number);
+    rack.add(foot);
+  }
+  const displayed = variants.slice(0, 5);
+  const ballSlots = [
+    [-0.62, 0.31, -0.34],
+    [-0.18, 0.31, -0.34],
+    [0.26, 0.31, -0.34],
+    [0.7, 0.31, -0.34],
+    [-0.4, 0.55, 0.08],
+    [0.16, 0.55, 0.08]
+  ];
+  displayed.forEach((variant, i) => {
+    const radius = CFG.ballR * 0.98;
+    const ball = new THREE.Mesh(
+      new THREE.SphereGeometry(radius, 48, 32),
+      matFactory(variant.colors)
+    );
+    ball.userData.bowlingBallWeight = variant.label;
+    ball.userData.pickupHitRadius = radius * 1.65;
+    pickupBalls?.push(ball);
+    const [x, y, z] = ballSlots[i];
+    ball.position.set(x, y + radius * 0.28, z);
+    ball.rotation.set(i * 0.37, i * 0.61, 0);
+    rack.add(ball);
+    const holeMat = new THREE.MeshBasicMaterial({
+      color: 0x020617,
+      transparent: true,
+      opacity: 0.82
+    });
+    for (const [hx, hy] of [
+      [-0.035, 0.12],
+      [0.045, 0.11],
+      [0.006, 0.045]
+    ]) {
+      const hole = new THREE.Mesh(new THREE.CircleGeometry(0.017, 14), holeMat);
+      hole.position.set(
+        ball.position.x + hx,
+        ball.position.y + hy,
+        ball.position.z + radius * 0.84
+      );
+      hole.rotation.y = Math.PI;
+      rack.add(hole);
+    }
+  });
+  enableShadow(rack);
+  return rack;
+}
+
+function createEnvironment(
+  scene: THREE.Scene,
+  loader: THREE.TextureLoader,
+  tableFinishId: string,
+  chromeColorId: string,
+  playerCount = 2
+): BowlingArenaDecor {
+  const group = new THREE.Group();
+  const decor: BowlingArenaDecor = {
+    returnBalls: [],
+    scoreboardPanels: [],
+    rackPickupBalls: [],
+    pinfallPanels: [],
+    crowdPulseLights: [],
+    resetMachine: new THREE.Group()
+  };
+  scene.add(group);
+  group.position.y = -0.32;
+  let laneMat: THREE.Material;
+  let woodMat: THREE.Material;
+  try {
+    laneMat = loadOakMaterial(loader, 1.05, 10.8);
+    woodMat = loadOakMaterial(loader, 0.72, 3.2);
+  } catch {
+    laneMat = makeFallbackWoodMaterial();
+    woodMat = makeFallbackWoodMaterial();
+  }
+
+  const gutterMat = (woodMat as THREE.Material).clone?.() || woodMat;
+  const metalMat = new THREE.MeshPhysicalMaterial({
+    color: 0xcfd7e2,
+    roughness: 0.11,
+    metalness: 1,
+    clearcoat: 1,
+    clearcoatRoughness: 0.03,
+    envMapIntensity: 1.6
+  });
+  const blackMat = new THREE.MeshStandardMaterial({
+    color: 0x101216,
+    roughness: 0.84
+  });
+  if (chromeColorId === 'gold') metalMat.color.set('#d4af37');
+  if (tableFinishId.includes('dark') || tableFinishId.includes('carbon'))
+    (woodMat as THREE.MeshStandardMaterial).color.set('#3a2b23');
+  if (tableFinishId.includes('rosewood'))
+    (woodMat as THREE.MeshStandardMaterial).color.set('#6f3a2f');
+  if ((laneMat as THREE.MeshStandardMaterial).color)
+    (laneMat as THREE.MeshStandardMaterial).color.multiplyScalar(1.18);
+
+  // Clean, open HDRI-driven venue shell: keep only floor, lane, lounge furniture, and gameplay mechanisms.
+  const carpetMat = new THREE.MeshStandardMaterial({
+    color: 0x23182f,
+    roughness: 0.9,
+    metalness: 0.01
+  });
+  const rubberMat = new THREE.MeshStandardMaterial({
+    color: 0x05070a,
+    roughness: 0.86,
+    metalness: 0.01
+  });
+  const ledCyan = new THREE.MeshBasicMaterial({
+    color: 0x38bdf8,
+    transparent: true,
+    opacity: 0.38,
+    toneMapped: false
+  });
+  const ledAmber = new THREE.MeshBasicMaterial({
+    color: 0xffb86b,
+    transparent: true,
+    opacity: 0.42,
+    toneMapped: false
+  });
+
+  const sidePanelLength = 33.2;
+  const sidePanelWidth = 2.56;
+  const sidePanelOffsetX = CFG.laneHalfW + CFG.gutterHalfW + sidePanelWidth * 0.5 + 0.2;
+  for (const side of [-1, 1] as const) {
+    const sidePanel = new THREE.Mesh(
+      new THREE.PlaneGeometry(sidePanelWidth, sidePanelLength),
+      carpetMat
+    );
+    sidePanel.rotation.x = -Math.PI / 2;
+    sidePanel.position.set(side * sidePanelOffsetX, CFG.laneY - 0.024, -7.2);
+    group.add(sidePanel);
+  }
+  const loungeCarpet = new THREE.Mesh(
+    new THREE.PlaneGeometry(3.8, 4.95),
+    carpetMat
+  );
+  loungeCarpet.rotation.x = -Math.PI / 2;
+  loungeCarpet.position.set(
+    BOWLING_LOUNGE_CENTER.x,
+    CFG.laneY - 0.014,
+    BOWLING_LOUNGE_CENTER.z
+  );
+  group.add(loungeCarpet);
+
+  const pairHalfW = CFG.laneCenterOffset + CFG.gutterHalfW + 0.32;
+  const approach = new THREE.Mesh(
+    new THREE.PlaneGeometry(pairHalfW * 2, 5.05, 44, 28),
+    woodMat
+  );
+  approach.rotation.x = -Math.PI / 2;
+  approach.position.set(0, CFG.laneY - 0.005, 7.18);
+  group.add(approach);
+
+  const boardLineMat = new THREE.MeshBasicMaterial({
+    color: 0x4b2e18,
+    transparent: true,
+    opacity: 0.18,
+    depthWrite: false
+  });
+  const boardNumberMat = new THREE.MeshBasicMaterial({
+    color: 0x1b365d,
+    transparent: true,
+    opacity: 0.38,
+    depthWrite: false
+  });
+  const reflectionMat = new THREE.MeshBasicMaterial({
+    color: 0xf8fbff,
+    transparent: true,
+    opacity: 0.07,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending
+  });
+  const wearMat = new THREE.MeshBasicMaterial({
+    color: 0x2b1608,
+    transparent: true,
+    opacity: 0.075,
+    depthWrite: false
+  });
+  const arrowMat = new THREE.MeshStandardMaterial({
+    color: 0x2d4f80,
+    roughness: 0.44
+  });
+  const spotMat = new THREE.MeshBasicMaterial({
+    color: 0x7f1d1d,
+    transparent: true,
+    opacity: 0.45,
+    depthWrite: false
+  });
+  const laneLabelMat = (label: string) =>
+    makeCanvasTextMaterial(label, {
+      width: 512,
+      height: 128,
+      accent: '#38bdf8',
+      bg: 'rgba(2,6,12,0.72)'
+    });
+
+  for (const [laneIndex, laneCenter] of LANE_CENTERS.entries()) {
+    const lane = new THREE.Mesh(
+      new THREE.PlaneGeometry(CFG.laneHalfW * 2, 33.2, 84, 500),
+      laneMat
+    );
+    lane.rotation.x = -Math.PI / 2;
+    lane.position.set(laneCenter, CFG.laneY, -7.2);
+    lane.receiveShadow = true;
+    group.add(lane);
+
+    for (let b = 1; b < LANE_BOARD_COUNT; b++) {
+      const x = laneCenter - CFG.laneHalfW + b * BOARD_WIDTH;
+      const board = new THREE.Mesh(
+        new THREE.PlaneGeometry(0.005, 28.4),
+        boardLineMat
+      );
+      board.rotation.x = -Math.PI / 2;
+      board.position.set(x, CFG.laneY + 0.004, -7.2);
+      group.add(board);
+    }
+    for (const board of [5, 10, 15, 20, 25, 30, 35]) {
+      const x = laneCenter - CFG.laneHalfW + (board - 0.5) * BOARD_WIDTH;
+      const dot = new THREE.Mesh(
+        new THREE.CircleGeometry(board === 20 ? 0.035 : 0.026, 18),
+        boardNumberMat
+      );
+      dot.rotation.x = -Math.PI / 2;
+      dot.position.set(x, CFG.laneY + 0.014, CFG.foulZ - 0.72);
+      group.add(dot);
+    }
+    const oil = new THREE.Mesh(
+      new THREE.PlaneGeometry(CFG.laneHalfW * 2 - 0.08, 23.2),
+      new THREE.MeshPhysicalMaterial({
+        color: 0xcfefff,
+        transparent: true,
+        opacity: 0.045,
+        roughness: 0.2,
+        metalness: 0,
+        clearcoat: 0.32,
+        clearcoatRoughness: 0.24,
+        reflectivity: 0.36
+      })
+    );
+    oil.rotation.x = -Math.PI / 2;
+    oil.position.set(laneCenter, CFG.laneY + 0.002, -6.4);
+    group.add(oil);
+    for (const [x, z, w, d] of [
+      [-0.52, -2.6, 0.14, 10.8],
+      [0.42, -5.8, 0.12, 13.6],
+      [0.02, -10.6, 0.18, 4.8]
+    ]) {
+      const streak = new THREE.Mesh(
+        new THREE.PlaneGeometry(w as number, d as number),
+        reflectionMat.clone()
+      );
+      streak.rotation.x = -Math.PI / 2;
+      streak.position.set(
+        laneCenter + (x as number),
+        CFG.laneY + 0.007,
+        z as number
+      );
+      group.add(streak);
+    }
+    for (let i = 0; i < 22; i++) {
+      const mark = new THREE.Mesh(
+        new THREE.PlaneGeometry(0.012 + (i % 4) * 0.006, 1.1 + (i % 5) * 0.28),
+        wearMat
+      );
+      mark.rotation.x = -Math.PI / 2;
+      mark.position.set(
+        laneCenter +
+          lerp(-CFG.laneHalfW * 0.82, CFG.laneHalfW * 0.82, (i % 11) / 10),
+        CFG.laneY + 0.006,
+        lerp(3.2, -11.6, i / 21)
+      );
+      group.add(mark);
+    }
+    const deck = new THREE.Mesh(
+      new THREE.BoxGeometry(CFG.laneHalfW * 2 + 0.56, 0.13, 3.18),
+      woodMat
+    );
+    deck.position.set(laneCenter, CFG.laneY + 0.02, CFG.pinDeckZ - 0.75);
+    group.add(deck);
+    for (const side of [-1, 1]) {
+      const gutter = new THREE.Mesh(
+        new THREE.BoxGeometry(0.42, 0.14, 23.55),
+        gutterMat
+      );
+      gutter.position.set(
+        laneCenter + side * (CFG.laneHalfW + 0.25),
+        CFG.laneY,
+        -5.98
+      );
+      group.add(gutter);
+      // Removed the two raised brown lane-side caps so the bowling field stays open and HDRI-clean.
+    }
+    const foulLine = new THREE.Mesh(
+      new THREE.BoxGeometry(CFG.laneHalfW * 2 + 0.08, 0.018, 0.055),
+      new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.42 })
+    );
+    foulLine.position.set(laneCenter, CFG.laneY + 0.012, CFG.foulZ);
+    group.add(foulLine);
+    for (let i = -2; i <= 2; i++) {
+      const tri = new THREE.Shape();
+      tri.moveTo(0, 0.22);
+      tri.lineTo(-0.11, -0.16);
+      tri.lineTo(0.11, -0.16);
+      tri.lineTo(0, 0.22);
+      const mesh = new THREE.Mesh(new THREE.ShapeGeometry(tri), arrowMat);
+      mesh.rotation.x = -Math.PI / 2;
+      mesh.position.set(laneCenter + i * 0.34, CFG.laneY + 0.012, CFG.arrowsZ);
+      group.add(mesh);
+    }
+    const pinS = CFG.pinSpotSpacing;
+    for (const [x, dz] of [
+      [0, 0],
+      [-pinS * 0.57, -pinS],
+      [pinS * 0.57, -pinS],
+      [-pinS * 1.14, -pinS * 2],
+      [0, -pinS * 2],
+      [pinS * 1.14, -pinS * 2],
+      [-pinS * 1.71, -pinS * 3],
+      [-pinS * 0.57, -pinS * 3],
+      [pinS * 0.57, -pinS * 3],
+      [pinS * 1.71, -pinS * 3]
+    ]) {
+      const spot = new THREE.Mesh(
+        new THREE.RingGeometry(0.07, 0.105, 24),
+        spotMat
+      );
+      spot.rotation.x = -Math.PI / 2;
+      spot.position.set(
+        laneCenter + (x as number),
+        CFG.laneY + 0.018,
+        CFG.pinDeckZ + (dz as number)
+      );
+      group.add(spot);
+    }
+    const laneNumber = new THREE.Mesh(
+      new THREE.PlaneGeometry(1.08, 0.26),
+      laneLabelMat(`LANE ${laneIndex + 1}`)
+    );
+    laneNumber.rotation.x = -Math.PI / 2;
+    laneNumber.position.set(laneCenter, CFG.laneY + 0.02, CFG.foulZ + 0.62);
+    group.add(laneNumber);
+  }
+
+  // Grounded black pinsetter wall restored behind the pins, with animated lane screens above each rack.
+  const backBoardMat = new THREE.MeshStandardMaterial({
+    color: 0x03050a,
+    roughness: 0.78,
+    metalness: 0.18
+  });
+  const backBoard = new THREE.Mesh(
+    new THREE.BoxGeometry(pairHalfW * 2 + 0.86, 1.34, 0.14),
+    backBoardMat
+  );
+  backBoard.position.set(0, CFG.laneY + 0.74, CFG.backStopZ + 0.88);
+  group.add(backBoard);
+  const lowerBoard = new THREE.Mesh(
+    new THREE.BoxGeometry(pairHalfW * 2 + 0.7, 0.58, 0.12),
+    new THREE.MeshStandardMaterial({
+      color: 0x05070d,
+      roughness: 0.84,
+      metalness: 0.12
+    })
+  );
+  lowerBoard.position.set(0, CFG.laneY + 0.34, CFG.backStopZ + 1.12);
+  group.add(lowerBoard);
+  for (const [laneIndex, laneCenter] of LANE_CENTERS.entries()) {
+    const pinFocus = new THREE.Mesh(
+      new THREE.BoxGeometry(CFG.laneHalfW * 2 + 0.38, 0.1, 0.08),
+      new THREE.MeshBasicMaterial({
+        color: 0x92e7ff,
+        transparent: true,
+        opacity: 0.46,
+        toneMapped: false
+      })
+    );
+    pinFocus.position.set(laneCenter, CFG.laneY + 0.94, CFG.backStopZ + 0.82);
+    group.add(pinFocus);
+    const pinfallScreen = new THREE.Mesh(
+      new THREE.PlaneGeometry(2.52, 0.62),
+      makeCanvasTextMaterial(`LANE ${laneIndex + 1} READY`, {
+        width: 1024,
+        height: 256,
+        accent: laneIndex === 0 ? '#38bdf8' : '#f97316'
+      })
+    );
+    pinfallScreen.position.set(
+      laneCenter,
+      CFG.laneY + 1.3,
+      CFG.backStopZ + 1.2
+    );
+    pinfallScreen.userData.baseScale = 1;
+    group.add(pinfallScreen);
+    decor.pinfallPanels.push(pinfallScreen);
+    for (const x of [-1, 1]) {
+      const kickback = new THREE.Mesh(
+        new THREE.BoxGeometry(0.16, 0.86, 4.2),
+        woodMat
+      );
+      kickback.position.set(
+        laneCenter + x * (CFG.laneHalfW + 0.52),
+        CFG.laneY + 0.42,
+        CFG.pinDeckZ - 1.02
+      );
+      group.add(kickback);
+      const shadowPocket = new THREE.Mesh(
+        new THREE.BoxGeometry(0.07, 0.52, 3.55),
+        rubberMat
+      );
+      shadowPocket.position.set(
+        laneCenter + x * (CFG.laneHalfW + 0.42),
+        CFG.laneY + 0.36,
+        CFG.pinDeckZ - 1.04
+      );
+      group.add(shadowPocket);
+    }
+  }
+  decor.resetMachine.position.set(
+    laneCenterForPlayer(0),
+    CFG.laneY + 1.16,
+    CFG.pinDeckZ - 0.92
+  );
+  decor.resetMachine.visible = false;
+  const resetHeadMat = new THREE.MeshStandardMaterial({
+    color: 0x121a26,
+    roughness: 0.58,
+    metalness: 0.32
+  });
+  const resetHead = new THREE.Mesh(
+    new THREE.BoxGeometry(CFG.laneHalfW * 2 + 0.5, 0.16, 0.58),
+    resetHeadMat
+  );
+  resetHead.position.set(0, 0, 0);
+  decor.resetMachine.add(resetHead);
+  const sweepBlade = new THREE.Mesh(
+    new THREE.BoxGeometry(CFG.laneHalfW * 2 + 0.34, 0.12, 0.18),
+    metalMat
+  );
+  sweepBlade.position.set(0, -0.3, 0.18);
+  decor.resetMachine.add(sweepBlade);
+  for (const x of [-0.94, -0.32, 0.32, 0.94]) {
+    const pinCup = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.09, 0.12, 0.18, 18),
+      resetHeadMat
+    );
+    pinCup.position.set(x, -0.22, -0.18);
+    pinCup.rotation.x = Math.PI / 2;
+    decor.resetMachine.add(pinCup);
+  }
+  const resetRail = new THREE.Mesh(
+    new THREE.BoxGeometry(CFG.laneHalfW * 2 + 0.48, 0.045, 0.05),
+    ledCyan
+  );
+  resetRail.position.set(0, -0.1, 0.32);
+  decor.resetMachine.add(resetRail);
+  group.add(decor.resetMachine);
+  const machineryHousing = new THREE.Group();
+  const housingMat = new THREE.MeshStandardMaterial({
+    color: 0x101827,
+    roughness: 0.72,
+    metalness: 0.18
+  });
+  const hood = new THREE.Mesh(
+    new THREE.BoxGeometry(pairHalfW * 2 + 0.9, 1.78, 1.72),
+    housingMat
+  );
+  hood.position.set(0, 1.42, CFG.backStopZ + 0.05);
+  machineryHousing.add(hood);
+  const fascia = new THREE.Mesh(
+    new THREE.BoxGeometry(pairHalfW * 2 + 0.72, 0.34, 0.06),
+    new THREE.MeshStandardMaterial({
+      color: 0x070b12,
+      roughness: 0.7,
+      metalness: 0.2
+    })
+  );
+  fascia.position.set(0, 2.05, CFG.backStopZ + 0.82);
+  machineryHousing.add(fascia);
+  for (const [i, laneCenter] of LANE_CENTERS.entries()) {
+    const scoreFrame = new THREE.Mesh(
+      new THREE.BoxGeometry(3.42, 0.88, 0.065),
+      new THREE.MeshStandardMaterial({
+        color: 0x020617,
+        roughness: 0.36,
+        metalness: 0.52,
+        emissive: new THREE.Color(i === 0 ? 0x075985 : 0x7c2d12),
+        emissiveIntensity: 0.18
+      })
+    );
+    scoreFrame.position.set(laneCenter, 2.13, CFG.backStopZ + 0.84);
+    machineryHousing.add(scoreFrame);
+    const slimScore = new THREE.Mesh(
+      new THREE.PlaneGeometry(3.18, 0.72),
+      makeCanvasTextMaterial(`LANE ${i + 1}`, {
+        width: 1024,
+        height: 220,
+        accent: i === 0 ? '#38bdf8' : '#f97316'
+      })
+    );
+    slimScore.position.set(laneCenter, 2.13, CFG.backStopZ + 0.885);
+    machineryHousing.add(slimScore);
+    decor.scoreboardPanels.push(slimScore);
+  }
+  for (const x of [-3.2, -1.05, 1.05, 3.2]) {
+    const servicePanel = new THREE.Mesh(
+      new THREE.BoxGeometry(0.92, 0.52, 0.04),
+      new THREE.MeshStandardMaterial({
+        color: 0x283242,
+        roughness: 0.66,
+        metalness: 0.24
+      })
+    );
+    servicePanel.position.set(x, 1.32, CFG.backStopZ + 0.84);
+    machineryHousing.add(servicePanel);
+  }
+  group.add(machineryHousing);
+
+  const snackMat = new THREE.MeshStandardMaterial({
+    color: 0xfbbf24,
+    roughness: 0.58
+  });
+  const glassMat = new THREE.MeshPhysicalMaterial({
+    color: 0x7dd3fc,
+    roughness: 0.08,
+    metalness: 0,
+    transmission: 0.2,
+    transparent: true,
+    opacity: 0.72,
+    clearcoat: 1
+  });
+  const tabletMat = new THREE.MeshBasicMaterial({
+    color: 0x0ea5e9,
+    transparent: true,
+    opacity: 0.86,
+    toneMapped: false
+  });
+  BOWLING_TABLE_CENTERS.forEach((center, tableIndex) => {
+    const lounge = new THREE.Group();
+    lounge.position.copy(center);
+    try {
+      createMurlanStyleTable({
+        THREE,
+        arena: lounge,
+        tableRadius: 0.98,
+        tableHeight: 0.74,
+        pedestalHeightScale: 0.82,
+        includeBase: true,
+        rotationY: tableIndex % 2 ? Math.PI / 8 : -Math.PI / 8
+      });
+    } catch {
+      // Emergency placeholder only: the real scene uses the shared Murlan Royale table builder above.
+      const tableTop = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.96, 0.96, 0.08, 8),
+        woodMat
+      );
+      tableTop.position.set(0, 0.74, 0);
+      tableTop.rotation.y = Math.PI / 8;
+      lounge.add(tableTop);
+      const pedestal = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.16, 0.24, 0.7, 16),
+        blackMat
+      );
+      pedestal.position.y = 0.36;
+      lounge.add(pedestal);
+    }
+
+    for (const [x, z, rot] of [
+      [-0.26, -0.18, -0.18],
+      [0.32, 0.2, 0.28]
+    ]) {
+      const drink = makeDrink(glassMat);
+      drink.position.set(x as number, 0.8, z as number);
+      drink.rotation.y = rot as number;
+      lounge.add(drink);
+    }
+    for (const [x, z] of [
+      [-0.12, 0.32],
+      [0.16, 0.34],
+      [0.24, -0.28]
+    ]) {
+      const snack = new THREE.Mesh(
+        new THREE.BoxGeometry(0.15, 0.035, 0.09),
+        snackMat
+      );
+      snack.position.set(x as number, 0.815, z as number);
+      snack.rotation.y = (x as number) * 2.4;
+      lounge.add(snack);
+    }
+    const tablet = new THREE.Mesh(
+      new THREE.BoxGeometry(0.54, 0.025, 0.34),
+      tabletMat
+    );
+    tablet.position.set(0.08, 0.82, -0.02);
+    tablet.rotation.y = tableIndex % 2 ? 0.36 : -0.36;
+    lounge.add(tablet);
+    group.add(lounge);
+
+    const loungeBoundary = new THREE.Mesh(
+      new THREE.RingGeometry(1.36, 1.44, 48),
+      new THREE.MeshBasicMaterial({
+        color: 0x7dd3fc,
+        transparent: true,
+        opacity: 0.16,
+        depthWrite: false
+      })
+    );
+    loungeBoundary.rotation.x = -Math.PI / 2;
+    loungeBoundary.position.set(center.x, CFG.laneY + 0.006, center.z);
+    group.add(loungeBoundary);
+  });
+
+  // The old sofa/procedural lounge has been removed so the seating reads as Murlan tables with paired chairs.
+
+  for (const x of [BOWLING_RETURN_SIDE_X + BOWLING_RETURN_SIDE_SIGN * 0.72]) {
+    const consoleGroup = new THREE.Group();
+    const pedestal = new THREE.Mesh(
+      new THREE.BoxGeometry(0.42, 0.72, 0.34),
+      new THREE.MeshStandardMaterial({
+        color: 0x0b1220,
+        roughness: 0.68,
+        metalness: 0.18
+      })
+    );
+    pedestal.position.y = 0.36;
+    consoleGroup.add(pedestal);
+    const screen = new THREE.Mesh(
+      new THREE.BoxGeometry(0.62, 0.06, 0.38),
+      new THREE.MeshBasicMaterial({
+        color: 0x075985,
+        transparent: true,
+        opacity: 0.92,
+        toneMapped: false
+      })
+    );
+    screen.position.set(0, 0.82, -0.08);
+    screen.rotation.x = -0.42;
+    consoleGroup.add(screen);
+    const cupTray = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.18, 0.18, 0.035, 24),
+      blackMat
+    );
+    cupTray.position.set(0.34 * Math.sign(x), 0.74, 0.16);
+    consoleGroup.add(cupTray);
+    consoleGroup.position.set(x, CFG.laneY, BOWLING_RETURN_Z);
+    consoleGroup.rotation.y = Math.PI / 2;
+    group.add(consoleGroup);
+  }
+  for (const [x, z] of [
+    [-4.34, 5.82],
+    [-3.28, 9.72]
+  ]) {
+    const drinkStation = new THREE.Group();
+    const barrel = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.18, 0.2, 0.72, 20),
+      new THREE.MeshStandardMaterial({
+        color: 0x111827,
+        roughness: 0.62,
+        metalness: 0.28
+      })
+    );
+    barrel.position.y = 0.36;
+    drinkStation.add(barrel);
+    const halo = new THREE.Mesh(
+      new THREE.TorusGeometry(0.19, 0.012, 8, 24),
+      ledAmber
+    );
+    halo.position.y = 0.75;
+    halo.rotation.x = Math.PI / 2;
+    drinkStation.add(halo);
+    drinkStation.position.set(x as number, CFG.laneY, z as number);
+    group.add(drinkStation);
+  }
+
+  const chairFallbackMat = new THREE.MeshPhysicalMaterial({
+    color: 0x5f3d26,
+    roughness: 0.42,
+    metalness: 0.05,
+    clearcoat: 0.35
+  });
+  for (const seat of BOWLING_LOUNGE_CHAIRS.slice(
+    0,
+    clamp(Math.round(Number(playerCount) || 2), 1, 5)
+  )) {
+    const chair = new THREE.Group();
+    chair.position.copy(seat.pos);
+    chair.rotation.y = seat.yaw;
+    const pad = new THREE.Mesh(
+      new THREE.BoxGeometry(0.82, 0.13, 0.82),
+      chairFallbackMat
+    );
+    pad.position.y = 0.43;
+    chair.add(pad);
+    const back = new THREE.Mesh(
+      new THREE.BoxGeometry(0.88, 0.92, 0.13),
+      chairFallbackMat
+    );
+    back.position.set(0, 0.88, 0.33);
+    chair.add(back);
+    for (const sx of [-0.27, 0.27])
+      for (const sz of [-0.24, 0.24]) {
+        const leg = new THREE.Mesh(
+          new THREE.CylinderGeometry(0.035, 0.045, 0.44, 12),
+          chairFallbackMat
+        );
+        leg.position.set(sx, 0.21, sz);
+        chair.add(leg);
+      }
+    group.add(chair);
+    loadFirstAvailableGltf(BOWLING_MURLAN_CHAIR_URLS, (gltf) => {
+      if (!group.parent) return;
+      const model = gltf.scene.clone(true);
+      enableShadow(model);
+      model.updateMatrixWorld(true);
+      const box = new THREE.Box3().setFromObject(model);
+      const span =
+        Math.max(
+          box.max.x - box.min.x,
+          box.max.y - box.min.y,
+          box.max.z - box.min.z
+        ) || 1;
+      model.scale.setScalar(1.18 / span);
+      model.updateMatrixWorld(true);
+      const box2 = new THREE.Box3().setFromObject(model);
+      model.position.set(
+        seat.pos.x - (box2.min.x + box2.max.x) / 2,
+        CFG.laneY - box2.min.y,
+        seat.pos.z - (box2.min.z + box2.max.z) / 2
+      );
+      model.rotation.y = seat.yaw;
+      group.add(model);
+      chair.visible = false;
+    });
+  }
+  const returnShellMat = new THREE.MeshPhysicalMaterial({
+    color: 0x050609,
+    roughness: 0.91,
+    metalness: 0.05,
+    clearcoat: 0.18,
+    clearcoatRoughness: 0.58
+  });
+  const returnTrimMat = new THREE.MeshPhysicalMaterial({
+    color: 0x111827,
+    roughness: 0.66,
+    metalness: 0.48,
+    clearcoat: 0.18,
+    envMapIntensity: 0.68
+  });
+  const returnRubberMat = new THREE.MeshStandardMaterial({
+    color: 0x020304,
+    roughness: 0.94,
+    metalness: 0.01
+  });
+  const returnBase = new THREE.Mesh(
+    new THREE.BoxGeometry(1.18, 0.18, 2.7),
+    returnShellMat
+  );
+  returnBase.position.set(
+    BOWLING_RETURN_SIDE_X,
+    CFG.laneY + 0.11,
+    BOWLING_RETURN_Z
+  );
+  group.add(returnBase);
+  const returnCover = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.31, 0.31, 2.68, 48, 1, false, 0, Math.PI),
+    returnShellMat
+  );
+  // The ball-return hood should run down-lane with the field instead of across the approach.
+  // CylinderGeometry's height axis starts on local Y; map it to world Z and keep the
+  // half-cylinder arch rising on world Y so the cover matches the lane direction.
+  returnCover.rotation.set(Math.PI / 2, 0, 0);
+  returnCover.position.set(
+    BOWLING_RETURN_SIDE_X,
+    CFG.laneY + 0.34,
+    BOWLING_RETURN_Z
+  );
+  returnCover.scale.y = 1.02;
+  group.add(returnCover);
+  const returnMouth = new THREE.Mesh(
+    new THREE.CylinderGeometry(
+      0.33,
+      0.33,
+      0.055,
+      32,
+      1,
+      false,
+      Math.PI * 0.08,
+      Math.PI * 0.84
+    ),
+    new THREE.MeshBasicMaterial({
+      color: 0x010204,
+      transparent: true,
+      opacity: 0.9
+    })
+  );
+  returnMouth.rotation.x = Math.PI / 2;
+  returnMouth.position.set(
+    BOWLING_RETURN_SIDE_X,
+    CFG.laneY + 0.37,
+    BOWLING_RACK_Z - 0.14
+  );
+  group.add(returnMouth);
+  for (const x of [-0.52, 0.52]) {
+    const sideRubber = new THREE.Mesh(
+      new THREE.BoxGeometry(0.08, 0.13, 2.24),
+      returnRubberMat
+    );
+    sideRubber.position.set(
+      BOWLING_RETURN_SIDE_X + x,
+      CFG.laneY + 0.31,
+      BOWLING_RETURN_Z
+    );
+    group.add(sideRubber);
+    const trim = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.026, 0.026, 2.18, 16),
+      returnTrimMat
+    );
+    trim.rotation.x = Math.PI / 2;
+    trim.position.set(
+      BOWLING_RETURN_SIDE_X + x,
+      CFG.laneY + 0.43,
+      BOWLING_RETURN_Z
+    );
+    group.add(trim);
+  }
+  const channel = new THREE.Mesh(
+    new THREE.BoxGeometry(0.62, 0.09, 12.9),
+    returnShellMat
+  );
+  channel.position.set(BOWLING_RETURN_SIDE_X, CFG.laneY + 0.065, 0.12);
+  group.add(channel);
+  for (const x of [-0.32, 0.32]) {
+    const rail = new THREE.Mesh(
+      new THREE.BoxGeometry(0.055, 0.075, 12.96),
+      returnTrimMat
+    );
+    rail.position.set(BOWLING_RETURN_SIDE_X + x, CFG.laneY + 0.18, 0.12);
+    group.add(rail);
+  }
+  for (const z of [4.92, 6.86]) {
+    const returnLed = new THREE.Mesh(
+      new THREE.BoxGeometry(2.12, 0.026, 0.04),
+      ledCyan
+    );
+    returnLed.position.set(BOWLING_RETURN_SIDE_X, CFG.laneY + 0.43, z);
+    group.add(returnLed);
+  }
+  const ballLift = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.42, 0.45, 1.04, 44),
+    returnTrimMat
+  );
+  ballLift.position.set(
+    BOWLING_RETURN_SIDE_X,
+    CFG.laneY + 0.22,
+    BOWLING_RACK_Z - 0.34
+  );
+  // Align the lift drum with the return lane (world Z). A Z rotation turns the
+  // cylinder sideways across the approach, which made the rack/return assembly
+  // look misplaced from the player camera.
+  ballLift.rotation.x = Math.PI / 2;
+  group.add(ballLift);
+  for (const [x, z] of [
+    [-0.44, 5.24],
+    [0.44, 5.24],
+    [-0.44, 7.02],
+    [0.44, 7.02]
+  ]) {
+    const leg = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.035, 0.045, 0.34, 16),
+      returnTrimMat
+    );
+    leg.position.set(
+      BOWLING_RETURN_SIDE_X + (x as number),
+      CFG.laneY + 0.13,
+      z as number
+    );
+    group.add(leg);
+    const foot = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.11, 0.11, 0.018, 24),
+      returnRubberMat
+    );
+    foot.position.set(
+      BOWLING_RETURN_SIDE_X + (x as number),
+      CFG.laneY + 0.012,
+      z as number
+    );
+    group.add(foot);
+  }
+  const animatedReturnColors: [string, string, string][] = [
+    ['#a7f3d0', '#059669', '#032d22'],
+    ['#93c5fd', '#2563eb', '#0b1b4a'],
+    ['#ffe59b', '#f57e09', '#5a2c00']
+  ];
+  animatedReturnColors.forEach((colors, i) => {
+    const rb = new THREE.Mesh(
+      new THREE.SphereGeometry(CFG.ballR * 0.98, 44, 32),
+      makeBallMaterial(colors)
+    );
+    rb.position.set(
+      BOWLING_RETURN_SIDE_X -
+        BOWLING_RETURN_SIDE_SIGN * 0.28 +
+        i * BOWLING_RETURN_SIDE_SIGN * 0.28,
+      CFG.laneY + 0.31,
+      5.14 + i * 0.5
+    );
+    rb.userData.returnPhase = i * 0.34;
+    decor.returnBalls.push(rb);
+    group.add(rb);
+  });
+  const commercialRack = makeBowlingBallRack(
+    BALL_VARIANTS,
+    makeBallMaterial,
+    decor.rackPickupBalls
+  );
+  commercialRack.position.set(BOWLING_RACK_SIDE_X, CFG.laneY, BOWLING_RACK_Z);
+  commercialRack.rotation.y = 0;
+  group.add(commercialRack);
+
+  for (const [x, z, color] of [
+    [BOWLING_RACK_SIDE_X, BOWLING_RACK_Z, 0x38bdf8],
+    [0, CFG.pinDeckZ - 0.4, 0xffb86b]
+  ]) {
+    const pulse = new THREE.PointLight(color as number, 0.42, 5.4, 2.1);
+    pulse.position.set(x as number, 1.35, z as number);
+    group.add(pulse);
+    decor.crowdPulseLights.push(pulse);
+  }
+
+  // 3D overhead monitor already removed so it no longer blocks or distracts the camera.
+  enableShadow(group);
+  return decor;
+}
+
+function createDominoBowlingCrowd(
+  scene: THREE.Scene,
+  playerCharacterId: string
+): BowlingCrowdMember[] {
+  const members: BowlingCrowdMember[] = [];
+  const behaviors: BowlingCrowdMember['behavior'][] = [
+    'talking',
+    'clapping',
+    'phone',
+    'drinking',
+    'spectating',
+    'celebrating'
+  ];
+  const spots = [
+    { pos: [-3.12, 0, 6.08], yaw: Math.PI * 0.78, seated: false },
+    { pos: [3.12, 0, 6.08], yaw: -Math.PI * 0.78, seated: false }
+  ];
+  const roster = HUMAN_CHARACTER_OPTIONS.filter(
+    (option) => option.id !== playerCharacterId
+  );
+  spots.forEach((spot, i) => {
+    const option =
+      roster[i % Math.max(1, roster.length)] || HUMAN_CHARACTER_OPTIONS[0];
+    const pos = new THREE.Vector3(spot.pos[0], CFG.laneY, spot.pos[2]);
+    const rig = addHuman(scene, pos.clone(), option, pos.clone(), spot.yaw);
+    rig.yaw = spot.yaw;
+    rig.targetYaw = spot.yaw;
+    rig.standPos.copy(pos);
+    if (spot.seated) applySeatedPose(rig);
+    else {
+      rig.action = 'idle';
+      syncHuman(rig);
+    }
+    members.push({
+      rig,
+      behavior: behaviors[i % behaviors.length],
+      phase: i * 0.73,
+      baseYaw: spot.yaw,
+      seated: spot.seated
+    });
+  });
+  return members;
+}
+
+function updateDominoBowlingCrowd(
+  crowd: BowlingCrowdMember[],
+  dt: number,
+  criticalPulse: boolean
+) {
+  const now = performance.now() * 0.001;
+  for (const member of crowd) {
+    const { rig } = member;
+    member.phase += dt * (criticalPulse ? 1.65 : 1);
+    const wave = Math.sin(now * 1.4 + member.phase);
+    rig.yaw = member.baseYaw + Math.sin(now * 0.55 + member.phase) * 0.11;
+    rig.targetYaw = rig.yaw;
+    rig.pos.copy(member.seated ? rig.seatPos : rig.standPos);
+    if (member.seated) {
+      rig.action = 'seated';
+      const cheerStand = criticalPulse
+        ? Math.abs(Math.sin(now * 5.4 + member.phase))
+        : 0;
+      const bounce = Math.abs(wave) * (criticalPulse ? 0.035 : 0.012);
+      if (rig.model) {
+        // Free Kick Arena-style seated celebration over the same Murlan seated base pose.
+        rig.model.position.set(
+          0,
+          -0.42 + bounce + cheerStand * 0.2,
+          -0.08 - cheerStand * 0.08
+        );
+        rig.model.rotation.set(
+          -0.18 +
+            cheerStand * 0.16 +
+            (member.behavior === 'clapping' ? Math.abs(wave) * 0.08 : 0),
+          0,
+          0.02 + wave * (criticalPulse ? 0.06 : 0.015)
+        );
+        const rightHand = findRightHand(rig.model) as THREE.Object3D | null;
+        if (rightHand && criticalPulse) {
+          rightHand.rotation.x = -1.55 + wave * 0.24;
+          rightHand.rotation.z = 0.32 + wave * 0.18;
+        }
+      }
+      animateFallbackHuman(
+        rig,
+        criticalPulse ? 'celebrate' : 'seat',
+        member.phase
+      );
+    } else {
+      rig.action = 'idle';
+      if (rig.model) {
+        rig.model.position.y = Math.abs(wave) * 0.018;
+        rig.model.rotation.x =
+          member.behavior === 'phone'
+            ? 0.16
+            : criticalPulse || member.behavior === 'celebrating'
+              ? Math.abs(wave) * 0.14
+              : 0;
+        rig.model.rotation.z =
+          member.behavior === 'clapping'
+            ? Math.sin(now * 6 + member.phase) * 0.08
+            : wave * 0.025;
+      }
+      animateFallbackHuman(
+        rig,
+        criticalPulse || member.behavior === 'celebrating'
+          ? 'celebrate'
+          : 'idle',
+        member.phase
+      );
+    }
+    syncHuman(rig);
+  }
+}
+
+function updateArenaDecor(
+  decor: BowlingArenaDecor,
+  elapsed: number,
+  criticalPulse: boolean
+) {
+  decor.returnBalls.forEach((ball, i) => {
+    const phase = (elapsed * 0.22 + (ball.userData.returnPhase || 0)) % 1;
+    ball.position.z = lerp(4.18, 6.98, phase);
+    ball.position.x =
+      BOWLING_RETURN_SIDE_X + Math.sin(phase * Math.PI * 2 + i) * 0.055;
+    ball.position.y = CFG.laneY + lerp(0.24, 0.4, easeOutCubic(phase));
+    ball.rotation.x -= 0.1;
+    ball.rotation.z += 0.055;
+    ball.visible = phase < 0.92;
+  });
+  decor.scoreboardPanels.forEach((panel, i) => {
+    const pulse = Math.sin(elapsed * 2.2 + i) * (criticalPulse ? 0.03 : 0.01);
+    panel.scale.set(1 + pulse, 1 + pulse * 0.65, 1);
+    const mat = panel.material as THREE.MeshBasicMaterial;
+    mat.opacity = clamp(0.86 + Math.sin(elapsed * 3.6 + i) * 0.08, 0.72, 1);
+  });
+  decor.pinfallPanels.forEach((panel, i) => {
+    const flashActive = (panel.userData.flashUntil || 0) > performance.now();
+    const baseScale = panel.userData.baseScale || 1;
+    const pulse = flashActive
+      ? Math.sin(elapsed * 14 + i) * 0.045
+      : Math.sin(elapsed * 2.8 + i) * 0.01;
+    panel.scale.setScalar(baseScale + pulse);
+    const mat = panel.material as THREE.MeshBasicMaterial;
+    if (mat?.opacity != null)
+      mat.opacity = flashActive ? 0.92 + Math.sin(elapsed * 18 + i) * 0.06 : 1;
+  });
+  decor.crowdPulseLights.forEach((light, i) => {
+    light.intensity =
+      (criticalPulse ? 1.2 : 0.42) + Math.sin(elapsed * 3 + i) * 0.12;
+  });
+}
+
+function createFrameRollSymbols(frame: BowlingFrame, frameIndex: number) {
+  const r = frame.rolls;
+  if (frameIndex < 9) {
+    if (r[0] === 10) return ['', 'X'];
+    const first = r[0] == null ? '' : r[0] === 0 ? '-' : String(r[0]);
+    const second =
+      r[1] == null
+        ? ''
+        : r[0] + r[1] === 10
+          ? '/'
+          : r[1] === 0
+            ? '-'
+            : String(r[1]);
+    return [first, second];
+  }
+  const a =
+    r[0] == null ? '' : r[0] === 10 ? 'X' : r[0] === 0 ? '-' : String(r[0]);
+  const b =
+    r[1] == null
+      ? ''
+      : r[0] === 10 && r[1] === 10
+        ? 'X'
+        : r[0] !== 10 && r[0] + r[1] === 10
+          ? '/'
+          : r[1] === 0
+            ? '-'
+            : String(r[1]);
+  const c =
+    r[2] == null
+      ? ''
+      : r[2] === 10
+        ? 'X'
+        : r[1] != null && r[1] < 10 && r[1] + r[2] === 10 && r[0] === 10
+          ? '/'
+          : r[2] === 0
+            ? '-'
+            : String(r[2]);
+  return [a, b, c];
+}
+
+function computeIntent(
+  hostWidth: number,
+  hostHeight: number,
+  startX: number,
+  startY: number,
+  x: number,
+  y: number,
+  spinInput: { x: number; y: number }
+): ThrowIntent {
+  const vertical = clamp((startY - y) / Math.max(170, hostHeight * 0.34), 0, 1);
+  const releaseScreenX = clamp((startX / hostWidth) * 2 - 1, -1, 1);
+  const targetScreenX = clamp((x / hostWidth) * 2 - 1, -1, 1);
+  const dragX = clamp((x - startX) / Math.max(70, hostWidth * 0.16), -1, 1);
+  // Map the finger positions directly to lane boards: where the swipe starts is
+  // the release board, and where it ends is the down-lane target board.
+  const releaseX = clamp(releaseScreenX * 0.82, -0.86, 0.86);
+  const targetX = clamp(targetScreenX * 1.02, -1.04, 1.04);
+  const power = vertical;
+  const spin = mapSpinForPhysics({ x: 0, y: 0 });
+  const forwardSpin = clamp(spin.y, -1, 1);
+  const speed =
+    lerp(6.6, 18.4, easeOutCubic(power)) *
+    lerp(0.92, 1.08, clamp01((forwardSpin + 1) / 2));
+  const spinCurve = spin.x * lerp(0.28, 1.18, power);
+  const swipeCurve = dragX * lerp(0.04, 0.34, power);
+  const hook = clamp(spinCurve + swipeCurve, -1.12, 1.12);
+  return { power, releaseX, targetX, hook, speed, spin };
+}
+
+function startApproach(rig: HumanRig, intent: ThrowIntent, laneCenter = 0) {
+  rig.action = 'approach';
+  rig.approachT = 0;
+  rig.throwT = 0;
+  rig.recoverT = 0;
+  rig.walkCycle = 0;
+  rig.approachFrom.copy(rig.pos);
+  const plant = bowlingReleaseFootPoint(laneCenter);
+  rig.approachTo.set(
+    plant.x + clamp(intent.releaseX * 0.16, -0.1, 0.1),
+    CFG.laneY,
+    plant.z
+  );
+  rig.yaw = Math.PI;
+  rig.targetYaw = Math.PI;
+}
+
+function updateHuman(
+  rig: HumanRig,
+  ball: BallState,
+  dt: number,
+  canStartReturnCycle: boolean
+) {
+  if (rig.action === 'seated') {
+    const breath = Math.sin(performance.now() * 0.002) * 0.008;
+    rig.pos.copy(rig.seatPos);
+    rig.yaw = rig.seatYaw;
+    rig.targetYaw = rig.seatYaw;
+    if (rig.model) {
+      applyMurlanSeatedBonePose(rig.model);
+      rig.model.position.set(0, -0.5 + breath, -0.1);
+      rig.model.rotation.set(-0.18, 0, 0.02);
+    }
+    animateFallbackHuman(rig, 'seat', rig.walkCycle);
+  } else if (rig.action === 'standingUp') {
+    rig.seatT = clamp01(rig.seatT + dt / CFG.standDuration);
+    const k = easeInOut(rig.seatT);
+    rig.pos.lerpVectors(rig.seatPos, rig.standPos, k);
+    rig.yaw = lerp(rig.seatYaw, Math.PI, k);
+    rig.targetYaw = rig.yaw;
+    if (rig.model) {
+      if (k > 0.78) resetBowlingHumanBonePose(rig.model);
+      rig.model.position.set(0, lerp(-0.5, 0, k), lerp(-0.1, 0, k));
+      rig.model.rotation.x = lerp(-0.18, 0, k);
+      rig.model.rotation.z = lerp(0.02, 0, k);
+    }
+    if (rig.seatT >= 1) {
+      rig.action = 'idle';
+      rig.pos.copy(rig.standPos);
+      rig.yaw = Math.PI;
+      rig.targetYaw = Math.PI;
+    }
+  } else if (rig.action === 'toSeat') {
+    rig.seatT = clamp01(rig.seatT + dt / CFG.seatWalkDuration);
+    rig.walkCycle += dt * 8.8;
+    const nextPos = new THREE.Vector3().lerpVectors(
+      rig.approachFrom,
+      rig.seatPos,
+      easeInOut(rig.seatT)
+    );
+    smoothFacing(rig, nextPos, dt);
+    rig.pos.copy(
+      keepHumanInBowlingWalkableArea(nextPos, rig.standPos.x < 0 ? -1 : 1)
+    );
+    if (rig.model) {
+      applyHumanWalkMotion(rig, 0.22, 0.0025, 0.55);
+    }
+    if (rig.seatT >= 1) applySeatedPose(rig);
+  } else if (rig.action === 'approach') {
+    rig.approachT = clamp01(rig.approachT + dt / CFG.approachDuration);
+    rig.walkCycle += dt * 24.2;
+    const nextPos = new THREE.Vector3().lerpVectors(
+      rig.approachFrom,
+      rig.approachTo,
+      easeInOut(rig.approachT)
+    );
+    smoothFacing(rig, nextPos, dt);
+    rig.pos.copy(nextPos);
+    if (rig.model) {
+      applyHumanWalkMotion(rig, 0.34, 0.0032, 0.78);
+      rig.model.rotation.x += 0.035;
+    }
+    animateFallbackHuman(rig, 'walk', rig.walkCycle);
+    if (rig.approachT >= 1) {
+      rig.action = 'throw';
+      rig.throwT = 0.001;
+    }
+  } else if (rig.action === 'throw') {
+    rig.throwT += dt / CFG.throwDuration;
+    animateFallbackHuman(rig, 'bowl', clamp01(rig.throwT));
+    if (rig.model) {
+      const t = clamp01(rig.throwT);
+      applyBowlingDeliveryPose(rig.model, t);
+      // right-handed delivery with anticipation, shoulder/hip separation, slide, and follow-through.
+      const windup = clamp01(t / 0.32);
+      const drive = clamp01((t - 0.26) / (CFG.releaseT - 0.26));
+      const follow = clamp01((t - CFG.releaseT) / (1 - CFG.releaseT));
+      const releaseSnap = Math.exp(-Math.pow((t - CFG.releaseT) / 0.075, 2));
+      const slideDrag =
+        t < CFG.releaseT
+          ? Math.sin(drive * Math.PI) * 0.035
+          : Math.exp(-follow * 5) * 0.025;
+
+      rig.model.position.y =
+        -Math.sin(drive * Math.PI) * 0.018 + follow * 0.012;
+      rig.model.rotation.x =
+        lerp(0, 0.16, windup) + Math.sin(drive * Math.PI) * 0.18 - follow * 0.1;
+      rig.model.rotation.z =
+        lerp(0.06, -0.2, drive) + follow * 0.26 + releaseSnap * 0.045;
+      rig.model.rotation.y = lerp(-0.18, 0.28, drive) - follow * 0.18;
+      rig.model.position.x = lerp(0.03, -0.11, drive) + follow * 0.07;
+      rig.model.position.z =
+        lerp(0.02, -0.09, drive) + follow * 0.07 + slideDrag;
+      const rightHand = findRightHand(rig.model) as THREE.Object3D | null;
+      if (rightHand) {
+        if (t < 0.3) {
+          const k = easeInOut(t / 0.3);
+          rightHand.rotation.x = lerp(0.08, 0.82, k);
+          rightHand.rotation.z = lerp(0, -0.2, k);
+        } else if (t < CFG.releaseT) {
+          const k = easeInOut((t - 0.3) / (CFG.releaseT - 0.3));
+          rightHand.rotation.x = lerp(0.82, -2.04, k);
+          rightHand.rotation.z = lerp(-0.2, 0.12, k);
+        } else {
+          const k = easeOutCubic(follow);
+          rightHand.rotation.x = lerp(-2.04, 1.12, k);
+          rightHand.rotation.z = lerp(0.12, 0.34, k);
+        }
+      }
+    }
+    if (rig.throwT >= 1) {
+      rig.action = 'recover';
+      rig.recoverT = 0.001;
+      rig.throwT = 0;
+    }
+  } else if (rig.action === 'recover') {
+    rig.recoverT += dt / CFG.recoverDuration;
+    if (rig.model) {
+      rig.model.rotation.x = lerp(-0.05, 0, clamp01(rig.recoverT));
+      rig.model.rotation.z *= 0.82;
+    }
+    if (rig.recoverT >= 1) {
+      rig.recoverT = 0;
+      rig.action = 'idle';
+      rig.returnWalkT = 0;
+    }
+  } else if (rig.action === 'toRack') {
+    rig.returnWalkT = clamp01(rig.returnWalkT + dt / CFG.returnWalkDuration);
+    rig.walkCycle += dt * 9.2;
+    const k = easeInOut(rig.returnWalkT);
+    const pickupPoint = returnPickupPointForRig(rig);
+    const nextPos = new THREE.Vector3().lerpVectors(
+      rig.approachTo,
+      pickupPoint,
+      k
+    );
+    smoothFacing(rig, nextPos, dt);
+    rig.pos.copy(
+      keepHumanInBowlingWalkableArea(nextPos, BOWLING_RACK_SIDE_SIGN)
+    );
+    if (rig.model) {
+      applyHumanWalkMotion(rig, 0.3, 0.003, 1);
+    }
+    animateFallbackHuman(rig, 'walk', rig.walkCycle);
+    if (rig.returnWalkT >= 1) {
+      rig.action = 'idle';
+      rig.returnWalkT = 0;
+    }
+  } else if (rig.action === 'pickBall') {
+    rig.pickT = clamp01(rig.pickT + dt / CFG.pickDuration);
+    if (rig.model) {
+      const k = easeInOut(rig.pickT);
+      const reach = Math.sin(clamp01(rig.pickT) * Math.PI);
+      rig.model.position.y = lerp(-0.12, 0.02, k);
+      rig.model.position.z = lerp(0.08, -0.03, k);
+      rig.model.rotation.x = lerp(0.28, -0.08, k);
+      rig.model.rotation.z = lerp(-0.08, 0.025, k);
+      const rightHand = findRightHand(rig.model) as THREE.Object3D | null;
+      if (rightHand) {
+        rightHand.rotation.x = lerp(0.42, -1.16, reach);
+        rightHand.rotation.z = lerp(-0.22, 0.16, k);
+      }
+    }
+    if (rig.pickT >= 1 && canStartReturnCycle) {
+      rig.action = 'toApproach';
+      rig.returnWalkT = 0.001;
+    }
+  } else if (rig.action === 'toApproach') {
+    rig.returnWalkT = clamp01(rig.returnWalkT + dt / CFG.returnWalkDuration);
+    rig.walkCycle += dt * 9.2;
+    const k = easeInOut(rig.returnWalkT);
+    const pickupPoint = returnPickupPointForRig(rig);
+    const readyPoint = shootingReadyPointForRig(
+      rig,
+      ball.laneCenter || rig.standPos.x
+    );
+    const nextPos = new THREE.Vector3().lerpVectors(
+      pickupPoint,
+      readyPoint,
+      easeInOut(k)
+    );
+    smoothFacing(rig, nextPos, dt);
+    rig.pos.copy(
+      keepHumanInBowlingWalkableArea(nextPos, BOWLING_RACK_SIDE_SIGN)
+    );
+    if (rig.model) {
+      applyHumanWalkMotion(rig, 0.3, 0.003, 1);
+    }
+    animateFallbackHuman(rig, 'walk', rig.walkCycle);
+    if (rig.returnWalkT >= 1) {
+      rig.pos.copy(
+        shootingReadyPointForRig(rig, ball.laneCenter || rig.standPos.x)
+      );
+      rig.action = 'idle';
+    }
+  } else if (rig.action === 'celebrate') {
+    rig.celebrateT = clamp01(rig.celebrateT + dt / CFG.celebrateDuration);
+    rig.walkCycle += dt * 12.5;
+    const dance = Math.sin(rig.walkCycle);
+    rig.targetYaw = Math.PI + dance * 0.22;
+    rig.yaw = lerp(rig.yaw, rig.targetYaw, 1 - Math.exp(-8 * dt));
+    if (rig.model) {
+      resetBowlingHumanBonePose(rig.model);
+      rig.model.position.y = Math.abs(dance) * 0.055;
+      rig.model.rotation.x = Math.sin(rig.walkCycle * 0.5) * 0.1;
+      rig.model.rotation.z = dance * 0.16;
+      const leftHand = findLeftHand(rig.model) as THREE.Object3D | null;
+      const rightHand = findRightHand(rig.model) as THREE.Object3D | null;
+      if (leftHand)
+        leftHand.rotation.x = -1.65 + Math.cos(rig.walkCycle) * 0.35;
+      if (rightHand)
+        rightHand.rotation.x = -1.5 - Math.cos(rig.walkCycle) * 0.32;
+    }
+    animateFallbackHuman(rig, 'celebrate', rig.walkCycle);
+    if (rig.celebrateT >= 1) {
+      rig.celebrateT = 0;
+      rig.celebrateNext = false;
+      rig.action = 'idle';
+      rig.targetYaw = Math.PI;
+    }
+  } else if (rig.action === 'idle') {
+    rig.walkCycle += dt * 1.25;
+    const breath = Math.sin(rig.walkCycle) * 0.012;
+    const weight = Math.sin(rig.walkCycle * 0.63) * 0.018;
+    if (rig.model) {
+      rig.model.position.set(0.02 + weight, breath, 0.02);
+      rig.model.rotation.x = 0.025 + breath * 0.6;
+      rig.model.rotation.y = weight * 0.25;
+      rig.model.rotation.z = -0.025 + weight * 0.9;
+    }
+    animateFallbackHuman(rig, 'idle', rig.walkCycle);
+  } else if (rig.model) {
+    rig.model.position.y *= 0.82;
+    rig.model.rotation.x *= 0.82;
+    rig.model.rotation.z *= 0.82;
+  }
+  if (rig.action === 'throw' || rig.action === 'recover') {
+    rig.targetYaw = Math.PI;
+    rig.yaw = lerp(rig.yaw, Math.PI, 1 - Math.pow(0.0008, dt));
+    rig.yawVelocity = 0;
+  }
+  if (rig.action === 'idle') {
+    rig.targetYaw = Math.PI;
+    rig.yaw = lerp(rig.yaw, Math.PI, 1 - Math.pow(0.0008, dt));
+    rig.yawVelocity = 0;
+  }
+  syncHuman(rig);
+  if (ball.held && canStartReturnCycle) {
+    ball.pos.copy(getHeldBallWorldPosition(rig));
+    ball.mesh.position.copy(ball.pos);
+  }
+}
+
+function syncHeldBallToHuman(ball: BallState, rig: HumanRig) {
+  ball.pos.copy(getHeldBallWorldPosition(rig));
+  ball.mesh.position.copy(ball.pos);
+  ball.mesh.visible = true;
+}
+
+function releaseBall(
+  ball: BallState,
+  intent: ThrowIntent,
+  laneCenter = ball.laneCenter,
+  rig?: HumanRig
+) {
+  ball.laneCenter = laneCenter;
+  const handReleaseX = rig
+    ? clamp(getHeldBallWorldPosition(rig).x - laneCenter, -0.86, 0.86)
+    : intent.releaseX * 0.86;
+  const releasePos = new THREE.Vector3(
+    laneCenter + lerp(intent.releaseX * 0.86, handReleaseX, rig ? 0.72 : 0),
+    CFG.laneY + ball.variant.radius + 0.015,
+    CFG.foulZ - 0.08
+  );
+  const target = new THREE.Vector3(
+    laneCenter + intent.targetX * 0.92,
+    CFG.laneY + ball.variant.radius + 0.02,
+    CFG.pinDeckZ + 0.4
+  );
+  const dir = target.clone().sub(releasePos).normalize();
+  ball.held = false;
+  ball.rolling = true;
+  ball.inGutter = false;
+  ball.hook = intent.hook;
+  ball.spin.set(intent.spin.x, intent.spin.y);
+  ball.pos.copy(releasePos);
+  ball.vel.copy(dir.multiplyScalar(intent.speed));
+  ball.vel.y = 0;
+  ball.mesh.position.copy(ball.pos);
+}
+
+function updateAimVisual(
+  line: THREE.Line,
+  marker: THREE.Mesh,
+  intent: ThrowIntent | null,
+  laneCenter = 0
+) {
+  line.visible = !!intent;
+  marker.visible = !!intent;
+  if (!intent) return;
+  const from = new THREE.Vector3(
+    laneCenter + intent.releaseX * 0.86,
+    CFG.laneY + 0.1,
+    CFG.foulZ - 0.08
+  );
+  const to = new THREE.Vector3(
+    laneCenter + intent.targetX * 0.92,
+    CFG.laneY + 0.1,
+    CFG.arrowsZ + lerp(2.4, -0.4, intent.power)
+  );
+  const pos = line.geometry.getAttribute('position') as THREE.BufferAttribute;
+  pos.setXYZ(0, from.x, from.y, from.z);
+  pos.setXYZ(1, to.x, to.y, to.z);
+  pos.needsUpdate = true;
+  marker.position.set(to.x, CFG.laneY + 0.11, to.z);
+}
+
+function collideBallWithPins(ball: BallState, pins: PinState[]) {
+  if (
+    !ball.rolling ||
+    Math.abs(ball.pos.x - ball.laneCenter) > CFG.laneHalfW + 0.08
+  )
+    return;
+  for (const pin of pins) {
+    if (!pin.root.visible) continue;
+    const dx = pin.pos.x - ball.pos.x;
+    const dz = pin.pos.z - ball.pos.z;
+    const dist = Math.hypot(dx, dz);
+    const minDist = CFG.ballR + CFG.pinR;
+    if (dist > minDist || dist < 0.001) continue;
+    const n = new THREE.Vector3(dx / dist, 0, dz / dist);
+    const speed = Math.hypot(ball.vel.x, ball.vel.z);
+    const impulse = Math.max(0.9, speed * 0.92 * ball.variant.massFactor);
+    const tangential = ball.hook * clamp(speed / 14, 0.08, 0.62);
+    pin.vel.addScaledVector(n, impulse);
+    pin.vel.z += ball.vel.z * 0.24;
+    pin.vel.x += tangential;
+    pin.angularVel += impulse * 2.2 + Math.abs(tangential) * 1.8;
+    pin.tiltDir
+      .copy(n)
+      .add(new THREE.Vector3(tangential * 0.25, 0, 0))
+      .normalize();
+    pin.standing = false;
+    pin.knocked = true;
+    ball.vel.addScaledVector(n, -0.6);
+    ball.vel.multiplyScalar(0.92);
+  }
+}
+
+function collidePins(pins: PinState[]) {
+  for (let i = 0; i < pins.length; i++) {
+    for (let j = i + 1; j < pins.length; j++) {
+      const a = pins[i];
+      const b = pins[j];
+      if (!a.root.visible || !b.root.visible) continue;
+      const dx = b.pos.x - a.pos.x;
+      const dz = b.pos.z - a.pos.z;
+      const dist = Math.hypot(dx, dz);
+      const minDist = CFG.pinR * 1.8;
+      if (dist > minDist || dist < 0.001) continue;
+      const n = new THREE.Vector3(dx / dist, 0, dz / dist);
+      const rel = a.vel.clone().sub(b.vel);
+      const along = Math.abs(rel.dot(n));
+      const impulse = clamp(0.25 + along * 0.18, 0.2, 0.9);
+      a.vel.addScaledVector(n, -impulse);
+      b.vel.addScaledVector(n, impulse);
+      a.standing = false;
+      b.standing = false;
+      a.knocked = true;
+      b.knocked = true;
+      a.angularVel += 0.42 + impulse * 0.92;
+      b.angularVel += 0.42 + impulse * 0.92;
+      a.tiltDir.copy(n).multiplyScalar(-1);
+      b.tiltDir.copy(n);
+    }
+  }
+}
+
+function updatePins(pins: PinState[], dt: number) {
+  collidePins(pins);
+  let moving = false;
+  for (const pin of pins) {
+    if (!pin.root.visible) continue;
+    const speed = Math.hypot(pin.vel.x, pin.vel.z);
+    if (speed > 0.015 || Math.abs(pin.angularVel) > 0.015) moving = true;
+    pin.pos.addScaledVector(pin.vel, dt);
+    pin.vel.multiplyScalar(Math.exp(-1.65 * dt));
+    if (!pin.standing || speed > 0.28) {
+      pin.standing = false;
+      pin.knocked = true;
+      pin.tilt = clamp(
+        pin.tilt + (pin.angularVel + speed * 1.32) * dt,
+        0,
+        1.52
+      );
+      pin.angularVel *= Math.exp(-1.28 * dt);
+    }
+    if (
+      Math.abs(pin.pos.x - pin.start.x) > 2.35 ||
+      pin.pos.z < CFG.backStopZ - 0.25 ||
+      pin.pos.z > CFG.pinDeckZ + 1.15
+    ) {
+      pin.knocked = true;
+      pin.root.visible = false;
+    }
+    pin.root.position.copy(pin.pos);
+    if (pin.standing) {
+      pin.root.rotation.x *= 0.88;
+      pin.root.rotation.z *= 0.88;
+    } else {
+      const d =
+        pin.tiltDir.lengthSq() > 0.001
+          ? pin.tiltDir.clone().normalize()
+          : new THREE.Vector3(0, 0, -1);
+      pin.root.rotation.x = d.z * pin.tilt;
+      pin.root.rotation.z = -d.x * pin.tilt;
+    }
+  }
+  return moving;
+}
+
+function startBallReturn(ball: BallState) {
+  if (ball.returnState !== 'idle') return;
+  ball.returnState = 'toPit';
+  ball.returnT = 0;
+  ball.rolling = false;
+  ball.vel.set(0, 0, 0);
+}
+
+function updateBallReturn(ball: BallState, dt: number) {
+  if (ball.returnState === 'idle') return false;
+  if (ball.returnState === 'toPit') {
+    ball.returnT += dt / 0.48;
+    ball.mesh.position.lerp(
+      new THREE.Vector3(
+        BOWLING_RETURN_SIDE_X,
+        CFG.laneY + 0.16,
+        CFG.backStopZ + 0.1
+      ),
+      1 - Math.exp(-8 * dt)
+    );
+    if (ball.returnT >= 1) {
+      ball.returnState = 'hidden';
+      ball.returnT = 0;
+      ball.mesh.visible = false;
+    }
+    return false;
+  }
+  if (ball.returnState === 'hidden') {
+    ball.returnT += dt / 0.86;
+    if (ball.returnT >= 1) {
+      ball.returnState = 'returning';
+      ball.returnT = 0;
+      ball.mesh.visible = true;
+      ball.pos.set(BOWLING_RETURN_SIDE_X, CFG.laneY + 0.24, -0.4);
+      ball.mesh.position.copy(ball.pos);
+    }
+    return false;
+  }
+  if (ball.returnState === 'returning') {
+    ball.returnT += dt / 1.35;
+    const t = easeOutCubic(clamp01(ball.returnT));
+    ball.pos.set(
+      BOWLING_RETURN_SIDE_X,
+      CFG.laneY + lerp(0.24, 0.42, t),
+      lerp(-0.4, BOWLING_RACK_Z - 0.62, t)
+    );
+    ball.mesh.position.copy(ball.pos);
+    ball.mesh.rotateZ(0.18);
+    ball.mesh.rotateX(0.26);
+    if (ball.returnT >= 1) {
+      ball.returnState = 'idle';
+      ball.returnT = 0;
+      ball.held = false;
+      ball.rolling = false;
+      ball.inGutter = false;
+      ball.mesh.visible = false;
+      return true;
+    }
+  }
+  return false;
+}
+
+function oilRatioAt(z: number) {
+  // House-shot style: slick through the heads, tapering to dry boards near the pin deck.
+  return clamp01(
+    (z - (CFG.pinDeckZ + 1.4)) / (CFG.foulZ - (CFG.pinDeckZ + 1.4))
+  );
+}
+
+function boardNumberFromX(x: number) {
+  return clamp(
+    Math.round(((x + CFG.laneHalfW) / (CFG.laneHalfW * 2)) * LANE_BOARD_COUNT),
+    1,
+    LANE_BOARD_COUNT
+  );
+}
+
+function updateBall(ball: BallState, pins: PinState[], dt: number) {
+  if (!ball.rolling) return false;
+  const flatSpeed = Math.hypot(ball.vel.x, ball.vel.z);
+  const localX = ball.pos.x - ball.laneCenter;
+  ball.inGutter = Math.abs(localX) > CFG.laneHalfW;
+  if (!ball.inGutter && flatSpeed > 0.85) {
+    const oil = oilRatioAt(ball.pos.z);
+    const dryBoards = clamp01(
+      (Math.abs(localX) - CFG.laneHalfW * 0.34) / (CFG.laneHalfW * 0.55)
+    );
+    const downLane = 1 - oil;
+    const hookPhase = clamp01(downLane * 0.78 + dryBoards * 0.42);
+    const hookGain =
+      lerp(0.42, 1.62, clamp01(flatSpeed / 16)) * (0.55 + dryBoards * 0.72);
+    ball.vel.x += ball.hook * hookPhase * hookGain * dt;
+  }
+  if (!ball.inGutter && flatSpeed > 0.85 && ball.spin.lengthSq() > 0.0001) {
+    const forward = ball.vel.clone().setY(0).normalize();
+    const lateral = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+    const spinOil = 1 - oilRatioAt(ball.pos.z);
+    const spinResponse =
+      lerp(0.28, 1.05, spinOil) * lerp(0.45, 1.15, clamp01(flatSpeed / 15));
+    ball.vel.addScaledVector(lateral, ball.spin.x * spinResponse * dt);
+    ball.vel.addScaledVector(forward, ball.spin.y * 0.34 * spinResponse * dt);
+    ball.spin.multiplyScalar(Math.exp(-0.18 * dt));
+  }
+  const oil = ball.inGutter ? 0 : oilRatioAt(ball.pos.z);
+  const dryDrag = clamp01(
+    (Math.abs(localX) - CFG.laneHalfW * 0.46) / (CFG.laneHalfW * 0.5)
+  );
+  const drag = ball.inGutter ? 1.28 : lerp(0.22, 0.58, 1 - oil) + dryDrag * 0.2;
+  ball.vel.multiplyScalar(Math.exp(-drag * dt));
+  ball.pos.addScaledVector(ball.vel, dt);
+  if (Math.abs(ball.pos.x - ball.laneCenter) > CFG.gutterHalfW) {
+    ball.pos.x =
+      ball.laneCenter +
+      clamp(ball.pos.x - ball.laneCenter, -CFG.gutterHalfW, CFG.gutterHalfW);
+    ball.vel.x *= -0.22;
+  }
+  ball.pos.y = CFG.laneY + ball.variant.radius + (ball.inGutter ? -0.08 : 0.02);
+  ball.mesh.position.copy(ball.pos);
+  const speed = Math.hypot(ball.vel.x, ball.vel.z);
+  if (speed > 0.02) {
+    const rollAxis = new THREE.Vector3(ball.vel.z, 0, -ball.vel.x).normalize();
+    if (rollAxis.lengthSq() > 0.001)
+      ball.mesh.rotateOnWorldAxis(rollAxis, (speed / ball.variant.radius) * dt);
+    if (ball.spin.lengthSq() > 0.0001) {
+      ball.mesh.rotateOnWorldAxis(UP, ball.spin.x * 5.2 * dt);
+      ball.mesh.rotateOnWorldAxis(rollAxis, ball.spin.y * 2.8 * dt);
+    }
+  }
+  collideBallWithPins(ball, pins);
+  if (ball.pos.z <= CFG.backStopZ + 0.45 || speed < 0.12) startBallReturn(ball);
+  return true;
+}
+
+function getPlayerPerspectiveCameraPose(
+  player: HumanRig,
+  ball: BallState,
+  dt: number
+) {
+  const laneCenter = ball.laneCenter || player.standPos.x;
+  const aimCenter =
+    laneCenter + clamp(ball.pos.x - laneCenter, -0.42, 0.42) * 0.32;
+  const faceSide = player.standPos.x < 0 ? -0.035 : 0.035;
+  const progress =
+    player.action === 'approach'
+      ? player.approachT
+      : player.action === 'throw'
+        ? Math.min(1, player.throwT)
+        : 0;
+  const releaseMomentum =
+    player.action === 'throw'
+      ? easeOutCubic(clamp01((player.throwT - 0.18) / 0.62)) * 0.7
+      : 0;
+  const faceForward = new THREE.Vector3(
+    Math.sin(player.yaw),
+    0,
+    Math.cos(player.yaw)
+  );
+  if (faceForward.lengthSq() < 0.001) faceForward.set(0, 0, -1);
+  faceForward.normalize();
+  const faceRight = new THREE.Vector3(
+    faceForward.z,
+    0,
+    -faceForward.x
+  ).normalize();
+  const face = player.pos
+    .clone()
+    .addScaledVector(faceForward, 0.28 + releaseMomentum * 0.08)
+    .addScaledVector(faceRight, faceSide)
+    .add(new THREE.Vector3(0, 1.62 + lerp(0.04, -0.05, progress), 0));
+  face.z = Math.max(face.z, CFG.foulZ + 0.1);
+  const desired = face;
+  const ballFocus = ball.held
+    ? ball.pos.clone().add(new THREE.Vector3(0, 0.18, -1.2))
+    : ball.pos.clone().add(new THREE.Vector3(0, 0.16, -0.7));
+  const pinFocus = new THREE.Vector3(
+    laneCenter,
+    CFG.laneY + 0.56,
+    CFG.pinDeckZ - 0.68
+  );
+  const look = ball.rolling
+    ? ballFocus.lerp(
+        pinFocus,
+        clamp01((CFG.foulZ - ball.pos.z) / (CFG.foulZ - CFG.pinDeckZ))
+      )
+    : new THREE.Vector3(
+        aimCenter,
+        CFG.laneY + 0.55,
+        lerp(CFG.arrowsZ, CFG.pinDeckZ - 0.2, 0.48 + progress * 0.22)
+      );
+  return { desired, look };
+}
+
+function applyCameraLookOffset(
+  position: THREE.Vector3,
+  look: THREE.Vector3,
+  lookState?: CameraLookState | null
+) {
+  if (!lookState) return look;
+  const forward = look.clone().sub(position);
+  const distance = Math.max(1, forward.length());
+  forward.normalize();
+  const yawQuat = new THREE.Quaternion().setFromAxisAngle(UP, lookState.yaw);
+  forward.applyQuaternion(yawQuat);
+  const right = new THREE.Vector3().crossVectors(forward, UP).normalize();
+  if (right.lengthSq() < 0.001) right.set(1, 0, 0);
+  const pitchQuat = new THREE.Quaternion().setFromAxisAngle(
+    right,
+    lookState.pitch
+  );
+  forward.applyQuaternion(pitchQuat).normalize();
+  return position.clone().addScaledVector(forward, distance);
+}
+
+type BroadcastCameraPhase =
+  | 'lounge'
+  | 'approach'
+  | 'release'
+  | 'laneFollow'
+  | 'pinDeck';
+
+function getBroadcastCameraPose(player: HumanRig, ball: BallState) {
+  const laneCenter = ball.laneCenter || player.standPos.x;
+  let phase: BroadcastCameraPhase = 'lounge';
+  if (player.action === 'approach') phase = 'approach';
+  if (player.action === 'throw' || player.action === 'recover')
+    phase = 'release';
+  if (ball.rolling)
+    phase = ball.pos.z < CFG.pinDeckZ + 3.0 ? 'pinDeck' : 'laneFollow';
+
+  if (phase === 'approach') {
+    return {
+      phase,
+      desired: new THREE.Vector3(
+        laneCenter - 2.18,
+        CFG.laneY + 2.42,
+        CFG.foulZ + 5.55
+      ),
+      look: player.pos.clone().add(new THREE.Vector3(0, 0.9, -1.55))
+    };
+  }
+  if (phase === 'release') {
+    return {
+      phase,
+      desired: new THREE.Vector3(
+        laneCenter + 1.92,
+        CFG.laneY + 1.92,
+        CFG.foulZ + 4.18
+      ),
+      look: new THREE.Vector3(laneCenter, CFG.laneY + 0.52, CFG.arrowsZ - 1.1)
+    };
+  }
+  if (phase === 'laneFollow') {
+    const speed01 = clamp01(Math.hypot(ball.vel.x, ball.vel.z) / 16);
+    return {
+      phase,
+      desired: new THREE.Vector3(
+        laneCenter + lerp(1.05, 0.58, speed01),
+        CFG.laneY + lerp(1.86, 1.52, speed01),
+        ball.pos.z + lerp(5.15, 4.25, speed01)
+      ),
+      look: ball.pos.clone().add(new THREE.Vector3(0, 0.28, -3.6))
+    };
+  }
+  if (phase === 'pinDeck') {
+    return {
+      phase,
+      desired: new THREE.Vector3(
+        laneCenter + 2.15,
+        CFG.laneY + 2.02,
+        CFG.pinDeckZ + 4.15
+      ),
+      look: new THREE.Vector3(laneCenter, CFG.laneY + 0.62, CFG.pinDeckZ - 0.58)
+    };
+  }
+  return {
+    phase,
+    desired: new THREE.Vector3(laneCenter - 1.24, CFG.laneY + 3.12, 16.35),
+    look: new THREE.Vector3(laneCenter * 0.34, CFG.laneY + 0.62, -5.6)
+  };
+}
+
+function updateCamera(
+  camera: THREE.PerspectiveCamera,
+  ball: BallState,
+  player: HumanRig,
+  dt: number,
+  usePlayerPerspective: boolean,
+  lookState?: CameraLookState | null,
+  replayShotView = false
+) {
+  const forceBroadcastShotCamera =
+    usePlayerPerspective &&
+    (['approach', 'throw', 'recover'].includes(player.action) || ball.rolling);
+  const usingPlayerPerspective = usePlayerPerspective && !forceBroadcastShotCamera;
+  let desired: THREE.Vector3;
+  let look: THREE.Vector3;
+  const isActiveGameplay =
+    ['idle', 'approach', 'throw', 'recover'].includes(player.action) &&
+    player !== undefined;
+  if (replayShotView) {
+    const laneCenter = ball.laneCenter || player.standPos.x;
+    desired = new THREE.Vector3(
+      laneCenter + (camera.aspect < 0.72 ? 0.72 : 1.18),
+      CFG.laneY + 1.96,
+      CFG.foulZ + 5.25
+    );
+    look = new THREE.Vector3(laneCenter, CFG.laneY + 0.5, CFG.arrowsZ - 0.9);
+  } else if (!usingPlayerPerspective) {
+    const laneCenter = ball.laneCenter || player.standPos.x;
+    const broadcast = getBroadcastCameraPose(player, ball);
+    desired = broadcast.desired;
+    look = broadcast.look;
+    if (ball.rolling) {
+      const speed01 = clamp01(Math.hypot(ball.vel.x, ball.vel.z) / 16);
+      desired.x = lerp(desired.x, laneCenter * 0.45, 0.38);
+      desired.y += speed01 * 0.22;
+      look.lerp(ball.pos.clone().add(new THREE.Vector3(0, 0.22, -2.0)), 0.42);
+      if (ball.pos.z < CFG.pinDeckZ + 2.4)
+        look.lerp(
+          new THREE.Vector3(laneCenter, CFG.laneY + 0.52, CFG.pinDeckZ - 0.7),
+          0.5
+        );
+    }
+  } else if (
+    !ball.rolling &&
+    ball.held &&
+    player.action === 'idle' &&
+    isAtShootingLine(player.pos, ball.laneCenter || player.standPos.x)
+  ) {
+    const laneCenter = ball.laneCenter || player.standPos.x;
+    desired = new THREE.Vector3(
+      laneCenter + (camera.aspect < 0.72 ? 0.32 : 0.56),
+      CFG.laneY + 1.86,
+      CFG.foulZ + 3.72
+    );
+    look = new THREE.Vector3(laneCenter, CFG.laneY + 0.44, CFG.pinDeckZ - 0.38);
+  } else if (['approach', 'throw', 'recover'].includes(player.action)) {
+    const laneCenter = ball.laneCenter || player.standPos.x;
+    const broadcast = getBroadcastCameraPose(player, ball);
+    desired = broadcast.desired.clone();
+    look = broadcast.look.clone();
+    const t =
+      player.action === 'approach'
+        ? player.approachT
+        : player.action === 'throw'
+          ? player.throwT
+          : 1;
+    const dynamicPull = easeOutCubic(clamp01(t));
+    desired.add(
+      new THREE.Vector3(
+        Math.sin(performance.now() * 0.006) * 0.08,
+        dynamicPull * 0.18,
+        BOWLING_HUMAN_SHOT_BROADCAST_PULLBACK * dynamicPull
+      )
+    );
+    look.lerp(
+      new THREE.Vector3(laneCenter, CFG.laneY + 0.48, CFG.arrowsZ - 1.2),
+      0.25 + dynamicPull * 0.2
+    );
+  } else if (ball.rolling) {
+    const laneCenter = ball.laneCenter;
+    if (usingPlayerPerspective) {
+      const broadcast = getBroadcastCameraPose(player, ball);
+      desired = broadcast.desired.clone();
+      look = broadcast.look.clone();
+      const speed01 = clamp01(Math.hypot(ball.vel.x, ball.vel.z) / 16);
+      desired.add(
+        new THREE.Vector3(
+          Math.sin(performance.now() * 0.007) * 0.05,
+          speed01 * 0.22,
+          0.62
+        )
+      );
+      if (ball.pos.z < CFG.pinDeckZ + 2.4)
+        look.lerp(
+          new THREE.Vector3(laneCenter, CFG.laneY + 0.52, CFG.pinDeckZ - 0.7),
+          0.45
+        );
+    } else {
+      const lead = ball.vel.clone().setY(0);
+      if (lead.lengthSq() < 0.001) lead.set(0, 0, -1);
+      lead.normalize();
+      const speed01 = clamp01(Math.hypot(ball.vel.x, ball.vel.z) / 16);
+      const chase = getPlayerPerspectiveCameraPose(player, ball, dt);
+      const laneChase = ball.pos
+        .clone()
+        .addScaledVector(lead, -4.85)
+        .add(new THREE.Vector3(0, lerp(1.48, 1.24, speed01), 1.22));
+      laneChase.x = lerp(laneChase.x, laneCenter, 0.44);
+      desired = chase.desired.lerp(
+        laneChase,
+        clamp01((CFG.foulZ - ball.pos.z) / 7.2)
+      );
+      look = ball.pos
+        .clone()
+        .addScaledVector(lead, lerp(3.2, 5.0, speed01))
+        .add(new THREE.Vector3(0, 0.24, 0));
+      if (ball.pos.z < CFG.pinDeckZ + 2.4)
+        look.lerp(
+          new THREE.Vector3(laneCenter, CFG.laneY + 0.52, CFG.pinDeckZ - 0.7),
+          0.45
+        );
+    }
+  } else if (player.action === 'pickBall') {
+    const rackBroadcast = getBroadcastCameraPose(player, ball);
+    desired = rackBroadcast.desired
+      .clone()
+      .lerp(player.pos.clone().add(new THREE.Vector3(-1.28, 2.02, 4.45)), 0.65);
+    look = player.pos.clone().add(new THREE.Vector3(0, 0.7, -0.85));
+  } else if (isActiveGameplay) {
+    const pose = getPlayerPerspectiveCameraPose(player, ball, dt);
+    desired = pose.desired;
+    look = pose.look;
+  } else if (
+    player.action === 'toRack' ||
+    player.action === 'toApproach' ||
+    player.action === 'standingUp'
+  ) {
+    const rackBroadcast = getBroadcastCameraPose(player, ball);
+    desired = rackBroadcast.desired
+      .clone()
+      .lerp(player.pos.clone().add(new THREE.Vector3(-1.36, 2.08, 4.85)), 0.68);
+    look = player.pos.clone().add(new THREE.Vector3(0, 0.7, -1.25));
+  } else {
+    const broadcast = getBroadcastCameraPose(player, ball);
+    desired = broadcast.desired;
+    look = broadcast.look;
+  }
+  const now = performance.now();
+  const pinsProximity = ball.rolling
+    ? clamp01((ball.pos.z - (CFG.pinDeckZ + 1.65)) / 1.6)
+    : 0;
+  let shake = camera.userData.impactShake || 0;
+  if (
+    ball.rolling &&
+    ball.pos.z < CFG.pinDeckZ + 1.4 &&
+    !camera.userData.impactShakeTriggered
+  ) {
+    shake = 1;
+    camera.userData.impactShakeTriggered = true;
+  }
+  if (!ball.rolling) camera.userData.impactShakeTriggered = false;
+  shake = Math.max(0, shake - dt * 2.2);
+  camera.userData.impactShake = shake;
+  const shakeVec = new THREE.Vector3(
+    Math.sin(now * 0.047) * 0.028 * shake,
+    Math.cos(now * 0.039) * 0.018 * shake,
+    Math.sin(now * 0.051) * 0.012 * shake
+  );
+  const naturalHeadMotion = new THREE.Vector3(
+    Math.sin(now * 0.001) * 0.01,
+    Math.sin(now * 0.0017) * 0.008,
+    0
+  );
+  const isPortraitCamera = camera.aspect < 0.72;
+  if (isPortraitCamera) {
+    desired.add(
+      new THREE.Vector3(
+        desired.x < 0
+          ? -PORTRAIT_CAMERA_SIDE_OFFSET
+          : PORTRAIT_CAMERA_SIDE_OFFSET,
+        PORTRAIT_CAMERA_HEIGHT_OFFSET,
+        -0.08
+      )
+    );
+    look.x = lerp(look.x, BOWLING_LOUNGE_CENTER.x * 0.38, 0.16);
+    look.z += 0.82;
+  }
+  const pullback = desired.clone().sub(look);
+  if (pullback.lengthSq() > 0.0001) {
+    desired.addScaledVector(pullback.normalize(), BOWLING_CAMERA_PULLBACK);
+  }
+  if (lookState) {
+    lookState.yaw = lerp(
+      lookState.yaw,
+      lookState.targetYaw,
+      1 - Math.exp(-7.5 * dt)
+    );
+    lookState.pitch = lerp(
+      lookState.pitch,
+      lookState.targetPitch,
+      1 - Math.exp(-7.5 * dt)
+    );
+  }
+  const baseFov = (isPortraitCamera ? 52 : 46) + BOWLING_CAMERA_WIDER_FOV_BOOST;
+  const speedFov = ball.rolling
+    ? clamp01(Math.hypot(ball.vel.x, ball.vel.z) / 16) * 3.5
+    : 0;
+  camera.fov = lerp(
+    camera.fov,
+    baseFov + speedFov + pinsProximity * 1.9,
+    1 - Math.exp(-3.6 * dt)
+  );
+  camera.updateProjectionMatrix();
+  camera.position.lerp(
+    desired.add(naturalHeadMotion).add(shakeVec),
+    1 - Math.exp(-5.8 * dt)
+  );
+  const adjustedLook = applyCameraLookOffset(camera.position, look, lookState);
+  const currentLook = new THREE.Vector3(0, 0, -1)
+    .applyQuaternion(camera.quaternion)
+    .multiplyScalar(8)
+    .add(camera.position);
+  currentLook.lerp(adjustedLook, 1 - Math.exp(-8.6 * dt));
+  camera.lookAt(currentLook);
+}
+
+function FrameBox({ frame, index }: { frame: BowlingFrame; index: number }) {
+  const rolls = createFrameRollSymbols(frame, index);
+  const smallCols = index === 9 ? 3 : 2;
+  return (
+    <div
+      style={{
+        minWidth: index === 9 ? 34 : 26,
+        border: '1px solid rgba(255,255,255,0.16)',
+        borderRadius: 5,
+        overflow: 'hidden',
+        background: 'rgba(255,255,255,0.035)'
+      }}
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${smallCols}, 1fr)`,
+          borderBottom: '1px solid rgba(255,255,255,0.12)',
+          minHeight: 14,
+          fontSize: 8,
+          fontWeight: 800,
+          color: 'rgba(255,255,255,0.96)'
+        }}
+      >
+        {rolls.map((r, i) => (
+          <div
+            key={i}
+            style={{
+              textAlign: 'center',
+              padding: '2px 0',
+              borderLeft: i > 0 ? '1px solid rgba(255,255,255,0.12)' : 'none'
+            }}
+          >
+            {r}
+          </div>
+        ))}
+      </div>
+      <div
+        style={{
+          textAlign: 'center',
+          padding: '2px 1px',
+          minHeight: 14,
+          fontSize: 9,
+          fontWeight: 900,
+          color: '#7fd6ff'
+        }}
+      >
+        {frame.cumulative ?? ''}
+      </div>
+    </div>
+  );
+}
+
+export default function MobileBowlingRealistic() {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const cameraLookInputRef = useRef({
+    active: false,
+    pointerId: null as number | null,
+    startX: 0,
+    startY: 0,
+    targetYaw: 0,
+    targetPitch: 0
+  });
+  const ballPickRequestRef = useRef<string | null>(null);
+  const spinControlRef = useRef({ x: 0, y: 0 });
+  const searchParams = useMemo(
+    () => new URLSearchParams(window.location.search),
+    []
+  );
+  const matchMode = searchParams.get('mode') || 'local';
+  const playerCount = clamp(
+    Math.round(Number(searchParams.get('players') || '2')),
+    1,
+    5
+  );
+  const [hud, setHud] = useState<HudState>({
+    power: 0,
+    status:
+      'Bowler stands automatically, walks to the side rack, then you pick a ball and swipe at the shooting line',
+    compliment: '',
+    activePlayer: 0,
+    p1: 0,
+    p2: 0,
+    frame: 1,
+    roll: 1,
+    rule: BOWLING_RULE_SUMMARY,
+    lane: 'Board 20 · house shot'
+  });
+  const [scores, setScores] = useState<ScorePlayer[]>(() =>
+    makeEmptyPlayers(playerCount)
+  );
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [graphicsQuality, setGraphicsQualityState] = useState<GraphicsQuality>(
+    () => {
+      const stored = localStorage.getItem(
+        'bowling.graphicsQuality'
+      ) as GraphicsQuality | null;
+      return stored === 'performance' ||
+        stored === 'balanced' ||
+        stored === 'ultra'
+        ? stored
+        : 'balanced';
+    }
+  );
+  const [selectedFps, setSelectedFpsState] = useState<BowlingFpsOption>(() => {
+    const stored = localStorage.getItem(
+      'bowling.fps'
+    ) as BowlingFpsOption | null;
+    return stored === '60' || stored === '90' || stored === '120'
+      ? stored
+      : 'auto';
+  });
+  const setGraphicsQuality = (quality: GraphicsQuality) => {
+    localStorage.setItem('bowling.graphicsQuality', quality);
+    setGraphicsQualityState(quality);
+    if (selectedFps === 'auto') {
+      const profile = BOWLING_GRAPHICS_PROFILES[quality];
+      setHud((prev) => ({
+        ...prev,
+        lane: `${quality} graphics · auto ${profile.targetFps} FPS target`
+      }));
+    }
+  };
+  const setSelectedFps = (fps: BowlingFpsOption) => {
+    localStorage.setItem('bowling.fps', fps);
+    setSelectedFpsState(fps);
+  };
+  const [selectedHdriId, setSelectedHdriId] = useState<string>(
+    () => localStorage.getItem('bowling.hdri') || DEFAULT_HDRI_ID
+  );
+  const [ownedPoolInventory, setOwnedPoolInventory] = useState<any>(() =>
+    getCachedPoolRoyalInventory()
+  );
+  const [selectedTableFinish, setSelectedTableFinish] = useState<string>(
+    () =>
+      localStorage.getItem('bowling.tableFinish') ||
+      POOL_ROYALE_DEFAULT_UNLOCKS.tableFinish[0]
+  );
+  const [selectedChromeColor, setSelectedChromeColor] = useState<string>(
+    () =>
+      localStorage.getItem('bowling.chromeColor') ||
+      POOL_ROYALE_DEFAULT_UNLOCKS.chromeColor[0]
+  );
+  const [selectedBallWeight] = useState<string>(
+    () => localStorage.getItem('bowling.ballWeight') || '12'
+  );
+  const [ballSelectionMode] = useState<BallSelectionMode>(() => {
+    localStorage.setItem('bowling.ballSelectionMode', 'random');
+    return 'random';
+  });
+  const [selectedHumanCharacterId, setSelectedHumanCharacterId] =
+    useState<string>(
+      () =>
+        localStorage.getItem('bowling.humanCharacter') ||
+        DEFAULT_HUMAN_CHARACTER_ID
+    );
+  const [skipReplays, setSkipReplays] = useState<boolean>(
+    () => localStorage.getItem('bowling.skipReplays') === '1'
+  );
+  const [replayActive, setReplayActive] = useState(false);
+  const replayActiveRef = useRef(false);
+  const setReplayMode = (active: boolean) => {
+    replayActiveRef.current = active;
+    setReplayActive(active);
+  };
+  const [shootingUiVisible, setShootingUiVisible] = useState(false);
+  const scoresMemo = useMemo(() => scores, [scores]);
+
+  const requestManualBallPickup = (label: string) => {
+    ballPickRequestRef.current = label;
+    setHud((prev) => ({
+      ...prev,
+      status: `Pickup requested: ${label} lb. The bowler will collect it from the rack.`
+    }));
+  };
+
+  useEffect(() => {
+    const refresh = () => setOwnedPoolInventory(getCachedPoolRoyalInventory());
+    refresh();
+    window.addEventListener(
+      'poolRoyalInventoryUpdate',
+      refresh as EventListener
+    );
+    return () =>
+      window.removeEventListener(
+        'poolRoyalInventoryUpdate',
+        refresh as EventListener
+      );
+  }, []);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    const canvas = canvasRef.current;
+    if (!host || !canvas) return;
+
+    const renderer = new THREE.WebGLRenderer({
+      canvas,
+      antialias: true,
+      alpha: false,
+      powerPreference: 'high-performance'
+    });
+    renderer.setClearColor(0x090b11, 1);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure =
+      graphicsQuality === 'ultra'
+        ? 0.92
+        : graphicsQuality === 'performance'
+          ? 0.78
+          : 0.86;
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x070a12);
+    scene.fog = new THREE.FogExp2(0x080a10, 0.026);
+
+    const camera = new THREE.PerspectiveCamera(44, 1, 0.05, 80);
+    camera.position.set(-0.82, 3.34, 14.45);
+
+    const playerCharacter = getCharacterById(selectedHumanCharacterId);
+    const aiCharacter = pickRandomAiCharacter(
+      playerCharacter?.id || DEFAULT_HUMAN_CHARACTER_ID
+    );
+
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    pmrem.compileEquirectangularShader();
+    let envTex: THREE.Texture | null = null;
+    let bgTex: THREE.Texture | null = null;
+    const applyHdri = (id: string) => {
+      const selected = HDRI_OPTIONS.find((h) => h.id === id) || HDRI_OPTIONS[0];
+      const menuPreferred =
+        graphicsQuality === 'performance'
+          ? ['2k', '1k']
+          : graphicsQuality === 'ultra'
+            ? ['8k', '4k', '2k']
+            : ['4k', '2k'];
+      const preferred = Array.isArray(selected?.preferredResolutions)
+        ? [...menuPreferred, ...selected.preferredResolutions]
+        : menuPreferred;
+      const candidates = [
+        ...(Object.values(selected?.assetUrls || {}) as string[]),
+        selected?.hdriUrl,
+        ...HDRI_RES_LADDER.map(
+          (r) =>
+            `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${r}/${selected?.assetId || 'studio_small_09'}_${r}.hdr`
+        )
+      ].filter(Boolean) as string[];
+      const ordered = [
+        ...new Set([
+          ...preferred.flatMap((res) =>
+            candidates.filter((u) => u.includes(`_${res}.`))
+          ),
+          ...candidates
+        ])
+      ];
+      const tryLoad = (idx: number) => {
+        if (idx >= ordered.length) {
+          scene.environment = null;
+          scene.background = new THREE.Color(0x090b11);
+          return;
+        }
+        new RGBELoader().setCrossOrigin('anonymous').load(
+          ordered[idx],
+          (hdr) => {
+            envTex?.dispose();
+            bgTex?.dispose();
+            hdr.mapping = THREE.EquirectangularReflectionMapping;
+            bgTex = hdr;
+            envTex = pmrem.fromEquirectangular(hdr).texture;
+            scene.environment = envTex;
+            scene.background = bgTex;
+            const selectedRotation =
+              (Number.isFinite(selected?.rotationY) ? selected.rotationY : 0) +
+              BOWLING_HDRI_WALL_ALIGNMENT_Y;
+            if ('backgroundRotation' in scene)
+              scene.backgroundRotation.set(0, selectedRotation, 0);
+            if ('environmentRotation' in scene)
+              scene.environmentRotation.set(0, selectedRotation, 0);
+            if ('backgroundBlurriness' in scene) scene.backgroundBlurriness = 0;
+            if ('backgroundIntensity' in scene)
+              scene.backgroundIntensity =
+                graphicsQuality === 'ultra'
+                  ? 0.42
+                  : graphicsQuality === 'performance'
+                    ? 0.32
+                    : 0.36;
+            if ('environmentIntensity' in scene)
+              scene.environmentIntensity =
+                graphicsQuality === 'performance'
+                  ? 0.34
+                  : graphicsQuality === 'ultra'
+                    ? 0.52
+                    : 0.42;
+          },
+          undefined,
+          () => tryLoad(idx + 1)
+        );
+      };
+      tryLoad(0);
+    };
+    applyHdri(selectedHdriId);
+
+    scene.add(new THREE.AmbientLight(0x8fa6d9, 0.035));
+    scene.add(new THREE.HemisphereLight(0xffecd6, 0x08070b, 0.18));
+    const key = new THREE.DirectionalLight(0xffefd8, 2.65);
+    key.position.set(-4.8, 8.2, 6.6);
+    key.castShadow = true;
+    key.shadow.mapSize.width =
+      BOWLING_GRAPHICS_PROFILES[graphicsQuality].shadowMapSize;
+    key.shadow.mapSize.height =
+      BOWLING_GRAPHICS_PROFILES[graphicsQuality].shadowMapSize;
+    key.shadow.camera.near = 0.5;
+    key.shadow.camera.far = 36;
+    key.shadow.camera.left = -8;
+    key.shadow.camera.right = 8;
+    key.shadow.camera.top = 12;
+    key.shadow.camera.bottom = -14;
+    scene.add(key);
+    const fill = new THREE.DirectionalLight(0x7dd3fc, 0.08);
+    fill.position.set(4.4, 4.8, 6.3);
+    scene.add(fill);
+    const rim = new THREE.DirectionalLight(0xff9a4f, 1.72);
+    rim.position.set(3.8, 4.6, -12.4);
+    scene.add(rim);
+    for (let i = 0; i < 8; i++) {
+      const z = lerp(6.7, -13.6, i / 7);
+      const light = new THREE.PointLight(
+        0xffd8a6,
+        i > 5 ? 0.95 : 0.54,
+        8.4,
+        2.15
+      );
+      light.position.set(i % 2 === 0 ? -1.18 : 1.18, 2.72, z);
+      scene.add(light);
+    }
+    const pinSpot = new THREE.SpotLight(
+      0xfff0c8,
+      3.2,
+      12,
+      Math.PI / 7.5,
+      0.42,
+      1.35
+    );
+    pinSpot.position.set(0, 3.36, CFG.pinDeckZ + 1.6);
+    pinSpot.target.position.set(0, CFG.laneY + 0.22, CFG.pinDeckZ - 0.62);
+    scene.add(pinSpot, pinSpot.target);
+    const laneSpot = new THREE.SpotLight(
+      0x9fe8ff,
+      1.15,
+      18,
+      Math.PI / 8,
+      0.54,
+      1.2
+    );
+    laneSpot.position.set(-1.2, 2.7, 5.4);
+    laneSpot.target.position.set(0, CFG.laneY + 0.08, -5.8);
+    scene.add(laneSpot, laneSpot.target);
+
+    const texLoader = new THREE.TextureLoader();
+    const arenaDecor = createEnvironment(
+      scene,
+      texLoader,
+      selectedTableFinish,
+      selectedChromeColor,
+      playerCount
+    );
+    const pickupPrompt = makePickupPromptSprite();
+    scene.add(pickupPrompt);
+    const lanePins = LANE_CENTERS.map((center) => createPins(scene, center));
+    createShootingLineGuides(scene);
+    const activePins = () => lanePins[0];
+    const activeLaneCenter = () => laneCenterForPlayer(activePlayer);
+    const playerRigs = Array.from({ length: playerCount }, (_, i) => {
+      const seat = PLAYER_SEATS[i] || PLAYER_SEATS[0];
+      const character = i === 0 ? playerCharacter : aiCharacter;
+      return addHuman(scene, seat.pos.clone(), character, seat.pos, seat.yaw);
+    });
+    playerRigs.forEach((rig, i) => {
+      rig.standPos.copy(PLAYER_SEATS[i]?.stand || PLAYER_READY_POINT);
+      applySeatedPose(rig);
+    });
+    standRigForTurn(playerRigs[0]);
+    let player = playerRigs[0];
+    const ballVariant =
+      BALL_VARIANTS.find((v) => v.label === selectedBallWeight) ||
+      BALL_VARIANTS[1];
+    const ball = createActiveBall(ballVariant);
+    scene.add(ball.mesh);
+
+    let localScores = makeEmptyPlayers(playerCount);
+    let activePlayer = 0;
+    let lastShotStandingBefore = 10;
+    let pinsWereMoving = false;
+    let settleTimer = 0;
+    const pinReset = makePinResetState();
+    let waitingForBallReturn = false;
+    let pendingIntent: ThrowIntent | null = null;
+    let shotResolved = false;
+    let nextAction: 'samePlayer' | 'nextPlayer' | 'gameOver' = 'samePlayer';
+    let shouldResetRackBeforeNextRoll = false;
+    let rackResetLane = 0;
+    let replayTimer = 0;
+
+    const currentFrameRoll = () => {
+      const p = localScores[activePlayer];
+      const f = currentFrameIndex(p);
+      const rolls = p.frames[f].rolls.length;
+      return { frame: Math.min(10, f + 1), roll: Math.min(3, rolls + 1) };
+    };
+
+    const syncReactScores = () => {
+      setScores(clonePlayers(localScores));
+      const turn = currentFrameRoll();
+      setHud((prev) => ({
+        ...prev,
+        activePlayer,
+        p1: localScores[0]?.total || 0,
+        p2: localScores[1]?.total || 0,
+        frame: turn.frame,
+        roll: turn.roll
+      }));
+    };
+    syncReactScores();
+
+    const aimGeom = new THREE.BufferGeometry();
+    aimGeom.setAttribute(
+      'position',
+      new THREE.BufferAttribute(new Float32Array(6), 3)
+    );
+    const aimLine = new THREE.Line(
+      aimGeom,
+      new THREE.LineBasicMaterial({
+        color: 0x8bd7ff,
+        transparent: true,
+        opacity: 0.85
+      })
+    );
+    aimLine.visible = false;
+    scene.add(aimLine);
+    const aimMarker = new THREE.Mesh(
+      new THREE.RingGeometry(0.24, 0.31, 36),
+      new THREE.MeshBasicMaterial({
+        color: 0x8bd7ff,
+        transparent: true,
+        opacity: 0.72,
+        side: THREE.DoubleSide
+      })
+    );
+    aimMarker.rotation.x = -Math.PI / 2;
+    aimMarker.visible = false;
+    scene.add(aimMarker);
+    const ballShadow = new THREE.Mesh(
+      new THREE.CircleGeometry(0.24, 32),
+      new THREE.MeshBasicMaterial({
+        color: 0x000000,
+        transparent: true,
+        opacity: 0.22,
+        depthWrite: false
+      })
+    );
+    ballShadow.rotation.x = -Math.PI / 2;
+    scene.add(ballShadow);
+
+    const control: ControlState = {
+      active: false,
+      pointerId: null,
+      startX: 0,
+      startY: 0,
+      lastX: 0,
+      lastY: 0,
+      intent: null
+    };
+    const cameraLook: CameraLookState = {
+      active: false,
+      pointerId: null,
+      startX: 0,
+      startY: 0,
+      yaw: 0,
+      pitch: 0,
+      targetYaw: 0,
+      targetPitch: 0
+    };
+    const raycaster = new THREE.Raycaster();
+    const pointerNdc = new THREE.Vector2();
+    const pickRackBallFromPointer = (e: PointerEvent) => {
+      if (!pickupPrompt.visible || ballSelectionMode !== 'manual') return false;
+      const rect = canvas.getBoundingClientRect();
+      pointerNdc.set(
+        ((e.clientX - rect.left) / Math.max(1, rect.width)) * 2 - 1,
+        -(((e.clientY - rect.top) / Math.max(1, rect.height)) * 2 - 1)
+      );
+      raycaster.setFromCamera(pointerNdc, camera);
+      raycaster.params.Points.threshold = 0.12;
+      const hits = raycaster.intersectObjects(
+        arenaDecor.rackPickupBalls,
+        false
+      );
+      const hit = hits.find(
+        (item) =>
+          item.distanceToRay == null ||
+          item.distanceToRay < (item.object.userData.pickupHitRadius || 0.32)
+      );
+      const weight = hit?.object?.userData?.bowlingBallWeight;
+      if (typeof weight === 'string') {
+        requestManualBallPickup(weight);
+        return true;
+      }
+      return false;
+    };
+
+    const resetPlayerPoseForNextBall = (resetPosition = true) => {
+      player.action = 'idle';
+      player.approachT = 0;
+      player.throwT = 0;
+      player.recoverT = 0;
+      player.walkCycle = 0;
+      if (resetPosition) player.pos.copy(player.standPos);
+      player.yaw = Math.PI;
+      player.targetYaw = Math.PI;
+      player.approachFrom.copy(player.pos);
+      player.approachTo.copy(player.pos);
+      applyStandingPose(player);
+      syncHuman(player);
+      ball.held = false;
+      ball.rolling = false;
+      ball.inGutter = false;
+      ball.vel.set(0, 0, 0);
+      ball.spin.set(0, 0);
+      ball.mesh.visible = ball.held;
+      if (ball.held) syncHeldBallToHuman(ball, player);
+    };
+
+    const prepareNextTurnAfterReturn = () => {
+      waitingForBallReturn = false;
+      shotResolved = false;
+      pinsWereMoving = false;
+      settleTimer = 0;
+      pendingIntent = null;
+      if (shouldResetRackBeforeNextRoll) resetPins(lanePins[0]);
+      shouldResetRackBeforeNextRoll = false;
+      const previousPlayer = player;
+      player = playerRigs[activePlayer];
+      ball.laneCenter = activeLaneCenter();
+      if (previousPlayer !== player) seatRigAfterTurn(previousPlayer);
+      resetPlayerPoseForNextBall(previousPlayer !== player);
+      if (previousPlayer !== player) standRigForTurn(player);
+      syncReactScores();
+      aiTurnDelay = activePlayer !== 0 ? 0.85 + Math.random() * 0.5 : 0.85;
+      const playerName = localScores[activePlayer].name;
+      setHud((prev) => ({
+        ...prev,
+        status:
+          nextAction === 'gameOver'
+            ? 'Game over'
+            : activePlayer !== 0
+              ? `${playerName} is choosing a line…`
+              : `${playerName}: walking to the rack. A random ball will be picked, then swipe at the shooting line`
+      }));
+    };
+
+    const finalizeShot = (afterStanding: number) => {
+      const rawKnocked = clamp(lastShotStandingBefore - afterStanding, 0, 10);
+      const foul = player.pos.z < CFG.foulZ - 0.05;
+      const scoringPlayerIndex = activePlayer;
+      const playerBefore = localScores[scoringPlayerIndex];
+      const result = addRollToPlayer(playerBefore, rawKnocked, foul);
+      const knocked = result.knocked;
+      const rollRead = describeRollResult(playerBefore, result, knocked);
+      let status = foul
+        ? `${playerBefore.name} fouled · 0 pins score`
+        : `${playerBefore.name} knocked ${knocked} pin${knocked === 1 ? '' : 's'}`;
+      let compliment: string =
+        RESULT_COMPLIMENTS.open[
+          Math.floor(Math.random() * RESULT_COMPLIMENTS.open.length)
+        ];
+      const strike = rollRead.isStrike;
+      const spare = rollRead.isSpare;
+      shouldResetRackBeforeNextRoll = result.resetPins;
+      rackResetLane = 0;
+      if (strike) {
+        void new Audio(BOWLING_SFX.strike).play().catch(() => undefined);
+        status = `${playerBefore.name} STRIKE!`;
+        compliment =
+          RESULT_COMPLIMENTS.strike[
+            Math.floor(Math.random() * RESULT_COMPLIMENTS.strike.length)
+          ] +
+          ' ' +
+          STRIKE_DANCE_LINES[
+            Math.floor(Math.random() * STRIKE_DANCE_LINES.length)
+          ];
+      }
+      if (spare) {
+        void new Audio(BOWLING_SFX.spare).play().catch(() => undefined);
+        status = `${playerBefore.name} SPARE!`;
+        compliment =
+          RESULT_COMPLIMENTS.spare[
+            Math.floor(Math.random() * RESULT_COMPLIMENTS.spare.length)
+          ];
+      }
+      player.celebrateNext = strike || spare;
+      if ((strike || spare) && scoringPlayerIndex === activePlayer) {
+        player.action = 'celebrate';
+        player.celebrateT = 0.001;
+        player.walkCycle = 0;
+      }
+      const allDone = localScores.every((p) => officialTenPinPlayerFinished(p));
+      if (allDone) nextAction = 'gameOver';
+      else if (result.frameEnded) {
+        const nextPlayerIndex = nextUnfinishedPlayerIndex(
+          localScores,
+          scoringPlayerIndex
+        );
+        activePlayer = nextPlayerIndex;
+        nextAction =
+          nextPlayerIndex === scoringPlayerIndex ? 'samePlayer' : 'nextPlayer';
+      } else nextAction = 'samePlayer';
+      syncReactScores();
+      updatePinfallBoards(
+        arenaDecor,
+        scoringPlayerIndex,
+        knocked,
+        afterStanding,
+        playerBefore.name.toUpperCase()
+      );
+      setHud((prev) => ({
+        ...prev,
+        status,
+        compliment,
+        rule: rollRead.rule,
+        lane: rollRead.lane
+      }));
+      shotResolved = true;
+      waitingForBallReturn = true;
+      if (!skipReplays && (strike || spare)) {
+        replayTimer = CFG.replayDuration;
+        setReplayMode(true);
+      }
+      if (ball.returnState === 'idle') startBallReturn(ball);
+    };
+
+    let aiTurnDelay = 0.85;
+    const makeAiIntent = (): ThrowIntent => {
+      const frame = currentFrameIndex(localScores[activePlayer]);
+      const roll = localScores[activePlayer].frames[frame]?.rolls.length || 0;
+      const targetJitter = (Math.random() - 0.5) * (roll ? 0.7 : 0.42);
+      const releaseJitter = (Math.random() - 0.5) * 0.5;
+      const power = clamp(0.72 + Math.random() * 0.22, 0, 1);
+      const targetX = clamp(targetJitter, -1.1, 1.1);
+      const releaseX = clamp(releaseJitter * 0.55, -0.72, 0.72);
+      const spin = {
+        x: (Math.random() - 0.5) * 0.28,
+        y: 0.12 + (Math.random() - 0.5) * 0.18
+      };
+      return {
+        power,
+        releaseX,
+        targetX,
+        hook: spin.x,
+        speed: lerp(10.8, 15.4, power),
+        spin
+      };
+    };
+
+    const manualMovePlayer = (_dt: number) => {};
+
+    const applyActiveBallVariant = (label: string) => {
+      const variant =
+        BALL_VARIANTS.find((v) => v.label === label) || BALL_VARIANTS[1];
+      if (ball.variant.label === variant.label) return;
+      ball.variant = variant;
+      ball.mesh.geometry.dispose();
+      ball.mesh.geometry = new THREE.SphereGeometry(variant.radius, 80, 64);
+      const oldMaterial = ball.mesh.material;
+      ball.mesh.material = makeBallMaterial(variant.colors);
+      if (Array.isArray(oldMaterial)) oldMaterial.forEach((m) => m.dispose());
+      else oldMaterial.dispose();
+    };
+
+    const tryManualBallPickup = () => {
+      const request = ballPickRequestRef.current;
+      if (
+        !request ||
+        activePlayer !== 0 ||
+        ball.rolling ||
+        waitingForBallReturn ||
+        player.action !== 'idle'
+      )
+        return;
+      const rackDistance = Math.hypot(
+        player.pos.x - bowlingRackPickupX(),
+        player.pos.z - BOWLING_RACK_Z
+      );
+      if (rackDistance > 1.9) {
+        setHud((prev) => ({
+          ...prev,
+          status:
+            'Bowler is walking to the ball rack. Pick again when the rack buttons are visible.'
+        }));
+        return;
+      }
+      applyActiveBallVariant(request);
+      if (request !== selectedBallWeight) {
+        localStorage.setItem('bowling.ballWeight', request);
+      }
+      ballPickRequestRef.current = null;
+      ball.held = true;
+      ball.rolling = false;
+      ball.returnState = 'idle';
+      ball.mesh.visible = true;
+      player.action = 'pickBall';
+      player.pickT = 0.001;
+      player.returnWalkT = 0;
+      player.targetYaw = Math.PI;
+      syncHeldBallToHuman(ball, player);
+      setHud((prev) => ({
+        ...prev,
+        status: `${request} lb ball collected. Same-hand pickup animation started—walk to the approach line and swipe to shoot.`,
+        lane: 'Random pickup ready'
+      }));
+    };
+
+    let frameId = 0;
+    let last = performance.now();
+
+    const resize = () => {
+      const w = Math.max(1, host.clientWidth);
+      const h = Math.max(1, host.clientHeight);
+      const qualityMaxPixelRatio =
+        BOWLING_GRAPHICS_PROFILES[graphicsQuality].maxPixelRatio;
+      renderer.setPixelRatio(
+        Math.min(qualityMaxPixelRatio, window.devicePixelRatio || 1)
+      );
+      renderer.setSize(w, h, false);
+      camera.aspect = w / h;
+      camera.fov = camera.aspect < 0.72 ? 54 : 48;
+      camera.updateProjectionMatrix();
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (control.active || cameraLook.active) return;
+      const canStartThrow =
+        nextAction !== 'gameOver' &&
+        !ball.rolling &&
+        !waitingForBallReturn &&
+        !replayActiveRef.current &&
+        activePlayer === 0 &&
+        player === playerRigs[0] &&
+        player.action === 'idle' &&
+        ball.held &&
+        isAtShootingLine(player.pos, activeLaneCenter());
+      if (!canStartThrow) {
+        if (pickRackBallFromPointer(e)) return;
+        if (
+          activePlayer === 0 &&
+          !ball.held &&
+          !ball.rolling &&
+          !waitingForBallReturn
+        ) {
+          setHud((prev) => ({
+            ...prev,
+            status:
+              'Bowler walks automatically to the side rack. Tap a ball when the rack buttons are visible.'
+          }));
+        } else if (
+          activePlayer === 0 &&
+          !isAtShootingLine(player.pos, activeLaneCenter()) &&
+          !ball.rolling &&
+          !waitingForBallReturn
+        ) {
+          setHud((prev) => ({
+            ...prev,
+            status:
+              'Wait for the bowler to finish at the shooting line. The spin controller appears there, then swipe anywhere on the lane view to shoot.'
+          }));
+        }
+        return;
+      }
+      canvas.setPointerCapture(e.pointerId);
+      control.active = true;
+      control.pointerId = e.pointerId;
+      control.startX = e.clientX;
+      control.startY = e.clientY;
+      control.lastX = e.clientX;
+      control.lastY = e.clientY;
+      control.intent = computeIntent(
+        host.clientWidth,
+        host.clientHeight,
+        e.clientX,
+        e.clientY,
+        e.clientX,
+        e.clientY,
+        spinControlRef.current
+      );
+      pendingIntent = control.intent;
+      updateAimVisual(aimLine, aimMarker, control.intent, activeLaneCenter());
+      setHud((prev) => ({
+        ...prev,
+        power: 0,
+        status: 'Swipe up on the screen to shoot. Slide left/right to aim.'
+      }));
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (cameraLook.active && cameraLook.pointerId === e.pointerId) {
+        const dx =
+          (e.clientX - cameraLook.startX) / Math.max(1, host.clientWidth);
+        const dy =
+          (e.clientY - cameraLook.startY) / Math.max(1, host.clientHeight);
+        cameraLook.targetYaw = clamp(
+          cameraLook.targetYaw - dx * 1.45,
+          -0.82,
+          0.82
+        );
+        cameraLook.targetPitch = clamp(
+          cameraLook.targetPitch - dy * 1.05,
+          -0.42,
+          0.48
+        );
+        cameraLookInputRef.current.targetYaw = cameraLook.targetYaw;
+        cameraLookInputRef.current.targetPitch = cameraLook.targetPitch;
+        cameraLook.startX = e.clientX;
+        cameraLook.startY = e.clientY;
+        return;
+      }
+      if (!control.active || control.pointerId !== e.pointerId) return;
+      control.lastX = e.clientX;
+      control.lastY = e.clientY;
+      control.intent = computeIntent(
+        host.clientWidth,
+        host.clientHeight,
+        control.startX,
+        control.startY,
+        e.clientX,
+        e.clientY,
+        spinControlRef.current
+      );
+      pendingIntent = control.intent;
+      updateAimVisual(aimLine, aimMarker, control.intent, activeLaneCenter());
+      setHud((prev) => ({
+        ...prev,
+        power: control.intent!.power,
+        lane: `Aim board ${boardNumberFromX(control.intent!.targetX)} · ${Math.round(control.intent!.power * 100)}% · spin ${control.intent!.spin.x >= 0 ? '+' : ''}${control.intent!.spin.x.toFixed(2)} / ${control.intent!.spin.y >= 0 ? '+' : ''}${control.intent!.spin.y.toFixed(2)}`
+      }));
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (cameraLook.active && cameraLook.pointerId === e.pointerId) {
+        try {
+          canvas.releasePointerCapture(e.pointerId);
+        } catch {}
+        cameraLook.active = false;
+        cameraLook.pointerId = null;
+        cameraLookInputRef.current.targetYaw = cameraLook.targetYaw;
+        cameraLookInputRef.current.targetPitch = cameraLook.targetPitch;
+        return;
+      }
+      if (!control.active || control.pointerId !== e.pointerId) return;
+      try {
+        canvas.releasePointerCapture(e.pointerId);
+      } catch {}
+      control.active = false;
+      control.pointerId = null;
+      aimLine.visible = false;
+      aimMarker.visible = false;
+      const intent = computeIntent(
+        host.clientWidth,
+        host.clientHeight,
+        control.startX,
+        control.startY,
+        e.clientX,
+        e.clientY,
+        spinControlRef.current
+      );
+      if (intent.power < 0.05) {
+        pendingIntent = null;
+        setHud((prev) => ({
+          ...prev,
+          power: 0,
+          status: 'Swipe higher for power'
+        }));
+        return;
+      }
+      pendingIntent = intent;
+      startApproach(player, intent, activeLaneCenter());
+      void new Audio(BOWLING_SFX.throw).play().catch(() => undefined);
+      setHud((prev) => ({
+        ...prev,
+        power: 0,
+        status:
+          'Shot triggered · four-step approach · release before foul line',
+        rule: 'Release must stay behind the foul line',
+        lane: `Target board ${boardNumberFromX(intent.targetX)} · hook ${intent.hook >= 0 ? 'right' : 'left'} · spin ${intent.spin.x >= 0 ? '+' : ''}${intent.spin.x.toFixed(2)} / ${intent.spin.y >= 0 ? '+' : ''}${intent.spin.y.toFixed(2)}`
+      }));
+    };
+
+    canvas.addEventListener('pointerdown', onPointerDown);
+    canvas.addEventListener('pointermove', onPointerMove);
+    canvas.addEventListener('pointerup', onPointerUp);
+    canvas.addEventListener('pointercancel', onPointerUp);
+    window.addEventListener('resize', resize);
+    resize();
+
+    function animate() {
+      frameId = requestAnimationFrame(animate);
+      const now = performance.now();
+      const frameSeconds = (now - last) / 1000;
+      last = now;
+      const fpsOverride = BOWLING_FPS_OPTIONS.find(
+        (option) => option.id === selectedFps
+      )?.fps;
+      const targetFps =
+        fpsOverride || BOWLING_GRAPHICS_PROFILES[graphicsQuality].targetFps;
+      const frameCap = Math.max(0.05, 2.5 / targetFps);
+      const dt = Math.min(0.06, Math.max(0.001, frameSeconds), frameCap);
+      if (replayTimer > 0) {
+        replayTimer = Math.max(0, replayTimer - dt);
+        if (replayTimer <= 0) setReplayMode(false);
+      }
+      if (
+        activePlayer !== 0 &&
+        !control.active &&
+        !ball.rolling &&
+        !waitingForBallReturn &&
+        !replayActiveRef.current &&
+        player.action === 'idle' &&
+        nextAction !== 'gameOver'
+      ) {
+        const rackDistance = Math.hypot(
+          player.pos.x - bowlingRackPickupX(),
+          player.pos.z - BOWLING_RACK_Z
+        );
+        if (officialTenPinPlayerFinished(localScores[activePlayer])) {
+          player.action = 'toSeat';
+          player.seatT = 0.001;
+          setHud((prev) => ({ ...prev, status: `${localScores[activePlayer].name} finished the game and is returning to the chair.` }));
+          player.approachFrom.copy(player.pos);
+          player.approachTo.copy(player.seatPos);
+        } else if (!ball.held && rackDistance > 1.9) {
+          player.action = 'toRack';
+          player.returnWalkT = 0.001;
+          player.approachTo.copy(player.pos);
+          setHud((prev) => ({
+            ...prev,
+            status: `${localScores[activePlayer].name} is walking to the ball rack`
+          }));
+        } else {
+          aiTurnDelay = Math.max(0, aiTurnDelay - dt);
+          if (aiTurnDelay <= 0) {
+            if (!ball.held) {
+              const randomVariant =
+                BALL_VARIANTS[Math.floor(Math.random() * BALL_VARIANTS.length)];
+              applyActiveBallVariant(randomVariant.label);
+              ball.held = true;
+              ball.mesh.visible = true;
+              player.action = 'idle';
+              player.pickT = 0.001;
+              syncHeldBallToHuman(ball, player);
+              aiTurnDelay = 0.55;
+              setHud((prev) => ({
+                ...prev,
+                status: `${localScores[activePlayer].name} picked a ball`
+              }));
+            } else {
+              pendingIntent = makeAiIntent();
+              startApproach(player, pendingIntent, activeLaneCenter());
+              void new Audio(BOWLING_SFX.throw).play().catch(() => undefined);
+              aiTurnDelay = 0.85 + Math.random() * 0.5;
+              setHud((prev) => ({
+                ...prev,
+                status: `${localScores[activePlayer].name} is bowling`
+              }));
+            }
+          }
+        }
+      }
+      if (
+        activePlayer === 0 &&
+        !ball.held &&
+        !ball.rolling &&
+        !waitingForBallReturn &&
+        !replayActiveRef.current &&
+        playerRigs[0].action === 'idle'
+      ) {
+        const rackDistance = Math.hypot(
+          playerRigs[0].pos.x - bowlingRackPickupX(),
+          playerRigs[0].pos.z - BOWLING_RACK_Z
+        );
+        if (officialTenPinPlayerFinished(localScores[0])) {
+          playerRigs[0].action = 'toSeat';
+          playerRigs[0].seatT = 0.001;
+          setHud((prev) => ({ ...prev, status: 'Frame complete — returning directly to chair.' }));
+          playerRigs[0].approachFrom.copy(playerRigs[0].pos);
+          playerRigs[0].approachTo.copy(playerRigs[0].seatPos);
+        } else if (rackDistance > 1.9) {
+          playerRigs[0].action = 'toRack';
+          playerRigs[0].returnWalkT = 0.001;
+          playerRigs[0].approachTo.copy(playerRigs[0].pos);
+          setHud((prev) => ({
+            ...prev,
+            status:
+              'Walking to the side rack automatically. A random ball will be picked, then the bowler moves to the shooting line for your swipe.'
+          }));
+        }
+      }
+      if (
+        activePlayer === 0 &&
+        !ball.held &&
+        !ball.rolling &&
+        !waitingForBallReturn &&
+        playerRigs[0].action === 'idle'
+      ) {
+        const randomVariant =
+          BALL_VARIANTS[Math.floor(Math.random() * BALL_VARIANTS.length)];
+        ballPickRequestRef.current = randomVariant.label;
+      }
+      tryManualBallPickup();
+      pickupPrompt.visible = false;
+      const shootingReady =
+        activePlayer === 0 &&
+        ball.held &&
+        !ball.rolling &&
+        !waitingForBallReturn &&
+        !replayActiveRef.current &&
+        playerRigs[0].action === 'idle' &&
+        isAtShootingLine(playerRigs[0].pos, activeLaneCenter());
+      setShootingUiVisible((visible) =>
+        visible === shootingReady ? visible : shootingReady
+      );
+      pickupPrompt.position.y =
+        CFG.laneY + 1.52 + Math.sin(now * 0.004) * 0.045;
+      // Human movement is automated: chair → rack → shooting line; the user only picks a ball and swipes the shot.
+      const criticalPulse = replayTimer > 0 || player.celebrateNext;
+      for (const rig of playerRigs) updateHuman(rig, ball, dt, rig === player);
+      keepPlayersSeparated(playerRigs, 0.62);
+      updateArenaDecor(arenaDecor, now * 0.001, criticalPulse);
+      if (
+        player.action === 'throw' &&
+        pendingIntent &&
+        player.throwT >= CFG.releaseT &&
+        ball.held
+      ) {
+        lastShotStandingBefore = standingPinsCount(activePins());
+        releaseBall(ball, pendingIntent, activeLaneCenter(), player);
+        pendingIntent = null;
+        setHud((prev) => ({
+          ...prev,
+          status: 'Shot triggered from the same pickup hand · ball rolling'
+        }));
+      }
+      updateBall(ball, activePins(), dt);
+      const pinsMoving = lanePins
+        .map((pins) => updatePins(pins, dt))
+        .some(Boolean);
+      const mechanismBusy =
+        ball.returnState !== 'idle' ||
+        ball.rolling ||
+        pinsMoving ||
+        pinReset.phase !== 'idle';
+      if (
+        (player.action === 'pickBall' || player.action === 'toApproach') &&
+        mechanismBusy
+      ) {
+        player.action = 'idle';
+      }
+      if (pinsMoving) pinsWereMoving = true;
+      const resetCompleteStanding = updatePinReset(pinReset, arenaDecor, dt);
+      if (resetCompleteStanding != null && !shotResolved)
+        finalizeShot(resetCompleteStanding);
+      if (
+        !shotResolved &&
+        pinReset.phase === 'idle' &&
+        !ball.rolling &&
+        (!pinsWereMoving || !pinsMoving)
+      ) {
+        settleTimer += dt;
+        const noPinContactReady =
+          !pinsWereMoving && ball.returnState !== 'idle' && settleTimer > 0.35;
+        const pinContactReady = pinsWereMoving && settleTimer > 0.72;
+        if (noPinContactReady || pinContactReady)
+          beginPinReset(pinReset, activePins(), arenaDecor);
+      } else if (pinsMoving) settleTimer = 0;
+      if (ball.returnState !== 'idle') {
+        const finished = updateBallReturn(ball, dt);
+        if (finished && waitingForBallReturn) prepareNextTurnAfterReturn();
+      }
+      ballShadow.visible = ball.mesh.visible;
+      ballShadow.position.set(ball.pos.x, CFG.laneY + 0.01, ball.pos.z);
+      ballShadow.scale.setScalar(ball.held ? 0.72 : ball.inGutter ? 0.9 : 1.04);
+      if (!cameraLook.active) {
+        cameraLook.targetYaw = cameraLookInputRef.current.targetYaw;
+        cameraLook.targetPitch = cameraLookInputRef.current.targetPitch;
+      }
+      if (control.active)
+        updateAimVisual(aimLine, aimMarker, control.intent, activeLaneCenter());
+      updateCamera(
+        camera,
+        ball,
+        player,
+        dt,
+        activePlayer === 0,
+        cameraLook,
+        replayActiveRef.current
+      );
+      renderer.render(scene, camera);
+    }
+    animate();
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', resize);
+      canvas.removeEventListener('pointerdown', onPointerDown);
+      canvas.removeEventListener('pointermove', onPointerMove);
+      canvas.removeEventListener('pointerup', onPointerUp);
+      canvas.removeEventListener('pointercancel', onPointerUp);
+      pmrem.dispose();
+      envTex?.dispose();
+      renderer.dispose();
+      scene.traverse((obj) => {
+        const mesh = obj as THREE.Mesh;
+        if (mesh.isMesh) {
+          mesh.geometry?.dispose?.();
+          const mat = mesh.material as THREE.Material | THREE.Material[];
+          if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+          else mat?.dispose?.();
+        }
+      });
+    };
+  }, [
+    graphicsQuality,
+    selectedFps,
+    selectedHdriId,
+    ballSelectionMode,
+    selectedTableFinish,
+    selectedChromeColor,
+    selectedHumanCharacterId,
+    skipReplays,
+    playerCount,
+    matchMode
+  ]);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        overflow: 'hidden',
+        background: '#090b11',
+        touchAction: 'none',
+        userSelect: 'none'
+      }}
+    >
+      <div ref={hostRef} style={{ position: 'absolute', inset: 0 }}>
+        <canvas
+          ref={canvasRef}
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'block',
+            touchAction: 'none'
+          }}
+        />
+      </div>
+
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          pointerEvents: 'none',
+          fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, sans-serif'
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            left: 18,
+            right: 18,
+            top: 6,
+            color: 'white',
+            background: 'rgba(5,8,14,0.66)',
+            border: '1px solid rgba(255,255,255,0.14)',
+            borderRadius: 14,
+            padding: '6px 6px 8px',
+            boxShadow: '0 10px 24px rgba(0,0,0,0.24)',
+            backdropFilter: 'blur(10px)',
+            transform: 'scale(0.78)',
+            transformOrigin: 'top center'
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 6,
+              gap: 8
+            }}
+          >
+            <div style={{ fontSize: 11, fontWeight: 900, letterSpacing: 0.2 }}>
+              REAL BOWLING SCOREBOARD
+            </div>
+            <div style={{ fontSize: 9, fontWeight: 800, color: '#7fd6ff' }}>
+              FRAME {hud.frame} · ROLL {hud.roll} · P{hud.activePlayer + 1}
+            </div>
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '38px repeat(10, minmax(19px, 1fr))',
+              gap: 3,
+              alignItems: 'center'
+            }}
+          >
+            <div
+              style={{
+                fontSize: 10,
+                fontWeight: 800,
+                opacity: 0.72,
+                textAlign: 'center'
+              }}
+            ></div>
+            {Array.from({ length: 10 }, (_, i) => (
+              <div
+                key={i}
+                style={{
+                  textAlign: 'center',
+                  fontSize: 10,
+                  fontWeight: 800,
+                  opacity: 0.7
+                }}
+              >
+                {i + 1}
+              </div>
+            ))}
+            {scoresMemo.map((p, row) => (
+              <React.Fragment key={p.name}>
+                <div
+                  style={{
+                    paddingLeft: 1,
+                    fontSize: 9,
+                    fontWeight: 900,
+                    color: row === hud.activePlayer ? '#7fd6ff' : '#ffffff'
+                  }}
+                >{`P${row + 1} ${p.total}`}</div>
+                {p.frames.map((f, i) => (
+                  <FrameBox key={`${row}-${i}`} frame={f} index={i} />
+                ))}
+              </React.Fragment>
+            ))}
+          </div>
+          <div
+            style={{
+              marginTop: 5,
+              textAlign: 'center',
+              fontSize: 10,
+              fontWeight: 700,
+              opacity: 0.9
+            }}
+          >
+            {hud.status}
+          </div>
+          <div
+            style={{
+              marginTop: 4,
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 5,
+              fontSize: 8,
+              fontWeight: 800
+            }}
+          >
+            <div
+              style={{
+                padding: '4px 5px',
+                borderRadius: 7,
+                background: 'rgba(14,165,233,0.16)',
+                border: '1px solid rgba(125,211,252,0.18)'
+              }}
+            >
+              {hud.lane}
+            </div>
+            <div
+              style={{
+                padding: '4px 5px',
+                borderRadius: 7,
+                background: 'rgba(34,197,94,0.14)',
+                border: '1px solid rgba(134,239,172,0.18)'
+              }}
+            >
+              {hud.rule}
+            </div>
+          </div>
+          {hud.compliment ? (
+            <div
+              style={{
+                marginTop: 4,
+                textAlign: 'center',
+                fontSize: 10,
+                fontWeight: 800,
+                color: '#86efac'
+              }}
+            >
+              {hud.compliment}
+            </div>
+          ) : null}
+        </div>
+
+        <button
+          onClick={() => setMenuOpen((v) => !v)}
+          style={{
+            position: 'absolute',
+            top: 102,
+            left: 8,
+            width: 40,
+            height: 40,
+            borderRadius: 10,
+            border: '1px solid rgba(255,255,255,0.28)',
+            background: 'rgba(5,8,14,0.72)',
+            color: '#fff',
+            fontSize: 22,
+            fontWeight: 900,
+            pointerEvents: 'auto'
+          }}
+        >
+          ☰
+        </button>
+        {menuOpen ? (
+          <div
+            style={{
+              position: 'absolute',
+              top: 148,
+              left: 8,
+              right: 8,
+              maxHeight: '48vh',
+              overflow: 'auto',
+              borderRadius: 14,
+              padding: 10,
+              background: 'rgba(5,8,14,0.88)',
+              border: '1px solid rgba(255,255,255,0.18)',
+              pointerEvents: 'auto'
+            }}
+          >
+            <div style={{ fontSize: 12, fontWeight: 800, marginBottom: 8 }}>
+              Graphics (Pool Royal style)
+            </div>
+            {(['performance', 'balanced', 'ultra'] as GraphicsQuality[]).map(
+              (q) => (
+                <button
+                  key={q}
+                  onClick={() => setGraphicsQuality(q)}
+                  style={{
+                    marginRight: 6,
+                    marginBottom: 6,
+                    padding: '6px 9px',
+                    borderRadius: 8,
+                    border: '1px solid rgba(255,255,255,0.2)',
+                    background:
+                      graphicsQuality === q
+                        ? '#7fd6ff'
+                        : 'rgba(255,255,255,0.08)',
+                    color: graphicsQuality === q ? '#001018' : '#fff'
+                  }}
+                >
+                  {q}
+                </button>
+              )
+            )}
+            <div style={{ fontSize: 11, color: '#c7eaff', margin: '0 0 8px' }}>
+              Auto uses {BOWLING_GRAPHICS_PROFILES[graphicsQuality].targetFps}{' '}
+              FPS target and{' '}
+              {BOWLING_GRAPHICS_PROFILES[graphicsQuality].maxPixelRatio}× max
+              pixel ratio for this quality.
+            </div>
+            <div
+              style={{ fontSize: 12, fontWeight: 800, margin: '10px 0 6px' }}
+            >
+              FPS target
+            </div>
+            {BOWLING_FPS_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                onClick={() => setSelectedFps(option.id)}
+                style={{
+                  marginRight: 6,
+                  marginBottom: 6,
+                  padding: '6px 9px',
+                  borderRadius: 8,
+                  border: '1px solid rgba(255,255,255,0.2)',
+                  background:
+                    selectedFps === option.id
+                      ? '#7fd6ff'
+                      : 'rgba(255,255,255,0.08)',
+                  color: selectedFps === option.id ? '#001018' : '#fff'
+                }}
+              >
+                {option.label}
+              </button>
+            ))}
+
+            <div
+              style={{ fontSize: 11, color: '#c7eaff', margin: '10px 0 8px' }}
+            >
+              Ball selection is automatic: each rack visit randomly picks one
+              owned bowling ball and keeps the same hand through pickup and
+              shot.
+            </div>
+            <div
+              style={{ fontSize: 12, fontWeight: 800, margin: '10px 0 6px' }}
+            >
+              Human character inventory
+            </div>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(2,minmax(0,1fr))',
+                gap: 8
+              }}
+            >
+              {HUMAN_CHARACTER_OPTIONS.filter(
+                (item) =>
+                  item.id === DEFAULT_HUMAN_CHARACTER_ID ||
+                  (ownedPoolInventory?.humanCharacter || []).includes(item.id)
+              ).map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => {
+                    setSelectedHumanCharacterId(item.id);
+                    localStorage.setItem('bowling.humanCharacter', item.id);
+                  }}
+                  style={{
+                    textAlign: 'left',
+                    border: '1px solid rgba(255,255,255,0.2)',
+                    borderRadius: 10,
+                    padding: 6,
+                    background:
+                      selectedHumanCharacterId === item.id
+                        ? 'rgba(127,214,255,0.2)'
+                        : 'rgba(255,255,255,0.05)',
+                    color: '#fff'
+                  }}
+                >
+                  {item.thumbnail ? (
+                    <img
+                      src={item.thumbnail}
+                      alt={item.label}
+                      style={{
+                        width: '100%',
+                        borderRadius: 8,
+                        marginBottom: 6
+                      }}
+                    />
+                  ) : null}
+                  <div style={{ fontSize: 11, fontWeight: 700 }}>
+                    {item.label}
+                  </div>
+                  <div style={{ fontSize: 10, opacity: 0.75 }}>
+                    Owned · AI randomizes from this set
+                  </div>
+                </button>
+              ))}
+            </div>
+
+            <div
+              style={{ fontSize: 12, fontWeight: 800, margin: '10px 0 6px' }}
+            >
+              HDRI inventory
+            </div>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(2,minmax(0,1fr))',
+                gap: 8
+              }}
+            >
+              {HDRI_OPTIONS.filter((h) =>
+                (ownedPoolInventory?.environmentHdri || []).includes(h.id)
+              ).map((h) => (
+                <button
+                  key={h.id}
+                  onClick={() => {
+                    setSelectedHdriId(h.id);
+                    localStorage.setItem('bowling.hdri', h.id);
+                  }}
+                  style={{
+                    textAlign: 'left',
+                    border: '1px solid rgba(255,255,255,0.2)',
+                    borderRadius: 10,
+                    padding: 6,
+                    background:
+                      selectedHdriId === h.id
+                        ? 'rgba(127,214,255,0.2)'
+                        : 'rgba(255,255,255,0.05)',
+                    color: '#fff'
+                  }}
+                >
+                  <img
+                    src={h.thumb}
+                    alt={h.name}
+                    style={{ width: '100%', borderRadius: 8, marginBottom: 6 }}
+                  />
+                  <div style={{ fontSize: 11, fontWeight: 700 }}>{h.name}</div>
+                  <div style={{ fontSize: 10, opacity: 0.75 }}>Owned</div>
+                </button>
+              ))}
+            </div>
+            <div
+              style={{ fontSize: 12, fontWeight: 800, margin: '10px 0 6px' }}
+            >
+              Table finish inventory
+            </div>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(2,minmax(0,1fr))',
+                gap: 8
+              }}
+            >
+              {TABLE_FINISH_ITEMS.filter((item) =>
+                (ownedPoolInventory?.tableFinish || []).includes(item.optionId)
+              ).map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => {
+                    setSelectedTableFinish(item.optionId);
+                    localStorage.setItem('bowling.tableFinish', item.optionId);
+                  }}
+                  style={{
+                    textAlign: 'left',
+                    border: '1px solid rgba(255,255,255,0.2)',
+                    borderRadius: 10,
+                    padding: 6,
+                    background:
+                      selectedTableFinish === item.optionId
+                        ? 'rgba(127,214,255,0.2)'
+                        : 'rgba(255,255,255,0.05)',
+                    color: '#fff'
+                  }}
+                >
+                  <div style={{ fontSize: 11, fontWeight: 700 }}>
+                    {item.name}
+                  </div>
+                </button>
+              ))}
+            </div>
+            <div
+              style={{ fontSize: 12, fontWeight: 800, margin: '10px 0 6px' }}
+            >
+              Chrome plates
+            </div>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(2,minmax(0,1fr))',
+                gap: 8
+              }}
+            >
+              {CHROME_ITEMS.filter((item) =>
+                (ownedPoolInventory?.chromeColor || []).includes(item.optionId)
+              ).map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => {
+                    setSelectedChromeColor(item.optionId);
+                    localStorage.setItem('bowling.chromeColor', item.optionId);
+                  }}
+                  style={{
+                    textAlign: 'left',
+                    border: '1px solid rgba(255,255,255,0.2)',
+                    borderRadius: 10,
+                    padding: 6,
+                    background:
+                      selectedChromeColor === item.optionId
+                        ? 'rgba(127,214,255,0.2)'
+                        : 'rgba(255,255,255,0.05)',
+                    color: '#fff'
+                  }}
+                >
+                  <div style={{ fontSize: 11, fontWeight: 700 }}>
+                    {POOL_ROYALE_OPTION_LABELS.chromeColor[item.optionId] ||
+                      item.name}
+                  </div>
+                </button>
+              ))}
+            </div>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                marginTop: 10,
+                fontSize: 12
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={skipReplays}
+                onChange={(e) => {
+                  setSkipReplays(e.target.checked);
+                  localStorage.setItem(
+                    'bowling.skipReplays',
+                    e.target.checked ? '1' : '0'
+                  );
+                }}
+              />
+              Skip strike/spare replays
+            </label>
+          </div>
+        ) : null}
+
+        <div
+          style={{
+            position: 'absolute',
+            left: 12,
+            right: 12,
+            bottom: 16,
+            padding: '9px 12px',
+            borderRadius: 16,
+            background:
+              'linear-gradient(90deg, rgba(5,8,14,0.78), rgba(15,23,42,0.62))',
+            border: '1px solid rgba(255,255,255,0.16)',
+            color: '#fff',
+            fontSize: 11,
+            fontWeight: 800,
+            pointerEvents: 'none',
+            display: 'flex',
+            justifyContent: 'space-between',
+            gap: 10
+          }}
+        >
+          <span>{shootingUiVisible ? '↕ Swipe to shoot' : '🚶 Auto walk'}</span>
+          <span>
+            {shootingUiVisible ? '🎥 Pull-back shot cam' : '🎲 Random ball'}
+          </span>
+          <span>📍 Auto shooting line</span>
+          <span>🎬 Broadcast camera</span>
+        </div>
+        {replayActive ? (
+          <button
+            onClick={() => setReplayMode(false)}
+            style={{
+              position: 'absolute',
+              top: 132,
+              right: 8,
+              padding: '8px 10px',
+              borderRadius: 10,
+              border: '1px solid rgba(255,255,255,0.28)',
+              background: 'rgba(190,20,20,0.75)',
+              color: '#fff',
+              fontWeight: 900,
+              pointerEvents: 'auto'
+            }}
+          >
+            Skip replay
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -1,0 +1,2448 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { useLocation } from "react-router-dom";
+import { MURLAN_CHARACTER_THEMES } from "../../config/murlanCharacterThemes.js";
+import { BallController } from "./tennis/BallController";
+import { CameraController } from "./tennis/CameraController";
+import { CourtRules } from "./tennis/CourtRules";
+import { AIController } from "./tennis/AIController";
+import { AudioVFXManager } from "./tennis/AudioVFXManager";
+import { PlayerController } from "./tennis/PlayerController";
+import { ScoreManager } from "./tennis/ScoreManager";
+import { ServeController } from "./tennis/ServeController";
+import { ShotTargeting } from "./tennis/ShotTargeting";
+import { UIOverlay } from "./tennis/UIOverlay";
+import { gameConfig, TennisBallState } from "./tennis/gameConfig";
+
+type PlayerSide = "near" | "far";
+type PointReason = "winner" | "out" | "doubleBounce" | "net" | "serviceFault" | "doubleFault";
+type StrokeAction = "ready" | "forehand" | "backhand" | "serve";
+
+type BallState = {
+  mesh: THREE.Mesh;
+  pos: THREE.Vector3;
+  vel: THREE.Vector3;
+  spin: number;
+  lastHitBy: PlayerSide | null;
+  bounceSide: PlayerSide | null;
+  bounceCount: number;
+  state: TennisBallState;
+};
+
+type ShotTechnique = "flat" | "topspin" | "slice" | "lob" | "drop" | "block";
+
+type DesiredHit = { target: THREE.Vector3; power: number; technique?: ShotTechnique; swipeDir?: THREE.Vector2; serveSide?: "deuce" | "ad" };
+
+type BonePack = {
+  spine?: THREE.Bone;
+  chest?: THREE.Bone;
+  neck?: THREE.Bone;
+  rightShoulder?: THREE.Bone;
+  rightUpperArm?: THREE.Bone;
+  rightForeArm?: THREE.Bone;
+  rightHand?: THREE.Bone;
+  leftShoulder?: THREE.Bone;
+  leftUpperArm?: THREE.Bone;
+  leftForeArm?: THREE.Bone;
+  leftHand?: THREE.Bone;
+};
+
+type BoneRest = { bone: THREE.Bone; q: THREE.Quaternion };
+
+type ArmChain = {
+  shoulder?: THREE.Bone;
+  upper: THREE.Bone;
+  fore: THREE.Bone;
+  hand: THREE.Bone;
+  upperLen: number;
+  foreLen: number;
+};
+
+type StrokePose = {
+  rightShoulder: THREE.Vector3;
+  rightElbow: THREE.Vector3;
+  rightHand: THREE.Vector3;
+  leftShoulder: THREE.Vector3;
+  leftElbow: THREE.Vector3;
+  leftHand: THREE.Vector3;
+  racketGrip: THREE.Vector3;
+  racketHead: THREE.Vector3;
+  torsoYaw: number;
+  torsoLean: number;
+  shoulderLift: number;
+  wristPronation: number;
+};
+
+type CharacterTheme = {
+  id?: string;
+  label?: string;
+  url?: string;
+  modelUrls?: string[];
+  clothCombo?: string;
+  hairColor?: number;
+  eyeColor?: number;
+  skinTone?: number;
+};
+
+type HumanRig = {
+  side: PlayerSide;
+  root: THREE.Group;
+  modelRoot: THREE.Group;
+  fallback: THREE.Group;
+  racket: THREE.Group;
+  model: THREE.Object3D | null;
+  bones: BonePack;
+  rest: BoneRest[];
+  rightArmChain?: ArmChain;
+  leftArmChain?: ArmChain;
+  pos: THREE.Vector3;
+  target: THREE.Vector3;
+  yaw: number;
+  action: StrokeAction;
+  swingT: number;
+  cooldown: number;
+  desiredHit: DesiredHit | null;
+  hitThisSwing: boolean;
+  speed: number;
+  walkCycle: number;
+  yawVelocity: number;
+};
+
+type HudState = { nearScore: number; farScore: number; nearLabel?: string; farLabel?: string; nearGames?: number; farGames?: number; nearSets?: number; farSets?: number; inTiebreak?: boolean; status: string; power: number; server?: PlayerSide; serveSide?: "deuce" | "ad"; firstServe?: boolean; debug?: string };
+
+type ControlState = {
+  active: boolean;
+  pointerId: number | null;
+  startX: number;
+  startY: number;
+  lastX: number;
+  lastY: number;
+  startPlayer: THREE.Vector3;
+  startTs: number;
+  lastTs: number;
+};
+
+const HUMAN_URL = "https://threejs.org/examples/models/gltf/readyplayer.me.glb";
+const COURT_ENVIRONMENT_ASSETS = [
+  {
+    name: "courtside-chair",
+    source: "Khronos glTF Sample Assets Chair Damask Purplegold (CC BY 4.0)",
+    url: "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ChairDamaskPurplegold/glTF-Binary/ChairDamaskPurplegold.glb",
+    position: new THREE.Vector3(-1, 0, 0),
+    rotationY: Math.PI / 2,
+    scale: 1.15,
+  },
+  {
+    name: "warmup-boombox",
+    source: "Khronos glTF Sample Assets Boom Box (CC0)",
+    url: "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/BoomBox/glTF-Binary/BoomBox.glb",
+    position: new THREE.Vector3(1, 0, 0),
+    rotationY: -Math.PI / 2,
+    scale: 0.0085,
+  },
+  {
+    name: "potted-plant",
+    source: "Khronos glTF Sample Assets Diffuse Transmission Plant (CC BY 4.0 / CC0 original)",
+    url: "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/DiffuseTransmissionPlant/glTF-Binary/DiffuseTransmissionPlant.glb",
+    position: new THREE.Vector3(0, 0, -1),
+    rotationY: -Math.PI / 5,
+    scale: 0.72,
+  },
+  {
+    name: "courtside-water-bottle",
+    source: "Khronos glTF Sample Assets Water Bottle (CC BY 4.0)",
+    url: "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/WaterBottle/glTF-Binary/WaterBottle.glb",
+    position: new THREE.Vector3(2.5, 0, 1.2),
+    rotationY: -Math.PI / 7,
+    scale: 0.62,
+  },
+  {
+    name: "courtside-lantern-case",
+    source: "Khronos glTF Sample Assets Lantern (CC BY 4.0)",
+    url: "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/Lantern/glTF-Binary/Lantern.glb",
+    position: new THREE.Vector3(-2.6, 0, -1.2),
+    rotationY: Math.PI / 8,
+    scale: 0.42,
+  },
+] as const;
+const UP = new THREE.Vector3(0, 1, 0);
+const Y_AXIS = UP;
+
+const CFG = gameConfig;
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+const clamp01 = (v: number) => clamp(v, 0, 1);
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+const easeInOut = (t: number) => t * t * (3 - 2 * t);
+const sideOfZ = (z: number): PlayerSide => (z >= 0 ? "near" : "far");
+const opposite = (side: PlayerSide): PlayerSide => (side === "near" ? "far" : "near");
+
+
+function serviceSideFromPoints(nearScore: number, farScore: number): "deuce" | "ad" {
+  return (nearScore + farScore) % 2 === 0 ? "deuce" : "ad";
+}
+
+function serveXForSide(player: PlayerSide, side: "deuce" | "ad") {
+  const outsideSingles = CFG.courtW / 2 + 0.42;
+  const laneMax = CFG.doublesW / 2 - 0.2;
+  const xAbs = clamp(outsideSingles, CFG.courtW / 2 + 0.12, laneMax);
+  const sign = side === "deuce" ? 1 : -1;
+  return (player === "near" ? sign : -sign) * xAbs;
+}
+
+
+function serveLaneBoundsX(side: "deuce" | "ad", player: PlayerSide = "near") {
+  const laneMinAbs = CFG.courtW / 2 + 0.12;
+  const laneMaxAbs = CFG.doublesW / 2 - 0.12;
+  const sign = side === "deuce" ? 1 : -1;
+  const playerAdjusted = player === "near" ? sign : -sign;
+  return playerAdjusted > 0 ? { min: laneMinAbs, max: laneMaxAbs } : { min: -laneMaxAbs, max: -laneMinAbs };
+}
+
+function serveTargetBoundsX(side: "deuce" | "ad", server: PlayerSide) {
+  const sign = side === "deuce" ? (server === "near" ? 1 : -1) : (server === "near" ? -1 : 1);
+  const minAbs = CFG.serviceBuffer;
+  const maxAbs = CFG.courtW / 2 - 0.46;
+  return sign > 0 ? { min: minAbs, max: maxAbs } : { min: -maxAbs, max: -minAbs };
+}
+
+function isInsideServiceBox(pos: THREE.Vector3, hitter: PlayerSide, side: "deuce" | "ad") {
+  const targetSide = opposite(hitter);
+  const targetRight = side === "deuce";
+  const xOk = targetRight ? pos.x >= 0 + CFG.serviceBuffer : pos.x <= 0 - CFG.serviceBuffer;
+  const xInCourt = Math.abs(pos.x) <= CFG.courtW / 2;
+  const zOk = targetSide === "far" ? pos.z <= -CFG.serviceBuffer && pos.z >= -CFG.serviceLineZ : pos.z >= CFG.serviceBuffer && pos.z <= CFG.serviceLineZ;
+  return xOk && xInCourt && zOk;
+}
+function material(color: number, roughness = 0.74, metalness = 0.02) {
+  return new THREE.MeshStandardMaterial({ color, roughness, metalness });
+}
+
+function transparentMaterial(color: number, opacity: number, roughness = 0.72) {
+  return new THREE.MeshStandardMaterial({ color, roughness, metalness: 0.02, transparent: true, opacity, depthWrite: false });
+}
+
+
+type TennisClothSlot = { material: keyof typeof POLYHAVEN_CLOTH_MATERIALS; tint: number; repeat: number };
+type TennisClothCombo = { upper: TennisClothSlot; lower: TennisClothSlot; accent: TennisClothSlot };
+type TennisClothTexture = {
+  source: string;
+  gltf: string;
+  color: string;
+  normal: string;
+  roughness: string;
+  tint: number;
+  repeat: number;
+};
+
+const POLYHAVEN_CLOTH_MATERIALS = Object.freeze({
+  denim: {
+    source: "Poly Haven denim_fabric 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/denim_fabric/denim_fabric_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/denim_fabric/denim_fabric_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/denim_fabric/denim_fabric_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/denim_fabric/denim_fabric_rough_1k.jpg",
+    tint: 0x314d86,
+  },
+  check: {
+    source: "Poly Haven gingham_check 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/gingham_check/gingham_check_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/gingham_check/gingham_check_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/gingham_check/gingham_check_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/gingham_check/gingham_check_rough_1k.jpg",
+    tint: 0x9f3651,
+  },
+  hessian: {
+    source: "Poly Haven hessian_230 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/hessian_230/hessian_230_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/hessian_230/hessian_230_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/hessian_230/hessian_230_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/hessian_230/hessian_230_rough_1k.jpg",
+    tint: 0xa27445,
+  },
+  floral: {
+    source: "Poly Haven floral_jacquard 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/floral_jacquard/floral_jacquard_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/floral_jacquard/floral_jacquard_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/floral_jacquard/floral_jacquard_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/floral_jacquard/floral_jacquard_rough_1k.jpg",
+    tint: 0x6d3f7f,
+  },
+  fleece: {
+    source: "Poly Haven knitted_fleece 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/knitted_fleece/knitted_fleece_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/knitted_fleece/knitted_fleece_diff_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/knitted_fleece/knitted_fleece_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/knitted_fleece/knitted_fleece_rough_1k.jpg",
+    tint: 0x4b5563,
+  },
+  picnic: {
+    source: "Poly Haven fabric_pattern_07 1k glTF CC0",
+    gltf: "https://dl.polyhaven.org/file/ph-assets/Textures/gltf/1k/fabric_pattern_07/fabric_pattern_07_1k.gltf",
+    color: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/fabric_pattern_07/fabric_pattern_07_col_1_1k.jpg",
+    normal: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/fabric_pattern_07/fabric_pattern_07_nor_gl_1k.jpg",
+    roughness: "https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/fabric_pattern_07/fabric_pattern_07_rough_1k.jpg",
+    tint: 0xc44f42,
+  },
+} as const);
+
+const TENNIS_CHARACTER_CLOTH_COMBOS: Record<string, TennisClothCombo> = Object.freeze({
+  royalDenim: {
+    upper: { material: "denim", tint: 0x2f5f9f, repeat: 4.2 },
+    lower: { material: "hessian", tint: 0x9b6b3f, repeat: 3.4 },
+    accent: { material: "fleece", tint: 0xd8dee9, repeat: 5.0 },
+  },
+  casinoCheck: {
+    upper: { material: "check", tint: 0xb7375d, repeat: 3.8 },
+    lower: { material: "denim", tint: 0x243e70, repeat: 4.4 },
+    accent: { material: "hessian", tint: 0xf4d7a1, repeat: 3.2 },
+  },
+  linenStreet: {
+    upper: { material: "hessian", tint: 0xb68452, repeat: 3.6 },
+    lower: { material: "fleece", tint: 0x374151, repeat: 5.2 },
+    accent: { material: "denim", tint: 0x4a6fa4, repeat: 4.0 },
+  },
+  jacquardNight: {
+    upper: { material: "floral", tint: 0x7c3f88, repeat: 3.2 },
+    lower: { material: "denim", tint: 0x1f335f, repeat: 4.5 },
+    accent: { material: "check", tint: 0xe3c16f, repeat: 4.0 },
+  },
+  softFleece: {
+    upper: { material: "fleece", tint: 0x556070, repeat: 5.3 },
+    lower: { material: "hessian", tint: 0x8b633f, repeat: 3.7 },
+    accent: { material: "floral", tint: 0xb88ab8, repeat: 3.0 },
+  },
+  patternedRed: {
+    upper: { material: "picnic", tint: 0xc44f42, repeat: 3.4 },
+    lower: { material: "denim", tint: 0x263f73, repeat: 4.7 },
+    accent: { material: "fleece", tint: 0xf1f5f9, repeat: 5.0 },
+  },
+  mixedDenim: {
+    upper: { material: "denim", tint: 0x3b6ea8, repeat: 4.0 },
+    lower: { material: "check", tint: 0x4f6f93, repeat: 4.2 },
+    accent: { material: "hessian", tint: 0xd6a35f, repeat: 3.2 },
+  },
+});
+
+const tennisTextureLoader = new THREE.TextureLoader();
+tennisTextureLoader.setCrossOrigin("anonymous");
+const TENNIS_CHARACTER_TEXTURE_CACHE = new Map<string, THREE.Texture>();
+
+function loadTennisCharacterTexture(url: string, { isColor = false, repeat = 3 } = {}) {
+  const cacheKey = `${url}|${isColor ? "srgb" : "linear"}|${repeat}`;
+  const cached = TENNIS_CHARACTER_TEXTURE_CACHE.get(cacheKey);
+  if (cached) return cached;
+  const texture = tennisTextureLoader.load(
+    url,
+    (loaded) => {
+      loaded.wrapS = THREE.RepeatWrapping;
+      loaded.wrapT = THREE.RepeatWrapping;
+      loaded.repeat.set(repeat, repeat);
+      loaded.anisotropy = 8;
+      loaded.generateMipmaps = true;
+      loaded.minFilter = THREE.LinearMipmapLinearFilter;
+      loaded.magFilter = THREE.LinearFilter;
+      if (isColor) loaded.colorSpace = THREE.SRGBColorSpace;
+      loaded.needsUpdate = true;
+    },
+    undefined,
+    () => TENNIS_CHARACTER_TEXTURE_CACHE.delete(cacheKey)
+  );
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(repeat, repeat);
+  texture.anisotropy = 8;
+  texture.generateMipmaps = true;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+  TENNIS_CHARACTER_TEXTURE_CACHE.set(cacheKey, texture);
+  return texture;
+}
+
+function isNearlyWhiteCharacterMaterial(mat: THREE.MeshStandardMaterial) {
+  if (!mat.color) return false;
+  return mat.color.r > 0.82 && mat.color.g > 0.82 && mat.color.b > 0.82 && !mat.map;
+}
+
+function isLowSaturationLightCharacterMaterial(mat: THREE.MeshStandardMaterial) {
+  if (!mat.color || mat.map) return false;
+  const max = Math.max(mat.color.r, mat.color.g, mat.color.b);
+  const min = Math.min(mat.color.r, mat.color.g, mat.color.b);
+  return max > 0.72 && max - min < 0.18;
+}
+
+function classifyTennisHumanSurface(obj: THREE.Object3D, mat: THREE.MeshStandardMaterial) {
+  const name = `${obj.name || ""} ${mat.name || ""}`.toLowerCase();
+  if (/eye|iris|pupil|cornea|wolf3d_eyes/.test(name)) return "eye";
+  if (/hair|brow|beard|mustache|moustache|lash|wolf3d_hair|wolf3d_beard|wolf3d_eyebrow/.test(name)) return "hair";
+  if (/teeth|tooth|tongue|mouth|gum/.test(name)) return "mouth";
+  if (/shoe|boot|sole|sneaker|footwear|wolf3d_outfit_footwear/.test(name)) return "shoe";
+  if (/skin|head|face|neck|hand|finger|wolf3d_head|wolf3d_body|bodymesh/.test(name) && !/outfit|shirt|pants|trouser|shoe|sock|cloth|jacket|hood|dress|skirt|uniform|suit/.test(name)) return "skin";
+  if (/shirt|top|torso|chest|jacket|hood|dress|skirt|sleeve|upper|outfit_top|wolf3d_outfit_top/.test(name)) return "upperCloth";
+  if (/pants|trouser|jean|short|legging|bottom|outfit_bottom|wolf3d_outfit_bottom/.test(name)) return "lowerCloth";
+  if (/tie|scarf|belt|strap|bag|hat|cap|glove|sock|accessory|accent/.test(name)) return "accentCloth";
+  if (/cloth|clothing|uniform|outfit|suit/.test(name)) return "upperCloth";
+  if (isNearlyWhiteCharacterMaterial(mat) && /torso|chest|spine|pelvis|hip|leg|arm|body|mesh/.test(name)) return "upperCloth";
+  return "other";
+}
+
+function resolveTennisClothSlot(theme: CharacterTheme | undefined, slot: "upper" | "lower" | "accent", side: PlayerSide): TennisClothTexture {
+  const combo = TENNIS_CHARACTER_CLOTH_COMBOS[theme?.clothCombo || ""] || TENNIS_CHARACTER_CLOTH_COMBOS.royalDenim;
+  const slotConfig = combo[slot] || combo.upper;
+  const source = POLYHAVEN_CLOTH_MATERIALS[slotConfig.material] || POLYHAVEN_CLOTH_MATERIALS.denim;
+  return {
+    ...source,
+    tint: slotConfig.tint ?? source.tint,
+    repeat: slotConfig.repeat + (side === "near" ? 0.55 : 0),
+  };
+}
+
+function applyTennisClothMaterial(mat: THREE.MeshStandardMaterial, cloth: TennisClothTexture) {
+  mat.map = loadTennisCharacterTexture(cloth.color, { isColor: true, repeat: cloth.repeat });
+  mat.normalMap = loadTennisCharacterTexture(cloth.normal, { repeat: cloth.repeat });
+  mat.roughnessMap = loadTennisCharacterTexture(cloth.roughness, { repeat: cloth.repeat });
+  mat.color = new THREE.Color(cloth.tint ?? 0xffffff);
+  mat.normalScale = new THREE.Vector2(0.28, 0.28);
+  mat.roughness = 0.86;
+  mat.metalness = 0.015;
+  mat.userData = { ...(mat.userData || {}), polyhavenCloth: cloth.source, polyhavenGltf: cloth.gltf };
+}
+
+function normalizeTennisMaterialTextures(mat: THREE.MeshStandardMaterial) {
+  [mat.map, mat.normalMap, mat.roughnessMap, mat.metalnessMap, mat.aoMap, mat.emissiveMap].forEach((tex) => {
+    if (!tex) return;
+    tex.anisotropy = Math.max(tex.anisotropy ?? 1, 8);
+    tex.generateMipmaps = true;
+    tex.minFilter = THREE.LinearMipmapLinearFilter;
+    tex.magFilter = THREE.LinearFilter;
+    tex.needsUpdate = true;
+  });
+  if (mat.map) mat.map.colorSpace = THREE.SRGBColorSpace;
+}
+
+function enhanceTennisCharacterMaterials(instance: THREE.Object3D, theme: CharacterTheme | undefined, side: PlayerSide) {
+  const clothSlots = {
+    upperCloth: resolveTennisClothSlot(theme, "upper", side),
+    lowerCloth: resolveTennisClothSlot(theme, "lower", side),
+    accentCloth: resolveTennisClothSlot(theme, "accent", side),
+  } as const;
+  const skinColor = new THREE.Color(theme?.skinTone ?? 0xd2a07c);
+  const hairColor = new THREE.Color(theme?.hairColor ?? 0x21150f);
+  const eyeColor = new THREE.Color(theme?.eyeColor ?? 0x3f5f75);
+
+  instance.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (!mesh.isMesh || !mesh.material) return;
+    const sourceMaterials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    const enhancedMaterials = sourceMaterials.map((sourceMat) => {
+      const mat = (sourceMat as THREE.MeshStandardMaterial).clone
+        ? (sourceMat as THREE.MeshStandardMaterial).clone()
+        : new THREE.MeshStandardMaterial();
+      const surface = classifyTennisHumanSurface(obj, mat);
+      if (surface === "upperCloth" || surface === "lowerCloth" || surface === "accentCloth") {
+        applyTennisClothMaterial(mat, clothSlots[surface]);
+      } else if (surface === "hair") {
+        mat.map = null;
+        mat.color = hairColor.clone();
+        mat.roughness = 0.56;
+        mat.metalness = 0.02;
+        mat.envMapIntensity = 0.28;
+      } else if (surface === "eye") {
+        mat.map = null;
+        mat.color = eyeColor.clone();
+        mat.roughness = 0.18;
+        mat.metalness = 0;
+        mat.envMapIntensity = 1.1;
+      } else if (surface === "skin") {
+        if (isLowSaturationLightCharacterMaterial(mat)) mat.color = skinColor.clone();
+        mat.roughness = Math.min(mat.roughness ?? 0.62, 0.62);
+        mat.metalness = 0;
+      } else if (surface === "shoe") {
+        if (isLowSaturationLightCharacterMaterial(mat)) mat.color = new THREE.Color(0x111827);
+        mat.roughness = 0.78;
+        mat.metalness = 0.02;
+      } else if (surface === "mouth") {
+        if (isNearlyWhiteCharacterMaterial(mat)) mat.color = new THREE.Color(0xf8fafc);
+        mat.roughness = 0.32;
+        mat.metalness = 0;
+      } else if (isNearlyWhiteCharacterMaterial(mat)) {
+        mat.color = skinColor.clone();
+        mat.roughness = 0.58;
+        mat.metalness = 0;
+      }
+      normalizeTennisMaterialTextures(mat);
+      mat.needsUpdate = true;
+      return mat;
+    });
+    mesh.material = Array.isArray(mesh.material) ? enhancedMaterials : enhancedMaterials[0];
+  });
+}
+
+function enableShadow(obj: THREE.Object3D) {
+  obj.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (mesh.isMesh) {
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      mesh.frustumCulled = false;
+    }
+  });
+  return obj;
+}
+
+function addBox(group: THREE.Group | THREE.Scene, size: [number, number, number], pos: [number, number, number], matArg: THREE.Material) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), matArg);
+  mesh.position.set(...pos);
+  enableShadow(mesh);
+  group.add(mesh);
+  return mesh;
+}
+
+function addCylinder(group: THREE.Group | THREE.Scene, radiusTop: number, radiusBottom: number, height: number, pos: [number, number, number], matArg: THREE.Material, segments = 32) {
+  const mesh = new THREE.Mesh(new THREE.CylinderGeometry(radiusTop, radiusBottom, height, segments), matArg);
+  mesh.position.set(...pos);
+  enableShadow(mesh);
+  group.add(mesh);
+  return mesh;
+}
+
+function yawFromForward(forward: THREE.Vector3) {
+  return Math.atan2(-forward.x, -forward.z);
+}
+
+function forwardFromYaw(yaw: number) {
+  return new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, yaw).normalize();
+}
+
+function rightFromForward(forward: THREE.Vector3) {
+  return new THREE.Vector3(-forward.z, 0, forward.x).normalize();
+}
+
+function getWorldPos(obj: THREE.Object3D) {
+  return obj.getWorldPosition(new THREE.Vector3());
+}
+
+
+function createCourtAcrylicTexture(base = "#396f86", lineNoise = 22000) {
+  const c = document.createElement("canvas");
+  c.width = 512;
+  c.height = 512;
+  const ctx = c.getContext("2d")!;
+  ctx.fillStyle = base;
+  ctx.fillRect(0, 0, 512, 512);
+  for (let i = 0; i < lineNoise; i++) {
+    const x = Math.random() * 512;
+    const y = Math.random() * 512;
+    const shade = 145 + Math.floor(Math.random() * 70);
+    ctx.fillStyle = `rgba(${shade},${shade + 8},${shade + 10},${0.035 + Math.random() * 0.055})`;
+    ctx.fillRect(x, y, 1 + Math.random() * 2.8, 1 + Math.random() * 1.4);
+  }
+  for (let i = 0; i < 46; i++) {
+    ctx.strokeStyle = `rgba(255,255,255,${0.035 + Math.random() * 0.05})`;
+    ctx.lineWidth = 1 + Math.random() * 2;
+    ctx.beginPath();
+    const y = Math.random() * 512;
+    ctx.moveTo(Math.random() * 80, y);
+    ctx.bezierCurveTo(150, y + (Math.random() - 0.5) * 18, 340, y + (Math.random() - 0.5) * 22, 512, y + (Math.random() - 0.5) * 14);
+    ctx.stroke();
+  }
+  const tex = new THREE.CanvasTexture(c);
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(2.2, 5.2);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.anisotropy = 6;
+  return tex;
+}
+
+function createSkyGradientTexture() {
+  const c = document.createElement("canvas");
+  c.width = 16;
+  c.height = 256;
+  const ctx = c.getContext("2d")!;
+  const grad = ctx.createLinearGradient(0, 0, 0, c.height);
+  grad.addColorStop(0, "#102035");
+  grad.addColorStop(0.42, "#304d62");
+  grad.addColorStop(1, "#d2b68d");
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, c.width, c.height);
+  const tex = new THREE.CanvasTexture(c);
+  tex.mapping = THREE.EquirectangularReflectionMapping;
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+function addCourt(scene: THREE.Scene, options: { hideFloor?: boolean } = {}) {
+  const group = new THREE.Group();
+  scene.add(group);
+
+  const hideFloor = !!options.hideFloor;
+  const apronTex = createCourtAcrylicTexture("#4d8460", 18000);
+  const courtTex = createCourtAcrylicTexture("#2f6f88", 26000);
+  const serviceTex = createCourtAcrylicTexture("#367d93", 24000);
+  const outerMat = new THREE.MeshStandardMaterial({ map: apronTex, roughness: 0.88, metalness: 0, color: new THREE.Color(0x6b8f57) });
+  const courtMat = new THREE.MeshStandardMaterial({ map: courtTex, roughness: 0.82, metalness: 0.01, color: new THREE.Color(0x4f93a7) });
+  const serviceMat = new THREE.MeshStandardMaterial({ map: serviceTex, roughness: 0.8, metalness: 0.01, color: new THREE.Color(0x5ea7ba) });
+  const lineMat = material(0xf8fbf7, 0.36, 0.0);
+  const netTexture = new THREE.CanvasTexture(makeCourtNetTexture());
+  netTexture.colorSpace = THREE.SRGBColorSpace;
+  netTexture.anisotropy = 8;
+  const netMat = new THREE.MeshStandardMaterial({
+    map: netTexture,
+    transparent: true,
+    opacity: 0.9,
+    roughness: 0.5,
+    metalness: 0.02,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+  });
+  const netWhite = material(0xf7f7f7, 0.44, 0.0);
+  const postMat = material(0x2a2f33, 0.32, 0.28);
+
+  if (!hideFloor) {
+    addBox(group, [CFG.doublesW + 9.5 * CFG.worldScale, 0.035, CFG.courtL + 10.5 * CFG.worldScale], [0, -0.015, 0], outerMat);
+    addBox(group, [CFG.courtW, 0.04, CFG.courtL], [0, 0.004, 0], courtMat);
+    addBox(group, [CFG.courtW - 0.2, 0.043, CFG.serviceLineZ * 2], [0, 0.012, 0], serviceMat);
+    addTrainingCourtSurrounds(group);
+  }
+
+  const y = 0.045 * CFG.worldScale;
+  const thick = 0.045 * CFG.worldScale;
+  const halfW = CFG.courtW / 2;
+  const halfL = CFG.courtL / 2;
+
+  addBox(group, [CFG.courtW + thick, thick, thick], [0, y, -halfL], lineMat);
+  addBox(group, [CFG.courtW + thick, thick, thick], [0, y, halfL], lineMat);
+  addBox(group, [thick, thick, CFG.courtL + thick], [-halfW, y, 0], lineMat);
+  addBox(group, [thick, thick, CFG.courtL + thick], [halfW, y, 0], lineMat);
+  addBox(group, [CFG.courtW, thick, thick], [0, y, -CFG.serviceLineZ], lineMat);
+  addBox(group, [CFG.courtW, thick, thick], [0, y, CFG.serviceLineZ], lineMat);
+  addBox(group, [thick, thick, CFG.serviceLineZ * 2], [0, y, 0], lineMat);
+  addBox(group, [thick, thick, 0.38 * CFG.worldScale], [0, y, -halfL + 0.18 * CFG.worldScale], lineMat);
+  addBox(group, [thick, thick, 0.38 * CFG.worldScale], [0, y, halfL - 0.18 * CFG.worldScale], lineMat);
+  addBox(group, [thick, thick, CFG.courtL + thick], [-CFG.doublesW / 2, y, 0], transparentMaterial(0xffffff, 0.34));
+  addBox(group, [thick, thick, CFG.courtL + thick], [CFG.doublesW / 2, y, 0], transparentMaterial(0xffffff, 0.34));
+
+  const netBody = new THREE.Mesh(new THREE.PlaneGeometry(CFG.doublesW + 0.42 * CFG.worldScale, CFG.netH), netMat);
+  netBody.position.set(0, CFG.netH / 2, 0);
+  enableShadow(netBody);
+  group.add(netBody);
+  addBox(group, [CFG.doublesW + 0.75 * CFG.worldScale, 0.085 * CFG.worldScale, 0.09 * CFG.worldScale], [0, CFG.netH + 0.03 * CFG.worldScale, 0], netWhite);
+  addBox(group, [CFG.doublesW + 0.55 * CFG.worldScale, 0.065 * CFG.worldScale, 0.07 * CFG.worldScale], [0, 0.06 * CFG.worldScale, 0], netWhite);
+  addBox(group, [0.09 * CFG.worldScale, CFG.netH + 0.12 * CFG.worldScale, 0.085 * CFG.worldScale], [-(CFG.doublesW / 2 + 0.28 * CFG.worldScale), CFG.netH / 2, 0], netWhite);
+  addBox(group, [0.09 * CFG.worldScale, CFG.netH + 0.12 * CFG.worldScale, 0.085 * CFG.worldScale], [CFG.doublesW / 2 + 0.28 * CFG.worldScale, CFG.netH / 2, 0], netWhite);
+  const postHeight = CFG.netH + 0.36 * CFG.worldScale;
+  addCylinder(group, 0.045 * CFG.worldScale, 0.052 * CFG.worldScale, postHeight, [-(CFG.doublesW / 2 + 0.22 * CFG.worldScale), postHeight / 2, 0], postMat, 22);
+  addCylinder(group, 0.045 * CFG.worldScale, 0.052 * CFG.worldScale, postHeight, [CFG.doublesW / 2 + 0.22 * CFG.worldScale, postHeight / 2, 0], postMat, 22);
+
+  return { group, netBody };
+}
+
+
+function addTrainingCourtSurrounds(group: THREE.Group) {
+  const fenceMat = transparentMaterial(0x243238, 0.5, 0.62);
+  const poleMat = material(0x28323a, 0.42, 0.34);
+  const padMat = material(0x1e4f35, 0.68, 0.02);
+  const benchMat = material(0x8b5a2b, 0.5, 0.08);
+  const plasticMat = material(0x0f2d45, 0.62, 0.05);
+  const metalMat = material(0xd8dde1, 0.34, 0.34);
+  const feltMat = material(0xd5ff37, 0.92, 0.0);
+  const towelMat = material(0xf6f1e6, 0.86, 0.0);
+  const scuffMat = new THREE.MeshStandardMaterial({ color: 0xa55532, roughness: 0.9, metalness: 0, transparent: true, opacity: 0.24, depthWrite: false });
+  const fenceY = 1.82 * CFG.worldScale;
+  const sideX = CFG.doublesW / 2 + 4.45 * CFG.worldScale;
+  const endZ = CFG.courtL / 2 + 4.35 * CFG.worldScale;
+  const sideFenceDepth = CFG.courtL + 8.7 * CFG.worldScale;
+  const endFenceWidth = CFG.doublesW + 8.9 * CFG.worldScale;
+
+  addBox(group, [0.042 * CFG.worldScale, fenceY, sideFenceDepth], [-sideX, fenceY / 2, 0], fenceMat);
+  addBox(group, [0.042 * CFG.worldScale, fenceY, sideFenceDepth], [sideX, fenceY / 2, 0], fenceMat);
+  addBox(group, [endFenceWidth, fenceY, 0.042 * CFG.worldScale], [0, fenceY / 2, -endZ], fenceMat);
+  addBox(group, [endFenceWidth, fenceY, 0.042 * CFG.worldScale], [0, fenceY / 2, endZ], fenceMat);
+
+  for (let i = -5; i <= 5; i++) {
+    const z = (i / 5) * (sideFenceDepth / 2);
+    addCylinder(group, 0.028 * CFG.worldScale, 0.028 * CFG.worldScale, fenceY + 0.22 * CFG.worldScale, [-sideX, (fenceY + 0.22 * CFG.worldScale) / 2, z], poleMat, 12);
+    addCylinder(group, 0.028 * CFG.worldScale, 0.028 * CFG.worldScale, fenceY + 0.22 * CFG.worldScale, [sideX, (fenceY + 0.22 * CFG.worldScale) / 2, z], poleMat, 12);
+  }
+  for (let i = -3; i <= 3; i++) {
+    const x = (i / 3) * (endFenceWidth / 2);
+    addCylinder(group, 0.028 * CFG.worldScale, 0.028 * CFG.worldScale, fenceY + 0.22 * CFG.worldScale, [x, (fenceY + 0.22 * CFG.worldScale) / 2, -endZ], poleMat, 12);
+    addCylinder(group, 0.028 * CFG.worldScale, 0.028 * CFG.worldScale, fenceY + 0.22 * CFG.worldScale, [x, (fenceY + 0.22 * CFG.worldScale) / 2, endZ], poleMat, 12);
+  }
+
+  const addBench = (x: number, z: number, yaw: number) => {
+    const bench = new THREE.Group();
+    bench.position.set(x, 0, z);
+    bench.rotation.y = yaw;
+    addBox(bench, [2.35 * CFG.worldScale, 0.13 * CFG.worldScale, 0.42 * CFG.worldScale], [0, 0.39 * CFG.worldScale, 0], benchMat);
+    addBox(bench, [2.35 * CFG.worldScale, 0.11 * CFG.worldScale, 0.35 * CFG.worldScale], [0, 0.72 * CFG.worldScale, -0.18 * CFG.worldScale], benchMat);
+    [-0.85, 0.85].forEach((lx) => {
+      addBox(bench, [0.12 * CFG.worldScale, 0.42 * CFG.worldScale, 0.14 * CFG.worldScale], [lx * CFG.worldScale, 0.18 * CFG.worldScale, 0.12 * CFG.worldScale], metalMat);
+    });
+    group.add(bench);
+  };
+
+  const addBallTube = (x: number, z: number, yaw: number) => {
+    const tube = new THREE.Group();
+    tube.position.set(x, 0, z);
+    tube.rotation.y = yaw;
+    addCylinder(tube, 0.16 * CFG.worldScale, 0.16 * CFG.worldScale, 0.86 * CFG.worldScale, [0, 0.43 * CFG.worldScale, 0], plasticMat, 24);
+    addCylinder(tube, 0.145 * CFG.worldScale, 0.145 * CFG.worldScale, 0.035 * CFG.worldScale, [0, 0.88 * CFG.worldScale, 0], metalMat, 24);
+    for (let i = 0; i < 4; i++) {
+      const ball = new THREE.Mesh(new THREE.SphereGeometry(0.078 * CFG.worldScale, 18, 12), feltMat);
+      ball.position.set(((i % 2) - 0.5) * 0.12 * CFG.worldScale, 0.96 * CFG.worldScale + Math.floor(i / 2) * 0.09 * CFG.worldScale, 0);
+      enableShadow(ball);
+      tube.add(ball);
+    }
+    group.add(tube);
+  };
+
+  const addUmpireChair = (x: number, z: number, yaw: number) => {
+    const chair = new THREE.Group();
+    chair.position.set(x, 0, z);
+    chair.rotation.y = yaw;
+    addBox(chair, [0.82 * CFG.worldScale, 0.12 * CFG.worldScale, 0.62 * CFG.worldScale], [0, 1.45 * CFG.worldScale, 0], metalMat);
+    addBox(chair, [0.82 * CFG.worldScale, 0.1 * CFG.worldScale, 0.2 * CFG.worldScale], [0, 1.78 * CFG.worldScale, -0.26 * CFG.worldScale], plasticMat);
+    [-0.33, 0.33].forEach((lx) => [-0.22, 0.22].forEach((lz) => {
+      addCylinder(chair, 0.025 * CFG.worldScale, 0.025 * CFG.worldScale, 1.45 * CFG.worldScale, [lx * CFG.worldScale, 0.72 * CFG.worldScale, lz * CFG.worldScale], metalMat, 10);
+    }));
+    for (let i = 0; i < 4; i++) {
+      addBox(chair, [0.62 * CFG.worldScale, 0.035 * CFG.worldScale, 0.12 * CFG.worldScale], [0, (0.34 + i * 0.22) * CFG.worldScale, 0.34 * CFG.worldScale], metalMat);
+    }
+    group.add(chair);
+  };
+
+  const addRacketRack = (x: number, z: number, yaw: number) => {
+    const rack = new THREE.Group();
+    rack.position.set(x, 0, z);
+    rack.rotation.y = yaw;
+    addBox(rack, [0.95 * CFG.worldScale, 0.06 * CFG.worldScale, 0.14 * CFG.worldScale], [0, 0.18 * CFG.worldScale, 0], metalMat);
+    [-0.34, 0, 0.34].forEach((lx, i) => {
+      const racket = createRacket(i === 1 ? 0x4bb3ff : 0xff8b2f);
+      racket.scale.setScalar(1.55 * CFG.worldScale);
+      racket.position.set(lx * CFG.worldScale, 0.28 * CFG.worldScale, 0.02 * CFG.worldScale);
+      racket.rotation.set(Math.PI * 0.08, 0, (i - 1) * 0.12);
+      rack.add(racket);
+    });
+    group.add(rack);
+  };
+
+  addBench(-CFG.doublesW / 2 - 2.25 * CFG.worldScale, CFG.courtL * 0.08, Math.PI / 2);
+  addBench(CFG.doublesW / 2 + 2.35 * CFG.worldScale, -CFG.courtL * 0.18, -Math.PI / 2);
+  addBox(group, [0.2 * CFG.worldScale, 0.5 * CFG.worldScale, 0.22 * CFG.worldScale], [-CFG.doublesW / 2 - 3.0 * CFG.worldScale, 0.2 * CFG.worldScale, -0.5 * CFG.worldScale], padMat);
+  addBox(group, [0.2 * CFG.worldScale, 0.5 * CFG.worldScale, 0.22 * CFG.worldScale], [CFG.doublesW / 2 + 3.0 * CFG.worldScale, 0.2 * CFG.worldScale, 0.5 * CFG.worldScale], padMat);
+  addBallTube(-CFG.doublesW / 2 - 2.55 * CFG.worldScale, -CFG.courtL * 0.23, Math.PI / 12);
+  addBallTube(CFG.doublesW / 2 + 2.55 * CFG.worldScale, CFG.courtL * 0.25, -Math.PI / 12);
+  addUmpireChair(CFG.doublesW / 2 + 1.28 * CFG.worldScale, 0, -Math.PI / 2);
+  addRacketRack(-CFG.doublesW / 2 - 2.15 * CFG.worldScale, CFG.courtL * 0.29, Math.PI / 2);
+
+  [-1, 1].forEach((side) => {
+    const towel = addBox(group, [0.62 * CFG.worldScale, 0.035 * CFG.worldScale, 0.34 * CFG.worldScale], [side * (CFG.doublesW / 2 + 2.45 * CFG.worldScale), 0.82 * CFG.worldScale, CFG.courtL * -0.04], towelMat);
+    towel.rotation.z = side * 0.16;
+    const drinks = addBox(group, [0.42 * CFG.worldScale, 0.3 * CFG.worldScale, 0.26 * CFG.worldScale], [side * (CFG.doublesW / 2 + 2.9 * CFG.worldScale), 0.15 * CFG.worldScale, CFG.courtL * 0.12], plasticMat);
+    drinks.name = "courtside-drinks-cooler";
+  });
+
+  for (let i = 0; i < 7; i++) {
+    const scuff = addBox(group, [(0.55 + Math.random() * 0.42) * CFG.worldScale, 0.006 * CFG.worldScale, 0.06 * CFG.worldScale], [(-0.5 + Math.random()) * CFG.courtW * 0.72, 0.058 * CFG.worldScale, (-0.5 + Math.random()) * CFG.courtL * 0.82], scuffMat);
+    scuff.rotation.y = Math.random() * Math.PI;
+  }
+}
+
+function addTrainingCourtLighting(scene: THREE.Scene) {
+  scene.background = createSkyGradientTexture();
+  scene.environment = null;
+  scene.add(new THREE.AmbientLight(0xfff8ec, 0.82));
+  scene.add(new THREE.HemisphereLight(0xf0f8ff, 0x6f835f, 0.98));
+
+  const keySun = new THREE.DirectionalLight(0xfff5d8, 1.32);
+  keySun.position.set(-6.5, 9.5, 6.2);
+  keySun.castShadow = true;
+  keySun.shadow.mapSize.width = 2048;
+  keySun.shadow.mapSize.height = 2048;
+  keySun.shadow.camera.near = 0.5;
+  keySun.shadow.camera.far = Math.max(25, CFG.courtL * 1.45);
+  const shadowHalfW = CFG.doublesW / 2 + 5.2 * CFG.worldScale;
+  const shadowHalfL = CFG.courtL / 2 + 5.8 * CFG.worldScale;
+  keySun.shadow.camera.left = -shadowHalfW;
+  keySun.shadow.camera.right = shadowHalfW;
+  keySun.shadow.camera.top = shadowHalfL;
+  keySun.shadow.camera.bottom = -shadowHalfL;
+  scene.add(keySun);
+
+  const poleMat = material(0x222b33, 0.36, 0.34);
+  const headMat = material(0x1d252c, 0.32, 0.22);
+  const glowMat = new THREE.MeshBasicMaterial({ color: 0xfff0c4, transparent: true, opacity: 0.72 });
+  const poleX = CFG.doublesW / 2 + 3.05 * CFG.worldScale;
+  const poleZs = [-0.36, 0.36].map((n) => n * CFG.courtL);
+  const poleH = 3.9 * CFG.worldScale;
+
+  poleZs.forEach((z) => {
+    [-1, 1].forEach((side) => {
+      const x = side * poleX;
+      addCylinder(scene, 0.045 * CFG.worldScale, 0.058 * CFG.worldScale, poleH, [x, poleH / 2, z], poleMat, 16);
+      const arm = addBox(scene, [0.9 * CFG.worldScale, 0.045 * CFG.worldScale, 0.055 * CFG.worldScale], [x - side * 0.34 * CFG.worldScale, poleH - 0.15 * CFG.worldScale, z], poleMat);
+      arm.rotation.z = side * 0.12;
+      for (let i = 0; i < 2; i++) {
+        const head = addBox(scene, [0.46 * CFG.worldScale, 0.2 * CFG.worldScale, 0.16 * CFG.worldScale], [x - side * (0.78 + i * 0.34) * CFG.worldScale, poleH - 0.2 * CFG.worldScale, z + (i - 0.5) * 0.18 * CFG.worldScale], headMat);
+        head.lookAt(0, 0.25 * CFG.worldScale, z * 0.35);
+        const glow = new THREE.Mesh(new THREE.PlaneGeometry(0.42 * CFG.worldScale, 0.16 * CFG.worldScale), glowMat.clone());
+        glow.position.copy(head.position);
+        glow.lookAt(0, 0.5 * CFG.worldScale, z * 0.2);
+        scene.add(glow);
+      }
+      const spot = new THREE.SpotLight(0xfff6df, 2.22, CFG.courtL * 1.25, Math.PI / 5.4, 0.52, 0.95);
+      spot.position.set(x - side * 0.95 * CFG.worldScale, poleH - 0.28 * CFG.worldScale, z);
+      spot.target.position.set(0, 0.05, z * 0.14);
+      spot.castShadow = true;
+      spot.shadow.mapSize.width = 1024;
+      spot.shadow.mapSize.height = 1024;
+      scene.add(spot, spot.target);
+
+      const fill = new THREE.PointLight(0xfff7df, 0.66, CFG.courtL * 0.72, 1.4);
+      fill.position.set(x - side * 0.72 * CFG.worldScale, poleH - 0.34 * CFG.worldScale, z);
+      scene.add(fill);
+    });
+  });
+}
+
+function addOnlineCourtEnvironmentAssets(scene: THREE.Scene) {
+  const group = new THREE.Group();
+  group.name = "online-tennis-court-environment-assets";
+  scene.add(group);
+
+  const loader = new GLTFLoader().setCrossOrigin("anonymous");
+  const placements = [
+    new THREE.Vector3(-(CFG.doublesW / 2 + 2.75 * CFG.worldScale), 0.08 * CFG.worldScale, CFG.courtL * 0.16),
+    new THREE.Vector3(CFG.doublesW / 2 + 2.65 * CFG.worldScale, 0.08 * CFG.worldScale, CFG.courtL * 0.1),
+    new THREE.Vector3(-(CFG.doublesW / 2 + 2.85 * CFG.worldScale), 0.08 * CFG.worldScale, -CFG.courtL * 0.24),
+    new THREE.Vector3(CFG.doublesW / 2 + 2.82 * CFG.worldScale, 0.08 * CFG.worldScale, CFG.courtL * 0.18),
+    new THREE.Vector3(-(CFG.doublesW / 2 + 3.05 * CFG.worldScale), 0.08 * CFG.worldScale, -CFG.courtL * 0.16),
+  ];
+
+  COURT_ENVIRONMENT_ASSETS.forEach((asset, idx) => {
+    loader.load(
+      asset.url,
+      (gltf) => {
+        const root = gltf.scene;
+        root.name = asset.name;
+        root.userData.source = asset.source;
+        root.position.copy(placements[idx] || asset.position);
+        root.rotation.y = asset.rotationY;
+        root.scale.setScalar(1);
+        root.updateMatrixWorld(true);
+
+        const box = new THREE.Box3().setFromObject(root);
+        const size = box.getSize(new THREE.Vector3());
+        const maxAxis = Math.max(size.x, size.y, size.z, 0.001);
+        root.scale.setScalar((asset.scale * CFG.worldScale) / maxAxis);
+        root.updateMatrixWorld(true);
+        const scaledBox = new THREE.Box3().setFromObject(root);
+        root.position.y += 0.08 * CFG.worldScale - scaledBox.min.y;
+
+        root.traverse((obj) => {
+          const mesh = obj as THREE.Mesh;
+          if (!mesh.isMesh) return;
+          enableShadow(mesh);
+          if (mesh.material instanceof THREE.MeshStandardMaterial) {
+            mesh.material.roughness = Math.max(mesh.material.roughness ?? 0, 0.48);
+          }
+        });
+        group.add(root);
+      },
+      undefined,
+      () => {
+        const fallbackMat = material(idx === 0 ? 0x8c5a38 : idx === 1 ? 0x2f3540 : 0x2f6f44, 0.56, 0.05);
+        const fallback = addBox(group, [0.6 * CFG.worldScale, 0.42 * CFG.worldScale, 0.42 * CFG.worldScale], placements[idx]?.toArray() || asset.position.toArray(), fallbackMat);
+        fallback.name = `${asset.name}-fallback`;
+      }
+    );
+  });
+
+  return group;
+}
+
+
+function addStadiumBillboards(scene: THREE.Scene) {
+  const boardGroup = new THREE.Group();
+  scene.add(boardGroup);
+  const banners = ["TONPLAYGRAM", "TENNIS PRO", "REAL SPEED", "LIVE ARENA"];
+  const fontCanvas = document.createElement("canvas");
+  fontCanvas.width = 512;
+  fontCanvas.height = 128;
+  const ctx = fontCanvas.getContext("2d");
+  const makeTexture = (text: string, t: number) => {
+    if (!ctx) return null;
+    ctx.clearRect(0, 0, fontCanvas.width, fontCanvas.height);
+    const grad = ctx.createLinearGradient(0, 0, fontCanvas.width, 0);
+    grad.addColorStop(0, `hsl(${(t * 40) % 360} 85% 55%)`);
+    grad.addColorStop(1, `hsl(${(180 + t * 65) % 360} 80% 45%)`);
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, fontCanvas.width, fontCanvas.height);
+    ctx.fillStyle = "rgba(255,255,255,0.94)";
+    ctx.font = "bold 54px Inter, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(text, fontCanvas.width / 2, fontCanvas.height / 2);
+    const texture = new THREE.CanvasTexture(fontCanvas);
+    texture.needsUpdate = true;
+    return texture;
+  };
+  const panels: THREE.Mesh[] = [];
+  for (let i = 0; i < 6; i++) {
+    const mat = new THREE.MeshStandardMaterial({ color: 0xffffff, emissive: 0x0a0a0a, roughness: 0.4, metalness: 0.05 });
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(2.6, 0.65), mat);
+    const side = i % 2 === 0 ? 1 : -1;
+    const lane = Math.floor(i / 2);
+    mesh.position.set(side * (CFG.doublesW / 2 + 1.25), 0.95, -4.8 + lane * 4.8);
+    mesh.rotation.y = side > 0 ? -Math.PI / 2 : Math.PI / 2;
+    boardGroup.add(mesh);
+    panels.push(mesh);
+  }
+  return (elapsed: number) => {
+    panels.forEach((panel, idx) => {
+      const text = banners[(Math.floor(elapsed * 1.8 + idx) % banners.length + banners.length) % banners.length];
+      const tex = makeTexture(text, elapsed + idx * 0.2);
+      if (tex && panel.material instanceof THREE.MeshStandardMaterial) panel.material.map = tex;
+      panel.position.y = 0.95 + Math.sin(elapsed * 2.1 + idx) * 0.03;
+      panel.material.needsUpdate = true;
+    });
+  };
+}
+function normalizeHuman(model: THREE.Object3D, targetHeight: number) {
+  model.rotation.set(0, CFG.playerVisualYawFix, 0);
+  model.position.set(0, 0, 0);
+  model.scale.setScalar(1);
+  model.updateMatrixWorld(true);
+  let box = new THREE.Box3().setFromObject(model);
+  const h = Math.max(0.001, box.max.y - box.min.y);
+  model.scale.setScalar(targetHeight / h);
+  model.updateMatrixWorld(true);
+  box = new THREE.Box3().setFromObject(model);
+  const center = box.getCenter(new THREE.Vector3());
+  model.position.add(new THREE.Vector3(-center.x, -box.min.y, -center.z));
+}
+
+function createFallbackHuman(color: number) {
+  const g = new THREE.Group();
+  const skin = material(0xf0c7a0, 0.78, 0.02);
+  const shirt = material(color, 0.74, 0.02);
+  const shorts = material(0x20232a, 0.76, 0.02);
+  const shoe = material(0xffffff, 0.55, 0.03);
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.17, 28, 20), skin);
+  head.position.y = 1.62;
+  g.add(head);
+  addCylinder(g, 0.055, 0.06, 0.12, [0, 1.43, 0], skin, 18);
+  const torso = addCylinder(g, 0.24, 0.31, 0.72, [0, 1.04, 0], shirt, 28);
+  torso.scale.x = 0.78;
+  const hips = addCylinder(g, 0.24, 0.25, 0.24, [0, 0.61, 0], shorts, 22);
+  hips.scale.x = 0.9;
+  const leftLeg = addCylinder(g, 0.07, 0.085, 0.63, [-0.13, 0.31, 0], shorts, 16);
+  const rightLeg = addCylinder(g, 0.07, 0.085, 0.63, [0.13, 0.31, 0], shorts, 16);
+  leftLeg.rotation.z = 0.06;
+  rightLeg.rotation.z = -0.06;
+  const leftFoot = addBox(g, [0.23, 0.055, 0.34], [-0.13, 0.035, -0.04], shoe);
+  const rightFoot = addBox(g, [0.23, 0.055, 0.34], [0.13, 0.035, -0.04], shoe);
+  g.userData.goalRushFallbackParts = { body: torso, head, leftFoot, rightFoot };
+  enableShadow(g);
+  return g;
+}
+
+
+
+function makeRacketHexStringTexture() {
+  const size = 512;
+  const c = document.createElement("canvas");
+  c.width = size;
+  c.height = size;
+  const ctx = c.getContext("2d")!;
+  const center = size / 2;
+  const radius = size * 0.46;
+  const hexRadius = size * 0.048;
+  const hexHeight = Math.sqrt(3) * hexRadius;
+  const stepX = hexRadius * 1.5;
+  const stepY = hexHeight;
+
+  ctx.clearRect(0, 0, size, size);
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(center, center, radius, 0, Math.PI * 2);
+  ctx.clip();
+  ctx.strokeStyle = "rgba(255,255,255,0.74)";
+  ctx.lineWidth = 4.5;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  for (let y = center - radius - stepY; y <= center + radius + stepY; y += stepY) {
+    const row = Math.round((y - (center - radius - stepY)) / stepY);
+    const offsetX = row % 2 === 0 ? 0 : stepX / 2;
+    for (let x = center - radius - stepX; x <= center + radius + stepX; x += stepX) {
+      const cx = x + offsetX;
+      ctx.beginPath();
+      for (let i = 0; i < 6; i++) {
+        const angle = Math.PI / 6 + (Math.PI / 3) * i;
+        const px = cx + Math.cos(angle) * hexRadius;
+        const py = y + Math.sin(angle) * hexRadius;
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      }
+      ctx.closePath();
+      ctx.stroke();
+    }
+  }
+
+  ctx.strokeStyle = "rgba(255,255,255,0.92)";
+  ctx.lineWidth = 5.5;
+  ctx.beginPath();
+  ctx.arc(center, center, radius - 2, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.restore();
+  return c;
+}
+
+function makeCourtNetTexture(width = 1024, height = 256) {
+  const c = document.createElement("canvas");
+  c.width = width;
+  c.height = height;
+  const ctx = c.getContext("2d")!;
+  const hexRadius = 17;
+  const stepX = hexRadius * 1.5;
+  const stepY = Math.sqrt(3) * hexRadius;
+
+  ctx.clearRect(0, 0, width, height);
+  ctx.strokeStyle = "rgba(245,248,244,0.86)";
+  ctx.lineWidth = 5;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  for (let y = -stepY; y <= height + stepY; y += stepY) {
+    const row = Math.round((y + stepY) / stepY);
+    const offsetX = row % 2 === 0 ? 0 : stepX / 2;
+    for (let x = -stepX; x <= width + stepX; x += stepX) {
+      const cx = x + offsetX;
+      ctx.beginPath();
+      for (let i = 0; i < 6; i++) {
+        const angle = Math.PI / 6 + (Math.PI / 3) * i;
+        const px = cx + Math.cos(angle) * hexRadius;
+        const py = y + Math.sin(angle) * hexRadius;
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      }
+      ctx.closePath();
+      ctx.stroke();
+    }
+  }
+  return c;
+}
+
+function createRacket(color: number) {
+  const g = new THREE.Group();
+  const handleMat = material(0x1d1d1f, 0.55, 0.1);
+  const frameMat = material(color, 0.36, 0.45);
+
+  const handle = new THREE.Mesh(new THREE.CylinderGeometry(0.026, 0.03, 0.42, 16), handleMat);
+  handle.position.y = -0.11;
+  enableShadow(handle);
+  g.add(handle);
+
+  const throatA = new THREE.Mesh(new THREE.CylinderGeometry(0.012, 0.014, 0.29, 12), frameMat);
+  throatA.position.set(-0.052, 0.24, -0.026);
+  throatA.rotation.z = 0.24;
+  enableShadow(throatA);
+  g.add(throatA);
+  const throatB = throatA.clone();
+  throatB.position.x *= -1;
+  throatB.rotation.z *= -1;
+  g.add(throatB);
+
+  const headRadius = 0.205;
+  const frameTubeRadius = 0.019;
+  const headScaleY = 1.34;
+  const innerHeadRadius = headRadius - frameTubeRadius;
+  const head = new THREE.Mesh(new THREE.TorusGeometry(headRadius, frameTubeRadius, 12, 52), frameMat);
+  head.scale.y = headScaleY;
+  head.position.y = 0.56;
+  enableShadow(head);
+  g.add(head);
+
+  const stringTexture = new THREE.CanvasTexture(makeRacketHexStringTexture());
+  stringTexture.colorSpace = THREE.SRGBColorSpace;
+  stringTexture.anisotropy = 4;
+  const stringMat = new THREE.MeshStandardMaterial({
+    map: stringTexture,
+    transparent: true,
+    opacity: 0.82,
+    roughness: 0.42,
+    metalness: 0.02,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+  });
+  const stringPlane = new THREE.Mesh(new THREE.CircleGeometry(innerHeadRadius, 72), stringMat);
+  stringPlane.scale.y = headScaleY;
+  stringPlane.position.set(0, 0.56, 0.007);
+  g.add(stringPlane);
+  return g;
+}
+
+function findFirstBone(root: THREE.Object3D, tests: string[]) {
+  let found: THREE.Bone | undefined;
+  root.traverse((o) => {
+    if (found) return;
+    const b = o as THREE.Bone;
+    if (!b.isBone) return;
+    const n = b.name.toLowerCase().replace(/[_.\-\s]/g, "");
+    if (tests.some((t) => n.includes(t))) found = b;
+  });
+  return found;
+}
+
+function findHumanBones(model: THREE.Object3D): BonePack {
+  return {
+    spine: findFirstBone(model, ["spine"]),
+    chest: findFirstBone(model, ["chest", "spine2", "upperchest"]),
+    neck: findFirstBone(model, ["neck"]),
+    rightShoulder: findFirstBone(model, ["rightshoulder", "rshoulder"]),
+    rightUpperArm: findFirstBone(model, ["rightarm", "rightupperarm", "rarm", "rupperarm"]),
+    rightForeArm: findFirstBone(model, ["rightforearm", "rightlowerarm", "rforearm", "rlowerarm"]),
+    rightHand: findFirstBone(model, ["righthand", "rhand"]),
+    leftShoulder: findFirstBone(model, ["leftshoulder", "lshoulder"]),
+    leftUpperArm: findFirstBone(model, ["leftarm", "leftupperarm", "larm", "lupperarm"]),
+    leftForeArm: findFirstBone(model, ["leftforearm", "leftlowerarm", "lforearm", "llowerarm"]),
+    leftHand: findFirstBone(model, ["lefthand", "lhand"]),
+  };
+}
+
+function captureRestPose(bones: BonePack) {
+  const out: BoneRest[] = [];
+  Object.values(bones).forEach((bone) => {
+    if (bone && !out.some((r) => r.bone === bone)) out.push({ bone, q: bone.quaternion.clone() });
+  });
+  return out;
+}
+
+function makeArmChain(shoulder: THREE.Bone | undefined, upper: THREE.Bone | undefined, fore: THREE.Bone | undefined, hand: THREE.Bone | undefined): ArmChain | undefined {
+  if (!upper || !fore || !hand) return undefined;
+  upper.updateMatrixWorld(true);
+  fore.updateMatrixWorld(true);
+  hand.updateMatrixWorld(true);
+  const a = getWorldPos(upper);
+  const b = getWorldPos(fore);
+  const c = getWorldPos(hand);
+  return {
+    shoulder,
+    upper,
+    fore,
+    hand,
+    upperLen: Math.max(0.05, a.distanceTo(b)),
+    foreLen: Math.max(0.05, b.distanceTo(c)),
+  };
+}
+
+function setBoneWorldQuaternion(bone: THREE.Bone, worldQ: THREE.Quaternion) {
+  const parentWorldQ = new THREE.Quaternion();
+  if (bone.parent) bone.parent.getWorldQuaternion(parentWorldQ);
+  bone.quaternion.copy(parentWorldQ.invert().multiply(worldQ));
+}
+
+function rotateBoneSoChildPointsTo(bone: THREE.Bone, child: THREE.Object3D, targetDirWorld: THREE.Vector3) {
+  bone.updateMatrixWorld(true);
+  child.updateMatrixWorld(true);
+  const bonePos = getWorldPos(bone);
+  const childPos = getWorldPos(child);
+  const currentDir = childPos.sub(bonePos).normalize();
+  const desiredDir = targetDirWorld.clone().normalize();
+  if (currentDir.lengthSq() < 1e-8 || desiredDir.lengthSq() < 1e-8) return;
+  const delta = new THREE.Quaternion().setFromUnitVectors(currentDir, desiredDir);
+  const currentWorldQ = bone.getWorldQuaternion(new THREE.Quaternion());
+  setBoneWorldQuaternion(bone, delta.multiply(currentWorldQ));
+}
+
+function solveTwoBoneArm(chain: ArmChain | undefined, shoulderTarget: THREE.Vector3, elbowHint: THREE.Vector3, handTarget: THREE.Vector3) {
+  if (!chain) return false;
+  const { shoulder, upper, fore, hand, upperLen, foreLen } = chain;
+  upper.updateMatrixWorld(true);
+  fore.updateMatrixWorld(true);
+  hand.updateMatrixWorld(true);
+
+  const rootPos = getWorldPos(upper);
+  const target = handTarget.clone();
+  const toTarget = target.clone().sub(rootPos);
+  const distRaw = Math.max(0.0001, toTarget.length());
+  const dist = clamp(distRaw, 0.001, upperLen + foreLen - 0.001);
+  const dir = toTarget.normalize();
+
+  const hintDir = elbowHint.clone().sub(rootPos);
+  let normal = new THREE.Vector3().crossVectors(dir, hintDir).normalize();
+  if (normal.lengthSq() < 1e-8) {
+    normal = new THREE.Vector3(0, 1, 0).cross(dir);
+    if (normal.lengthSq() < 1e-8) normal = new THREE.Vector3(1, 0, 0);
+    normal.normalize();
+  }
+  const bendAxis = new THREE.Vector3().crossVectors(normal, dir).normalize();
+  const a = (upperLen * upperLen - foreLen * foreLen + dist * dist) / (2 * dist);
+  const h = Math.sqrt(Math.max(0, upperLen * upperLen - a * a));
+  const mid = rootPos.clone().addScaledVector(dir, a);
+  const elbowA = mid.clone().addScaledVector(bendAxis, h);
+  const elbowB = mid.clone().addScaledVector(bendAxis, -h);
+  const elbow = elbowA.distanceToSquared(elbowHint) < elbowB.distanceToSquared(elbowHint) ? elbowA : elbowB;
+
+  if (shoulder) {
+    shoulder.updateMatrixWorld(true);
+    const shoulderPos = getWorldPos(shoulder);
+    const shoulderDir = shoulderTarget.clone().sub(shoulderPos);
+    if (shoulderDir.lengthSq() > 1e-8) rotateBoneSoChildPointsTo(shoulder, upper, shoulderDir.normalize());
+  }
+  upper.updateMatrixWorld(true);
+  rotateBoneSoChildPointsTo(upper, fore, elbow.clone().sub(getWorldPos(upper)).normalize());
+  fore.updateMatrixWorld(true);
+  rotateBoneSoChildPointsTo(fore, hand, target.clone().sub(getWorldPos(fore)).normalize());
+  hand.updateMatrixWorld(true);
+  return true;
+}
+
+function addLocalRotation(bone: THREE.Bone | undefined, x: number, y: number, z: number) {
+  if (!bone) return;
+  bone.quaternion.multiply(new THREE.Quaternion().setFromEuler(new THREE.Euler(x, y, z, "XYZ")));
+}
+
+
+type TennisLocomotionMode = "idle" | "forward" | "backpedal" | "shuffle";
+
+function tennisPoseBone(model: THREE.Object3D, key: string) {
+  const hints: Record<string, string[]> = {
+    hips: ["hips", "pelvis", "pelvisjoint", "hipjoint"],
+    spine: ["spine", "chest", "torso"],
+    leftUpperArm: ["leftarm", "leftupperarm", "lupperarm", "shoulderl"],
+    leftForeArm: ["leftforearm", "leftlowerarm", "lforearm", "elbowl"],
+    rightUpperArm: ["rightarm", "rightupperarm", "rupperarm", "shoulderr"],
+    rightForeArm: ["rightforearm", "rightlowerarm", "rforearm", "elbowr"],
+    leftThigh: ["leftupleg", "leftthigh", "lthigh", "legjointl1"],
+    leftCalf: ["leftleg", "leftcalf", "lcalf", "legjointl2"],
+    leftFoot: ["leftfoot", "lfoot", "footl", "lefttoe", "lefttoebase"],
+    rightThigh: ["rightupleg", "rightthigh", "rthigh", "legjointr1"],
+    rightCalf: ["rightleg", "rightcalf", "rcalf", "legjointr2"],
+    rightFoot: ["rightfoot", "rfoot", "footr", "righttoe", "righttoebase"],
+  };
+  return findFirstBone(model, hints[key] || []);
+}
+
+function captureTennisLocomotionDefaultPose(model: THREE.Object3D) {
+  if (model.userData.tennisLocomotionDefaultPose) return;
+  const bones = [
+    "hips",
+    "spine",
+    "leftUpperArm",
+    "leftForeArm",
+    "rightUpperArm",
+    "rightForeArm",
+    "leftThigh",
+    "leftCalf",
+    "leftFoot",
+    "rightThigh",
+    "rightCalf",
+    "rightFoot",
+  ] as const;
+  const pose: Record<string, THREE.Euler> = {};
+  for (const key of bones) {
+    const bone = tennisPoseBone(model, key);
+    if (bone) pose[key] = bone.rotation.clone();
+  }
+  model.userData.tennisLocomotionDefaultPose = pose;
+}
+
+function resetTennisLocomotionPose(model: THREE.Object3D | null) {
+  const pose = model?.userData?.tennisLocomotionDefaultPose as Record<string, THREE.Euler> | undefined;
+  if (!model || !pose) return;
+  Object.entries(pose).forEach(([key, rotation]) => {
+    const bone = tennisPoseBone(model, key);
+    if (bone) bone.rotation.copy(rotation);
+  });
+}
+
+function applyTennisRotationOffset(bone: THREE.Object3D | undefined, x = 0, y = 0, z = 0) {
+  if (!bone) return;
+  bone.rotation.x += x;
+  bone.rotation.y += y;
+  bone.rotation.z += z;
+}
+
+function applyGoalRushStyleTennisWalk(player: HumanRig, mode: TennisLocomotionMode, runAmount: number, sideDot: number) {
+  const isWalking = mode !== "idle" && runAmount > 0.08;
+  const fallbackParts = player.fallback.userData.goalRushFallbackParts as
+    | { body?: THREE.Object3D; head?: THREE.Object3D; leftFoot?: THREE.Object3D; rightFoot?: THREE.Object3D }
+    | undefined;
+
+  if (player.model) {
+    captureTennisLocomotionDefaultPose(player.model);
+    resetTennisLocomotionPose(player.model);
+    player.model.position.set(0, 0, 0);
+    player.model.rotation.set(0, CFG.playerVisualYawFix, 0);
+  }
+  if (fallbackParts) {
+    fallbackParts.leftFoot?.rotation.set(0, 0, 0);
+    fallbackParts.rightFoot?.rotation.set(0, 0, 0);
+    fallbackParts.body?.rotation.set(0, 0, 0);
+    fallbackParts.head?.rotation.set(0, 0, 0);
+    player.fallback.position.y = 0;
+  }
+
+  if (!isWalking) return;
+
+  // Match GoalRush3DUpgrade's human fallback footwork exactly: the same
+  // performance.now cadence, walk/run speed threshold, and opposite foot swing.
+  const speedRatio = clamp01(runAmount);
+  const stride = Math.sin(performance.now() * (speedRatio > 0.72 ? 0.018 : 0.012)) * speedRatio;
+  const bodyRoll = -sideDot * speedRatio * 0.035;
+
+  if (fallbackParts) {
+    if (fallbackParts.leftFoot) fallbackParts.leftFoot.rotation.x = stride * 0.8;
+    if (fallbackParts.rightFoot) fallbackParts.rightFoot.rotation.x = -stride * 0.8;
+    if (fallbackParts.body) fallbackParts.body.rotation.z = bodyRoll;
+    if (fallbackParts.head) fallbackParts.head.rotation.x = 0;
+  }
+
+  if (!player.model) return;
+
+  const leftFoot = tennisPoseBone(player.model, "leftFoot");
+  const rightFoot = tennisPoseBone(player.model, "rightFoot");
+  const leftThigh = tennisPoseBone(player.model, "leftThigh");
+  const rightThigh = tennisPoseBone(player.model, "rightThigh");
+  const leftCalf = tennisPoseBone(player.model, "leftCalf");
+  const rightCalf = tennisPoseBone(player.model, "rightCalf");
+
+  applyTennisRotationOffset(leftFoot, stride * 0.8, 0, 0);
+  applyTennisRotationOffset(rightFoot, -stride * 0.8, 0, 0);
+  applyTennisRotationOffset(leftThigh, stride * 0.42, 0, 0);
+  applyTennisRotationOffset(rightThigh, -stride * 0.42, 0, 0);
+  applyTennisRotationOffset(leftCalf, Math.max(0, -stride) * 0.26, 0, 0);
+  applyTennisRotationOffset(rightCalf, Math.max(0, stride) * 0.26, 0, 0);
+  player.model.rotation.z = bodyRoll;
+}
+
+
+function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, accent: number, theme?: CharacterTheme): HumanRig {
+  const root = new THREE.Group();
+  const modelRoot = new THREE.Group();
+  const fallback = createFallbackHuman(accent);
+  const racket = createRacket(accent);
+
+  root.position.copy(start);
+  modelRoot.position.copy(start);
+  modelRoot.add(fallback);
+  scene.add(root, modelRoot, racket);
+
+  const rig: HumanRig = {
+    side,
+    root,
+    modelRoot,
+    fallback,
+    racket,
+    model: null,
+    bones: {},
+    rest: [],
+    rightArmChain: undefined,
+    leftArmChain: undefined,
+    pos: start.clone(),
+    target: start.clone(),
+    yaw: side === "near" ? 0 : Math.PI,
+    action: "ready",
+    swingT: 0,
+    cooldown: 0,
+    desiredHit: null,
+    hitThisSwing: false,
+    speed: side === "near" ? CFG.playerSpeed : CFG.aiSpeed,
+    walkCycle: 0,
+    yawVelocity: 0,
+  };
+
+  modelRoot.rotation.y = rig.yaw;
+  modelRoot.scale.setScalar(1);
+  fallback.scale.setScalar(CFG.playerHeight / 1.82);
+  racket.scale.setScalar(CFG.worldScale * 1.18);
+  racket.visible = false;
+
+  const modelUrl = theme?.modelUrls?.[0] || theme?.url || HUMAN_URL;
+  new GLTFLoader().setCrossOrigin("anonymous").load(
+    modelUrl,
+    (gltf) => {
+      const model = gltf.scene;
+      normalizeHuman(model, CFG.playerHeight);
+      enhanceTennisCharacterMaterials(model, theme, side);
+      enableShadow(model);
+      rig.model = model;
+      rig.bones = findHumanBones(model);
+      rig.rest = captureRestPose(rig.bones);
+      captureTennisLocomotionDefaultPose(model);
+      rig.fallback.visible = false;
+      model.position.y += 0.08 * CFG.worldScale;
+      rig.modelRoot.add(model);
+      rig.modelRoot.updateMatrixWorld(true);
+      rig.rightArmChain = makeArmChain(rig.bones.rightShoulder, rig.bones.rightUpperArm, rig.bones.rightForeArm, rig.bones.rightHand);
+      rig.leftArmChain = makeArmChain(rig.bones.leftShoulder, rig.bones.leftUpperArm, rig.bones.leftForeArm, rig.bones.leftHand);
+      rig.racket.visible = true;
+    },
+    undefined,
+    () => {
+      rig.fallback.visible = true;
+      rig.racket.visible = false;
+    }
+  );
+
+  return rig;
+}
+
+function createBall() {
+  const tex = new THREE.CanvasTexture(makeBallTexture());
+  tex.colorSpace = THREE.SRGBColorSpace;
+  const mat = new THREE.MeshStandardMaterial({ map: tex, roughness: 0.42, metalness: 0.01 });
+  const mesh = new THREE.Mesh(new THREE.SphereGeometry(CFG.ballR, 32, 24), mat);
+  enableShadow(mesh);
+  return {
+    mesh,
+    pos: new THREE.Vector3(0, 1.18, CFG.courtL / 2 - 1.25),
+    vel: new THREE.Vector3(),
+    spin: 0,
+    lastHitBy: null,
+    bounceSide: null,
+    bounceCount: 0,
+    state: TennisBallState.ServeReady,
+  } as BallState;
+}
+
+function makeBallTexture() {
+  const c = document.createElement("canvas");
+  c.width = 256;
+  c.height = 256;
+  const ctx = c.getContext("2d")!;
+  ctx.fillStyle = "#d7ff35";
+  ctx.fillRect(0, 0, 256, 256);
+  ctx.strokeStyle = "rgba(255,255,255,0.92)";
+  ctx.lineWidth = 18;
+  ctx.beginPath();
+  ctx.arc(62, 128, 92, -Math.PI / 2, Math.PI / 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(194, 128, 92, Math.PI / 2, (Math.PI * 3) / 2);
+  ctx.stroke();
+  return c;
+}
+
+function baseVectors(player: HumanRig) {
+  const forward = forwardFromYaw(player.yaw);
+  const right = rightFromForward(forward);
+  return { forward, right };
+}
+
+function strokePose(player: HumanRig, ball: BallState): StrokePose {
+  const { forward, right } = baseVectors(player);
+  const tRaw = player.swingT > 0 ? clamp01(player.swingT) : 0;
+  const sideSign = player.side === "near" ? 1 : -1;
+  const poseScale = CFG.worldScale;
+  const base = player.pos.clone();
+  const rightShoulder = base.clone().addScaledVector(right, 0.31 * poseScale).addScaledVector(forward, -0.02 * poseScale).setY(1.43 * poseScale);
+  const leftShoulder = base.clone().addScaledVector(right, -0.31 * poseScale).addScaledVector(forward, -0.02 * poseScale).setY(1.43 * poseScale);
+
+  let rightElbow = rightShoulder.clone().addScaledVector(right, 0.24 * poseScale).addScaledVector(forward, -0.15 * poseScale).setY(1.08 * poseScale);
+  let rightHand = rightShoulder.clone().addScaledVector(right, 0.47 * poseScale).addScaledVector(forward, 0.04 * poseScale).setY(0.88 * poseScale);
+  let leftElbow = leftShoulder.clone().addScaledVector(right, -0.18 * poseScale).addScaledVector(forward, 0.0).setY(1.05 * poseScale);
+  let leftHand = leftShoulder.clone().addScaledVector(right, -0.25 * poseScale).addScaledVector(forward, 0.18 * poseScale).setY(0.82 * poseScale);
+  let racketHead = rightHand.clone().addScaledVector(right, 0.1 * poseScale).setY(1.45 * poseScale);
+  let torsoYaw = 0;
+  let torsoLean = 0;
+  let shoulderLift = 0;
+  let wristPronation = 0;
+
+  const isServeReady = ball.lastHitBy === null && player.side === "near" && player.action === "ready";
+  if (player.action === "serve" || isServeReady) {
+    const s = player.action === "serve" ? tRaw : 0;
+    const toss = clamp01(s / 0.34);
+    const trophy = clamp01((s - 0.18) / 0.3);
+    const drop = clamp01((s - 0.45) / 0.2);
+    const contact = clamp01((s - 0.62) / 0.16);
+    const follow = clamp01((s - 0.74) / 0.26);
+
+    torsoYaw = -0.42 * sideSign + 0.72 * contact - 0.34 * follow;
+    torsoLean = -0.08 - 0.2 * trophy + 0.28 * contact;
+    shoulderLift = 0.28 * trophy + 0.32 * contact;
+
+    rightElbow = rightShoulder.clone().addScaledVector(right, lerp(0.34, 0.18, drop) * poseScale).addScaledVector(forward, lerp(-0.28, -0.02, contact) * poseScale).setY((lerp(0.96, 1.55, trophy) - 0.18 * drop + 0.22 * contact) * poseScale);
+    rightHand = rightShoulder.clone().addScaledVector(right, lerp(0.48, 0.24, contact) * poseScale).addScaledVector(forward, lerp(-0.32, 0.46, contact) * poseScale).setY((lerp(0.82, 1.76, trophy) - 0.56 * drop + 0.78 * contact) * poseScale);
+    racketHead = rightHand.clone().addScaledVector(right, lerp(0.1, -0.2, follow) * poseScale).addScaledVector(forward, (lerp(-0.12, 0.52, contact) - 0.22 * follow) * poseScale).setY((lerp(1.34, 2.38, contact) - 0.95 * follow) * poseScale);
+
+    leftElbow = leftShoulder.clone().addScaledVector(right, -0.12 * poseScale).addScaledVector(forward, 0.12 * poseScale).setY((lerp(1.0, 1.7, toss) - 0.68 * contact) * poseScale);
+    leftHand = leftShoulder.clone().addScaledVector(right, -0.16 * poseScale).addScaledVector(forward, 0.28 * poseScale).setY((lerp(0.86, 2.02, toss) - 1.1 * contact) * poseScale);
+
+    if (follow > 0) {
+      rightHand.lerp(base.clone().addScaledVector(right, -0.34 * poseScale).addScaledVector(forward, 0.38 * poseScale).setY(1.07 * poseScale), easeOutCubic(follow));
+      rightElbow.lerp(base.clone().addScaledVector(right, -0.08 * poseScale).addScaledVector(forward, 0.2 * poseScale).setY(1.18 * poseScale), follow);
+      racketHead.lerp(base.clone().addScaledVector(right, -0.58 * poseScale).addScaledVector(forward, 0.18 * poseScale).setY(0.78 * poseScale), easeOutCubic(follow));
+    }
+    wristPronation = 1.2 * contact - 0.55 * follow;
+  } else {
+    const prep = clamp01(tRaw / 0.28);
+    const slot = clamp01((tRaw - 0.18) / 0.26);
+    const contact = clamp01((tRaw - 0.42) / 0.18);
+    const follow = clamp01((tRaw - 0.58) / 0.42);
+    const ballSide = clamp((ball.pos.x - player.pos.x) * 0.9, -0.4 * poseScale, 0.4 * poseScale);
+
+    torsoYaw = -0.52 * prep + 0.88 * contact - 0.25 * follow;
+    torsoLean = -0.1 * prep + 0.08 * contact;
+    shoulderLift = 0.12 * contact;
+
+    const prepHand = rightShoulder.clone().addScaledVector(right, 0.62 * poseScale + ballSide).addScaledVector(forward, -0.35 * poseScale).setY(1.05 * poseScale);
+    const slotHand = rightShoulder.clone().addScaledVector(right, 0.54 * poseScale + ballSide).addScaledVector(forward, -0.05 * poseScale).setY(0.82 * poseScale);
+    const contactHand = player.pos.clone().addScaledVector(right, 0.38 * poseScale + ballSide * 0.45).addScaledVector(forward, 0.72 * poseScale).setY(clamp(ball.pos.y, 0.72 * poseScale, 1.24 * poseScale));
+    const followHand = player.pos.clone().addScaledVector(right, -0.42 * poseScale).addScaledVector(forward, 0.34 * poseScale).setY(1.38 * poseScale);
+
+    rightHand.copy(prepHand).lerp(slotHand, slot).lerp(contactHand, contact).lerp(followHand, follow);
+    rightElbow = rightShoulder.clone().lerp(rightHand, 0.52).addScaledVector(right, 0.1 * poseScale * (1 - follow)).setY((rightShoulder.y + rightHand.y) * 0.5 + 0.12 * poseScale);
+
+    const lagHead = rightHand.clone().addScaledVector(right, 0.35 * poseScale).addScaledVector(forward, -0.26 * poseScale).setY(1.25 * poseScale);
+    const contactHead = ball.pos.clone().addScaledVector(forward, 0.02 * poseScale).setY(clamp(ball.pos.y, 0.74 * poseScale, 1.3 * poseScale));
+    const followHead = player.pos.clone().addScaledVector(right, -0.68 * poseScale).addScaledVector(forward, 0.22 * poseScale).setY(1.56 * poseScale);
+    racketHead.copy(lagHead).lerp(contactHead, contact).lerp(followHead, follow);
+
+    leftElbow = leftShoulder.clone().addScaledVector(right, -0.23 * poseScale).addScaledVector(forward, 0.08 * poseScale).setY((1.08 + 0.12 * follow) * poseScale);
+    leftHand = leftShoulder.clone().addScaledVector(right, (-0.42 + 0.34 * follow) * poseScale).addScaledVector(forward, 0.15 * poseScale).setY((0.92 + 0.46 * follow) * poseScale);
+    wristPronation = 1.15 * contact + 0.25 * follow;
+  }
+
+  return { rightShoulder, rightElbow, rightHand, leftShoulder, leftElbow, leftHand, racketGrip: rightHand.clone(), racketHead, torsoYaw, torsoLean, shoulderLift, wristPronation };
+}
+
+function serveTossPosition(player: HumanRig, tRaw: number) {
+  const { forward, right } = baseVectors(player);
+  const arc = easeOutCubic(clamp01(tRaw / 0.36));
+  return player.pos.clone().addScaledVector(right, -0.18 * CFG.worldScale).addScaledVector(forward, lerp(0.22, 0.46, arc) * CFG.worldScale).setY(lerp(0.96, 2.36, arc) * CFG.worldScale);
+}
+
+function serveContactPosition(player: HumanRig) {
+  const { forward, right } = baseVectors(player);
+  return player.pos.clone().addScaledVector(right, 0.16 * CFG.worldScale).addScaledVector(forward, 0.52 * CFG.worldScale).setY(2.22 * CFG.worldScale);
+}
+
+function serveReadyBallPosition(player: HumanRig) {
+  const { forward, right } = baseVectors(player);
+  return player.pos.clone().addScaledVector(right, -0.14 * CFG.worldScale).addScaledVector(forward, 0.26 * CFG.worldScale).setY(1.12 * CFG.worldScale);
+}
+
+function resetBallForServe(ball: BallState, serverPlayer: HumanRig, serveSide: "deuce" | "ad") {
+  const serveZ = serverPlayer.side === "near" ? CFG.serveNearBaselineZ : -CFG.serveNearBaselineZ;
+  serverPlayer.pos.x = serveXForSide(serverPlayer.side, serveSide);
+  serverPlayer.target.x = serverPlayer.pos.x;
+  serverPlayer.pos.z = serveZ;
+  serverPlayer.target.z = serveZ;
+  serverPlayer.root.position.copy(serverPlayer.pos);
+  serverPlayer.modelRoot.position.copy(serverPlayer.pos);
+  ball.pos.copy(serveReadyBallPosition(serverPlayer));
+  ball.vel.set(0, 0, 0);
+  ball.spin = 0;
+  ball.lastHitBy = null;
+  ball.bounceSide = null;
+  ball.bounceCount = 0;
+  ball.state = TennisBallState.ServeReady;
+  ball.mesh.position.copy(ball.pos);
+}
+
+function setRacketPose(racket: THREE.Group, grip: THREE.Vector3, head: THREE.Vector3, roll: number) {
+  const dir = head.clone().sub(grip).normalize();
+  racket.position.copy(grip);
+  racket.quaternion.setFromUnitVectors(UP, dir);
+  racket.rotateY(roll);
+}
+
+function restoreRestPose(player: HumanRig) {
+  for (const r of player.rest) r.bone.quaternion.copy(r.q);
+}
+
+function updateSkeletonTorso(player: HumanRig, pose: StrokePose) {
+  addLocalRotation(player.bones.spine, pose.torsoLean, pose.torsoYaw * 0.22, pose.torsoYaw * 0.08);
+  addLocalRotation(player.bones.chest, pose.torsoLean * 0.6, pose.torsoYaw * 0.38, pose.torsoYaw * 0.18);
+  addLocalRotation(player.bones.neck, -pose.torsoLean * 0.45, -pose.torsoYaw * 0.18, 0);
+}
+
+function updateModelRigWithCharacterHands(player: HumanRig, pose: StrokePose) {
+  if (!player.model) return false;
+  restoreRestPose(player);
+  updateSkeletonTorso(player, pose);
+
+  const rightSolved = solveTwoBoneArm(player.rightArmChain, pose.rightShoulder, pose.rightElbow, pose.rightHand);
+  const leftSolved = solveTwoBoneArm(player.leftArmChain, pose.leftShoulder, pose.leftElbow, pose.leftHand);
+
+  if (rightSolved) {
+    addLocalRotation(player.bones.rightHand, 0.05, pose.wristPronation, -0.12);
+    addLocalRotation(player.bones.rightForeArm, 0, 0.05, pose.shoulderLift * 0.15);
+    addLocalRotation(player.bones.rightUpperArm, -pose.shoulderLift * 0.08, 0, 0);
+  }
+  if (leftSolved) {
+    addLocalRotation(player.bones.leftForeArm, -0.04, 0, 0.05);
+  }
+  player.modelRoot.updateMatrixWorld(true);
+  return rightSolved;
+}
+
+function updatePoseAndRacket(player: HumanRig, ball: BallState) {
+  const pose = strokePose(player, ball);
+  const handSolved = updateModelRigWithCharacterHands(player, pose);
+
+  if (handSolved && player.bones.rightHand) {
+    const actualGrip = getWorldPos(player.bones.rightHand);
+    const desiredVector = pose.racketHead.clone().sub(pose.racketGrip);
+    setRacketPose(player.racket, actualGrip, actualGrip.clone().add(desiredVector), pose.wristPronation);
+    player.racket.visible = true;
+  } else {
+    player.racket.visible = false;
+  }
+}
+
+function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: number, serve = false) {
+  const flatDist = Math.hypot(target.x - from.x, target.z - from.z);
+  const speedScale = CFG.worldScale * 1.54;
+  const shotPowerTrim = serve ? 0.9 : 0.84;
+  const matchPower = power * CFG.matchPowerMultiplier;
+  const baseSpeed = (serve ? 23.8 + power * 14.8 : 17.2 + power * 12.6) * speedScale * shotPowerTrim * CFG.matchPowerMultiplier;
+  const flight = clamp(flatDist / baseSpeed, serve ? 0.38 : 0.5, serve ? 0.88 : 1.16);
+  const velocity = new THREE.Vector3(
+    (target.x - from.x) / flight,
+    (target.y - from.y + 0.5 * CFG.gravity * flight * flight) / flight,
+    (target.z - from.z) / flight
+  );
+
+  const crossesNet = (from.z > 0 && target.z < 0) || (from.z < 0 && target.z > 0);
+  if (crossesNet && Math.abs(target.z - from.z) > 0.001) {
+    const tToNet = (-from.z / (target.z - from.z)) * flight;
+    if (tToNet > 0 && tToNet < flight) {
+      const yAtNet = from.y + velocity.y * tToNet - 0.5 * CFG.gravity * tToNet * tToNet;
+      const desiredClearance = CFG.netH + CFG.ballR * (serve ? 2.45 : 2.05) + matchPower * 0.22 * CFG.worldScale;
+      if (yAtNet < desiredClearance) {
+        velocity.y += (desiredClearance - yAtNet) / tToNet;
+      }
+    }
+  }
+
+  return velocity;
+}
+
+function makeUserTargetFromSwipe(
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  durationMs: number,
+  isServe: boolean,
+  serveSide: "deuce" | "ad",
+  viewportW = 390,
+  viewportH = 720
+) {
+  const dx = endX - startX;
+  const dy = endY - startY;
+  const dist = Math.hypot(dx, dy);
+  const duration = Math.max(durationMs, 16);
+  const shortAxis = Math.max(1, Math.min(viewportW, viewportH));
+  const longAxis = Math.max(1, Math.max(viewportW, viewportH));
+
+  // Aim is intentionally deterministic: horizontal swipe controls court width,
+  // upward swipe controls depth, and release distance/speed controls power.
+  const lateral = clamp(dx / (shortAxis * 0.42), -1, 1);
+  const forward = clamp((-dy) / (longAxis * 0.44), 0, 1);
+  const travelPower = clamp01(dist / (shortAxis * 0.62));
+  const speedPower = clamp01(((dist / duration) * 1000 - 140) / 1280);
+  const intentPowerLinear = clamp01(travelPower * 0.7 + speedPower * 0.3);
+  // Slight easing gives better low/mid control while preserving max power at full swipes.
+  const intentPower = Math.pow(intentPowerLinear, 0.9);
+  const powerFloorBoost = isServe ? 0.03 : 0.05;
+  const power = clamp(
+    lerp((isServe ? CFG.servePower.min : CFG.shotPower.min) + powerFloorBoost, isServe ? CFG.servePower.max : CFG.shotPower.max, intentPower),
+    isServe ? CFG.servePower.min : CFG.shotPower.min,
+    isServe ? CFG.servePower.max : CFG.shotPower.max
+  );
+
+  let aimX: number;
+  let targetZ: number;
+  if (isServe) {
+    const serveBounds = serveTargetBoundsX(serveSide, "near");
+    const minX = Math.min(serveBounds.min, serveBounds.max);
+    const maxX = Math.max(serveBounds.min, serveBounds.max);
+    const centerX = (minX + maxX) * 0.5;
+    const halfRange = (maxX - minX) * 0.5;
+    aimX = clamp(centerX + lateral * halfRange, minX, maxX);
+    targetZ = lerp(-CFG.serviceLineZ + 0.72 * CFG.worldScale, -CFG.serviceBuffer - 0.48 * CFG.worldScale, forward);
+  } else {
+    const swipeAngle = Math.atan2(-dy, dx);
+    const directionalLateral = Math.cos(swipeAngle);
+    const directionalForward = Math.max(0, Math.sin(swipeAngle));
+    const lateralBlend = clamp(directionalLateral * 0.7 + lateral * 0.3, -1, 1);
+    const forwardBlend = clamp01(directionalForward * 0.75 + forward * 0.25);
+    aimX = clamp(lateralBlend * (CFG.courtW / 2 - 0.52 * CFG.worldScale), -CFG.courtW / 2 + 0.52 * CFG.worldScale, CFG.courtW / 2 - 0.52 * CFG.worldScale);
+    const minimumDepth = lerp(-0.95 * CFG.worldScale, -CFG.serviceLineZ * 0.52, intentPower);
+    const maximumDepth = -CFG.courtL / 2 + 0.78 * CFG.worldScale;
+    targetZ = lerp(minimumDepth, maximumDepth, forwardBlend);
+  }
+
+  return {
+    target: ShotTargeting.clampTarget(new THREE.Vector3(aimX, CFG.ballR, targetZ), "near", isServe),
+    power,
+    technique: ShotTargeting.techniqueFromSwipe(dx, dy),
+    serveSide: isServe ? serveSide : undefined,
+  };
+}
+
+function makeAiTarget(near: HumanRig, ball: BallState): DesiredHit {
+  const pressure = clamp01((Math.abs(ball.pos.z) - 1.0 * CFG.worldScale) / (CFG.courtL / 2 - 1.0 * CFG.worldScale));
+  const stretched = clamp01((Math.abs(ball.pos.x) - CFG.courtW * 0.18) / (CFG.courtW * 0.28));
+  const nearDeep = near.pos.z > CFG.serviceLineZ * 0.72;
+  const openCourtSign = near.pos.x >= 0 ? -1 : 1;
+  const attackable = pressure > 0.48 && stretched < 0.68 && ball.pos.y > CFG.minContactHeight * 1.08;
+  const targetWide = openCourtSign * CFG.courtW * (attackable ? 0.38 : 0.28);
+  const recoveryPunish = Math.abs(near.pos.x) > CFG.courtW * 0.25 ? -Math.sign(near.pos.x) * CFG.courtW * 0.4 : targetWide;
+  const x = clamp(
+    recoveryPunish + clamp(ball.vel.x * 0.065, -0.22 * CFG.worldScale, 0.22 * CFG.worldScale) + (Math.random() - 0.5) * (1 - CFG.aiDifficulty.accuracy) * CFG.worldScale,
+    -CFG.courtW / 2 + 0.48 * CFG.worldScale,
+    CFG.courtW / 2 - 0.48 * CFG.worldScale
+  );
+  const shortReply = stretched > 0.72 || (nearDeep && Math.random() > 0.58);
+  const z = shortReply
+    ? lerp(1.2 * CFG.worldScale, CFG.serviceLineZ * 0.72, Math.random())
+    : lerp(CFG.serviceLineZ * 0.52, CFG.courtL / 2 - 0.92 * CFG.worldScale, 0.38 + pressure * 0.54);
+  const roll = Math.random();
+  const technique: ShotTechnique = shortReply
+    ? (stretched > 0.74 ? "block" : "drop")
+    : stretched > 0.72
+      ? "slice"
+      : attackable && roll > 0.18
+        ? "topspin"
+        : near.pos.z < CFG.serviceLineZ * 0.22 && roll > 0.68
+          ? "lob"
+          : roll > 0.78
+            ? "slice"
+            : "flat";
+  const powerBase = shortReply ? 0.38 : attackable ? 0.66 : 0.54;
+  const power = clamp(powerBase + pressure * 0.14 + CFG.aiDifficulty.power * 0.08, CFG.shotPower.min, CFG.shotPower.max);
+  return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique };
+}
+
+function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = false) {
+  const target = hit.target.clone();
+  if (serve) {
+    const serveBounds = serveTargetBoundsX(hit.serveSide || "deuce", player.side);
+    target.x = clamp(target.x, Math.min(serveBounds.min, serveBounds.max), Math.max(serveBounds.min, serveBounds.max));
+    target.z = player.side === "near"
+      ? clamp(target.z, -CFG.serviceLineZ + 0.55 * CFG.worldScale, -CFG.serviceBuffer - 0.45 * CFG.worldScale)
+      : clamp(target.z, CFG.serviceBuffer + 0.45 * CFG.worldScale, CFG.serviceLineZ - 0.55 * CFG.worldScale);
+  } else {
+    target.x = clamp(target.x, -CFG.courtW / 2 + 0.45, CFG.courtW / 2 - 0.45);
+    target.z = player.side === "near" ? clamp(target.z, -CFG.courtL / 2 + 0.85, -0.8) : clamp(target.z, 0.8, CFG.courtL / 2 - 0.85);
+  }
+
+  if (serve) ball.pos.copy(serveContactPosition(player));
+  else ball.pos.y = clamp(ball.pos.y, 0.58, 1.25);
+
+  ball.vel.copy(ballisticVelocity(ball.pos, target, hit.power, serve));
+  const technique = hit.technique || "flat";
+  if (technique === "lob") {
+    ball.vel.y += (1.85 + hit.power * CFG.matchPowerMultiplier * 0.86) * CFG.worldScale;
+    ball.vel.multiplyScalar(0.86);
+    ball.spin = 0.8 + hit.power * 0.7;
+  } else if (technique === "drop") {
+    ball.vel.multiplyScalar(0.58);
+    ball.vel.y += 0.25;
+    ball.spin = -0.7;
+  } else if (technique === "block") {
+    ball.vel.multiplyScalar(0.72);
+    ball.spin = 0.25;
+  } else if (technique === "topspin") {
+    ball.vel.y += (0.34 + hit.power * CFG.matchPowerMultiplier * 0.3) * CFG.worldScale;
+    ball.spin = 1.1 + hit.power * CFG.matchPowerMultiplier * 1.28;
+  } else if (technique === "slice") {
+    ball.vel.y -= 0.1;
+    ball.spin = -1.25 - hit.power * CFG.matchPowerMultiplier * 0.72;
+  } else {
+    ball.spin = serve ? 0.95 + hit.power * CFG.matchPowerMultiplier * 0.9 : 0.6 + hit.power * CFG.matchPowerMultiplier * 1.25;
+  }
+  ball.lastHitBy = player.side;
+  ball.state = serve ? TennisBallState.ServeHit : (player.side === "near" ? TennisBallState.RacketHitPlayer : TennisBallState.RacketHitAI);
+  ball.bounceSide = null;
+  ball.bounceCount = 0;
+  player.cooldown = serve ? 0.42 : 0.28;
+  player.hitThisSwing = true;
+}
+
+function hasBouncedForReceiver(player: HumanRig, ball: BallState) {
+  return ball.lastHitBy !== null && ball.lastHitBy !== player.side && ball.bounceSide === player.side && ball.bounceCount >= 1;
+}
+
+function canReachBall(player: HumanRig, ball: BallState, requireBounce = true) {
+  if (player.cooldown > 0) return false;
+  if (sideOfZ(ball.pos.z) !== player.side && ball.lastHitBy !== null) return false;
+  if (requireBounce && !hasBouncedForReceiver(player, ball)) return false;
+  if (ball.pos.y < 0.16 * CFG.worldScale || ball.pos.y > 1.62 * CFG.playerHeight / 1.82) return false;
+  const pose = strokePose(player, ball);
+  const dx = ball.pos.x - pose.racketHead.x;
+  const dy = ball.pos.y - pose.racketHead.y;
+  const dz = ball.pos.z - pose.racketHead.z;
+  const racketRadius = 0.48 * CFG.playerHeight / 1.82;
+  const racketNear = dx * dx + dy * dy * 0.45 + dz * dz < racketRadius * racketRadius;
+  const bodyDx = ball.pos.x - player.pos.x;
+  const bodyDz = ball.pos.z - player.pos.z;
+  return racketNear || bodyDx * bodyDx + bodyDz * bodyDz < CFG.reach * CFG.reach;
+}
+
+function startSwing(player: HumanRig, desiredHit: DesiredHit, action: StrokeAction) {
+  player.action = action;
+  player.swingT = 0.001;
+  player.desiredHit = desiredHit;
+  player.hitThisSwing = false;
+}
+
+function updatePlayerMotion(player: HumanRig, ball: BallState, dt: number) {
+  const previousPos = player.pos.clone();
+  const to = player.target.clone().sub(player.pos);
+  const dist = to.length();
+  const maxStep = player.speed * dt;
+  if (dist > 0.0001) player.pos.addScaledVector(to.normalize(), Math.min(maxStep, dist));
+
+  PlayerController.clampMovement(player.pos, player.side);
+  const actualStep = player.pos.distanceTo(previousPos);
+  const actualSpeed = actualStep / Math.max(0.0001, dt);
+
+  let face: THREE.Vector3;
+  if (ball.lastHitBy === null && player.side === "near") face = new THREE.Vector3(0.22, 0, -1).normalize();
+  else face = ball.pos.clone().sub(player.pos).setY(0);
+  if (face.lengthSq() < 0.02) face.set(0, 0, player.side === "near" ? -1 : 1);
+  face.normalize();
+
+  const targetYaw = yawFromForward(face);
+  let delta = targetYaw - player.yaw;
+  while (delta > Math.PI) delta -= Math.PI * 2;
+  while (delta < -Math.PI) delta += Math.PI * 2;
+  const yawStep = delta * (1 - Math.exp(-8 * dt));
+  player.yaw += yawStep;
+  player.yawVelocity = yawStep / Math.max(0.0001, dt);
+
+  player.root.position.copy(player.pos);
+  player.modelRoot.position.copy(player.pos);
+  player.modelRoot.rotation.y = player.yaw;
+
+  const runAmount = clamp01(actualSpeed / Math.max(0.0001, player.speed));
+  const moveDir = actualStep > 0.0001 ? player.pos.clone().sub(previousPos).normalize() : new THREE.Vector3();
+  const localForward = forwardFromYaw(player.yaw);
+  const localRight = rightFromForward(localForward);
+  const forwardDot = moveDir.dot(localForward);
+  const sideDot = moveDir.dot(localRight);
+  const footwork = PlayerController.footworkFromDelta(player.pos.x - previousPos.x, player.pos.z - previousPos.z, player.side, player.action === "ready" ? null : player.action);
+  const canUseLocomotion = ball.lastHitBy !== null && player.action === "ready" && actualStep > 0.001 * CFG.worldScale;
+  const mode: TennisLocomotionMode = !canUseLocomotion
+    ? "idle"
+    : Math.abs(sideDot) > Math.abs(forwardDot) * 0.72 || footwork === "MoveLeft" || footwork === "MoveRight"
+      ? "shuffle"
+      : forwardDot < -0.2 || footwork === "MoveBack"
+        ? "backpedal"
+        : "forward";
+  applyGoalRushStyleTennisWalk(player, mode, canUseLocomotion ? runAmount : 0, sideDot);
+
+  player.cooldown = Math.max(0, player.cooldown - dt);
+  if (player.swingT > 0) {
+    const duration = player.action === "serve" ? CFG.serveDuration : CFG.swingDuration;
+    player.swingT += dt / duration;
+    if (player.swingT >= 1) {
+      player.swingT = 0;
+      player.action = "ready";
+      player.desiredHit = null;
+      player.hitThisSwing = false;
+    }
+  }
+}
+
+function predictLanding(ball: BallState) {
+  const p = ball.pos.clone();
+  const v = ball.vel.clone();
+  let spin = ball.spin;
+  const dt = 1 / 45;
+  for (let i = 0; i < 95; i++) {
+    v.y -= CFG.gravity * (1 + Math.max(0, spin) * 0.12) * dt;
+    v.multiplyScalar(Math.exp(-CFG.airDrag * dt));
+    spin *= Math.exp(-1.25 * dt);
+    p.addScaledVector(v, dt);
+    if (p.y <= CFG.ballR) return p.setY(CFG.ballR);
+  }
+  return p;
+}
+
+type ReceiverPlayPrediction = { landing: THREE.Vector3; contact: THREE.Vector3; footTarget: THREE.Vector3; postBounce: boolean; contactOffsetX: number };
+
+function predictReceiverPlay(ball: BallState, side: PlayerSide): ReceiverPlayPrediction {
+  const p = ball.pos.clone();
+  const v = ball.vel.clone();
+  let spin = ball.spin;
+  const dt = 1 / 90;
+  const backSign = side === "near" ? 1 : -1;
+  let landing: THREE.Vector3 | null = null;
+  let postBounce = false;
+  let contact: THREE.Vector3 | null = null;
+
+  for (let i = 0; i < 260; i++) {
+    const spinDip = Math.max(0, spin) * 0.11;
+    const spinLift = Math.max(0, -spin) * 0.035;
+    v.y -= CFG.gravity * (1 + spinDip - spinLift) * dt;
+    if (ball.lastHitBy && Math.abs(v.z) > 0.001) {
+      const forwardSign = ball.lastHitBy === "near" ? -1 : 1;
+      v.z += forwardSign * spin * 0.14 * CFG.worldScale * dt;
+      v.x += Math.sin(spin * 0.65) * 0.022 * CFG.worldScale * dt;
+    }
+    v.multiplyScalar(Math.exp(-CFG.airDrag * dt));
+    p.addScaledVector(v, dt);
+    spin *= Math.exp(-1.25 * dt);
+
+    if (p.y <= CFG.ballR && v.y < 0) {
+      p.y = CFG.ballR;
+      if (!landing) landing = p.clone();
+      const forwardSign = ball.lastHitBy === "near" ? -1 : ball.lastHitBy === "far" ? 1 : Math.sign(v.z || 1);
+      const forwardSpeed = Math.max(0, Math.abs(v.z) * CFG.groundFriction + Math.max(-1.1, Math.min(1.1, spin)) * 0.08 * CFG.worldScale);
+      v.y = Math.max(0.18 * CFG.worldScale, -v.y * CFG.bounceRestitution * clamp(1 - Math.max(0, spin) * 0.03, 0.84, 1.04));
+      v.x = v.x * CFG.groundFriction + Math.sign(v.x || Math.sin(spin) || 1) * Math.min(Math.abs(spin) * 0.022 * CFG.worldScale, 0.09 * CFG.worldScale);
+      v.z = forwardSign * forwardSpeed;
+      spin *= -0.32;
+      postBounce = true;
+    }
+
+    const onReceiverSide = side === "near" ? p.z > CFG.serviceBuffer * 0.5 : p.z < -CFG.serviceBuffer * 0.5;
+    if (postBounce && onReceiverSide && p.y >= CFG.minContactHeight * 0.86 && p.y <= CFG.maxContactHeight * 0.96) {
+      contact = p.clone();
+      break;
+    }
+  }
+
+  const fallbackLanding = landing ?? predictLanding(ball);
+  const contactPoint = contact ?? fallbackLanding.clone().setY(clamp(CFG.minContactHeight * 1.05, CFG.ballR, CFG.maxContactHeight));
+  const rawContactOffsetX = clamp(v.x * 0.22, -0.34 * CFG.worldScale, 0.34 * CFG.worldScale);
+  // Keep the hitter visually offset to the left/right of the ball (portrait screen),
+  // so the racket arm reaches out instead of getting jammed straight behind the ball.
+  const contactOffsetX = Math.abs(rawContactOffsetX) > 0.08 * CFG.worldScale
+    ? rawContactOffsetX
+    : (contactPoint.x >= 0 ? 1 : -1) * 0.14 * CFG.worldScale;
+  const footTarget = new THREE.Vector3(
+    clamp(contactPoint.x - contactOffsetX, -CFG.courtW / 2 + 0.38 * CFG.worldScale, CFG.courtW / 2 - 0.38 * CFG.worldScale),
+    0,
+    clamp(
+      contactPoint.z + backSign * 1.18 * CFG.worldScale,
+      side === "near" ? 0.82 * CFG.worldScale : -CFG.courtL / 2 + 0.72 * CFG.worldScale,
+      side === "near" ? CFG.courtL / 2 - 0.58 * CFG.worldScale : -0.82 * CFG.worldScale
+    )
+  );
+  return { landing: fallbackLanding, contact: contactPoint, footTarget, postBounce, contactOffsetX };
+}
+
+export default function MobileThreeTennisPrototype() {
+  const { search } = useLocation();
+  const query = new URLSearchParams(search);
+  const playerName = query.get("name") || "You";
+  const playerAvatar = query.get("avatar") || "";
+  const rivalName = query.get("mode") === "online" ? "Opponent" : "AI";
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [hud, setHud] = useState<HudState>({ nearScore: 0, farScore: 0, nearSets: 0, farSets: 0, status: "Swipe up to serve", power: 0 });
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [selectedHumanCharacterId, setSelectedHumanCharacterId] = useState(() => localStorage.getItem("tennisSelectedHumanCharacter") || MURLAN_CHARACTER_THEMES[0]?.id || "rpm-current");
+  const tennisPoint = (score: number) => ["0", "15", "30", "40", "Ad"][Math.min(score, 4)];
+  const hudRef = useRef(hud);
+  const controlRef = useRef<ControlState>({ active: false, pointerId: null, startX: 0, startY: 0, lastX: 0, lastY: 0, startPlayer: new THREE.Vector3(), startTs: 0, lastTs: 0 });
+
+  useEffect(() => { hudRef.current = hud; }, [hud]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    const canvas = canvasRef.current;
+    if (!host || !canvas) return;
+
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: false });
+    renderer.setClearColor(0x07100c, 1);
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.38;
+    const scene = new THREE.Scene();
+    scene.fog = null;
+
+    const camera = new THREE.PerspectiveCamera(44, 1, 0.05, Math.max(70, CFG.courtL * 1.8));
+    const cameraTarget = new THREE.Vector3(0, 1.72 * CFG.cameraViewScale, -2.8 * CFG.cameraViewScale);
+    const cameraOffset = new THREE.Vector3(0, 10.45 * CFG.cameraViewScale, 17.35 * CFG.cameraViewScale);
+    const cameraPosTarget = new THREE.Vector3();
+
+    addTrainingCourtLighting(scene);
+    const courtVisual = addCourt(scene, { hideFloor: false });
+    addOnlineCourtEnvironmentAssets(scene);
+    const updateBillboards = () => {};
+
+    const nearHuman = MURLAN_CHARACTER_THEMES.find((c) => c.id === selectedHumanCharacterId) || MURLAN_CHARACTER_THEMES[0];
+    const aiPool = MURLAN_CHARACTER_THEMES.filter((c) => c.id !== nearHuman?.id);
+    const aiHuman = (aiPool.length ? aiPool : MURLAN_CHARACTER_THEMES)[Math.floor(Math.random() * (aiPool.length ? aiPool.length : MURLAN_CHARACTER_THEMES.length))];
+    const nearPlayer = addHuman(scene, "near", new THREE.Vector3(0, 0, CFG.courtL / 2 - 1.04), 0xff7a2f, nearHuman);
+    const farPlayer = addHuman(scene, "far", new THREE.Vector3(0, 0, -CFG.courtL / 2 + 1.04), 0x62d2ff, aiHuman);
+    const ball = createBall();
+    scene.add(ball.mesh);
+    const courtRules = new CourtRules();
+    const ballController = new BallController(courtRules);
+    const scoreManager = new ScoreManager();
+    const serveController = new ServeController();
+    const aiController = new AIController();
+    const cameraController = new CameraController();
+    const audioVfx = new AudioVFXManager();
+    let currentServeSide: "deuce" | "ad" = scoreManager.snapshot().serveSide;
+    let firstServeAttempt = true;
+    let awaitingServeResult = false;
+    let lastShotLabel = "";
+    resetBallForServe(ball, nearPlayer, currentServeSide);
+    serveController.start("near", currentServeSide);
+    let netShakeT = 0;
+
+    const ghost = new THREE.Mesh(
+      new THREE.RingGeometry(0.25, 0.32, 36),
+      new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.42, side: THREE.DoubleSide })
+    );
+    ghost.rotation.x = -Math.PI / 2;
+    ghost.position.copy(nearPlayer.target).setY(0.07);
+    scene.add(ghost);
+
+    const landingMarker = new THREE.Mesh(
+      new THREE.RingGeometry(0.18, 0.24, 40),
+      new THREE.MeshBasicMaterial({ color: 0xd7ff35, transparent: true, opacity: 0, side: THREE.DoubleSide, depthWrite: false })
+    );
+    landingMarker.rotation.x = -Math.PI / 2;
+    landingMarker.position.set(0, 0.075, 0);
+    scene.add(landingMarker);
+
+    let frameId = 0;
+    let last = performance.now();
+    let pointLock = false;
+    let pointLockT = 0;
+    let replayText = "";
+    let replayT = 0;
+
+    const setHudSafe = (patch: Partial<HudState>) => setHud((prev) => ({ ...prev, ...patch }));
+    setHudSafe({ nearLabel: "0", farLabel: "0", nearGames: 0, farGames: 0, nearSets: 0, farSets: 0, inTiebreak: false, server: "near", serveSide: currentServeSide, firstServe: true });
+
+    const awardPoint = (winner: PlayerSide, reason: PointReason) => {
+      if (pointLock) return;
+      pointLock = true;
+      pointLockT = 0.9;
+      ball.state = TennisBallState.PointEnded;
+      awaitingServeResult = false;
+      const score = scoreManager.awardPoint(winner);
+      currentServeSide = score.serveSide;
+      firstServeAttempt = true;
+      serveController.start(score.server, currentServeSide);
+      const reasonText = reason === "doubleFault" ? "Double Fault" : reason === "serviceFault" ? "Service fault" : reason === "out" ? "Out" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net" : "Point";
+      const gameText = score.gameWonBy ? ` · Game ${score.gameWonBy === "near" ? "You" : "AI"}` : "";
+      const setText = score.setWonBy ? ` · Set ${score.setWonBy === "near" ? "You" : "AI"}` : "";
+      replayText = `Replay: ${reasonText} — ${winner === "near" ? "You" : "AI"} scores${gameText}${setText}`;
+      replayT = 1.7;
+      audioVfx.play("point");
+      setHud({
+        ...hudRef.current,
+        nearScore: score.points.near,
+        farScore: score.points.far,
+        nearLabel: score.label.near,
+        farLabel: score.label.far,
+        nearGames: score.games.near,
+        farGames: score.games.far,
+        nearSets: score.sets.near,
+        farSets: score.sets.far,
+        inTiebreak: score.inTiebreak,
+        server: score.server,
+        serveSide: score.serveSide,
+        firstServe: true,
+        status: `${reasonText}: ${winner === "near" ? "You" : "AI"} scores${gameText}${setText}`,
+        power: 0,
+      });
+    };
+
+    const resize = () => {
+      const w = Math.max(1, host.clientWidth);
+      const h = Math.max(1, host.clientHeight);
+      renderer.setSize(w, h, false);
+      renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
+      camera.aspect = w / h;
+      camera.fov = camera.aspect < 0.72 ? 52 : 46;
+      if (camera.aspect < 0.72) cameraOffset.set(0, 7.95 * CFG.cameraViewScale, 12.95 * CFG.cameraViewScale);
+      else cameraOffset.set(0, 7.35 * CFG.cameraViewScale, 11.85 * CFG.cameraViewScale);
+      cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
+      camera.position.copy(cameraPosTarget);
+      camera.lookAt(cameraTarget);
+      camera.updateProjectionMatrix();
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (controlRef.current.active) return;
+      canvas.setPointerCapture(e.pointerId);
+      controlRef.current = {
+        active: true,
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        lastX: e.clientX,
+        lastY: e.clientY,
+        startPlayer: nearPlayer.target.clone(),
+        startTs: performance.now(),
+        lastTs: performance.now(),
+      };
+      setHudSafe({ status: ball.lastHitBy === null ? "Hold, aim serve, release" : "Drag to move, release to swing", power: 0 });
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      const control = controlRef.current;
+      if (!control.active || control.pointerId !== e.pointerId) return;
+      control.lastX = e.clientX;
+      control.lastY = e.clientY;
+      control.lastTs = performance.now();
+      const dx = e.clientX - control.startX;
+      const dy = e.clientY - control.startY;
+      nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.012, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
+      const minZ = ball.lastHitBy === null ? CFG.serveNearBaselineZ : 0.76;
+      if (ball.lastHitBy === null) {
+        const lane = serveLaneBoundsX(currentServeSide, "near");
+        nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.012, Math.min(lane.min, lane.max), Math.max(lane.min, lane.max));
+      }
+      nearPlayer.target.z = clamp(control.startPlayer.z + dy * 0.012, minZ, CFG.courtL / 2 - 0.42);
+      setHudSafe({ power: clamp01(Math.hypot(dx, dy) / 185) });
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      const control = controlRef.current;
+      if (!control.active || control.pointerId !== e.pointerId) return;
+      try { canvas.releasePointerCapture(e.pointerId); } catch {}
+      control.active = false;
+      control.pointerId = null;
+      const isServe = ball.lastHitBy === null && scoreManager.snapshot().server === "near";
+      if (ball.lastHitBy === null && scoreManager.snapshot().server !== "near") return;
+      const endTs = performance.now();
+      const hit = makeUserTargetFromSwipe(control.startX, control.startY, e.clientX, e.clientY, Math.max(16, endTs - control.startTs), isServe, currentServeSide, canvas.clientWidth, canvas.clientHeight);
+      startSwing(nearPlayer, hit, isServe ? "serve" : "forehand");
+      setHudSafe({ status: isServe ? "Serve motion" : "Forehand swing", power: 0 });
+    };
+
+    canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("pointercancel", onPointerUp);
+    window.addEventListener("resize", resize);
+    resize();
+
+    function currentServerPlayer() {
+      return scoreManager.snapshot().server === "near" ? nearPlayer : farPlayer;
+    }
+
+    function updateServeTossLock() {
+      if (ball.lastHitBy !== null) return false;
+      const serverPlayer = currentServerPlayer();
+      const preparingServe = serverPlayer.action === "ready" || serverPlayer.swingT <= 0;
+      if (preparingServe) {
+        ball.pos.copy(serveReadyBallPosition(serverPlayer));
+        ball.vel.set(0, 0, 0);
+        ball.spin = 0;
+        ball.mesh.position.copy(ball.pos);
+        return true;
+      }
+      const serving = serverPlayer.action === "serve" && serverPlayer.swingT > 0 && !serverPlayer.hitThisSwing;
+      if (!serving) return false;
+      if (serverPlayer.swingT < CFG.serveContactT) {
+        ball.pos.copy(serveTossPosition(serverPlayer, serverPlayer.swingT));
+        ball.vel.set(0, 0, 0);
+        ball.spin = 0;
+        ball.mesh.position.copy(ball.pos);
+        return true;
+      }
+      return false;
+    }
+
+    function updateBall(dt: number) {
+      const prevZ = ball.pos.z;
+      const spinDip = Math.max(0, ball.spin) * 0.11;
+      const spinLift = Math.max(0, -ball.spin) * 0.035;
+      ball.vel.y -= CFG.gravity * (1 + spinDip - spinLift) * dt;
+      if (ball.lastHitBy && Math.abs(ball.vel.z) > 0.001) {
+        const forwardSign = ball.lastHitBy === "near" ? -1 : 1;
+        ball.vel.z += forwardSign * ball.spin * 0.14 * CFG.worldScale * dt;
+        ball.vel.x += Math.sin(ball.spin * 0.65) * 0.022 * CFG.worldScale * dt;
+      }
+      ball.vel.multiplyScalar(Math.exp(-CFG.airDrag * dt));
+      ball.pos.addScaledVector(ball.vel, dt);
+      ball.spin *= Math.exp(-1.25 * dt);
+
+      if (ball.vel.length() > 0.02) {
+        const rollAxis = new THREE.Vector3(ball.vel.z, 0, -ball.vel.x);
+        if (rollAxis.lengthSq() > 0.0001) ball.mesh.rotateOnWorldAxis(rollAxis.normalize(), (ball.vel.length() / CFG.ballR) * dt);
+      }
+
+      const crossesNet = (prevZ > 0 && ball.pos.z <= 0) || (prevZ < 0 && ball.pos.z >= 0) || Math.abs(ball.pos.z) < 0.055;
+      if (crossesNet && Math.abs(ball.pos.x) <= CFG.doublesW / 2 + 0.1 && ball.pos.y < CFG.netH + CFG.ballR * 0.6 && ball.lastHitBy) {
+        const incoming = ball.vel.clone();
+        const outgoing = incoming.multiplyScalar(0.2); // 80% power loss on net impact
+        outgoing.z = Math.sign(outgoing.z || (ball.lastHitBy === "near" ? -1 : 1)) * Math.max(0.4, Math.abs(outgoing.z));
+        outgoing.y = Math.max(0.45, Math.abs(outgoing.y) + 0.2);
+        ball.vel.copy(outgoing);
+        ball.pos.z = ball.lastHitBy === "near" ? -0.12 : 0.12;
+        netShakeT = 0.45;
+        audioVfx.play("net");
+        awardPoint(opposite(ball.lastHitBy), "net");
+      }
+
+      if (ball.pos.y <= CFG.ballR) {
+        ball.pos.y = CFG.ballR;
+        if (ball.vel.y < 0) {
+          const forwardSign = ball.lastHitBy === "near" ? -1 : ball.lastHitBy === "far" ? 1 : Math.sign(ball.vel.z || 1);
+          const spinKick = clamp(ball.spin, -1.1, 1.1) * 0.08 * CFG.worldScale;
+          const forwardSpeed = Math.max(0.04 * CFG.worldScale, Math.abs(ball.vel.z) * CFG.groundFriction + spinKick);
+          ball.vel.y = Math.max(0.18 * CFG.worldScale, -ball.vel.y * CFG.bounceRestitution);
+          ball.vel.x = ball.vel.x * CFG.groundFriction + Math.sign(ball.vel.x || Math.sin(ball.spin) || 1) * Math.min(Math.abs(ball.spin) * 0.022 * CFG.worldScale, 0.09 * CFG.worldScale);
+          ball.vel.z = forwardSign * forwardSpeed;
+          ball.vel.y *= clamp(1 - Math.max(0, ball.spin) * 0.03, 0.84, 1.04);
+          ball.spin *= -0.32;
+          const bounceSide = sideOfZ(ball.pos.z);
+          audioVfx.play("bounce");
+          if (ball.bounceSide === bounceSide) ball.bounceCount += 1;
+          else {
+            ball.bounceSide = bounceSide;
+            ball.bounceCount = 1;
+          }
+          const isServeBall = awaitingServeResult && ball.lastHitBy !== null && ball.bounceCount === 1;
+          const serveHitter = isServeBall ? ball.lastHitBy : null;
+          if (serveHitter && !courtRules.isInsideServiceBox(ball.pos, serveHitter, currentServeSide)) {
+            if (firstServeAttempt) {
+              firstServeAttempt = false;
+              pointLock = false;
+              pointLockT = 0;
+              serveController.markFault();
+              setHudSafe({ status: "Fault. Second serve", firstServe: false });
+              nearPlayer.action = "ready";
+              farPlayer.action = "ready";
+              resetBallForServe(ball, serveHitter === "near" ? nearPlayer : farPlayer, currentServeSide);
+              return;
+            } else {
+              serveController.markFault();
+              awardPoint(opposite(serveHitter), "doubleFault");
+              return;
+            }
+          }
+          if (isServeBall) {
+            awaitingServeResult = false;
+            serveController.markValid();
+            setHudSafe({ status: "Serve in. Rally!", firstServe: true });
+          }
+          const outsideX = Math.abs(ball.pos.x) > CFG.courtW / 2;
+          const outsideZ = Math.abs(ball.pos.z) > CFG.courtL / 2;
+          if (!isServeBall && (outsideX || outsideZ) && ball.lastHitBy) awardPoint(opposite(ball.lastHitBy), "out");
+          else if (!isServeBall && ball.bounceCount > 1) awardPoint(opposite(bounceSide), "doubleBounce");
+        }
+      }
+
+      if ((Math.abs(ball.pos.x) > CFG.courtW / 2 + 3.2 * CFG.worldScale || Math.abs(ball.pos.z) > CFG.courtL / 2 + 3.2 * CFG.worldScale || ball.pos.y < -1.2) && ball.lastHitBy) awardPoint(opposite(ball.lastHitBy), "out");
+      if (ball.vel.length() < CFG.minBallSpeed && ball.pos.y <= CFG.ballR + 0.002 && ball.lastHitBy) awardPoint(opposite(sideOfZ(ball.pos.z)), "doubleBounce");
+      ball.mesh.position.copy(ball.pos);
+    }
+
+    function updateNearAutoChase(landing: THREE.Vector3, dt: number) {
+      if (!CFG.playerAutoChase.enabled || controlRef.current.active || pointLock) return;
+      if (ball.lastHitBy === null) return;
+      if (nearPlayer.swingT > 0) return;
+
+      const ballComingToHuman = ball.lastHitBy === "far" && (ball.pos.z > -0.35 * CFG.worldScale || landing.z > 0);
+      if (!ballComingToHuman) {
+        const home = new THREE.Vector3(0, 0, CFG.courtL / 2 - 1.18 * CFG.worldScale);
+        nearPlayer.target.lerp(home, 1 - Math.exp(-1.45 * dt));
+        PlayerController.clampMovement(nearPlayer.target, "near");
+        return;
+      }
+
+      const play = predictReceiverPlay(ball, "near");
+      nearPlayer.target.lerp(play.footTarget, 1 - Math.exp(-CFG.playerAutoChase.maxBlendPerSecond * dt));
+      PlayerController.clampMovement(nearPlayer.target, "near");
+    }
+
+    function updateAi() {
+      const landing = predictLanding(ball);
+      const aiHomeZ = scoreManager.snapshot().server === "far" && ball.lastHitBy === null ? -CFG.serveNearBaselineZ : -CFG.courtL / 2 + 1.2 * CFG.worldScale;
+      const home = new THREE.Vector3(0, 0, aiHomeZ);
+
+      if (ball.lastHitBy === null && scoreManager.snapshot().server === "far") {
+        farPlayer.target.copy(home);
+        if (farPlayer.swingT === 0 && farPlayer.cooldown <= 0) {
+          startSwing(farPlayer, { ...aiController.chooseServeTarget(currentServeSide, "far"), serveSide: currentServeSide }, "serve");
+          setHudSafe({ status: "AI serve" });
+        }
+        return;
+      }
+
+      const ballComingToAi = ball.lastHitBy === "near" && (ball.pos.z < 0.65 * CFG.worldScale || landing.z < 0);
+      if (ballComingToAi) {
+        const play = predictReceiverPlay(ball, "far");
+        farPlayer.target.copy(play.footTarget);
+      } else {
+        farPlayer.target.lerp(home, 0.035);
+      }
+
+      if (ballComingToAi && hasBouncedForReceiver(farPlayer, ball) && canReachBall(farPlayer, ball) && farPlayer.swingT === 0) {
+        startSwing(farPlayer, makeAiTarget(nearPlayer, ball), "forehand");
+      }
+    }
+
+    function checkSwingHits() {
+      for (const player of [nearPlayer, farPlayer]) {
+        if (player.swingT <= 0 || player.hitThisSwing || !player.desiredHit) continue;
+        if (player.action === "serve") {
+          if (player.swingT >= CFG.serveContactT) {
+            performHit(player, ball, player.desiredHit, true);
+            awaitingServeResult = true;
+            serveController.markContact();
+            audioVfx.play("racket");
+            setHudSafe({ status: "Serve!", firstServe: firstServeAttempt });
+          }
+          continue;
+        }
+        const isAi = player.side === "far";
+        const hitStart = isAi ? Math.max(0.3, CFG.timingWindow.start - 0.12) : CFG.timingWindow.start;
+        const hitEnd = isAi ? Math.min(0.88, CFG.timingWindow.end + 0.14) : CFG.timingWindow.end;
+        if (player.swingT < hitStart || player.swingT > hitEnd) continue;
+        if (canReachBall(player, ball)) {
+          performHit(player, ball, player.desiredHit, false);
+          audioVfx.play("racket");
+          const sideLabel = ball.pos.x < player.pos.x ? "Backhand" : "Forehand";
+          lastShotLabel = `${sideLabel} ${player.desiredHit.technique || "flat"}`;
+          setHudSafe({ status: player.side === "near" ? `${lastShotLabel} return` : `AI ${lastShotLabel}` });
+        }
+      }
+    }
+
+    function animate() {
+      frameId = requestAnimationFrame(animate);
+      const now = performance.now();
+      const dt = Math.min(0.033, (now - last) / 1000);
+      last = now;
+
+      if (replayT > 0) {
+        replayT -= dt;
+        if (replayT > 0.05) setHudSafe({ status: replayText });
+      }
+
+      if (pointLock) {
+        pointLockT -= dt;
+        if (pointLockT <= 0) {
+          pointLock = false;
+          nearPlayer.action = "ready";
+          farPlayer.action = "ready";
+          nearPlayer.target.set(0, 0, CFG.courtL / 2 - 1.04);
+          farPlayer.target.set(0, 0, -CFG.courtL / 2 + 1.04);
+          currentServeSide = scoreManager.snapshot().serveSide;
+          const serverPlayer = scoreManager.snapshot().server === "near" ? nearPlayer : farPlayer;
+          resetBallForServe(ball, serverPlayer, currentServeSide);
+          serveController.start(scoreManager.snapshot().server, currentServeSide);
+          setHudSafe({ status: scoreManager.snapshot().server === "near" ? (firstServeAttempt ? "Swipe up to serve from behind the baseline" : "Second serve") : "AI preparing serve", power: 0, serveSide: currentServeSide, firstServe: firstServeAttempt, server: scoreManager.snapshot().server, inTiebreak: scoreManager.snapshot().inTiebreak });
+        }
+      } else {
+        ballController.accumulator = Math.min(ballController.accumulator + dt, CFG.fixedTimeStep * CFG.maxPhysicsSteps);
+        let steps = 0;
+        while (ballController.accumulator >= CFG.fixedTimeStep && steps < CFG.maxPhysicsSteps) {
+          updateAi();
+          const ballLockedByServe = updateServeTossLock();
+          checkSwingHits();
+          if (!ballLockedByServe || ball.lastHitBy !== null) updateBall(CFG.fixedTimeStep);
+          ballController.accumulator -= CFG.fixedTimeStep;
+          steps += 1;
+        }
+      }
+
+      const predictedLanding = predictLanding(ball);
+      updateNearAutoChase(predictedLanding, dt);
+
+      updatePlayerMotion(nearPlayer, ball, dt);
+      updatePlayerMotion(farPlayer, ball, dt);
+      updatePoseAndRacket(nearPlayer, ball);
+      updatePoseAndRacket(farPlayer, ball);
+
+      if (netShakeT > 0) {
+        netShakeT = Math.max(0, netShakeT - dt);
+        const k = netShakeT / 0.45;
+        const wobble = Math.sin((0.45 - netShakeT) * 55) * 0.05 * k;
+        courtVisual.netBody.scale.z = 1 + Math.abs(wobble) * 1.6;
+        courtVisual.netBody.position.z = wobble;
+      } else {
+        courtVisual.netBody.scale.z += (1 - courtVisual.netBody.scale.z) * (1 - Math.exp(-10 * dt));
+        courtVisual.netBody.position.z += (0 - courtVisual.netBody.position.z) * (1 - Math.exp(-10 * dt));
+      }
+
+      ghost.position.x += (nearPlayer.target.x - ghost.position.x) * (1 - Math.exp(-12 * dt));
+      ghost.position.z += (nearPlayer.target.z - ghost.position.z) * (1 - Math.exp(-12 * dt));
+      (ghost.material as THREE.MeshBasicMaterial).opacity = controlRef.current.active ? 0.62 : 0.28;
+
+      const landingUseful = ball.lastHitBy !== null && ball.vel.lengthSq() > 0.25 && predictedLanding.y <= CFG.ballR + 0.05 && Math.abs(predictedLanding.x) <= CFG.courtW / 2 + 0.6 && Math.abs(predictedLanding.z) <= CFG.courtL / 2 + 0.8;
+      landingMarker.position.set(clamp(predictedLanding.x, -CFG.courtW / 2, CFG.courtW / 2), 0.078, clamp(predictedLanding.z, -CFG.courtL / 2, CFG.courtL / 2));
+      (landingMarker.material as THREE.MeshBasicMaterial).opacity += ((landingUseful ? 0.55 : 0) - (landingMarker.material as THREE.MeshBasicMaterial).opacity) * (1 - Math.exp(-10 * dt));
+
+      const preServe = ball.lastHitBy === null;
+      cameraController.update(camera, cameraTarget, cameraPosTarget, nearPlayer.target, ball.pos, cameraOffset, preServe, dt, {
+        incomingSide: ball.lastHitBy === "far" ? "near" : ball.lastHitBy === "near" ? "far" : null,
+        predictedLanding,
+      });
+      updateBillboards();
+      renderer.render(scene, camera);
+    }
+
+    animate();
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener("resize", resize);
+      canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("pointercancel", onPointerUp);
+      renderer.dispose();
+      scene.traverse((obj) => {
+        const mesh = obj as THREE.Mesh;
+        if (mesh.isMesh) {
+          mesh.geometry?.dispose?.();
+          const mat = mesh.material as THREE.Material | THREE.Material[];
+          if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+          else mat?.dispose?.();
+        }
+      });
+    };
+  }, [selectedHumanCharacterId]);
+
+  useEffect(() => {
+    localStorage.setItem("tennisSelectedHumanCharacter", selectedHumanCharacterId);
+  }, [selectedHumanCharacterId]);
+
+
+  return (
+    <div style={{ position: "fixed", inset: 0, overflow: "hidden", background: "#07100c", touchAction: "none", userSelect: "none" }}>
+      <div ref={hostRef} style={{ position: "absolute", inset: 0 }}>
+        <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block", touchAction: "none" }} />
+      </div>
+      <div style={{ position: "fixed", inset: 0, pointerEvents: "none", fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif" }}>
+        <UIOverlay hud={hud} playerName={playerName} rivalName={rivalName} playerAvatar={playerAvatar} onMenu={() => setMenuOpen((v) => !v)} />
+
+        {menuOpen && (
+          <div style={{ position: "absolute", right: 10, top: 108, width: 230, maxHeight: 330, overflow: "auto", background: "rgba(8,16,24,0.94)", border: "1px solid rgba(255,255,255,0.22)", borderRadius: 12, padding: 8, pointerEvents: "auto" }}>
+            <div style={{ color: "#fff", fontSize: 12, fontWeight: 700, marginBottom: 6 }}>Domino Royal Characters</div>
+            <div style={{ color: "rgba(255,255,255,.7)", fontSize: 10, marginBottom: 8 }}>HDRIs removed: training court uses built-in lights, sky, fence, Poly Haven mapped cloth textures and model-native hair/eyes styling.</div>
+            {MURLAN_CHARACTER_THEMES.slice(0, 7).map((opt) => (
+              <button key={opt.id} type="button" onClick={() => setSelectedHumanCharacterId(opt.id)} style={{ width: "100%", display: "flex", gap: 8, alignItems: "center", marginBottom: 6, borderRadius: 10, border: selectedHumanCharacterId === opt.id ? "1px solid #7dd3fc" : "1px solid rgba(255,255,255,.18)", background: "rgba(255,255,255,0.08)", padding: 6, color: "#fff" }}>
+                <span style={{ width: 42, height: 24, borderRadius: 6, background: `linear-gradient(135deg,#${(opt.hairColor ?? 0x24150f).toString(16).padStart(6, "0")},#${(opt.eyeColor ?? 0x2f5d7c).toString(16).padStart(6, "0")})`, border: "1px solid rgba(255,255,255,.2)" }} />
+                <span style={{ fontSize: 11, textAlign: "left" }}>{opt.label}</span>
+              </button>
+            ))}
+          </div>
+        )}
+  
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/TennisLobby.jsx
+++ b/webapp/src/pages/Games/TennisLobby.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { ensureAccountId, getTelegramFirstName, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import { runSimpleOnlineFlow } from '../../utils/simpleOnlineFlow.js';
+import { socket } from '../../utils/socket.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+
+export default function TennisLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+  const [mode, setMode] = useState('ai');
+  const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
+  const [avatar, setAvatar] = useState('');
+  const [matching, setMatching] = useState(false);
+  const [playerFlag, setPlayerFlag] = useState('🇺🇸');
+  const [aiFlag, setAiFlag] = useState('🇬🇧');
+  const [matchStatus, setMatchStatus] = useState('');
+  const [matchError, setMatchError] = useState('');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+
+  const playerAvatar = useMemo(() => `${playerFlag} You`, [playerFlag]);
+  const aiAvatar = useMemo(() => `${aiFlag} AI`, [aiFlag]);
+
+  const randomAiFlag = () => {
+    const available = FLAG_EMOJIS.filter((flag) => flag !== playerFlag);
+    if (!available.length) return '🤖';
+    return available[Math.floor(Math.random() * available.length)] || '🤖';
+  };
+
+  const startGame = async () => {
+    if (mode === 'online') {
+      await runSimpleOnlineFlow({
+        gameType: 'tennis',
+        stake,
+        maxPlayers: 2,
+        avatar,
+        playerName: getTelegramFirstName() || 'Player',
+        state: { setMatching, setMatchStatus, setMatchError },
+        deps: { ensureAccountId, getAccountBalance, addTransaction, getTelegramId, socket },
+        onMatched: ({ accountId, tableId }) => {
+          const params = new URLSearchParams();
+          params.set('mode', 'online');
+          params.set('tableId', tableId);
+          params.set('accountId', accountId);
+          if (stake.token) params.set('token', stake.token);
+          if (stake.amount) params.set('amount', String(stake.amount));
+          if (avatar) params.set('avatar', avatar);
+          params.set('name', getTelegramFirstName() || 'Player');
+          params.set('playerFlag', playerFlag);
+          navigate(`/games/tennis?${params.toString()}`);
+        }
+      });
+      return;
+    }
+
+    const params = new URLSearchParams();
+    params.set('mode', 'ai');
+    const pickedAiFlag = randomAiFlag();
+    setAiFlag(pickedAiFlag);
+    if (avatar) params.set('avatar', avatar);
+    params.set('name', getTelegramFirstName() || 'Player');
+    params.set('playerFlag', playerFlag);
+    params.set('opponent', `${pickedAiFlag} AI`);
+    navigate(`/games/tennis?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[#070b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-60" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <GameLobbyHeader slug="tennis" title="Tennis Lobby" badge="1v1 only" />
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4 text-white/80">
+          <p className="text-xs">Mode rules: 1v1 only. Vs AI is free, Online uses TPC streak stake.</p>
+          <div className="mt-3 grid grid-cols-2 gap-3">
+            <button type="button" onClick={() => setPlayerFlag(FLAG_EMOJIS[(FLAG_EMOJIS.indexOf(playerFlag) + 1) % FLAG_EMOJIS.length] || '🇺🇸')} className="lobby-option-card lobby-option-card-inactive">
+              <p className="lobby-option-label">{playerAvatar}</p><p className="lobby-option-subtitle">Tap to change your flag avatar</p>
+            </button>
+            <div className="lobby-option-card lobby-option-card-inactive">
+              <p className="lobby-option-label">{aiAvatar}</p><p className="lobby-option-subtitle">AI avatar randomizes every new AI game</p>
+            </div>
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-3">
+            <button type="button" onClick={() => setMode('ai')} className={`lobby-option-card ${mode === 'ai' ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}>
+              <p className="lobby-option-label">Vs AI</p><p className="lobby-option-subtitle">Free practice</p>
+            </button>
+            <button type="button" onClick={() => setMode('online')} className={`lobby-option-card ${mode === 'online' ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}>
+              <p className="lobby-option-label">Online 1v1</p><p className="lobby-option-subtitle">TPC streak match</p>
+            </button>
+          </div>
+          {mode === 'online' && (
+            <div className="mt-3">
+              <label className="text-xs uppercase text-white/60">TPC Stake</label>
+              <input type="number" min={1} value={stake.amount} onChange={(e) => setStake((s) => ({ ...s, amount: Number(e.target.value) || 0 }))} className="mt-1 w-full rounded-xl border border-white/15 bg-black/20 p-2 text-white" />
+            </div>
+          )}
+          <button type="button" onClick={startGame} disabled={matching} className="mt-4 w-full rounded-xl bg-primary px-4 py-3 font-semibold text-black disabled:opacity-60">
+            {matching ? 'Finding opponent...' : mode === 'online' ? 'Start Online 1v1' : 'Start Vs AI'}
+          </button>
+          {(matchStatus || matchError) && <p className="mt-2 text-xs text-white/70">{matchError || matchStatus}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/bowlingTenPinRules.js
+++ b/webapp/src/pages/Games/bowlingTenPinRules.js
@@ -1,0 +1,123 @@
+export const OFFICIAL_TEN_PIN_RULE_SUMMARY =
+  'Official ten-pin: 10 frames · max two rolls per frames 1-9 unless strike · strike scores 10 plus next two rolls · spare scores 10 plus next roll · open frame scores pinfall · 10th frame grants bonus rolls only after strike/spare · each full rack is limited to 10 pins · foul rolls score 0 while still counting as delivered balls.';
+
+export function frameComplete(frame, index) {
+  const r = frame.rolls || [];
+  if (index < 9) return r[0] === 10 || r.length >= 2;
+  if (r.length < 2) return false;
+  if (r[0] === 10 || r[0] + r[1] === 10) return r.length >= 3;
+  return r.length >= 2;
+}
+
+export function currentFrameIndex(player) {
+  const idx = player.frames.findIndex((f, i) => !frameComplete(f, i));
+  return idx === -1 ? 9 : idx;
+}
+
+export function playerFinished(player) {
+  return player.frames.every((f, i) => frameComplete(f, i));
+}
+
+export function getLegalTenPinMax(frame, frameIndex, rollIndex) {
+  if (frameIndex < 9)
+    return rollIndex === 0 ? 10 : Math.max(0, 10 - (frame.rolls[0] || 0));
+  if (rollIndex === 0) return 10;
+  if (rollIndex === 1)
+    return frame.rolls[0] === 10 ? 10 : Math.max(0, 10 - (frame.rolls[0] || 0));
+  if (rollIndex === 2) {
+    if (frame.rolls[0] === 10 && frame.rolls[1] !== 10)
+      return Math.max(0, 10 - (frame.rolls[1] || 0));
+    return 10;
+  }
+  return 0;
+}
+
+export function clampTenPinRoll(frame, frameIndex, rollIndex, knocked) {
+  const max = getLegalTenPinMax(frame, frameIndex, rollIndex);
+  return Math.max(0, Math.min(max, Math.round(Number(knocked) || 0)));
+}
+
+export function recomputePlayerTotals(player) {
+  const flat = player.frames.flatMap((f) => f.rolls);
+  let rollIndex = 0;
+  let running = 0;
+
+  for (let frame = 0; frame < 10; frame++) {
+    const out = player.frames[frame];
+    out.cumulative = null;
+
+    if (frame < 9) {
+      const a = flat[rollIndex];
+      if (a == null) break;
+      if (a === 10) {
+        const b = flat[rollIndex + 1];
+        const c = flat[rollIndex + 2];
+        if (b == null || c == null) break;
+        running += 10 + b + c;
+        out.cumulative = running;
+        rollIndex += 1;
+      } else {
+        const b = flat[rollIndex + 1];
+        if (b == null) break;
+        const base = a + b;
+        if (base === 10) {
+          const c = flat[rollIndex + 2];
+          if (c == null) break;
+          running += 10 + c;
+        } else running += base;
+        out.cumulative = running;
+        rollIndex += 2;
+      }
+    } else {
+      if (!frameComplete(out, frame)) break;
+      running += out.rolls.reduce((s, v) => s + v, 0);
+      out.cumulative = running;
+    }
+  }
+
+  player.total = running;
+  return player;
+}
+
+export function shouldResetPinsForNextRoll(
+  frame,
+  frameIndex,
+  rollIndex,
+  knocked,
+  frameEnded
+) {
+  if (frameEnded) return true;
+  if (frameIndex < 9) return knocked === 10;
+  if (rollIndex === 0) return knocked === 10;
+  if (rollIndex === 1)
+    return frame.rolls[0] === 10 || frame.rolls[0] + frame.rolls[1] === 10;
+  return false;
+}
+
+export function addTenPinRoll(player, knocked, options = {}) {
+  const frameIndex = currentFrameIndex(player);
+  const frame = player.frames[frameIndex];
+  const rollIndex = frame.rolls.length;
+  const foul = Boolean(options.foul);
+  const legalKnocked = foul
+    ? 0
+    : clampTenPinRoll(frame, frameIndex, rollIndex, knocked);
+  if (rollIndex < (frameIndex < 9 ? 2 : 3)) frame.rolls.push(legalKnocked);
+  recomputePlayerTotals(player);
+  const frameEnded = frameComplete(frame, frameIndex);
+  return {
+    frameIndex,
+    rollIndex,
+    knocked: legalKnocked,
+    foul,
+    frameEnded,
+    resetPins: shouldResetPinsForNextRoll(
+      frame,
+      frameIndex,
+      rollIndex,
+      legalKnocked,
+      frameEnded
+    ),
+    gameFinished: playerFinished(player)
+  };
+}

--- a/webapp/src/pages/Games/tennis/AIController.ts
+++ b/webapp/src/pages/Games/tennis/AIController.ts
@@ -1,0 +1,149 @@
+import * as THREE from "three";
+import { clamp, clamp01, gameConfig, lerp, PlayerSide, ServeSide, ShotTechnique } from "./gameConfig";
+
+export type AIPrediction = { landing: THREE.Vector3; t: number; descending: boolean };
+export type AIIntercept = AIPrediction & { contact: THREE.Vector3; contactT: number; postBounce: boolean; reachable: boolean };
+
+type ReturnContext = {
+  receiverPos?: THREE.Vector3;
+  prediction?: AIPrediction;
+  hasBounced?: boolean;
+};
+
+const COURT_EDGE_PADDING = 0.55;
+
+export class AIController {
+  mistakeRoll(pressure = 0) {
+    const pressureBonus = clamp01(pressure) * 0.012;
+    return Math.random() < gameConfig.aiDifficulty.mistakeChance + pressureBonus;
+  }
+
+  predictLanding(pos: THREE.Vector3, vel: THREE.Vector3, spin = 0): AIPrediction {
+    const p = pos.clone();
+    const v = vel.clone();
+    const dt = 1 / 90;
+    for (let i = 0; i < 260; i++) {
+      v.y -= gameConfig.gravity * (1 + spin * 0.18) * dt;
+      v.multiplyScalar(Math.exp(-gameConfig.airDrag * dt));
+      p.addScaledVector(v, dt);
+      if (p.y <= gameConfig.ballR) return { landing: p.setY(gameConfig.ballR), t: i * dt, descending: v.y < 0 };
+    }
+    return { landing: p, t: 260 * dt, descending: v.y < 0 };
+  }
+
+  predictIntercept(pos: THREE.Vector3, vel: THREE.Vector3, spin = 0, receiverPos = new THREE.Vector3()): AIIntercept {
+    const p = pos.clone();
+    const v = vel.clone();
+    const dt = 1 / 90;
+    let firstLanding = p.clone();
+    let firstLandingT = 0;
+    let foundLanding = false;
+    let postBounce = false;
+    const contactMin = gameConfig.minContactHeight * 0.85;
+    const contactMax = gameConfig.maxContactHeight * 1.06;
+
+    for (let i = 0; i < 300; i++) {
+      v.y -= gameConfig.gravity * (1 + spin * 0.16) * dt;
+      v.multiplyScalar(Math.exp(-gameConfig.airDrag * dt));
+      p.addScaledVector(v, dt);
+      const t = i * dt;
+
+      if (p.y <= gameConfig.ballR && v.y < 0) {
+        if (!foundLanding) {
+          firstLanding = p.clone().setY(gameConfig.ballR);
+          firstLandingT = t;
+          foundLanding = true;
+        }
+        p.y = gameConfig.ballR;
+        v.y = -v.y * gameConfig.bounceRestitution;
+        v.x *= gameConfig.groundFriction;
+        v.z *= gameConfig.groundFriction;
+        postBounce = true;
+      }
+
+      const onAiSide = p.z < -gameConfig.serviceBuffer * 0.5;
+      const hittableHeight = p.y >= contactMin && p.y <= contactMax;
+      const courtX = Math.abs(p.x) <= gameConfig.courtW / 2 + gameConfig.worldScale;
+      if (onAiSide && hittableHeight && courtX && v.z <= gameConfig.worldScale * 2.4) {
+        const contact = p.clone();
+        const targetFoot = new THREE.Vector3(
+          clamp(contact.x, -gameConfig.courtW / 2 + COURT_EDGE_PADDING, gameConfig.courtW / 2 - COURT_EDGE_PADDING),
+          receiverPos.y,
+          clamp(contact.z + 0.28 * gameConfig.worldScale, -gameConfig.courtL / 2 - 0.85 * gameConfig.worldScale, -0.82 * gameConfig.worldScale)
+        );
+        const travel = receiverPos.distanceTo(targetFoot);
+        const reachable = travel <= gameConfig.aiDifficulty.moveSpeed * Math.max(0.06, t + 0.2) + gameConfig.aiDifficulty.reachRadius * 0.42;
+        return { landing: foundLanding ? firstLanding : contact.clone().setY(gameConfig.ballR), t: foundLanding ? firstLandingT : t, descending: v.y < 0, contact, contactT: t, postBounce, reachable };
+      }
+    }
+
+    return {
+      landing: foundLanding ? firstLanding : p.clone(),
+      t: foundLanding ? firstLandingT : 300 * dt,
+      descending: v.y < 0,
+      contact: foundLanding ? firstLanding.clone().setY(gameConfig.minContactHeight) : p,
+      contactT: foundLanding ? firstLandingT + 0.28 : 300 * dt,
+      postBounce,
+      reachable: false,
+    };
+  }
+
+  chooseReturnTarget(opponentPos: THREE.Vector3, ballPos: THREE.Vector3, ballVel: THREE.Vector3, context: ReturnContext = {}) {
+    const prediction = context.prediction ?? this.predictLanding(ballPos, ballVel);
+    const landing = prediction.landing;
+    const receiverX = context.receiverPos?.x ?? 0;
+    const pressure = clamp01((Math.abs(ballPos.z) - gameConfig.serviceLineZ * 0.2) / (gameConfig.courtL / 2 - 0.65));
+    const stretched = clamp01((Math.abs(ballPos.x - receiverX) - gameConfig.reach * 0.38) / (gameConfig.courtW * 0.42));
+    const opponentOpenCourt = opponentPos.x >= 0 ? -1 : 1;
+    const ballWide = Math.abs(landing.x) > gameConfig.courtW * 0.28 || Math.abs(ballPos.x) > gameConfig.courtW * 0.3;
+    const opponentDeep = opponentPos.z > gameConfig.serviceLineZ * 0.58;
+    const attackable = pressure > 0.5 && stretched < 0.62 && ballPos.y > gameConfig.minContactHeight * 1.08;
+
+    let xBase = ballWide
+      ? -Math.sign(landing.x || ballPos.x || 1) * gameConfig.courtW * 0.36
+      : opponentOpenCourt * gameConfig.courtW * (attackable ? 0.34 : 0.24);
+    if (Math.abs(opponentPos.x) > gameConfig.courtW * 0.24) xBase = -Math.sign(opponentPos.x) * gameConfig.courtW * 0.36;
+
+    const shortReply = stretched > 0.68 || (opponentDeep && Math.random() > 0.62);
+    const zDepth = shortReply
+      ? lerp(gameConfig.serviceLineZ * 0.2, gameConfig.serviceLineZ * 0.78, Math.random())
+      : lerp(gameConfig.serviceLineZ * 0.5, gameConfig.courtL / 2 - 0.9 * gameConfig.worldScale, 0.34 + pressure * 0.58);
+    const x = clamp(
+      xBase + clamp(ballVel.x * 0.08, -0.28 * gameConfig.worldScale, 0.28 * gameConfig.worldScale) + (Math.random() - 0.5) * (1 - gameConfig.aiDifficulty.accuracy) * gameConfig.worldScale,
+      -gameConfig.courtW / 2 + COURT_EDGE_PADDING,
+      gameConfig.courtW / 2 - COURT_EDGE_PADDING
+    );
+
+    const roll = Math.random();
+    let technique: ShotTechnique = "flat";
+    if (shortReply) technique = stretched > 0.66 ? "block" : "drop";
+    else if (stretched > 0.74) technique = "slice";
+    else if (attackable && roll > 0.22) technique = "topspin";
+    else if (opponentPos.z < gameConfig.serviceLineZ * 0.28 && roll > 0.72) technique = "lob";
+    else if (roll > 0.76) technique = "slice";
+
+    const controlledPower = shortReply ? 0.38 : attackable ? 0.66 : 0.52;
+    const power = clamp(
+      controlledPower + pressure * 0.13 + (1 - stretched) * 0.08 + gameConfig.aiDifficulty.power * 0.08,
+      gameConfig.shotPower.min,
+      gameConfig.shotPower.max
+    );
+
+    return { target: new THREE.Vector3(x, gameConfig.ballR, zDepth), power, technique };
+  }
+
+  chooseServeTarget(side: ServeSide, server: PlayerSide = "far") {
+    const targetZ = server === "far"
+      ? lerp(1.25 * gameConfig.worldScale, gameConfig.serviceLineZ - 0.75 * gameConfig.worldScale, 0.58)
+      : -lerp(1.25 * gameConfig.worldScale, gameConfig.serviceLineZ - 0.75 * gameConfig.worldScale, 0.58);
+    const laneSign = side === "deuce" ? (server === "far" ? -1 : 1) : (server === "far" ? 1 : -1);
+    const targetX = laneSign * lerp(gameConfig.courtW * 0.16, gameConfig.courtW * 0.36, Math.random());
+    const technique: ShotTechnique = Math.random() > 0.42 ? "topspin" : "slice";
+    return {
+      target: new THREE.Vector3(targetX, gameConfig.ballR, targetZ),
+      power: clamp(0.58 + gameConfig.aiDifficulty.serveQuality * 0.16 + Math.random() * 0.035, gameConfig.servePower.min, gameConfig.servePower.max),
+      technique,
+    };
+  }
+
+}

--- a/webapp/src/pages/Games/tennis/AudioVFXManager.ts
+++ b/webapp/src/pages/Games/tennis/AudioVFXManager.ts
@@ -1,0 +1,18 @@
+export class AudioVFXManager {
+  racketHit = new Audio("https://assets.mixkit.co/active_storage/sfx/1104/1104-preview.mp3");
+  courtBounce = new Audio("https://assets.mixkit.co/active_storage/sfx/522/522-preview.mp3");
+  netHit = new Audio("/assets/sounds/goal net.mp3");
+  pointWon = new Audio("/assets/sounds/crowd-cheering-383111.mp3");
+
+  constructor() {
+    this.racketHit.volume = 0.62;
+    this.courtBounce.volume = 0.4;
+    this.netHit.volume = 0.42;
+    this.pointWon.volume = 0.32;
+  }
+
+  play(sound: "racket" | "bounce" | "net" | "point") {
+    const item = sound === "racket" ? this.racketHit : sound === "bounce" ? this.courtBounce : sound === "net" ? this.netHit : this.pointWon;
+    void item.play().catch(() => {});
+  }
+}

--- a/webapp/src/pages/Games/tennis/BallController.ts
+++ b/webapp/src/pages/Games/tennis/BallController.ts
@@ -1,0 +1,71 @@
+import * as THREE from "three";
+import { clamp, gameConfig, PlayerSide, sideOfZ, TennisBallState } from "./gameConfig";
+import { CourtRules, courtRules, CourtRuleEvent } from "./CourtRules";
+
+export type BallLike = {
+  pos: THREE.Vector3;
+  vel: THREE.Vector3;
+  spin: number;
+  lastHitBy: PlayerSide | null;
+  bounceSide: PlayerSide | null;
+  bounceCount: number;
+  state?: TennisBallState;
+  mesh?: THREE.Mesh;
+};
+
+export class BallController {
+  accumulator = 0;
+  constructor(private readonly rules: CourtRules = courtRules) {}
+
+  stepFixed(ball: BallLike, dt: number, opts: { awaitingServe: boolean; serveSide: "deuce" | "ad"; onRuleEvent?: (event: CourtRuleEvent) => void; onBounce?: () => void; onNet?: () => void }) {
+    const prevZ = ball.pos.z;
+    const spinDip = Math.max(0, ball.spin) * 0.11;
+    const spinLift = Math.max(0, -ball.spin) * 0.035;
+    ball.vel.y -= gameConfig.gravity * (1 + spinDip - spinLift) * dt;
+    if (ball.lastHitBy && Math.abs(ball.vel.z) > 0.001) {
+      const forwardSign = ball.lastHitBy === "near" ? -1 : 1;
+      ball.vel.z += forwardSign * ball.spin * 0.14 * gameConfig.worldScale * dt;
+      ball.vel.x += Math.sin(ball.spin * 0.65) * 0.022 * gameConfig.worldScale * dt;
+    }
+    ball.vel.multiplyScalar(Math.exp(-gameConfig.airDrag * dt));
+    ball.pos.addScaledVector(ball.vel, dt);
+    ball.spin *= Math.exp(-1.25 * dt);
+
+    if (ball.lastHitBy && this.rules.isNetCollision(ball.pos, prevZ)) {
+      ball.state = TennisBallState.NetHit;
+      ball.vel.multiplyScalar(0.2);
+      ball.vel.z = Math.sign(ball.vel.z || (ball.lastHitBy === "near" ? -1 : 1)) * Math.max(0.4, Math.abs(ball.vel.z));
+      ball.vel.y = Math.max(0.45, Math.abs(ball.vel.y) + 0.2);
+      ball.pos.z = ball.lastHitBy === "near" ? -0.12 : 0.12;
+      opts.onNet?.();
+      opts.onRuleEvent?.({ type: opts.awaitingServe ? "serveFault" : "net", reason: "net", hitter: ball.lastHitBy, side: sideOfZ(ball.pos.z) } as CourtRuleEvent);
+      return;
+    }
+
+    if (ball.pos.y <= gameConfig.ballR) {
+      ball.pos.y = gameConfig.ballR;
+      if (ball.vel.y < 0) {
+        ball.state = TennisBallState.CourtBounce;
+        const forwardSign = ball.lastHitBy === "near" ? -1 : ball.lastHitBy === "far" ? 1 : Math.sign(ball.vel.z || 1);
+        const spinKick = clamp(ball.spin, -1.1, 1.1) * 0.08 * gameConfig.worldScale;
+        const forwardSpeed = Math.max(0.04 * gameConfig.worldScale, Math.abs(ball.vel.z) * gameConfig.groundFriction + spinKick);
+        ball.vel.y = Math.max(0.18 * gameConfig.worldScale, -ball.vel.y * gameConfig.bounceRestitution);
+        ball.vel.x = ball.vel.x * gameConfig.groundFriction + Math.sign(ball.vel.x || Math.sin(ball.spin) || 1) * Math.min(Math.abs(ball.spin) * 0.022 * gameConfig.worldScale, 0.09 * gameConfig.worldScale);
+        ball.vel.z = forwardSign * forwardSpeed;
+        ball.vel.y *= clamp(1 - Math.max(0, ball.spin) * 0.03, 0.84, 1.04);
+        ball.spin *= -0.32;
+        const bounceSide = sideOfZ(ball.pos.z);
+        ball.bounceCount = ball.bounceSide === bounceSide ? ball.bounceCount + 1 : 1;
+        ball.bounceSide = bounceSide;
+        opts.onBounce?.();
+        const event = this.rules.evaluateBounce(ball.pos, ball.lastHitBy, opts.serveSide, opts.awaitingServe, ball.bounceCount);
+        if (event) opts.onRuleEvent?.(event);
+      }
+    }
+
+    if ((Math.abs(ball.pos.x) > gameConfig.courtW / 2 + 0.9 * gameConfig.worldScale || Math.abs(ball.pos.z) > gameConfig.courtL / 2 + 0.9 * gameConfig.worldScale || ball.pos.y < -1.2) && ball.lastHitBy) {
+      ball.state = TennisBallState.Out;
+      opts.onRuleEvent?.({ type: "out", side: sideOfZ(ball.pos.z), landing: ball.pos.clone() });
+    }
+  }
+}

--- a/webapp/src/pages/Games/tennis/CameraController.ts
+++ b/webapp/src/pages/Games/tennis/CameraController.ts
@@ -1,0 +1,61 @@
+import * as THREE from "three";
+import { gameConfig, PlayerSide } from "./gameConfig";
+
+type CameraUpdateOptions = {
+  incomingSide?: PlayerSide | null;
+  predictedLanding?: THREE.Vector3 | null;
+};
+
+const tempIncomingTarget = new THREE.Vector3();
+const tempBallBias = new THREE.Vector3();
+const tempBaseTarget = new THREE.Vector3();
+const tempLookTarget = new THREE.Vector3();
+const tempFollowAnchor = new THREE.Vector3();
+const tempOffset = new THREE.Vector3();
+
+export class CameraController {
+  update(
+    camera: THREE.PerspectiveCamera,
+    cameraTarget: THREE.Vector3,
+    cameraPosTarget: THREE.Vector3,
+    playerTarget: THREE.Vector3,
+    ballPos: THREE.Vector3,
+    cameraOffset: THREE.Vector3,
+    preServe: boolean,
+    dt: number,
+    options: CameraUpdateOptions = {}
+  ) {
+    const incomingToPlayer = options.incomingSide === "near";
+    const targetDamping = 1 - Math.exp(-5.2 * dt);
+    const zDamping = 1 - Math.exp(-4.3 * dt);
+    const lateral = Math.max(-0.45, Math.min(0.45, ballPos.x * 0.08));
+
+    if (preServe) {
+      cameraPosTarget.copy(playerTarget).add(tempOffset.set(playerTarget.x * 0.08 + lateral, 11.55 * gameConfig.cameraViewScale, 19.95 * gameConfig.cameraViewScale));
+      tempLookTarget.set(playerTarget.x * 0.2 + lateral, 2.2 * gameConfig.cameraViewScale, -gameConfig.courtL * 0.34);
+      cameraTarget.lerp(tempLookTarget, targetDamping);
+    } else {
+      tempFollowAnchor.copy(playerTarget);
+      tempBaseTarget.set(playerTarget.x + lateral, 2.18 * gameConfig.cameraViewScale, playerTarget.z - 12.9 * gameConfig.cameraViewScale);
+
+      if (incomingToPlayer) {
+        tempIncomingTarget.copy(options.predictedLanding || ballPos);
+        tempIncomingTarget.x = THREE.MathUtils.clamp(tempIncomingTarget.x, -gameConfig.courtW / 2, gameConfig.courtW / 2);
+        tempIncomingTarget.z = THREE.MathUtils.clamp(tempIncomingTarget.z, 0.25 * gameConfig.worldScale, gameConfig.courtL / 2);
+        tempFollowAnchor.lerp(tempIncomingTarget, gameConfig.cameraPlayerFollowBlend);
+
+        tempBallBias.copy(ballPos).lerp(tempIncomingTarget, 0.45);
+        tempBallBias.y = Math.max(2.05 * gameConfig.cameraViewScale, ballPos.y * 0.34 + 1.92 * gameConfig.cameraViewScale);
+        tempBaseTarget.lerp(tempBallBias, gameConfig.cameraBallLookAhead);
+      }
+
+      cameraPosTarget.copy(tempFollowAnchor).add(cameraOffset).add(tempOffset.set(lateral, 0, 0));
+      cameraTarget.x += (tempBaseTarget.x - cameraTarget.x) * targetDamping;
+      cameraTarget.y += (tempBaseTarget.y - cameraTarget.y) * targetDamping;
+      cameraTarget.z += (tempBaseTarget.z - cameraTarget.z) * zDamping;
+    }
+
+    camera.position.lerp(cameraPosTarget, 1 - Math.exp(-gameConfig.cameraDamping * dt));
+    camera.lookAt(cameraTarget);
+  }
+}

--- a/webapp/src/pages/Games/tennis/CourtRules.ts
+++ b/webapp/src/pages/Games/tennis/CourtRules.ts
@@ -1,0 +1,57 @@
+import * as THREE from "three";
+import { gameConfig, opposite, PlayerSide, ServeSide, sideOfZ } from "./gameConfig";
+
+export type CourtRuleEvent =
+  | { type: "serveIn"; side: PlayerSide; landing: THREE.Vector3 }
+  | { type: "serveFault"; reason: "serviceBox" | "net"; side: PlayerSide; landing?: THREE.Vector3 }
+  | { type: "rallyIn"; side: PlayerSide; landing: THREE.Vector3 }
+  | { type: "out"; side: PlayerSide; landing: THREE.Vector3 }
+  | { type: "net"; hitter: PlayerSide }
+  | { type: "doubleBounce"; side: PlayerSide };
+
+export class CourtRules {
+  readonly cfg = gameConfig;
+
+  serviceSideFromPoints(totalPoints: number): ServeSide {
+    return totalPoints % 2 === 0 ? "deuce" : "ad";
+  }
+
+  isInsideSingles(pos: THREE.Vector3) {
+    return Math.abs(pos.x) <= this.cfg.courtW / 2 && Math.abs(pos.z) <= this.cfg.courtL / 2;
+  }
+
+  isInsideServiceBox(pos: THREE.Vector3, hitter: PlayerSide, serveSide: ServeSide) {
+    const targetSide = opposite(hitter);
+    const targetRight = serveSide === "deuce";
+    const xOk = targetRight ? pos.x >= this.cfg.serviceBuffer : pos.x <= -this.cfg.serviceBuffer;
+    const xInCourt = Math.abs(pos.x) <= this.cfg.courtW / 2;
+    const zOk = targetSide === "far"
+      ? pos.z <= -this.cfg.serviceBuffer && pos.z >= -this.cfg.serviceLineZ
+      : pos.z >= this.cfg.serviceBuffer && pos.z <= this.cfg.serviceLineZ;
+    return xOk && xInCourt && zOk;
+  }
+
+  evaluateBounce(pos: THREE.Vector3, hitter: PlayerSide | null, serveSide: ServeSide, awaitingServe: boolean, bounceCountOnSide: number): CourtRuleEvent | null {
+    const landing = pos.clone();
+    const landingSide = sideOfZ(pos.z);
+    if (!hitter) return null;
+    if (awaitingServe) {
+      return this.isInsideServiceBox(pos, hitter, serveSide)
+        ? { type: "serveIn", side: landingSide, landing }
+        : { type: "serveFault", reason: "serviceBox", side: landingSide, landing };
+    }
+    if (!this.isInsideSingles(pos)) return { type: "out", side: landingSide, landing };
+    if (bounceCountOnSide > 1) return { type: "doubleBounce", side: landingSide };
+    return { type: "rallyIn", side: landingSide, landing };
+  }
+
+  crossesNet(prevZ: number, nextZ: number) {
+    return (prevZ > 0 && nextZ <= 0) || (prevZ < 0 && nextZ >= 0) || Math.abs(nextZ) < 0.055;
+  }
+
+  isNetCollision(pos: THREE.Vector3, prevZ: number) {
+    return this.crossesNet(prevZ, pos.z) && Math.abs(pos.x) <= this.cfg.doublesW / 2 + 0.1 && pos.y < this.cfg.netH + this.cfg.ballR * 0.6;
+  }
+}
+
+export const courtRules = new CourtRules();

--- a/webapp/src/pages/Games/tennis/GameManager.ts
+++ b/webapp/src/pages/Games/tennis/GameManager.ts
@@ -1,0 +1,17 @@
+import { BallController } from "./BallController";
+import { CourtRules } from "./CourtRules";
+import { ScoreManager } from "./ScoreManager";
+import { ServeController } from "./ServeController";
+import { AIController } from "./AIController";
+import { CameraController } from "./CameraController";
+import { AudioVFXManager } from "./AudioVFXManager";
+
+export class GameManager {
+  readonly courtRules = new CourtRules();
+  readonly ballController = new BallController(this.courtRules);
+  readonly scoreManager = new ScoreManager();
+  readonly serveController = new ServeController();
+  readonly aiController = new AIController();
+  readonly cameraController = new CameraController();
+  readonly audioVfx = new AudioVFXManager();
+}

--- a/webapp/src/pages/Games/tennis/PlayerController.ts
+++ b/webapp/src/pages/Games/tennis/PlayerController.ts
@@ -1,0 +1,21 @@
+import * as THREE from "three";
+import { clamp, FootworkState, gameConfig, PlayerSide } from "./gameConfig";
+
+export class PlayerController {
+  static clampMovement(pos: THREE.Vector3, side: PlayerSide) {
+    pos.x = clamp(pos.x, -gameConfig.courtW / 2 + 0.35 * gameConfig.worldScale, gameConfig.courtW / 2 - 0.35 * gameConfig.worldScale);
+    pos.z = side === "near"
+      ? clamp(pos.z, 0.76 * gameConfig.worldScale, gameConfig.courtL / 2 - 0.42 * gameConfig.worldScale)
+      : clamp(pos.z, -gameConfig.courtL / 2 + 0.42 * gameConfig.worldScale, -0.76 * gameConfig.worldScale);
+    return pos;
+  }
+
+  static footworkFromDelta(dx: number, dz: number, side: PlayerSide, swinging: "forehand" | "backhand" | "serve" | null): FootworkState {
+    if (swinging === "serve") return "Serve";
+    if (swinging === "forehand") return "Forehand";
+    if (swinging === "backhand") return "Backhand";
+    if (Math.abs(dx) > Math.abs(dz) && Math.abs(dx) > 0.03) return dx > 0 ? "MoveRight" : "MoveLeft";
+    if (Math.abs(dz) > 0.03) return (side === "near" ? dz < 0 : dz > 0) ? "MoveForward" : "MoveBack";
+    return "IdleReady";
+  }
+}

--- a/webapp/src/pages/Games/tennis/RacketHitDetector.ts
+++ b/webapp/src/pages/Games/tennis/RacketHitDetector.ts
@@ -1,0 +1,28 @@
+import * as THREE from "three";
+import { gameConfig } from "./gameConfig";
+
+export type RacketContact = {
+  racketHead: THREE.Vector3;
+  racketGrip: THREE.Vector3;
+  playerPos: THREE.Vector3;
+  ballPos: THREE.Vector3;
+  ballVel: THREE.Vector3;
+  swingT: number;
+  isServe?: boolean;
+};
+
+export class RacketHitDetector {
+  static validate(c: RacketContact) {
+    const radius = c.isServe ? gameConfig.racketHitRadius * 1.25 : gameConfig.racketHitRadius;
+    const distance = c.ballPos.distanceTo(c.racketHead);
+    const faceNormal = c.racketHead.clone().sub(c.racketGrip).cross(new THREE.Vector3(0, 1, 0)).normalize();
+    const incoming = c.ballVel.clone().normalize();
+    const inFrontOfFace = c.isServe || faceNormal.lengthSq() < 0.01 || incoming.dot(faceNormal) <= 1 - gameConfig.contactAngleTolerance;
+    const timingOk = c.isServe || (c.swingT >= gameConfig.timingWindow.start && c.swingT <= gameConfig.timingWindow.end);
+    const heightOk = c.ballPos.y >= gameConfig.minContactHeight && c.ballPos.y <= gameConfig.maxContactHeight;
+    const reachOk = c.playerPos.distanceTo(c.ballPos) <= gameConfig.maxReachDistance;
+    const valid = distance <= radius && inFrontOfFace && timingOk && heightOk && reachOk;
+    const timingQuality = c.isServe ? 1 : Math.max(0, 1 - Math.abs(c.swingT - 0.57) / 0.18);
+    return { valid, distance, inFrontOfFace, timingOk, heightOk, reachOk, timingQuality };
+  }
+}

--- a/webapp/src/pages/Games/tennis/ScoreManager.ts
+++ b/webapp/src/pages/Games/tennis/ScoreManager.ts
@@ -1,0 +1,127 @@
+import { gameConfig, PlayerSide, ServeSide } from "./gameConfig";
+
+export type ScoreSnapshot = {
+  points: Record<PlayerSide, number>;
+  games: Record<PlayerSide, number>;
+  sets: Record<PlayerSide, number>;
+  server: PlayerSide;
+  serveSide: ServeSide;
+  pointTotal: number;
+  label: Record<PlayerSide, string>;
+  gameWonBy?: PlayerSide;
+  setWonBy?: PlayerSide;
+  inTiebreak: boolean;
+};
+
+const otherSide = (side: PlayerSide): PlayerSide => (side === "near" ? "far" : "near");
+
+/**
+ * Singles scoring modelled after the standard ITF Rules of Tennis flow:
+ * - games use love/15/30/40, deuce, advantage, and two-clear-points game wins;
+ * - service starts from the deuce court each game and alternates deuce/ad by the
+ *   number of points played in the current game (not by total match points);
+ * - sets are first to six games, win by two, with a 7-point tie-break at 6-6;
+ * - tie-break service order is first point by the next server, then two points
+ *   per player, and tie-break points are won by two from seven.
+ */
+export class ScoreManager {
+  private points: Record<PlayerSide, number> = { near: 0, far: 0 };
+  private games: Record<PlayerSide, number> = { near: 0, far: 0 };
+  private sets: Record<PlayerSide, number> = { near: 0, far: 0 };
+  private pointTotal = 0;
+  private inTiebreakGame = false;
+  private tiebreakFirstServer: PlayerSide = "near";
+  server: PlayerSide = "near";
+
+  awardPoint(winner: PlayerSide): ScoreSnapshot {
+    this.points[winner] += 1;
+    this.pointTotal += 1;
+    let gameWonBy: PlayerSide | undefined;
+    let setWonBy: PlayerSide | undefined;
+
+    if (this.inTiebreakGame) {
+      if (this.hasWonTiebreak(winner)) {
+        gameWonBy = winner;
+        setWonBy = winner;
+        this.games[winner] += 1;
+        this.sets[winner] += 1;
+        this.points = { near: 0, far: 0 };
+        this.games = { near: 0, far: 0 };
+        this.inTiebreakGame = false;
+        this.server = otherSide(this.tiebreakFirstServer);
+      } else {
+        this.server = this.tiebreakServerForPoint(this.points.near + this.points.far);
+      }
+      return { ...this.snapshot(), gameWonBy, setWonBy };
+    }
+
+    if (this.hasWonGame(winner)) {
+      gameWonBy = winner;
+      this.games[winner] += 1;
+      this.points = { near: 0, far: 0 };
+      this.server = otherSide(this.server);
+
+      if (this.hasWonSet(winner)) {
+        setWonBy = winner;
+        this.sets[winner] += 1;
+        this.games = { near: 0, far: 0 };
+      } else if (this.games.near === 6 && this.games.far === 6) {
+        this.inTiebreakGame = true;
+        this.tiebreakFirstServer = this.server;
+      }
+    }
+
+    return { ...this.snapshot(), gameWonBy, setWonBy };
+  }
+
+  snapshot(): ScoreSnapshot {
+    return {
+      points: { ...this.points },
+      games: { ...this.games },
+      sets: { ...this.sets },
+      server: this.server,
+      serveSide: this.serveSide,
+      pointTotal: this.pointTotal,
+      label: this.pointLabels(),
+      inTiebreak: this.inTiebreakGame,
+    };
+  }
+
+  get serveSide(): ServeSide {
+    return (this.points.near + this.points.far) % 2 === 0 ? "deuce" : "ad";
+  }
+
+  private hasWonGame(side: PlayerSide) {
+    const other = otherSide(side);
+    return this.points[side] >= 4 && this.points[side] - this.points[other] >= 2;
+  }
+
+  private hasWonSet(side: PlayerSide) {
+    const other = otherSide(side);
+    return this.games[side] >= gameConfig.scoring.gamesPerSet && this.games[side] - this.games[other] >= 2;
+  }
+
+  private hasWonTiebreak(side: PlayerSide) {
+    const other = otherSide(side);
+    return this.points[side] >= gameConfig.scoring.tiebreakPoints && this.points[side] - this.points[other] >= 2;
+  }
+
+  private tiebreakServerForPoint(pointIndex: number): PlayerSide {
+    if (pointIndex === 0) return this.tiebreakFirstServer;
+    const pairIndex = Math.floor((pointIndex - 1) / 2);
+    return pairIndex % 2 === 0 ? otherSide(this.tiebreakFirstServer) : this.tiebreakFirstServer;
+  }
+
+  private pointLabels(): Record<PlayerSide, string> {
+    if (this.inTiebreakGame) return { near: String(this.points.near), far: String(this.points.far) };
+
+    const near = this.points.near;
+    const far = this.points.far;
+    if (near >= 3 && far >= 3) {
+      if (near === far) return { near: "40", far: "40" };
+      return near > far ? { near: "Ad", far: "40" } : { near: "40", far: "Ad" };
+    }
+    const label = ["0", "15", "30", "40"];
+    return { near: label[Math.min(near, 3)], far: label[Math.min(far, 3)] };
+  }
+}

--- a/webapp/src/pages/Games/tennis/ServeController.ts
+++ b/webapp/src/pages/Games/tennis/ServeController.ts
@@ -1,0 +1,32 @@
+import { PlayerSide, ServeSide, TennisBallState } from "./gameConfig";
+
+export type ServePhase = "ready" | "toss" | "swing" | "contact" | "ballFlight" | "fault" | "valid";
+
+export class ServeController {
+  phase: ServePhase = "ready";
+  firstServe = true;
+  server: PlayerSide = "near";
+  side: ServeSide = "deuce";
+
+  start(server: PlayerSide, side: ServeSide) {
+    this.server = server;
+    this.side = side;
+    this.phase = "ready";
+    this.firstServe = true;
+  }
+
+  beginToss() { this.phase = "toss"; }
+  markContact() { this.phase = "contact"; return TennisBallState.ServeHit; }
+  markFlight() { this.phase = "ballFlight"; }
+  markValid() { this.phase = "valid"; this.firstServe = true; }
+  markFault() {
+    if (this.firstServe) {
+      this.firstServe = false;
+      this.phase = "fault";
+      return "fault" as const;
+    }
+    this.phase = "fault";
+    this.firstServe = true;
+    return "doubleFault" as const;
+  }
+}

--- a/webapp/src/pages/Games/tennis/ShotTargeting.ts
+++ b/webapp/src/pages/Games/tennis/ShotTargeting.ts
@@ -1,0 +1,29 @@
+import * as THREE from "three";
+import { clamp, clamp01, gameConfig, PlayerSide, ShotTechnique } from "./gameConfig";
+
+export type DesiredShot = { target: THREE.Vector3; power: number; technique: ShotTechnique; timingQuality?: number };
+
+export class ShotTargeting {
+  static clampTarget(target: THREE.Vector3, hitter: PlayerSide, serve = false) {
+    const out = target.clone();
+    out.x = clamp(out.x, -gameConfig.courtW / 2 + 0.28, gameConfig.courtW / 2 - 0.28);
+    out.z = hitter === "near"
+      ? clamp(out.z, -gameConfig.courtL / 2 + 0.6, serve ? -0.4 : -0.65)
+      : clamp(out.z, serve ? 0.4 : 0.65, gameConfig.courtL / 2 - 0.6);
+    out.y = gameConfig.ballR;
+    return out;
+  }
+
+  static techniqueFromSwipe(dx: number, dy: number, isUnderPressure = false): ShotTechnique {
+    if (dy > 120) return "drop";
+    if (dy < -210) return "lob";
+    if (Math.abs(dx) > 115) return "slice";
+    if (isUnderPressure) return "block";
+    return dy < -70 ? "topspin" : "flat";
+  }
+
+  static accuracyJitter(power: number, timingQuality = 1, movementPressure = 0, difficulty = 1) {
+    const miss = (1 - timingQuality) * 0.75 + movementPressure * 0.45 + power * 0.08 + (1 - difficulty) * 0.5;
+    return clamp01(miss) * gameConfig.courtW * 0.16;
+  }
+}

--- a/webapp/src/pages/Games/tennis/UIOverlay.tsx
+++ b/webapp/src/pages/Games/tennis/UIOverlay.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+export type TennisHud = {
+  nearScore: number;
+  farScore: number;
+  nearLabel?: string;
+  farLabel?: string;
+  nearGames?: number;
+  farGames?: number;
+  nearSets?: number;
+  farSets?: number;
+  inTiebreak?: boolean;
+  status: string;
+  power: number;
+  server?: "near" | "far";
+  serveSide?: "deuce" | "ad";
+  firstServe?: boolean;
+  debug?: string;
+};
+
+export function pointLabel(score: number) {
+  return ["0", "15", "30", "40", "Ad"][Math.min(score, 4)];
+}
+
+export function UIOverlay({ hud, playerName, rivalName, playerAvatar, onMenu }: { hud: TennisHud; playerName: string; rivalName: string; playerAvatar?: string; onMenu: () => void }) {
+  return (
+    <div style={{ position: "absolute", left: 10, right: 10, top: 10, color: "white", zIndex: 5, pointerEvents: "none" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr auto 1fr", alignItems: "center", gap: 8, background: "rgba(5,12,18,0.72)", border: "1px solid rgba(255,255,255,.18)", borderRadius: 16, padding: "8px 10px", boxShadow: "0 12px 26px rgba(0,0,0,.26)", backdropFilter: "blur(10px)" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+          {playerAvatar ? <img src={playerAvatar} alt="" style={{ width: 28, height: 28, borderRadius: 999, objectFit: "cover" }} /> : null}
+          <div style={{ minWidth: 0 }}><div style={{ fontSize: 11, opacity: .78 }}>Player</div><div style={{ fontWeight: 900, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{playerName}</div></div>
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontWeight: 950, fontSize: 18, letterSpacing: 1 }}>{hud.nearLabel ?? pointLabel(hud.nearScore)} : {hud.farLabel ?? pointLabel(hud.farScore)}</div>
+          <div style={{ fontSize: 10, opacity: .78 }}>Sets {hud.nearSets ?? 0}-{hud.farSets ?? 0} · Games {hud.nearGames ?? 0}-{hud.farGames ?? 0}{hud.inTiebreak ? " · TB" : ""} · {hud.server === "far" ? rivalName : playerName} serves {hud.serveSide ?? "deuce"}</div>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 8, minWidth: 0 }}>
+          <div style={{ textAlign: "right", minWidth: 0 }}><div style={{ fontSize: 11, opacity: .78 }}>Opponent</div><div style={{ fontWeight: 900, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{rivalName}</div></div>
+          <button type="button" onClick={onMenu} style={{ pointerEvents: "auto", border: "1px solid rgba(255,255,255,.22)", borderRadius: 10, padding: "6px 8px", color: "#fff", background: "rgba(255,255,255,.10)", fontWeight: 800 }}>Menu</button>
+        </div>
+      </div>
+      <div style={{ margin: "7px auto 0", width: "fit-content", maxWidth: "92%", background: "rgba(0,0,0,.46)", border: "1px solid rgba(255,255,255,.14)", borderRadius: 999, padding: "5px 10px", fontSize: 12, fontWeight: 800, textAlign: "center" }}>{hud.status}</div>
+      {hud.power > 0 ? <div style={{ height: 5, margin: "7px auto 0", maxWidth: 180, borderRadius: 999, background: "rgba(255,255,255,.18)", overflow: "hidden" }}><div style={{ width: `${Math.round(hud.power * 100)}%`, height: "100%", background: "linear-gradient(90deg,#c8ff39,#ffb02e)" }} /></div> : null}
+      {hud.debug ? <pre style={{ margin: "8px auto 0", maxWidth: 320, fontSize: 10, background: "rgba(0,0,0,.55)", borderRadius: 10, padding: 8, whiteSpace: "pre-wrap" }}>{hud.debug}</pre> : null}
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/tennis/gameConfig.ts
+++ b/webapp/src/pages/Games/tennis/gameConfig.ts
@@ -1,0 +1,112 @@
+export type PlayerSide = "near" | "far";
+export type ServeSide = "deuce" | "ad";
+export type ShotTechnique = "flat" | "topspin" | "slice" | "lob" | "drop" | "block";
+export type FootworkState =
+  | "IdleReady"
+  | "SplitStep"
+  | "MoveLeft"
+  | "MoveRight"
+  | "MoveForward"
+  | "MoveBack"
+  | "Forehand"
+  | "Backhand"
+  | "Serve"
+  | "Recover";
+
+export enum TennisBallState {
+  Idle = "Idle",
+  ServeReady = "ServeReady",
+  Toss = "Toss",
+  ServeHit = "ServeHit",
+  InFlight = "InFlight",
+  CourtBounce = "CourtBounce",
+  RacketHitPlayer = "RacketHitPlayer",
+  RacketHitAI = "RacketHitAI",
+  NetHit = "NetHit",
+  Out = "Out",
+  DoubleBounce = "DoubleBounce",
+  PointEnded = "PointEnded",
+}
+
+const BASE_WORLD_SCALE = 1.72;
+const COURT_AND_CHARACTER_SIZE_MULTIPLIER = 4.08;
+const COURT_WIDTH_MULTIPLIER = 1.22;
+const WORLD_SCALE = BASE_WORLD_SCALE * COURT_AND_CHARACTER_SIZE_MULTIPLIER;
+// Keep camera scaling independent from world scale so camera framing can be
+// tuned precisely while the enlarged court keeps its regulation proportions.
+const CAMERA_VIEW_SCALE = BASE_WORLD_SCALE * 1.5;
+// Extra character scale keeps human avatars visibly bigger than the court uplift.
+const PLAYER_CHARACTER_SCALE = 1.42;
+const PLAYER_SCALE = WORLD_SCALE * PLAYER_CHARACTER_SCALE;
+
+export const gameConfig = {
+  worldScale: WORLD_SCALE,
+  courtAndCharacterSizeMultiplier: COURT_AND_CHARACTER_SIZE_MULTIPLIER,
+  courtWidthMultiplier: COURT_WIDTH_MULTIPLIER,
+  cameraViewScale: CAMERA_VIEW_SCALE,
+  fixedTimeStep: 1 / 90,
+  maxPhysicsSteps: 5,
+  // Regulation court proportions in world metres, scaled as a single unit so
+  // the tennis play area reads larger and more arena-like against HDRIs.
+  courtW: 8.23 * WORLD_SCALE * COURT_WIDTH_MULTIPLIER,
+  doublesW: 10.97 * WORLD_SCALE * COURT_WIDTH_MULTIPLIER,
+  courtL: 23.77 * WORLD_SCALE,
+  serviceLineZ: 6.4 * WORLD_SCALE,
+  netH: 0.914 * WORLD_SCALE,
+  ballR: 0.085 * WORLD_SCALE,
+  gravity: 9.81 * WORLD_SCALE * 1.04,
+  airDrag: 0.13,
+  bounceRestitution: 0.61,
+  groundFriction: 0.74,
+  minBallSpeed: 0.12 * WORLD_SCALE,
+  courtFriction: 0.74,
+  playerHeight: 1.88 * PLAYER_SCALE,
+  playerSpeed: 8.9 * PLAYER_SCALE,
+  playerAcceleration: 28 * PLAYER_SCALE,
+  playerDeceleration: 34 * PLAYER_SCALE,
+  aiSpeed: 11.7 * PLAYER_SCALE,
+  reach: 1.62 * PLAYER_SCALE,
+  racketHitRadius: 0.56 * PLAYER_SCALE,
+  contactAngleTolerance: 0.18,
+  timingWindow: { start: 0.42, end: 0.72 },
+  minContactHeight: 0.25 * PLAYER_SCALE,
+  maxContactHeight: 1.85 * PLAYER_SCALE,
+  maxReachDistance: 1.62 * PLAYER_SCALE,
+  swingDuration: 0.42,
+  serveDuration: 0.86,
+  serveContactT: 0.72,
+  serveTossMinHeight: 1.85 * PLAYER_SCALE,
+  // Scales the full match shot force so player and AI strokes share a softer, lower power ceiling.
+  matchPowerMultiplier: 0.68,
+  servePower: { min: 0.48, max: 0.74 },
+  shotPower: { min: 0.2, max: 0.68 },
+  spinAmount: { flat: 0.8, topspin: 1.6, slice: -1.4, lob: 1.1, drop: -0.7, block: 0.25 },
+  playerVisualYawFix: Math.PI,
+  serveNearBaselineZ: (23.77 / 2 + 0.92) * WORLD_SCALE,
+  serviceBuffer: 0.28 * WORLD_SCALE,
+  cameraDamping: 5.5,
+  cameraBallLookAhead: 0.58,
+  cameraPlayerFollowBlend: 0.72,
+  playerAutoChase: {
+    enabled: true,
+    anticipation: 0.74,
+    maxBlendPerSecond: 5.8,
+  },
+  scoring: { gamesPerSet: 6, winByTwoGames: true, tiebreakAtGamesAll: 6, tiebreakPoints: 7 },
+  aiDifficulty: {
+    reactionTime: 0.045,
+    moveSpeed: 15.2 * PLAYER_SCALE,
+    reachRadius: 2.16 * PLAYER_SCALE,
+    accuracy: 0.975,
+    power: 0.72,
+    spin: 0.94,
+    mistakeChance: 0.008,
+    serveQuality: 0.93,
+  },
+} as const;
+
+export const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+export const clamp01 = (v: number) => clamp(v, 0, 1);
+export const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+export const sideOfZ = (z: number): PlayerSide => (z >= 0 ? "near" : "far");
+export const opposite = (side: PlayerSide): PlayerSide => (side === "near" ? "far" : "near");

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -120,6 +120,7 @@ import {
   TEXAS_HOLDEM_OPTION_LABELS,
   TEXAS_HOLDEM_STORE_ITEMS
 } from '../config/texasHoldemInventoryConfig.js';
+import { BOWLING_DEFAULT_LOADOUT, BOWLING_OPTION_LABELS, BOWLING_STORE_ITEMS } from '../config/bowlingInventoryConfig.js';
 import { TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import {
@@ -1226,6 +1227,8 @@ const USAGE_BY_TYPE = {
 };
 
 
+const TENNIS_HDRI_OPTION_IDS = Object.freeze(['suburbanGarden','countryTrackMidday','autumnPark','rooitouPark','rotesRathaus','veniceDawn2','piazzaSanMarco']);
+
 const hashString = (value) => {
   let hash = 0;
   if (!value) return hash;
@@ -1243,6 +1246,17 @@ const formatShortDate = (date) =>
   }).format(date);
 
 const storeMeta = {
+  tennis: {
+    name: 'Tennis',
+    items: [
+      ...POOL_ROYALE_STORE_ITEMS.filter((item) => item.type === 'environmentHdri' && TENNIS_HDRI_OPTION_IDS.includes(item.optionId)),
+      ...LUDO_BATTLE_STORE_ITEMS.filter((item) => item.type === 'humanCharacter')
+    ],
+    defaults: [...POOL_ROYALE_DEFAULT_LOADOUT, ...LUDO_BATTLE_DEFAULT_LOADOUT.filter((entry) => entry.type === 'humanCharacter')],
+    labels: { ...POOL_ROYALE_OPTION_LABELS, humanCharacter: LUDO_BATTLE_OPTION_LABELS.humanCharacter },
+    typeLabels: TYPE_LABELS,
+    accountId: POOL_STORE_ACCOUNT_ID
+  },
   poolroyale: {
     name: 'Pool Royale',
     items: POOL_ROYALE_STORE_ITEMS,
@@ -1352,6 +1366,14 @@ const storeMeta = {
     labels: SNAKE_OPTION_LABELS,
     typeLabels: SNAKE_TYPE_LABELS,
     accountId: SNAKE_STORE_ACCOUNT_ID
+  },
+  bowling: {
+    name: 'Real Bowling',
+    items: BOWLING_STORE_ITEMS,
+    defaults: BOWLING_DEFAULT_LOADOUT,
+    labels: BOWLING_OPTION_LABELS,
+    typeLabels: TYPE_LABELS,
+    accountId: POOL_STORE_ACCOUNT_ID
   },
   texasholdem: {
     name: "Texas Hold'em",
@@ -1887,10 +1909,20 @@ export default function Store() {
         key: createItemKey(item.type, item.optionId),
         slug: 'snake'
       })),
+      bowling: BOWLING_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'bowling'
+      })),
       texasholdem: TEXAS_HOLDEM_STORE_ITEMS.map((item) => ({
         ...item,
         key: createItemKey(item.type, item.optionId),
         slug: 'texasholdem'
+      })),
+      tennis: POOL_ROYALE_STORE_ITEMS.filter((item) => item.type === 'environmentHdri' && TENNIS_HDRI_OPTION_IDS.includes(item.optionId)).map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'tennis'
       })),
     }),
     []
@@ -1924,6 +1956,10 @@ export default function Store() {
         isDominoOptionUnlocked(type, optionId, dominoOwned),
       snake: (type, optionId) =>
         isSnakeOptionUnlocked(type, optionId, snakeOwned),
+      tennis: (type, optionId) =>
+        isPoolOptionUnlocked(type, optionId, poolOwned),
+      bowling: (type, optionId) =>
+        optionId === BOWLING_DEFAULT_LOADOUT[type] || isPoolOptionUnlocked(type, optionId, poolOwned),
       texasholdem: (type, optionId) =>
         isTexasOptionUnlocked(type, optionId, texasOwned),
     }),
@@ -1973,6 +2009,8 @@ export default function Store() {
         SNAKE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       texasholdem: (item) =>
         TEXAS_HOLDEM_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      tennis: (item) =>
+        POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
     }),
     []
   );
@@ -1991,7 +2029,8 @@ export default function Store() {
       weaponkart: { humanCharacter: 'Seated Characters' },
       'domino-royal': DOMINO_TYPE_LABELS,
       snake: SNAKE_TYPE_LABELS,
-      texasholdem: TEXAS_TYPE_LABELS
+      texasholdem: TEXAS_TYPE_LABELS,
+      tennis: TYPE_LABELS
     }),
     []
   );
@@ -2580,7 +2619,7 @@ export default function Store() {
 
       const backgroundSyncTasks = [];
       for (const [slug, group] of Object.entries(groupedBySlug)) {
-        if (slug === 'poolroyale' || slug === 'bilardoshqip') {
+        if (slug === 'poolroyale' || slug === 'bilardoshqip' || slug === 'tennis' || slug === 'bowling') {
           for (const entry of group.items) {
             const syncTask = addPoolRoyalUnlock(
               entry.type,


### PR DESCRIPTION
### Motivation
- Revert the earlier retired-game cleanup and restore the Real Bowling and Tennis features (pages, routes, assets, gameplay code and store integration) so the games are available again in the web app catalog and lobbies.
- Recover gameplay support for Tennis (Unity scripts + frontend table-tennis module) and the Real Bowling runtime, visuals and inventory so they behave like before removal.
- Restore store/catalog entries, thumbnails and inventory wiring so bowling/tennis customizations and unlocks are available to the store flow and background sync.
- Bring back the official ten-pin bowling rules module and its regression test that validate scoring logic.

### Description
- Re-added lazy imports and routes in `webapp/src/App.jsx` for Tennis and Real Bowling (lobbies and in-game routes) so both games are reachable from the UI.
- Restored game pages and gameplay implementations including `webapp/src/pages/Games/Tennis.tsx`, `webapp/src/pages/Games/TennisLobby.jsx`, `webapp/src/pages/Games/BowlingRealistic.tsx`, and `webapp/src/pages/Games/BowlingLobby.jsx` plus many tennis submodules under `webapp/src/pages/Games/tennis/` and bowling support files.
- Restored frontend table-tennis implementation under `frontend/src/table-tennis/*` and Unity tennis support scripts under `Assets/Scripts/Gameplay/Tennis/*`, as well as icons `webapp/public/assets/icons/tennis-icon.svg`, `table-tennis-icon.svg`, and `tennis-royal.svg`.
- Reinstated store/catalog/config changes: `webapp/src/config/gamesCatalog.js`, `webapp/src/config/gameAssets.js`, `webapp/src/config/bowlingInventoryConfig.js`, and `webapp/src/pages/Store.jsx` updates to include tennis and bowling assets, store meta and background sync handling.
- Restored the official bowling rules module and regression test at `webapp/src/pages/Games/bowlingTenPinRules.js` and `test/bowlingTenPinRules.test.js`.

### Testing
- Ran the bowling rules unit test with `npm test -- --runInBand test/bowlingTenPinRules.test.js`, and the test suite passed.
- Built the web app production bundle with `npm --prefix webapp run build`, and the Vite production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28fdf39ee0832985dae5ccb5ac179a)