### PR TITLE
Fix Chess Battle Royal online matchmaking recovery

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1273,6 +1273,7 @@ async function seatTableSocket(
   if (!map.has(String(accountId))) {
     map.set(String(accountId), {
       id: accountId,
+      tpcAccountNumber: String(accountId),
       name: playerName || String(accountId),
       avatar: playerAvatar || '',
       ts: Date.now(),
@@ -1281,6 +1282,7 @@ async function seatTableSocket(
     });
     table.players.push({
       id: accountId,
+      tpcAccountNumber: String(accountId),
       name: playerName || String(accountId),
       avatar: playerAvatar || '',
       position: 0,

--- a/test/chessLobbyAliasCriteriaMatchmaking.test.js
+++ b/test/chessLobbyAliasCriteriaMatchmaking.test.js
@@ -81,6 +81,10 @@ test(
       assert.equal(secondSeat.success, true);
       assert.equal(secondSeat.tableId, firstSeat.tableId);
       assert.equal(secondSeat.players.length, 2);
+      assert.deepEqual(
+        secondSeat.players.map((player) => player.tpcAccountNumber),
+        ['chess-alias-a', 'chess-alias-b']
+      );
     } finally {
       s1.disconnect();
       s2.disconnect();

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -308,6 +308,7 @@ export default function ChessBattleRoyalLobby() {
   const lobbyHandlersRef = useRef({
     gameStart: null,
     lobbyUpdate: null,
+    reconnect: null,
     connectError: null,
     disconnect: null,
     errorMessage: null
@@ -490,6 +491,7 @@ export default function ChessBattleRoyalLobby() {
     const {
       gameStart,
       lobbyUpdate,
+      reconnect,
       connectError,
       disconnect,
       errorMessage
@@ -499,12 +501,14 @@ export default function ChessBattleRoyalLobby() {
       socket.off('gameStarted', gameStart);
     }
     if (lobbyUpdate) socket.off('lobbyUpdate', lobbyUpdate);
+    if (reconnect) socket.off('connect', reconnect);
     if (connectError) socket.off('connect_error', connectError);
     if (disconnect) socket.off('disconnect', disconnect);
     if (errorMessage) socket.off('errorMessage', errorMessage);
     lobbyHandlersRef.current = {
       gameStart: null,
       lobbyUpdate: null,
+      reconnect: null,
       connectError: null,
       disconnect: null,
       errorMessage: null
@@ -669,6 +673,22 @@ export default function ChessBattleRoyalLobby() {
       }
     };
 
+    // A Socket.IO reconnect creates a new server-side socket. The server removes
+    // lobby seats owned by the disconnected socket, so merely reconnecting the
+    // transport leaves the player looking for a match forever. Re-register the
+    // canonical TPC account and restore the same seat after every reconnect.
+    const handleReconnect = async () => {
+      const interruptedTableId = pendingTableRef.current;
+      if (!interruptedTableId) return;
+      setMatchStatus('Restoring your lobby seat…');
+      const registered = await ensureSocketRegistered(seatAccountId);
+      if (!registered || !pendingTableRef.current) {
+        setMatchError('Could not restore your TPC account session. Please retry.');
+        return;
+      }
+      seatPlayer(interruptedTableId, true);
+    };
+
     const handleErrorMessage = (error) => {
       if (!pendingTableRef.current) return;
       const message = resolveSeatErrorMessage(error);
@@ -681,12 +701,14 @@ export default function ChessBattleRoyalLobby() {
     socket.on('gameStart', handleGameStart);
     socket.on('gameStarted', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
+    socket.on('connect', handleReconnect);
     socket.on('connect_error', handleConnectError);
     socket.on('disconnect', handleDisconnect);
     socket.on('errorMessage', handleErrorMessage);
     lobbyHandlersRef.current = {
       gameStart: handleGameStart,
       lobbyUpdate: handleLobbyUpdate,
+      reconnect: handleReconnect,
       connectError: handleConnectError,
       disconnect: handleDisconnect,
       errorMessage: handleErrorMessage
@@ -704,8 +726,8 @@ export default function ChessBattleRoyalLobby() {
       getTelegramFirstName() || getTelegramUsername() || 'Player';
     let seatAttempts = 0;
     const maxSeatAttempts = 4;
-    const seatPlayer = () => {
-      seatAttempts += 1;
+    const seatPlayer = (tableIdOverride = '', reconnecting = false) => {
+      if (!reconnecting) seatAttempts += 1;
       socket.emit(
         'seatTable',
         {
@@ -714,7 +736,7 @@ export default function ChessBattleRoyalLobby() {
           tpcAccountId: seatAccountId,
           gameType: 'chess',
           stake: stake.amount ?? 0,
-          tableId: hostedTableId || undefined,
+          tableId: tableIdOverride || hostedTableId || undefined,
           maxPlayers: 2,
           mode: 'online',
           playerName: friendlyName,
@@ -726,7 +748,7 @@ export default function ChessBattleRoyalLobby() {
           if (!res?.success || !res.tableId) {
             const shouldRetry =
               MATCHMAKING_RECOVERABLE_ERRORS.has(res?.error) &&
-              seatAttempts < maxSeatAttempts;
+              (reconnecting || seatAttempts < maxSeatAttempts);
             if (shouldRetry) {
               const retryDelay = Math.min(
                 SEAT_RETRY_BASE_DELAY_MS * 2 ** (seatAttempts - 1),
@@ -763,7 +785,7 @@ export default function ChessBattleRoyalLobby() {
                     return;
                   }
                 }
-                seatPlayer();
+                seatPlayer(tableIdOverride, reconnecting);
               }, retryDelay);
               return;
             }


### PR DESCRIPTION
### Motivation

- Players were getting stuck in online matchmaking after Socket.IO reconnects because the server removes seats owned by the previous socket and the client did not re-register/restored its seat. 
- Matchmaking and lobby state should be tracked by the canonical unique TPC account number so players keep their identity across reconnects.

### Description

- Add a reconnect recovery flow in `ChessBattleRoyalLobby.jsx` that listens for socket `connect`, re-registers the canonical TPC identity via `ensureSocketRegistered`, and re-attempts seating using the original table id so seats are restored after Socket.IO reconnects. 
- Make `seatPlayer` accept a `tableIdOverride` and `reconnecting` flag so seat requests can be retried and can preserve the intended table id during recovery attempts. 
- Wire the reconnect handler into `lobbyHandlersRef` and ensure the `connect` listener is removed in `cleanupLobby` to avoid duplicate handlers. 
- Expose `tpcAccountNumber` in server-side matchmaking records by adding `tpcAccountNumber` to the seat map entries and `table.players` objects in `bot/server.js` so matched player objects include their canonical TPC id. 
- Add an integration assertion in `test/chessLobbyAliasCriteriaMatchmaking.test.js` to verify matched players contain the expected `tpcAccountNumber` values.

### Testing

- Ran the matchmaking-related integration tests with `node --test test/chessLobbyAliasCriteriaMatchmaking.test.js test/chessLobbyPreferredSideMatchmaking.test.js test/chessOnlineMoveValidation.test.js` and all 3 tests passed. 
- Ran the single alias test `node --test test/chessLobbyAliasCriteriaMatchmaking.test.js` after adding the TPC assertion and it passed. 
- Built the webapp with `npm --prefix webapp run build` and the Vite production build completed successfully. 
- Executed `git diff --check` and `npx eslint` during verification; ESLint reported many pre-existing style errors in the legacy `bot/server.js` but these did not affect the functional tests or the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71670c3ca483299402cc03554566b1)