### PR TITLE
Refine pool cue stroke to match SnookerRoyalProvided gap model and improve forward-only stroke handling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1940,6 +1940,10 @@ const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.07;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.24; // widen the visible air gap so the cue sits a little farther from the cue ball
 const CUE_TIP_GAP = BALL_R * 1.42 + CUE_TIP_CLEARANCE; // pull the cue tip slightly farther back so the blue tip remains visible
+const POOL_CUE_PROVIDED_POSE_SCALE = BALL_R / 0.0525; // mirror SnookerRoyalProvided cue gap timing against Pool ball size
+const POOL_CUE_PROVIDED_IDLE_GAP = 0.012 * POOL_CUE_PROVIDED_POSE_SCALE;
+const POOL_CUE_PROVIDED_CONTACT_GAP = 0.0012 * POOL_CUE_PROVIDED_POSE_SCALE;
+const POOL_CUE_PROVIDED_PULL_RANGE = 0.42 * POOL_CUE_PROVIDED_POSE_SCALE;
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -24901,13 +24905,15 @@ const shotPowerRef = useRef(0);
             const safeHoldDuration = Math.max(0, holdDuration ?? 45);
             const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
             const resolvedIdlePos = idlePos ?? impactPos ?? stroke.contactPos ?? pullPos;
+            const resolvedImpactPos = impactPos ?? stroke.contactPos ?? resolvedIdlePos ?? pullPos;
             const normalizedStroke = ensureCueStrokeForwardMotion({
               pullPos: pullPos ?? resolvedIdlePos,
-              impactPos: resolvedIdlePos ?? pullPos,
+              impactPos: resolvedImpactPos ?? resolvedIdlePos ?? pullPos,
               fallbackDirection: tmpCueStrokeB.set(Math.sin(baseRotationY ?? 0), 0, Math.cos(baseRotationY ?? 0))
             });
             const resolvedPullPos = normalizedStroke.pullPos ?? pullPos ?? resolvedIdlePos;
-            const resolvedContactPos = resolvedIdlePos ?? stroke.contactPos ?? impactPos ?? pullPos;
+            const resolvedContactPos = stroke.contactPos ?? resolvedImpactPos ?? resolvedIdlePos ?? pullPos;
+            const resolvedFollowPos = followPos ?? resolvedContactPos;
             const strikeProgress = THREE.MathUtils.clamp(
               elapsed / Math.max(safeStrikeDuration, 1e-6),
               0,
@@ -24928,7 +24934,22 @@ const shotPowerRef = useRef(0);
               stroke.onImpact?.();
             }
 
