### PR TITLE
Chess Battle Royal: quick-match by stake only, isolate private tables, clean stale seats

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -547,6 +547,14 @@ function normalizeMatchMeta(rawMeta = {}) {
 function isMatchMetaCompatible(existing = {}, requested = {}, gameType = '') {
   const normalizedGameType = String(gameType || '').trim().toLowerCase();
 
+  if (normalizedGameType === 'chess') {
+    // Chess Battle Royal quick matchmaking has one queue criterion: stake.
+    // Color, client mode labels, token casing, and other lobby metadata are
+    // seat/game preferences and must never split otherwise compatible users.
+    // The numeric stake is compared by getAvailableTable.
+    return true;
+  }
+
   if (normalizedGameType === 'domino-royal') {
     return isDominoMatchCompatible(existing, requested);
   }
@@ -729,6 +737,7 @@ function getAvailableTable(
     (t) =>
       t.stake === stake &&
       t.players.length < t.maxPlayers &&
+      !isReservedHostedTableId(t.id, gameType, maxPlayers) &&
       isMatchMetaCompatible(t.meta, normalizedMeta, gameType)
   );
   if (open) return open;
@@ -1263,6 +1272,9 @@ async function seatTableSocket(
   console.log(
     `Seating player ${playerName || accountId} at ${gameType}-${maxPlayers} (stake ${stake})`
   );
+  // Remove disconnected/expired seats before choosing an open table so a
+  // quick-match request always searches the current queue state.
+  cleanupSeats();
   const table = getAvailableTable(
     gameType,
     stake,
@@ -1272,7 +1284,6 @@ async function seatTableSocket(
   );
   if (!table) return null;
   const tableId = table.id;
-  cleanupSeats();
   // Ensure this user is not seated at any other table
   for (const id of Array.from(tableSeats.keys())) {
     if (id !== tableId && tableSeats.get(id)?.has(String(accountId))) {

--- a/test/chessLobbyAliasCriteriaMatchmaking.test.js
+++ b/test/chessLobbyAliasCriteriaMatchmaking.test.js
@@ -72,8 +72,10 @@ test(
         gameType: 'chess-battle-royale',
         stake: 100,
         maxPlayers: 2,
-        mode: 'online',
-        token: 'tpc',
+        // Quick matchmaking intentionally ignores every criterion except the
+        // numeric stake, including legacy client mode/token metadata.
+        mode: 'ranked',
+        token: 'legacy-tpc',
         preferredSide: 'black'
       });
 

--- a/test/chessLobbyPrivateCodeIsolation.test.js
+++ b/test/chessLobbyPrivateCodeIsolation.test.js
@@ -40,12 +40,14 @@ test(
     };
     const server = await startServer(env);
     const quick = io('http://localhost:3214', { auth: { token: apiToken } });
+    const quickB = io('http://localhost:3214', { auth: { token: apiToken } });
     const privateA = io('http://localhost:3214', { auth: { token: apiToken } });
     const privateB = io('http://localhost:3214', { auth: { token: apiToken } });
 
     try {
       await Promise.all([
         new Promise((resolve) => quick.on('connect', resolve)),
+        new Promise((resolve) => quickB.on('connect', resolve)),
         new Promise((resolve) => privateA.on('connect', resolve)),
         new Promise((resolve) => privateB.on('connect', resolve))
       ]);
@@ -56,6 +58,7 @@ test(
         });
       await Promise.all([
         register(quick, 'chess-private-quick'),
+        register(quickB, 'chess-private-quick-b'),
         register(privateA, 'chess-private-a'),
         register(privateB, 'chess-private-b')
       ]);
@@ -65,14 +68,6 @@ test(
           socket.emit('seatTable', payload, resolve);
         });
 
-      const quickSeat = await seat(quick, {
-        accountId: 'chess-private-quick',
-        gameType: 'chess',
-        stake: 100,
-        maxPlayers: 2,
-        mode: 'online',
-        token: 'TPC'
-      });
       const codedSeatA = await seat(privateA, {
         accountId: 'chess-private-a',
         gameType: 'chess',
@@ -81,6 +76,22 @@ test(
         mode: 'online',
         token: 'TPC',
         tableId: 'chess-2-host-FRIEND123'
+      });
+      const quickSeat = await seat(quick, {
+        accountId: 'chess-private-quick',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC'
+      });
+      const quickSeatB = await seat(quickB, {
+        accountId: 'chess-private-quick-b',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC'
       });
       const codedSeatB = await seat(privateB, {
         accountId: 'chess-private-b',
@@ -95,11 +106,14 @@ test(
       assert.equal(quickSeat.success, true);
       assert.equal(codedSeatA.success, true);
       assert.equal(codedSeatB.success, true);
+      assert.equal(quickSeatB.success, true);
       assert.notEqual(codedSeatA.tableId, quickSeat.tableId);
+      assert.equal(quickSeatB.tableId, quickSeat.tableId);
       assert.equal(codedSeatA.tableId, 'chess-2-host-FRIEND123');
       assert.equal(codedSeatB.tableId, codedSeatA.tableId);
     } finally {
       quick.disconnect();
+      quickB.disconnect();
       privateA.disconnect();
       privateB.disconnect();
       server.kill();


### PR DESCRIPTION
### Motivation
- Quick matchmaking for Chess Battle Royal was splitting compatible players due to legacy metadata (mode/token casing, preferred side) and could seat quick-match players into private code-hosted tables; this change ensures quick-match pairs only by stake and avoids private table collisions.

### Description
- For `chess` games `isMatchMetaCompatible` now treats all match metadata as compatible so quick-match only uses the numeric stake as the matchmaking partition. (`bot/server.js`)
- `getAvailableTable` excludes reserved/hosted table ids from public quick-match selection so private code tables remain isolated from the public queue. (`bot/server.js`)
- Move `cleanupSeats()` ahead of table selection in `seatTableSocket` so stale or disconnected seats are removed before choosing an open table. (`bot/server.js`)
- Update/add regression tests to cover legacy metadata and private-table isolation by exercising different game aliases, mode/token variants, and multiple quick-match clients. (`test/chessLobbyAliasCriteriaMatchmaking.test.js`, `test/chessLobbyPrivateCodeIsolation.test.js`)

### Testing
- Ran `node --test test/chessLobbyAliasCriteriaMatchmaking.test.js test/chessLobbyPrivateCodeIsolation.test.js test/chessLobbyPreferredSideMatchmaking.test.js test/chessLobbyStaleTableIdMatchmaking.test.js`, and all tests passed (5/5).
- Ran `git diff --check` with no issues reported.
- Ran `npx eslint` on the changed files which completed without errors but produced warnings that the files are excluded by the repository ignore configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71a4595a508329a9540b466a5578ec)