### PR TITLE
Add developer protest video uploader and gallery integration

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -9,6 +9,7 @@
     "test": "node --test tests/*.test.js"
   },
   "dependencies": {
+    "busboy": "^1.6.0",
     "canvas": "^2.11.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/bot/routes/protestVideos.js
+++ b/bot/routes/protestVideos.js
@@ -1,0 +1,172 @@
+import Busboy from 'busboy';
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { existsSync } from 'fs';
+import { copyFile, mkdir, readFile, rename, rm, writeFile } from 'fs/promises';
+import { createWriteStream } from 'fs';
+
+const router = express.Router();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const ONE_GB = 1024 * 1024 * 1024;
+const MAX_VIDEO_BYTES = Number(process.env.PROTEST_VIDEO_MAX_BYTES || ONE_GB);
+const VIDEO_LIBRARY_DIR = path.join(REPO_ROOT, 'webapp/public/ProtestVideo');
+const VIDEO_DIST_ROOT = path.join(REPO_ROOT, 'webapp/dist');
+const VIDEO_DIST_DIR = path.join(VIDEO_DIST_ROOT, 'ProtestVideo');
+const DEV_ACCOUNTS = [
+  process.env.VITE_DEV_ACCOUNT_ID,
+  process.env.VITE_DEV_ACCOUNT_ID_1,
+  process.env.VITE_DEV_ACCOUNT_ID_2,
+  process.env.DEV_ACCOUNT_ID,
+  process.env.DEV_ACCOUNT_ID_1,
+  process.env.DEV_ACCOUNT_ID_2
+].filter(Boolean);
+
+function normalize(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function isAuthorized(req) {
+  const account = normalize(req.get('x-tpc-account-id'));
+  return Boolean(account && DEV_ACCOUNTS.some((devAccount) => normalize(devAccount) === account));
+}
+
+function sanitizeSlug(value, fallback = 'protest-video') {
+  const slug = String(value || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+  return slug || fallback;
+}
+
+function sanitizeDate(value) {
+  const date = String(value || '').trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(date)) return date;
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function loadLibrary(libraryPath) {
+  try {
+    const parsed = JSON.parse(await readFile(libraryPath, 'utf8'));
+    return { ...parsed, videos: Array.isArray(parsed.videos) ? parsed.videos : [] };
+  } catch {
+    return { videos: [] };
+  }
+}
+
+async function saveLibrary(directory, entry) {
+  await mkdir(directory, { recursive: true });
+  const libraryPath = path.join(directory, 'library.json');
+  const library = await loadLibrary(libraryPath);
+  const videos = [entry, ...library.videos.filter((video) => video.id !== entry.id)];
+  await writeFile(libraryPath, `${JSON.stringify({ ...library, videos }, null, 2)}\n`);
+}
+
+function parseUpload(req) {
+  return new Promise((resolve, reject) => {
+    const busboy = Busboy({
+      headers: req.headers,
+      limits: { fileSize: MAX_VIDEO_BYTES, files: 1, fields: 2 }
+    });
+    const fields = {};
+    const upload = { bytes: 0, limited: false, mimeType: '', originalName: '', tempPath: '' };
+    let writePromise = null;
+    let hasFile = false;
+
+    busboy.on('field', (name, value) => {
+      if (name === 'date') fields.date = value;
+    });
+
+    busboy.on('file', (name, file, info) => {
+      if (name !== 'video') {
+        file.resume();
+        return;
+      }
+      hasFile = true;
+      upload.mimeType = String(info.mimeType || '').toLowerCase();
+      upload.originalName = info.filename || 'protest-video.mp4';
+      upload.tempPath = path.join(VIDEO_LIBRARY_DIR, `.upload-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`);
+      const output = createWriteStream(upload.tempPath);
+      file.on('data', (chunk) => {
+        upload.bytes += chunk.length;
+      });
+      file.on('limit', () => {
+        upload.limited = true;
+        file.unpipe(output);
+        output.destroy();
+      });
+      writePromise = new Promise((resolveWrite, rejectWrite) => {
+        output.on('finish', resolveWrite);
+        output.on('error', rejectWrite);
+        file.on('error', rejectWrite);
+      });
+      file.pipe(output);
+    });
+
+    busboy.on('error', reject);
+    busboy.on('finish', async () => {
+      try {
+        if (writePromise) await writePromise;
+        if (!hasFile) throw new Error('A video file is required.');
+        resolve({ fields, upload });
+      } catch (err) {
+        reject(err);
+      }
+    });
+
+    req.pipe(busboy);
+  });
+}
+
+router.post('/upload', async (req, res) => {
+  if (!isAuthorized(req)) return res.status(403).json({ error: 'Developer upload is locked.' });
+
+  await mkdir(VIDEO_LIBRARY_DIR, { recursive: true });
+  let parsed;
+  try {
+    parsed = await parseUpload(req);
+  } catch (err) {
+    return res.status(400).json({ error: err.message || 'Upload failed.' });
+  }
+
+  const { fields, upload } = parsed;
+  if (upload.limited || upload.bytes > MAX_VIDEO_BYTES) {
+    if (upload.tempPath) await rm(upload.tempPath, { force: true });
+    return res.status(413).json({ error: 'Video file is too large. Maximum size is 1GB.' });
+  }
+  if (!upload.mimeType.startsWith('video/')) {
+    if (upload.tempPath) await rm(upload.tempPath, { force: true });
+    return res.status(400).json({ error: 'Only video files can be uploaded.' });
+  }
+
+  const ext = path.extname(upload.originalName).toLowerCase().replace(/[^.a-z0-9]/g, '') || '.mp4';
+  const baseSlug = sanitizeSlug(path.basename(upload.originalName, ext));
+  const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e6).toString(36)}`;
+  const file = `${baseSlug}-${uniqueSuffix}${ext}`;
+  const id = sanitizeSlug(`${baseSlug}-${uniqueSuffix}`);
+  const entry = {
+    id,
+    title: path.basename(upload.originalName, ext).replace(/[-_]+/g, ' '),
+    date: sanitizeDate(fields.date),
+    file
+  };
+
+  const publicPath = path.join(VIDEO_LIBRARY_DIR, file);
+  await rename(upload.tempPath, publicPath);
+
+  const targetDirs = [VIDEO_LIBRARY_DIR];
+  if (existsSync(VIDEO_DIST_ROOT)) {
+    await mkdir(VIDEO_DIST_DIR, { recursive: true });
+    await copyFile(publicPath, path.join(VIDEO_DIST_DIR, file));
+    targetDirs.push(VIDEO_DIST_DIR);
+  }
+
+  await Promise.all(targetDirs.map((directory) => saveLibrary(directory, entry)));
+  res.status(201).json({ video: { ...entry, source: 'library', url: `/ProtestVideo/${file}` } });
+});
+
+export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -29,6 +29,7 @@ import poolRoyaleRoutes from './routes/poolRoyale.js';
 import snookerRoyaleRoutes from './routes/snookerRoyal.js';
 import exchangeRoutes from './routes/exchange.js';
 import pushRoutes from './routes/push.js';
+import protestVideoRoutes from './routes/protestVideos.js';
 import User from './models/User.js';
 import GameResult from './models/GameResult.js';
 import AdView from './models/AdView.js';
@@ -273,6 +274,7 @@ app.use(helmet({
   }
 }));
 app.use(compression());
+app.use('/api/protest-videos', protestVideoRoutes);
 // Increase JSON body limit to handle large photo uploads
 app.use(express.json({ limit: '10mb' }));
 app.use(optionalAuthenticate);

--- a/webapp/public/pwa/app-build.js
+++ b/webapp/public/pwa/app-build.js
@@ -1,1 +1,1 @@
-self.__TONPLAYGRAM_APP_BUILD__ = "467f5ab";
+self.__TONPLAYGRAM_APP_BUILD__ = "c85731f";

--- a/webapp/public/version.json
+++ b/webapp/public/version.json
@@ -1,4 +1,4 @@
 {
-  "build": "467f5ab",
-  "generatedAt": "2026-07-17T14:28:10.192Z"
+  "build": "c85731f",
+  "generatedAt": "2026-07-17T15:51:43.876Z"
 }

--- a/webapp/src/config/buildInfo.js
+++ b/webapp/src/config/buildInfo.js
@@ -1,2 +1,2 @@
-export const APP_BUILD = "467f5ab";
-export const APP_BUILD_GENERATED_AT = "2026-07-17T14:28:10.192Z";
+export const APP_BUILD = "c85731f";
+export const APP_BUILD_GENERATED_AT = "2026-07-17T15:51:43.876Z";

--- a/webapp/src/pages/ProtestVideoGallery.jsx
+++ b/webapp/src/pages/ProtestVideoGallery.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { FaArrowLeft, FaDownload, FaUpload, FaVideo } from 'react-icons/fa';
 import { useTonAddress } from '@tonconnect/ui-react';
+import { uploadProtestVideo } from '../utils/api.js';
 
 const PROTEST_VIDEO_LIBRARY_URL = '/ProtestVideo/library.json';
 const PROTEST_VIDEO_BASE_URL = '/ProtestVideo/';
@@ -24,21 +25,7 @@ const normalizeAddress = (address) =>
     .trim()
     .toLowerCase();
 
-const buildUploadedVideo = (file) => ({
-  id: `upload-${file.name}-${file.lastModified}`,
-  title: file.name.replace(/\.[^/.]+$/, '').replace(/[-_]+/g, ' '),
-  fileName: file.name,
-  size: file.size,
-  date: new Date(file.lastModified || Date.now()).toLocaleDateString(),
-  time: new Date(file.lastModified || Date.now()).toLocaleTimeString([], {
-    hour: '2-digit',
-    minute: '2-digit'
-  }),
-  quality: 'Developer upload',
-  source: 'upload',
-  url: URL.createObjectURL(file),
-  file
-});
+const getVideoId = (video) => video.id || video.file || video.url;
 
 const formatBytes = (bytes = 0) => {
   if (!bytes) return 'Unknown size';
@@ -54,8 +41,13 @@ export default function ProtestVideoGallery() {
   const tonAddress = useTonAddress();
   const fileInputRef = useRef(null);
   const [libraryVideos, setLibraryVideos] = useState([]);
-  const [uploadedVideos, setUploadedVideos] = useState([]);
   const [selectedIds, setSelectedIds] = useState([]);
+  const [uploadDate, setUploadDate] = useState(() =>
+    new Date().toISOString().slice(0, 10)
+  );
+  const [isDraggingUpload, setIsDraggingUpload] = useState(false);
+  const [uploadStatus, setUploadStatus] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
   const [status, setStatus] = useState('loading');
   const [walletAddress, setWalletAddress] = useState(
     () => tonAddress || getStoredWalletAddress()
@@ -99,25 +91,48 @@ export default function ProtestVideoGallery() {
       });
   }, []);
 
-  const allVideos = useMemo(
-    () => [...uploadedVideos, ...libraryVideos],
-    [uploadedVideos, libraryVideos]
-  );
+  const allVideos = useMemo(() => libraryVideos, [libraryVideos]);
   const selectedVideos = allVideos.filter((video) =>
-    selectedIds.includes(video.id || video.file || video.url)
+    selectedIds.includes(getVideoId(video))
   );
 
-  const handleUpload = (event) => {
-    const files = Array.from(event.target.files || []).filter((file) =>
+
+  const addUploadedFiles = async (fileList) => {
+    const files = Array.from(fileList || []).filter((file) =>
       file.type.startsWith('video/')
     );
-    if (!files.length) return;
-    setUploadedVideos((current) => [
-      ...files.map(buildUploadedVideo),
-      ...current
+    if (!files.length) {
+      setUploadStatus('Choose a video clip from your phone first.');
+      return;
+    }
+
+    setIsUploading(true);
+    setUploadStatus(`Uploading ${files.length} video clip${files.length > 1 ? 's' : ''}…`);
+
+    const uploaded = [];
+    for (const file of files) {
+      const result = await uploadProtestVideo(file, { date: uploadDate });
+      if (result.error) {
+        setUploadStatus(result.error);
+        setIsUploading(false);
+        return;
+      }
+      if (result.video) uploaded.push(result.video);
+    }
+
+    setLibraryVideos((current) => [...uploaded, ...current]);
+    setSelectedIds((current) => [
+      ...new Set([...uploaded.map(getVideoId), ...current])
     ]);
+    setUploadStatus('Upload complete. Your clips are now published in the gallery.');
+    setIsUploading(false);
+  };
+
+  const handleUpload = (event) => {
+    addUploadedFiles(event.target.files);
     event.target.value = '';
   };
+
 
   const toggleSelected = (id) => {
     setSelectedIds((current) =>
@@ -165,7 +180,7 @@ export default function ProtestVideoGallery() {
             </h1>
             <p className="mt-2 text-sm leading-6 text-subtext">
               Select one video or many videos, then download them together.
-              Published videos are grouped with their date, time, and quality.
+              Published videos are grouped by their protest date.
             </p>
           </div>
         </div>
@@ -177,11 +192,11 @@ export default function ProtestVideoGallery() {
             Developer only
           </p>
           <h2 className="mt-1 text-lg font-black text-white">
-            Upload multiple videos
+            Direct page uploads
           </h2>
           <p className="mt-1 text-sm text-subtext">
-            This uploader is hidden from regular users. Choose multiple videos
-            to preview and download in this device session.
+            Add clips directly from your phone gallery/camera roll. Choose the
+            protest date once, then upload clips up to 1GB.
           </p>
           <input
             ref={fileInputRef}
@@ -191,13 +206,48 @@ export default function ProtestVideoGallery() {
             className="hidden"
             onChange={handleUpload}
           />
+          <label className="mt-3 block text-xs font-bold uppercase tracking-[0.16em] text-amber-100">
+            Clip date
+          </label>
+          <input
+            type="date"
+            value={uploadDate}
+            onChange={(event) => setUploadDate(event.target.value)}
+            className="mt-2 w-full rounded-xl border border-white/10 bg-black/30 px-3 py-3 text-sm text-white"
+          />
           <button
             type="button"
-            onClick={() => fileInputRef.current?.click()}
-            className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-amber-300 px-4 py-3 text-sm font-black text-slate-950"
+            onDragOver={(event) => {
+              event.preventDefault();
+              setIsDraggingUpload(true);
+            }}
+            onDragLeave={() => setIsDraggingUpload(false)}
+            onDrop={(event) => {
+              event.preventDefault();
+              setIsDraggingUpload(false);
+              addUploadedFiles(event.dataTransfer.files);
+            }}
+            onClick={() => !isUploading && fileInputRef.current?.click()}
+            disabled={isUploading}
+            className={`mt-3 inline-flex w-full flex-col items-center justify-center gap-2 rounded-2xl border border-dashed px-4 py-5 text-sm font-black ${
+              isDraggingUpload
+                ? 'border-amber-100 bg-amber-200 text-slate-950'
+                : 'border-amber-200/60 bg-amber-300 text-slate-950'
+            }`}
           >
-            <FaUpload /> Select videos to upload
+            <span className="inline-flex items-center gap-2">
+              <FaUpload /> {isUploading ? 'Uploading…' : 'Upload clips from phone'}
+            </span>
+            <span className="text-xs font-semibold opacity-80">
+              Opens your phone gallery/camera roll. Uploaded clips are published
+              and selected automatically.
+            </span>
           </button>
+          {uploadStatus && (
+            <p className="mt-3 rounded-xl bg-black/30 p-3 text-sm font-semibold text-amber-50">
+              {uploadStatus}
+            </p>
+          )}
         </section>
       )}
 
@@ -236,10 +286,8 @@ export default function ProtestVideoGallery() {
 
       <div className="grid grid-cols-1 gap-4">
         {allVideos.map((video) => {
-          const id = video.id || video.file || video.url;
-          const recordedAt = [video.date, video.time, video.timezone]
-            .filter(Boolean)
-            .join(' • ');
+          const id = getVideoId(video);
+          const recordedAt = video.date;
           const checked = selectedIds.includes(id);
 
           return (
@@ -271,14 +319,9 @@ export default function ProtestVideoGallery() {
                 <p className="text-xs font-semibold text-red-200">
                   {recordedAt || 'Date and time not set'}
                 </p>
-                {video.description && (
-                  <p className="text-sm leading-5 text-subtext">
-                    {video.description}
-                  </p>
-                )}
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <span className="rounded-full bg-red-500/15 px-3 py-1 text-xs font-semibold text-red-100">
-                    {video.quality || formatBytes(video.size) || 'High quality'}
+                    {formatBytes(video.size)}
                   </span>
                   <a
                     href={video.url}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -317,6 +317,42 @@ export function completeQuest(telegramId) {
   return post('/api/ads/quest-watch', { telegramId });
 }
 
+
+export async function uploadProtestVideo(file, metadata = {}) {
+  const formData = new FormData();
+  formData.append('video', file, file.name || 'protest-video.mp4');
+  if (metadata.date) formData.append('date', metadata.date);
+  const headers = buildHeaders();
+
+  let res;
+  try {
+    res = await fetchWithRetry(`${API_BASE_URL}/api/protest-videos/upload`, {
+      method: 'POST',
+      headers,
+      body: formData
+    }, 0);
+  } catch {
+    return { error: 'Network request failed' };
+  }
+
+  let text;
+  try {
+    text = await res.text();
+  } catch {
+    return { error: 'Invalid server response' };
+  }
+
+  let data;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    return { error: 'Invalid server response' };
+  }
+
+  if (!res.ok) return { error: data.error || res.statusText || 'Upload failed' };
+  return data;
+}
+
 export function submitInfluencerVideo(telegramId, platform, videoUrl) {
   return post('/api/influencer/submit', { telegramId, platform, videoUrl });
 }


### PR DESCRIPTION
### Motivation

- Provide a developer-only in-page uploader so clips can be uploaded directly from phone galleries and published into the ProtestVideo library.

### Description

- Add a new Express route `routes/protestVideos.js` that handles multipart video uploads with `busboy`, validates file type/size (default 1GB), writes files to `webapp/public/ProtestVideo`, copies to `webapp/dist/ProtestVideo` when present, and updates `library.json` entries.
- Mount the route at `/api/protest-videos` in `bot/server.js` and add `busboy` to `bot/package.json` dependencies.
- Add client helper `uploadProtestVideo` in `webapp/src/utils/api.js` which sends the multipart `FormData` to `/api/protest-videos/upload` and returns server response/errors.
- Extend `webapp/src/pages/ProtestVideoGallery.jsx` with a developer-only upload UI including date selection, drag-and-drop, upload status, automatic library insertion and auto-selection of uploaded clips, plus UI tweaks to displayed metadata (size formatting and protest date grouping).
- Bump app build/version markers in `webapp/public/pwa/app-build.js`, `webapp/public/version.json`, and `webapp/src/config/buildInfo.js`.

### Testing

- Ran the existing Node test suite via `npm test` (`node --test tests/*.test.js`) and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a4442bc608329bb29ac3d36724456)