### PR TITLE
Make Domino Royal online matches authoritative and reconnectable

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -49,6 +49,10 @@ import { fileURLToPath } from 'url';
 import { existsSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
 import { randomUUID } from 'crypto';
+import {
+  createDominoTableNumber,
+  validateDominoStateSubmission
+} from './utils/dominoRoyalOnline.js';
 import compression from 'compression';
 import rateLimit from 'express-rate-limit';
 import helmet from 'helmet';
@@ -471,6 +475,7 @@ const tableMap = new Map();
 const poolStates = new Map();
 const snookerStates = new Map();
 const dominoRoyalStates = new Map();
+const dominoRoyalTableNumbers = new Set();
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
@@ -644,6 +649,10 @@ function createLobbyTable({
   if (!lobbyTables[key]) lobbyTables[key] = [];
   const table = {
     id,
+    tableNumber:
+      gameType === 'domino-royal'
+        ? createDominoTableNumber((number) => dominoRoyalTableNumbers.has(number))
+        : null,
     gameType,
     stake,
     maxPlayers,
@@ -652,6 +661,7 @@ function createLobbyTable({
     ready: new Set(),
     meta
   };
+  if (table.tableNumber) dominoRoyalTableNumbers.add(table.tableNumber);
   lobbyTables[key].push(table);
   tableMap.set(table.id, table);
   console.log(
@@ -1297,6 +1307,7 @@ async function seatTableSocket(
   }
   io.to(tableId).emit('lobbyUpdate', {
     tableId,
+    tableNumber: table.tableNumber,
     players: table.players,
     currentTurn: table.currentTurn,
     ready: Array.from(table.ready),
@@ -1348,6 +1359,7 @@ function maybeStartGame(table) {
       }
       io.to(table.id).emit('gameStart', {
         tableId: table.id,
+        tableNumber: table.tableNumber,
         players: table.players,
         currentTurn: table.currentTurn,
         stake: table.stake,
@@ -1401,6 +1413,7 @@ function unseatTableSocket(accountId, tableId, socketId) {
       }
       if (table.gameType === 'domino-royal') {
         dominoRoyalStates.delete(tableId);
+        if (table.tableNumber) dominoRoyalTableNumbers.delete(table.tableNumber);
       }
       tableMap.delete(tableId);
       const key = `${table.gameType}-${table.maxPlayers}`;
@@ -1414,6 +1427,7 @@ function unseatTableSocket(accountId, tableId, socketId) {
     }
     io.to(tableId).emit('lobbyUpdate', {
       tableId,
+      tableNumber: table.tableNumber,
       players: table.players,
       currentTurn: table.currentTurn,
       ready: Array.from(table.ready || []),
@@ -2140,6 +2154,7 @@ io.on('connection', (socket) => {
         cb({
           success: true,
           tableId: table.id,
+          tableNumber: table.tableNumber,
           players: table.players,
           currentTurn: table.currentTurn,
           ready: Array.from(table.ready),
@@ -2181,6 +2196,7 @@ io.on('connection', (socket) => {
     table.ready.add(String(resolvedAccountId));
     io.to(tableId).emit('lobbyUpdate', {
       tableId,
+      tableNumber: table.tableNumber,
       players: table.players,
       currentTurn: table.currentTurn,
       ready: Array.from(table.ready)
@@ -2280,11 +2296,21 @@ io.on('connection', (socket) => {
 
   socket.on('joinDominoRoyalTable', async ({ tableId, accountId } = {}) => {
     if (!tableId) return;
-    if (accountId && !ensureRegistered(socket, accountId)) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId });
+    if (!ensureRegistered(socket, resolvedAccountId)) return;
+    const table = tableMap.get(tableId);
+    if (
+      !table ||
+      table.gameType !== 'domino-royal' ||
+      !table.players.some((player) => String(player.id) === String(resolvedAccountId))
+    ) {
+      socket.emit('dominoRoyalSyncError', { tableId, error: 'seat_required' });
+      return;
+    }
     socket.join(tableId);
-    if (accountId) {
+    if (resolvedAccountId) {
       await registerConnection({
-        userId: String(accountId),
+        userId: String(resolvedAccountId),
         roomId: tableId,
         socketId: socket.id
       });
@@ -2300,8 +2326,12 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('dominoRoyalSyncRequest', ({ tableId } = {}) => {
+  socket.on('dominoRoyalSyncRequest', ({ tableId, accountId } = {}) => {
     if (!tableId) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId });
+    if (!ensureRegistered(socket, resolvedAccountId)) return;
+    const table = tableMap.get(tableId);
+    if (!table?.players.some((player) => String(player.id) === String(resolvedAccountId))) return;
     const cached = dominoRoyalStates.get(tableId);
     if (cached?.state) {
       socket.emit('dominoRoyalState', {
@@ -2313,21 +2343,43 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('dominoRoyalState', ({ tableId, state, action } = {}) => {
+  socket.on('dominoRoyalState', ({ tableId, accountId, state, action } = {}, cb) => {
     if (!tableId || !state || typeof state !== 'object') return;
     if (!socket.rooms.has(tableId)) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId, tpcAccountNumber: action?.accountId });
+    if (!ensureRegistered(socket, resolvedAccountId)) return;
+    const table = tableMap.get(tableId);
+    const cached = dominoRoyalStates.get(tableId);
+    const validation = validateDominoStateSubmission({
+      table,
+      cached,
+      accountId: resolvedAccountId,
+      state,
+      action
+    });
+    if (!validation.ok) {
+      cb && cb({ success: false, error: validation.error });
+      socket.emit('dominoRoyalSyncError', { tableId, error: validation.error });
+      if (cached?.state) socket.emit('dominoRoyalState', { tableId, state: cached.state, action: cached.action, updatedAt: cached.ts });
+      return;
+    }
+    const revision = Number(cached?.revision || 0) + 1;
+    const authoritativeState = { ...state, seq: revision };
     const payload = {
       tableId,
-      state,
-      action: action || null,
+      tableNumber: table.tableNumber,
+      state: authoritativeState,
+      action: { ...(action || {}), accountId: String(resolvedAccountId) },
       updatedAt: Date.now()
     };
     dominoRoyalStates.set(tableId, {
-      state,
+      state: authoritativeState,
       action: payload.action,
-      ts: payload.updatedAt
+      ts: payload.updatedAt,
+      revision
     });
     socket.to(tableId).emit('dominoRoyalState', payload);
+    cb && cb({ success: true, revision });
   });
 
   socket.on('joinPoolTable', async ({ tableId, accountId }) => {

--- a/bot/utils/dominoRoyalOnline.js
+++ b/bot/utils/dominoRoyalOnline.js
@@ -1,0 +1,57 @@
+import { randomInt } from 'crypto'
+
+const TABLE_NUMBER_SPACE = 1_000_000
+
+export function createDominoTableNumber (isInUse = () => false) {
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    const number = `DR-${String(randomInt(TABLE_NUMBER_SPACE)).padStart(6, '0')}`
+    if (!isInUse(number)) return number
+  }
+  return `DR-${Date.now().toString(36).toUpperCase()}`
+}
+
+export function getDominoPlayerSeat (table, accountId) {
+  if (!table || !accountId || !Array.isArray(table.players)) return -1
+  return table.players.findIndex(
+    (player) => String(player?.id || '') === String(accountId)
+  )
+}
+
+export function validateDominoStateSubmission ({ table, cached, accountId, state, action }) {
+  if (!table || table.gameType !== 'domino-royal') {
+    return { ok: false, error: 'table_not_found' }
+  }
+  const seat = getDominoPlayerSeat(table, accountId)
+  if (seat < 0) return { ok: false, error: 'seat_required' }
+  if (!state || typeof state !== 'object') return { ok: false, error: 'invalid_state' }
+
+  const playerCount = table.players.length
+  if (
+    playerCount < 2 ||
+    playerCount > 4 ||
+    Number(state.humanCount) !== playerCount ||
+    !Array.isArray(state.players) ||
+    state.players.length !== playerCount
+  ) {
+    return { ok: false, error: 'invalid_player_count' }
+  }
+
+  const actionType = String(action?.type || 'sync')
+  if (!cached?.state) {
+    if (seat !== 0 || actionType !== 'initial') {
+      return { ok: false, error: 'waiting_for_host' }
+    }
+    return { ok: true, seat }
+  }
+
+  const authoritativeTurn = Number(cached.state.current)
+  if (!Number.isInteger(authoritativeTurn) || authoritativeTurn !== seat) {
+    return { ok: false, error: 'not_your_turn' }
+  }
+  const nextTurn = Number(state.current)
+  const allowedNextTurn = (seat - 1 + playerCount) % playerCount
+  if (nextTurn !== seat && nextTurn !== allowedNextTurn) {
+    return { ok: false, error: 'invalid_turn_transition' }
+  }
+  return { ok: true, seat }
+}

--- a/test/dominoRoyalOnline.test.js
+++ b/test/dominoRoyalOnline.test.js
@@ -1,0 +1,33 @@
+/* global describe, test, expect */
+import {
+  createDominoTableNumber,
+  validateDominoStateSubmission
+} from '../bot/utils/dominoRoyalOnline.js'
+
+const table = {
+  gameType: 'domino-royal',
+  players: [{ id: 'TPC-100' }, { id: 'TPC-200' }]
+}
+const state = (current = 0) => ({
+  humanCount: 2,
+  current,
+  players: [{ hand: [] }, { hand: [] }]
+})
+
+describe('Domino Royal online synchronization', () => {
+  test('creates a human-readable unique table number', () => {
+    const number = createDominoTableNumber(() => false)
+    expect(number).toMatch(/^DR-\d{6}$/)
+  })
+
+  test('only lets the first TPC seat initialize the table', () => {
+    expect(validateDominoStateSubmission({ table, accountId: 'TPC-100', state: state(), action: { type: 'initial' } }).ok).toBe(true)
+    expect(validateDominoStateSubmission({ table, accountId: 'TPC-200', state: state(), action: { type: 'initial' } })).toMatchObject({ ok: false, error: 'waiting_for_host' })
+  })
+
+  test('only accepts actions from the authoritative current TPC seat', () => {
+    const cached = { state: state(1) }
+    expect(validateDominoStateSubmission({ table, cached, accountId: 'TPC-100', state: state(1), action: { type: 'play' } })).toMatchObject({ ok: false, error: 'not_your_turn' })
+    expect(validateDominoStateSubmission({ table, cached, accountId: 'TPC-200', state: state(0), action: { type: 'turn' } }).ok).toBe(true)
+  })
+})

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -10876,9 +10876,9 @@ function serializeDominoSegment(segment) {
 
 function buildDominoOnlineState() {
   return {
-    seq: ++dominoOnlineStateSeq,
+    seq: dominoOnlineStateSeq,
     players: players.map((player, idx) => ({
-      id: player?.id ?? idx,
+      id: DOMINO_ONLINE_MATCH?.players?.[idx]?.id ?? player?.id ?? idx,
       hand: Array.isArray(player?.hand) ? player.hand.map(stripRuntimeTile).filter(Boolean) : []
     })),
     boneyard: Array.isArray(boneyard) ? boneyard.map(stripRuntimeTile).filter(Boolean) : [],
@@ -10902,8 +10902,19 @@ function emitDominoOnlineState(action = 'sync') {
   }
   DOMINO_ONLINE_SOCKET.emit('dominoRoyalState', {
     tableId: DOMINO_ONLINE_TABLE_ID,
+    accountId: DOMINO_ONLINE_ACCOUNT_ID,
     action: { type: action, accountId: DOMINO_ONLINE_ACCOUNT_ID, seat: human },
     state: buildDominoOnlineState()
+  }, (response = {}) => {
+    if (response.success && Number.isInteger(response.revision)) {
+      dominoOnlineStateSeq = response.revision;
+      dominoOnlineHasState = true;
+      return;
+    }
+    DOMINO_ONLINE_SOCKET.emit('dominoRoyalSyncRequest', {
+      tableId: DOMINO_ONLINE_TABLE_ID,
+      accountId: DOMINO_ONLINE_ACCOUNT_ID
+    });
   });
 }
 
@@ -10966,10 +10977,17 @@ function applyDominoOnlineState(remoteState = {}) {
 
 function connectDominoOnlineTable() {
   if (!DOMINO_ONLINE_MODE || !DOMINO_ONLINE_SOCKET || !DOMINO_ONLINE_TABLE_ID) return;
-  DOMINO_ONLINE_SOCKET.emit('joinDominoRoyalTable', {
-    tableId: DOMINO_ONLINE_TABLE_ID,
-    accountId: DOMINO_ONLINE_ACCOUNT_ID
-  });
+  const joinAndSync = () => {
+    DOMINO_ONLINE_SOCKET.emit('joinDominoRoyalTable', {
+      tableId: DOMINO_ONLINE_TABLE_ID,
+      accountId: DOMINO_ONLINE_ACCOUNT_ID
+    });
+    DOMINO_ONLINE_SOCKET.emit('dominoRoyalSyncRequest', {
+      tableId: DOMINO_ONLINE_TABLE_ID,
+      accountId: DOMINO_ONLINE_ACCOUNT_ID
+    });
+  };
+  joinAndSync();
   if (dominoOnlineStateHandler) {
     DOMINO_ONLINE_SOCKET.off?.('dominoRoyalState', dominoOnlineStateHandler);
   }
@@ -10978,7 +10996,9 @@ function connectDominoOnlineTable() {
     applyDominoOnlineState(state);
   };
   DOMINO_ONLINE_SOCKET.on('dominoRoyalState', dominoOnlineStateHandler);
-  DOMINO_ONLINE_SOCKET.emit('dominoRoyalSyncRequest', { tableId: DOMINO_ONLINE_TABLE_ID });
+  DOMINO_ONLINE_SOCKET.off?.('connect', joinAndSync);
+  DOMINO_ONLINE_SOCKET.on('connect', joinAndSync);
+  window.__dominoRoyalOnlineReconnectHandler = joinAndSync;
 }
 
 async function bootstrapDominoRoyal() {
@@ -12050,6 +12070,10 @@ function shutdownDominoRoyal(reason = 'unknown') {
   if (DOMINO_ONLINE_SOCKET && dominoOnlineStateHandler) {
     DOMINO_ONLINE_SOCKET.off?.('dominoRoyalState', dominoOnlineStateHandler);
     dominoOnlineStateHandler = null;
+  }
+  if (DOMINO_ONLINE_SOCKET && window.__dominoRoyalOnlineReconnectHandler) {
+    DOMINO_ONLINE_SOCKET.off?.('connect', window.__dominoRoyalOnlineReconnectHandler);
+    delete window.__dominoRoyalOnlineReconnectHandler;
   }
 }
 

--- a/webapp/src/pages/Games/DominoRoyal.jsx
+++ b/webapp/src/pages/Games/DominoRoyal.jsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import DominoRoyalArena from './DominoRoyalArena.jsx';
 import { socket } from '../../utils/socket.js';
-import { ensureAccountId, getTelegramUsername } from '../../utils/telegram.js';
+import { ensureAccountId } from '../../utils/telegram.js';
 
 export default function DominoRoyal() {
   useTelegramBackButton();
@@ -24,12 +24,6 @@ export default function DominoRoyal() {
       }
       if (cancelled || !resolvedAccountId) return;
       socket.emit('register', { playerId: resolvedAccountId });
-      socket.emit('joinRoom', {
-        roomId: tableId,
-        accountId: resolvedAccountId,
-        name: getTelegramUsername() || 'Player'
-      });
-      socket.emit('confirmReady', { accountId: resolvedAccountId, tableId });
     };
 
     syncRuntime().catch(() => {});

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -5,7 +5,7 @@ import { socket } from '../../utils/socket.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-06-07-online-sync-v66';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-08-03-authoritative-online-v67';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -230,7 +230,7 @@ export default function DominoRoyalLobby() {
           queuedTableIdRef.current = res.tableId;
           setQueuedTableId(res.tableId);
           const seated = Array.isArray(res.players) ? res.players.length : 1;
-          setQueueStatus(`Table ${res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players ready`);
+          setQueueStatus(`Table ${res.tableNumber || res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players ready`);
           socket.emit('confirmReady', { accountId, tableId: res.tableId });
         }
       );
@@ -250,14 +250,14 @@ export default function DominoRoyalLobby() {
   useEffect(() => {
     if (mode !== 'online') return undefined;
 
-    const handleLobbyUpdate = ({ tableId, players: lobbyPlayers = [], ready = [] } = {}) => {
+    const handleLobbyUpdate = ({ tableId, tableNumber, players: lobbyPlayers = [], ready = [] } = {}) => {
       if (!tableId || tableId !== queuedTableIdRef.current) return;
       setQueueStatus(
-        `Table ${String(tableId).slice(0, 8)} • ${lobbyPlayers.length}/${totalPlayers} players connected • ${ready.length}/${totalPlayers} ready`
+        `Table ${tableNumber || String(tableId).slice(0, 8)} • ${lobbyPlayers.length}/${totalPlayers} players connected • ${ready.length}/${totalPlayers} ready`
       );
     };
 
-    const handleGameStart = ({ tableId, players, stake: onlineStake, meta }) => {
+    const handleGameStart = ({ tableId, tableNumber, players, stake: onlineStake, meta }) => {
       if (!tableId || tableId !== queuedTableIdRef.current) return;
       const accountId = ensureAccountId().catch(() => '');
       Promise.resolve(accountId).then((resolvedAccountId) => {
@@ -282,6 +282,7 @@ export default function DominoRoyalLobby() {
             'dominoRoyalOnlineMatch',
             JSON.stringify({
               tableId,
+              tableNumber: tableNumber || '',
               accountId: resolvedAccountId,
               players: Array.isArray(players) ? players : [],
               meta: meta || {},


### PR DESCRIPTION
### Motivation
- Provide deterministic, server-authoritative synchronization for Domino Royal online matches so players cannot desync or spoof turns. 
- Give each online match a short human-visible table number to simplify matchmaking status and recovery.
- Bind all online room actions to each player's unique TPC account to ensure identity-based seat ownership and replay safety.

### Description
- Added `bot/utils/dominoRoyalOnline.js` with `createDominoTableNumber` and `validateDominoStateSubmission` to generate collision-checked `DR-######` table numbers and validate submitted game states and turn ownership. 
- Wire server-side authoritative flow into `bot/server.js`: create and track `tableNumber` for Domino tables, include it in `lobbyUpdate` and `gameStart` payloads, restrict `join`/`sync`/`state` operations to the registered seated TPC account, validate state submissions with `validateDominoStateSubmission`, and assign authoritative `revision`/`seq` on accepted states before broadcasting. 
- Update client runtime in `webapp/public/domino-royal-game.js` to send `accountId` with `dominoRoyalState` and to treat server revisions as authoritative (apply returned `revision`, request sync when rejected), plus automatic rejoin+sync on Socket.IO reconnect. 
- Surface the new `tableNumber` in lobby UX in `webapp/src/pages/Games/DominoRoyalLobby.jsx` and persist it in `dominoRoyalOnlineMatch` session metadata; prevent the page route from re-confirming an already-started lobby by removing duplicate in-route ready emits in `webapp/src/pages/Games/DominoRoyal.jsx`. 
- Bump the inlined Domino script version identifier in `DominoRoyalArena.jsx` to reflect the authoritative sync changes. 
- Add unit tests `test/dominoRoyalOnline.test.js` covering table-number format, host-only initialization, and turn-authority validation.

### Testing
- Ran unit tests with `npx jest test/dominoRoyalOnline.test.js --runInBand` and all tests passed. 
- Verified server and client JavaScript parse checks with `node --check bot/server.js` and `node --check webapp/public/domino-royal-game.js`, both succeeded. 
- Performed a production web build with `npm --prefix webapp run build`, which completed successfully (Vite reported its existing chunk-size advisory only). 
- Ran focused linting (`eslint`) and applied fixes where necessary for the new files; final checks were completed for affected files. 
- Attempted a portrait Playwright screenshot of the lobby but the environment lacked the Playwright Chromium binary, so the screenshot step was skipped (no change to game logic).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7092e8665083298d1b6a3a6daa1d58)