### PR TITLE
Park firearms on token rails and aim toward opposite seat (LudoBattleRoyal)

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -206,6 +206,19 @@ describe('cross-game inventory alignment', () => {
   });
 
 
+  test('ludo battle royal parks each firearm beside player token rails with opposite-side aim', async () => {
+    const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain('FIREARM_TOKEN_RAIL_SIDE_OFFSET');
+    expect(source).toContain("Put the parked weapon on the same tabletop rail as the player's home tokens and dice.");
+    expect(source).toContain('Pull it slightly toward the board so the handle remains on the character side for pickup.');
+    expect(source).toContain('const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({');
+    expect(source).toContain('1: 3');
+    expect(source).toContain('3: 1');
+    expect(source).toContain('orientWeaponHolderTowardBoardCenter(entry, firearmAimTarget);');
+  });
+
+
   test('ludo battle royal pins Gunify weapon loading to the May 9 texture baseline', async () => {
     const source = await readFile('webapp/src/pages/Games/LudoBattleRoyal.jsx', 'utf8');
     const may9Ref = '27232cf389a2be3f8f476c667cb293e978aaf5f9';

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -363,13 +363,15 @@ const FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS = Object.freeze([
   Object.freeze({ side: -0.012, inward: 0.052 }), // top
   Object.freeze({ side: -0.008, inward: 0.004 }) // left
 ]);
-const FIREARM_RACK_DICE_SIDE_OFFSET = 0.102;
-const FIREARM_RACK_DICE_INWARD_OFFSET = 0.018;
-const FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA = 0.036;
-const FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA = 0.012;
+const FIREARM_TOKEN_RAIL_SIDE_OFFSET = 0.108;
+const FIREARM_TOKEN_RAIL_INWARD_OFFSET = 0.024;
+const FIREARM_TOKEN_RAIL_LONG_GUN_SIDE_EXTRA = 0.05;
+const FIREARM_TOKEN_RAIL_LONG_GUN_INWARD_EXTRA = 0.018;
 const FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER = Object.freeze({
   0: 2,
-  2: 0
+  1: 3,
+  2: 0,
+  3: 1
 });
 // Latest Gunify commit visible at the end of May 9, 2026; keep Ludo weapons
 // pinned to that tree so texture folders/material JSON cannot drift under main.
@@ -8674,15 +8676,26 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     rightWorld.normalize();
 
     const isLargeFirearm = LARGE_RACK_FIREARM_IDS.has(captureAnimationId);
-    const sideOffset = FIREARM_RACK_DICE_SIDE_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_SIDE_EXTRA : 0);
-    const inwardOffset = FIREARM_RACK_DICE_INWARD_OFFSET + (isLargeFirearm ? FIREARM_RACK_DICE_LONG_GUN_INWARD_EXTRA : 0);
+    const sideOffset = FIREARM_TOKEN_RAIL_SIDE_OFFSET + (isLargeFirearm ? FIREARM_TOKEN_RAIL_LONG_GUN_SIDE_EXTRA : 0);
+    const inwardOffset = FIREARM_TOKEN_RAIL_INWARD_OFFSET + (isLargeFirearm ? FIREARM_TOKEN_RAIL_LONG_GUN_INWARD_EXTRA : 0);
     const position = railWorld
       .clone()
+      // Put the parked weapon on the same tabletop rail as the player's home tokens and dice.
       .addScaledVector(rightWorld, sideOffset)
+      // Pull it slightly toward the board so the handle remains on the character side for pickup.
       .addScaledVector(forwardWorld, -inwardOffset);
     position.y = (arena.tableInfo?.surfaceY ?? position.y) + 0.002;
-    return { position, aimTarget: railWorld.clone().addScaledVector(forwardWorld, -0.22) };
-  }, []);
+    const oppositeSeatTarget = resolveFirearmRackAimTarget(
+      arena,
+      playerIndex,
+      getKingTokenPositionForPlayer
+    );
+    const aimTarget = oppositeSeatTarget?.isVector3
+      ? oppositeSeatTarget.clone()
+      : railWorld.clone().addScaledVector(forwardWorld, -0.32);
+    aimTarget.y = position.y;
+    return { position, aimTarget };
+  }, [getKingTokenPositionForPlayer]);
 
   const resolveCaptureParkingAnchors = useCallback((playerIndex, vehicleType = 'fighter') => {
     const arena = arenaRef.current;


### PR DESCRIPTION
### Motivation
- Make parked weapons visible and easy to pick up by placing each selected firearm on the same tabletop rail as the player’s home tokens/dice, with the grip near the player and the barrel visually aimed at the opposite seat.\

### Description
- Add new token-rail tuning constants (`FIREARM_TOKEN_RAIL_SIDE_OFFSET`, `FIREARM_TOKEN_RAIL_INWARD_OFFSET`, `FIREARM_TOKEN_RAIL_LONG_GUN_*`) and replace the previous rack offsets so parked weapons sit on the token/dice rail.\
- Compute parked weapon world `position` from the dice/token rail in `resolveFirearmRackDicePose` and supply an `aimTarget` resolved via `resolveFirearmRackAimTarget` so the weapon muzzle points at the opposite seat; include `getKingTokenPositionForPlayer` as a hook dependency.\
- Broaden the opposite-seat mapping to cover all four seats via `FIREARM_RACK_OPPOSITE_SEAT_TARGET_BY_PLAYER`.\
- Add a regression test `ludo battle royal parks each firearm beside player token rails with opposite-side aim` in `test/inventoryCrossGameConfig.test.js` that asserts the new constants, inline comment strings, opposite-seat mapping, and that `orientWeaponHolderTowardBoardCenter(entry, firearmAimTarget)` is present.\
- Files changed: `webapp/src/pages/Games/LudoBattleRoyal.jsx`, `test/inventoryCrossGameConfig.test.js`.\

### Testing
- Ran the focused Jest test: `npm test -- --runInBand test/inventoryCrossGameConfig.test.js -t "ludo battle royal parks each firearm"` which passed.\
- Ran the full cross-game inventory test file: `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` which executed the suite but failed on pre-existing unrelated inventory alignment assertions (several other expectations unrelated to this change).\
- Lint: `npm --prefix webapp run lint -- src/pages/Games/LudoBattleRoyal.jsx` succeeded.\
- Production build: `npm --prefix webapp run build` succeeded and produced `dist` artifacts.\
- Playwright: `npx playwright install chromium` and `npx playwright install-deps chromium` completed successfully.\
- Dev + browser check: launched local dev server and ran a Playwright screenshot run against `/games/ludobattleroyal?tableId=practice&ai=3`; screenshot saved to `artifacts/ludo-weapon-token-rail.png` (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29448b6eac8329af398c9ad7471245)