### PR TITLE
Fix Snake & Ladder dice roll and jump layout

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -269,7 +269,10 @@ const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
 // Keep Snake dice motion aligned with Ludo Battle Royal's frame-synced single-arc spinDice roll.
-const DICE_ROLL_DURATION = 1100;
+// Ludo Battle Royal's spinDice defaults to a 900 ms physical throw. Keep the
+// same duration here so the hidden result generator cannot stop the 3D roll
+// before the cube has completed its arc.
+const DICE_ROLL_DURATION = 900;
 const DICE_SETTLE_DURATION = 220;
 const DICE_RESULT_HOLD_DURATION = 720;
 const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.78;
@@ -5331,7 +5334,7 @@ function updateTokens(
   });
 }
 
-function updateLadders(group, ladders, indexToPosition, serpentineIndexToXZ, railTexture, theme = {}) {
+function updateLadders(group, ladders, snakes, indexToPosition, serpentineIndexToXZ, railTexture, theme = {}) {
   while (group.children.length) {
     const child = group.children.pop();
     if (child) {
@@ -5363,7 +5366,13 @@ function updateLadders(group, ladders, indexToPosition, serpentineIndexToXZ, rai
   group.userData.paths = new Map();
 
   const ladderEntries = parseJumpMap(ladders).filter(([a, b]) => b > a);
-  const resolveLadderLane = createJumpLaneResolver(ladderEntries);
+  // Resolve lanes against every jump, not only other ladders. This gives a
+  // snake and a ladder that cross the same run different height/side lanes.
+  const allJumpEntries = [
+    ...ladderEntries,
+    ...parseJumpMap(snakes).filter(([a, b]) => b < a)
+  ];
+  const resolveLadderLane = createJumpLaneResolver(allJumpEntries);
   ladderEntries.forEach(([start, end]) => {
     const laneConfig = resolveLadderLane(start);
     const A = (indexToPosition.get(start) || serpentineIndexToXZ(start)).clone();
@@ -5442,7 +5451,7 @@ function updateLadders(group, ladders, indexToPosition, serpentineIndexToXZ, rai
   });
 }
 
-function updateSnakes(group, snakes, indexToPosition, serpentineIndexToXZ, snakeTexture, theme = {}) {
+function updateSnakes(group, snakes, ladders, indexToPosition, serpentineIndexToXZ, snakeTexture, theme = {}) {
   while (group.children.length) {
     const child = group.children.pop();
     if (child) {
@@ -5483,7 +5492,11 @@ function updateSnakes(group, snakes, indexToPosition, serpentineIndexToXZ, snake
   });
 
   const entries = parseJumpMap(snakes).filter(([a, b]) => b < a);
-  const resolveSnakeLane = createJumpLaneResolver(entries);
+  const allJumpEntries = [
+    ...parseJumpMap(ladders).filter(([a, b]) => b > a),
+    ...entries
+  ];
+  const resolveSnakeLane = createJumpLaneResolver(allJumpEntries);
 
   group.userData.paths = new Map();
 
@@ -7389,23 +7402,25 @@ export default function SnakeBoard3D({
     updateLadders(
       boardRef.current.laddersGroup,
       ladders,
+      snakes,
       boardRef.current.indexToPosition,
       boardRef.current.serpentineIndexToXZ,
       railTextureRef.current
     );
-  }, [ladders, ladderOffsets, keyForEffect]);
+  }, [ladders, snakes, ladderOffsets, keyForEffect]);
 
   useEffect(() => {
     if (!boardRef.current || !snakeTextureRef.current) return;
     updateSnakes(
       boardRef.current.snakesGroup,
       snakes,
+      ladders,
       boardRef.current.indexToPosition,
       boardRef.current.serpentineIndexToXZ,
       snakeTextureRef.current,
       snakeTheme
     );
-  }, [snakes, snakeOffsets, keyForEffect, snakeTheme]);
+  }, [snakes, ladders, snakeOffsets, keyForEffect, snakeTheme]);
 
   useEffect(() => {
     if (!slide || !boardRef.current) return;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -192,6 +192,8 @@ const TURN_ADVANCE_AFTER_DICE_MS = 0;
 const DICE_RESULT_HOLD_MS = 2000;
 // Match the 3D Ludo/Pool dice: a server-authoritative value should only
 // replace the rolling face after the physical throw has had time to land.
+// The Ludo-style physical roll lasts 900 ms. Reveal just after landing so the
+// authoritative face is visible before any token movement can begin.
 const DICE_BOARD_ROLL_REVEAL_DELAY_MS = 930;
 const DICE_SFX_MIN_INTERVAL_MS = 850;
 const DEFAULT_CAPACITY = 4;


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder 3D dice roll match the Ludo Battle Royal physical throw so the cube performs a full spin arc instead of appearing to "shake" and to ensure the visible animation completes before the authoritative result is applied.
- Ensure the authoritative dice result is revealed only after the physical landing so token movement is synchronized and precise.
- Prevent visual overlap between snakes and ladders by assigning crossing jumps to distinct lanes/heights for a cleaner board layout.

### Description
- Aligned dice timing by changing `DICE_ROLL_DURATION` in `webapp/src/components/SnakeBoard3D.jsx` to `900` ms and kept the reveal timing comment/constant in `webapp/src/pages/Games/SnakeAndLadder.jsx` (`DICE_BOARD_ROLL_REVEAL_DELAY_MS = 930`) so the face is applied right after landing.
- Made lane resolution consider both snakes and ladders by passing the opposite jump map into `updateLadders` and `updateSnakes` and building a combined `allJumpEntries` list before calling `createJumpLaneResolver`, so crossing jumps are given distinct lane/side assignments (changes in `webapp/src/components/SnakeBoard3D.jsx`).
- Kept the 3D jump renderers synchronized by updating effect dependencies and calling the updated `updateLadders`/`updateSnakes` with the additional parameters so layout refreshes when either snakes or ladders change (hook dependency updates in `SnakeBoard3D.jsx`).

### Testing
- Ran ESLint: `npx eslint --no-ignore --no-warn-ignored src/components/SnakeBoard3D.jsx src/pages/Games/SnakeAndLadder.jsx` (succeeded).
- Built the frontend: `node scripts/run-vite-build.mjs` (production build completed successfully and assets updated).
- Ran repository checks: `git diff --check` (no check errors) and committed the changes as `Fix snake dice roll and jump layout`.
- Attempted automated visual validation with Playwright at a 390x844 portrait viewport, but the headless browser failed to launch in the container due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a716238ff3c8329b6482b146a21ad07)