### PR TITLE
Lower and align Chess Battle Royal air attacks

### DIFF
--- a/test/chessBattleInventoryConfig.test.js
+++ b/test/chessBattleInventoryConfig.test.js
@@ -68,17 +68,20 @@ describe('chess battle inventory config', () => {
     ).toBe(true);
   });
 
-  test('keeps the short missile and both inventory drones on dedicated low flight lanes', async () => {
+  test('keeps the lowered short missile and both inventory drones on the same low flight lane', async () => {
     const source = await readFile('webapp/src/pages/Games/ChessBattleRoyal.jsx', 'utf8');
 
     expect(source).toContain(
-      'const CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 2.15;'
+      'const CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 1.25;'
     );
     expect(source).toContain(
-      'const CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 2.25;'
+      'const CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE = CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE;'
     );
     expect(source).toContain(
-      'const CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 1.55;'
+      'const CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT = CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE;'
+    );
+    expect(source).toContain(
+      'const CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE = CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE;'
     );
     expect(source).toContain('strikeAltitude: CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE');
     expect(source).toContain('strikeAltitude: CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE');

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -170,12 +170,13 @@ const CAPTURE_PRECISION_STRIKE_DROP_RATIO = 0.34; // longer vertical terminal dr
 const CAPTURE_DRONE_PRECISION_LOCK_RATIO = 0.72; // lock horizontal coordinates earlier so drone impacts are extremely precise
 const CAPTURE_SHORT_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 3.55; // raise shared missile lane to keep aerial/truck strikes at a higher altitude
 const CAPTURE_AIRCRAFT_CRUISE_HEIGHT = CAPTURE_JET_ALTITUDE; // keep jet/helicopter on the same high lane as the jet missile apex reference altitude
-// These three inventory attacks use portrait-friendly low lanes independently of
-// the much higher jet/helicopter flyover lane.
-const CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 2.15;
-const CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 2.25;
+// Keep these three inventory attacks together on one portrait-friendly low lane,
+// independently of the much higher jet/helicopter flyover lane.
+const CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 1.25;
+const CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE = CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE;
+const CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT = CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE;
 const CAPTURE_UKRAINIAN_DRONE_MISSILE_CLEARANCE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 1.35;
-const CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 1.55;
+const CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE = CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE;
 const CAPTURE_LOOP_TAKEOFF_RATIO = 0.24; // shorter lift so vehicles enter the orbit earlier
 const CAPTURE_AIR_APPROACH_RATIO = 0.96; // keep jet/helicopter on the long arc for a longer pass before strike
 const CAPTURE_RELOAD_SHOW_TIME = 0.58;


### PR DESCRIPTION
### Motivation
- Improve portrait-screen readability by lowering the short-missile flight lane so it reads closer to drone strikes. 
- Ensure the Shahad drone and the Ukrainian drone share the exact same visual flight height when using the same inventory attack so captures appear consistent. 

### Description
- Introduce a shared low-flight constant `CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 1.25` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`. 
- Set `CAPTURE_SHAHAD_DRONE_STRIKE_ALTITUDE`, `CAPTURE_UKRAINIAN_DRONE_CRUISE_HEIGHT`, and `CAPTURE_SHORT_MISSILE_STRIKE_ALTITUDE` to use the new shared low-flight constant so all three attacks fly at the same lowered altitude. 
- Update the test `test/chessBattleInventoryConfig.test.js` to expect the new `CAPTURE_LOW_ATTACK_FLIGHT_ALTITUDE` and to rename the test to reflect the lowered, shared flight lane. 

### Testing
- Ran the specific Jest suite with `npm test -- --runInBand test/chessBattleInventoryConfig.test.js`, which passed (6 tests, all green). 
- Executed the frontend production build with `npm --prefix webapp run build`, and the Vite build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7094e9121483298c7fb9a98d2882ae)