### PR TITLE
Remove weapons from Ludo, Snake & Chess store surfaces and hide parked models

### DIFF
--- a/test/chessBattleInventoryConfig.test.js
+++ b/test/chessBattleInventoryConfig.test.js
@@ -8,6 +8,8 @@ import {
   CHESS_TABLE_FINISH_OPTIONS
 } from '../webapp/src/config/chessBattleInventoryConfig.js';
 import { CAPTURE_ANIMATION_OPTIONS } from '../webapp/src/config/ludoBattleOptions.js';
+import { LUDO_BATTLE_STORE_ITEMS } from '../webapp/src/config/ludoBattleInventoryConfig.js';
+import { SNAKE_STORE_ITEMS } from '../webapp/src/config/snakeInventoryConfig.js';
 
 describe('chess battle inventory config', () => {
   test('defaults to octagon table for battle royal', () => {
@@ -36,7 +38,7 @@ describe('chess battle inventory config', () => {
     });
   });
 
-  test('adds Ukrainian drone and renames the existing drone to Shahad Drone', () => {
+  test('keeps capture effects available to gameplay but removes weapons from every related store', () => {
     const labelsById = Object.fromEntries(CAPTURE_ANIMATION_OPTIONS.map((option) => [option.id, option.label]));
     expect(labelsById.droneAttack).toBe('Shahad Drone');
     expect(labelsById.ukrainianDroneAttack).toBe('Ukrainian Drone');
@@ -44,11 +46,9 @@ describe('chess battle inventory config', () => {
     expect(CHESS_BATTLE_DEFAULT_UNLOCKS.captureAnimation).toContain('ukrainianDroneAttack');
     expect(CHESS_BATTLE_ROYAL_DEFAULT_UNLOCKS.captureAnimation).toContain('ukrainianDroneAttack');
 
-    const storeDroneIds = new Set(
-      CHESS_BATTLE_ROYAL_STORE_ITEMS.filter((item) => item.type === 'captureAnimation').map((item) => item.optionId)
-    );
-    expect(storeDroneIds.has('droneAttack')).toBe(true);
-    expect(storeDroneIds.has('ukrainianDroneAttack')).toBe(true);
+    expect(CHESS_BATTLE_ROYAL_STORE_ITEMS.some((item) => item.type === 'captureAnimation')).toBe(false);
+    expect(LUDO_BATTLE_STORE_ITEMS.some((item) => item.type === 'captureAnimation')).toBe(false);
+    expect(SNAKE_STORE_ITEMS.some((item) => item.type === 'captureWeapon')).toBe(false);
   });
 
   test('keeps current avatar free by default and sells exactly the 5 requested WebGL humans', () => {

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -6359,6 +6359,14 @@ function createSeatWeaponMesh(weaponType = 'fighter', options = {}) {
 
 function updateSeatWeaponDisplays(board, players = []) {
   if (!board?.weaponDisplayGroup || !Array.isArray(board?.seatAnchors)) return;
+  // Capture effects still use their transient models, but inventory weapons no
+  // longer remain parked around the tabletop.
+  const showParkedWeapons = board.userData?.showParkedWeapons === true;
+  if (!showParkedWeapons) {
+    board.weaponDisplayGroup.clear();
+    board.weaponDisplayGroup.userData.byPlayer = new Map();
+    return;
+  }
   const anchors = board.seatAnchors;
   const boardLookTarget = board.boardLookTarget;
   if (!boardLookTarget) return;

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -810,35 +810,6 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     description: 'Unlocks an additional pawn head glass preset.',
     thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.headStyle.headGold
   },
-  ...CAPTURE_ANIMATION_OPTIONS.slice(1).map((option, idx) => ({
-    id: `chess-capture-animation-${option.id}`,
-    type: 'captureAnimation',
-    optionId: option.id,
-    name: option.label,
-    price: option.id === 'ukrainianDroneAttack' || option.id === 'helicopterAttack' ? 0 : 900 + idx * 110,
-    description:
-      option.id === 'ukrainianDroneAttack'
-        ? 'Exact srcejon Ukrainian drone.glb inventory weapon with original texture preflight, direct-loader fallbacks, and a straight-down no-smoke missile drop.'
-        : option.id === 'helicopterAttack'
-          ? 'Same srcejon helicopter.glb used by Snake & Ladder, with Chess Battle Royal flyover and missile timing.'
-          : option.description || 'Ludo Battle Royal weapon animation pack adapted for Chess Battle Royal.',
-    thumbnail: option.thumbnail,
-    swatches: option.id === 'ukrainianDroneAttack' ? ['#020617', '#2563eb', '#facc15'] : option.id === 'helicopterAttack' ? ['#5f6871', '#848f99', '#a5b1ba'] : undefined,
-    previewShape: option.id === 'ukrainianDroneAttack' ? 'ukrainian-drone' : option.id === 'helicopterAttack' ? 'helicopter' : undefined,
-    modelUrls: option.id === 'ukrainianDroneAttack'
-      ? [
-          'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/drone.glb',
-          'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/drone.glb',
-          'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
-        ]
-      : option.id === 'helicopterAttack'
-        ? [
-            'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/helicopter.glb',
-            'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/helicopter.glb',
-            'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/helicopter.glb'
-          ]
-        : undefined
-  })),
   ...CHESS_HUMAN_CHARACTER_OPTIONS.filter((option) =>
     CHESS_STORE_HUMAN_CHARACTER_IDS.includes(option.id)
   ).map((option, idx) => ({
@@ -887,11 +858,6 @@ export const CHESS_BATTLE_DEFAULT_LOADOUT = [
     optionId: DEFAULT_HDRI_ID,
     label: CHESS_BATTLE_OPTION_LABELS.environmentHdri[DEFAULT_HDRI_ID] || 'HDR Environment'
   },
-  {
-    type: 'captureAnimation',
-    optionId: CAPTURE_ANIMATION_OPTIONS[0]?.id,
-    label: CAPTURE_ANIMATION_OPTIONS[0]?.label
-  }
 ];
 
 export const CHESS_BATTLE_ROYAL_OPTION_LABELS = Object.freeze({

--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -221,17 +221,6 @@ export const LUDO_BATTLE_STORE_ITEMS = uniqueStoreItemsByName([
     description: 'Unlock an alternate piece identity for your pawns.',
     thumbnail: swatchThumbnail(['#f8fafc', '#0f172a', '#fbbf24'])
   })),
-  ...CAPTURE_ANIMATION_OPTIONS.slice(1)
-    .filter((option) => shouldShowCaptureAnimationInStore(option.id))
-    .map((option, idx) => ({
-      id: `ludo-capture-animation-${option.id}`,
-      type: 'captureAnimation',
-      optionId: option.id,
-      name: option.label,
-      price: 950 + idx * 120,
-      description: option.description,
-      thumbnail: option.thumbnail || swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316'])
-    })),
   ...HUMAN_CHARACTER_OPTIONS.slice(1).map((option, idx) => ({
     id: `ludo-human-character-${option.id}`,
     type: 'humanCharacter',
@@ -266,11 +255,6 @@ export const LUDO_BATTLE_DEFAULT_LOADOUT = [
   { type: 'tokenPalette', optionId: TOKEN_PALETTE_OPTIONS[0]?.id, label: `${TOKEN_PALETTE_OPTIONS[0]?.label} Palette` },
   { type: 'tokenStyle', optionId: TOKEN_STYLE_OPTIONS[0]?.id, label: TOKEN_STYLE_OPTIONS[0]?.label },
   { type: 'tokenPiece', optionId: TOKEN_PIECE_OPTIONS[0]?.id, label: TOKEN_PIECE_OPTIONS[0]?.label },
-  {
-    type: 'captureAnimation',
-    optionId: CAPTURE_ANIMATION_OPTIONS[0]?.id,
-    label: CAPTURE_ANIMATION_OPTIONS[0]?.label
-  },
   {
     type: 'humanCharacter',
     optionId: HUMAN_CHARACTER_OPTIONS[0]?.id,

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -163,18 +163,6 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
 });
 
 export const SNAKE_STORE_ITEMS = [
-  ...SNAKE_CAPTURE_WEAPON_OPTIONS.filter((option, idx) => idx > 0).map((option, idx) => ({
-    id: `capture-${option.id}`,
-    type: 'captureWeapon',
-    optionId: option.id,
-    name: option.label,
-    price: 390 + idx * 30,
-    description: 'Weapon set for Snake & Ladder capture animations with dedicated GLTF/GLB fallback chain.',
-    thumbnail:
-      option.thumbnail ||
-      SNAKE_THEME_THUMBNAILS.captureWeapon.fighter ||
-      SNAKE_THEME_THUMBNAILS.captureWeapon.drone
-  })),
   {
     id: 'arena-crystalLagoon',
     type: 'arenaTheme',

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -12293,7 +12293,7 @@ function Chess3D({
     };
     const returnParkedAirUnit = (unit) => {
       if (!unit?.root) return;
-      unit.root.visible = true;
+      unit.root.visible = false;
       if (unit.kind === 'jet') {
         setJetExhaustVisible(unit, false);
       }
@@ -14358,7 +14358,7 @@ function Chess3D({
       });
       parkedAirUnits.forEach((unit) => {
         if (!unit?.root) return;
-        unit.root.visible = true;
+        unit.root.visible = false;
         unit.baseChildren = [...unit.root.children];
         const parkedBounds = getRenderableMeshBounds(unit.root) || new THREE.Box3().setFromObject(unit.root);
         const parkedSize = parkedBounds.getSize(new THREE.Vector3());

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4625,7 +4625,6 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tokenPalette', label: 'Token Palette', options: TOKEN_PALETTE_OPTIONS },
   { key: 'tokenStyle', label: 'Token Style', options: TOKEN_STYLE_OPTIONS },
   { key: 'tokenPiece', label: 'Token Piece', options: TOKEN_PIECE_OPTIONS },
-  { key: 'captureAnimation', label: 'Capture Animation', options: CAPTURE_ANIMATION_OPTIONS },
   { key: 'humanCharacter', label: 'Human Character', options: HUMAN_CHARACTER_OPTIONS }
 ];
 
@@ -8769,6 +8768,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           refreshWeaponRackPose(entry, selectedCaptureAnimationId);
         }
       }
+      // Weapons are available only while a capture effect is running; do not
+      // leave inventory models, vehicles, racks, or controls on the table.
+      ['jet', 'helicopter', 'drone', 'droneTruck', 'missile', 'weaponRack', 'weaponHolder', 'actionButton', 'actionButtonHit', 'weaponRackHit']
+        .forEach((key) => {
+          if (entry?.[key]?.isObject3D) entry[key].visible = false;
+        });
     });
   }, [aiLoadoutByPlayer, getKingTokenPositionForPlayer]);
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -872,7 +872,6 @@ const SNAKE_CUSTOMIZATION_SECTIONS = [
   { key: 'boardPalette', label: 'Board Palette', options: BOARD_PALETTE_OPTIONS },
   { key: 'diceTheme', label: 'Dice Finish', options: DICE_THEME_OPTIONS },
   { key: 'tokenShape', label: 'Token Shape', options: TOKEN_SHAPE_OPTIONS },
-  { key: 'captureWeapon', label: 'Capture Weapon', options: CAPTURE_WEAPON_OPTIONS },
   { key: 'headStyle', label: 'Pawn Heads', options: PAWN_HEAD_PRESET_OPTIONS },
   { key: 'tableFinish', label: 'Table Finish', options: TABLE_FINISH_OPTIONS },
   { key: 'tables', label: 'Table Models', options: TABLE_THEME_OPTIONS },
@@ -1336,7 +1335,6 @@ export default function SnakeAndLadder() {
   const [aiAvatars, setAiAvatars] = useState([]);
   const [burning, setBurning] = useState([]); // indices of tokens burning
   const [refreshTick, setRefreshTick] = useState(0);
-  const [showWeaponSwapMenu, setShowWeaponSwapMenu] = useState(false);
   const [rollCooldown, setRollCooldown] = useState(0);
   const [moving, setMoving] = useState(false);
   const [pendingExtraRoll, setPendingExtraRoll] = useState(false);
@@ -1348,25 +1346,6 @@ export default function SnakeAndLadder() {
   const normalizedAppearance = useMemo(() => normalizeAppearance(appearance), [appearance]);
   const appearanceKey = useMemo(() => buildAppearanceKey(appearance), [appearance]);
   const resolvedAppearance = useMemo(() => resolveAppearance(appearance), [appearance]);
-  const ownedCaptureWeapons = useMemo(() => {
-    const inventoryWeaponIds = Array.isArray(snakeInventory?.captureWeapon)
-      ? snakeInventory.captureWeapon
-      : [];
-    const resolvedInventoryWeapons = inventoryWeaponIds
-      .map((weaponId) => resolveCaptureWeaponOptionById(weaponId))
-      .filter(Boolean);
-    const unlockedCatalogWeapons = CAPTURE_WEAPON_OPTIONS.filter((option) =>
-      isSnakeOptionUnlocked('captureWeapon', option.id, snakeInventory)
-    );
-    const merged = new Map();
-    [...resolvedInventoryWeapons, ...unlockedCatalogWeapons].forEach((weapon) => {
-      merged.set(weapon.id, weapon);
-    });
-    if (!merged.size && CAPTURE_WEAPON_OPTIONS[0]) {
-      merged.set(CAPTURE_WEAPON_OPTIONS[0].id, CAPTURE_WEAPON_OPTIONS[0]);
-    }
-    return Array.from(merged.values());
-  }, [snakeInventory]);
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((option) => option.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
@@ -3970,61 +3949,12 @@ export default function SnakeAndLadder() {
             showMute={false}
             showGift
             showCamera2d={false}
-            order={['swapWeapon', 'gift']}
-            extraActions={[
-              {
-                key: 'swapWeapon',
-                label: 'Swap',
-                icon: '🔁',
-                onClick: () => setShowWeaponSwapMenu((prev) => !prev),
-                ariaLabel: 'Swap capture weapon'
-              }
-            ]}
+            order={['gift']}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"
           />
         </div>
-        {showWeaponSwapMenu ? (
-          <div
-            className="pointer-events-auto fixed z-30 right-3 rounded-2xl border border-white/15 bg-slate-900/95 p-2 shadow-2xl backdrop-blur-md"
-            style={{
-              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 7.3rem)',
-              maxWidth: '18rem',
-              width: 'min(72vw, 18rem)'
-            }}
-          >
-            <div className="px-2 pb-2 text-[10px] font-bold uppercase tracking-[0.16em] text-yellow-200/90">
-              Weapon Swap
-            </div>
-            <div className="max-h-64 space-y-1 overflow-y-auto pr-1">
-              {ownedCaptureWeapons.map((weapon) => {
-                const active = resolvedAppearance?.captureWeapon?.id === weapon.id;
-                return (
-                  <button
-                    key={`swap-${weapon.id}`}
-                    type="button"
-                    onClick={() => {
-                      const idx = CAPTURE_WEAPON_OPTIONS.findIndex((option) => option.id === weapon.id);
-                      if (idx >= 0) {
-                        setAppearance((prev) => normalizeAppearance({ ...prev, captureWeapon: idx }));
-                      }
-                      setShowWeaponSwapMenu(false);
-                    }}
-                    className={`flex w-full items-center gap-2 rounded-xl border px-2 py-2 text-left text-[11px] font-semibold ${
-                      active
-                        ? 'border-yellow-300/70 bg-yellow-400/90 text-slate-950'
-                        : 'border-white/15 bg-white/5 text-slate-100 hover:bg-white/10'
-                    }`}
-                  >
-                    <img src={weapon.thumbnail} alt={weapon.label} className="h-8 w-8 rounded-md border border-white/20 object-cover" />
-                    <span className="truncate">{weapon.label}</span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        ) : null}
         {/* Player photos stacked vertically */}
         <div className="absolute inset-0 z-20 pointer-events-none">
           {players.map((player, seat) => {


### PR DESCRIPTION
### Motivation
- Remove purchasable weapons/capture-animation items and related inventory UI so weapons are no longer exposed in the Ludo Battle Royal, Snake & Ladder, and Chess Battle Royal stores.
- Keep transient capture animations functional during gameplay while preventing inventory models from remaining parked on tables.

### Description
- Deleted weapon and capture-animation store entries and default `captureAnimation` loadouts from `webapp/src/config/ludoBattleInventoryConfig.js`, `webapp/src/config/snakeInventoryConfig.js`, and `webapp/src/config/chessBattleInventoryConfig.js` so those items no longer appear in the stores or default loadouts.
- Removed weapon customization/quick-swap UI and owned-weapon lookups from `webapp/src/pages/Games/SnakeAndLadder.jsx` to hide portrait controls and weapon-swap flows.
- Stopped rendering parked/inventory weapon models on the board by clearing `board.weaponDisplayGroup` unless `board.userData?.showParkedWeapons === true` in `webapp/src/components/SnakeBoard3D.jsx` and by forcing parked weapon/vehicle `visible = false` for Ludo/Chess table parking code in `webapp/src/pages/Games/LudoBattleRoyal.jsx` and `webapp/src/pages/Games/ChessBattleRoyal.jsx` so inventory visuals are hidden when not active.
- Updated `test/chessBattleInventoryConfig.test.js` to assert that capture effects remain available to gameplay but that store catalogs no longer contain weapon items (`captureAnimation`/`captureWeapon`) and added imports that check the three stores.

### Testing
- Ran lint: `npm run lint --prefix webapp -- --quiet` (passed).
- Ran targeted unit tests: `npm test -- --runInBand test/chessBattleInventoryConfig.test.js` and all tests in that suite passed (5/5).
- Built the webapp: `npm run build --prefix webapp` (production build completed successfully).
- Confirmed runtime store UI with a portrait screenshot of `/store/snake` at 390×844 using a headless browser run (Playwright); screenshot generation completed (Playwright install and deps handled during the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7060e06c388329a07cb13f36568fa6)