### PR TITLE
Lower Chess Battle Royal missile and drone flight lanes

### DIFF
--- a/test/chessBattleInventoryConfig.test.js
+++ b/test/chessBattleInventoryConfig.test.js
@@ -10,6 +10,7 @@ import {
   CHESS_TABLE_FINISH_OPTIONS
 } from '../webapp/src/config/chessBattleInventoryConfig.js';
 import { CAPTURE_ANIMATION_OPTIONS } from '../webapp/src/config/ludoBattleOptions.js';
+import { readFile } from 'node:fs/promises';
 
 describe('chess battle inventory config', () => {
   test('defaults to octagon table for battle royal', () => {
@@ -65,6 +66,23 @@ describe('chess battle inventory config', () => {
         .filter((item) => item.type === 'captureAnimation')
         .every((item) => CHESS_BATTLE_WEAPON_IDS.includes(item.optionId))
     ).toBe(true);
+  });
+
+  test('keeps the short missile and both inventory drones on dedicated low flight lanes', async () => {
+    const source = await readFile('webapp/src/pages/Games/ChessBattleRoyal.jsx', 'utf8');
+
+    expect(source).toContain(
+      'const CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 2.15;'
+    );
+    expect(source).toContain(
+      'const CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 2.25;'
+    );
+    expect(source).toContain(
+      'const CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 1.55;'
+    );
+    expect(source).toContain('strikeAltitude: CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE');
+    expect(source).toContain('strikeAltitude: CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE');
+    expect(source).toContain('cruiseHeight: CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT');
   });
 
   test('keeps current avatar free by default and sells exactly the 5 requested WebGL humans', () => {

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -170,8 +170,12 @@ const CAPTURE_PRECISION_STRIKE_DROP_RATIO = 0.34; // longer vertical terminal dr
 const CAPTURE_DRONE_PRECISION_LOCK_RATIO = 0.72; // lock horizontal coordinates earlier so drone impacts are extremely precise
 const CAPTURE_SHORT_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 3.55; // raise shared missile lane to keep aerial/truck strikes at a higher altitude
 const CAPTURE_AIRCRAFT_CRUISE_HEIGHT = CAPTURE_JET_ALTITUDE; // keep jet/helicopter on the same high lane as the jet missile apex reference altitude
-const CAPTURE_DRONE_STRIKE_ALTITUDE = CAPTURE_AIRCRAFT_CRUISE_HEIGHT * 1.03; // keep drone on a very slightly higher precision lane for cleaner impact lines
-const CAPTURE_TRUCK_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 2.35; // truck missile should skim lower than drone/jet/helicopter attacks
+// These three inventory attacks use portrait-friendly low lanes independently of
+// the much higher jet/helicopter flyover lane.
+const CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 2.15;
+const CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 2.25;
+const CAPTURE_UKRAINIAN_DRONE_MISSILE_CLEARANCE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 1.35;
+const CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 1.55;
 const CAPTURE_LOOP_TAKEOFF_RATIO = 0.24; // shorter lift so vehicles enter the orbit earlier
 const CAPTURE_AIR_APPROACH_RATIO = 0.96; // keep jet/helicopter on the long arc for a longer pass before strike
 const CAPTURE_RELOAD_SHOW_TIME = 0.58;
@@ -13400,7 +13404,7 @@ function Chess3D({
           strictPrecision: true,
           longArc: true,
           verticalStrike: true,
-          strikeAltitude: CAPTURE_TRUCK_STRIKE_ALTITUDE,
+          strikeAltitude: CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE,
           targetLift: CAPTURE_TRUCK_STRIKE_TARGET_LIFT
         });
         return withAuto3d({
@@ -13428,7 +13432,7 @@ function Chess3D({
           returnToOrigin: false,
           sourceUnit: null,
           droneFx,
-          strikeAltitude: CAPTURE_DRONE_STRIKE_ALTITUDE
+          strikeAltitude: CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE
         });
         return withAuto3d({
           moveDelayMs: CAPTURE_DRONE_ATTACK_TOTAL * 1000,
@@ -15793,7 +15797,7 @@ function Chess3D({
               from: launchPos,
               to: fx.flightTarget || fx.to,
               progress: droneU,
-              cruiseHeight: CAPTURE_AIRCRAFT_CRUISE_HEIGHT + CAPTURE_HELICOPTER_ALTITUDE_BOOST,
+              cruiseHeight: CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT,
               returnToOrigin: true,
               constrainToBoard: false
             });
@@ -15817,7 +15821,10 @@ function Chess3D({
             } else {
               if (!missile.launchPos) {
                 missile.launchPos = liveTargetPos.clone();
-                missile.launchPos.y = Math.max(dronePos.y - 0.04, liveTargetPos.y + CAPTURE_SHORT_STRIKE_ALTITUDE);
+                missile.launchPos.y = Math.max(
+                  dronePos.y - 0.04,
+                  liveTargetPos.y + CAPTURE_UKRAINIAN_DRONE_MISSILE_CLEARANCE
+                );
               }
               const missileU = clamp01((fx.t - releaseStart) / missileTravel);
               if (missileU <= 0 || missileU >= 1) {


### PR DESCRIPTION
### Motivation
- Improve portrait-screen readability by moving inventory air attacks (Short Missile, Shahad Drone, Ukrainian Drone) onto dedicated, lower flight lanes without affecting jet/helicopter flyovers.

### Description
- Introduce portrait-friendly constants in `webapp/src/pages/Games/ChessBattleRoyal.jsx`: `CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE`, `CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT`, `CAPTURE_UKRAINIAN_DRONE_MISSILE_CLEARANCE`, and `CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE` to separate inventory attack lanes from aircraft flyovers.
- Apply the new low-lane constants to Short Missile and Shahad Drone capture flows by replacing prior `strikeAltitude` usages with the new values.
- Lower the Ukrainian Drone cruise path and adjust its missile release altitude to use the new cruise and clearance constants.
- Add a regression test in `test/chessBattleInventoryConfig.test.js` that verifies the presence and use of the new constants in the source.

### Testing
- Ran unit tests with `npx jest test/chessBattleInventoryConfig.test.js --runInBand`, all tests passed (6/6).
- Built the webapp with `npm --prefix webapp run build`, production build completed successfully.
- Lint check reported file-ignore warnings for the two edited files when running ESLint (no lint errors reported for changed code); this is due to repo ignore configuration.
- Attempted automated Playwright screenshot of the preview but it failed because the environment does not have the Playwright Chromium executable installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7091d94c6883299071ca86d43a4556)