### PR TITLE
Add chess table numbers and auto-ready/start for Chess Battle Royal; surface tableNumber in UI

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -48,7 +48,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
-import { randomUUID } from 'crypto';
+import { randomInt, randomUUID } from 'crypto';
 import {
   createDominoTableNumber,
   isDominoMatchCompatible,
@@ -477,6 +477,15 @@ const poolStates = new Map();
 const snookerStates = new Map();
 const dominoRoyalStates = new Map();
 const dominoRoyalTableNumbers = new Set();
+const chessTableNumbers = new Set();
+
+function createChessTableNumber() {
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    const number = `CBR-${String(randomInt(1_000_000)).padStart(6, '0')}`;
+    if (!chessTableNumbers.has(number)) return number;
+  }
+  return `CBR-${Date.now().toString(36).toUpperCase()}`;
+}
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
@@ -657,7 +666,9 @@ function createLobbyTable({
     tableNumber:
       gameType === 'domino-royal'
         ? createDominoTableNumber((number) => dominoRoyalTableNumbers.has(number))
-        : null,
+        : gameType === 'chess'
+          ? createChessTableNumber()
+          : null,
     gameType,
     stake,
     maxPlayers,
@@ -666,7 +677,10 @@ function createLobbyTable({
     ready: new Set(),
     meta
   };
-  if (table.tableNumber) dominoRoyalTableNumbers.add(table.tableNumber);
+  if (gameType === 'domino-royal' && table.tableNumber) {
+    dominoRoyalTableNumbers.add(table.tableNumber);
+  }
+  if (gameType === 'chess' && table.tableNumber) chessTableNumbers.add(table.tableNumber);
   lobbyTables[key].push(table);
   tableMap.set(table.id, table);
   console.log(
@@ -1434,6 +1448,9 @@ function unseatTableSocket(accountId, tableId, socketId) {
         dominoRoyalStates.delete(tableId);
         if (table.tableNumber) dominoRoyalTableNumbers.delete(table.tableNumber);
       }
+      if (table.gameType === 'chess' && table.tableNumber) {
+        chessTableNumbers.delete(table.tableNumber);
+      }
       tableMap.delete(tableId);
       const key = `${table.gameType}-${table.maxPlayers}`;
       lobbyTables[key] = (lobbyTables[key] || []).filter(
@@ -2171,7 +2188,12 @@ io.on('connection', (socket) => {
         );
       }
       if (table) {
-        if (readyOnJoin) {
+        // Chess quick matches have no separate ready-up screen. Once a player
+        // owns a seat, that seat is ready. Keeping this server-authoritative
+        // also lets older/mobile clients match when confirmReady is delayed or
+        // lost while Telegram's WebView reconnects.
+        const shouldReadySeat = validation.normalizedGameType === 'chess' || readyOnJoin;
+        if (shouldReadySeat) {
           table.ready.add(String(resolvedAccountId));
           io.to(table.id).emit('lobbyUpdate', {
             tableId: table.id,
@@ -2181,7 +2203,6 @@ io.on('connection', (socket) => {
             ready: Array.from(table.ready),
             meta: table.meta
           });
-          maybeStartGame(table);
         }
         cb && cb({
           success: true,
@@ -2192,6 +2213,7 @@ io.on('connection', (socket) => {
           ready: Array.from(table.ready),
           meta: table.meta
         });
+        if (shouldReadySeat) maybeStartGame(table);
       } else if (cb) {
         cb({ success: false, error: 'table_join_failed' });
       }

--- a/test/chessLobbyAliasCriteriaMatchmaking.test.js
+++ b/test/chessLobbyAliasCriteriaMatchmaking.test.js
@@ -80,11 +80,21 @@ test(
       assert.equal(firstSeat.success, true);
       assert.equal(secondSeat.success, true);
       assert.equal(secondSeat.tableId, firstSeat.tableId);
+      assert.match(firstSeat.tableNumber, /^CBR-\w{6,}$/);
+      assert.equal(secondSeat.tableNumber, firstSeat.tableNumber);
       assert.equal(secondSeat.players.length, 2);
       assert.deepEqual(
         secondSeat.players.map((player) => player.tpcAccountNumber),
         ['chess-alias-a', 'chess-alias-b']
       );
+      // Chess has no ready-up screen: seating the second same-stake player is
+      // sufficient to start both clients without a confirmReady round trip.
+      const [gameStartA, gameStartB] = await Promise.all([
+        new Promise((resolve) => s1.once('gameStart', resolve)),
+        new Promise((resolve) => s2.once('gameStart', resolve))
+      ]);
+      assert.equal(gameStartA.tableId, firstSeat.tableId);
+      assert.equal(gameStartB.tableNumber, firstSeat.tableNumber);
     } finally {
       s1.disconnect();
       s2.disconnect();

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8939,6 +8939,7 @@ function Chess3D({
   initialAiFlag,
   accountId,
   initialTableId,
+  initialTableNumber,
   initialSide,
   initialOpponent
 }) {
@@ -16854,7 +16855,9 @@ function Chess3D({
                   : `Status: ${onlineStatus}`}
               </div>
               {tableId && (
-                <div className="text-[10px] text-emerald-50/70">Table {tableId.slice(0, 8)}</div>
+                <div className="text-[10px] text-emerald-50/70">
+                  Table {initialTableNumber || tableId.slice(0, 8)}
+                </div>
               )}
             </div>
           )}
@@ -17540,6 +17543,7 @@ export default function ChessBattleRoyal() {
   const initialAccountId = params.get('accountId') || '';
   const mode = params.get('mode') || 'ai';
   const initialTableId = params.get('tableId') || '';
+  const initialTableNumber = params.get('tableNumber') || '';
   const preferredSideParam = params.get('preferredSide');
   const [accountId, setAccountId] = useState(initialAccountId);
   const [redirecting, setRedirecting] = useState(false);
@@ -17600,6 +17604,7 @@ export default function ChessBattleRoyal() {
       initialAiFlag={initialAiFlag}
       accountId={accountId}
       initialTableId={initialTableId}
+      initialTableNumber={initialTableNumber}
       initialSide={initialSide}
       initialOpponent={initialOpponent}
     />

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -305,6 +305,7 @@ export default function ChessBattleRoyalLobby() {
   const [matchError, setMatchError] = useState('');
   const preferredSide = 'auto';
   const pendingTableRef = useRef('');
+  const [tableNumber, setTableNumber] = useState('');
   const lobbyHandlersRef = useRef({
     gameStart: null,
     lobbyUpdate: null,
@@ -522,6 +523,7 @@ export default function ChessBattleRoyalLobby() {
       });
     }
     pendingTableRef.current = '';
+    setTableNumber('');
     setMatching(false);
     setMatchStatus('');
     setMatchPlayers([]);
@@ -636,10 +638,12 @@ export default function ChessBattleRoyalLobby() {
 
     const handleLobbyUpdate = ({
       tableId: tid,
+      tableNumber: updatedTableNumber,
       players: list = [],
       ready = []
     } = {}) => {
       if (!tid || String(tid) !== String(pendingTableRef.current)) return;
+      if (updatedTableNumber) setTableNumber(String(updatedTableNumber));
       const playersList = Array.isArray(list) ? list : [];
       const readyIds = Array.isArray(ready) ? ready.map((id) => String(id)) : [];
       setMatchPlayers(playersList);
@@ -647,7 +651,11 @@ export default function ChessBattleRoyalLobby() {
       setMatchStatus(resolveLobbyStatus(playersList, readyIds, seatAccountId));
     };
 
-    const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
+    const handleGameStart = ({
+      tableId: startedId,
+      tableNumber: startedTableNumber,
+      players = []
+    } = {}) => {
       if (!startedId || String(startedId) !== String(pendingTableRef.current)) return;
       stakeCharged = false;
       const mySide = resolveChessSide(players, seatAccountId);
@@ -657,6 +665,7 @@ export default function ChessBattleRoyalLobby() {
         tgId,
         trackedAccountId,
         tableId: startedId,
+        tableNumber: startedTableNumber,
         side: mySide,
         opponentName: resolvePlayerName(opp),
         opponentAvatar: opp?.avatar
@@ -796,6 +805,7 @@ export default function ChessBattleRoyalLobby() {
             return;
           }
           pendingTableRef.current = res.tableId;
+          setTableNumber(String(res.tableNumber || ''));
           setMatchPlayers(Array.isArray(res.players) ? res.players : []);
           setReadyList(
             Array.isArray(res.ready) ? res.ready.map((id) => String(id)) : []
@@ -805,12 +815,6 @@ export default function ChessBattleRoyalLobby() {
               ? resolvePrivateMatchStatus(res.tableId, hostCodeInput)
               : resolveLobbyStatus(res.players, res.ready, seatAccountId)
           );
-          socket.emit('confirmReady', {
-            accountId: seatAccountId,
-            tpcAccountNumber: seatAccountId,
-            tpcAccountId: seatAccountId,
-            tableId: res.tableId
-          });
           cleanupRef.current = () => {
             clearTimeout(matchTimeout);
             matchmakingTimeoutRef.current = null;
@@ -1035,6 +1039,11 @@ export default function ChessBattleRoyalLobby() {
             <p className="text-sm text-white/60">
               {matchStatus || 'Syncing with the lobby…'}
             </p>
+            {tableNumber && (
+              <p className="text-center text-sm font-semibold text-emerald-300">
+                Table {tableNumber}
+              </p>
+            )}
             <div className="lobby-tile w-full flex items-center justify-between">
               <span>🎯 {spinningPlayer || 'Searching…'}</span>
               <span className="text-xs text-white/60">


### PR DESCRIPTION
### Motivation
- Provide persistent, human-readable table identifiers for Chess Battle Royal matches to improve UX and linking.
- Make chess quick-matches start immediately without requiring a separate client `confirmReady` round trip to improve reliability across reconnects.
- Surface the server-assigned table number in the webapp lobby and game UI so players can see/share the table identifier.
- Ensure matchmaking tests validate the new behavior and number format.

### Description
- Import `randomInt` and add a `chessTableNumbers` set and `createChessTableNumber()` that generates `CBR-` prefixed IDs for chess tables.
- Assign a `tableNumber` for lobby tables when `gameType === 'chess'` inside `createLobbyTable` and ensure removal from `chessTableNumbers` on table cleanup in `unseatTableSocket`.
- Make the server treat chess seats as implicitly ready by adding server-side ready-up for chess and calling `maybeStartGame()` immediately for chess or when `readyOnJoin` applies.
- Update the client: pass and display `initialTableNumber` in `ChessBattleRoyal.jsx` and track/show `tableNumber` in `ChessBattleRoyalLobby.jsx`, and remove the now-unnecessary client `confirmReady` emission path.
- Update the test `test/chessLobbyAliasCriteriaMatchmaking.test.js` to assert the `tableNumber` format, assert both seats share the same table number, and wait for `gameStart` events to validate auto-start behavior.

### Testing
- Ran the project test suite (`npm test`) including the updated `chessLobbyAliasCriteriaMatchmaking.test.js` test, and the test passed.
- Verified the modified lobby flow emits `lobbyUpdate` with `tableNumber` and that the clients display the table number during matching and in-game via updated UI props.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a716b8258a88329864757fe50a2388e)