### PR TITLE
Fix Chess Battle Royal online matchmaking: atomic seating, table numbers, and UI propagation

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -48,7 +48,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
-import { randomUUID } from 'crypto';
+import { randomInt, randomUUID } from 'crypto';
 import {
   createDominoTableNumber,
   isDominoMatchCompatible,
@@ -477,6 +477,15 @@ const poolStates = new Map();
 const snookerStates = new Map();
 const dominoRoyalStates = new Map();
 const dominoRoyalTableNumbers = new Set();
+const chessTableNumbers = new Set();
+
+function createChessTableNumber() {
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    const number = `CBR-${String(randomInt(1_000_000)).padStart(6, '0')}`;
+    if (!chessTableNumbers.has(number)) return number;
+  }
+  return `CBR-${Date.now().toString(36).toUpperCase()}`;
+}
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
@@ -657,7 +666,9 @@ function createLobbyTable({
     tableNumber:
       gameType === 'domino-royal'
         ? createDominoTableNumber((number) => dominoRoyalTableNumbers.has(number))
-        : null,
+        : gameType === 'chess'
+          ? createChessTableNumber()
+          : null,
     gameType,
     stake,
     maxPlayers,
@@ -666,7 +677,10 @@ function createLobbyTable({
     ready: new Set(),
     meta
   };
-  if (table.tableNumber) dominoRoyalTableNumbers.add(table.tableNumber);
+  if (gameType === 'domino-royal' && table.tableNumber) {
+    dominoRoyalTableNumbers.add(table.tableNumber);
+  }
+  if (gameType === 'chess' && table.tableNumber) chessTableNumbers.add(table.tableNumber);
   lobbyTables[key].push(table);
   tableMap.set(table.id, table);
   console.log(
@@ -1433,6 +1447,9 @@ function unseatTableSocket(accountId, tableId, socketId) {
       if (table.gameType === 'domino-royal') {
         dominoRoyalStates.delete(tableId);
         if (table.tableNumber) dominoRoyalTableNumbers.delete(table.tableNumber);
+      }
+      if (table.gameType === 'chess' && table.tableNumber) {
+        chessTableNumbers.delete(table.tableNumber);
       }
       tableMap.delete(tableId);
       const key = `${table.gameType}-${table.maxPlayers}`;

--- a/test/chessLobbyAliasCriteriaMatchmaking.test.js
+++ b/test/chessLobbyAliasCriteriaMatchmaking.test.js
@@ -65,7 +65,8 @@ test(
         maxPlayers: 2,
         mode: 'Online',
         token: 'TPC',
-        preferredSide: 'WHITE'
+        preferredSide: 'WHITE',
+        ready: true
       });
       const secondSeat = await seat(s2, {
         accountId: 'chess-alias-b',
@@ -74,17 +75,26 @@ test(
         maxPlayers: 2,
         mode: 'online',
         token: 'tpc',
-        preferredSide: 'black'
+        preferredSide: 'black',
+        ready: true
       });
 
       assert.equal(firstSeat.success, true);
       assert.equal(secondSeat.success, true);
       assert.equal(secondSeat.tableId, firstSeat.tableId);
+      assert.match(firstSeat.tableNumber, /^CBR-\w{6,}$/);
+      assert.equal(secondSeat.tableNumber, firstSeat.tableNumber);
       assert.equal(secondSeat.players.length, 2);
       assert.deepEqual(
         secondSeat.players.map((player) => player.tpcAccountNumber),
         ['chess-alias-a', 'chess-alias-b']
       );
+      const [gameStartA, gameStartB] = await Promise.all([
+        new Promise((resolve) => s1.once('gameStart', resolve)),
+        new Promise((resolve) => s2.once('gameStart', resolve))
+      ]);
+      assert.equal(gameStartA.tableId, firstSeat.tableId);
+      assert.equal(gameStartB.tableNumber, firstSeat.tableNumber);
     } finally {
       s1.disconnect();
       s2.disconnect();

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8939,6 +8939,7 @@ function Chess3D({
   initialAiFlag,
   accountId,
   initialTableId,
+  initialTableNumber,
   initialSide,
   initialOpponent
 }) {
@@ -16854,7 +16855,9 @@ function Chess3D({
                   : `Status: ${onlineStatus}`}
               </div>
               {tableId && (
-                <div className="text-[10px] text-emerald-50/70">Table {tableId.slice(0, 8)}</div>
+                <div className="text-[10px] text-emerald-50/70">
+                  Table {initialTableNumber || tableId.slice(0, 8)}
+                </div>
               )}
             </div>
           )}
@@ -17540,6 +17543,7 @@ export default function ChessBattleRoyal() {
   const initialAccountId = params.get('accountId') || '';
   const mode = params.get('mode') || 'ai';
   const initialTableId = params.get('tableId') || '';
+  const initialTableNumber = params.get('tableNumber') || '';
   const preferredSideParam = params.get('preferredSide');
   const [accountId, setAccountId] = useState(initialAccountId);
   const [redirecting, setRedirecting] = useState(false);
@@ -17600,6 +17604,7 @@ export default function ChessBattleRoyal() {
       initialAiFlag={initialAiFlag}
       accountId={accountId}
       initialTableId={initialTableId}
+      initialTableNumber={initialTableNumber}
       initialSide={initialSide}
       initialOpponent={initialOpponent}
     />

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -305,6 +305,7 @@ export default function ChessBattleRoyalLobby() {
   const [matchError, setMatchError] = useState('');
   const preferredSide = 'auto';
   const pendingTableRef = useRef('');
+  const [tableNumber, setTableNumber] = useState('');
   const lobbyHandlersRef = useRef({
     gameStart: null,
     lobbyUpdate: null,
@@ -522,6 +523,7 @@ export default function ChessBattleRoyalLobby() {
       });
     }
     pendingTableRef.current = '';
+    setTableNumber('');
     setMatching(false);
     setMatchStatus('');
     setMatchPlayers([]);
@@ -636,10 +638,12 @@ export default function ChessBattleRoyalLobby() {
 
     const handleLobbyUpdate = ({
       tableId: tid,
+      tableNumber: updatedTableNumber,
       players: list = [],
       ready = []
     } = {}) => {
       if (!tid || String(tid) !== String(pendingTableRef.current)) return;
+      if (updatedTableNumber) setTableNumber(String(updatedTableNumber));
       const playersList = Array.isArray(list) ? list : [];
       const readyIds = Array.isArray(ready) ? ready.map((id) => String(id)) : [];
       setMatchPlayers(playersList);
@@ -647,7 +651,11 @@ export default function ChessBattleRoyalLobby() {
       setMatchStatus(resolveLobbyStatus(playersList, readyIds, seatAccountId));
     };
 
-    const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
+    const handleGameStart = ({
+      tableId: startedId,
+      tableNumber: startedTableNumber,
+      players = []
+    } = {}) => {
       if (!startedId || String(startedId) !== String(pendingTableRef.current)) return;
       stakeCharged = false;
       const mySide = resolveChessSide(players, seatAccountId);
@@ -657,6 +665,7 @@ export default function ChessBattleRoyalLobby() {
         tgId,
         trackedAccountId,
         tableId: startedId,
+        tableNumber: startedTableNumber,
         side: mySide,
         opponentName: resolvePlayerName(opp),
         opponentAvatar: opp?.avatar
@@ -742,7 +751,9 @@ export default function ChessBattleRoyalLobby() {
           playerName: friendlyName,
           avatar,
           preferredSide,
-          token: stake.token
+          token: stake.token,
+          // Seat and ready are atomic so a reconnect cannot lose confirmReady.
+          ready: true
         },
         async (res) => {
           if (!res?.success || !res.tableId) {
@@ -796,6 +807,7 @@ export default function ChessBattleRoyalLobby() {
             return;
           }
           pendingTableRef.current = res.tableId;
+          setTableNumber(String(res.tableNumber || ''));
           setMatchPlayers(Array.isArray(res.players) ? res.players : []);
           setReadyList(
             Array.isArray(res.ready) ? res.ready.map((id) => String(id)) : []
@@ -805,12 +817,6 @@ export default function ChessBattleRoyalLobby() {
               ? resolvePrivateMatchStatus(res.tableId, hostCodeInput)
               : resolveLobbyStatus(res.players, res.ready, seatAccountId)
           );
-          socket.emit('confirmReady', {
-            accountId: seatAccountId,
-            tpcAccountNumber: seatAccountId,
-            tpcAccountId: seatAccountId,
-            tableId: res.tableId
-          });
           cleanupRef.current = () => {
             clearTimeout(matchTimeout);
             matchmakingTimeoutRef.current = null;
@@ -1035,6 +1041,11 @@ export default function ChessBattleRoyalLobby() {
             <p className="text-sm text-white/60">
               {matchStatus || 'Syncing with the lobby…'}
             </p>
+            {tableNumber && (
+              <p className="text-center text-sm font-semibold text-emerald-300">
+                Table {tableNumber}
+              </p>
+            )}
             <div className="lobby-tile w-full flex items-center justify-between">
               <span>🎯 {spinningPlayer || 'Searching…'}</span>
               <span className="text-xs text-white/60">


### PR DESCRIPTION
### Motivation

- Prevent players from being left waiting when a separate `confirmReady` is lost during reconnects by making seating and ready confirmation atomic. 
- Provide a human-readable table identifier for Chess Battle Royal so matched players can verify they share the same table. 
- Surface the assigned table number in lobby UI and game view so players know they were matched correctly.

### Description

- Server: add `chessTableNumbers` set and `createChessTableNumber()` to produce unique `CBR-######` table numbers and avoid collisions, and register/cleanup those numbers when tables are created or removed (`bot/server.js`).
- Server: create chess table numbers in `createLobbyTable()` when the `gameType` is `chess` and keep table-number bookkeeping in `unseatTableSocket()` cleanup (`bot/server.js`).
- Client (Lobby): send `ready: true` together with `seatTable` so seating + ready are atomic, remove the separate `confirmReady` call, store `tableNumber` from server updates, and show the table number in the matchmaking panel (`webapp/src/pages/Games/ChessBattleRoyalLobby.jsx`).
- Client (Game): accept and display `tableNumber` on the game screen and pass `initialTableNumber` into the 3D component to display the human-friendly table ID (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Tests: extend the chess alias matchmaking integration test to request seats as ready in one step and assert both players receive the same `CBR-######` table number and that `gameStart` is emitted to both clients (`test/chessLobbyAliasCriteriaMatchmaking.test.js`).
- Commit: changes committed under message `Fix chess battle royal online matchmaking`.

### Testing

- Ran `git diff --check` with no reported lint diffs related to the changes (passed). 
- Built the webapp (`npx vite build`) successfully to verify client changes (passed). 
- Ran unit/integration test attempts for the chess lobby, but the in-environment bot/server tests were cancelled due to missing native dependencies in the sandbox (first missing modules like `compression`/`mongoose` then `canvas` native binary), so the full Node tests did not complete in this environment (failed due to environment constraints). 
- Attempted an automated headless snapshot via Playwright but the Chromium browser was not installed in the environment so the screenshot step could not run (failed due to environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a716b8258a88329864757fe50a2388e)