### PR TITLE
Align PoolRoyale live cue stroke with SnookerRoyalProvided timing, gaps and pull math

### DIFF
--- a/test/poolRoyaleCueStrokeContact.test.js
+++ b/test/poolRoyaleCueStrokeContact.test.js
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+
+const source = fs.readFileSync('webapp/src/pages/Games/PoolRoyale.jsx', 'utf8');
+
+describe('Pool Royale live cue contact stroke wiring', () => {
+  it('uses the same cue gap and pull ratios as SnookerRoyalProvided CFG', () => {
+    expect(source).toContain('const SNOOKER_PROVIDED_IDLE_GAP = BALL_R * 0.31022900763358785');
+    expect(source).toContain('const SNOOKER_PROVIDED_CONTACT_GAP = BALL_R * 0.03102290076335878');
+    expect(source).toContain('const SNOOKER_PROVIDED_PULL_RANGE = BALL_R * 10.858015267175574');
+    expect(source).toContain('const CUE_TIP_GAP = BALL_R + SNOOKER_PROVIDED_IDLE_GAP');
+    expect(source).toContain('const impactPos = buildCuePosition(-contactAdvance)');
+  });
+
+  it('does not apply cue-ball power before the animated cue reaches impact', () => {
+    const payloadIndex = source.indexOf('const shotImpactPayload = {');
+    const helperIndex = source.indexOf('const applyShotImpactOnce = () => {', payloadIndex);
+    const animationIndex = source.indexOf('if (ENABLE_CUE_STROKE_ANIMATION)', helperIndex);
+    const prematureSection = source.slice(payloadIndex, helperIndex);
+
+    expect(payloadIndex).toBeGreaterThan(-1);
+    expect(helperIndex).toBeGreaterThan(payloadIndex);
+    expect(animationIndex).toBeGreaterThan(helperIndex);
+    expect(prematureSection).not.toContain('applyShotAtImpact(shotImpactPayload);');
+    expect(source).toContain('onImpact: () => applyShotImpactOnce()');
+  });
+
+  it('arms impact at the same normalized stroke timing as SnookerRoyalProvided', () => {
+    expect(source).toContain('const SNOOKER_PROVIDED_STRIKE_MS = 120');
+    expect(source).toContain('const SNOOKER_PROVIDED_HOLD_MS = 50');
+    expect(source).toContain('const SNOOKER_PROVIDED_IMPACT_THRESHOLD = 0.88');
+    expect(source).toContain('if (!stroke.shotApplied && strikeProgress > impactThreshold)');
+    expect(source).toContain('strikeImpactThreshold: strokeProfile.impactThreshold ?? SNOOKER_PROVIDED_IMPACT_THRESHOLD');
+  });
+
+  it('uses SnookerRoyalProvided pull math instead of Pool visual multipliers for the shot', () => {
+    expect(source).toContain('const pullRatio = easeOutCubic(p)');
+    expect(source).toContain('pullDistance: SNOOKER_PROVIDED_PULL_RANGE * pullRatio');
+    expect(source).toContain('const visualPull = startPull');
+    expect(source).not.toContain('const visualPull = applyVisualPullCompensation(startPull, dir);');
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1938,9 +1938,21 @@ const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.07;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
-const CUE_TIP_CLEARANCE = BALL_R * 0.24; // widen the visible air gap so the cue sits a little farther from the cue ball
-const CUE_TIP_GAP = BALL_R * 1.42 + CUE_TIP_CLEARANCE; // pull the cue tip slightly farther back so the blue tip remains visible
-const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
+const CUE_TIP_CLEARANCE = BALL_R * 0.24; // legacy clearance retained for non-shot helpers
+// These ratios are copied from SnookerRoyalProvided.jsx CFG: idleGap / ballR,
+// contactGap / ballR, and pullRange / ballR. Keeping Pool Royale on the
+// same ratios makes the portrait cue physically pull and push like Snooker.
+const SNOOKER_PROVIDED_IDLE_GAP = BALL_R * 0.31022900763358785;
+const SNOOKER_PROVIDED_CONTACT_GAP = BALL_R * 0.03102290076335878;
+const SNOOKER_PROVIDED_PULL_RANGE = BALL_R * 10.858015267175574;
+const SNOOKER_PROVIDED_STRIKE_MS = 120;
+const SNOOKER_PROVIDED_HOLD_MS = 50;
+const SNOOKER_PROVIDED_IMPACT_THRESHOLD = 0.88;
+const CUE_TIP_GAP = BALL_R + SNOOKER_PROVIDED_IDLE_GAP; // SnookerRoyalProvided idle cue-tip distance from cue-ball center
+const CUE_CONTACT_GAP = SNOOKER_PROVIDED_CONTACT_GAP;
+const CUE_CONTACT_DISTANCE = BALL_R + CUE_CONTACT_GAP;
+const CUE_CONTACT_ADVANCE = Math.max(0, CUE_TIP_GAP - CUE_CONTACT_DISTANCE);
+const CUE_PULL_BASE = SNOOKER_PROVIDED_PULL_RANGE;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
 const CUE_PULL_VISUAL_MULTIPLIER = 1.28;
@@ -24901,13 +24913,15 @@ const shotPowerRef = useRef(0);
             const safeHoldDuration = Math.max(0, holdDuration ?? 45);
             const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
             const resolvedIdlePos = idlePos ?? impactPos ?? stroke.contactPos ?? pullPos;
+            const resolvedImpactPos = impactPos ?? stroke.contactPos ?? resolvedIdlePos ?? pullPos;
             const normalizedStroke = ensureCueStrokeForwardMotion({
               pullPos: pullPos ?? resolvedIdlePos,
-              impactPos: resolvedIdlePos ?? pullPos,
+              impactPos: resolvedImpactPos ?? resolvedIdlePos ?? pullPos,
               fallbackDirection: tmpCueStrokeB.set(Math.sin(baseRotationY ?? 0), 0, Math.cos(baseRotationY ?? 0))
             });
             const resolvedPullPos = normalizedStroke.pullPos ?? pullPos ?? resolvedIdlePos;
-            const resolvedContactPos = resolvedIdlePos ?? stroke.contactPos ?? impactPos ?? pullPos;
+            const resolvedContactPos = stroke.contactPos ?? resolvedImpactPos ?? resolvedIdlePos ?? pullPos;
+            const resolvedFollowPos = followPos ?? resolvedContactPos;
             const strikeProgress = THREE.MathUtils.clamp(
               elapsed / Math.max(safeStrikeDuration, 1e-6),
               0,
@@ -24922,13 +24936,32 @@ const shotPowerRef = useRef(0);
               (baseRotationY ?? cueStick.rotation.y) +
               Math.sin(strikeProgress * Math.PI) * 0.0014;
 
-            const impactThreshold = THREE.MathUtils.clamp(strikeImpactThreshold ?? 0.88, 0.05, 0.995);
-            if (!stroke.shotApplied && strikeProgress >= impactThreshold) {
+            const impactThreshold = THREE.MathUtils.clamp(
+              strikeImpactThreshold ?? SNOOKER_PROVIDED_IMPACT_THRESHOLD,
+              0.05,
+              0.995
+            );
+            if (!stroke.shotApplied && strikeProgress > impactThreshold) {
               stroke.shotApplied = true;
               stroke.onImpact?.();
             }
 
+            if (elapsed < safeStrikeDuration) {
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
             if (elapsed < safeStrikeDuration + safeHoldDuration) {
+              const holdT = THREE.MathUtils.clamp(
+                (elapsed - safeStrikeDuration) / Math.max(safeHoldDuration, 1e-6),
+                0,
+                1
+              );
+              cueStick.position.lerpVectors(
+                resolvedContactPos,
+                resolvedFollowPos,
+                easeInOutCubic(holdT)
+              );
               cueAnimating = true;
               syncCueShadow();
               return true;
@@ -24940,7 +24973,7 @@ const shotPowerRef = useRef(0);
             );
             if (recoverT < 1) {
               cueStick.position.lerpVectors(
-                resolvedContactPos,
+                resolvedFollowPos,
                 resolvedIdlePos ?? impactPos ?? pullPos,
                 easeInOutCubic(recoverT)
               );
@@ -28885,20 +28918,20 @@ const shotPowerRef = useRef(0);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(110, 190, p);
-        const strikeDuration = THREE.MathUtils.lerp(128, 92, p);
-        const holdDuration = THREE.MathUtils.lerp(40, 68, p);
+        const pullRatio = easeOutCubic(p);
         return {
-          // Snooker Royal-style live stroke: slider pull maps directly to cue pullback,
-          // then release performs one forward push back to the original cue-start pose.
-          motion: 'classic',
-          pullRatio: p,
+          // 100% SnookerRoyalProvided live stroke timing: pull =
+          // pullRange * easeOutCubic(power), strikeTime = 0.12s,
+          // holdTime = 0.05s, hit when strikeNorm > 0.88.
+          motion: 'snookerRoyalProvided',
+          pullRatio,
+          pullDistance: SNOOKER_PROVIDED_PULL_RANGE * pullRatio,
           pullSmoothing: 1,
-          strikeDuration,
-          holdDuration,
-          pullbackDuration,
+          strikeDuration: SNOOKER_PROVIDED_STRIKE_MS,
+          holdDuration: SNOOKER_PROVIDED_HOLD_MS,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 0.86,
+          impactThreshold: SNOOKER_PROVIDED_IMPACT_THRESHOLD,
           forwardOnly: true,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
@@ -28981,7 +29014,11 @@ const shotPowerRef = useRef(0);
       const computePullTargetFromPower = (power, maxPull = CUE_PULL_BASE) => {
         const ratio = THREE.MathUtils.clamp(power ?? 0, 0, 1);
         const style = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
-        const styleRatio = resolveCueStrokeProfile(style, ratio).pullRatio;
+        const profile = resolveCueStrokeProfile(style, ratio);
+        if (Number.isFinite(profile.pullDistance)) {
+          return Math.max(0, profile.pullDistance);
+        }
+        const styleRatio = profile.pullRatio;
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
         const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
         const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
@@ -29573,7 +29610,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29601,24 +29637,12 @@ const shotPowerRef = useRef(0);
           if (cue?.pos) {
             cueStickAnchorRef.current.set(cue.pos.x, CUE_Y, cue.pos.y);
           }
-          const backInfo = calcTarget(
-            cue,
-            aimDir.clone().multiplyScalar(-1),
-            balls
-          );
-          const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
-          const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          // Rebuilt stroke pullback: tie visible pull directly to slider power
-          // and the currently available room behind the cue ball.
-          const pullRange = THREE.MathUtils.clamp(
-            maxPull * 0.92,
-            CUE_PULL_MIN_VISUAL,
-            Math.max(CUE_PULL_MIN_VISUAL, maxPull)
-          );
-          const pullTarget = pullRange * strokeProfile.pullRatio;
-          const pulledNow = cuePullCurrentRef.current ?? pullTarget;
-          const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
-          const visualPull = applyVisualPullCompensation(startPull, dir);
+          // SnookerRoyalProvided.jsx uses pull = CFG.pullRange *
+          // easeOutCubic(power) directly; do not scale it by camera angle,
+          // obstruction fudge, or the old Pool visual multiplier.
+          const pullTarget = strokeProfile.pullDistance ?? (SNOOKER_PROVIDED_PULL_RANGE * strokeProfile.pullRatio);
+          const startPull = Math.max(0, pullTarget);
+          const visualPull = startPull;
           shotImpactPayload.pullDistance = visualPull;
           cuePullCurrentRef.current = startPull;
           cuePullTargetRef.current = startPull;
@@ -29674,16 +29698,14 @@ const shotPowerRef = useRef(0);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = 0;
           const startTime = performance.now();
-          const impactPos = idlePos.clone();
-          const contactAdvance = 0; // push forward only to the original idle pose where the slider pull began
+          // Match SnookerRoyalProvided.jsx exactly: gap starts at
+          // idleGap + pullRange * easeOutCubic(power), then interpolates to
+          // contactGap and holds while the cue-ball impulse is applied.
+          const contactAdvance = CUE_CONTACT_ADVANCE;
+          const impactPos = buildCuePosition(-contactAdvance);
           shotImpactPayload.contactAdvance = contactAdvance;
-          const contactPos = impactPos
-            .clone()
-            .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
-          const followPos = contactPos
-            .clone()
-            .addScaledVector(dir, followDistance);
+          const contactPos = impactPos.clone();
+          const followPos = contactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =
@@ -29806,10 +29828,10 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: strokeProfile.impactThreshold ?? SNOOKER_PROVIDED_IMPACT_THRESHOLD,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
-              // Match Snooker Royal's release: push from the pulled pose and
-              // stop exactly at the cue's original idle/contact pose.
+              // Match SnookerRoyalProvided's release: push from pullback
+              // into physical cue-ball contact, then hold that contact.
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,


### PR DESCRIPTION
### Motivation

- Make Pool Royale's portrait live cue behave physically like `SnookerRoyalProvided` by reusing its idle/contact gap ratios, pull range and normalized strike timing to fix mismatched pull/impact behavior and visual compensation.
- Prevent the game from applying the cue-ball impulse before the animated cue visually reaches the impact pose.

### Description

- Added `SNOOKER_PROVIDED_*` constants (`IDLE_GAP`, `CONTACT_GAP`, `PULL_RANGE`, `STRIKE_MS`, `HOLD_MS`, `IMPACT_THRESHOLD`) and wired them into `CUE_TIP_GAP`, `CUE_CONTACT_GAP`, `CUE_CONTACT_DISTANCE`, `CUE_CONTACT_ADVANCE`, and `CUE_PULL_BASE` so Pool Royale uses the same physical ratios as Snooker.
- Reworked stroke profile resolution to return a `motion: 'snookerRoyalProvided'` profile that uses `pullDistance: SNOOKER_PROVIDED_PULL_RANGE * easeOutCubic(power)` and fixed strike/hold/pullback durations to the provided constants.
- Updated pull target computation to prefer `profile.pullDistance` when present and removed the old Pool visual compensation so visible pull equals the configured physical pull.
- Reworked the cue animation and impact flow: compute `impactPos` from `buildCuePosition(-contactAdvance)`, set `contactPos`/`followPos` to hold at impact, clamp and use `SNOOKER_PROVIDED_IMPACT_THRESHOLD` for arming, call `onImpact: () => applyShotImpactOnce()` (so impulse is applied only at the animated impact), and added proper hold interpolation and early returns while the cue is animating.
- Removed the immediate `applyShotAtImpact` call in favor of the `onImpact` callback during the animated stroke.
- Added a new unit test file `test/poolRoyaleCueStrokeContact.test.js` that asserts the presence of the new constants and key logic strings in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing

- Added `test/poolRoyaleCueStrokeContact.test.js` which validates the presence of constants, impact arming logic, timing values, and pull math in the modified source file; the test file was included in the test suite.
- Ran the project's automated tests (`yarn test` / `npm test`) and the test suite containing the new unit test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28eab547388329a188696ddceff2a7)