### PR TITLE
Use TPC account as canonical identity and fix private chess matchmaking join

### DIFF
--- a/bot/routes/matchmaking.js
+++ b/bot/routes/matchmaking.js
@@ -20,7 +20,9 @@ router.post('/session', async (req, res) => {
   let telegram = null;
   if (verified?.user) telegram = JSON.parse(verified.user);
 
-  const accountId = String(req.body?.accountId || '').trim().slice(0, 80);
+  const accountId = String(
+    req.body?.tpcAccountNumber || req.body?.accountId || ''
+  ).trim().slice(0, 80);
   const googleId = String(req.body?.googleId || '').trim().slice(0, 160);
   const identity = telegram?.id
     ? { telegramId: Number(telegram.id) }

--- a/chess-multiplayer-server/src/auth.test.ts
+++ b/chess-multiplayer-server/src/auth.test.ts
@@ -35,7 +35,13 @@ describe('authenticatePlayer', () => {
       accountId: 'legacy-account', googleId: 'google-42'
     })).resolves.toMatchObject({ accountId: 'TPC-900', name: 'Web player', balance: 500 });
     expect(fetchMock).toHaveBeenCalledWith('https://accounts.example/api/matchmaking/session', expect.objectContaining({
-      body: JSON.stringify({ initData: '', accountId: 'legacy-account', googleId: 'google-42' })
+      body: JSON.stringify({ initData: '', accountId: 'legacy-account', tpcAccountNumber: 'legacy-account', googleId: 'google-42' })
     }));
+  });
+
+  it('uses the TPC account number before legacy account aliases', async () => {
+    await expect(authenticatePlayer({} as never, {
+      tpcAccountNumber: 'TPC-PRIMARY', accountId: 'legacy-account', name: 'Ada'
+    })).resolves.toMatchObject({ accountId: 'TPC-PRIMARY' });
   });
 });

--- a/chess-multiplayer-server/src/auth.ts
+++ b/chess-multiplayer-server/src/auth.ts
@@ -16,7 +16,7 @@ async function authenticateWithAccountServer(initData: string, accountId: string
   const response = await fetch(`${base}/api/matchmaking/session`, {
     method: 'POST',
     headers: { 'content-type': 'application/json', 'x-matchmaking-secret': String(process.env.MATCHMAKING_SERVICE_SECRET || '') },
-    body: JSON.stringify({ initData, accountId, googleId })
+    body: JSON.stringify({ initData, accountId, tpcAccountNumber: accountId, googleId })
   });
   const body = await response.json().catch(() => ({})) as any;
   if (!response.ok) throw new Error(String(body.error || `authentication_failed_${response.status}`));
@@ -41,7 +41,9 @@ function validateTelegram(initData: string, botToken: string): Record<string, st
 }
 
 export async function authenticatePlayer(_client: Client, options: Record<string, unknown>): Promise<PlayerAuth> {
-  const accountId = String(options.accountId || '').trim().slice(0, 80);
+  // The canonical TPC account number is the primary real-time identity. Keep
+  // accountId as a compatibility fallback for clients deployed before this field.
+  const accountId = String(options.tpcAccountNumber || options.accountId || '').trim().slice(0, 80);
   const initData = String(options.initData || '');
   const googleId = String(options.googleId || '').trim().slice(0, 160);
   const botToken = process.env.TELEGRAM_BOT_TOKEN || '';

--- a/render.yaml
+++ b/render.yaml
@@ -43,7 +43,7 @@ services:
       - key: AUTH_REQUIRED
         value: true
       - key: ACCOUNT_API_URL
-        value: https://tonplaygram-bot.onrender.com
+        value: https://tonplaygram-api.onrender.com
       - key: MATCHMAKING_SERVICE_SECRET
         fromSecret: MATCHMAKING_SERVICE_SECRET
       - key: REDIS_URL

--- a/webapp/src/pages/Games/ChessMultiplayerLobby.tsx
+++ b/webapp/src/pages/Games/ChessMultiplayerLobby.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Client, Room } from '@colyseus/sdk';
 import { useNavigate } from 'react-router-dom';
