### PR TITLE
Domino Royal: use TPC account as primary identity and tighten matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -52,7 +52,9 @@ import { execSync } from 'child_process';
 import { randomInt, randomUUID } from 'crypto';
 import {
   createDominoTableNumber,
+  hasConflictingPrimaryTpcIdentities,
   isDominoMatchCompatible,
+  resolvePrimaryTpcAccountNumber,
   validateDominoStateSubmission
 } from './utils/dominoRoyalOnline.js';
 import compression from 'compression';
@@ -620,26 +622,11 @@ function isRateLimited(socket, key, cooldownMs) {
 }
 
 function resolveTpcIdentity(payload = {}) {
-  const tpcAccountNumber = String(
-    payload?.tpcAccountNumber ||
-      payload?.tpcAccountId ||
-      payload?.accountId ||
-      payload?.playerId ||
-      ''
-  ).trim();
-  return tpcAccountNumber;
+  return resolvePrimaryTpcAccountNumber(payload);
 }
 
 function hasConflictingIdentities(payload = {}) {
-  const ids = [
-    payload?.tpcAccountNumber,
-    payload?.tpcAccountId,
-    payload?.accountId,
-    payload?.playerId
-  ]
-    .map((id) => String(id || '').trim())
-    .filter(Boolean);
-  return new Set(ids).size > 1;
+  return hasConflictingPrimaryTpcIdentities(payload);
 }
 
 function ensureRegistered(socket, tpcAccountNumber) {

--- a/bot/utils/dominoRoyalOnline.js
+++ b/bot/utils/dominoRoyalOnline.js
@@ -1,12 +1,57 @@
 import { randomInt } from 'crypto'
 
 const TABLE_NUMBER_SPACE = 1_000_000
-const DOMINO_MATCH_KEYS = Object.freeze(['mode', 'variant', 'targetPoints', 'token'])
+const DOMINO_REQUIRED_MATCH_KEYS = Object.freeze(['mode', 'variant', 'token'])
+
+function normalizeDominoMatchValue (key, value) {
+  const normalized = String(value || '').trim()
+  if (!normalized) return ''
+  if (key === 'token') return normalized.toUpperCase()
+  if (key === 'targetPoints') return String(Number(normalized) || '')
+  return normalized.toLowerCase()
+}
+
+export function resolvePrimaryTpcAccountNumber (payload = {}) {
+  return String(
+    payload?.tpcAccountNumber ||
+      payload?.tpcAccountId ||
+      payload?.accountId ||
+      payload?.playerId ||
+      ''
+  ).trim()
+}
+
+export function hasConflictingPrimaryTpcIdentities (payload = {}) {
+  const primaryIds = [payload?.tpcAccountNumber, payload?.tpcAccountId]
+    .map((id) => String(id || '').trim())
+    .filter(Boolean)
+  if (new Set(primaryIds).size > 1) return true
+
+  // Once a TPC account number is present, it is authoritative for matchmaking.
+  // Legacy accountId/playerId fields can lag behind during mobile migrations,
+  // so they must not block seating into the lobby.
+  if (primaryIds.length > 0) return false
+
+  const fallbackIds = [payload?.accountId, payload?.playerId]
+    .map((id) => String(id || '').trim())
+    .filter(Boolean)
+  return new Set(fallbackIds).size > 1
+}
 
 export function isDominoMatchCompatible (existing = {}, requested = {}) {
-  return DOMINO_MATCH_KEYS.every((key) =>
-    String(existing?.[key] || '') === String(requested?.[key] || '')
-  )
+  for (const key of DOMINO_REQUIRED_MATCH_KEYS) {
+    if (normalizeDominoMatchValue(key, existing?.[key]) !== normalizeDominoMatchValue(key, requested?.[key])) {
+      return false
+    }
+  }
+
+  const existingVariant = normalizeDominoMatchValue('variant', existing?.variant)
+  const requestedVariant = normalizeDominoMatchValue('variant', requested?.variant)
+  if (existingVariant === 'points' || requestedVariant === 'points') {
+    return normalizeDominoMatchValue('targetPoints', existing?.targetPoints) === normalizeDominoMatchValue('targetPoints', requested?.targetPoints)
+  }
+
+  return true
 }
 
 export function createDominoTableNumber (isInUse = () => false) {

--- a/test/dominoRoyalOnline.test.js
+++ b/test/dominoRoyalOnline.test.js
@@ -1,6 +1,9 @@
 /* global describe, test, expect */
 import {
   createDominoTableNumber,
+  hasConflictingPrimaryTpcIdentities,
+  isDominoMatchCompatible,
+  resolvePrimaryTpcAccountNumber,
   validateDominoStateSubmission
 } from '../bot/utils/dominoRoyalOnline.js'
 
@@ -29,5 +32,29 @@ describe('Domino Royal online synchronization', () => {
     const cached = { state: state(1) }
     expect(validateDominoStateSubmission({ table, cached, accountId: 'TPC-100', state: state(1), action: { type: 'play' } })).toMatchObject({ ok: false, error: 'not_your_turn' })
     expect(validateDominoStateSubmission({ table, cached, accountId: 'TPC-200', state: state(0), action: { type: 'turn' } }).ok).toBe(true)
+  })
+
+  test('uses the TPC account number as the primary lobby identity', () => {
+    const payload = {
+      tpcAccountNumber: 'TPC-777',
+      accountId: 'legacy-local-storage-id',
+      playerId: 'legacy-player-id'
+    }
+
+    expect(resolvePrimaryTpcAccountNumber(payload)).toBe('TPC-777')
+    expect(hasConflictingPrimaryTpcIdentities(payload)).toBe(false)
+    expect(hasConflictingPrimaryTpcIdentities({ tpcAccountNumber: 'TPC-1', tpcAccountId: 'TPC-2' })).toBe(true)
+  })
+
+  test('matches Domino Royal lobbies by stake-compatible game rules', () => {
+    expect(isDominoMatchCompatible(
+      { mode: 'online', variant: 'single', token: 'tpc' },
+      { mode: 'ONLINE', variant: 'SINGLE', token: 'TPC', targetPoints: '0' }
+    )).toBe(true)
+
+    expect(isDominoMatchCompatible(
+      { mode: 'online', variant: 'points', token: 'TPC', targetPoints: '51' },
+      { mode: 'online', variant: 'points', token: 'TPC', targetPoints: 101 }
+    )).toBe(false)
   })
 })


