### PR TITLE
LudoBattleRoyal: park firearms in legacy slot, ignore stale weapon loads, add ukrainian drone anim, and tweak portrait camera

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -280,6 +280,29 @@ describe('cross-game inventory alignment', () => {
     expect(materialSetup).not.toContain('material.opacity = 1');
   });
 
+
+  test('ludo battle royal parks each selected firearm in the legacy table slot and ignores stale loads', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('const PARKED_FIREARM_HOLDER_LOCAL_POSITION = Object.freeze([0.04, 0.004, -0.018])');
+    expect(source).toContain('weaponHolder.position.set(...PARKED_FIREARM_HOLDER_LOCAL_POSITION);');
+    expect(source).toContain('if (entry.weaponDisplayRequestId !== requestId) return;');
+    expect(source).toContain('entry.weaponHolder.visible = true;');
+    expect(source).toContain('if (entry.selectedCaptureAnimationId === selectedCaptureAnimationId) {');
+    expect(source).toContain("const UKRAINIAN_DRONE_CAPTURE_ANIMATION_IDS = new Set(['ukrainianDroneAttack']);");
+    expect(source).toContain('entry.drone.visible = UKRAINIAN_DRONE_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId);');
+  });
+
+  test('ludo portrait camera is higher, closer, and wider without pulling back', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('const CAMERA_FOV = 78;');
+    expect(source).toContain('const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.365 * MODEL_SCALE;');
+    expect(source).toContain('const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.76 * MODEL_SCALE;');
+    expect(source).toContain('forwardOffset: PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT + 0.1');
+    expect(source).toContain('heightOffset: PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT + 0.06');
+  });
+
   test('snake store mirrors ludo battle royal capture weapons', () => {
     const snakeCaptureStoreIds = new Set(
       SNAKE_STORE_ITEMS.filter((item) => item.type === 'captureWeapon').map((item) => item.optionId)

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -138,7 +138,8 @@ const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
   missile: 1.2,
   drone: 1.2
 });
-const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
+const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'ukrainianDroneAttack', 'missileJavelin']);
+const UKRAINIAN_DRONE_CAPTURE_ANIMATION_IDS = new Set(['ukrainianDroneAttack']);
 const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'assaultRifleAttack',
   'fpsGunAttack',
@@ -293,6 +294,8 @@ const UNIFORM_FIREARM_RACK_GRIP_ANCHOR = Object.freeze({
   position: [0.086, 0.008, -0.02],
   minSurfaceY: 0
 });
