### PR TITLE
Fix Domino Royal online lobby socket handshake

### DIFF
--- a/test/dominoRoyalMatchmaking.test.js
+++ b/test/dominoRoyalMatchmaking.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { joinDominoRoyalLobby } from '../webapp/src/pages/Games/dominoRoyalMatchmaking.js';
+
+class FakeSocket {
+  constructor({ connected = true, registerResponse = { success: true }, seatResponse } = {}) {
+    this.connected = connected;
+    this.registerResponse = registerResponse;
+    this.seatResponse = seatResponse || { success: true, tableId: 'DR-table-1' };
+    this.events = [];
+    this.listeners = new Map();
+  }
+
+  once(event, handler) {
+    this.listeners.set(event, handler);
+  }
+
+  off(event) {
+    this.listeners.delete(event);
+  }
+
+  connect() {
+    this.connected = true;
+    queueMicrotask(() => this.listeners.get('connect')?.());
+  }
+
+  emit(event, payload, callback) {
+    this.events.push({ event, payload });
+    const response = event === 'register' ? this.registerResponse : this.seatResponse;
+    queueMicrotask(() => callback?.(response));
+  }
+}
+
+test('Domino lobby waits for registration before seating with matching criteria', async () => {
+  const socket = new FakeSocket({ connected: false });
+  const criteria = {
+    gameType: 'domino-royal',
+    maxPlayers: 4,
+    stake: 100,
+    matchMeta: { variant: 'points', targetPoints: '101', token: 'TPC' }
+  };
+
+  const result = await joinDominoRoyalLobby({ socket, accountId: 'TPC-100', criteria });
+
+  assert.equal(result.success, true);
+  assert.deepEqual(socket.events.map(({ event }) => event), ['register', 'seatTable']);
+  assert.deepEqual(socket.events[1].payload, { ...criteria, accountId: 'TPC-100' });
+});
+
+test('Domino lobby never requests a seat when registration fails', async () => {
+  const socket = new FakeSocket({
+    registerResponse: { success: false, error: 'identity_mismatch' }
+  });
+
+  const result = await joinDominoRoyalLobby({
+    socket,
+    accountId: 'TPC-200',
+    criteria: { gameType: 'domino-royal', maxPlayers: 2, stake: 0 }
+  });
+
+  assert.deepEqual(result, { success: false, error: 'identity_mismatch' });
+  assert.deepEqual(socket.events.map(({ event }) => event), ['register']);
+});

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -18,6 +18,7 @@ import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
 import { socket } from '../../utils/socket.js';
 import { getOnlineReadiness } from '../../config/onlineContract.js';
+import { joinDominoRoyalLobby } from './dominoRoyalMatchmaking.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -195,14 +196,20 @@ export default function DominoRoyalLobby() {
       }
     } catch {}
 
