### PR TITLE
Fix protest video upload folder icon

### DIFF
--- a/webapp/src/pages/ProtestVideoGallery.jsx
+++ b/webapp/src/pages/ProtestVideoGallery.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { FaArrowLeft, FaDownload, FaUpload, FaVideo } from 'react-icons/fa';
+import { FaArrowLeft, FaDownload, FaFolderOpen, FaUpload, FaVideo } from 'react-icons/fa';
 import { useTonAddress } from '@tonconnect/ui-react';
 import { uploadProtestVideo } from '../utils/api.js';
 
@@ -249,11 +249,11 @@ export default function ProtestVideoGallery() {
             }`}
           >
             <span className="inline-flex items-center gap-2">
-              <FaUpload /> {pendingUploadFiles.length ? 'Change selected clips' : 'Choose clips from phone'}
+              <FaFolderOpen className="text-lg" /> {pendingUploadFiles.length ? 'Change selected clips' : 'Choose clips from phone'}
             </span>
             <span className="text-xs font-semibold opacity-80">
-              Opens your phone gallery/camera roll. Clips stay private until you
-              confirm with the Upload button below.
+              Tap the folder icon to open your phone gallery/camera roll. Clips stay
+              private until you confirm with the Upload button below.
             </span>
           </button>
           {pendingUploadFiles.length > 0 && (


### PR DESCRIPTION
### Motivation
- The developer upload control on the ProtestVideo gallery used an ambiguous upload icon and copy, making it unclear that the button should open the phone gallery/camera roll for selecting video clips.

### Description
- Replaced the upload icon with a folder-open icon and updated the helper copy in `webapp/src/pages/ProtestVideoGallery.jsx` so the button clearly indicates it opens the phone gallery.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced a production build.
- Ran `npm --prefix webapp run lint -- src/pages/ProtestVideoGallery.jsx` which completed successfully to validate the changed file.
- Note: an earlier lint invocation using the package-relative path failed due to an incorrect pattern, but the corrected lint run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a632821988329aa92ab96b793f65e)