### PR TITLE
Align Snooker GLB fit and ball sizing to official snooker dimensions

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1179,8 +1179,8 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   );
 const MARKINGS_MM_TO_UNITS = innerLong / WIDTH_REF;
 const OBJECT_MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_MM_TO_UNITS = OBJECT_MM_TO_UNITS / SNOOKER_TABLE_FOOTPRINT_ENLARGE; // preserve the previous ball size while the table expands
-const BALL_SIZE_SCALE = 0.965; // trim Snooker Royal balls just a bit smaller while keeping the table/pocket mapping full-size
+const BALL_MM_TO_UNITS = OBJECT_MM_TO_UNITS; // official snooker balls use the same table millimetre mapping as the 3569mm playfield
+const BALL_SIZE_SCALE = 1; // keep Snooker Royal balls at the official 52.5mm diameter, with no gameplay shrink
 const BALL_DIAMETER = BALL_D_REF * BALL_MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1240,8 +1240,8 @@ console.assert(
   'Side pocket mouth width mismatch.'
 );
 console.assert(
-  Math.abs(BALL_DIAMETER - BALL_D_REF * BALL_MM_TO_UNITS * BALL_SIZE_SCALE) <= BALL_DIAMETER_TOLERANCE,
-  'Ball diameter must match the configured Snooker Royal ball size scale.'
+  Math.abs(BALL_DIAMETER - BALL_D_REF * OBJECT_MM_TO_UNITS) <= BALL_DIAMETER_TOLERANCE,
+  'Ball diameter must remain the official 52.5mm size on the snooker table millimetre mapping.'
 );
 console.assert(
   Math.abs(BALL_DIAMETER - BALL_R * 2) <= BALL_DIAMETER_TOLERANCE,

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -1,40 +1,73 @@
-export const TABLE_MODEL_CLASSIC = 'classic';
-export const TABLE_MODEL_OPENSOURCE = 'opensource';
+export const TABLE_MODEL_CLASSIC = 'classic'
+export const TABLE_MODEL_OPENSOURCE = 'opensource'
 export const TABLE_MODEL_OPENSOURCE_GLB_URL =
-  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb'
 
+const MIN_GLB_FIT_SIZE = 0.0001
+const DEFAULT_GLB_FIT_OPTIONS = Object.freeze({ preserveOriginalShape: true })
 
-const MIN_GLB_FIT_SIZE = 0.0001;
-
-function safePositiveDimension(value, fallback = MIN_GLB_FIT_SIZE) {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) && numeric > MIN_GLB_FIT_SIZE ? numeric : fallback;
+function safePositiveDimension (value, fallback = MIN_GLB_FIT_SIZE) {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) && numeric > MIN_GLB_FIT_SIZE ? numeric : fallback
 }
 
-export function resolveSnookerGlbFitTransform(sourceSize = {}, targetSize = {}) {
-  const sourceX = safePositiveDimension(sourceSize.x);
-  const sourceY = safePositiveDimension(sourceSize.y);
-  const sourceZ = safePositiveDimension(sourceSize.z);
+function resolveUniformOfficialScale (sourceX, sourceZ, targetX, targetZ) {
+  const sourceLong = Math.max(sourceX, sourceZ)
+  const targetLong = Math.max(targetX, targetZ)
+  const longAxisScale = targetLong / sourceLong
+  if (Number.isFinite(longAxisScale) && longAxisScale > MIN_GLB_FIT_SIZE) {
+    return longAxisScale
+  }
+  const sourceShort = Math.min(sourceX, sourceZ)
+  const targetShort = Math.min(targetX, targetZ)
+  const shortAxisScale = targetShort / sourceShort
+  return Number.isFinite(shortAxisScale) && shortAxisScale > MIN_GLB_FIT_SIZE ? shortAxisScale : 1
+}
+
+export function resolveSnookerGlbFitTransform (sourceSize = {}, targetSize = {}, options = {}) {
+  const fitOptions = { ...DEFAULT_GLB_FIT_OPTIONS, ...(options || {}) }
+  const sourceX = safePositiveDimension(sourceSize.x)
+  const sourceY = safePositiveDimension(sourceSize.y)
+  const sourceZ = safePositiveDimension(sourceSize.z)
+  const targetX = safePositiveDimension(targetSize.x)
+  const targetY = safePositiveDimension(targetSize.y)
+  const targetZ = safePositiveDimension(targetSize.z)
+
+  if (fitOptions.preserveOriginalShape !== false) {
+    const horizontalScale = resolveUniformOfficialScale(sourceX, sourceZ, targetX, targetZ)
+    return {
+      scale: {
+        x: horizontalScale,
+        y: horizontalScale,
+        z: horizontalScale
+      },
+      preservesOriginalShape: true,
+      mapping: 'official-long-axis-uniform-scale'
+    }
+  }
+
   return {
     scale: {
-      x: safePositiveDimension(targetSize.x) / sourceX,
-      y: safePositiveDimension(targetSize.y) / sourceY,
-      z: safePositiveDimension(targetSize.z) / sourceZ
-    }
-  };
+      x: targetX / sourceX,
+      y: targetY / sourceY,
+      z: targetZ / sourceZ
+    },
+    preservesOriginalShape: false,
+    mapping: 'axis-fit-scale'
+  }
 }
 
