### PR TITLE
Add friend voice/video calls and Add-Friend action to Games leaderboard

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -2920,6 +2920,55 @@ io.on('connection', (socket) => {
     });
   });
 
+  socket.on('friendCall:invite', async (payload = {}, cb) => {
+    const fromAccountId = String(socket.data?.playerId || '');
+    const toAccountId = String(payload.toAccountId || '');
+    const fromTelegramId = Number(payload.fromTelegramId);
+    const toTelegramId = Number(payload.toTelegramId);
+    const type = payload.type === 'video' ? 'video' : 'voice';
+    if (!fromAccountId || !toAccountId || !fromTelegramId || !toTelegramId) {
+      return cb?.({ success: false, error: 'Invalid call details' });
+    }
+    try {
+      const caller = await User.findOne({ telegramId: fromTelegramId }).select('friends accountId');
+      if (!caller || String(caller.accountId) !== fromAccountId || !caller.friends.map(String).includes(String(toTelegramId))) {
+        return cb?.({ success: false, error: 'Calls are available between friends only' });
+      }
+      const target = await User.findOne({ telegramId: toTelegramId, accountId: toAccountId }).select('_id');
+      if (!target) return cb?.({ success: false, error: 'Friend not found' });
+      const targets = userSockets.get(toAccountId);
+      if (!targets?.size) return cb?.({ success: false, error: 'Friend is offline' });
+      const call = {
+        roomId: `friend-call-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        fromAccountId,
+        toAccountId,
+        fromName: String(payload.fromName || 'Friend').slice(0, 60),
+        type
+      };
+      for (const sid of targets) io.to(sid).emit('friendCall:incoming', call);
+      cb?.({ success: true, call });
+    } catch (error) {
+      console.error('friend call invite failed', error);
+      cb?.({ success: false, error: 'Unable to start call' });
+    }
+  });
+
+  socket.on('friendCall:accept', ({ roomId, fromAccountId } = {}) => {
+    const targets = userSockets.get(String(fromAccountId || ''));
+    for (const sid of targets || []) io.to(sid).emit('friendCall:accepted', { roomId });
+  });
+
+  socket.on('friendCall:reject', ({ roomId, fromAccountId } = {}) => {
+    const targets = userSockets.get(String(fromAccountId || ''));
+    for (const sid of targets || []) io.to(sid).emit('friendCall:ended', { roomId, reason: 'declined' });
+  });
+
+  socket.on('friendCall:end', ({ roomId, fromAccountId, toAccountId } = {}) => {
+    const peerId = String(socket.data?.playerId) === String(fromAccountId) ? toAccountId : fromAccountId;
+    const targets = userSockets.get(String(peerId || ''));
+    for (const sid of targets || []) io.to(sid).emit('friendCall:ended', { roomId });
+  });
+
   socket.on('rollDice', async (payload = {}) => {
     const { accountId, tableId } = payload;
     if (accountId && tableId && tableMap.has(tableId)) {

--- a/webapp/src/components/FriendCallOverlay.jsx
+++ b/webapp/src/components/FriendCallOverlay.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { FaMicrophone, FaMicrophoneSlash, FaPhoneSlash, FaVideo, FaVideoSlash } from 'react-icons/fa';
+import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
+
+function Video({ stream, muted = false, className = '' }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (ref.current) ref.current.srcObject = stream || null;
+  }, [stream]);
+  return <video ref={ref} autoPlay playsInline muted={muted} className={className} />;
+}
+
+export default function FriendCallOverlay({ call, displayName, onEnd }) {
+  const chat = useLiveVideoChat({
+    roomId: call?.roomId,
+    displayName,
+    enabled: !!call,
+    video: call?.type === 'video'
+  });
+
+  useEffect(() => {
+    if (call) chat.startLiveChat();
+  }, [call?.roomId]); // start once for this call
+
+  if (!call) return null;
+  const remote = chat.remotePeers[0];
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex flex-col bg-[#07101d] text-white" role="dialog" aria-label={`${call.type} call`}>
+      <div className="flex-1 relative flex items-center justify-center overflow-hidden">
+        {call.type === 'video' && remote?.stream ? (
+          <Video stream={remote.stream} className="h-full w-full object-cover" />
+        ) : (
+          <div className="text-center px-6">
+            <img src={call.photo || '/assets/icons/profile.svg'} alt="" className="mx-auto h-28 w-28 rounded-full border-4 border-cyan-400 object-cover shadow-xl" />
+            <h2 className="mt-4 text-2xl font-bold">{call.name || 'Friend'}</h2>
+            <p className="mt-2 text-white/60">{remote ? 'Connected' : 'Connecting…'}</p>
+          </div>
+        )}
+        {call.type === 'video' && chat.localStream && (
+          <Video stream={chat.localStream} muted className="absolute right-3 top-3 h-36 w-24 rounded-2xl border-2 border-white/40 bg-black object-cover shadow-xl" />
+        )}
+      </div>
+      {chat.error && <p className="bg-red-950 px-4 py-2 text-center text-sm text-red-200">{chat.error}</p>}
+      <div className="flex justify-center gap-5 bg-black/40 px-4 pb-[max(2rem,env(safe-area-inset-bottom))] pt-5">
+        <button onClick={chat.toggleMicrophone} className="rounded-full bg-white/15 p-4" aria-label="Toggle microphone">
+          {chat.mediaState.microphone ? <FaMicrophone /> : <FaMicrophoneSlash />}
+        </button>
+        {call.type === 'video' && <button onClick={chat.toggleCamera} className="rounded-full bg-white/15 p-4" aria-label="Toggle camera">
+          {chat.mediaState.camera ? <FaVideo /> : <FaVideoSlash />}
+        </button>}
+        <button onClick={() => { chat.stopLiveChat(); onEnd(); }} className="rounded-full bg-red-600 p-4" aria-label="End call"><FaPhoneSlash /></button>
+      </div>
+    </div>, document.body
+  );
+}

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -8,6 +8,7 @@ import { isGameMuted, getGameVolume } from '../utils/sound.js';
 import { chatBeep as inviteBeep } from '../assets/coreSoundData.js';
 import usePwaInstallPrompt from '../hooks/usePwaInstallPrompt.js';
 import InvitePopup from './InvitePopup.jsx';
+import FriendCallOverlay from './FriendCallOverlay.jsx';
 
 import Navbar from './Navbar.jsx';
 
@@ -23,6 +24,8 @@ export default function Layout({ children }) {
   const location = useLocation();
   const navigate = useNavigate();
   const [invite, setInvite] = useState(null);
+  const [incomingCall, setIncomingCall] = useState(null);
+  const [activeCall, setActiveCall] = useState(null);
   const inviteSoundRef = useRef(null);
   const {
     canInstall,
@@ -33,6 +36,22 @@ export default function Layout({ children }) {
     dismiss
   } = usePwaInstallPrompt();
   const { isUpdating } = useAppUpdate();
+
+  useEffect(() => {
+    const onIncomingCall = (call) => setIncomingCall(call);
+    const onStartCall = (event) => setActiveCall(event.detail);
+    const onEnded = ({ roomId } = {}) => {
+      if (!roomId || activeCall?.roomId === roomId) setActiveCall(null);
+    };
+    socket.on('friendCall:incoming', onIncomingCall);
+    socket.on('friendCall:ended', onEnded);
+    window.addEventListener('friend-call:start', onStartCall);
+    return () => {
+      socket.off('friendCall:incoming', onIncomingCall);
+      socket.off('friendCall:ended', onEnded);
+      window.removeEventListener('friend-call:start', onStartCall);
+    };
+  }, [activeCall?.roomId]);
 
   useEffect(() => {
     inviteSoundRef.current = new Audio(inviteBeep);
@@ -203,6 +222,20 @@ export default function Layout({ children }) {
         }}
         onReject={() => setInvite(null)}
       />
+
+      {incomingCall && !activeCall && (
+        <div className="fixed inset-0 z-[90] flex items-end justify-center bg-black/70 p-4 pb-24">
+          <div className="w-full max-w-sm rounded-3xl border border-white/15 bg-[#101b2a] p-6 text-center shadow-2xl">
+            <p className="text-xs uppercase tracking-widest text-cyan-300">Incoming {incomingCall.type} call</p>
+            <h2 className="mt-2 text-xl font-bold">{incomingCall.fromName || 'Friend'}</h2>
+            <div className="mt-6 flex justify-center gap-4">
+              <button onClick={() => { socket.emit('friendCall:reject', incomingCall); setIncomingCall(null); }} className="rounded-full bg-red-600 px-6 py-3 font-semibold">Decline</button>
+              <button onClick={() => { socket.emit('friendCall:accept', incomingCall); setActiveCall({ ...incomingCall, name: incomingCall.fromName }); setIncomingCall(null); }} className="rounded-full bg-emerald-600 px-6 py-3 font-semibold">Accept</button>
+            </div>
+          </div>
+        </div>
+      )}
+      <FriendCallOverlay call={activeCall} displayName="TonPlaygram player" onEnd={() => { socket.emit('friendCall:end', activeCall); setActiveCall(null); }} />
 
       <PwaInstallBanner
         mode={showPwaBanner ? mode : 'none'}

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -10,6 +10,8 @@ import {
   getProfile,
   getWatchCount,
   pingOnline,
+  listFriends,
+  sendFriendRequest,
 } from '../utils/api.js';
 import { getAvatarUrl, saveAvatar, loadAvatar } from '../utils/avatarUtils.js';
 import { socket } from '../utils/socket.js';
@@ -59,6 +61,8 @@ export default function LeaderboardCard() {
   const [selected, setSelected] = useState([]);
   const [groupPopup, setGroupPopup] = useState(false);
   const [watchFrame, setWatchFrame] = useState(null);
+  const [friendIds, setFriendIds] = useState(new Set());
+  const [pendingFriendIds, setPendingFriendIds] = useState(new Set());
 
   const openWatchFrame = (tableId) => {
     if (!tableId) return;
@@ -69,6 +73,13 @@ export default function LeaderboardCard() {
       url: `/games/${game}?table=${tableId}&watch=1`,
     });
   };
+
+  useEffect(() => {
+    if (!telegramId) return;
+    listFriends(telegramId).then((friends) => {
+      setFriendIds(new Set((friends || []).map((friend) => String(friend.telegramId))));
+    }).catch(() => {});
+  }, [telegramId]);
 
   useEffect(() => {
     const saved = loadAvatar();
@@ -492,6 +503,26 @@ export default function LeaderboardCard() {
         onlineStatus={inviteTarget ? onlineUsers[String(inviteTarget.accountId)] : 'offline'}
         stake={stake}
         onStakeChange={setStake}
+        friendship={inviteTarget && friendIds.has(String(inviteTarget.telegramId)) ? 'friend' : inviteTarget && pendingFriendIds.has(String(inviteTarget.telegramId)) ? 'pending' : 'none'}
+        onAddFriend={async () => {
+          if (!inviteTarget?.telegramId) return;
+          await sendFriendRequest(telegramId, inviteTarget.telegramId);
+          setPendingFriendIds((current) => new Set(current).add(String(inviteTarget.telegramId)));
+        }}
+        onCall={(type) => {
+          if (!inviteTarget) return;
+          socket.emit('friendCall:invite', {
+            toAccountId: inviteTarget.accountId,
+            fromTelegramId: telegramId,
+            toTelegramId: inviteTarget.telegramId,
+            fromName: myName,
+            type
+          }, (response) => {
+            if (!response?.success) return alert(response?.error || 'Unable to start call');
+            window.dispatchEvent(new CustomEvent('friend-call:start', { detail: { ...response.call, name: inviteTarget.nickname || inviteTarget.firstName, photo: inviteTarget.photo || inviteTarget.photoUrl } }));
+            setInviteTarget(null);
+          });
+        }}
         onInvite={(game) => {
           if (inviteTarget) {
             const roomId = `invite-${accountId}-${inviteTarget.accountId}-${Date.now()}-2`;

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import RoomSelector from './RoomSelector.jsx';
 import GiftPopup from './GiftPopup.jsx';
 import GiftIcon from './GiftIcon.jsx';
-import { FaCircle, FaDesktop, FaTimes, FaTv } from 'react-icons/fa';
+import { FaCircle, FaDesktop, FaPhone, FaTimes, FaTv, FaUserPlus, FaVideo } from 'react-icons/fa';
 import { getAccountInfo, getSnakeResults, getWatchCount } from '../utils/api.js';
 import { NFT_GIFTS } from '../utils/nftGifts.js';
 import gamesCatalog from '../config/gamesCatalog.js';
@@ -30,6 +30,9 @@ export default function PlayerInvitePopup({
   onInvite,
   onClose,
   onlineStatus,
+  friendship = 'none',
+  onAddFriend,
+  onCall,
 }) {
   const [info, setInfo] = useState(null);
   const [records, setRecords] = useState([]);
@@ -226,6 +229,14 @@ export default function PlayerInvitePopup({
             tokens={['TPC']}
           />
           <div className="flex justify-center gap-2">
+            {friendship === 'friend' ? <>
+              <button onClick={() => onCall?.('voice')} className="px-3 py-2 bg-emerald-600 rounded text-white" aria-label={`Voice call ${name}`}><FaPhone /></button>
+              <button onClick={() => onCall?.('video')} className="px-3 py-2 bg-cyan-600 rounded text-white" aria-label={`Video call ${name}`}><FaVideo /></button>
+            </> : (
+              <button onClick={onAddFriend} disabled={friendship === 'pending'} className="inline-flex items-center gap-1 px-2 py-1 bg-cyan-700 rounded text-white text-sm disabled:opacity-60">
+                <FaUserPlus /> {friendship === 'pending' ? 'Request sent' : 'Add friend'}
+              </button>
+            )}
             <button
               onClick={() => onInvite(game)}
               className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow text-sm"

--- a/webapp/src/hooks/useLiveVideoChat.js
+++ b/webapp/src/hooks/useLiveVideoChat.js
@@ -10,7 +10,7 @@ const RTC_CONFIG = {
 
 const EMPTY_MEDIA_STATE = Object.freeze({ microphone: true, camera: true });
 
-export default function useLiveVideoChat({ roomId, displayName, enabled }) {
+export default function useLiveVideoChat({ roomId, displayName, enabled, video = true }) {
   const [isConnected, setIsConnected] = useState(false);
   const [remotePeers, setRemotePeers] = useState([]);
   const [mediaState, setMediaState] = useState(EMPTY_MEDIA_STATE);
@@ -133,11 +133,11 @@ export default function useLiveVideoChat({ roomId, displayName, enabled }) {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: true,
-        video: {
+        video: video ? {
           width: { ideal: 640 },
           height: { ideal: 360 },
           facingMode: 'user'
-        }
+        } : false
       });
 
       localStreamRef.current = stream;
@@ -151,7 +151,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled }) {
         roomId: safeRoomId,
         participant: {
           displayName: displayName || 'Player',
-          mediaState: { microphone: true, camera: true }
+          mediaState: { microphone: true, camera: video }
         }
       });
       setIsConnected(true);
@@ -160,7 +160,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled }) {
       setError(message);
       console.error('live chat media init failed', mediaError);
     }
-  }, [displayName, enabled, isConnected, safeRoomId]);
+  }, [displayName, enabled, isConnected, safeRoomId, video]);
 
   const toggleTrack = useCallback((kind) => {
     const stream = localStreamRef.current;


### PR DESCRIPTION
### Motivation

- Provide in-lobby social actions so leaderboard profiles can become friends, and friends can call each other by voice or video without leaving the app.
- Show incoming game invites and incoming friend calls as global popups so users see them regardless of current page.
- Validate calls on the server so only mutual friends (and online targets) can start real-time calls.

### Description

- Add friend UI and call controls to leaderboard flows by extending `LeaderboardCard` to load the friend list via `listFriends` and expose `sendFriendRequest` and call actions; the popup `PlayerInvitePopup` now shows an `Add friend` button (or `Request sent`) and friend-only `voice`/`video` call buttons when appropriate (`webapp/src/components/LeaderboardCard.jsx`, `webapp/src/components/PlayerInvitePopup.jsx`).
- Implement a portrait-first full-screen call UI in a new `FriendCallOverlay` component that renders remote and local video, microphone/camera toggles and an end-call button (`webapp/src/components/FriendCallOverlay.jsx`).
- Extend the live-chat hook `useLiveVideoChat` with a `video` option so calls can be started as voice-only or with camera and to surface `startLiveChat`/`stopLiveChat`/toggle controls (`webapp/src/hooks/useLiveVideoChat.js`).
- Add global incoming-call handling and accept/decline UI to the main layout so calls are visible from any page and accepted calls open the overlay (`webapp/src/components/Layout.jsx`).
- Add server-side socket handlers to create, route and lifecycle friend-call invitations and ensure the caller and callee are friends and the callee is online before notifying sockets; handlers include `friendCall:invite`, `friendCall:accept`, `friendCall:reject` and `friendCall:end` (`bot/server.js`).
- Wire client/server via socket events and a short-lived generated `roomId` for each friend call; client emits `friendCall:invite` and receives `friendCall:incoming` to trigger UI flows.

### Testing

- Ran lint: `npm --prefix webapp run lint -- --quiet` (succeeded).
- Built the web app: `npm --prefix webapp run build` (production build completed; standard bundle-size warnings emitted but build succeeded).
- Performed a server check: `node --check bot/server.js` (no syntax errors).
- Ran repository checks: `git diff --check` (no whitespace/diff issues found).
- Attempted a headless Playwright mobile screenshot to exercise the new UI, but the container lacked required system libraries at runtime (Playwright browser install/run issues), so the end-to-end screenshot test could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71eae7cda88329aaa5872e9035f165)