### PR TITLE
Adjust Chess Battle Poly Haven table height

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -886,7 +886,7 @@ const LAYOUT_SCALE_FACTOR = 0.7225;
 const TABLE_LAYOUT_SCALE_FACTOR = 0.84; // Slightly enlarge the board/chair footprint so board + pieces read bigger in portrait.
 const PIECE_SCALE_FACTOR = 0.73 * LAYOUT_SCALE_FACTOR * 1.5 * 0.82 * 1.42; // Make pieces a bit bigger for clearer readability.
 const PIECE_FOOTPRINT_RATIO = 0.86;
-const BOARD_GROUP_Y_OFFSET = -0.065; // lower the board slab so it sits flush on the table surface.
+const BOARD_GROUP_Y_OFFSET = 0.012; // keep the chess board visibly above the tabletop surface.
 const BOARD_MODEL_Y_OFFSET = -0.12;
 const BOARD_VISUAL_Y_OFFSET = -0.03;
 const BOARD_SURFACE_DROP = 0.05;
@@ -919,6 +919,8 @@ const COFFEE_TABLE_01_REFERENCE_RADIUS = TABLE_RADIUS;
 const COFFEE_TABLE_01_REFERENCE_HEIGHT = TABLE_HEIGHT;
 const TABLE_MODEL_TARGET_DIAMETER = COFFEE_TABLE_01_REFERENCE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = COFFEE_TABLE_01_REFERENCE_HEIGHT;
+const COFFEE_TABLE_01_POLYHAVEN_ID = 'coffeetable_01';
+const POLYHAVEN_TABLE_MATCH_HEIGHT_SCALE = 0.94;
 const AI_CHAIR_GAP = (0.4 * MODEL_SCALE * CARD_SCALE) * 0.4;
 const CAMERA_TABLE_SPAN_FACTOR = 2.6;
 
@@ -2377,12 +2379,20 @@ function disposeObjectResources(object) {
   });
 }
 
-function fitTableModelToArena(model) {
-  if (!model) return { surfaceY: TABLE_MODEL_TARGET_HEIGHT, radius: TABLE_RADIUS };
+function getPolyhavenTableTargetHeight(theme = null) {
+  const assetId = String(theme?.assetId || theme?.id || '').toLowerCase();
+  if (!assetId || assetId === COFFEE_TABLE_01_POLYHAVEN_ID) {
+    return TABLE_MODEL_TARGET_HEIGHT;
+  }
+  return TABLE_MODEL_TARGET_HEIGHT * POLYHAVEN_TABLE_MATCH_HEIGHT_SCALE;
+}
+
+function fitTableModelToArena(model, theme = null) {
+  if (!model) return { surfaceY: getPolyhavenTableTargetHeight(theme), radius: TABLE_RADIUS };
   const box = new THREE.Box3().setFromObject(model);
   const size = box.getSize(new THREE.Vector3());
   const maxXZ = Math.max(size.x, size.z);
-  const targetHeight = TABLE_MODEL_TARGET_HEIGHT;
+  const targetHeight = getPolyhavenTableTargetHeight(theme);
   const targetDiameter = TABLE_MODEL_TARGET_DIAMETER;
   const targetRadius = COFFEE_TABLE_01_REFERENCE_RADIUS;
   const scaleY = size.y > 0 ? targetHeight / size.y : 1;
@@ -3455,13 +3465,16 @@ function alignGroupToFloorY(group, floorY = 0) {
 
 function getChessBoardSurfaceY(tableInfo = null) {
   const parentY = tableInfo?.group?.position?.y ?? 0;
-  return parentY + COFFEE_TABLE_01_REFERENCE_HEIGHT + BOARD_GROUP_Y_OFFSET;
+  const surfaceY = Number.isFinite(tableInfo?.surfaceY)
+    ? tableInfo.surfaceY
+    : parentY + COFFEE_TABLE_01_REFERENCE_HEIGHT;
+  return surfaceY + BOARD_GROUP_Y_OFFSET;
 }
 
 function alignBoardGroupToTableSurface(boardGroup, tableInfo) {
   if (!boardGroup) return 0;
-  // Every selectable table is normalized to Coffee Table 01's height/width,
-  // so the chess board keeps the exact same visible tabletop position on mobile.
+  // Anchor the board to the current tabletop surface so Poly Haven models
+  // keep the same board-above-table clearance as Coffee Table 01 on mobile.
   return alignGroupToFloorY(boardGroup, getChessBoardSurfaceY(tableInfo));
 }
 
@@ -3983,7 +3996,7 @@ async function buildTableFromTheme(theme, options = {}) {
         textureCache,
         fallbackTexture
       });
-      const fitted = fitTableModelToArena(model);
+      const fitted = fitTableModelToArena(model, selectedTheme);
       if (selectedTheme.rotationY || rotationY) {
         model.rotation.y += (selectedTheme.rotationY ?? 0) + (rotationY ?? 0);
       }


### PR DESCRIPTION
### Motivation
- Make Poly Haven table models slightly shorter (except Coffee Table 01) so their tabletop height visually matches the Coffee Table 01 reference and ensure the chess board sits above the table surface as on Coffee Table 01.

### Description
- Raise the board clearance by changing `BOARD_GROUP_Y_OFFSET` to `0.012` so the chess board is visibly above tabletop surface.
- Add `COFFEE_TABLE_01_POLYHAVEN_ID` and `POLYHAVEN_TABLE_MATCH_HEIGHT_SCALE = 0.94` plus `getPolyhavenTableTargetHeight(theme)` to compute a per-theme target height for Poly Haven models.
- Change `fitTableModelToArena` to accept an optional `theme` parameter and use `getPolyhavenTableTargetHeight(theme)` when normalizing model height, and update the `buildTableFromTheme` call to pass `selectedTheme`.
- Anchor board placement to the table's computed `surfaceY` by updating `getChessBoardSurfaceY` to prefer `tableInfo.surfaceY` when available.

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully.
- Ran `git diff --check` and committed the modified file `webapp/src/pages/Games/ChessBattleRoyal.jsx` with the message `Adjust Chess Battle Poly Haven table height`.
- Installed Playwright browsers via `npx playwright install chromium`, but an automated screenshot attempt failed because the container lacked the system library `libatk-1.0.so.0`, preventing Chromium from launching.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a292d5b2ea88329b4267dd07e072b52)