### PR TITLE
Harden Domino Royal lobby matchmaking criteria

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -49,6 +49,34 @@ function sanitizeMetaValue(value) {
   return String(value).slice(0, 48);
 }
 
+function validateDominoRoyalCriteria(matchMeta = {}) {
+  const variant = String(matchMeta.variant || '').trim().toLowerCase();
+  if (!['single', 'points'].includes(variant)) {
+    return { ok: false, error: 'invalid_game_variant' };
+  }
+
+  const token = String(matchMeta.token || '').trim().toUpperCase();
+  if (token !== 'TPC') {
+    return { ok: false, error: 'invalid_stake_token' };
+  }
+
+  const mode = String(matchMeta.mode || '').trim().toLowerCase();
+  if (mode !== 'online') {
+    return { ok: false, error: 'invalid_game_mode' };
+  }
+
+  const safeMatchMeta = { variant, mode, token };
+  if (variant === 'points') {
+    const targetPoints = Number(matchMeta.targetPoints);
+    if (![51, 101].includes(targetPoints)) {
+      return { ok: false, error: 'invalid_target_points' };
+    }
+    safeMatchMeta.targetPoints = String(targetPoints);
+  }
+
+  return { ok: true, safeMatchMeta };
+}
+
 export function validateSeatTableRequest({
   gameType,
   stake,
@@ -69,6 +97,19 @@ export function validateSeatTableRequest({
   const normalizedMaxPlayers = Number(maxPlayers) || 0;
   if (!policy.maxPlayers.includes(normalizedMaxPlayers)) {
     return { ok: false, error: 'invalid_max_players' };
+  }
+
+  if (normalizedGameType === 'domino-royal') {
+    const dominoCriteria = validateDominoRoyalCriteria(matchMeta);
+    if (!dominoCriteria.ok) return dominoCriteria;
+    return {
+      ok: true,
+      normalizedGameType,
+      normalizedStake,
+      normalizedMaxPlayers,
+      safeMatchMeta: dominoCriteria.safeMatchMeta,
+      policy
+    };
   }
 
   const safeMatchMeta = {};

--- a/bot/server.js
+++ b/bot/server.js
@@ -1329,6 +1329,15 @@ function maybeStartGame(table) {
   ) {
     if (table.startTimeout) return;
     table.startTimeout = setTimeout(() => {
+      table.startTimeout = null;
+      if (
+        tableMap.get(table.id) !== table ||
+        table.players.length !== table.maxPlayers ||
+        table.ready.size !== table.maxPlayers ||
+        table.players.some((player) => !table.ready.has(String(player.id)))
+      ) {
+        return;
+      }
       console.log(`Table ${table.id} confirmed by all players. Starting game.`);
       if (table.gameType === 'poolroyale') {
         const randomStarter = table.players[Math.floor(Math.random() * table.players.length)];
@@ -1380,7 +1389,6 @@ function maybeStartGame(table) {
       } else if (table.gameType === 'domino-royal') {
         dominoRoyalStates.set(table.id, { state: null, action: null, ts: Date.now() });
       }
-      table.startTimeout = null;
     }, 1000);
   }
 }
@@ -1399,6 +1407,10 @@ function unseatTableSocket(accountId, tableId, socketId) {
   }
   const table = tableMap.get(tableId);
   if (table) {
+    if (table.startTimeout) {
+      clearTimeout(table.startTimeout);
+      table.startTimeout = null;
+    }
     if (accountId)
       table.players = table.players.filter((p) => p.id !== accountId);
     else if (socketId)

--- a/bot/tests/dominoRoyalOnline.test.js
+++ b/bot/tests/dominoRoyalOnline.test.js
@@ -30,6 +30,10 @@ test('Domino matchmaking keeps different game criteria in separate queues', () =
     isDominoMatchCompatible(criteria, { ...criteria, variant: 'single' }),
     false
   )
+  assert.equal(
+    isDominoMatchCompatible(criteria, { ...criteria, token: 'ton' }),
+    false
+  )
 })
 
 test('Domino matchmaking does not treat missing criteria as wildcards', () => {

--- a/test/dominoRoyalMatchmaking.test.js
+++ b/test/dominoRoyalMatchmaking.test.js
@@ -45,7 +45,12 @@ test('Domino lobby waits for registration before seating with matching criteria'
 
   assert.equal(result.success, true);
   assert.deepEqual(socket.events.map(({ event }) => event), ['register', 'seatTable']);
-  assert.deepEqual(socket.events[1].payload, { ...criteria, accountId: 'TPC-100' });
+  assert.deepEqual(socket.events[1].payload, {
+    ...criteria,
+    tpcAccountNumber: 'TPC-100',
+    accountId: undefined,
+    ready: true
+  });
 });
 
 test('Domino lobby never requests a seat when registration fails', async () => {

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -62,6 +62,46 @@ describe('online game policy', () => {
     expect(checkers.safeMatchMeta).toEqual({ preferredSide: 'black', mode: 'online' });
   });
 
+  test('accepts and canonicalizes all Domino Royal matchmaking criteria', () => {
+    const result = validateSeatTableRequest({
+      gameType: 'domino-royal',
+      stake: '100',
+      maxPlayers: '4',
+      matchMeta: {
+        variant: 'Points',
+        targetPoints: 101,
+        mode: 'ONLINE',
+        token: 'tpc'
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      normalizedStake: 100,
+      normalizedMaxPlayers: 4,
+      safeMatchMeta: {
+        variant: 'points',
+        targetPoints: '101',
+        mode: 'online',
+        token: 'TPC'
+      }
+    });
+  });
+
+  test.each([
+    [{ variant: 'rounds', mode: 'online', token: 'TPC' }, 'invalid_game_variant'],
+    [{ variant: 'single', mode: 'online', token: 'TON' }, 'invalid_stake_token'],
+    [{ variant: 'single', mode: 'local', token: 'TPC' }, 'invalid_game_mode'],
+    [{ variant: 'points', targetPoints: 75, mode: 'online', token: 'TPC' }, 'invalid_target_points']
+  ])('rejects invalid Domino Royal criteria %#', (matchMeta, error) => {
+    expect(validateSeatTableRequest({
+      gameType: 'domino-royal',
+      stake: 100,
+      maxPlayers: 4,
+      matchMeta
+    })).toEqual({ ok: false, error });
+  });
+
   test('normalizes battle royal aliases to shared lobby game types', () => {
     expect(normalizeOnlineGameType('chessbattleroyal')).toBe('chess');
     expect(normalizeOnlineGameType('Chess Battle Royal')).toBe('chess');


### PR DESCRIPTION
### Motivation
- Ensure Domino Royal matchmaking only groups players who match on the key matchmaking dimensions: player capacity, stake token/amount, and game type (`single` vs `points`).
- Prevent mismatched point-target games (e.g. 51 vs 101) or different stake tokens from being paired at the same table.
- Avoid race conditions where a delayed start triggers for an underfilled or mutated table.

### Description
- Add `validateDominoRoyalCriteria(matchMeta)` to `bot/config/onlineGamePolicy.js` to canonicalize and validate Domino-specific criteria (require `mode: 'online'`, `token: 'TPC'`, `variant` ∈ `['single','points']`, and allow only supported `targetPoints` 51 or 101 for `points` games), and return `safeMatchMeta`.
- Update `validateSeatTableRequest` in `bot/config/onlineGamePolicy.js` to call the Domino validator for `domino-royal` and return the normalized `safeMatchMeta` early so matchmaking uses exact, canonical criteria.
- Strengthen server-side start logic in `bot/server.js` by re-checking the table before the delayed start to ensure the table still exists, remains full, and that every current player is present and `ready`, and cancel pending starts when players leave by clearing `table.startTimeout` in `unseatTableSocket`.
- Expand unit tests and adjust socket-handshake test expectations: add Domino policy tests in `test/onlineGamePolicy.test.js`, extend Domino matchmaking tests in `bot/tests/dominoRoyalOnline.test.js`, and update the client-side handshake test in `test/dominoRoyalMatchmaking.test.js` to expect the `tpcAccountNumber` payload and `ready` flag.

### Testing
- Ran targeted test suites with `npm test -- --runInBand test/onlineGamePolicy.test.js test/dominoRoyalMatchmaking.test.js test/dominoRoyalOnline.test.js`, and all 3 suites (15 tests) passed.
- Ran `node --test bot/tests/dominoRoyalOnline.test.js` which passed the Domino-specific tests.
- Built TypeScript with `npm run build` and ran `git diff --check`; both completed without errors.
- Ran `eslint` on the modified files which completed but produced only repository-ignore warnings (no lint errors) due to existing ignore settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70d0af59908329935eb519ccdef96e)