### PR TITLE
Align Snooker Royal with official snooker table scale

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -22,7 +22,8 @@ import {
   usesProceduralSnookerTableRailDecor,
   TABLE_MODEL_CLASSIC,
   TABLE_MODEL_OPENSOURCE,
-  TABLE_MODEL_OPENSOURCE_GLB_URL
+  TABLE_MODEL_OPENSOURCE_GLB_URL,
+  OFFICIAL_SNOOKER_SPEC
 } from './snookerTableModel.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
@@ -977,9 +978,9 @@ function addPocketCuts(
 // Dimensions tuned for the Pool Royale footprint for identical table sizing and layout.
 const TABLE_SIZE_SHRINK = 0.85; // tighten the table footprint by ~8% to add breathing room without altering proportions
 const TABLE_REDUCTION = 0.84 * TABLE_SIZE_SHRINK; // apply the legacy trim plus the tighter shrink so the arena stays compact without distorting proportions
-const SNOOKER_TABLE_FOOTPRINT_ENLARGE = 1.12; // enlarge the playable table footprint while keeping ball geometry unchanged
-const TABLE_FOOTPRINT_SCALE = 0.82 * SNOOKER_TABLE_FOOTPRINT_ENLARGE; // make the table 12% larger in portrait without changing its proportions
-const BASE_FOOTPRINT_SHRINK = 0.82 * SNOOKER_TABLE_FOOTPRINT_ENLARGE; // keep the base matched to the larger table footprint without changing overall height
+const SNOOKER_TABLE_FOOTPRINT_ENLARGE = 1; // keep the imported GLB, playfield mapping, and balls on the same official snooker scale
+const TABLE_FOOTPRINT_SCALE = 0.82 * SNOOKER_TABLE_FOOTPRINT_ENLARGE; // keep portrait framing compact while preserving the official snooker proportions
+const BASE_FOOTPRINT_SHRINK = 0.82 * SNOOKER_TABLE_FOOTPRINT_ENLARGE; // keep the base matched to the official GLB/table footprint without changing overall height
 const SIZE_REDUCTION = 0.78; // enlarge the playfield/balls to better match Pool Royale sizing
 const GLOBAL_SIZE_FACTOR = 0.85 * SIZE_REDUCTION;
 const TABLE_DISPLAY_SCALE = 1.12; // enlarge the Snooker Royal table a bit more while preserving proportions
@@ -1148,16 +1149,16 @@ const FRAME_TOP_Y = -TABLE.THICK + 0.01; // mirror the snooker rail stackup so c
 const TABLE_RAIL_TOP_Y = FRAME_TOP_Y + RAIL_HEIGHT;
   // Official 12ft snooker playfield and ball references. Pocket mouths use the original snooker
   // cushion-template proportions instead of the wider Pool Royale pocket layout.
-  const WIDTH_REF = 3569;
-  const HEIGHT_REF = 1778;
-  const BALL_D_REF = 52.5;
-  const BALL_D_TOLERANCE_REF = 0.05;
-  const BAULK_FROM_BAULK_REF = 737; // Baulk-line distance from the baulk cushion (29")
-  const D_RADIUS_REF = 292;
-  const PINK_FROM_TOP_REF = 737;
-  const BLACK_FROM_TOP_REF = 324; // Black spot distance from the top cushion (12.75")
-  const CORNER_MOUTH_REF = 83; // original snooker corner cushion-template mouth width (mm)
-  const SIDE_MOUTH_REF = 87; // original snooker side cushion-template mouth width (mm)
+  const WIDTH_REF = OFFICIAL_SNOOKER_SPEC.playfieldWidthMm;
+  const HEIGHT_REF = OFFICIAL_SNOOKER_SPEC.playfieldHeightMm;
+  const BALL_D_REF = OFFICIAL_SNOOKER_SPEC.ballDiameterMm;
+  const BALL_D_TOLERANCE_REF = OFFICIAL_SNOOKER_SPEC.ballDiameterToleranceMm;
+  const BAULK_FROM_BAULK_REF = OFFICIAL_SNOOKER_SPEC.baulkLineFromBaulkCushionMm; // Baulk-line distance from the baulk cushion (29")
+  const D_RADIUS_REF = OFFICIAL_SNOOKER_SPEC.dRadiusMm;
+  const PINK_FROM_TOP_REF = OFFICIAL_SNOOKER_SPEC.pinkSpotFromTopCushionMm;
+  const BLACK_FROM_TOP_REF = OFFICIAL_SNOOKER_SPEC.blackSpotFromTopCushionMm; // Black spot distance from the top cushion (12.75")
+  const CORNER_MOUTH_REF = OFFICIAL_SNOOKER_SPEC.cornerPocketMouthMm; // original snooker corner cushion-template mouth width (mm)
+  const SIDE_MOUTH_REF = OFFICIAL_SNOOKER_SPEC.sidePocketMouthMm; // original snooker side cushion-template mouth width (mm)
   const SIDE_RAIL_INNER_REDUCTION = 0.72; // nudge the rails further inward so the cloth footprint tightens slightly more
   const SIDE_RAIL_INNER_SCALE = 1 - SIDE_RAIL_INNER_REDUCTION;
   const SIDE_RAIL_INNER_THICKNESS = TABLE.WALL * SIDE_RAIL_INNER_SCALE;
@@ -1179,8 +1180,8 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   );
 const MARKINGS_MM_TO_UNITS = innerLong / WIDTH_REF;
 const OBJECT_MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_MM_TO_UNITS = OBJECT_MM_TO_UNITS / SNOOKER_TABLE_FOOTPRINT_ENLARGE; // preserve the previous ball size while the table expands
