### PR TITLE
Fix Chess Battle Royal online lobby entry

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -23,7 +23,6 @@ import { socket, refreshSocketAuthIdentity } from '../../utils/socket.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
-import ChessMultiplayerLobby from './ChessMultiplayerLobby.tsx';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -1011,10 +1010,6 @@ export default function ChessBattleRoyalLobby() {
         </div>
 
         {mode === 'online' && (
-          <ChessMultiplayerLobby />
-        )}
-
-        {mode === 'online' && false && (
           <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 shadow">
             <div className="flex items-center gap-3">
               <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-yellow-400/40 to-orange-500/40 p-[1px]">
@@ -1147,7 +1142,7 @@ export default function ChessBattleRoyalLobby() {
           </div>
         )}
 
-        {mode !== 'online' && <button
+        <button
           onClick={startGame}
           disabled={matching}
           className="w-full rounded-2xl bg-primary px-4 py-3 text-base font-semibold text-background shadow-[0_16px_30px_rgba(14,165,233,0.35)] transition hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
@@ -1157,7 +1152,7 @@ export default function ChessBattleRoyalLobby() {
               ? 'Finding Online Match…'
               : 'Find Online Match'
             : 'Play vs AI'}
-        </button>}
+        </button>
 
         <FlagPickerModal
           open={showFlagPicker}


### PR DESCRIPTION
### Motivation
- Restore the Chess Battle Royal lobby UI so Online mode (Quick Match and Private Match) uses the existing socket-based matchmaking flow instead of the disabled/incorrect Colyseus panel. 
- Users could not stake, create/join private codes, or start online matches from the lobby because the online controls were not rendered and the main action button only launched AI matches. 

### Description
- Removed the unused `ChessMultiplayerLobby` Colyseus import and stopped rendering that component from `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx`. 
- Re-enabled the in-lobby TPC stake selector, Quick Match / Private Code options and private-code input so online table creation/joining uses the existing socket.io flow. 
- Restored the primary action button to always call `startGame` so the button now launches online matchmaking when `mode === 'online'` and AI when not. 
- Committed the change to the `ChessBattleRoyalLobby.jsx` file to fix rendering logic and preserved the socket-based table flow used by the rest of the app. 

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully and produced the Vite output bundles (build warnings about large chunks were unchanged and did not fail the build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f5f11f448329be92135519b4474d)