-export function resolveSnookerTableModel(value) {
-  const requested = String(value || '').toLowerCase();
-  return requested === TABLE_MODEL_CLASSIC ? TABLE_MODEL_CLASSIC : TABLE_MODEL_OPENSOURCE;
+export function resolveSnookerTableModel (value) {
+  const requested = String(value || '').toLowerCase()
+  return requested === TABLE_MODEL_CLASSIC ? TABLE_MODEL_CLASSIC : TABLE_MODEL_OPENSOURCE
 }
 
-export function applySnookerTableModelParam(params, tableModel) {
-  const resolved = resolveSnookerTableModel(tableModel);
-  params.set('tableModel', resolved);
-  return resolved;
+export function applySnookerTableModelParam (params, tableModel) {
+  const resolved = resolveSnookerTableModel(tableModel)
+  params.set('tableModel', resolved)
+  return resolved
 }
 
-export function usesProceduralSnookerTableRailDecor(tableModel) {
-  return resolveSnookerTableModel(tableModel) === TABLE_MODEL_CLASSIC;
+export function usesProceduralSnookerTableRailDecor (tableModel) {
+  return resolveSnookerTableModel(tableModel) === TABLE_MODEL_CLASSIC
 }


### PR DESCRIPTION
### Motivation
- Ensure imported snooker GLB tables are used at their original shape and proportions so visual mapping (cushions, jaws, pockets) matches the official table geometry.
- Guarantee the in-game snooker balls use the official 52.5mm diameter and the same table millimetre mapping as the official 3569mm playfield to avoid footprint compensation or hidden size changes.

### Description
- Update `webapp/src/pages/Games/snookerTableModel.js` to change `resolveSnookerGlbFitTransform` so it preserves the GLB’s original shape by default and applies a single uniform long-axis scale for X/Z fitting, with an explicit opt-out (`preserveOriginalShape: false`) to use the previous axis-fit behavior; added safe-dimension helpers and metadata fields (`preservesOriginalShape`, `mapping`).
- Restore ball sizing in `webapp/src/pages/Games/SnookerRoyal.jsx` by setting `BALL_MM_TO_UNITS = OBJECT_MM_TO_UNITS`, `BALL_SIZE_SCALE = 1`, and tighten the runtime diameter assertion to verify the ball remains the official 52.5mm on the snooker table mapping.
- Minor formatting / lint fixes for the new module exports and helper functions.

### Testing
- Ran a small runtime check using `node --input-type=module - <<'NODE' ... NODE` to validate `resolveSnookerGlbFitTransform` returns a uniform scale by default and that the axis-fit opt-out remains available; this check passed.
- Ran linter: `npm --prefix webapp run lint -- src/pages/Games/snookerTableModel.js src/pages/Games/SnookerRoyal.jsx` and it completed with no remaining lint errors after formatting fixes.
- Built the webapp: `npm --prefix webapp run build` and the production build completed successfully.
- Installed Playwright browsers and dependencies (`npx playwright install chromium` and `npx playwright install-deps chromium`) successfully, but a headless screenshot attempt timed out in this environment (Playwright screenshot timed out after dependency install); installation steps succeeded even though the capture attempt failed due to environment constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2905285d3c8329a79507e89d059f32)