### PR TITLE
Preserve snooker GLB proportions and use official 52.5mm ball scale

### DIFF
--- a/webapp/src/pages/Games/SnookerChampionProvided.jsx
+++ b/webapp/src/pages/Games/SnookerChampionProvided.jsx
@@ -827,10 +827,9 @@ function addTable(scene, renderer, options = {}) {
     const sourceFitSize = sourceFitBounds.getSize(new THREE.Vector3());
     const fit = resolveSnookerGlbFitTransform(
       { x: sourceFitSize.x, y: sourceFitSize.y, z: sourceFitSize.z },
-      { x: targetSize.x, y: targetSize.y, z: targetSize.z }
+      { x: targetSize.x, y: targetSize.y, z: targetSize.z },
+      { fitAxis: sourceFitSize.x >= sourceFitSize.z ? 'x' : 'z' }
     );
-    const horizontalScale = Math.min(fit.scale.x, fit.scale.z);
-    fit.scale.y = horizontalScale;
     model.scale.set(fit.scale.x, fit.scale.y, fit.scale.z);
     model.updateMatrixWorld(true);
     const scaledFullBounds = new THREE.Box3().setFromObject(model);

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -1179,8 +1179,8 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   );
 const MARKINGS_MM_TO_UNITS = innerLong / WIDTH_REF;
 const OBJECT_MM_TO_UNITS = innerLong / WIDTH_REF;
