### PR TITLE
Make transaction counterpart tappable and harden friend-request flows

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -181,8 +181,8 @@ router.post('/by-account', async (req, res) => {
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
   const user = await User.findOne({ accountId });
   if (!user) return res.status(404).json({ error: 'account not found' });
-  const { nickname, firstName, lastName, photo } = user;
-  res.json({ nickname, firstName, lastName, photo });
+  const { telegramId, nickname, firstName, lastName, photo } = user;
+  res.json({ accountId: user.accountId, telegramId, nickname, firstName, lastName, photo });
 });
 
 router.post('/update', authenticate, async (req, res) => {

--- a/bot/routes/social.js
+++ b/bot/routes/social.js
@@ -46,8 +46,30 @@ router.post('/request', async (req, res) => {
     return res.status(400).json({ error: 'fromId and toId required' });
   }
   if (!requireMatchingTelegram(req, res, fromId)) return;
-  let reqDoc = await FriendRequest.findOne({ from: fromId, to: toId });
-  if (!reqDoc) reqDoc = await FriendRequest.create({ from: fromId, to: toId });
+  const normalizedFromId = Number(fromId);
+  const normalizedToId = Number(toId);
+  if (!Number.isFinite(normalizedFromId) || !Number.isFinite(normalizedToId)) {
+    return res.status(400).json({ error: 'invalid player id' });
+  }
+  if (normalizedFromId === normalizedToId) {
+    return res.status(400).json({ error: 'you cannot add yourself' });
+  }
+  const recipientExists = await User.exists({ telegramId: normalizedToId });
+  if (!recipientExists) return res.status(404).json({ error: 'player not found' });
+
+  const alreadyFriends = await User.exists({
+    telegramId: normalizedFromId,
+    friends: normalizedToId
+  });
+  if (alreadyFriends) return res.status(409).json({ error: 'already friends' });
+
+  // Reuse a previous rejected/accepted pair rather than failing against the
+  // unique index, and make repeated taps on a pending request idempotent.
+  const reqDoc = await FriendRequest.findOneAndUpdate(
+    { from: normalizedFromId, to: normalizedToId },
+    { $set: { status: 'pending', createdAt: new Date() } },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
   const sender = await User.findOne({ telegramId: Number(fromId) })
     .select('accountId firstName lastName nickname photo')
     .lean();
@@ -103,8 +125,43 @@ router.post('/requests', async (req, res) => {
   const { telegramId } = req.body;
   if (!telegramId) return res.status(400).json({ error: 'telegramId required' });
   if (!requireMatchingTelegram(req, res, telegramId)) return;
-  const incoming = await FriendRequest.find({ to: telegramId, status: 'pending' });
-  res.json(incoming);
+  const normalizedId = Number(telegramId);
+  const requests = await FriendRequest.find({
+    status: 'pending',
+    $or: [{ to: normalizedId }, { from: normalizedId }]
+  })
+    .sort({ createdAt: -1 })
+    .lean();
+  const participantIds = [
+    ...new Set(requests.flatMap((request) => [request.from, request.to]))
+  ];
+  const users = await User.find({ telegramId: { $in: participantIds } })
+    .select('telegramId accountId firstName lastName nickname photo')
+    .lean();
+  const userById = new Map(users.map((user) => [Number(user.telegramId), user]));
+  const response = requests.map((request) => {
+    const fromUser = userById.get(Number(request.from));
+    const toUser = userById.get(Number(request.to));
+    const displayName = (user) =>
+      user?.nickname ||
+      `${user?.firstName || ''} ${user?.lastName || ''}`.trim() ||
+      '';
+    return {
+      ...request,
+      requestId: String(request._id),
+      fromId: request.from,
+      toId: request.to,
+      fromTelegramId: request.from,
+      toTelegramId: request.to,
+      fromAccountId: fromUser?.accountId,
+      toAccountId: toUser?.accountId,
+      fromName: displayName(fromUser),
+      toName: displayName(toUser),
+      fromPhoto: fromUser?.photo || '',
+      toPhoto: toUser?.photo || ''
+    };
+  });
+  res.json(response);
 });
 
 router.post('/friends', async (req, res) => {

--- a/webapp/src/components/HomeSocialHub.jsx
+++ b/webapp/src/components/HomeSocialHub.jsx
@@ -10,6 +10,8 @@ import {
   listFriendRequests
 } from '../utils/api.js';
 
+const FRIEND_REQUEST_REFRESH_MS = 15000;
+
 const INVITES_STORAGE_KEY = 'tonplaygram-game-invites';
 
 function normalizeRequests(payload) {
@@ -94,13 +96,19 @@ export default function HomeSocialHub() {
 
   useEffect(() => {
     let active = true;
-    listFriendRequests(telegramId)
-      .then((requests) => {
-        if (active) setFriendRequests(normalizeRequests(requests));
-      })
-      .catch(() => {
-        if (active) setFriendRequests([]);
-      });
+    const refreshFriendRequests = () =>
+      listFriendRequests(telegramId)
+        .then((requests) => {
+          if (active) setFriendRequests(normalizeRequests(requests));
+        })
+        .catch(() => {
+          if (active) setFriendRequests([]);
+        });
+    refreshFriendRequests();
+    const refreshId = window.setInterval(
+      refreshFriendRequests,
+      FRIEND_REQUEST_REFRESH_MS
+    );
     getUnreadCount(telegramId)
       .then((count) => {
         if (active) setUnreadCount(count?.count ?? count ?? 0);
@@ -110,7 +118,18 @@ export default function HomeSocialHub() {
       });
     return () => {
       active = false;
+      window.clearInterval(refreshId);
     };
+  }, [telegramId]);
+
+  useEffect(() => {
+    const onFriendRequest = () => {
+      listFriendRequests(telegramId)
+        .then((requests) => setFriendRequests(normalizeRequests(requests)))
+        .catch(() => {});
+    };
+    socket.on('friendRequest', onFriendRequest);
+    return () => socket.off('friendRequest', onFriendRequest);
   }, [telegramId]);
 
   useEffect(() => {

--- a/webapp/src/components/LeaderboardCard.jsx
+++ b/webapp/src/components/LeaderboardCard.jsx
@@ -506,8 +506,14 @@ export default function LeaderboardCard() {
         friendship={inviteTarget && friendIds.has(String(inviteTarget.telegramId)) ? 'friend' : inviteTarget && pendingFriendIds.has(String(inviteTarget.telegramId)) ? 'pending' : 'none'}
         onAddFriend={async () => {
           if (!inviteTarget?.telegramId) return;
-          await sendFriendRequest(telegramId, inviteTarget.telegramId);
-          setPendingFriendIds((current) => new Set(current).add(String(inviteTarget.telegramId)));
+          try {
+            await sendFriendRequest(telegramId, inviteTarget.telegramId);
+            setPendingFriendIds((current) =>
+              new Set(current).add(String(inviteTarget.telegramId))
+            );
+          } catch (error) {
+            alert(error?.message || 'Failed to send friend request');
+          }
         }}
         onCall={(type) => {
           if (!inviteTarget) return;

--- a/webapp/src/components/PlayerInvitePopup.jsx
+++ b/webapp/src/components/PlayerInvitePopup.jsx
@@ -33,6 +33,7 @@ export default function PlayerInvitePopup({
   friendship = 'none',
   onAddFriend,
   onCall,
+  profileOnly = false,
 }) {
   const [info, setInfo] = useState(null);
   const [records, setRecords] = useState([]);
@@ -207,7 +208,7 @@ export default function PlayerInvitePopup({
               )}
             </ul>
           </div>
-          <div className="space-y-1">
+          {!profileOnly && <div className="space-y-1">
             <p className="font-semibold text-white-shadow">Game</p>
             <div className="flex flex-wrap justify-center gap-2">
               {inviteGames.map((g) => (
@@ -222,12 +223,12 @@ export default function PlayerInvitePopup({
                 />
               ))}
             </div>
-          </div>
-          <RoomSelector
+          </div>}
+          {!profileOnly && <RoomSelector
             selected={stake}
             onSelect={onStakeChange}
             tokens={['TPC']}
-          />
+          />}
           <div className="flex justify-center gap-2">
             {friendship === 'friend' ? <>
               <button onClick={() => onCall?.('voice')} className="px-3 py-2 bg-emerald-600 rounded text-white" aria-label={`Voice call ${name}`}><FaPhone /></button>
@@ -237,12 +238,12 @@ export default function PlayerInvitePopup({
                 <FaUserPlus /> {friendship === 'pending' ? 'Request sent' : 'Add friend'}
               </button>
             )}
-            <button
+            {!profileOnly && <button
               onClick={() => onInvite(game)}
               className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow text-sm"
             >
               Invite
-            </button>
+            </button>}
             <button
               onClick={() => setGiftOpen(true)}
               className="px-2 py-1 bg-primary hover:bg-primary-hover rounded text-white-shadow text-sm"

--- a/webapp/src/components/TransactionDetailsPopup.jsx
+++ b/webapp/src/components/TransactionDetailsPopup.jsx
@@ -4,12 +4,15 @@ import { createPortal } from 'react-dom';
 
 import { FiCopy } from 'react-icons/fi';
 
-import { getProfileByAccount } from '../utils/api.js';
+import { getProfileByAccount, sendFriendRequest } from '../utils/api.js';
+
+import { getTelegramId } from '../utils/telegram.js';
 
 import { getAvatarUrl } from '../utils/avatarUtils.js';
 
 import { NFT_GIFTS } from '../utils/nftGifts.js';
 import GiftIcon from './GiftIcon.jsx';
+import PlayerInvitePopup from './PlayerInvitePopup.jsx';
 
 const GAME_NAME_MAP = {
   snake: 'Snake & Ladder',
@@ -30,6 +33,8 @@ function getGameName(slug = '') {
 export default function TransactionDetailsPopup({ tx, onClose }) {
 
   const [counterparty, setCounterparty] = useState(null);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const [friendship, setFriendship] = useState('none');
 
   useEffect(() => {
 
@@ -110,7 +115,11 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
   });
 
-  return createPortal(
+  const openCounterpartyProfile = () => {
+    if (counterparty) setProfileOpen(true);
+  };
+
+  const popup = createPortal(
 
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
 
@@ -183,7 +192,12 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
           {counterparty && (
 
-            <div className="flex items-center space-x-2">
+            <button
+              type="button"
+              onClick={openCounterpartyProfile}
+              className="flex items-center space-x-2 rounded-lg p-2 text-left hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-primary"
+              aria-label={`View ${displayName || 'player'} profile`}
+            >
 
                 {counterparty.photo && (
                   <img
@@ -213,7 +227,7 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
               </div>
 
-            </div>
+            </button>
 
           )}
 
@@ -277,6 +291,36 @@ export default function TransactionDetailsPopup({ tx, onClose }) {
 
     document.body
 
+  );
+
+  return (
+    <>
+      {popup}
+      <PlayerInvitePopup
+        open={profileOpen}
+        player={counterparty ? { ...counterparty, accountId: account } : null}
+        stake={{ token: 'TPC', amount: 100 }}
+        onStakeChange={() => {}}
+        onInvite={() => {}}
+        onClose={() => setProfileOpen(false)}
+        onlineStatus="offline"
+        friendship={friendship}
+        profileOnly
+        onAddFriend={async () => {
+          const telegramId = getTelegramId();
+          if (!telegramId || !counterparty?.telegramId) {
+            window.alert('This player cannot receive a friend request right now.');
+            return;
+          }
+          try {
+            await sendFriendRequest(telegramId, counterparty.telegramId);
+            setFriendship('pending');
+          } catch (error) {
+            window.alert(error?.message || 'Failed to send friend request');
+          }
+        }}
+      />
+    </>
   );
 
 }

--- a/webapp/src/components/UserSearchBar.jsx
+++ b/webapp/src/components/UserSearchBar.jsx
@@ -14,8 +14,12 @@ export default function UserSearchBar() {
 
   async function requestFriend(id) {
     const fromId = getTelegramId();
-    await sendFriendRequest(fromId, id);
-    alert('Friend request sent');
+    try {
+      await sendFriendRequest(fromId, id);
+      alert('Friend request sent');
+    } catch (error) {
+      alert(error?.message || 'Failed to send friend request');
+    }
   }
 
   return (

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -544,7 +544,10 @@ export function searchUsers(query) {
 }
 
 export function sendFriendRequest(fromId, toId) {
-  return post('/api/social/request', { fromId, toId });
+  return post('/api/social/request', { fromId, toId }).then((result) => {
+    if (result?.error) throw new Error(result.error);
+    return result;
+  });
 }
 
 export function listFriendRequests(telegramId) {


### PR DESCRIPTION
### Motivation

- Users need to tap the sender/receiver on a TPC statement to view the same player profile used in the leaderboard. 
- The friend-request flow was unreliable: requests could not be sent, pending requests did not always appear in the Social Hub, and the client did not surface API errors consistently. 

### Description

- Make the counterparty row in `TransactionDetailsPopup` tappable and open `PlayerInvitePopup` in a `profileOnly` mode so the transaction view reuses the leaderboard profile UI without game controls. 
- Add `profileOnly` mode to `PlayerInvitePopup` so it can be embedded as a simple profile viewer and expose an `onAddFriend` action for sending requests from the profile. 
- Harden friend-request server logic in `bot/routes/social.js` with validation (numeric ids, no self-requests), duplicate/friend checks, idempotent upsert of pending requests, and an enriched `/requests` response that returns both sides with names, photos, Telegram IDs and account IDs. 
- Return `accountId` and `telegramId` from the profile-by-account endpoint in `bot/routes/profile.js` and make `sendFriendRequest` on the web client propagate API errors, plus add UI error handling in `LeaderboardCard` and `UserSearchBar`. 
- Make the Social Hub poll pending friend requests every 15s and refresh immediately on incoming `friendRequest` socket events so sent/received requests show up in both sections.

### Testing

- Built the web app with `npm --prefix webapp run build`, which completed successfully. 
- Basic server checks with `node --check bot/routes/social.js && node --check bot/routes/profile.js` passed. 
- Linting (`npm --prefix webapp run lint ...`) reported many pre-existing style errors in the repository (mostly semicolon/spacing issues) and was not used to gate this change. 
- The test suite (`npm test -- --runInBand`) ran but failed on unrelated existing tests (`inventoryCrossGameConfig.test.js` and `poolRoyaleMatchmakingMeta.test.js`), so no new unit-test regressions for the social/profile changes were observed in the passing suites. 
- Attempted mobile preview screenshot via Playwright failed because Chromium could not launch due to missing system libraries and the environment stalled installing Playwright system deps, so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71f994ac8c8329ba0441b34fcc714a)