-    if (mode === 'online' && accountId) {
+    if (mode === 'online' && !accountId) {
+      setQueueStatus('');
+      setQueueError('Unable to identify your online account. Please reopen the lobby and try again.');
+      return;
+    }
+
+    if (mode === 'online') {
       setQueueError('');
       setQueueStatus('Connecting to Domino Royal lobby…');
       onlineStakeDebitedRef.current = false;
-      socket.emit('register', { playerId: accountId });
-      socket.emit(
-        'seatTable',
-        {
+      const res = await joinDominoRoyalLobby({
+        socket,
+        accountId,
+        criteria: {
           accountId,
           gameType: 'domino-royal',
           stake: Number(stake.amount) || 0,
@@ -219,21 +226,19 @@ export default function DominoRoyalLobby() {
             targetPoints: gameType === 'points' ? String(targetPoints) : '',
             token: stake.token
           }
-        },
-        (res = {}) => {
-          if (!res.success || !res.tableId) {
-            const message = `Unable to join Domino online table (${res.error || 'try_again'}).`;
-            setQueueError(message);
-            setQueueStatus('');
-            return;
-          }
-          queuedTableIdRef.current = res.tableId;
-          setQueuedTableId(res.tableId);
-          const seated = Array.isArray(res.players) ? res.players.length : 1;
-          setQueueStatus(`Table ${res.tableNumber || res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players ready`);
-          socket.emit('confirmReady', { accountId, tableId: res.tableId });
         }
-      );
+      });
+      if (!res.success || !res.tableId) {
+        const message = `Unable to join Domino online table (${res.error || 'try_again'}).`;
+        setQueueError(message);
+        setQueueStatus('');
+        return;
+      }
+      queuedTableIdRef.current = res.tableId;
+      setQueuedTableId(res.tableId);
+      const seated = Array.isArray(res.players) ? res.players.length : 1;
+      setQueueStatus(`Table ${res.tableNumber || res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players ready`);
+      socket.emit('confirmReady', { accountId, tableId: res.tableId });
       return;
     }
 

--- a/webapp/src/pages/Games/dominoRoyalMatchmaking.js
+++ b/webapp/src/pages/Games/dominoRoyalMatchmaking.js
@@ -1,0 +1,79 @@
+const DEFAULT_CONNECT_TIMEOUT_MS = 15000
+const DEFAULT_ACK_TIMEOUT_MS = 6000
+
+function waitForSocketConnection (socket, timeoutMs = DEFAULT_CONNECT_TIMEOUT_MS) {
+  if (socket?.connected) return Promise.resolve(true)
+  if (!socket) return Promise.resolve(false)
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (connected) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      socket.off?.('connect', onConnect)
+      resolve(connected)
+    }
+    const onConnect = () => finish(true)
+    const timer = setTimeout(() => finish(Boolean(socket.connected)), timeoutMs)
+
+    socket.once?.('connect', onConnect)
+    socket.connect?.()
+  })
+}
+
+function emitWithAck (socket, event, payload, timeoutMs = DEFAULT_ACK_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      resolve({ success: false, error: `${event}_timeout` })
+    }, timeoutMs)
+
+    socket.emit(event, payload, (response = {}) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(response)
+    })
+  })
+}
+
+/**
+ * Completes the Socket.IO lobby handshake in order. Waiting for the register
+ * acknowledgement prevents seatTable from racing the server's async identity
+ * registration on mobile or high-latency connections.
+ */
+export async function joinDominoRoyalLobby ({
+  socket,
+  accountId,
+  criteria,
+  connectTimeoutMs = DEFAULT_CONNECT_TIMEOUT_MS,
+  ackTimeoutMs = DEFAULT_ACK_TIMEOUT_MS
+}) {
+  if (!socket || !accountId) {
+    return { success: false, error: 'missing_identity' }
+  }
+
+  const connected = await waitForSocketConnection(socket, connectTimeoutMs)
+  if (!connected) return { success: false, error: 'socket_unavailable' }
+
+  const identity = String(accountId)
+  const registration = await emitWithAck(
+    socket,
+    'register',
+    { accountId: identity },
+    ackTimeoutMs
+  )
+  if (!registration?.success) {
+    return { success: false, error: registration?.error || 'register_failed' }
+  }
+
+  return emitWithAck(
+    socket,
+    'seatTable',
+    { ...criteria, accountId: identity },
+    ackTimeoutMs
+  )
+}


### PR DESCRIPTION
### Motivation

- Prevent lobby race where the client emitted `seatTable` before the server finished identity registration, which caused players to fail to join online Domino Royal matches on high-latency/mobile conditions.
- Provide clear, actionable lobby errors when the client lacks an account identity or the socket/register step times out.

### Description

- Add a dedicated matchmaking helper `joinDominoRoyalLobby` (`webapp/src/pages/Games/dominoRoyalMatchmaking.js`) that waits for a socket connection, emits `register` with an acknowledgement and only then emits `seatTable` (implements `waitForSocketConnection` and `emitWithAck`).
- Update `DominoRoyalLobby.jsx` to use `joinDominoRoyalLobby`, show a friendly error when `accountId` is not available, and preserve the original matchmaking criteria (player count, stake, token, variant, target points) when joining the lobby.
- Add regression tests (`test/dominoRoyalMatchmaking.test.js`) using a `FakeSocket` to assert that `register` runs and is acknowledged before `seatTable` is sent and that seating is not attempted if registration fails.
- Keep using the existing Socket.IO client/server; this change fixes ordering and error handling rather than introducing a new networking stack.

### Testing

- Ran lints: `npm --prefix webapp run lint -- src/pages/Games/dominoRoyalMatchmaking.js src/pages/Games/DominoRoyalLobby.jsx` (passed).
- Unit tests: `node --test test/dominoRoyalMatchmaking.test.js` (new tests passed) and `npx jest test/dominoRoyalOnline.test.js --runInBand` (existing Domino Royal online sync tests passed).
- Built the web app with `npm --prefix webapp run build` and ran `git diff --check` to ensure no whitespace issues; build succeeded and checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70b8651884832982cb4ac6bdce8e65)