### PR TITLE
Adjust Chess Battle Royal table proportions

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -884,7 +884,7 @@ const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.24; // Lower tokens slightly so they stay grounded on the board after shrinking.
 const LAYOUT_SCALE_FACTOR = 0.7225;
 const TABLE_LAYOUT_SCALE_FACTOR = 0.84; // Slightly enlarge the board/chair footprint so board + pieces read bigger in portrait.
-const PIECE_SCALE_FACTOR = 0.73 * LAYOUT_SCALE_FACTOR * 1.5 * 0.82 * 1.42; // Make pieces a bit bigger for clearer readability.
+const PIECE_SCALE_FACTOR = 0.73 * LAYOUT_SCALE_FACTOR * 1.5 * 0.82 * 1.42 * 0.95; // Keep pieces slightly smaller so they sit cleaner on the raised boards.
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0.012; // keep the chess board visibly above the tabletop surface.
 const BOARD_MODEL_Y_OFFSET = -0.12;
@@ -920,7 +920,8 @@ const COFFEE_TABLE_01_REFERENCE_HEIGHT = TABLE_HEIGHT;
 const TABLE_MODEL_TARGET_DIAMETER = COFFEE_TABLE_01_REFERENCE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = COFFEE_TABLE_01_REFERENCE_HEIGHT;
 const COFFEE_TABLE_01_POLYHAVEN_ID = 'coffeetable_01';
-const POLYHAVEN_TABLE_MATCH_HEIGHT_SCALE = 0.94;
+const POLYHAVEN_TABLE_MATCH_HEIGHT_SCALE = 1; // All Poly Haven table surfaces match Coffee Table 01 height.
+const POLYHAVEN_NON_REFERENCE_BOARD_LIFT = 0.02; // Lift boards slightly on every non-reference Poly Haven table.
 const AI_CHAIR_GAP = (0.4 * MODEL_SCALE * CARD_SCALE) * 0.4;
 const CAMERA_TABLE_SPAN_FACTOR = 2.6;
 
@@ -2379,29 +2380,30 @@ function disposeObjectResources(object) {
   });
 }
 