+const PARKED_FIREARM_HOLDER_LOCAL_POSITION = Object.freeze([0.04, 0.004, -0.018]);
+const PARKED_FIREARM_HIT_LOCAL_POSITION = Object.freeze([...PARKED_FIREARM_HOLDER_LOCAL_POSITION]);
 
 const FIREARM_RACK_MUZZLE_YAW_CORRECTION_BY_ID = Object.freeze({
   // Gunify's AK-47 GLTF imports with the stock/muzzle reversed after the flat-table
@@ -2064,8 +2067,10 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
 async function createCaptureWeaponRackFx() {
   const root = new THREE.Group();
   const weaponHolder = new THREE.Group();
-  weaponHolder.position.set(0.04, 0.004, -0.018);
+  // Park every selected firearm in the same local table slot that the legacy rack used.
+  weaponHolder.position.set(...PARKED_FIREARM_HOLDER_LOCAL_POSITION);
   weaponHolder.rotation.set(0, 0, 0);
+  weaponHolder.visible = true;
   root.add(weaponHolder);
 
   const buttonBase = new THREE.Mesh(
@@ -2096,7 +2101,11 @@ async function createCaptureWeaponRackFx() {
     new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
   );
   weaponRackHit.name = 'captureWeaponRackHit';
-  weaponRackHit.position.set(0.04, 0.01, -0.018);
+  weaponRackHit.position.set(
+    PARKED_FIREARM_HIT_LOCAL_POSITION[0],
+    0.01,
+    PARKED_FIREARM_HIT_LOCAL_POSITION[2]
+  );
   root.add(weaponRackHit);
 
   return {
@@ -2112,21 +2121,29 @@ async function createCaptureWeaponRackFx() {
 async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   if (!entry?.weaponHolder) return;
   if (!FIREARM_CAPTURE_ANIMATION_IDS.has(captureAnimationId)) {
+    entry.weaponDisplayRequestId = (entry.weaponDisplayRequestId ?? 0) + 1;
     entry.weaponHolder.children.forEach((child) => {
       stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
     });
     entry.weaponHolder.clear();
+    entry.weaponHolder.visible = false;
     entry.selectedCaptureAnimationId = null;
     return;
   }
+  entry.weaponHolder.visible = true;
   if (entry.selectedCaptureAnimationId === captureAnimationId && entry.weaponHolder.children.length > 0) return;
+  const requestId = (entry.weaponDisplayRequestId ?? 0) + 1;
+  entry.weaponDisplayRequestId = requestId;
   entry.weaponHolder.children.forEach((child) => {
     stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
   });
   entry.weaponHolder.clear();
+  entry.selectedCaptureAnimationId = null;
   const weaponModel = await loadCaptureWeaponModel(captureAnimationId);
+  if (entry.weaponDisplayRequestId !== requestId) return;
   if (!weaponModel) {
     entry.selectedCaptureAnimationId = null;
+    entry.weaponHolder.visible = false;
     return;
   }
   entry.selectedCaptureAnimationId = captureAnimationId;
@@ -2162,6 +2179,7 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   if (!Number.isFinite(stabilizedCenter.x) || !Number.isFinite(stabilizedCenter.y) || !Number.isFinite(stabilizedCenter.z) || stabilizedCenter.length() > 0.32) {
     clone.position.set(displayPosition[0], displayPosition[1], displayPosition[2]);
   }
+  entry.weaponHolder.visible = true;
   entry.weaponHolder.add(clone);
 }
 
@@ -4382,10 +4400,10 @@ const SEATED_HELPER_FACE_CAMERA_UP = 0.146 * MODEL_SCALE;
 const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.072 * MODEL_SCALE;
 // The bottom-seat gameplay camera is intentionally raised and pushed farther toward the table so
 // portrait players see over the local avatar and closer into the Ludo board/action area.
-const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.335 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_FORWARD = 0.365 * MODEL_SCALE;
 // Lift the human player's locked first-person camera higher so portrait gameplay has a clearer
 // over-the-table view of the dice, tokens, and board while staying only slightly closer.
-const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.72 * MODEL_SCALE;
+const SEATED_FACE_CAMERA_GAMEPLAY_UP = 0.76 * MODEL_SCALE;
 const SEATED_FACE_CAMERA_GAMEPLAY_LOOK_DOWN = 0.37 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 9;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.34;
@@ -4434,7 +4452,7 @@ function resolvePlayerColors(appearance = {}) {
   return PLAYER_COLOR_ORDER.map((_, idx) => normalizeColorValue(swatches[idx], DEFAULT_PLAYER_COLORS[idx]));
 }
 
-const CAMERA_FOV = 75;
+const CAMERA_FOV = 78;
 const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
@@ -4480,8 +4498,8 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
 });
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT,
-  forwardOffset: PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT,
-  heightOffset: PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT,
+  forwardOffset: PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT + 0.1,
+  heightOffset: PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT + 0.06,
   targetLift: 0.03 * MODEL_SCALE
 });
 const CAMERA_EXTRA_PULLBACK = 0.1;
@@ -8756,7 +8774,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         CAPTURE_ANIMATION_OPTIONS[optionIndex]?.id ?? CAPTURE_ANIMATION_OPTIONS[0]?.id ?? 'missileJavelin';
       if (entry?.jet) entry.jet.visible = selectedCaptureAnimationId === 'fighterJetAttack';
       if (entry?.helicopter) entry.helicopter.visible = selectedCaptureAnimationId === 'helicopterAttack';
-      if (entry?.drone) entry.drone.visible = false;
+      if (entry?.drone) entry.drone.visible = UKRAINIAN_DRONE_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId);
       if (entry?.droneTruck) entry.droneTruck.visible = selectedCaptureAnimationId === 'droneAttack';
       if (entry?.missile) entry.missile.visible = selectedCaptureAnimationId === 'missileJavelin';
       if (entry?.weaponRack) {
@@ -8782,14 +8800,19 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           entry.weaponRackHit.visible = showFirearm;
         }
         if (showFirearm) {
+          if (entry.weaponHolder?.isObject3D) entry.weaponHolder.visible = true;
           void applyCaptureWeaponDisplay(entry, selectedCaptureAnimationId).then(() => {
-            refreshWeaponRackPose(entry, selectedCaptureAnimationId);
+            if (entry.selectedCaptureAnimationId === selectedCaptureAnimationId) {
+              refreshWeaponRackPose(entry, selectedCaptureAnimationId);
+            }
           });
         } else {
+          entry.weaponDisplayRequestId = (entry.weaponDisplayRequestId ?? 0) + 1;
           entry?.weaponHolder?.children?.forEach?.((child) => {
             stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
           });
           entry.weaponHolder?.clear?.();
+          if (entry.weaponHolder?.isObject3D) entry.weaponHolder.visible = false;
           entry.selectedCaptureAnimationId = null;
           refreshWeaponRackPose(entry, selectedCaptureAnimationId);
         }
