### PR TITLE
Fix expired Chess quick-match seats (prevent ghost opponents)

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -489,6 +489,7 @@ function createChessTableNumber() {
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
+const lobbySeatTtlMs = Number(process.env.LOBBY_SEAT_TTL_MS) || 60_000;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
 
@@ -781,9 +782,14 @@ function cleanupSeats() {
   const now = Date.now();
   for (const [tableId, players] of tableSeats) {
     for (const [pid, info] of players) {
-      if (now - info.ts > 60_000) players.delete(pid);
+      if (now - info.ts > lobbySeatTtlMs) {
+        // Keep the public table and its authoritative seat map in sync. Merely
+        // deleting the seat-map entry leaves a ghost in table.players; the next
+        // quick-match player can then be started against that disconnected
+        // ghost instead of another person who is genuinely waiting.
+        unseatTableSocket(pid, tableId, info.socketId);
+      }
     }
-    if (players.size === 0) tableSeats.delete(tableId);
   }
 }
 

--- a/test/chessLobbyExpiredSeatMatchmaking.test.js
+++ b/test/chessLobbyExpiredSeatMatchmaking.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test(
+  'chess quick matchmaking removes expired players instead of starting against a ghost seat',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const server = await startServer({
+      ...process.env,
+      PORT: '3222',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      LOBBY_SEAT_TTL_MS: '50',
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    });
+    const stale = io('http://localhost:3222', { auth: { token: apiToken } });
+    const waiting = io('http://localhost:3222', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => stale.on('connect', resolve)),
+        new Promise((resolve) => waiting.on('connect', resolve))
+      ]);
+      await Promise.all([
+        new Promise((resolve) => stale.emit('register', { playerId: 'expired-chess-player' }, resolve)),
+        new Promise((resolve) => waiting.emit('register', { playerId: 'waiting-chess-player' }, resolve))
+      ]);
+
+      const seat = (socket, accountId) =>
+        new Promise((resolve) => socket.emit('seatTable', {
+          accountId,
+          gameType: 'chess',
+          stake: 100,
+          maxPlayers: 2,
+          mode: 'online',
+          token: 'TPC'
+        }, resolve));
+
+      const staleSeat = await seat(stale, 'expired-chess-player');
+      assert.equal(staleSeat.success, true);
+      await delay(80);
+
+      const waitingSeat = await seat(waiting, 'waiting-chess-player');
+      assert.equal(waitingSeat.success, true);
+      assert.notEqual(waitingSeat.tableId, staleSeat.tableId);
+      assert.deepEqual(
+        waitingSeat.players.map((player) => player.tpcAccountNumber),
+        ['waiting-chess-player']
+      );
+    } finally {
+      stale.disconnect();
+      waiting.disconnect();
+      server.kill();
+    }
+  }
+);


### PR DESCRIPTION
### Motivation
- Quick-match could pair active players with stale/disconnected seats because expired seat entries were only removed from the seat registry, leaving ghost entries in the authoritative lobby table that other players could be matched against.
- Ensure online chess matchmaking only pairs genuinely waiting players and keep private/hosted tables isolated from quick-match queues.

### Description
- Add a configurable lobby seat TTL `lobbySeatTtlMs` (env `LOBBY_SEAT_TTL_MS`) with a default of `60000` ms to control when queued seats expire.
- Replace blind deletion of expired entries in `cleanupSeats` with a call to `unseatTableSocket(pid, tableId, info.socketId)` so expired seats are removed from both the seat registry and the authoritative `table.players` list, preventing ghost matches.
- Add an integration regression test `test/chessLobbyExpiredSeatMatchmaking.test.js` that starts the server with a short `LOBBY_SEAT_TTL_MS`, creates an expired seat, then verifies a subsequent quick-match request is not assigned the stale table.
- Keep existing private/hosted-table handling unchanged so coded tables remain isolated from quick matchmaking.

### Testing
- Ran `node --test test/chessLobbyExpiredSeatMatchmaking.test.js test/chessLobbyAliasCriteriaMatchmaking.test.js test/chessLobbyPrivateCodeIsolation.test.js test/chessLobbyStaleTableIdMatchmaking.test.js`, and all tests passed (5/5).
- Ran `npx eslint bot/server.js test/chessLobbyExpiredSeatMatchmaking.test.js`, which reported only ignore warnings and no lint errors.
- Ran `git diff --check` with no problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71a6b5c56c8329a51391367b3abfa9)