### PR TITLE
Add protest video gallery to home page

### DIFF
--- a/webapp/public/ProtestVideo/README.md
+++ b/webapp/public/ProtestVideo/README.md
@@ -1,0 +1,29 @@
+# ProtestVideo library
+
+Upload high-quality protest videos into this folder and publish them on the home-page gallery by editing `library.json`.
+
+Each video entry must include:
+
+- `id`: unique slug for the video.
+- `title`: public title shown in the gallery.
+- `date`: protest/video date in `YYYY-MM-DD` format.
+- `time`: protest/video time in `HH:mm` 24-hour format.
+- `timezone`: time zone label, for example `UTC`, `Europe/Tirane`, or `America/New_York`.
+- `file`: exact filename in this `ProtestVideo` folder.
+- `quality`: optional quality note, for example `1080p MP4` or `4K MP4`.
+- `description`: optional short context for users.
+
+Example:
+
+```json
+{
+  "id": "tirana-protest-2026-07-17-1800",
+  "title": "Tirana protest evening march",
+  "date": "2026-07-17",
+  "time": "18:00",
+  "timezone": "Europe/Tirane",
+  "file": "tirana-protest-2026-07-17-1800.mp4",
+  "quality": "4K MP4",
+  "description": "High-quality downloadable footage from the evening march."
+}
+```

--- a/webapp/public/ProtestVideo/library.json
+++ b/webapp/public/ProtestVideo/library.json
@@ -1,0 +1,14 @@
+{
+  "videos": [
+    {
+      "id": "sample-protest-video",
+      "title": "Sample protest video",
+      "date": "2026-07-17",
+      "time": "12:00",
+      "timezone": "UTC",
+      "file": "sample-protest-video.mp4",
+      "quality": "Upload high quality MP4 here",
+      "description": "Replace this entry after uploading a real protest video to public/ProtestVideo."
+    }
+  ]
+}

--- a/webapp/public/pwa/app-build.js
+++ b/webapp/public/pwa/app-build.js
@@ -1,1 +1,1 @@
-self.__TONPLAYGRAM_APP_BUILD__ = "d992be4";
+self.__TONPLAYGRAM_APP_BUILD__ = "467f5ab";

--- a/webapp/public/version.json
+++ b/webapp/public/version.json
@@ -1,4 +1,4 @@
 {
-  "build": "d992be4",
-  "generatedAt": "2026-06-07T03:14:48.068Z"
+  "build": "467f5ab",
+  "generatedAt": "2026-07-17T14:28:10.192Z"
 }

--- a/webapp/src/config/buildInfo.js
+++ b/webapp/src/config/buildInfo.js
@@ -1,2 +1,2 @@
-export const APP_BUILD = "d992be4";
-export const APP_BUILD_GENERATED_AT = "2026-06-07T03:14:48.068Z";
+export const APP_BUILD = "467f5ab";
+export const APP_BUILD_GENERATED_AT = "2026-07-17T14:28:10.192Z";

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -5,7 +5,7 @@ import PwaDownloadFrame from '../components/PwaDownloadFrame.jsx';
 import HomeSocialHub from '../components/HomeSocialHub.jsx';
 import PlatformStatsCard from '../components/PlatformStatsCard.jsx';
 