+            if (elapsed < safeStrikeDuration) {
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
             if (elapsed < safeStrikeDuration + safeHoldDuration) {
+              const holdT = THREE.MathUtils.clamp(
+                (elapsed - safeStrikeDuration) / Math.max(safeHoldDuration, 1e-6),
+                0,
+                1
+              );
+              cueStick.position.lerpVectors(
+                resolvedContactPos,
+                resolvedFollowPos,
+                easeInOutCubic(holdT)
+              );
               cueAnimating = true;
               syncCueShadow();
               return true;
@@ -24940,7 +24961,7 @@ const shotPowerRef = useRef(0);
             );
             if (recoverT < 1) {
               cueStick.position.lerpVectors(
-                resolvedContactPos,
+                resolvedFollowPos,
                 resolvedIdlePos ?? impactPos ?? pullPos,
                 easeInOutCubic(recoverT)
               );
@@ -28890,7 +28911,7 @@ const shotPowerRef = useRef(0);
         const holdDuration = THREE.MathUtils.lerp(40, 68, p);
         return {
           // Snooker Royal-style live stroke: slider pull maps directly to cue pullback,
-          // then release performs one forward push back to the original cue-start pose.
+          // then release performs one forward push through cue-ball contact.
           motion: 'classic',
           pullRatio: p,
           pullSmoothing: 1,
@@ -29573,7 +29594,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29659,10 +29679,19 @@ const shotPowerRef = useRef(0);
             return new THREE.Vector3(tipTarget.x, tipTarget.y, tipTarget.z)
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
-          const idlePos = buildCuePosition(0);
-          // Start the release exactly from the computed pull position so the
-          // cue always pushes forward from the same pulled depth the player set.
-          const releaseStartPos = buildCuePosition(visualPull);
+          const providedGapToPullAmount = (gap) =>
+            BALL_R + gap - CUE_TIP_GAP;
+          const providedIdlePull = providedGapToPullAmount(POOL_CUE_PROVIDED_IDLE_GAP);
+          const providedPullRange = Math.min(
+            Math.max(0, maxPull),
+            POOL_CUE_PROVIDED_PULL_RANGE * easeOutCubic(clampedPower)
+          );
+          const providedPulledGap = POOL_CUE_PROVIDED_IDLE_GAP + providedPullRange;
+          const providedPulledPull = providedGapToPullAmount(providedPulledGap);
+          const idlePos = buildCuePosition(providedIdlePull);
+          // Start the release from the same real-life gap model used by
+          // SnookerRoyalProvided: idle gap + power pull, then drive to contact.
+          const releaseStartPos = buildCuePosition(providedPulledPull);
           cueStick.position.copy(releaseStartPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
@@ -29674,16 +29703,14 @@ const shotPowerRef = useRef(0);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = 0;
           const startTime = performance.now();
-          const impactPos = idlePos.clone();
-          const contactAdvance = 0; // push forward only to the original idle pose where the slider pull began
-          shotImpactPayload.contactAdvance = contactAdvance;
-          const contactPos = impactPos
-            .clone()
-            .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
-          const followPos = contactPos
-            .clone()
-            .addScaledVector(dir, followDistance);
+          // Match SnookerRoyalProvided's strike gap exactly: release from
+          // idle gap + pull, then physically close down to the cue-ball contact
+          // gap before the ball receives power.
+          const contactPull = providedGapToPullAmount(POOL_CUE_PROVIDED_CONTACT_GAP);
+          const impactPos = buildCuePosition(contactPull);
+          shotImpactPayload.contactAdvance = Math.max(0, providedIdlePull - contactPull);
+          const contactPos = impactPos.clone();
+          const followPos = contactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =
@@ -29806,10 +29833,10 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: 0.88,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
-              // Match Snooker Royal's release: push from the pulled pose and
-              // stop exactly at the cue's original idle/contact pose.
+              // Match Snooker Royal's release: push from the pulled pose
+              // through cue-ball contact, then hold the forward follow-through.
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,
@@ -33134,7 +33161,10 @@ const shotPowerRef = useRef(0);
         if (isAiTurn) {
           autoPlaceAiCueBall();
         }
+        const liveCueStrokeActive =
+          ENABLE_CUE_STROKE_ANIMATION && Boolean(cueStrokeStateRef.current);
         const canShowCue =
+          !liveCueStrokeActive &&
           allStopped(balls) &&
           cue?.active &&
           !(currentHud?.over) &&


### PR DESCRIPTION
### Motivation

- Make Pool Royale cue animation and release behavior match the SnookerRoyalProvided real-life gap model so the idle/pull/contact gaps and timing produce consistent visual and physical contact.  
- Fix subtle forward-only stroke edge cases where impact/contact/follow positions were resolved inconsistently and hold/recover interpolation could read from the wrong pose.  

### Description

- Introduces new constants `POOL_CUE_PROVIDED_POSE_SCALE`, `POOL_CUE_PROVIDED_IDLE_GAP`, `POOL_CUE_PROVIDED_CONTACT_GAP`, and `POOL_CUE_PROVIDED_PULL_RANGE` and derives provided idle/pull/contact positions from a gap-to-pull conversion to mirror SnookerRoyalProvided behaviour.  
- Reworks forward-only stroke resolution by adding `resolvedImpactPos`, using it to compute `resolvedContactPos` and `resolvedFollowPos`, and fixes the hold/recover lerps so the cue moves from pull -> contact -> follow -> idle in the intended order.  
- Uses the provided gap model when building `idlePos`, `releaseStartPos`, `impactPos`, and `contactPos`, sets `shotImpactPayload.contactAdvance` accordingly, and moves impact application to the stroke `onImpact` callback to align with the animation timeline.  
- Small adjustments: reduces `strikeImpactThreshold` from `0.9` to `0.88` and prevents the cue from being shown during an active live cue stroke by gating `canShowCue` with `liveCueStrokeActive`.  

### Testing

- Ran the frontend test suite with `yarn test` and all automated tests passed.  
- Built the webapp with `yarn build` to validate bundling and the production bundle compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28eab547388329a188696ddceff2a7)