### PR TITLE
Fix game invites and friend call flows (Telegram notifications, Messages UI, live chat startup)

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -3,7 +3,7 @@ import { validateEnv } from './env.js';
 import express from 'express';
 import cors from 'cors';
 import bot from './bot.js';
-import { getInviteUrl } from './utils/notifications.js';
+import { getInviteUrl, sendInviteNotification } from './utils/notifications.js';
 import mongoose from 'mongoose';
 import { proxyUrl, proxyAgent } from './utils/proxyAgent.js';
 import http from 'http';
@@ -3057,14 +3057,31 @@ io.on('connection', (socket) => {
       amount,
       game
     });
-    const url = getInviteUrl(roomId, token, amount, game);
+    let url = getInviteUrl(roomId, token, amount, game);
+    if (toTelegramId) {
+      try {
+        url = await sendInviteNotification(
+          bot,
+          toTelegramId,
+          payload?.fromTelegramId || fromId,
+          fromName,
+          '1v1',
+          roomId,
+          token,
+          amount,
+          game
+        );
+      } catch (error) {
+        console.error('Failed to send 1v1 invite notification:', error.message);
+      }
+    }
     cb && cb({ success: true, url });
   });
 
   socket.on(
     'inviteGroup',
     async (
-      { fromId, fromName, toIds, telegramIds = [], opponentNames = [], roomId, token, amount, game = 'snake' },
+      { fromId, fromTelegramId, fromName, toIds, telegramIds = [], opponentNames = [], roomId, token, amount, game = 'snake' },
       cb
     ) => {
       if (!fromId || !Array.isArray(toIds) || toIds.length === 0) {
@@ -3081,6 +3098,23 @@ io.on('connection', (socket) => {
       for (let i = 0; i < toIds.length; i++) {
         const toId = toIds[i];
         const targets = await getUserSocketIds({ accountId: toId, telegramId: telegramIds[i] });
+        if (telegramIds[i]) {
+          try {
+            url = await sendInviteNotification(
+              bot,
+              telegramIds[i],
+              fromTelegramId || fromId,
+              fromName,
+              'group',
+              roomId,
+              token,
+              amount,
+              game
+            );
+          } catch (error) {
+            console.error('Failed to send group invite notification:', error.message);
+          }
+        }
         if (targets.size > 0) {
           for (const sid of targets) {
             io.to(sid).emit('gameInvite', {

--- a/webapp/src/hooks/useLiveVideoChat.js
+++ b/webapp/src/hooks/useLiveVideoChat.js
@@ -131,6 +131,10 @@ export default function useLiveVideoChat({ roomId, displayName, enabled, video =
     if (!enabled || !safeRoomId || isConnected) return;
     setError('');
     try {
+      if (!navigator?.mediaDevices?.getUserMedia) {
+        throw new Error('Camera and microphone are unavailable in this browser. Open TonPlaygram over HTTPS or inside Telegram with media permissions enabled.');
+      }
+      if (!socket.connected) socket.connect();
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: true,
         video: video ? {

--- a/webapp/src/pages/Messages.jsx
+++ b/webapp/src/pages/Messages.jsx
@@ -12,8 +12,9 @@ import {
 } from 'react-icons/fa';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LoginOptions from '../components/LoginOptions.jsx';
-import { getTelegramId } from '../utils/telegram.js';
+import { getPlayerId, getTelegramId } from '../utils/telegram.js';
 import { getMessages, sendMessage, listFriends, markInboxRead } from '../utils/api.js';
+import { socket } from '../utils/socket.js';
 
 export default function Messages() {
   useTelegramBackButton();
@@ -32,6 +33,7 @@ export default function Messages() {
   const [activeFolder, setActiveFolder] = useState('inbox');
   const [actionNote, setActionNote] = useState('');
   const [clipFile, setClipFile] = useState(null);
+  const accountId = getPlayerId();
 
   useEffect(() => {
     markInboxRead(telegramId);
@@ -59,9 +61,72 @@ export default function Messages() {
     markInboxRead(telegramId);
   }
 
+  function flashActionNote(message) {
+    setActionNote(message);
+    setTimeout(() => setActionNote(''), 2500);
+  }
+
   function handleQuickAction(label) {
-    setActionNote(`${label} queued`);
-    setTimeout(() => setActionNote(''), 2000);
+    flashActionNote(`${label} queued`);
+  }
+
+  function selectedName() {
+    return selected?.nickname ||
+      `${selected?.firstName || ''} ${selected?.lastName || ''}`.trim() ||
+      'Friend';
+  }
+
+  function startFriendCall(type) {
+    if (!selected?.accountId || !selected?.telegramId) {
+      flashActionNote('This friend is missing call details.');
+      return;
+    }
+
+    socket.emit('friendCall:invite', {
+      toAccountId: selected.accountId,
+      fromTelegramId: telegramId,
+      toTelegramId: selected.telegramId,
+      fromName: 'TonPlaygram player',
+      type
+    }, (response) => {
+      if (!response?.success) {
+        flashActionNote(response?.error || 'Unable to start call.');
+        return;
+      }
+      window.dispatchEvent(new CustomEvent('friend-call:start', {
+        detail: {
+          ...response.call,
+          name: selectedName(),
+          photo: selected.photo || selected.photoUrl
+        }
+      }));
+      flashActionNote(`${type === 'video' ? 'Video' : 'Voice'} call started.`);
+    });
+  }
+
+  function sendGameInvite() {
+    if (!selected?.accountId || !selected?.telegramId) {
+      flashActionNote('This friend is missing invite details.');
+      return;
+    }
+    const roomId = `invite-${accountId}-${selected.accountId}-${Date.now()}-2`;
+    socket.emit('invite1v1', {
+      fromId: accountId,
+      fromTelegramId: telegramId,
+      fromName: 'TonPlaygram player',
+      toId: selected.accountId,
+      toTelegramId: selected.telegramId,
+      roomId,
+      game: 'snake',
+      token: 'TPC',
+      amount: 100
+    }, (response) => {
+      if (!response?.success) {
+        flashActionNote(response?.error || 'Failed to send invite.');
+        return;
+      }
+      flashActionNote('Game invite sent.');
+    });
   }
 
   const filteredFriends = useMemo(() => {
@@ -192,6 +257,24 @@ export default function Messages() {
                 </div>
                 <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap">
                   <button
+                    onClick={() => startFriendCall('voice')}
+                    className="inline-flex items-center justify-center gap-1 rounded-full border border-emerald-400/50 px-3 py-1 text-[11px] text-white"
+                  >
+                    <FaMicrophone /> Voice
+                  </button>
+                  <button
+                    onClick={() => startFriendCall('video')}
+                    className="inline-flex items-center justify-center gap-1 rounded-full border border-cyan-400/50 px-3 py-1 text-[11px] text-white"
+                  >
+                    <FaVideo /> Video
+                  </button>
+                  <button
+                    onClick={sendGameInvite}
+                    className="inline-flex items-center justify-center gap-1 rounded-full border border-primary/70 px-3 py-1 text-[11px] text-white"
+                  >
+                    Invite Game
+                  </button>
+                  <button
                     onClick={() => handleQuickAction('Archive')}
                     className="inline-flex items-center justify-center gap-1 rounded-full border border-border px-3 py-1 text-[11px] text-white"
                   >
@@ -284,10 +367,10 @@ export default function Messages() {
                     />
                   </label>
                   <button
-                    onClick={() => handleQuickAction('Voice')}
-                    className="inline-flex items-center justify-center gap-2 rounded-full border border-border px-3 py-1 text-xs text-white"
+                    onClick={() => startFriendCall('voice')}
+                    className="inline-flex items-center justify-center gap-2 rounded-full border border-emerald-400/50 px-3 py-1 text-xs text-white"
                   >
-                    <FaMicrophone /> Voice
+                    <FaMicrophone /> Voice Call
                   </button>
                   <button
                     onClick={() => handleQuickAction('Report')}


### PR DESCRIPTION
### Motivation
- Game invites (1v1/group) should deliver an actionable open-game URL to recipients and not only trigger socket popups. 
- Friend voice/video calls from the Messages UI were only placeholders and needed real client-server wiring to start calls. 
- Live chat startup must better handle browsers with missing media APIs and ensure the socket is connected before requesting media.

### Description
- Backend: integrate Telegram notifications into invite flows by importing `sendInviteNotification` and calling it for `invite1v1` and `inviteGroup` paths so invites send open-game URLs when recipient `telegramId` is available (`bot/server.js`).
- Frontend (Messages): add real call and invite actions to the Messages page by wiring `friendCall:invite` and `invite1v1` socket events from `webapp/src/pages/Messages.jsx`, adding UI buttons for Voice/Video/Invite Game and user-facing flash messages.
- Frontend (live chat): harden `startLiveChat` in `webapp/src/hooks/useLiveVideoChat.js` to check `navigator.mediaDevices.getUserMedia` and reconnect the socket before requesting camera/microphone access.

### Testing
- Ran `npm test -- --runInBand test/onlineRoutes.test.js test/lobbyWait.test.js` and both targeted suites passed locally. 
- Built the project with `npm run build` which completed successfully. 
- Ran ESLint checks: `npx eslint` reported that the files are ignored by repo ignore patterns, and `npx eslint --no-ignore` surfaced many pre-existing style/semicolon issues unrelated to this change, so lint warnings/errors were noted but did not block the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f5a1fd4483298f953244a79ca462)