### PR DESCRIPTION
### Motivation
- Ensure online Domino Royal lobby and matchmaking use the canonical TPC account number for player identity to avoid mismatched/duplicate seats from legacy fields.
- Prevent quick-match queue fragmentation by normalizing Domino matchmaking fields and only enforcing `targetPoints` when playing the `points` variant.

### Description
- Introduced `resolvePrimaryTpcAccountNumber` and `hasConflictingPrimaryTpcIdentities` and exported them from `bot/utils/dominoRoyalOnline.js` to centralize TPC identity resolution and conflict detection. 
- Normalized Domino matchmaking comparisons in `isDominoMatchCompatible` so `mode`, `variant`, and `token` are compared case- and format-insensitively and `targetPoints` is only required to match when either side uses the `points` variant. 
- Wired the server lobby code to call the new helpers (server now resolves TPC identity via the new resolver and uses the improved conflict logic) so the Socket.IO lobby honors TPC as the primary account identifier. 
- Added unit tests covering the TPC identity resolver and the Domino matchmaking compatibility rules in `test/dominoRoyalOnline.test.js`.

### Testing
- Ran `npm test -- --runTestsByPath test/dominoRoyalOnline.test.js --runInBand` and the Domino Royal test suite passed (5 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f6f5830883299eda5634747a8692)