### PR TITLE
LudoBattleRoyal: park firearms in legacy slot, add ukrainian drone, and tweak portrait camera

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -280,6 +280,28 @@ describe('cross-game inventory alignment', () => {
     expect(materialSetup).not.toContain('material.opacity = 1');
   });
 
+
+  test('ludo battle royal parks each selected firearm in the legacy table slot and ignores stale loads', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('const PARKED_FIREARM_HOLDER_LOCAL_POSITION = Object.freeze([0.04, 0.004, -0.018])');
+    expect(source).toContain('weaponHolder.position.set(...PARKED_FIREARM_HOLDER_LOCAL_POSITION);');
+    expect(source).toContain('if (entry.weaponDisplayRequestId !== requestId || entry.selectedCaptureAnimationId !== captureAnimationId) return;');
+    expect(source).toContain('createParkedFirearmFallbackModel(captureAnimationId)');
+    expect(source).toContain('installParkedCaptureWeaponModel(entry, weaponModel, captureAnimationId);');
+    expect(source).toContain('entry.weaponHolder.visible = true;');
+    expect(source).toContain('if (entry.selectedCaptureAnimationId === selectedCaptureAnimationId) {');
+  });
+
+  test('ludo battle royal keeps portrait camera higher, closer, and wider without adding pullback', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('const CAMERA_FOV = 79;');
+    expect(source).toContain('const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 2.46;');
+    expect(source).toContain('const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.36;');
+    expect(source).toContain('const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.18;');
+  });
+
   test('snake store mirrors ludo battle royal capture weapons', () => {
     const snakeCaptureStoreIds = new Set(
       SNAKE_STORE_ITEMS.filter((item) => item.type === 'captureWeapon').map((item) => item.optionId)

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -138,7 +138,7 @@ const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
   missile: 1.2,
   drone: 1.2
 });
-const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
+const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'ukrainianDroneAttack', 'missileJavelin']);
 const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'assaultRifleAttack',
   'fpsGunAttack',
@@ -293,6 +293,10 @@ const UNIFORM_FIREARM_RACK_GRIP_ANCHOR = Object.freeze({
   position: [0.086, 0.008, -0.02],
   minSurfaceY: 0
 });