-const BALL_MM_TO_UNITS = OBJECT_MM_TO_UNITS / SNOOKER_TABLE_FOOTPRINT_ENLARGE; // preserve the previous ball size while the table expands
-const BALL_SIZE_SCALE = 0.965; // trim Snooker Royal balls just a bit smaller while keeping the table/pocket mapping full-size
+const BALL_MM_TO_UNITS = OBJECT_MM_TO_UNITS; // official 52.5mm balls share the same mm-to-table mapping as the 3569mm x 1778mm playfield
+const BALL_SIZE_SCALE = 1; // regulation snooker ball size: 52.5mm diameter, no visual trim
 const BALL_DIAMETER = BALL_D_REF * BALL_MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1240,8 +1240,8 @@ console.assert(
   'Side pocket mouth width mismatch.'
 );
 console.assert(
-  Math.abs(BALL_DIAMETER - BALL_D_REF * BALL_MM_TO_UNITS * BALL_SIZE_SCALE) <= BALL_DIAMETER_TOLERANCE,
-  'Ball diameter must match the configured Snooker Royal ball size scale.'
+  Math.abs(BALL_DIAMETER - BALL_D_REF * OBJECT_MM_TO_UNITS) <= BALL_DIAMETER_TOLERANCE,
+  'Ball diameter must match official snooker ball size: 52.5mm on the same mapping as the 3569mm playfield.'
 );
 console.assert(
   Math.abs(BALL_DIAMETER - BALL_R * 2) <= BALL_DIAMETER_TOLERANCE,
@@ -11770,13 +11770,10 @@ function Table3D(
         const sourceFitSize = sourceFitBounds.getSize(new THREE.Vector3());
         const fit = resolveSnookerGlbFitTransform(
           { x: sourceFitSize.x, y: sourceFitSize.y, z: sourceFitSize.z },
-          { x: targetSize.x, y: targetSize.y, z: targetSize.z }
+          { x: targetSize.x, y: targetSize.y, z: targetSize.z },
+          { fitAxis: sourceFitSize.x >= sourceFitSize.z ? 'x' : 'z' }
         );
-        const upperTableScale = Math.min(fit.scale.x, fit.scale.z);
-        if (Number.isFinite(upperTableScale) && upperTableScale > MICRO_EPS) {
-          fit.scale.y = upperTableScale;
-          fit.preservesOriginalUpperTableProportions = true;
-        }
+        fit.preservesOriginalUpperTableProportions = true;
         model.scale.set(fit.scale.x, fit.scale.y, fit.scale.z);
 
         model.updateMatrixWorld(true);

--- a/webapp/src/pages/Games/SnookerRoyalProvided.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalProvided.jsx
@@ -829,10 +829,9 @@ function addTable(scene, renderer, options = {}) {
     const sourceFitSize = sourceFitBounds.getSize(new THREE.Vector3());
     const fit = resolveSnookerGlbFitTransform(
       { x: sourceFitSize.x, y: sourceFitSize.y, z: sourceFitSize.z },
-      { x: targetSize.x, y: targetSize.y, z: targetSize.z }
+      { x: targetSize.x, y: targetSize.y, z: targetSize.z },
+      { fitAxis: sourceFitSize.x >= sourceFitSize.z ? 'x' : 'z' }
     );
-    const horizontalScale = Math.min(fit.scale.x, fit.scale.z);
-    fit.scale.y = horizontalScale;
     model.scale.set(fit.scale.x, fit.scale.y, fit.scale.z);
     model.updateMatrixWorld(true);
     const scaledFullBounds = new THREE.Box3().setFromObject(model);

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -11,16 +11,39 @@ function safePositiveDimension(value, fallback = MIN_GLB_FIT_SIZE) {
   return Number.isFinite(numeric) && numeric > MIN_GLB_FIT_SIZE ? numeric : fallback;
 }
 
-export function resolveSnookerGlbFitTransform(sourceSize = {}, targetSize = {}) {
+export function resolveSnookerGlbFitTransform(sourceSize = {}, targetSize = {}, options = {}) {
   const sourceX = safePositiveDimension(sourceSize.x);
   const sourceY = safePositiveDimension(sourceSize.y);
   const sourceZ = safePositiveDimension(sourceSize.z);
+  const targetX = safePositiveDimension(targetSize.x);
+  const targetY = safePositiveDimension(targetSize.y);
+  const targetZ = safePositiveDimension(targetSize.z);
+  const xScale = targetX / sourceX;
+  const yScale = targetY / sourceY;
+  const zScale = targetZ / sourceZ;
+  const preserveOriginalShape = options.preserveOriginalShape !== false;
+
+  if (!preserveOriginalShape) {
+    return {
+      scale: { x: xScale, y: yScale, z: zScale },
+      preservesOriginalShape: false
+    };
+  }
+
+  const fitAxis = options.fitAxis === 'z' || options.fitAxis === 'long' ? 'z' : 'x';
+  const uniformHorizontalScale = fitAxis === 'z' ? zScale : xScale;
+
   return {
     scale: {
-      x: safePositiveDimension(targetSize.x) / sourceX,
-      y: safePositiveDimension(targetSize.y) / sourceY,
-      z: safePositiveDimension(targetSize.z) / sourceZ
-    }
+      x: uniformHorizontalScale,
+      y: uniformHorizontalScale,
+      z: uniformHorizontalScale
+    },
+    preservesOriginalShape: true,
+    fitAxis,
+    sourceAspect: sourceX / sourceZ,
+    targetAspect: targetX / targetZ,
+    nonUniformCandidateScale: { x: xScale, y: yScale, z: zScale }
   };
 }
 


### PR DESCRIPTION
### Motivation
- Ensure imported Snooker GLB visuals keep their original shape and cushion/jaw mapping instead of being non-uniformly stretched to fit the game playfield. 
- Use the official snooker measurement system (3569mm × 1778mm playfield and 52.5mm ball diameter) so gameplay physics, pocket mapping, and visuals align with regulation snooker. 
- Apply the same preserved-proportion logic to both the Champion/Provided loaders so all Snooker table variants match visually and physically. 

### Description
- Added an enhanced `resolveSnookerGlbFitTransform(sourceSize, targetSize, options)` in `webapp/src/pages/Games/snookerTableModel.js` that defaults to a uniform horizontal scale and supports `fitAxis` and `preserveOriginalShape` options. 
- Updated GLB table loaders in `SnookerRoyal.jsx`, `SnookerChampionProvided.jsx` and `SnookerRoyalProvided.jsx` to call `resolveSnookerGlbFitTransform(..., { fitAxis: ... })` and preserve the GLB’s upper-table proportions when mapping to the procedural table. 
- Changed ball-to-mm mapping in `SnookerRoyal.jsx` to map directly to the official 52.5mm diameter (`BALL_SIZE_SCALE = 1`) and tightened the runtime assertion message to validate official sizing on the 3569mm playfield mapping. 

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully. 
- Executed a smoke check using `node --input-type=module` to validate `resolveSnookerGlbFitTransform` behavior and the test passed (uniform fit by default, non-uniform fit when requested). 
- Attempted a Playwright-based mobile render/screenshot of `/games/snookerroyale` to visually verify the mobile portrait view, but the headless screenshot attempt timed out / encountered runtime resource/network issues in the CI container despite installing Playwright and its browser dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2905285d3c8329a79507e89d059f32)