### PR TITLE
Adopt SnookerRoyalProvided cue-stroke (deferred impact) for Pool Royale and add unit tests

### DIFF
--- a/test/poolRoyaleCueStrokeContact.test.js
+++ b/test/poolRoyaleCueStrokeContact.test.js
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+
+const source = fs.readFileSync('webapp/src/pages/Games/PoolRoyale.jsx', 'utf8');
+
+describe('Pool Royale live cue contact stroke wiring', () => {
+  it('uses a SnookerRoyalProvided-style cue-ball contact gap for the strike target', () => {
+    expect(source).toContain('const CUE_IDLE_GAP = BALL_R * (0.012 / 0.0525)');
+    expect(source).toContain('const CUE_CONTACT_GAP = BALL_R * (0.0012 / 0.0525)');
+    expect(source).toContain('const CUE_SNOOKER_PROVIDED_PULL_RANGE = BALL_R * (0.42 / 0.0525)');
+    expect(source).toContain('const impactPos = buildCuePositionFromSnookerGap(CUE_CONTACT_GAP)');
+  });
+
+  it('does not apply cue-ball power before the animated cue reaches impact', () => {
+    const payloadIndex = source.indexOf('const shotImpactPayload = {');
+    const helperIndex = source.indexOf('const applyShotImpactOnce = () => {', payloadIndex);
+    const animationIndex = source.indexOf('if (ENABLE_CUE_STROKE_ANIMATION)', helperIndex);
+    const prematureSection = source.slice(payloadIndex, helperIndex);
+
+    expect(payloadIndex).toBeGreaterThan(-1);
+    expect(helperIndex).toBeGreaterThan(payloadIndex);
+    expect(animationIndex).toBeGreaterThan(helperIndex);
+    expect(prematureSection).not.toContain('applyShotAtImpact(shotImpactPayload);');
+    expect(source).toContain('onImpact: () => applyShotImpactOnce()');
+    expect(source).toContain('pendingImpactRef.current = {');
+    expect(source).toContain('apply: applyShotImpactOnce');
+  });
+
+  it('keeps the turn alive while the cue is still winding up to impact', () => {
+    expect(source).toContain('const pendingCueImpact =');
+    expect(source).toContain('!cueStrokeStateRef.current.shotApplied');
+    expect(source).toContain('Boolean(pendingImpactRef.current)');
+    expect(source).toContain('Do not resolve the turn as a miss/foul during this');
+  });
+
+  it('arms impact at the same normalized stroke timing as SnookerRoyalProvided', () => {
+    expect(source).toContain('impactThreshold: CUE_SNOOKER_PROVIDED_IMPACT_THRESHOLD');
+    expect(source).toContain('strikeImpactThreshold: strokeProfile.impactThreshold ?? CUE_SNOOKER_PROVIDED_IMPACT_THRESHOLD');
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1938,8 +1938,17 @@ const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
 const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.07;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
-const CUE_TIP_CLEARANCE = BALL_R * 0.24; // widen the visible air gap so the cue sits a little farther from the cue ball
-const CUE_TIP_GAP = BALL_R * 1.42 + CUE_TIP_CLEARANCE; // pull the cue tip slightly farther back so the blue tip remains visible
+// Mirror SnookerRoyalProvided.jsx CFG values using Pool Royale's ball radius:
+// idleGap: 0.012 / 0.0525 ball radii, contactGap: 0.0012 / 0.0525, pullRange: 0.42 / 0.0525.
+const CUE_IDLE_GAP = BALL_R * (0.012 / 0.0525);
+const CUE_CONTACT_GAP = BALL_R * (0.0012 / 0.0525);
+const CUE_TIP_GAP = BALL_R + CUE_IDLE_GAP;
+const CUE_CONTACT_DISTANCE = BALL_R + CUE_CONTACT_GAP;
+const CUE_CONTACT_ADVANCE = Math.max(0, CUE_TIP_GAP - CUE_CONTACT_DISTANCE);
+const CUE_SNOOKER_PROVIDED_PULL_RANGE = BALL_R * (0.42 / 0.0525);
+const CUE_SNOOKER_PROVIDED_STRIKE_MS = 120;
+const CUE_SNOOKER_PROVIDED_HOLD_MS = 50;
+const CUE_SNOOKER_PROVIDED_IMPACT_THRESHOLD = 0.88;
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -24901,13 +24910,15 @@ const shotPowerRef = useRef(0);
             const safeHoldDuration = Math.max(0, holdDuration ?? 45);
             const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
             const resolvedIdlePos = idlePos ?? impactPos ?? stroke.contactPos ?? pullPos;
+            const resolvedImpactPos = impactPos ?? stroke.contactPos ?? resolvedIdlePos ?? pullPos;
             const normalizedStroke = ensureCueStrokeForwardMotion({
               pullPos: pullPos ?? resolvedIdlePos,
-              impactPos: resolvedIdlePos ?? pullPos,
+              impactPos: resolvedImpactPos ?? resolvedIdlePos ?? pullPos,
               fallbackDirection: tmpCueStrokeB.set(Math.sin(baseRotationY ?? 0), 0, Math.cos(baseRotationY ?? 0))
             });
             const resolvedPullPos = normalizedStroke.pullPos ?? pullPos ?? resolvedIdlePos;
-            const resolvedContactPos = resolvedIdlePos ?? stroke.contactPos ?? impactPos ?? pullPos;
+            const resolvedContactPos = stroke.contactPos ?? resolvedImpactPos ?? resolvedIdlePos ?? pullPos;
+            const resolvedFollowPos = followPos ?? resolvedContactPos;
             const strikeProgress = THREE.MathUtils.clamp(
               elapsed / Math.max(safeStrikeDuration, 1e-6),
               0,
@@ -24928,7 +24939,22 @@ const shotPowerRef = useRef(0);
               stroke.onImpact?.();
             }
 
+            if (elapsed < safeStrikeDuration) {
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
             if (elapsed < safeStrikeDuration + safeHoldDuration) {
+              const holdT = THREE.MathUtils.clamp(
+                (elapsed - safeStrikeDuration) / Math.max(safeHoldDuration, 1e-6),
+                0,
+                1
+              );
+              cueStick.position.lerpVectors(
+                resolvedContactPos,
+                resolvedFollowPos,
+                easeInOutCubic(holdT)
+              );
               cueAnimating = true;
               syncCueShadow();
               return true;
@@ -24940,7 +24966,7 @@ const shotPowerRef = useRef(0);
             );
             if (recoverT < 1) {
               cueStick.position.lerpVectors(
-                resolvedContactPos,
+                resolvedFollowPos,
                 resolvedIdlePos ?? impactPos ?? pullPos,
                 easeInOutCubic(recoverT)
               );
@@ -28885,20 +28911,17 @@ const shotPowerRef = useRef(0);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(110, 190, p);
-        const strikeDuration = THREE.MathUtils.lerp(128, 92, p);
-        const holdDuration = THREE.MathUtils.lerp(40, 68, p);
         return {
-          // Snooker Royal-style live stroke: slider pull maps directly to cue pullback,
-          // then release performs one forward push back to the original cue-start pose.
-          motion: 'classic',
-          pullRatio: p,
+          // SnookerRoyalProvided-style live stroke: activePower is eased into
+          // pull range, then strike interpolates the gap to contact at 0.88.
+          motion: 'snookerRoyalProvided',
+          pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration,
-          holdDuration,
-          pullbackDuration,
+          strikeDuration: CUE_SNOOKER_PROVIDED_STRIKE_MS,
+          holdDuration: CUE_SNOOKER_PROVIDED_HOLD_MS,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 0.86,
+          impactThreshold: CUE_SNOOKER_PROVIDED_IMPACT_THRESHOLD,
           forwardOnly: true,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
@@ -28983,11 +29006,7 @@ const shotPowerRef = useRef(0);
         const style = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const styleRatio = resolveCueStrokeProfile(style, ratio).pullRatio;
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
-        const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
-        const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
-        const target =
-          amplifiedMax * styleRatio * CUE_PULL_VISUAL_MULTIPLIER * CUE_PULL_DISTANCE_SCALE;
-        return Math.min(target, visualMax);
+        return Math.min(CUE_SNOOKER_PROVIDED_PULL_RANGE * styleRatio, effectiveMax);
       };
       // Easing adapted from easings.net (MIT) for a smoother pull/release cue stroke.
       const easeInOutCubic = (t) =>
@@ -29573,7 +29592,6 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
-          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -29608,17 +29626,12 @@ const shotPowerRef = useRef(0);
           );
           const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          // Rebuilt stroke pullback: tie visible pull directly to slider power
-          // and the currently available room behind the cue ball.
-          const pullRange = THREE.MathUtils.clamp(
-            maxPull * 0.92,
-            CUE_PULL_MIN_VISUAL,
-            Math.max(CUE_PULL_MIN_VISUAL, maxPull)
-          );
-          const pullTarget = pullRange * strokeProfile.pullRatio;
-          const pulledNow = cuePullCurrentRef.current ?? pullTarget;
-          const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
-          const visualPull = applyVisualPullCompensation(startPull, dir);
+          // SnookerRoyalProvided.jsx equivalent:
+          // const pull = CFG.pullRange * easeOutCubic(activePower);
+          // gap starts at CFG.idleGap + pull and strikes into CFG.contactGap.
+          const pullTarget = computePullTargetFromPower(clampedPower, maxPull);
+          const startPull = THREE.MathUtils.clamp(pullTarget, 0, Math.max(maxPull, 0));
+          const visualPull = startPull;
           shotImpactPayload.pullDistance = visualPull;
           cuePullCurrentRef.current = startPull;
           cuePullTargetRef.current = startPull;
@@ -29659,10 +29672,11 @@ const shotPowerRef = useRef(0);
             return new THREE.Vector3(tipTarget.x, tipTarget.y, tipTarget.z)
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
-          const idlePos = buildCuePosition(0);
-          // Start the release exactly from the computed pull position so the
-          // cue always pushes forward from the same pulled depth the player set.
-          const releaseStartPos = buildCuePosition(visualPull);
+          const buildCuePositionFromSnookerGap = (gap) =>
+            buildCuePosition(BALL_R + gap - CUE_TIP_GAP);
+          const idlePos = buildCuePositionFromSnookerGap(CUE_IDLE_GAP);
+          // Start exactly like SnookerRoyalProvided.jsx: gap = idleGap + pull.
+          const releaseStartPos = buildCuePositionFromSnookerGap(CUE_IDLE_GAP + visualPull);
           cueStick.position.copy(releaseStartPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
@@ -29674,16 +29688,15 @@ const shotPowerRef = useRef(0);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = 0;
           const startTime = performance.now();
-          const impactPos = idlePos.clone();
-          const contactAdvance = 0; // push forward only to the original idle pose where the slider pull began
+          // Match SnookerRoyalProvided.jsx exactly: the visible cue stroke
+          // interpolates the tip gap from idle + pull to a tiny contact gap at
+          // the cue ball, then holds that physical contact while the cue-ball
+          // impulse is applied.
+          const contactAdvance = CUE_CONTACT_ADVANCE;
+          const impactPos = buildCuePositionFromSnookerGap(CUE_CONTACT_GAP);
           shotImpactPayload.contactAdvance = contactAdvance;
-          const contactPos = impactPos
-            .clone()
-            .addScaledVector(dir, contactAdvance);
-          const followDistance = 0; // stop at cue-ball contact instead of visually following the moving cue ball
-          const followPos = contactPos
-            .clone()
-            .addScaledVector(dir, followDistance);
+          const contactPos = impactPos.clone();
+          const followPos = contactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =
@@ -29765,8 +29778,19 @@ const shotPowerRef = useRef(0);
           const applyShotImpactOnce = () => {
             if (shotImpactApplied) return;
             shotImpactApplied = true;
+            pendingImpactRef.current = null;
             applyShotAtImpact(shotImpactPayload);
           };
+          const impactDelayMs = Math.max(
+            0,
+            strikeDuration * (strokeProfile.impactThreshold ?? CUE_SNOOKER_PROVIDED_IMPACT_THRESHOLD)
+          );
+          if (ENABLE_CUE_STROKE_ANIMATION) {
+            pendingImpactRef.current = {
+              time: startTime + impactDelayMs,
+              apply: applyShotImpactOnce
+            };
+          }
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
             const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
             shotRecording.cueStroke = {
@@ -29806,10 +29830,10 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: strokeProfile.impactThreshold ?? CUE_SNOOKER_PROVIDED_IMPACT_THRESHOLD,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
-              // Match Snooker Royal's release: push from the pulled pose and
-              // stop exactly at the cue's original idle/contact pose.
+              // Match SnookerRoyalProvided's release: push from pullback
+              // into physical cue-ball contact, then hold that contact.
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,
@@ -35151,7 +35175,16 @@ const shotPowerRef = useRef(0);
             const any = balls.some(
               (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
             );
-            if (!any) {
+            const pendingCueImpact =
+              ENABLE_CUE_STROKE_ANIMATION &&
+              ((cueStrokeStateRef.current && !cueStrokeStateRef.current.shotApplied) ||
+                Boolean(pendingImpactRef.current));
+            if (!any && pendingCueImpact) {
+              // The SnookerRoyalProvided-style stroke intentionally delays the
+              // cue-ball impulse until the cue tip reaches the 0.88 contact
+              // point. Do not resolve the turn as a miss/foul during this
+              // wind-up window just because the balls are still stationary.
+            } else if (!any) {
               resolve();
             } else if (shotStartedAt > 0 && now - shotStartedAt >= STUCK_SHOT_TIMEOUT_MS) {
               console.warn('Shot timeout reached; forcing resolve to prevent a stuck frame.');


### PR DESCRIPTION
### Motivation
- Match Pool Royale's live cue stroke to the `SnookerRoyalProvided` behavior so the visible cue interpolates gaps and the physics impulse is applied at the visual contact point rather than immediately.
- Prevent resolving a turn as a miss/foul while the animated cue is still winding up to its impact point.
- Provide automated assertions to guard the new wiring and timing contract.

### Description
- Introduces Snooker-style config constants (`CUE_IDLE_GAP`, `CUE_CONTACT_GAP`, `CUE_SNOOKER_PROVIDED_PULL_RANGE`, timing and `impactThreshold`) and translates Pool Royale cue geometry to those values.
- Reworks pull/strike logic to compute pull from the Snooker-provided pull range, build cue positions from gap values (`buildCuePositionFromSnookerGap`), and advance the visual tip from idle+pull into the tiny contact gap while holding that contact.
- Defers application of the physics impulse via `applyShotImpactOnce` and schedules it using `pendingImpactRef.current` when `ENABLE_CUE_STROKE_ANIMATION` is enabled, and clears the pending impact when applied.
- Keeps the turn alive while the cue animation is still in its strike/hold window by checking `pendingCueImpact` so the game doesn't resolve early, and tweaks several stroke-state resolution paths and easing/timing values.
- Adds unit test `test/poolRoyaleCueStrokeContact.test.js` that asserts the source contains the new constants, deferred-impact wiring, pending-impact turn-hold behavior, and correct impact threshold usage.

### Testing
- Added the `test/poolRoyaleCueStrokeContact.test.js` unit test covering static source assertions for the new cue stroke wiring and timing.
- Ran the test suite with `yarn test` and confirmed the new tests pass. 
- Existing automated tests continued to pass after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28eab547388329a188696ddceff2a7)