### PR TITLE
Match Murlan Royale characters to Domino Royal

### DIFF
--- a/webapp/src/config/murlanCharacterThemes.js
+++ b/webapp/src/config/murlanCharacterThemes.js
@@ -1,6 +1,6 @@
 import { khronosThumb } from './storeThumbnails.js';
 
-export const MURLAN_CHARACTER_THEMES = Object.freeze([
+const CHARACTER_THEME_CATALOG = Object.freeze([
   {
     id: 'rpm-current',
     label: 'Current Avatar',
@@ -361,3 +361,22 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     skinTone: 0xc9906e
   }
 ]);
+
+// Murlan Royale intentionally uses the same seven-player roster as Domino
+// Royal. Keep Pool Royale's additional standing/shooter models in the shared
+// catalog without exposing them in Murlan's character picker or AI seats.
+const DOMINO_ROYAL_CHARACTER_IDS = new Set([
+  'rpm-current',
+  'rpm-67d411',
+  'rpm-67f433',
+  'rpm-67e1b5',
+  'webgl-vietnam-human',
+  'webgl-ai-teacher',
+  'webgl-ai-teacher-1'
+]);
+
+export const MURLAN_CHARACTER_THEMES = Object.freeze(
+  CHARACTER_THEME_CATALOG.filter((theme) => DOMINO_ROYAL_CHARACTER_IDS.has(theme.id))
+);
+
+export const POOL_ROYALE_CHARACTER_THEMES = CHARACTER_THEME_CATALOG;

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -1,6 +1,6 @@
 import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
-import { MURLAN_CHARACTER_THEMES } from './murlanCharacterThemes.js';
+import { POOL_ROYALE_CHARACTER_THEMES } from './murlanCharacterThemes.js';
 
 const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
   neonPhotostudio: {
@@ -700,7 +700,7 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
 
 
 export const POOL_ROYALE_HUMAN_CHARACTER_OPTIONS = Object.freeze(
-  MURLAN_CHARACTER_THEMES.map((theme) => ({
+  POOL_ROYALE_CHARACTER_THEMES.map((theme) => ({
     id: theme.id,
     label: theme.label,
     price: theme.price ?? 0,


### PR DESCRIPTION
### Motivation
- Ensure Murlan Royale uses the same seated human roster as Domino Royal for a consistent seven-player experience while preserving extra character models for Pool Royale.

### Description
- Consolidated the full character catalog into `CHARACTER_THEME_CATALOG` and derived `MURLAN_CHARACTER_THEMES` by filtering that catalog to the seven Domino roster IDs in `webapp/src/config/murlanCharacterThemes.js`.
- Added `POOL_ROYALE_CHARACTER_THEMES` as an export that preserves the complete catalog for Pool Royale usage.
- Updated `webapp/src/config/poolRoyaleInventoryConfig.js` to import `POOL_ROYALE_CHARACTER_THEMES` and keep Pool Royale character options unchanged.
- Changes are limited to configuration-level mappings and do not modify runtime character-loading logic.

### Testing
- Ran a Node assertion that verifies `MURLAN_CHARACTER_THEMES` contains the expected 7 IDs and that `POOL_ROYALE_CHARACTER_THEMES` is larger, and the assertion passed (`Murlan roster: 7; Pool catalog: 14`).
- Performed a production build with `npm run build`, which completed successfully and produced the application `dist` artifacts.
- Executed `git diff --check` to validate there are no diff-check issues reported by the change tooling.
- Ran `npm run lint` targeted at the edited files and observed pre-existing ESLint formatting/semicolon errors in the repository that are unrelated to the functional change and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7161767ecc8329b7bf2dcc803886c6)