### PR TITLE
Fix Render deployment port timeout

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -348,6 +348,15 @@ function ensureWebappBuilt() {
   ) {
     return true;
   }
+  // Production deploys must build the client during the provider's build phase.
+  // Installing/building here blocks the event loop before httpServer.listen(),
+  // which makes platforms such as Render report that no port is open.
+  if (process.env.NODE_ENV === 'production') {
+    console.error(
+      'Webapp build is missing. Run the repository postinstall/build step before starting the server.'
+    );
+    return false;
+  }
   try {
     console.log('Building webapp...');
     const webappDir = path.join(__dirname, '../webapp');
@@ -372,8 +381,6 @@ function ensureWebappBuilt() {
     return false;
   }
 }
-
-ensureWebappBuilt();
 
 const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "main": "bot/server.js",
   "scripts": {
-    "prestart": "npm run build",
     "start": "node bot/server.js",
+    "postinstall": "npm --prefix webapp install --ignore-scripts && npm run build:webapp",
     "install-all": "npm install && npm install --prefix bot && npm install --prefix webapp",
     "build": "tsc -p tsconfig.build.json",
+    "build:webapp": "npm --prefix webapp run build",
     "test": "jest",
     "demo": "node dist/demo.js demo/demo.json",
     "lint": "eslint .",


### PR DESCRIPTION
### Motivation

- Render deployments were failing with a port timeout because `bot/server.js` performed a synchronous `npm install` / Vite build of the `webapp` during startup and blocked before binding to the assigned port. 
- Production services must rely on the platform's install/build phase to produce `webapp/dist` so `npm start` can open the port quickly. 
- Keep on-demand client build behavior for local development but avoid blocking builds in production.

### Description

- Add a root-level `postinstall` script in `package.json` to install and build the `webapp` during repository install and add a `build:webapp` helper script. 
- Remove the blocking `prestart` build and stop running the webapp install/build from the server in production by having `ensureWebappBuilt()` return `false` (and log an error) when `NODE_ENV === 'production'`. 
- Stop invoking `ensureWebappBuilt()` synchronously during startup so the server can bind to the port even if `webapp/dist` is missing and can return a `503` for missing builds instead of blocking. 
- Preserve the existing on-demand build fallback for non-production environments so local development still auto-builds the client when needed.

### Testing

- Successfully ran `npm run build` and `npm run build:webapp` to produce the frontend `dist`. 
- Executed `npm test -- --runInBand test/apiGoogleHeaderFallback.test.js` and the test passed. 
- Performed a production-mode smoke test with `NODE_ENV=production` and `webapp/dist` temporarily absent and confirmed the server bound to the assigned port and returned `503` rather than blocking startup. 
- Verified with `curl` that the server responds quickly with `Webapp build not available` when the client build is absent, confirming the Render timeout is avoided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a706a1de0448329920b957307af5d25)