### PR TITLE
Adopt SnookerRoyalProvided cue stroke/contact math for Pool Royale and add tests

### DIFF
--- a/test/poolRoyaleCueStrokeContact.test.js
+++ b/test/poolRoyaleCueStrokeContact.test.js
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+
+const source = fs.readFileSync('webapp/src/pages/Games/PoolRoyale.jsx', 'utf8');
+
+describe('Pool Royale live cue contact stroke wiring', () => {
+  it('uses the same idle/contact gap ratios as SnookerRoyalProvided for the strike target', () => {
+    expect(source).toContain('const SNOOKER_PROVIDED_IDLE_GAP_RATIO = 0.62244');
+    expect(source).toContain('const SNOOKER_PROVIDED_CONTACT_GAP_RATIO = 0.06224');
+    expect(source).toContain('const CUE_TIP_GAP = BALL_R + CUE_TIP_CLEARANCE');
+    expect(source).toContain('const CUE_CONTACT_DISTANCE = BALL_R + CUE_CONTACT_GAP');
+    expect(source).toContain('const impactPos = buildCuePosition(-contactAdvance)');
+  });
+
+  it('does not apply cue-ball power before the animated cue reaches impact', () => {
+    const payloadIndex = source.indexOf('const shotImpactPayload = {');
+    const helperIndex = source.indexOf('const applyShotImpactOnce = () => {', payloadIndex);
+    const animationIndex = source.indexOf('if (ENABLE_CUE_STROKE_ANIMATION)', helperIndex);
+    const prematureSection = source.slice(payloadIndex, helperIndex);
+
+    expect(payloadIndex).toBeGreaterThan(-1);
+    expect(helperIndex).toBeGreaterThan(payloadIndex);
+    expect(animationIndex).toBeGreaterThan(helperIndex);
+    expect(prematureSection).not.toContain('applyShotAtImpact(shotImpactPayload);');
+    expect(source).toContain('onImpact: () => applyShotImpactOnce()');
+  });
+
+  it('uses SnookerRoyalProvided pull, timing, and frozen contact stroke math', () => {
+    expect(source).toContain('const SNOOKER_PROVIDED_PULL_RANGE_RATIO = 21.78538');
+    expect(source).toContain('const SNOOKER_PROVIDED_STRIKE_TIME_MS = 120');
+    expect(source).toContain('const SNOOKER_PROVIDED_HOLD_TIME_MS = 50');
+    expect(source).toContain('const SNOOKER_PROVIDED_IMPACT_NORM = 0.88');
+    expect(source).toContain('pullRatio: easeOutCubic(p)');
+    expect(source).toContain('const strikeMotionNorm = stroke.shotApplied ? impactThreshold : strikeProgress');
+    expect(source).toContain('strikeImpactThreshold: strokeProfile.impactThreshold ?? SNOOKER_PROVIDED_IMPACT_NORM');
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1938,9 +1938,18 @@ const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.07;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
-const CUE_TIP_CLEARANCE = BALL_R * 0.24; // widen the visible air gap so the cue sits a little farther from the cue ball
-const CUE_TIP_GAP = BALL_R * 1.42 + CUE_TIP_CLEARANCE; // pull the cue tip slightly farther back so the blue tip remains visible
-const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
+const SNOOKER_PROVIDED_IDLE_GAP_RATIO = 0.62244; // CFG.idleGap / CFG.ballR from SnookerRoyalProvided.jsx
+const SNOOKER_PROVIDED_CONTACT_GAP_RATIO = 0.06224; // CFG.contactGap / CFG.ballR from SnookerRoyalProvided.jsx
+const SNOOKER_PROVIDED_PULL_RANGE_RATIO = 21.78538; // CFG.pullRange / CFG.ballR from SnookerRoyalProvided.jsx
+const SNOOKER_PROVIDED_STRIKE_TIME_MS = 120; // CFG.strikeTime from SnookerRoyalProvided.jsx
+const SNOOKER_PROVIDED_HOLD_TIME_MS = 50; // CFG.holdTime from SnookerRoyalProvided.jsx
+const SNOOKER_PROVIDED_IMPACT_NORM = 0.88;
+const CUE_TIP_CLEARANCE = BALL_R * SNOOKER_PROVIDED_IDLE_GAP_RATIO; // same visual idle gap as SnookerRoyalProvided.jsx
+const CUE_TIP_GAP = BALL_R + CUE_TIP_CLEARANCE;
+const CUE_CONTACT_GAP = BALL_R * SNOOKER_PROVIDED_CONTACT_GAP_RATIO;
+const CUE_CONTACT_DISTANCE = BALL_R + CUE_CONTACT_GAP;
+const CUE_CONTACT_ADVANCE = Math.max(0, CUE_TIP_GAP - CUE_CONTACT_DISTANCE);
+const CUE_PULL_BASE = BALL_R * SNOOKER_PROVIDED_PULL_RANGE_RATIO;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
 const CUE_PULL_VISUAL_MULTIPLIER = 1.28;
@@ -24901,37 +24910,78 @@ const shotPowerRef = useRef(0);
             const safeHoldDuration = Math.max(0, holdDuration ?? 45);
             const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
             const resolvedIdlePos = idlePos ?? impactPos ?? stroke.contactPos ?? pullPos;
+            const resolvedImpactPos = impactPos ?? stroke.contactPos ?? resolvedIdlePos ?? pullPos;
             const normalizedStroke = ensureCueStrokeForwardMotion({
               pullPos: pullPos ?? resolvedIdlePos,
-              impactPos: resolvedIdlePos ?? pullPos,
+              impactPos: resolvedImpactPos ?? resolvedIdlePos ?? pullPos,
               fallbackDirection: tmpCueStrokeB.set(Math.sin(baseRotationY ?? 0), 0, Math.cos(baseRotationY ?? 0))
             });
             const resolvedPullPos = normalizedStroke.pullPos ?? pullPos ?? resolvedIdlePos;
-            const resolvedContactPos = resolvedIdlePos ?? stroke.contactPos ?? impactPos ?? pullPos;
+            const resolvedContactPos = stroke.contactPos ?? resolvedImpactPos ?? resolvedIdlePos ?? pullPos;
+            const resolvedFollowPos = followPos ?? resolvedContactPos;
             const strikeProgress = THREE.MathUtils.clamp(
               elapsed / Math.max(safeStrikeDuration, 1e-6),
               0,
               1
             );
-            const strikeEase = easeOutCubic(strikeProgress);
-            cueStick.visible = true;
-            cueStick.position.lerpVectors(resolvedPullPos, resolvedContactPos, strikeEase);
-            cueStick.position.y -= (strikeDip ?? 0.0035) * strikeEase;
-            cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
-            cueStick.rotation.y =
-              (baseRotationY ?? cueStick.rotation.y) +
-              Math.sin(strikeProgress * Math.PI) * 0.0014;
-
-            const impactThreshold = THREE.MathUtils.clamp(strikeImpactThreshold ?? 0.88, 0.05, 0.995);
-            if (!stroke.shotApplied && strikeProgress >= impactThreshold) {
+            const impactThreshold = THREE.MathUtils.clamp(
+              strikeImpactThreshold ?? SNOOKER_PROVIDED_IMPACT_NORM,
+              0.05,
+              0.995
+            );
+            if (!stroke.shotApplied && strikeProgress > impactThreshold) {
               stroke.shotApplied = true;
               stroke.onImpact?.();
             }
 
-            if (elapsed < safeStrikeDuration + safeHoldDuration) {
-              cueAnimating = true;
-              syncCueShadow();
-              return true;
+            if (stroke.motionTechnique === 'snookerRoyalProvided') {
+              // Same as SnookerRoyalProvided.jsx:
+              //   const strikeMotionNorm = didHit ? 0.88 : strikeNorm;
+              //   gap = lerp(CFG.idleGap + pull, CFG.contactGap, easeOutCubic(strikeMotionNorm));
+              const strikeMotionNorm = stroke.shotApplied ? impactThreshold : strikeProgress;
+              cueStick.visible = true;
+              cueStick.position.lerpVectors(
+                resolvedPullPos,
+                resolvedContactPos,
+                easeOutCubic(strikeMotionNorm)
+              );
+              cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+              cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
+              if (elapsed < safeStrikeDuration + safeHoldDuration) {
+                cueAnimating = true;
+                syncCueShadow();
+                return true;
+              }
+            } else {
+              const strikeEase = easeOutCubic(strikeProgress);
+              cueStick.visible = true;
+              cueStick.position.lerpVectors(resolvedPullPos, resolvedContactPos, strikeEase);
+              cueStick.position.y -= (strikeDip ?? 0.0035) * strikeEase;
+              cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+              cueStick.rotation.y =
+                (baseRotationY ?? cueStick.rotation.y) +
+                Math.sin(strikeProgress * Math.PI) * 0.0014;
+
+              if (elapsed < safeStrikeDuration) {
+                cueAnimating = true;
+                syncCueShadow();
+                return true;
+              }
+              if (elapsed < safeStrikeDuration + safeHoldDuration) {
+                const holdT = THREE.MathUtils.clamp(
+                  (elapsed - safeStrikeDuration) / Math.max(safeHoldDuration, 1e-6),
+                  0,
+                  1
+                );
+                cueStick.position.lerpVectors(
+                  resolvedContactPos,
+                  resolvedFollowPos,
+                  easeInOutCubic(holdT)
+                );
+                cueAnimating = true;
+                syncCueShadow();
+                return true;
+              }
             }
             const recoverT = THREE.MathUtils.clamp(
               (elapsed - (safeStrikeDuration + safeHoldDuration)) / Math.max(safeRecoverDuration || 1, 1),
@@ -24940,7 +24990,7 @@ const shotPowerRef = useRef(0);
             );
             if (recoverT < 1) {
               cueStick.position.lerpVectors(
-                resolvedContactPos,
+                resolvedFollowPos,
                 resolvedIdlePos ?? impactPos ?? pullPos,
                 easeInOutCubic(recoverT)
               );
@@ -28885,20 +28935,18 @@ const shotPowerRef = useRef(0);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(110, 190, p);
-        const strikeDuration = THREE.MathUtils.lerp(128, 92, p);
-        const holdDuration = THREE.MathUtils.lerp(40, 68, p);
         return {
-          // Snooker Royal-style live stroke: slider pull maps directly to cue pullback,
-          // then release performs one forward push back to the original cue-start pose.
-          motion: 'classic',
-          pullRatio: p,
+          // Keep Pool Royale's live shot math identical to SnookerRoyalProvided.jsx:
+          // pull = CFG.pullRange * easeOutCubic(activePower) and strike uses
+          // CFG.strikeTime/holdTime with impact at normalized 0.88.
+          motion: 'snookerRoyalProvided',
+          pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration,
-          holdDuration,
-          pullbackDuration,
+          strikeDuration: SNOOKER_PROVIDED_STRIKE_TIME_MS,
+          holdDuration: SNOOKER_PROVIDED_HOLD_TIME_MS,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 0.86,
+          impactThreshold: SNOOKER_PROVIDED_IMPACT_NORM,
           forwardOnly: true,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
@@ -29573,7 +29621,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29601,24 +29648,12 @@ const shotPowerRef = useRef(0);
           if (cue?.pos) {
             cueStickAnchorRef.current.set(cue.pos.x, CUE_Y, cue.pos.y);
           }
-          const backInfo = calcTarget(
-            cue,
-            aimDir.clone().multiplyScalar(-1),
-            balls
-          );
-          const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
-          const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          // Rebuilt stroke pullback: tie visible pull directly to slider power
-          // and the currently available room behind the cue ball.
-          const pullRange = THREE.MathUtils.clamp(
-            maxPull * 0.92,
-            CUE_PULL_MIN_VISUAL,
-            Math.max(CUE_PULL_MIN_VISUAL, maxPull)
-          );
+          // SnookerRoyalProvided.jsx uses a fixed CFG.pullRange scaled by
+          // easeOutCubic(activePower), not a camera-compensated follow-through.
+          const pullRange = CUE_PULL_BASE;
           const pullTarget = pullRange * strokeProfile.pullRatio;
-          const pulledNow = cuePullCurrentRef.current ?? pullTarget;
-          const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
-          const visualPull = applyVisualPullCompensation(startPull, dir);
+          const startPull = Math.max(0, pullTarget);
+          const visualPull = startPull;
           shotImpactPayload.pullDistance = visualPull;
           cuePullCurrentRef.current = startPull;
           cuePullTargetRef.current = startPull;
@@ -29674,16 +29709,15 @@ const shotPowerRef = useRef(0);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = 0;
           const startTime = performance.now();
-          const impactPos = idlePos.clone();
-          const contactAdvance = 0; // push forward only to the original idle pose where the slider pull began
+          // Match SnookerRoyalProvided.jsx exactly: the visible cue stroke
+          // interpolates the tip gap from idle + pull to a tiny contact gap at
+          // the cue ball, then holds that physical contact while the cue-ball
+          // impulse is applied.
+          const contactAdvance = CUE_CONTACT_ADVANCE;
+          const impactPos = buildCuePosition(-contactAdvance);
           shotImpactPayload.contactAdvance = contactAdvance;
-          const contactPos = impactPos
-            .clone()
-            .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
-          const followPos = contactPos
-            .clone()
-            .addScaledVector(dir, followDistance);
+          const contactPos = impactPos.clone();
+          const followPos = contactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =
@@ -29806,10 +29840,10 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: strokeProfile.impactThreshold ?? SNOOKER_PROVIDED_IMPACT_NORM,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
-              // Match Snooker Royal's release: push from the pulled pose and
-              // stop exactly at the cue's original idle/contact pose.
+              // Match SnookerRoyalProvided's release: push from pullback
+              // into physical cue-ball contact, then hold that contact.
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,


### PR DESCRIPTION
### Motivation
- Make Pool Royale's live cue stroke visuals and timing match the existing `SnookerRoyalProvided` implementation for consistent feel and collision behavior.
- Ensure the cue-ball impulse is applied only at the animated impact moment rather than immediately when the shot is started.
- Centralize and expose the constants used by the snooker-style stroke for clarity and easier tuning.

### Description
- Introduce `SNOOKER_PROVIDED_*` constants and compute `CUE_TIP_GAP`, `CUE_CONTACT_GAP`, `CUE_CONTACT_DISTANCE`, and `CUE_CONTACT_ADVANCE` from those ratios. 
- Change the live stroke profile to use `motion: 'snookerRoyalProvided'` with `pullRatio: easeOutCubic(p)` and fixed `strikeDuration`/`holdDuration`/`impactThreshold` from the new constants.
- Defer applying the shot impulse by removing the immediate `applyShotAtImpact(shotImpactPayload)` call and instead register `onImpact: () => applyShotImpactOnce()` on the stroke state so physics is applied at the visual impact time.
- Add an animation branch for `motionTechnique === 'snookerRoyalProvided'` that uses `strikeMotionNorm`/`easeOutCubic` to interpolate tip gap/contact and holds contact while the impulse is applied, and adjust contact/impact/follow position resolution and recover interpolation to reflect the contact-hold behavior.
- Replace camera-compensated pull calculations with a fixed pull range derived from `SNOOKER_PROVIDED_PULL_RANGE_RATIO` and tie visible pull to slider power per the snooker model.
- Add `test/poolRoyaleCueStrokeContact.test.js` which asserts the presence of the new constants and verifies the intended wiring (deferred impact, impact threshold, pull/timing constants and interpolation hooks).

### Testing
- Added unit test `test/poolRoyaleCueStrokeContact.test.js` to assert constants and stroke wiring are present.
- Ran the JavaScript test suite via `npm test` and the test run completed successfully (new test passed along with existing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28eab547388329a188696ddceff2a7)