### PR TITLE
Fix chess online stake matchmaking handoff

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8931,6 +8931,9 @@ function bestAIMove(board, aiPlaysWhite, depth = 4) {
 const formatTime = (t) =>
   `${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`;
 
+const resolveOnlinePlayerId = (player) =>
+  String(player?.id ?? player?.accountId ?? player?.tpcAccountNumber ?? player?.playerId ?? '').trim();
+
 // ======================= Main Component =======================
 function Chess3D({
   avatar,
@@ -8941,7 +8944,10 @@ function Chess3D({
   initialTableId,
   initialTableNumber,
   initialSide,
-  initialOpponent
+  initialOpponent,
+  preferredSideParam = 'auto',
+  stakeAmount = 0,
+  stakeToken = 'TPC'
 }) {
   const wrapRef = useRef(null);
   const normalizedInitialSide = initialSide === 'black' ? 'black' : 'white';
@@ -9310,11 +9316,11 @@ function Chess3D({
 
     const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
       if (!startedId || startedId !== tableJoin.current) return;
-      const meIndex = players.findIndex((p) => String(p.id) === String(accountId));
-      const opp = players.find((p) => String(p.id) !== String(accountId));
+      const meIndex = players.findIndex((p) => resolveOnlinePlayerId(p) === String(accountId));
+      const opp = players.find((p) => resolveOnlinePlayerId(p) !== String(accountId));
       if (opp) setOpponent(opp);
       const mySide =
-        players.find((p) => String(p.id) === String(accountId))?.side ||
+        players.find((p) => resolveOnlinePlayerId(p) === String(accountId))?.side ||
         (meIndex === 0 ? 'white' : 'black');
       onlineRef.current.side = mySide;
       onlineRef.current.status = 'started';
@@ -9350,12 +9356,23 @@ function Chess3D({
       socket.emit('chessSyncRequest', { tableId: target });
     };
 
+    const handleLobbyUpdate = ({ tableId: updatedId, players = [] } = {}) => {
+      if (!updatedId || String(updatedId) !== String(tableJoin.current)) return;
+      const opp = (Array.isArray(players) ? players : []).find((p) => resolveOnlinePlayerId(p) !== String(accountId));
+      if (opp) setOpponent(opp);
+      setOnlineStatus(opp ? 'matched' : 'waiting');
+    };
+
     socket.on('gameStart', handleGameStart);
+    socket.on('gameStarted', handleGameStart);
+    socket.on('lobbyUpdate', handleLobbyUpdate);
     socket.on('chessState', handleChessState);
     socket.on('chessMove', handleChessState);
 
     cleanups.push(() => {
       socket.off('gameStart', handleGameStart);
+      socket.off('gameStarted', handleGameStart);
+      socket.off('lobbyUpdate', handleLobbyUpdate);
       socket.off('chessState', handleChessState);
       socket.off('chessMove', handleChessState);
       if (tableJoin.current)
@@ -9366,8 +9383,9 @@ function Chess3D({
       setTableId(tableIdToJoin);
       tableJoin.current = tableIdToJoin;
       onlineRef.current.tableId = tableIdToJoin;
-      setOnlineStatus('starting');
+      setOnlineStatus('waiting');
       socket.emit('joinChessRoom', { tableId: tableIdToJoin, accountId });
+      socket.emit('confirmReady', { accountId, tableId: tableIdToJoin });
       onlineRef.current.requestSync?.();
     };
 
@@ -9381,7 +9399,8 @@ function Chess3D({
         {
           accountId,
           gameType: 'chess',
-          stake: 0,
+          stake: Number(stakeAmount) || 0,
+          token: stakeToken || 'TPC',
           maxPlayers: 2,
           playerName: username,
           avatar,
@@ -9402,7 +9421,7 @@ function Chess3D({
       active = false;
       cleanups.forEach((fn) => fn());
     };
-  }, [accountId, avatar, initialTableId, normalizedInitialSide, username]);
+  }, [accountId, avatar, initialTableId, normalizedInitialSide, preferredSideParam, stakeAmount, stakeToken, username]);
 
   useEffect(() => {
     whiteTimeRef.current = whiteTime;
@@ -17561,6 +17580,9 @@ export default function ChessBattleRoyal() {
       : preferredSideParam === 'black'
       ? 'black'
       : 'white';
+  const rawStakeAmount = Number(params.get('amount') || 0);
+  const stakeAmount = Number.isFinite(rawStakeAmount) && rawStakeAmount > 0 ? rawStakeAmount : 0;
+  const stakeToken = params.get('token') || 'TPC';
   const opponentName = params.get('opponentName') || '';
   const opponentAvatar = params.get('opponentAvatar') || '';
   const initialOpponent =
@@ -17607,6 +17629,9 @@ export default function ChessBattleRoyal() {
       initialTableNumber={initialTableNumber}
       initialSide={initialSide}
       initialOpponent={initialOpponent}
+      preferredSideParam={preferredSideParam}
+      stakeAmount={stakeAmount}
+      stakeToken={stakeToken}
     />
   );
 }

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -851,19 +851,31 @@ export default function ChessBattleRoyalLobby() {
           setReadyList(
             Array.isArray(res.ready) ? res.ready.map((id) => String(id)) : []
           );
+          const playersList = Array.isArray(res.players) ? res.players : [];
+          const mySide = resolveChessSide(playersList, seatAccountId);
+          const opp = resolveChessOpponent(playersList, seatAccountId);
           setMatchStatus(
-            onlineQueueMode === 'private'
-              ? resolvePrivateMatchStatus(res.tableId, hostCodeInput)
-              : resolveLobbyStatus(res.players, res.ready, seatAccountId)
+            opp
+              ? 'Match found. Opening the board…'
+              : onlineQueueMode === 'private'
+                ? resolvePrivateMatchStatus(res.tableId, hostCodeInput)
+                : 'Opening the board while we find the same-stake opponent…'
           );
-          armSearchRefresh();
-          cleanupRef.current = () => {
-            clearTimeout(matchmakingTimeoutRef.current);
-            matchmakingTimeoutRef.current = null;
-            clearInterval(matchmakingCountdownRef.current);
-            matchmakingCountdownRef.current = null;
-            cleanupLobby({ account: trackedAccountId, skipRefReset: true });
-          };
+          // Keep the reserved stake attached to this table and move immediately into
+          // the game scene. The game screen stays in a waiting state until another
+          // player with the same chess stake/table joins, then both ready signals
+          // start the match. Do not leave the lobby seat during this handoff.
+          stakeCharged = false;
+          cleanupLobby({ account: trackedAccountId, skipLeave: true });
+          navigateToGame({
+            tgId,
+            trackedAccountId,
+            tableId: res.tableId,
+            tableNumber: res.tableNumber,
+            side: mySide,
+            opponentName: resolvePlayerName(opp),
+            opponentAvatar: opp?.avatar
+          });
         }
       );
     };


### PR DESCRIPTION
### Motivation
- Players were failing to find opponents or reported "insufficient TPC" because the online flow didn't reliably preserve or propagate the selected stake and the code assumed a specific player id field when detecting opponents.  
- When a player pressed "find online match" the app stayed in the lobby instead of moving the player into the game scene and waiting there for an opponent, which caused UX and matching mismatches.  
- The lobby needed to allow two players with the same stake to reserve a table and match while the reserved player is already in the game scene.

### Description
- Add `resolveOnlinePlayerId` to normalize player identity from `id`, `accountId`, `tpcAccountNumber`, or `playerId`, fixing opponent detection when different payload shapes are used.  
- Parse `amount` and `token` URL params in the route wrapper and pass `stakeAmount`/`stakeToken` into `Chess3D`, and send them with `seatTable` so the reserved stake/token is preserved when seating.  
- In `Chess3D` add a `lobbyUpdate` handler and change the online handoff so a successful seat/table reservation immediately navigates the player into the game scene (in a waiting state) while keeping the lobby seat active; emit `confirmReady` and listen for `gameStart` to actually begin.  
- Update the Chess Battle Royal lobby so that after `seatTable` succeeds it opens the board immediately (keeps the stake attached and the seat reserved) and relies on lobby/game-start updates to start the match once an equal-stake opponent arrives.

### Testing
- Ran `npm run build` which completed successfully and produced production assets.  
- Ran `npm run lint -- src/pages/Games/ChessBattleRoyal.jsx src/pages/Games/ChessBattleRoyalLobby.jsx` and linting passed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72fcfec548832981557345af6f43d5)