### PR TITLE
Refresh socket identity before joining Domino Royal online lobby

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -16,7 +16,7 @@ import { loadAvatar } from '../../utils/avatarUtils.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
-import { socket } from '../../utils/socket.js';
+import { refreshSocketAuthIdentity, socket } from '../../utils/socket.js';
 import { getOnlineReadiness } from '../../config/onlineContract.js';
 import { joinDominoRoyalLobby } from './dominoRoyalMatchmaking.js';
 
@@ -205,6 +205,7 @@ export default function DominoRoyalLobby() {
     if (mode === 'online') {
       setQueueError('');
       setQueueStatus('Connecting to Domino Royal lobby…');
+      refreshSocketAuthIdentity({ accountId: String(accountId) }, { reconnect: true });
       onlineStakeDebitedRef.current = false;
       const res = await joinDominoRoyalLobby({
         socket,


### PR DESCRIPTION
### Motivation
- Prevent Domino Royal online join failures where the client socket identity is stale and causes `socket_unavailable` when attempting to seat a player in the online lobby.

### Description
- Import `refreshSocketAuthIdentity` from `webapp/src/utils/socket.js` and call `refreshSocketAuthIdentity({ accountId: String(accountId) }, { reconnect: true })` immediately before invoking `joinDominoRoyalLobby` in `webapp/src/pages/Games/DominoRoyalLobby.jsx` to ensure the socket auth matches the current account.

### Testing
- Ran `npm run lint -- webapp/src/pages/Games/DominoRoyalLobby.jsx` which initially failed due to an incorrect cwd and was then corrected; `npm run lint -- src/pages/Games/DominoRoyalLobby.jsx` passed.
- Built the frontend with `npm run build` in `webapp` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72fbf06a908329b90258395cd3166e)