-import { ensureAccountId, getTelegramFirstName, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { ensureAccountId, getTelegramFirstName, getTelegramPhotoUrl, getTpcAccountId } from '../../utils/telegram.js';
 
 type Player = { sessionId: string; accountId: string; name: string; avatar: string; ready: boolean; connected: boolean };
 type LobbySnapshot = { players: Player[]; phase: string; invitationCode: string; countdownEndsAt: number; minPlayers: number; maxPlayers: number; tableNumber: string };
@@ -87,7 +87,10 @@ export default function ChessMultiplayerLobby() {
 
   const authOptions = async () => {
     const resolved = await ensureAccountId();
-    const resolvedAccountId = String(resolved || accountId);
+    // The TPC account number is the durable identity shared by the account API,
+    // lobby and game. Never replace it with a Telegram id or a room session id.
+    const resolvedAccountId = String(getTpcAccountId() || resolved || accountId).trim();
+    if (!resolvedAccountId) throw new Error('Your TPC account is not ready. Reopen your profile and try again.');
     const googleId = localStorage.getItem('googleId') || (() => {
       try {
         const profile = JSON.parse(localStorage.getItem('googleProfile') || 'null');
@@ -100,6 +103,7 @@ export default function ChessMultiplayerLobby() {
     setAccountId(resolvedAccountId);
     return {
       accountId: resolvedAccountId,
+      tpcAccountNumber: resolvedAccountId,
       googleId,
       name: getTelegramFirstName() || 'Player',
       avatar: getTelegramPhotoUrl() || '',
@@ -114,7 +118,22 @@ export default function ChessMultiplayerLobby() {
       const visibility = roomType;
       const code = visibility === 'private' ? (createPrivate ? newCode() : inviteCode.trim().toUpperCase()) : '';
       if (visibility === 'private' && !code) throw new Error('Enter an invitation code.');
-      const joinRequest = getClient().joinOrCreate(ROOM_NAME, { ...identity, visibility, invitationCode: code, stake: selectedStake, token: 'TPC' });
+      const options = { ...identity, visibility, invitationCode: code, stake: selectedStake, token: 'TPC' };
+      // Joining a private code must never create a second, isolated room when the
+      // host code is missing or mistyped. Hosts create; guests locate and join.
+      const joinRequest = visibility === 'private' && !createPrivate
+        ? getClient().getAvailableRooms(ROOM_NAME).then((rooms) => {
+            const target = rooms.find((candidate) => {
+              const metadata = (candidate.metadata || {}) as Record<string, unknown>;
+              return metadata.visibility === 'private'
+                && String(metadata.invitationCode || '').toUpperCase() === code
+                && Number(metadata.stake) === selectedStake
+                && candidate.clients < candidate.maxClients;
+            });
+            if (!target) throw new Error('Private match not found. Check the code and stake.');
+            return getClient().joinById(target.roomId, options);
+          })
+        : getClient().joinOrCreate(ROOM_NAME, options);
       let timedOut = false;
       let timeoutId = 0;
       const timeout = new Promise<never>((_, reject) => {


### PR DESCRIPTION
### Motivation
- Ensure the lobby and realtime matchmaking use the canonical TPC account number as the durable player identity so seats, stakes and reconnections are tracked correctly across clients and the account API.
- Prevent private-match invitation code collisions where a mistyped or missing code could create a new isolated room instead of locating the host room.

### Description
- Client: `ChessMultiplayerLobby.tsx` now resolves the durable identity from `getTpcAccountId()` and includes `tpcAccountNumber` in join/auth payloads, and it throws a clear error when no TPC id is available.
- Client: Private-join logic changed to search existing `chess_lobby` rooms via `getAvailableRooms` and join the matching room by `invitationCode`, `stake`, and room capacity instead of blindly `joinOrCreate` for guests.
- Server: `chess-multiplayer-server/src/auth.ts` now prefers `options.tpcAccountNumber` over legacy `accountId` and sends/accepts `tpcAccountNumber` when calling the authoritative account API.
- Bot API: `bot/routes/matchmaking.js` session endpoint now accepts `tpcAccountNumber` (or falls back to `accountId`) and resolves the canonical TPC account consistently when returning session data.
- Config: `render.yaml` updated to point the matchmaking service at the `tonplaygram-api` account service URL used by deployments.
- Tests: added/updated unit test coverage in `chess-multiplayer-server/src/auth.test.ts` to assert `tpcAccountNumber` precedence and account-server request shape.

### Testing
- Built the matchmaking server with `npm install --prefix chess-multiplayer-server` and `npm run build --prefix chess-multiplayer-server` and the web client with `npm install --prefix webapp` and `npm run build --prefix webapp` (build completed with typical warnings about engines/chunk sizes but produced a `dist` output).
- Ran server unit tests with `npm test --prefix chess-multiplayer-server` (Vitest), and all tests passed: 3 test files, 9 tests — green.
- Verified basic runtime flows locally by exercising private join behavior and session request shape to the account API (automated tests covered the `authenticatePlayer` scenarios and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71e758329083298a31971bf5f78caa)