-function getPolyhavenTableTargetHeight(theme = null) {
-  const assetId = String(theme?.assetId || theme?.id || '').toLowerCase();
-  if (!assetId || assetId === COFFEE_TABLE_01_POLYHAVEN_ID) {
-    return TABLE_MODEL_TARGET_HEIGHT;
-  }
+function getPolyhavenTableTargetHeight(_theme = null) {
   return TABLE_MODEL_TARGET_HEIGHT * POLYHAVEN_TABLE_MATCH_HEIGHT_SCALE;
+}
+
+function isCoffeeTable01Theme(theme = null) {
+  const assetId = String(theme?.assetId || theme?.id || '').toLowerCase();
+  return !assetId || assetId === COFFEE_TABLE_01_POLYHAVEN_ID;
 }
 
 function fitTableModelToArena(model, theme = null) {
   if (!model) return { surfaceY: getPolyhavenTableTargetHeight(theme), radius: TABLE_RADIUS };
   const box = new THREE.Box3().setFromObject(model);
   const size = box.getSize(new THREE.Vector3());
-  const maxXZ = Math.max(size.x, size.z);
   const targetHeight = getPolyhavenTableTargetHeight(theme);
   const targetDiameter = TABLE_MODEL_TARGET_DIAMETER;
   const targetRadius = COFFEE_TABLE_01_REFERENCE_RADIUS;
   const scaleY = size.y > 0 ? targetHeight / size.y : 1;
-  const scaleXZ = maxXZ > 0 ? targetDiameter / maxXZ : 1;
-  if (scaleY !== 1 || scaleXZ !== 1) {
+  const scaleX = size.x > 0 ? targetDiameter / size.x : 1;
+  const scaleZ = size.z > 0 ? targetDiameter / size.z : 1;
+  if (scaleY !== 1 || scaleX !== 1 || scaleZ !== 1) {
     model.scale.set(
-      model.scale.x * scaleXZ,
+      model.scale.x * scaleX,
       model.scale.y * scaleY,
-      model.scale.z * scaleXZ
+      model.scale.z * scaleZ
     );
   }
   const scaledBox = new THREE.Box3().setFromObject(model);
@@ -2409,7 +2411,8 @@ function fitTableModelToArena(model, theme = null) {
   model.position.add(new THREE.Vector3(-center.x, -scaledBox.min.y, -center.z));
   return {
     surfaceY: COFFEE_TABLE_01_REFERENCE_HEIGHT,
-    radius: targetRadius
+    radius: targetRadius,
+    boardSurfaceOffset: isCoffeeTable01Theme(theme) ? 0 : POLYHAVEN_NON_REFERENCE_BOARD_LIFT
   };
 }
 
@@ -3468,7 +3471,10 @@ function getChessBoardSurfaceY(tableInfo = null) {
   const surfaceY = Number.isFinite(tableInfo?.surfaceY)
     ? tableInfo.surfaceY
     : parentY + COFFEE_TABLE_01_REFERENCE_HEIGHT;
-  return surfaceY + BOARD_GROUP_Y_OFFSET;
+  const tableBoardLift = Number.isFinite(tableInfo?.boardSurfaceOffset)
+    ? tableInfo.boardSurfaceOffset
+    : 0;
+  return surfaceY + BOARD_GROUP_Y_OFFSET + tableBoardLift;
 }
 
 function alignBoardGroupToTableSurface(boardGroup, tableInfo) {
@@ -4007,6 +4013,7 @@ async function buildTableFromTheme(theme, options = {}) {
         group,
         surfaceY: fitted.surfaceY,
         radius: fitted.radius,
+        boardSurfaceOffset: fitted.boardSurfaceOffset ?? 0,
         dispose: () => {
           disposeObjectResources(group);
           group.removeFromParent();


### PR DESCRIPTION
### Motivation
- Ensure all table shapes visually match the Coffee Table 01 tabletop height and footprint while keeping the Coffee Table 01 and procedural oval/hexagon/octagon tables unchanged. 
- Make the board sit slightly higher on non-reference Poly Haven tables so pieces and highlights read consistently on mobile portrait framing. 
- Reduce piece scale slightly so tokens fit neatly on the raised boards and avoid visual overlap.

### Description
- Updated `webapp/src/pages/Games/ChessBattleRoyal.jsx` to normalize Poly Haven table X/Z spans to the Coffee Table 01 footprint and to use the Coffee Table 01 height as the canonical tabletop height by setting `POLYHAVEN_TABLE_MATCH_HEIGHT_SCALE` to `1` and adding `POLYHAVEN_NON_REFERENCE_BOARD_LIFT` for a small per-table lift. 
- Reworked `fitTableModelToArena` to scale independently in X, Y and Z (instead of using a combined XZ scale) and return a new `boardSurfaceOffset` value for non-reference Poly Haven tables. 
- Added `isCoffeeTable01Theme` helper and threaded `boardSurfaceOffset` through `loadPolyhavenModel` / `buildTableFromTheme` so the per-table lift is stored on `tableInfo`. 
- Adjusted `getChessBoardSurfaceY` / `alignBoardGroupToTableSurface` to apply the new per-table board lift when aligning boards to table surfaces. 
- Reduced chess piece base scale by multiplying `PIECE_SCALE_FACTOR` by `0.95` so pieces appear slightly smaller on the adjusted boards.

### Testing
- Ran a production build with `npm --prefix webapp run build` and the build completed successfully. 
- Ran linter with `npm --prefix webapp run lint -- src/pages/Games/ChessBattleRoyal.jsx` and no lint errors were produced. 
- Attempted a visual preview and screenshot via Playwright; a screenshot was produced at `/tmp/chess-battle-royal-table-adjustments.png`, but the headless preview environment experienced external asset/network failures so the full 3D board materials/models did not fully load in that run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2932c0d1c48329bc5f3db24709ae44)