### PR TITLE
Fix Domino Royal TPC matchmaking search

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1265,7 +1265,8 @@ async function seatTableSocket(
     map = new Map();
     tableSeats.set(tableId, map);
   }
-  if (!map.has(String(accountId))) {
+  const isNewSeat = !map.has(String(accountId));
+  if (isNewSeat) {
     map.set(String(accountId), {
       id: accountId,
       name: playerName || String(accountId),
@@ -1292,7 +1293,9 @@ async function seatTableSocket(
     info.ts = Date.now();
     info.socketId = socket?.id;
     info.sidePreference = normalizeSidePreference(preferredSide || info.sidePreference);
-    const p = table.players.find((pl) => pl.id === accountId);
+    const p = table.players.find(
+      (pl) => String(pl.id) === String(accountId)
+    );
     if (p) {
       p.socketId = socket?.id;
       p.avatar = playerAvatar || p.avatar;
@@ -1301,7 +1304,9 @@ async function seatTableSocket(
   }
   console.log(`Player ${playerName || accountId} joined table ${tableId}`);
   socket?.join(tableId);
-  table.ready.delete(String(accountId));
+  // A matchmaking refresh is also the seat heartbeat. Do not revoke a
+  // player's ready confirmation merely because the client is searching again.
+  if (isNewSeat) table.ready.delete(String(accountId));
   if (!table.meta) {
     table.meta = normalizeMatchMeta(matchMeta);
   }

--- a/test/dominoRoyalMatchmaking.test.js
+++ b/test/dominoRoyalMatchmaking.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { joinDominoRoyalLobby } from '../webapp/src/pages/Games/dominoRoyalMatchmaking.js';
+import { joinDominoRoyalLobby, searchDominoRoyalLobby } from '../webapp/src/pages/Games/dominoRoyalMatchmaking.js';
 
 class FakeSocket {
   constructor({ connected = true, registerResponse = { success: true }, seatResponse } = {}) {
@@ -45,7 +45,39 @@ test('Domino lobby waits for registration before seating with matching criteria'
 
   assert.equal(result.success, true);
   assert.deepEqual(socket.events.map(({ event }) => event), ['register', 'seatTable']);
-  assert.deepEqual(socket.events[1].payload, { ...criteria, accountId: 'TPC-100' });
+  assert.deepEqual(socket.events[0].payload, {
+    accountId: 'TPC-100',
+    tpcAccountNumber: 'TPC-100'
+  });
+  assert.deepEqual(socket.events[1].payload, {
+    ...criteria,
+    accountId: 'TPC-100',
+    tpcAccountNumber: 'TPC-100'
+  });
+});
+
+test('Domino lobby refresh searches again using the same TPC account number', async () => {
+  const socket = new FakeSocket({
+    seatResponse: { success: true, tableId: 'DR-table-2', players: [{ id: 'TPC-300' }] }
+  });
+
+  const result = await searchDominoRoyalLobby({
+    socket,
+    accountId: 'TPC-300',
+    criteria: { gameType: 'domino-royal', maxPlayers: 2, stake: 100 }
+  });
+
+  assert.equal(result.tableId, 'DR-table-2');
+  assert.deepEqual(socket.events, [{
+    event: 'seatTable',
+    payload: {
+      gameType: 'domino-royal',
+      maxPlayers: 2,
+      stake: 100,
+      accountId: 'TPC-300',
+      tpcAccountNumber: 'TPC-300'
+    }
+  }]);
 });
 
 test('Domino lobby never requests a seat when registration fails', async () => {

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -18,7 +18,7 @@ import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
 import { socket } from '../../utils/socket.js';
 import { getOnlineReadiness } from '../../config/onlineContract.js';
-import { joinDominoRoyalLobby } from './dominoRoyalMatchmaking.js';
+import { joinDominoRoyalLobby, searchDominoRoyalLobby } from './dominoRoyalMatchmaking.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -69,6 +69,9 @@ export default function DominoRoyalLobby() {
   const [queueStatus, setQueueStatus] = useState('');
   const [queueError, setQueueError] = useState('');
   const queuedTableIdRef = useRef('');
+  const queuedAccountIdRef = useRef('');
+  const queuedCriteriaRef = useRef(null);
+  const searchInFlightRef = useRef(false);
   const onlineStakeDebitedRef = useRef(false);
   const startBet = stake.amount / 100;
   const readiness = getOnlineReadiness('domino-royal');
@@ -235,6 +238,24 @@ export default function DominoRoyalLobby() {
         return;
       }
       queuedTableIdRef.current = res.tableId;
+      queuedAccountIdRef.current = String(accountId);
+      queuedCriteriaRef.current = {
+        gameType: 'domino-royal',
+        stake: Number(stake.amount) || 0,
+        maxPlayers: totalPlayers,
+        playerName: getTelegramUsername() || 'Player',
+        avatar,
+        mode: 'online',
+        token: stake.token,
+        variant: gameType,
+        targetPoints: gameType === 'points' ? Number(targetPoints) : 0,
+        matchMeta: {
+          mode: 'online',
+          variant: gameType,
+          targetPoints: gameType === 'points' ? String(targetPoints) : '',
+          token: stake.token
+        }
+      };
       setQueuedTableId(res.tableId);
       const seated = Array.isArray(res.players) ? res.players.length : 1;
       setQueueStatus(`Table ${res.tableNumber || res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players ready`);
@@ -254,6 +275,31 @@ export default function DominoRoyalLobby() {
 
   useEffect(() => {
     if (mode !== 'online') return undefined;
+
+    const searchTimer = window.setInterval(async () => {
+      if (!queuedTableIdRef.current || searchInFlightRef.current) return;
+      const accountId = queuedAccountIdRef.current;
+      const criteria = queuedCriteriaRef.current;
+      if (!accountId || !criteria) return;
+      searchInFlightRef.current = true;
+      try {
+        const result = await searchDominoRoyalLobby({ socket, accountId, criteria });
+        if (!result?.success || !result.tableId) return;
+        queuedTableIdRef.current = result.tableId;
+        setQueuedTableId(result.tableId);
+        const seated = Array.isArray(result.players) ? result.players.length : 1;
+        setQueueStatus(
+          `Searching matching tables • ${seated}/${totalPlayers} players found`
+        );
+        socket.emit('confirmReady', {
+          accountId,
+          tpcAccountNumber: accountId,
+          tableId: result.tableId
+        });
+      } finally {
+        searchInFlightRef.current = false;
+      }
+    }, 3000);
 
     const handleLobbyUpdate = ({ tableId, tableNumber, players: lobbyPlayers = [], ready = [] } = {}) => {
       if (!tableId || tableId !== queuedTableIdRef.current) return;
@@ -315,11 +361,14 @@ export default function DominoRoyalLobby() {
     return () => {
       socket.off('lobbyUpdate', handleLobbyUpdate);
       socket.off('gameStart', handleGameStart);
+      window.clearInterval(searchTimer);
       if (queuedTableIdRef.current) {
         ensureAccountId()
           .then((accountId) => socket.emit('leaveLobby', { accountId, tableId: queuedTableIdRef.current }))
           .catch(() => {});
       }
+      queuedAccountIdRef.current = '';
+      queuedCriteriaRef.current = null;
     };
   }, [mode, stake.token, stake.amount, totalPlayers, avatar, flags, gameType, targetPoints]);
 

--- a/webapp/src/pages/Games/dominoRoyalMatchmaking.js
+++ b/webapp/src/pages/Games/dominoRoyalMatchmaking.js
@@ -1,6 +1,17 @@
 const DEFAULT_CONNECT_TIMEOUT_MS = 15000
 const DEFAULT_ACK_TIMEOUT_MS = 6000
 
+function buildSeatPayload (accountId, criteria = {}) {
+  const tpcAccountNumber = String(accountId || '').trim()
+  return {
+    ...criteria,
+    // Keep accountId for older servers, while making the canonical lobby
+    // identity explicit for current servers and reconnects.
+    accountId: tpcAccountNumber,
+    tpcAccountNumber
+  }
+}
+
 function waitForSocketConnection (socket, timeoutMs = DEFAULT_CONNECT_TIMEOUT_MS) {
   if (socket?.connected) return Promise.resolve(true)
   if (!socket) return Promise.resolve(false)
@@ -63,7 +74,7 @@ export async function joinDominoRoyalLobby ({
   const registration = await emitWithAck(
     socket,
     'register',
-    { accountId: identity },
+    { accountId: identity, tpcAccountNumber: identity },
     ackTimeoutMs
   )
   if (!registration?.success) {
@@ -73,7 +84,28 @@ export async function joinDominoRoyalLobby ({
   return emitWithAck(
     socket,
     'seatTable',
-    { ...criteria, accountId: identity },
+    buildSeatPayload(identity, criteria),
+    ackTimeoutMs
+  )
+}
+
+/**
+ * Refreshes a queued seat and asks the server to search all compatible open
+ * tables again. This also keeps the online seat alive during long searches.
+ */
+export async function searchDominoRoyalLobby ({
+  socket,
+  accountId,
+  criteria,
+  ackTimeoutMs = DEFAULT_ACK_TIMEOUT_MS
+}) {
+  if (!socket?.connected || !accountId) {
+    return { success: false, error: 'socket_unavailable' }
+  }
+  return emitWithAck(
+    socket,
+    'seatTable',
+    buildSeatPayload(accountId, criteria),
     ackTimeoutMs
   )
 }


### PR DESCRIPTION
### Motivation
- Matchmaking could fail to consolidate players because clients used inconsistent identity fields and could race seating before registration completed. 
- The lobby needed a way to keep searching for compatible open tables while a player remains queued so fragmented seats can be consolidated automatically. 
- Players who refresh matchmaking should not lose their previously-confirmed "ready" status just because the client resends a seat heartbeat. 

### Description
- Use the TPC account number as the canonical lobby identity by sending `tpcAccountNumber` (and preserving legacy `accountId`) when calling `register` and `seatTable` in `webapp/src/pages/Games/dominoRoyalMatchmaking.js` and by centralizing payload construction in `buildSeatPayload`.
- Add `searchDominoRoyalLobby` in `webapp/src/pages/Games/dominoRoyalMatchmaking.js` and wire a periodic 3s matchmaking refresh from `webapp/src/pages/Games/DominoRoyalLobby.jsx` that re-sends the same criteria to search compatible open tables and issues `confirmReady` when appropriate.
- Track queued TPC account and criteria in `DominoRoyalLobby.jsx` via refs (`queuedAccountIdRef`, `queuedCriteriaRef`) and avoid concurrent refreshes with `searchInFlightRef`; clean up interval and refs on unmount.
- Update server seat handling in `bot/server.js` to normalize ID comparisons (`String(...)`) and treat re-seating as a heartbeat so an existing `ready` confirmation is not revoked when the client refreshes its seat.
- Add/extend unit tests in `test/dominoRoyalMatchmaking.test.js` to cover registration-before-seating, failed registration, and repeated lobby search behavior.

### Testing
- Ran unit tests with `node --test test/dominoRoyalMatchmaking.test.js`, which passed (3 tests OK).
- Ran lint on modified client files with `npm --prefix webapp run lint -- --quiet src/pages/Games/DominoRoyalLobby.jsx src/pages/Games/dominoRoyalMatchmaking.js`, which succeeded.
- Built the webapp with `npm --prefix webapp run build`, which completed successfully.
- Attempted a Playwright portrait screenshot to visually validate the lobby, but Playwright Chromium failed to launch in the container due to a missing native library (`libatk-1.0.so.0`), so headless screenshoting could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70c03ff1388329b3d31a30b2da29f4)