### PR TITLE
Add confirm step for dev protest video uploads

### DIFF
--- a/webapp/src/pages/ProtestVideoGallery.jsx
+++ b/webapp/src/pages/ProtestVideoGallery.jsx
@@ -46,6 +46,7 @@ export default function ProtestVideoGallery() {
     new Date().toISOString().slice(0, 10)
   );
   const [isDraggingUpload, setIsDraggingUpload] = useState(false);
+  const [pendingUploadFiles, setPendingUploadFiles] = useState([]);
   const [uploadStatus, setUploadStatus] = useState('');
   const [isUploading, setIsUploading] = useState(false);
   const [status, setStatus] = useState('loading');
@@ -97,20 +98,31 @@ export default function ProtestVideoGallery() {
   );
 
 
-  const addUploadedFiles = async (fileList) => {
+  const chooseUploadFiles = (fileList) => {
     const files = Array.from(fileList || []).filter((file) =>
       file.type.startsWith('video/')
     );
-    if (!files.length) {
+    setPendingUploadFiles(files);
+    setUploadStatus(
+      files.length
+        ? `${files.length} video clip${files.length > 1 ? 's' : ''} ready. Tap Upload to publish.`
+        : 'Choose a video clip from your phone first.'
+    );
+  };
+
+  const uploadPendingFiles = async () => {
+    if (!pendingUploadFiles.length) {
       setUploadStatus('Choose a video clip from your phone first.');
       return;
     }
 
     setIsUploading(true);
-    setUploadStatus(`Uploading ${files.length} video clip${files.length > 1 ? 's' : ''}…`);
+    setUploadStatus(
+      `Uploading ${pendingUploadFiles.length} video clip${pendingUploadFiles.length > 1 ? 's' : ''}…`
+    );
 
     const uploaded = [];
-    for (const file of files) {
+    for (const file of pendingUploadFiles) {
       const result = await uploadProtestVideo(file, { date: uploadDate });
       if (result.error) {
         setUploadStatus(result.error);
@@ -124,12 +136,13 @@ export default function ProtestVideoGallery() {
     setSelectedIds((current) => [
       ...new Set([...uploaded.map(getVideoId), ...current])
     ]);
+    setPendingUploadFiles([]);
     setUploadStatus('Upload complete. Your clips are now published in the gallery.');
     setIsUploading(false);
   };
 
   const handleUpload = (event) => {
-    addUploadedFiles(event.target.files);
+    chooseUploadFiles(event.target.files);
     event.target.value = '';
   };
 
@@ -225,7 +238,7 @@ export default function ProtestVideoGallery() {
             onDrop={(event) => {
               event.preventDefault();
               setIsDraggingUpload(false);
-              addUploadedFiles(event.dataTransfer.files);
+              chooseUploadFiles(event.dataTransfer.files);
             }}
             onClick={() => !isUploading && fileInputRef.current?.click()}
             disabled={isUploading}
@@ -236,13 +249,35 @@ export default function ProtestVideoGallery() {
             }`}
           >
             <span className="inline-flex items-center gap-2">
-              <FaUpload /> {isUploading ? 'Uploading…' : 'Upload clips from phone'}
+              <FaUpload /> {pendingUploadFiles.length ? 'Change selected clips' : 'Choose clips from phone'}
             </span>
             <span className="text-xs font-semibold opacity-80">
-              Opens your phone gallery/camera roll. Uploaded clips are published
-              and selected automatically.
+              Opens your phone gallery/camera roll. Clips stay private until you
+              confirm with the Upload button below.
             </span>
           </button>
+          {pendingUploadFiles.length > 0 && (
+            <div className="mt-3 rounded-2xl border border-amber-200/40 bg-black/30 p-3">
+              <p className="text-xs font-bold uppercase tracking-[0.16em] text-amber-100">
+                Ready to upload
+              </p>
+              <ul className="mt-2 space-y-1 text-xs font-semibold text-white">
+                {pendingUploadFiles.map((file) => (
+                  <li key={`${file.name}-${file.lastModified}`} className="truncate">
+                    {file.name} · {formatBytes(file.size)}
+                  </li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                onClick={uploadPendingFiles}
+                disabled={isUploading}
+                className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-full bg-white px-4 py-3 text-sm font-black text-slate-950 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <FaUpload /> {isUploading ? 'Uploading…' : 'Upload'}
+              </button>
+            </div>
+          )}
           {uploadStatus && (
             <p className="mt-3 rounded-xl bg-black/30 p-3 text-sm font-semibold text-amber-50">
               {uploadStatus}


### PR DESCRIPTION
### Motivation
- Developer-upload flow should stage clips selected from a phone and show a clear upload icon and UI instead of uploading immediately. 
- Provide a lightweight QA step so devs can review filenames/sizes and explicitly confirm publishing to the ProtestVideo library.

### Description
- Introduce `pendingUploadFiles` state and a `chooseUploadFiles` handler to stage phone/dragged files instead of uploading immediately. 
- Add `uploadPendingFiles` to perform the actual upload, clear `pendingUploadFiles`, update `libraryVideos`, and select newly uploaded videos. 
- Replace immediate-upload behavior on file input change and drop with staging, update upload button text/helper copy, and add a “Ready to upload” review box listing file names and sizes with a dedicated `Upload` button. 
- Preserve existing drag/drop and hidden file input behavior and keep existing validation, `isUploading` flow, and status messages.

### Testing
- Ran production build with `npm --prefix webapp run build` which completed successfully. 
- Ran lint with `npm --prefix webapp run lint -- src/pages/ProtestVideoGallery.jsx` which succeeded with no reported errors. 
- Installed Playwright browsers and dependencies using `npx playwright install chromium` and `npx playwright install-deps chromium` which completed successfully. 
- Captured a mobile-viewport screenshot of the updated page via Playwright and saved it to `/tmp/protest-upload-dev.png` to verify the new staging UI visually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a52e4649483298a3c80b516cc4ef4)