-const BALL_SIZE_SCALE = 0.965; // trim Snooker Royal balls just a bit smaller while keeping the table/pocket mapping full-size
+const BALL_MM_TO_UNITS = OBJECT_MM_TO_UNITS; // same mm-to-world mapping as the official snooker table and GLB playfield
+const BALL_SIZE_SCALE = 1; // official snooker ball diameter: 52.5mm with no gameplay shrink
 const BALL_DIAMETER = BALL_D_REF * BALL_MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1240,8 +1241,8 @@ console.assert(
   'Side pocket mouth width mismatch.'
 );
 console.assert(
-  Math.abs(BALL_DIAMETER - BALL_D_REF * BALL_MM_TO_UNITS * BALL_SIZE_SCALE) <= BALL_DIAMETER_TOLERANCE,
-  'Ball diameter must match the configured Snooker Royal ball size scale.'
+  Math.abs(BALL_DIAMETER - BALL_D_REF * OBJECT_MM_TO_UNITS) <= BALL_DIAMETER_TOLERANCE,
+  'Ball diameter must match the official 52.5mm snooker spec on the table mapping.'
 );
 console.assert(
   Math.abs(BALL_DIAMETER - BALL_R * 2) <= BALL_DIAMETER_TOLERANCE,
@@ -11770,13 +11771,9 @@ function Table3D(
         const sourceFitSize = sourceFitBounds.getSize(new THREE.Vector3());
         const fit = resolveSnookerGlbFitTransform(
           { x: sourceFitSize.x, y: sourceFitSize.y, z: sourceFitSize.z },
-          { x: targetSize.x, y: targetSize.y, z: targetSize.z }
+          { x: targetSize.x, y: targetSize.y, z: targetSize.z },
+          { preserveOriginalHorizontalShape: true, preserveVerticalFromHorizontal: true }
         );
-        const upperTableScale = Math.min(fit.scale.x, fit.scale.z);
-        if (Number.isFinite(upperTableScale) && upperTableScale > MICRO_EPS) {
-          fit.scale.y = upperTableScale;
-          fit.preservesOriginalUpperTableProportions = true;
-        }
         model.scale.set(fit.scale.x, fit.scale.y, fit.scale.z);
 
         model.updateMatrixWorld(true);
@@ -11804,6 +11801,8 @@ function Table3D(
           isOpenSourceVisual: true,
           sourceUrl: TABLE_MODEL_OPENSOURCE_GLB_URL,
           fitToProceduralMapping: true,
+          officialSnookerSpec: OFFICIAL_SNOOKER_SPEC,
+          preservesOriginalGlbHorizontalShape: fit.preservesOriginalHorizontalShape === true,
           keepsDefaultPocketDropHardware: true,
           preservesProceduralChromeHoldersLeatherStrapsAndNets: true,
           removesProceduralFrameRailsChromePlatesAndJaws: !keepProceduralRailDecor,

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -3,6 +3,20 @@ export const TABLE_MODEL_OPENSOURCE = 'opensource';
 export const TABLE_MODEL_OPENSOURCE_GLB_URL =
   'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
 
+export const OFFICIAL_SNOOKER_SPEC = Object.freeze({
+  // WPBSA full-size snooker playing area: 11 ft 8.5 in x 5 ft 10 in.
+  playfieldWidthMm: 3569,
+  playfieldHeightMm: 1778,
+  ballDiameterMm: 52.5,
+  ballDiameterToleranceMm: 0.05,
+  baulkLineFromBaulkCushionMm: 737,
+  dRadiusMm: 292,
+  pinkSpotFromTopCushionMm: 737,
+  blackSpotFromTopCushionMm: 324,
+  cornerPocketMouthMm: 83,
+  sidePocketMouthMm: 87
+});
+
 
 const MIN_GLB_FIT_SIZE = 0.0001;
 
@@ -11,16 +25,39 @@ function safePositiveDimension(value, fallback = MIN_GLB_FIT_SIZE) {
   return Number.isFinite(numeric) && numeric > MIN_GLB_FIT_SIZE ? numeric : fallback;
 }
 
-export function resolveSnookerGlbFitTransform(sourceSize = {}, targetSize = {}) {
+export function resolveSnookerGlbFitTransform(sourceSize = {}, targetSize = {}, options = {}) {
   const sourceX = safePositiveDimension(sourceSize.x);
   const sourceY = safePositiveDimension(sourceSize.y);
   const sourceZ = safePositiveDimension(sourceSize.z);
+  const targetX = safePositiveDimension(targetSize.x);
+  const targetY = safePositiveDimension(targetSize.y);
+  const targetZ = safePositiveDimension(targetSize.z);
+  const rawScale = {
+    x: targetX / sourceX,
+    y: targetY / sourceY,
+    z: targetZ / sourceZ
+  };
+
+  if (!options?.preserveOriginalHorizontalShape) {
+    return { scale: rawScale, rawScale };
+  }
+
+  const longScale = Math.max(targetX, targetZ) / Math.max(sourceX, sourceZ);
+  const shortScale = Math.min(targetX, targetZ) / Math.min(sourceX, sourceZ);
+  const horizontalScale = options.fitMode === 'contain'
+    ? Math.min(longScale, shortScale)
+    : longScale;
+
   return {
     scale: {
-      x: safePositiveDimension(targetSize.x) / sourceX,
-      y: safePositiveDimension(targetSize.y) / sourceY,
-      z: safePositiveDimension(targetSize.z) / sourceZ
-    }
+      x: horizontalScale,
+      y: options.preserveVerticalFromHorizontal === false ? rawScale.y : horizontalScale,
+      z: horizontalScale
+    },
+    rawScale,
+    horizontalScale,
+    preservesOriginalHorizontalShape: true,
+    fitMode: options.fitMode || 'long-edge'
   };
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the Snooker GLB import and in-game geometry use the official WPBSA 12ft snooker dimensions and ball diameter so visuals, physics, and mapping match the real game.
- Preserve the original horizontal proportions of third-party GLB tables when fitting them into the procedural mapping to avoid non-uniform X/Z stretching of the model.
- Remove ad-hoc ball shrink so the in-game balls match the official 52.5mm diameter used for play/physics calculations.

### Description
- Added `OFFICIAL_SNOOKER_SPEC` (playfield, ball, baulk/D/spot, pocket mouth mm values) in `webapp/src/pages/Games/snookerTableModel.js` and exported it for consumers.
- Extended `resolveSnookerGlbFitTransform` to accept options and return a fit that can preserve the GLB's original horizontal shape with a uniform X/Z scale when requested.
- Updated `SnookerRoyal.jsx` to consume `OFFICIAL_SNOOKER_SPEC` for marking constants and playfield ratio, set mm→world mappings so balls use the official 52.5mm diameter (no gameplay shrink), and to call the GLB fit helper with the new preserve-horizontal-shape options when loading the open-source GLB.
- When an open-source GLB is applied the code now stores `officialSnookerSpec` and `preservesOriginalGlbHorizontalShape` metadata on `model.userData` and keeps procedural mappings for cloth/physics aligned to the official spec.

### Testing
- Ran `npm run build` which completed successfully and produced the app bundles (build output reported, warning about large chunks only); result: success.
- Ran `npm run lint` which completed with no lint errors; result: success.
- Installed Playwright browsers and OS deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) which completed successfully; result: success.
- Attempted an automated headless Chromium render of `/games/snookerroyale?mode=practice&tableModel=opensource` to capture a screenshot; a preview screenshot file was generated but the headless environment reported WebGL/GL errors and network/SSL noise, so while the page frame was captured the run reported runtime limitations (headless GPU / WebGL not available) rather than a deterministic visual validation; result: partial (screenshot produced but environment limitations noted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2905285d3c8329a79507e89d059f32)