### PR TITLE
Limit Snake & Ladder capture weapons to five (Ukrainian Drone, Shahad Drone, Short Missile, Helicopter, Fighter Jet)

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -311,21 +311,15 @@ describe('cross-game inventory alignment', () => {
     const snakeCatalogIds = new Set(SNAKE_CAPTURE_WEAPON_OPTIONS.slice(1).map((option) => option.id));
 
     expect(snakeCaptureStoreIds).toEqual(snakeCatalogIds);
-    expect(new Set(SNAKE_DEFAULT_UNLOCKS.captureWeapon)).toEqual(new Set([SNAKE_CAPTURE_WEAPON_OPTIONS[0]?.id]));
-
-    [
-      'poly-robot-large-gun-01',
-      'poly-robot-flying-gun-01',
-      'poly-bazooka-01',
-      'poly-grenade-launcher-01',
-      'poly-dynamite-bomb-01',
-      'poly-molotov-01',
-      'poly-gas-tank-01',
-      'poly-hand-grenade-01',
-      'poly-tank-01'
-    ].forEach((weaponId) => {
-      expect(snakeCatalogIds.has(weaponId)).toBe(true);
-      expect(snakeCaptureStoreIds.has(weaponId)).toBe(true);
-    });
+    expect(new Set(SNAKE_DEFAULT_UNLOCKS.captureWeapon)).toEqual(
+      new Set(SNAKE_CAPTURE_WEAPON_OPTIONS.map((option) => option.id))
+    );
+    expect(SNAKE_CAPTURE_WEAPON_OPTIONS.map(({ id, label }) => ({ id, label }))).toEqual([
+      { id: 'ukrainianDroneAttack', label: 'Ukrainian Drone' },
+      { id: 'droneAttack', label: 'Shahad Drone' },
+      { id: 'missileJavelin', label: 'Short Missile' },
+      { id: 'helicopterAttack', label: 'Helicopter Strike' },
+      { id: 'fighterJetAttack', label: 'Fighter Jet Attack' }
+    ]);
   });
 });

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -109,13 +109,7 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
   headStyle: [SNAKE_PAWN_HEAD_OPTIONS[0].id],
   tokenShape: [SNAKE_TOKEN_SHAPE_OPTIONS[0].id],
