### PR TITLE
Keep Chess quick-match seats through mobile reconnects

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -703,7 +703,8 @@ function getAvailableTable(
   stake = 0,
   maxPlayers = 4,
   matchMeta = {},
-  forcedTableId = null
+  forcedTableId = null,
+  accountId = ''
 ) {
   const normalizedMeta = normalizeMatchMeta(matchMeta);
   const key = `${gameType}-${maxPlayers}`;
@@ -713,10 +714,13 @@ function getAvailableTable(
     const existing = tableMap.get(forcedTableId);
     if (existing) {
       const normalizedStake = Number(stake) || 0;
+      const alreadySeated = existing.players.some(
+        (player) => String(player.id) === String(accountId)
+      );
       const canJoinForced =
         existing.gameType === gameType &&
         Number(existing.stake || 0) === normalizedStake &&
-        existing.players.length < existing.maxPlayers &&
+        (alreadySeated || existing.players.length < existing.maxPlayers) &&
         isMatchMetaCompatible(existing.meta, normalizedMeta, gameType);
       if (canJoinForced) return existing;
       if (isHostedTable) return null;
@@ -1286,7 +1290,8 @@ async function seatTableSocket(
     stake,
     maxPlayers,
     matchMeta,
-    forcedTableId
+    forcedTableId,
+    accountId
   );
   if (!table) return null;
   const tableId = table.id;

--- a/test/chessLobbyAliasCriteriaMatchmaking.test.js
+++ b/test/chessLobbyAliasCriteriaMatchmaking.test.js
@@ -89,6 +89,22 @@ test(
         secondSeat.players.map((player) => player.tpcAccountNumber),
         ['chess-alias-a', 'chess-alias-b']
       );
+      // A mobile reconnect can restore its seat after both seats have filled
+      // but before the one-second start lock completes. It must rejoin the
+      // same full table rather than being moved into a fresh empty queue.
+      await new Promise((resolve) => setTimeout(resolve, 550));
+      const restoredSeat = await seat(s2, {
+        accountId: 'chess-alias-b',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: secondSeat.tableId
+      });
+      assert.equal(restoredSeat.success, true);
+      assert.equal(restoredSeat.tableId, firstSeat.tableId);
+      assert.equal(restoredSeat.players.length, 2);
       // Chess has no ready-up screen: seating the second same-stake player is
       // sufficient to start both clients without a confirmReady round trip.
       const [gameStartA, gameStartB] = await Promise.all([


### PR DESCRIPTION
### Motivation

- Prevent mobile clients that reconnect while a same-stake Chess quick-match table is filling from being removed and requeued, which caused players to miss pairing or be started against a ghost seat. 

### Description

- Pass the requesting player identity into table selection and allow joining a forced/hosted table if the account is already seated there, by adding an `accountId` parameter to `getAvailableTable` and checking `existing.players` for the seat owner. (changes in `bot/server.js`.)
- Propagate the `accountId` through `seatTableSocket` when choosing/creating a table so reconnections can reassign the original seat instead of creating a new table. (changes in `bot/server.js`.)
- Add an integration regression test that simulates a mobile reconnect restoring a filled Chess seat during the one-second start lock, confirming the reconnect rejoins the same table and both players receive the game-start. (changes in `test/chessLobbyAliasCriteriaMatchmaking.test.js`.)

### Testing

- Ran the Chess lobby integration tests: `node --test test/chessLobbyAliasCriteriaMatchmaking.test.js test/chessLobbyStaleTableIdMatchmaking.test.js test/chessLobbyExpiredSeatMatchmaking.test.js test/chessLobbyPrivateCodeIsolation.test.js test/chessLobbyPreferredSideMatchmaking.test.js` and all tests passed. 
- Performed runtime checks with `node --check bot/server.js` and `node --check test/chessLobbyAliasCriteriaMatchmaking.test.js`, which succeeded. 
- Executed `npx eslint` which reported repository legacy/style issues unrelated to the functional change; these lint findings are pre-existing and did not affect the integration test results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71a9acf10c83298aeaba319a269b08)