-import { FaArrowUp, FaArrowDown, FaWallet } from 'react-icons/fa';
+import { FaArrowUp, FaArrowDown, FaDownload, FaTimes, FaWallet } from 'react-icons/fa';
 import { IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
 import { useTonAddress } from '@tonconnect/ui-react';
@@ -17,6 +17,9 @@ const ALBANIA_PAUSE_NOTICE = {
   detail:
     'Faleminderit për durimin dhe mbështetjen. Platforma do të mbetet online për informacionet kryesore dhe lidhjet e komunitetit.'
 };
+
+const PROTEST_VIDEO_LIBRARY_URL = '/ProtestVideo/library.json';
+const PROTEST_VIDEO_BASE_URL = '/ProtestVideo/';
 
 const xIcon = (
   <img
@@ -49,6 +52,9 @@ const getStoredWalletAddress = () => {
 
 export default function Home() {
   const [status, setStatus] = useState('checking');
+  const [isProtestGalleryOpen, setIsProtestGalleryOpen] = useState(false);
+  const [protestVideos, setProtestVideos] = useState([]);
+  const [protestVideosStatus, setProtestVideosStatus] = useState('idle');
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
@@ -159,6 +165,28 @@ export default function Home() {
       window.removeEventListener('profilePhotoUpdated', handleUpdate);
   }, []);
 
+  useEffect(() => {
+    if (!isProtestGalleryOpen || protestVideosStatus !== 'idle') return;
+
+    setProtestVideosStatus('loading');
+    fetch(PROTEST_VIDEO_LIBRARY_URL, { cache: 'no-store' })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Unable to load protest video library.');
+        }
+        return response.json();
+      })
+      .then((library) => {
+        const videos = Array.isArray(library?.videos) ? library.videos : [];
+        setProtestVideos(videos);
+        setProtestVideosStatus('ready');
+      })
+      .catch(() => {
+        setProtestVideos([]);
+        setProtestVideosStatus('error');
+      });
+  }, [isProtestGalleryOpen, protestVideosStatus]);
+
   return (
     <div className="space-y-4">
       <section className="rounded-2xl border border-red-400/40 bg-gradient-to-br from-red-950/90 via-slate-950 to-black p-4 shadow-xl">
@@ -176,9 +204,124 @@ export default function Home() {
             <p className="text-xs leading-5 text-subtext">
               {ALBANIA_PAUSE_NOTICE.detail}
             </p>
+            <button
+              type="button"
+              onClick={() => setIsProtestGalleryOpen(true)}
+              className="mt-2 w-full rounded-xl border border-red-300/50 bg-red-600/90 px-4 py-3 text-sm font-bold text-white shadow-lg shadow-red-950/30 transition hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-200"
+            >
+              Open protest video gallery
+            </button>
           </div>
         </div>
       </section>
+
+      {isProtestGalleryOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/80 px-3 py-4 sm:items-center"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="protest-video-gallery-title"
+        >
+          <div className="max-h-[88vh] w-full max-w-lg overflow-hidden rounded-3xl border border-red-300/40 bg-slate-950 shadow-2xl">
+            <div className="flex items-start justify-between gap-3 border-b border-red-300/20 p-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-300">
+                  ProtestVideo Library
+                </p>
+                <h2
+                  id="protest-video-gallery-title"
+                  className="text-xl font-black text-white"
+                >
+                  High-quality protest videos
+                </h2>
+                <p className="mt-1 text-xs leading-5 text-subtext">
+                  Download original higher-quality videos. Every item keeps its
+                  recorded date and time.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsProtestGalleryOpen(false)}
+                className="rounded-full border border-white/20 bg-white/10 p-2 text-white"
+                aria-label="Close protest video gallery"
+              >
+                <FaTimes />
+              </button>
+            </div>
+
+            <div className="max-h-[65vh] space-y-3 overflow-y-auto p-4">
+              {protestVideosStatus === 'loading' && (
+                <p className="rounded-2xl border border-border bg-background/60 p-4 text-sm text-subtext">
+                  Loading protest video library…
+                </p>
+              )}
+
+              {protestVideosStatus === 'error' && (
+                <p className="rounded-2xl border border-red-400/40 bg-red-950/50 p-4 text-sm text-red-100">
+                  The protest video library could not load. Check
+                  public/ProtestVideo/library.json.
+                </p>
+              )}
+
+              {protestVideosStatus === 'ready' && protestVideos.length === 0 && (
+                <p className="rounded-2xl border border-border bg-background/60 p-4 text-sm text-subtext">
+                  No protest videos are published yet. Upload videos into
+                  public/ProtestVideo and add them to library.json.
+                </p>
+              )}
+
+              {protestVideos.map((video) => {
+                const videoUrl = `${PROTEST_VIDEO_BASE_URL}${video.file || ''}`;
+                const recordedAt = [video.date, video.time, video.timezone]
+                  .filter(Boolean)
+                  .join(' • ');
+
+                return (
+                  <article
+                    key={video.id || video.file}
+                    className="rounded-2xl border border-white/10 bg-white/[0.04] p-3"
+                  >
+                    <video
+                      className="aspect-video w-full rounded-xl bg-black object-cover"
+                      src={videoUrl}
+                      controls
+                      preload="metadata"
+                    />
+                    <div className="mt-3 space-y-2">
+                      <div>
+                        <h3 className="text-base font-bold text-white">
+                          {video.title || 'Untitled protest video'}
+                        </h3>
+                        <p className="text-xs font-semibold text-red-200">
+                          {recordedAt || 'Date and time not set'}
+                        </p>
+                      </div>
+                      {video.description && (
+                        <p className="text-sm leading-5 text-subtext">
+                          {video.description}
+                        </p>
+                      )}
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="rounded-full bg-red-500/15 px-3 py-1 text-xs font-semibold text-red-100">
+                          {video.quality || 'High quality'}
+                        </span>
+                        <a
+                          href={videoUrl}
+                          download
+                          className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-xs font-black text-slate-950"
+                        >
+                          <FaDownload />
+                          Download
+                        </a>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="flex flex-col items-center">
         {photoUrl && (


### PR DESCRIPTION
### Motivation
- Provide users a way on the home page to access and download higher-quality protest videos from a public folder called `ProtestVideo`.
- Allow manual upload and publishing of videos with clear metadata so each item records date/time/timezone for provenance and display.

### Description
- Added an "Open protest video gallery" button and a mobile-friendly modal to `webapp/src/pages/Home.jsx` which fetches `/ProtestVideo/library.json` and renders video previews, recorded date/time/timezone, quality notes, descriptions, and a download button. 
- Implemented client-side state and fetch flow with `PROTEST_VIDEO_LIBRARY_URL` and `PROTEST_VIDEO_BASE_URL` and loading/error states for the gallery. 
- Added `webapp/public/ProtestVideo/library.json` as the manifest example and `webapp/public/ProtestVideo/README.md` with instructions for manually uploading videos and required fields (`id`, `title`, `date`, `time`, `timezone`, `file`, `quality`, `description`).
- Updated build metadata files (`webapp/src/config/buildInfo.js`, `webapp/public/version.json`, and `webapp/public/pwa/app-build.js`) after running a production build.

### Testing
- Ran a production build with `cd webapp && npm run build` and the build completed successfully. 
- Ran linting with `cd webapp && npm run lint` and it completed without errors. 
- Started the dev server (`cd webapp && npm run dev`) and the site served locally for manual testing. 
- Attempted an automated screenshot with Playwright, but the headless Chromium could not launch in this environment due to a missing system library (`libatk-1.0.so.0`), so the visual verification screenshot was not captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a3ba3628c8329a44cc07d13141032)