-  captureWeapon: [
-    SNAKE_CAPTURE_WEAPON_OPTIONS[0].id,
-    'fighterJetAttack',
-    'helicopterAttack',
-    'droneAttack',
-    'supportTruckAttack'
-  ],
+  captureWeapon: SNAKE_CAPTURE_WEAPON_OPTIONS.map((option) => option.id),
   tables: [MURLAN_TABLE_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
   environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -45,8 +45,8 @@ const gunifyWeapon = (id, label, modelName, colors, extra = {}) => ({
   ...extra
 })
 
-
 const LUDO_CAPTURE_WEAPON_IDS = Object.freeze([
+  'missileJavelin',
   'fighterJetAttack',
   'helicopterAttack',
   'droneAttack'
@@ -102,7 +102,7 @@ export const SNAKE_FPS_GUN_MODEL_CONFIG = Object.freeze({
   ludoHandScaleMultiplier: 3.2
 })
 
-export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
+export const SNAKE_SHARED_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   {
     id: 'ukrainianDroneAttack',
     label: 'Ukrainian Drone',
@@ -163,6 +163,33 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b', '#0f172a', '#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
   SNAKE_FPS_GUN_MODEL_CONFIG
 ])
+
+const SNAKE_CAPTURE_WEAPON_IDS = Object.freeze([
+  'ukrainianDroneAttack',
+  'droneAttack',
+  'missileJavelin',
+  'helicopterAttack',
+  'fighterJetAttack'
+])
+
+const SNAKE_SHARED_CAPTURE_WEAPON_BY_ID = new Map(
+  SNAKE_SHARED_CAPTURE_WEAPON_OPTIONS.map((option) => [option.id, option])
+)
+
+export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze(
+  SNAKE_CAPTURE_WEAPON_IDS.map((id) => {
+    if (id === 'missileJavelin') {
+      return ludoVehicleWeapon(
+        id,
+        'javelin',
+        'Short Missile',
+        swatchThumbnail(['#1d4ed8', '#64748b', '#dbeafe']),
+        { label: 'Short Missile' }
+      )
+    }
+    return SNAKE_SHARED_CAPTURE_WEAPON_BY_ID.get(id)
+  }).filter(Boolean)
+)
 
 export const SNAKE_CAPTURE_WEAPON_ALIAS_MAP = Object.freeze({
   fighter: 'fighterJetAttack',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -54,7 +54,8 @@ import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../../config/murlanThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from '../../config/poolRoyaleInventoryConfig.js';
 import { LUDO_WEAPON_DIRECTOR_BRIDGE } from '../../config/ludoWeaponDirectorBridge.js';
-import { SNAKE_CAPTURE_WEAPON_OPTIONS, SNAKE_FPS_GUN_MODEL_CONFIG } from '../../config/snakeWeaponCatalog.js';
+import { SNAKE_FPS_GUN_MODEL_CONFIG } from '../../config/snakeWeaponCatalog.js';
+import { SNAKE_SHARED_CAPTURE_WEAPON_OPTIONS } from '../../config/snakeWeaponCatalog.js';
 import { TOKEN_TYPE_SEQUENCE } from '../../utils/ludoTokenConstants.js';
 import {
   getLudoBattleInventory,
@@ -386,7 +387,7 @@ const gunifyModelUrls = (modelName) => {
 };
 
 const SNAKE_CAPTURE_WEAPON_OPTION_BY_ID = Object.freeze(
-  SNAKE_CAPTURE_WEAPON_OPTIONS.reduce((acc, option) => {
+  SNAKE_SHARED_CAPTURE_WEAPON_OPTIONS.reduce((acc, option) => {
     acc[option.id] = option;
     return acc;
   }, {})


### PR DESCRIPTION
### Motivation
- Reduce the Snake & Ladder capture-weapon catalog to a curated set of five vehicles/attacks for the game UI and inventory.
- Keep the larger shared model catalog intact so Ludo Battle Royal and other systems still reference the original asset pool.

### Description
- Replace the Snake catalog with a five-item canonical ordering and id list by introducing `SNAKE_CAPTURE_WEAPON_IDS` and mapping it to a curated set containing `ukrainianDroneAttack`, `droneAttack` (Shahad), `missileJavelin` (Short Missile), `helicopterAttack`, and `fighterJetAttack`, while keeping the larger shared list as `SNAKE_SHARED_CAPTURE_WEAPON_OPTIONS` in `webapp/src/config/snakeWeaponCatalog.js`.
- Make the Snake default unlocks expose the full five-weapon set via `SNAKE_CAPTURE_WEAPON_OPTIONS.map((option) => option.id)` in `webapp/src/config/snakeInventoryConfig.js` so players get the curated set by default.
- Update `LudoBattleRoyal.jsx` to continue using the larger shared catalog (`SNAKE_SHARED_CAPTURE_WEAPON_OPTIONS`) so Ludo’s existing firearm and model integrations are unaffected.
- Update automated coverage in `test/inventoryCrossGameConfig.test.js` to assert the exact five-item Snake catalog, labels, store alignment, and default unlocks.

### Testing
- Ran the targeted inventory test: `npx jest test/inventoryCrossGameConfig.test.js --runInBand --silent -t "snake store mirrors"` which passed (the test suite run for that file passed).
- Built the web app: `npm --prefix webapp run build` which completed successfully and produced the production `dist` output.
- Ran lint and auto-fix steps and verified `git diff --check` (no whitespace/check errors) after fixes.
- Attempted a portrait screenshot with Playwright to visually verify the UI, but the capture failed because the container lacked the Chromium runtime library `libatk-1.0.so.0` (Playwright download/launch was attempted but the system libraries were missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a708d95ad0483298fb24873bb061fa6)