### PR TITLE
Fix leaderboard invites delivery and add on-screen friend-request notifications

### DIFF
--- a/bot/routes/social.js
+++ b/bot/routes/social.js
@@ -46,9 +46,27 @@ router.post('/request', async (req, res) => {
     return res.status(400).json({ error: 'fromId and toId required' });
   }
   if (!requireMatchingTelegram(req, res, fromId)) return;
-  const existing = await FriendRequest.findOne({ from: fromId, to: toId });
-  if (existing) return res.json(existing);
-  const reqDoc = await FriendRequest.create({ from: fromId, to: toId });
+  let reqDoc = await FriendRequest.findOne({ from: fromId, to: toId });
+  if (!reqDoc) reqDoc = await FriendRequest.create({ from: fromId, to: toId });
+  const sender = await User.findOne({ telegramId: Number(fromId) })
+    .select('accountId firstName lastName nickname photo')
+    .lean();
+  const recipient = await User.findOne({ telegramId: Number(toId) }).select('accountId').lean();
+  const sockets = req.app.get('userSockets');
+  const io = req.app.get('io');
+  const targets = new Set([
+    ...(sockets?.get(String(toId)) || []),
+    ...(recipient?.accountId ? sockets?.get(String(recipient.accountId)) || [] : [])
+  ]);
+  for (const socketId of targets) {
+    io?.to(socketId).emit('friendRequest', {
+      requestId: String(reqDoc._id),
+      fromTelegramId: Number(fromId),
+      fromAccountId: sender?.accountId,
+      fromName: sender?.nickname || `${sender?.firstName || ''} ${sender?.lastName || ''}`.trim() || String(fromId),
+      fromPhoto: sender?.photo || ''
+    });
+  }
   try {
     await bot.telegram.sendMessage(
       String(toId),

--- a/bot/server.js
+++ b/bot/server.js
@@ -470,6 +470,23 @@ const pendingInvites = new Map();
 
 app.set('userSockets', userSockets);
 
+async function getUserSocketIds({ accountId, telegramId } = {}) {
+  const identities = new Set(
+    [accountId, telegramId].filter((value) => value !== undefined && value !== null && value !== '').map(String)
+  );
+
+  if (telegramId) {
+    const user = await User.findOne({ telegramId: Number(telegramId) }).select('accountId').lean();
+    if (user?.accountId) identities.add(String(user.accountId));
+  }
+
+  const socketIds = new Set();
+  for (const identity of identities) {
+    for (const socketId of userSockets.get(identity) || []) socketIds.add(socketId);
+  }
+  return socketIds;
+}
+
 const tableWatchers = new Map();
 const liveChatRooms = new Map();
 // Dynamic lobby tables grouped by game type and capacity
@@ -3016,12 +3033,12 @@ io.on('connection', (socket) => {
   });
 
   socket.on('invite1v1', async (payload, cb) => {
-    let { fromId, fromName, toId, roomId, token, amount, game } = payload || {};
+    let { fromId, fromName, toId, toTelegramId, roomId, token, amount, game } = payload || {};
     if (!fromId || !toId)
       return cb && cb({ success: false, error: 'invalid ids' });
 
-    const targets = userSockets.get(String(toId));
-    if (targets && targets.size > 0) {
+    const targets = await getUserSocketIds({ accountId: toId, telegramId: toTelegramId });
+    if (targets.size > 0) {
       for (const sid of targets) {
         io.to(sid).emit('gameInvite', {
           fromId,
@@ -3047,7 +3064,7 @@ io.on('connection', (socket) => {
   socket.on(
     'inviteGroup',
     async (
-      { fromId, fromName, toIds, opponentNames = [], roomId, token, amount },
+      { fromId, fromName, toIds, telegramIds = [], opponentNames = [], roomId, token, amount, game = 'snake' },
       cb
     ) => {
       if (!fromId || !Array.isArray(toIds) || toIds.length === 0) {
@@ -3058,13 +3075,13 @@ io.on('connection', (socket) => {
         toIds: [...toIds],
         token,
         amount,
-        game: 'snake'
+        game
       });
-      let url = getInviteUrl(roomId, token, amount, 'snake');
+      let url = getInviteUrl(roomId, token, amount, game);
       for (let i = 0; i < toIds.length; i++) {
         const toId = toIds[i];
-        const targets = userSockets.get(String(toId));
-        if (targets && targets.size > 0) {
+        const targets = await getUserSocketIds({ accountId: toId, telegramId: telegramIds[i] });
+        if (targets.size > 0) {
           for (const sid of targets) {
             io.to(sid).emit('gameInvite', {
               fromId,
@@ -3074,7 +3091,7 @@ io.on('connection', (socket) => {
               amount,
               group: toIds,
               opponentNames,
-              game: 'snake'
+              game
             });
           }
         } else {

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 
 import { useLocation, useNavigate } from 'react-router-dom';
 import { socket } from '../utils/socket.js';
-import { pingOnline } from '../utils/api.js';
+import { acceptFriendRequest, pingOnline } from '../utils/api.js';
 import { getPlayerId } from '../utils/telegram.js';
 import { isGameMuted, getGameVolume } from '../utils/sound.js';
 import { chatBeep as inviteBeep } from '../assets/coreSoundData.js';
@@ -24,6 +24,7 @@ export default function Layout({ children }) {
   const location = useLocation();
   const navigate = useNavigate();
   const [invite, setInvite] = useState(null);
+  const [friendRequest, setFriendRequest] = useState(null);
   const [incomingCall, setIncomingCall] = useState(null);
   const [activeCall, setActiveCall] = useState(null);
   const inviteSoundRef = useRef(null);
@@ -36,6 +37,18 @@ export default function Layout({ children }) {
     dismiss
   } = usePwaInstallPrompt();
   const { isUpdating } = useAppUpdate();
+
+  useEffect(() => {
+    const onFriendRequest = (request) => {
+      setFriendRequest(request);
+      if (inviteSoundRef.current && !isGameMuted()) {
+        inviteSoundRef.current.currentTime = 0;
+        inviteSoundRef.current.play().catch(() => {});
+      }
+    };
+    socket.on('friendRequest', onFriendRequest);
+    return () => socket.off('friendRequest', onFriendRequest);
+  }, []);
 
   useEffect(() => {
     const onIncomingCall = (call) => setIncomingCall(call);
@@ -222,6 +235,21 @@ export default function Layout({ children }) {
         }}
         onReject={() => setInvite(null)}
       />
+
+      {friendRequest && (
+        <div className="fixed inset-0 z-[95] flex items-end justify-center bg-black/70 p-4 pb-24" role="dialog" aria-modal="true" aria-label="New friend request">
+          <div className="w-full max-w-sm rounded-3xl border border-cyan-300/30 bg-[#101b2a] p-6 text-center shadow-2xl">
+            <p className="text-xs font-semibold uppercase tracking-widest text-cyan-300">New friend request</p>
+            <img src={friendRequest.fromPhoto || '/assets/icons/profile.svg'} alt="" className="mx-auto mt-4 h-16 w-16 rounded-full border-2 border-cyan-300 object-cover" />
+            <h2 className="mt-3 text-xl font-bold text-white">{friendRequest.fromName || 'TonPlaygram player'}</h2>
+            <p className="mt-1 text-sm text-white/65">wants to add you as a friend.</p>
+            <div className="mt-6 grid grid-cols-2 gap-3">
+              <button type="button" onClick={() => setFriendRequest(null)} className="rounded-xl border border-white/15 px-4 py-3 font-semibold text-white">Not now</button>
+              <button type="button" onClick={async () => { await acceptFriendRequest(friendRequest.requestId); setFriendRequest(null); }} className="rounded-xl bg-cyan-500 px-4 py-3 font-semibold text-[#07111d]">Accept</button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {incomingCall && !activeCall && (
         <div className="fixed inset-0 z-[90] flex items-end justify-center bg-black/70 p-4 pb-24">


### PR DESCRIPTION
### Motivation
- Ensure game invites reach recipients connected by either account ID or Telegram ID so invites actually appear for online users. 
- Surface friend requests immediately in the web UI as an on-screen popup (in addition to Telegram) so users receive instant feedback.
- Reuse the existing invite sound to provide consistent audible feedback for incoming friend requests.

### Description
- Added `getUserSocketIds` helper in `bot/server.js` to resolve active socket IDs for a recipient by `accountId` and/or `telegramId`. 
- Updated socket handlers in `bot/server.js` to use `getUserSocketIds` for `invite1v1` and `inviteGroup`, preserve the requested `game` value, and send `gameInvite` to resolved sockets. 
- Extended `/api/social/request` in `bot/routes/social.js` to emit a `friendRequest` socket event (with `requestId`, sender name and photo) to any live sockets for the recipient (by Telegram ID and account ID) while still sending the Telegram bot message. 
- Added client-side handling in `webapp/src/components/Layout.jsx` to listen for `friendRequest`, play the invite sound, and show a modal-like popup with sender info and `Not now` / `Accept` actions that call `acceptFriendRequest`. 

### Testing
- Ran `node --check bot/server.js` and `node --check bot/routes/social.js`, both succeeded. 
- Ran lint on the modified web component with `npm --prefix webapp run lint -- src/components/Layout.jsx`, which succeeded. 
- Ran the bot test suite with `npm --prefix bot test`, where all tests passed (`6` tests passed). 
- Attempted `npm --prefix webapp run build`, which transformed modules but failed packaging due to an existing unresolved external dependency (`@colyseus/sdk`) unrelated to these changes; the runtime socket/invite logic was not impacted by this build warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71f07caee48329b87c161aee90bd82)