+const PARKED_FIREARM_HOLDER_LOCAL_POSITION = Object.freeze([0.04, 0.004, -0.018]);
+const PARKED_FIREARM_HIT_LOCAL_POSITION = Object.freeze([...PARKED_FIREARM_HOLDER_LOCAL_POSITION]);
+const PARKED_SHAHAD_DRONE_ATTACK_ID = 'droneAttack';
+const PARKED_UKRAINIAN_DRONE_ATTACK_ID = 'ukrainianDroneAttack';
 
 const FIREARM_RACK_MUZZLE_YAW_CORRECTION_BY_ID = Object.freeze({
   // Gunify's AK-47 GLTF imports with the stock/muzzle reversed after the flat-table
@@ -1312,6 +1316,7 @@ const CAPTURE_ATTACK_TUNING = Object.freeze({
   fighterJetAttack: { speed: 1.2, height: 0.92, inward: 0.94, takeoff: 0.2, landing: 0.24 },
   helicopterAttack: { speed: 1.26, height: 0.84, inward: 0.88, takeoff: 0.24, landing: 0.28 },
   droneAttack: { speed: 1.14, height: 0.9, inward: 0.94, takeoff: 0.22, landing: 0.26 },
+  ukrainianDroneAttack: { speed: 1.14, height: 0.9, inward: 0.94, takeoff: 0.22, landing: 0.26 },
   missileJavelin: { speed: 1.12, height: 0.88, inward: 0.92, takeoff: 0.18, landing: 0.24 }
 });
 const CAPTURE_CAMERA_ZOOM_OUT_FACTOR = 1.08;
@@ -1321,6 +1326,7 @@ const HELICOPTER_AUX_ROTOR_SPIN_SPEED = 24;
 const QUICK_SWAP_WEAPON_ICON_KIND_BY_ID = Object.freeze({
   missileJavelin: 'rocket',
   droneAttack: 'drone',
+  ukrainianDroneAttack: 'drone',
   fighterJetAttack: 'jet',
   helicopterAttack: 'helicopter',
   fpsGunAttack: 'rifle',
@@ -2064,8 +2070,10 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
 async function createCaptureWeaponRackFx() {
   const root = new THREE.Group();
   const weaponHolder = new THREE.Group();
-  weaponHolder.position.set(0.04, 0.004, -0.018);
+  // Park every selected firearm in the same local table slot that the legacy rack used.
+  weaponHolder.position.set(...PARKED_FIREARM_HOLDER_LOCAL_POSITION);
   weaponHolder.rotation.set(0, 0, 0);
+  weaponHolder.visible = true;
   root.add(weaponHolder);
 
   const buttonBase = new THREE.Mesh(
@@ -2096,7 +2104,11 @@ async function createCaptureWeaponRackFx() {
     new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
   );
   weaponRackHit.name = 'captureWeaponRackHit';
-  weaponRackHit.position.set(0.04, 0.01, -0.018);
+  weaponRackHit.position.set(
+    PARKED_FIREARM_HIT_LOCAL_POSITION[0],
+    0.01,
+    PARKED_FIREARM_HIT_LOCAL_POSITION[2]
+  );
   root.add(weaponRackHit);
 
   return {
@@ -2109,27 +2121,23 @@ async function createCaptureWeaponRackFx() {
   };
 }
 
-async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
-  if (!entry?.weaponHolder) return;
-  if (!FIREARM_CAPTURE_ANIMATION_IDS.has(captureAnimationId)) {
-    entry.weaponHolder.children.forEach((child) => {
-      stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
-    });
-    entry.weaponHolder.clear();
-    entry.selectedCaptureAnimationId = null;
-    return;
-  }
-  if (entry.selectedCaptureAnimationId === captureAnimationId && entry.weaponHolder.children.length > 0) return;
-  entry.weaponHolder.children.forEach((child) => {
-    stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
-  });
-  entry.weaponHolder.clear();
-  const weaponModel = await loadCaptureWeaponModel(captureAnimationId);
-  if (!weaponModel) {
-    entry.selectedCaptureAnimationId = null;
-    return;
-  }
-  entry.selectedCaptureAnimationId = captureAnimationId;
+function createParkedFirearmFallbackModel(captureAnimationId) {
+  const root = new THREE.Group();
+  root.userData.parkedWeaponFallback = true;
+  const isLargeFirearm = LARGE_RACK_FIREARM_IDS.has(captureAnimationId);
+  const bodyLength = isLargeFirearm ? 0.36 : 0.2;
+  const bodyWidth = isLargeFirearm ? 0.026 : 0.022;
+  addFxBox(root, [bodyLength, 0.018, bodyWidth], [0, 0.012, 0], '#1f2937', 0.52, 0.42);
+  addFxBox(root, [bodyLength * 0.38, 0.022, bodyWidth * 1.28], [-bodyLength * 0.18, 0.018, 0], '#374151', 0.48, 0.34);
+  addFxBox(root, [bodyLength * 0.34, 0.014, bodyWidth * 0.58], [bodyLength * 0.56, 0.017, 0], '#94a3b8', 0.36, 0.68);
+  const grip = addFxBox(root, [bodyLength * 0.12, 0.058, bodyWidth * 0.82], [-bodyLength * 0.16, -0.02, 0], '#7c2d12', 0.62, 0.12);
+  grip.rotation.z = -Math.PI * 0.12;
+  addFxBox(root, [bodyLength * 0.16, 0.01, bodyWidth * 0.7], [-bodyLength * 0.02, -0.004, 0], '#0f172a', 0.5, 0.32);
+  return root;
+}
+
+function installParkedCaptureWeaponModel(entry, weaponModel, captureAnimationId) {
+  if (!entry?.weaponHolder?.isObject3D || !weaponModel?.isObject3D) return;
   entry.weaponHolder.children.forEach((child) => {
     stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
   });
@@ -2162,7 +2170,33 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   if (!Number.isFinite(stabilizedCenter.x) || !Number.isFinite(stabilizedCenter.y) || !Number.isFinite(stabilizedCenter.z) || stabilizedCenter.length() > 0.32) {
     clone.position.set(displayPosition[0], displayPosition[1], displayPosition[2]);
   }
+  entry.weaponHolder.visible = true;
   entry.weaponHolder.add(clone);
+}
+
+async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
+  if (!entry?.weaponHolder) return;
+  if (!FIREARM_CAPTURE_ANIMATION_IDS.has(captureAnimationId)) {
+    entry.weaponDisplayRequestId = (entry.weaponDisplayRequestId ?? 0) + 1;
+    entry.weaponHolder.children.forEach((child) => {
+      stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
+    });
+    entry.weaponHolder.clear();
+    entry.weaponHolder.visible = false;
+    entry.selectedCaptureAnimationId = null;
+    return;
+  }
+  entry.weaponHolder.visible = true;
+  if (entry.selectedCaptureAnimationId === captureAnimationId && entry.weaponHolder.children.length > 0) return;
+  const requestId = (entry.weaponDisplayRequestId ?? 0) + 1;
+  entry.weaponDisplayRequestId = requestId;
+  entry.selectedCaptureAnimationId = captureAnimationId;
+  installParkedCaptureWeaponModel(entry, createParkedFirearmFallbackModel(captureAnimationId), captureAnimationId);
+  const weaponModel = await loadCaptureWeaponModel(captureAnimationId);
+  if (entry.weaponDisplayRequestId !== requestId || entry.selectedCaptureAnimationId !== captureAnimationId) return;
+  if (weaponModel?.isObject3D) {
+    installParkedCaptureWeaponModel(entry, weaponModel, captureAnimationId);
+  }
 }
 
 function getCaptureVehicleTexture(kind = 'generic', toneSeed = null) {
@@ -4434,7 +4468,7 @@ function resolvePlayerColors(appearance = {}) {
   return PLAYER_COLOR_ORDER.map((_, idx) => normalizeColorValue(swatches[idx], DEFAULT_PLAYER_COLORS[idx]));
 }
 
-const CAMERA_FOV = 75;
+const CAMERA_FOV = 79;
 const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
@@ -4465,9 +4499,9 @@ const LUDO_CAMERA_PHI_MAX = 1.14;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.18;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.26;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 2.34;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 2.46;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.98;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.28;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.36;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.9;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT = 0.42 * MODEL_SCALE;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_LANDSCAPE = 0.2 * MODEL_SCALE;
@@ -8756,15 +8790,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         CAPTURE_ANIMATION_OPTIONS[optionIndex]?.id ?? CAPTURE_ANIMATION_OPTIONS[0]?.id ?? 'missileJavelin';
       if (entry?.jet) entry.jet.visible = selectedCaptureAnimationId === 'fighterJetAttack';
       if (entry?.helicopter) entry.helicopter.visible = selectedCaptureAnimationId === 'helicopterAttack';
-      if (entry?.drone) entry.drone.visible = false;
-      if (entry?.droneTruck) entry.droneTruck.visible = selectedCaptureAnimationId === 'droneAttack';
+      if (entry?.drone) entry.drone.visible = selectedCaptureAnimationId === PARKED_UKRAINIAN_DRONE_ATTACK_ID;
+      if (entry?.droneTruck) entry.droneTruck.visible = selectedCaptureAnimationId === PARKED_SHAHAD_DRONE_ATTACK_ID;
       if (entry?.missile) entry.missile.visible = selectedCaptureAnimationId === 'missileJavelin';
       if (entry?.weaponRack) {
         const showFirearm = FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId);
         const showActionButton =
           selectedCaptureAnimationId === 'fighterJetAttack' ||
           selectedCaptureAnimationId === 'helicopterAttack' ||
-          selectedCaptureAnimationId === 'droneAttack';
+          selectedCaptureAnimationId === PARKED_SHAHAD_DRONE_ATTACK_ID ||
+          selectedCaptureAnimationId === PARKED_UKRAINIAN_DRONE_ATTACK_ID;
         entry.weaponRack.visible = showFirearm || showActionButton;
         if (entry.actionButton?.isObject3D) {
           entry.actionButton.visible = showActionButton;
@@ -8782,14 +8817,19 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           entry.weaponRackHit.visible = showFirearm;
         }
         if (showFirearm) {
+          if (entry.weaponHolder?.isObject3D) entry.weaponHolder.visible = true;
           void applyCaptureWeaponDisplay(entry, selectedCaptureAnimationId).then(() => {
-            refreshWeaponRackPose(entry, selectedCaptureAnimationId);
+            if (entry.selectedCaptureAnimationId === selectedCaptureAnimationId) {
+              refreshWeaponRackPose(entry, selectedCaptureAnimationId);
+            }
           });
         } else {
+          entry.weaponDisplayRequestId = (entry.weaponDisplayRequestId ?? 0) + 1;
           entry?.weaponHolder?.children?.forEach?.((child) => {
             stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
           });
           entry.weaponHolder?.clear?.();
+          if (entry.weaponHolder?.isObject3D) entry.weaponHolder.visible = false;
           entry.selectedCaptureAnimationId = null;
           refreshWeaponRackPose(entry, selectedCaptureAnimationId);
         }
@@ -8895,6 +8935,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         actionButtonHit: weaponRackFx.actionButtonHit ?? null,
         weaponRackHit: weaponRackFx.weaponRackHit ?? null,
         selectedCaptureAnimationId: null,
+        weaponDisplayRequestId: 0,
         helicopterRotor: helicopterFx.rotor ?? null,
         helicopterTailRotor: helicopterFx.tailRotor ?? null,
         helicopterRotorNodes: Array.isArray(helicopterFx.rotorNodes) ? helicopterFx.rotorNodes : [],
@@ -11611,7 +11652,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         };
         const captureTuning = resolveCaptureAttackTuning(resolvedCaptureAnimationId);
         const isHelicopterAttack = resolvedCaptureAnimationId === 'helicopterAttack';
-        const isDroneAttack = resolvedCaptureAnimationId === 'droneAttack';
+        const isDroneAttack = resolvedCaptureAnimationId === PARKED_SHAHAD_DRONE_ATTACK_ID;
+        const isUkrainianDroneAttack = resolvedCaptureAnimationId === PARKED_UKRAINIAN_DRONE_ATTACK_ID;
+        const isDroneLikeAttack = isDroneAttack || isUkrainianDroneAttack;
         const isFighterJetAttack = resolvedCaptureAnimationId === 'fighterJetAttack';
         const isFirearmAttack = FIREARM_CAPTURE_ANIMATION_IDS.has(resolvedCaptureAnimationId);
         if (isFirearmAttack) {
@@ -12042,6 +12085,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? parkedEntry?.helicopterPark?.clone?.()
             : isDroneAttack
             ? parkedEntry?.droneTruckPark?.clone?.() ?? parkedEntry?.dronePark?.clone?.()
+            : isUkrainianDroneAttack
+            ? parkedEntry?.dronePark?.clone?.()
             : isMissileTruckAttack
             ? parkedEntry?.missilePark?.clone?.()
             : null;
@@ -12050,8 +12095,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? parkedEntry?.jet
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? parkedEntry?.helicopter
-            : resolvedCaptureAnimationId === 'droneAttack'
+            : isDroneAttack
             ? parkedEntry?.droneTruck ?? parkedEntry?.drone
+            : isUkrainianDroneAttack
+            ? parkedEntry?.drone
             : resolvedCaptureAnimationId === 'missileJavelin'
             ? parkedEntry?.missile
             : null;
@@ -12073,10 +12120,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           stopFighterJetSound();
           playHelicopterSound();
         }
-        if (isDroneAttack) playDroneSound();
+        if (isDroneLikeAttack) playDroneSound();
         if (isFighterJetAttack) playFighterJetSound();
         const primaryFx =
-          resolvedCaptureAnimationId === 'droneAttack'
+          isDroneLikeAttack
             ? await createCaptureDroneFx()
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? await createCaptureHelicopterFx()
@@ -12112,7 +12159,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? 0.34
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? 0.24
-            : resolvedCaptureAnimationId === 'droneAttack'
+            : isDroneLikeAttack
             ? 0.26
             : 1;
         const parkedScale =
@@ -12120,7 +12167,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? parkedEntry?.jet?.scale
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? parkedEntry?.helicopter?.scale
-            : resolvedCaptureAnimationId === 'droneAttack'
+            : isDroneLikeAttack
             ? parkedEntry?.drone?.scale
             : parkedEntry?.missile?.scale;
         if (parkedScale?.isVector3) {
@@ -12200,13 +12247,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? 2860
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? 3320
-            : resolvedCaptureAnimationId === 'droneAttack'
+            : isDroneLikeAttack
             ? 1780
             : 1780;
         const airAttackSlowFactor =
           resolvedCaptureAnimationId === 'fighterJetAttack' ||
           resolvedCaptureAnimationId === 'helicopterAttack' ||
-          resolvedCaptureAnimationId === 'droneAttack'
+          isDroneLikeAttack
             ? CAPTURE_AIRCRAFT_SLOW_FACTOR
             : 1;
         const travelTime =
@@ -12404,7 +12451,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   .add(new THREE.Vector3(0, topStrikeHeight * 0.2, 0));
                 return quadraticBezier(apex, apex.clone().lerp(flyByEnd, 0.5), flyByEnd, d);
               }
-              const isDroneStrike = selectedCaptureAnimationId === 'droneAttack';
+              const isDroneStrike =
+                selectedCaptureAnimationId === PARKED_SHAHAD_DRONE_ATTACK_ID ||
+                selectedCaptureAnimationId === PARKED_UKRAINIAN_DRONE_ATTACK_ID;
               if (isDroneStrike) {
                 return quadraticBezier(apex, apex.clone().lerp(dynamicTo, 0.46), dynamicTo, d);
               }
@@ -12439,7 +12488,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             }
             const isVerticalImpactVehicle =
               selectedCaptureAnimationId === 'missileJavelin' ||
-              selectedCaptureAnimationId === 'droneAttack';
+              selectedCaptureAnimationId === PARKED_SHAHAD_DRONE_ATTACK_ID ||
+              selectedCaptureAnimationId === PARKED_UKRAINIAN_DRONE_ATTACK_ID;
             if (isVerticalImpactVehicle && u > phaseSplit) {
               primaryFx.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, new THREE.Vector3(0, -1, 0));
             }


### PR DESCRIPTION
### Motivation
- Preserve the legacy visual placement for parked firearms on the table and avoid flashes caused by stale async model loads by showing a consistent fallback and ignoring outdated load completions.
- Add explicit support for an additional drone capture animation variant (`ukrainianDroneAttack`) and ensure it is treated alongside the existing drone presentation where appropriate.
- Keep the portrait player camera higher, closer, and wider (no added pullback) to match intended framing across portrait layouts.

### Description
- Added table/rack positioning constants `PARKED_FIREARM_HOLDER_LOCAL_POSITION` and `PARKED_FIREARM_HIT_LOCAL_POSITION`, plus drone constants `PARKED_SHAHAD_DRONE_ATTACK_ID` and `PARKED_UKRAINIAN_DRONE_ATTACK_ID` and registered `ukrainianDroneAttack` in `CAPTURE_AIR_ATTACK_ID_SET`, `CAPTURE_ATTACK_TUNING`, and `QUICK_SWAP_WEAPON_ICON_KIND_BY_ID`.
- Reworked weapon rack rendering: `createCaptureWeaponRackFx` now uses the parked position constant, exposes `weaponHolder.visible`, and positions the rack hit using the new hit constant.
- Introduced `createParkedFirearmFallbackModel` and `installParkedCaptureWeaponModel` to produce a fallback visual immediately, and refactored `applyCaptureWeaponDisplay` to use a per-entry `weaponDisplayRequestId` so async `loadCaptureWeaponModel` results are ignored when stale; the fallback is installed first and replaced when the real model finishes loading.
- Initialized `weaponDisplayRequestId` for parked entries and adjusted visibility/clear logic so parked firearms are shown/hidden deterministically and pose refreshes are gated to the currently selected animation.
- Camera tuning changes: bumped `CAMERA_FOV` to `79` and updated portrait offsets `PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT` to `2.46` and `PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT` to `1.36` to keep portrait view higher/closer/wider.

### Testing
- Ran the Jest unit tests including the updated `test/inventoryCrossGameConfig.test.js` which asserts the new constants, fallback and install functions, stale-load protection guard, and camera constants; the test file expectations matched the updated source and passed.
- Executed the full unit test suite (`yarn test`) and observed no failures after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a291e6b9b988329aed1ff4570820e20)