@@ -8895,6 +8918,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         actionButtonHit: weaponRackFx.actionButtonHit ?? null,
         weaponRackHit: weaponRackFx.weaponRackHit ?? null,
         selectedCaptureAnimationId: null,
+        weaponDisplayRequestId: 0,
         helicopterRotor: helicopterFx.rotor ?? null,
         helicopterTailRotor: helicopterFx.tailRotor ?? null,
         helicopterRotorNodes: Array.isArray(helicopterFx.rotorNodes) ? helicopterFx.rotorNodes : [],


### PR DESCRIPTION
### Motivation
- Ensure selected firearms are parked in the legacy rack slot and avoid visual glitches from stale asynchronous model loads.
- Support the Ukrainian drone capture animation as a special-case visibility for parked drones.
- Improve portrait-mode framing by moving the camera slightly closer, higher, and increasing FOV for better board visibility.

### Description
- Added `PARKED_FIREARM_HOLDER_LOCAL_POSITION` and `PARKED_FIREARM_HIT_LOCAL_POSITION` constants and used them to position the parked firearm holder and hit area to match the legacy rack slot via `weaponHolder.position.set(...PARKED_FIREARM_HOLDER_LOCAL_POSITION)` and hit placement.
- Introduced `entry.weaponDisplayRequestId` request-id gating in `applyCaptureWeaponDisplay` and the parked-rack update path to ignore stale async loads and avoid flashing; weapon holders are hidden when not showing a firearm and re-shown only when the latest request completes.
- Ensured parked firearms reuse a single consistent slot and preserved visibility handling by making `weaponHolder.visible` toggles and avoiding unnecessary reposes when the selected animation matches (`refreshWeaponRackPose` guarded by a selected-id check).
- Added `ukrainianDroneAttack` to the air attack set and created `UKRAINIAN_DRONE_CAPTURE_ANIMATION_IDS` to drive parked drone visibility for that animation.
- Tweaked portrait camera and related tuning: increased `CAMERA_FOV` from `75` to `78`, raised `SEATED_FACE_CAMERA_GAMEPLAY_FORWARD` to `0.365 * MODEL_SCALE`, increased `SEATED_FACE_CAMERA_GAMEPLAY_UP` to `0.76 * MODEL_SCALE`, and offset portrait `forwardOffset` and `heightOffset` by `+0.1` and `+0.06` respectively in `PORTRAIT_CAMERA_TUNING`.
- Minor cleanup: made the new weapon holder visible by default on creation and initialized `weaponDisplayRequestId` on parked entries.
- Updated `test/inventoryCrossGameConfig.test.js` with new tests that assert the presence of the new constants, request-id checks, visibility behavior, and camera tuning changes.

### Testing
- Ran the unit tests in `test/inventoryCrossGameConfig.test.js` (including the new tests `ludo battle royal parks each selected firearm in the legacy table slot and ignores stale loads` and `ludo portrait camera is higher, closer, and wider without pulling back`) with `jest`, and all tests passed.
- Confirmed existing capture-weapon and material-preservation tests still pass after changes with the same test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a291e6b9b988329aed1ff4570820e20)