### PR TITLE
Remove community notice from Home page

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -10,13 +10,6 @@ import { IoLogoTiktok } from 'react-icons/io5';
 import { RiTelegramFill } from 'react-icons/ri';
 import { useTonAddress } from '@tonconnect/ui-react';
 
-const ALBANIA_PAUSE_NOTICE = {
-  title: 'Njoftim për komunitetin',
-  body: 'Puna në projektin e lojës është ndalur përkohësisht. Zhvillimi do të rifillojë vetëm kur populli i Shqipërisë të arrijë qëllimin e tij.',
-  detail:
-    'Faleminderit për durimin dhe mbështetjen. Platforma do të mbetet online për informacionet kryesore dhe lidhjet e komunitetit.'
-};
-
 const xIcon = (
   <img
     src="/assets/icons/new-twitter-x-logo-twitter-icon-x-social-media-icon-free-png.webp"
@@ -164,25 +157,6 @@ export default function Home() {
 
   return (
     <div className="space-y-4">
-      <section className="rounded-2xl border border-red-400/40 bg-gradient-to-br from-red-950/90 via-slate-950 to-black p-4 shadow-xl">
-        <div className="flex items-start gap-3">
-          <div className="text-3xl leading-none" aria-hidden="true">
-            🇦🇱
-          </div>
-          <div className="space-y-2">
-            <p className="text-lg font-bold text-white">
-              {ALBANIA_PAUSE_NOTICE.title}
-            </p>
-            <p className="text-sm leading-6 text-white/90">
-              {ALBANIA_PAUSE_NOTICE.body}
-            </p>
-            <p className="text-xs leading-5 text-subtext">
-              {ALBANIA_PAUSE_NOTICE.detail}
-            </p>
-          </div>
-        </div>
-      </section>
-
       <div className="flex flex-col items-center">
         {photoUrl && (
           <div className="relative">


### PR DESCRIPTION
### Motivation
- The temporary Albanian community pause banner and its static content were removed from the Home page to follow the request to stop showing the "Njoftim për komunitetin" notice.

### Description
- Deleted the `ALBANIA_PAUSE_NOTICE` constant and removed the banner/notice markup from `webapp/src/pages/Home.jsx` so the home page now begins directly with the profile/account section.

### Testing
- Ran `npm run lint -- src/pages/Home.jsx` and it completed successfully.
- Ran the production build with `npm run build` and the build succeeded.
- Verified in a 390×844 portrait browser viewport that the notice text ("Njoftim për komunitetin") is no longer present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70774dc5c4832982e038a428710051)