### PR TITLE
Increase chess online matchmaking wait to 120s; server TTL and UI updates

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -510,7 +510,7 @@ function createChessTableNumber() {
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
-const lobbySeatTtlMs = Number(process.env.LOBBY_SEAT_TTL_MS) || 60_000;
+const lobbySeatTtlMs = Number(process.env.LOBBY_SEAT_TTL_MS) || 120_000;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
 

--- a/test/chessLobbyHelpers.test.mjs
+++ b/test/chessLobbyHelpers.test.mjs
@@ -90,9 +90,9 @@ test('chess lobby builds online game params and seat account fallback', () => {
   assert.match(sandbox.resolveSeatErrorMessage('stake_mismatch'), /different stake/);
 });
 
-test('chess quick match refreshes every minute and keeps searching', () => {
-  assert.match(source, /const MATCHMAKING_REFRESH_MS = 60000;/);
-  assert.match(source, /Refreshing the queue and looking again/);
+test('chess quick match waits two minutes and keeps searching', () => {
+  assert.match(source, /const MATCHMAKING_REFRESH_MS = 120000;/);
+  assert.match(source, /Still searching the ordered queue/);
   assert.match(source, /onlineQueueMode === 'quick' \|\|/);
-  assert.match(source, /Queue refresh in \{searchSecondsLeft\}s/);
+  assert.match(source, /120s opponent search window: \{searchSecondsLeft\}s left/);
 });

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -199,6 +199,8 @@ const SNAKE_SHARED_CAPTURE_VEHICLE_MODEL_HOSTS = Object.freeze([
 ]);
 const snakeSharedCaptureVehicleUrls = (fileName) =>
   SNAKE_SHARED_CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${fileName}`);
+const CHESS_ONLINE_OPPONENT_WAIT_MS = 120000;
+
 const CAPTURE_MODEL_URLS = Object.freeze({
   drone: snakeSharedCaptureVehicleUrls('drone.glb'),
   // Keep the Chess Battle Royal jet and helicopter on the exact same source
@@ -9074,6 +9076,9 @@ function Chess3D({
   const [onlineStatus, setOnlineStatus] = useState(
     onlineRef.current.enabled ? 'connecting' : 'offline'
   );
+  const [onlineWaitSecondsLeft, setOnlineWaitSecondsLeft] = useState(
+    CHESS_ONLINE_OPPONENT_WAIT_MS / 1000
+  );
   useEffect(() => {
     if (accountId) {
       setOnlineStatus((prev) => (prev === 'offline' ? 'connecting' : prev));
@@ -9099,6 +9104,30 @@ function Chess3D({
       onlineRef.current.opponent = initialOpponent;
     }
   }, [initialOpponent]);
+
+  useEffect(() => {
+    if (!onlineRef.current.enabled || opponent || onlineStatus === 'in-game') {
+      setOnlineWaitSecondsLeft(CHESS_ONLINE_OPPONENT_WAIT_MS / 1000);
+      return undefined;
+    }
+    if (!['waiting', 'matched', 'connecting', 'starting'].includes(onlineStatus)) {
+      return undefined;
+    }
+    const expiresAt = Date.now() + CHESS_ONLINE_OPPONENT_WAIT_MS;
+    setOnlineWaitSecondsLeft(CHESS_ONLINE_OPPONENT_WAIT_MS / 1000);
+    const timer = window.setInterval(() => {
+      const secondsLeft = Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000));
+      setOnlineWaitSecondsLeft(secondsLeft);
+      if (secondsLeft <= 0) {
+        window.clearInterval(timer);
+        if (onlineRef.current.tableId) {
+          socket.emit('leaveLobby', { accountId, tableId: onlineRef.current.tableId });
+        }
+        setOnlineStatus('timeout');
+      }
+    }, 250);
+    return () => window.clearInterval(timer);
+  }, [accountId, onlineStatus, opponent]);
   const resolvedAccountId = useMemo(() => chessBattleAccountId(accountId), [accountId]);
   const [inventoryVersion, setInventoryVersion] = useState(0);
   const chessInventory = useMemo(
@@ -16871,7 +16900,11 @@ function Chess3D({
               <div className="text-emerald-50/80">
                 {onlineStatus === 'in-game'
                   ? `Synced${opponent ? ` vs ${avatarToName(opponent.avatar) || opponent.name || opponent.id}` : ''}`
-                  : `Status: ${onlineStatus}`}
+                  : onlineStatus === 'waiting'
+                    ? `Waiting for opponent · ${onlineWaitSecondsLeft}s`
+                    : onlineStatus === 'timeout'
+                      ? 'Opponent was not found in 120s'
+                      : `Status: ${onlineStatus}`}
               </div>
               {tableId && (
                 <div className="text-[10px] text-emerald-50/70">

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -33,7 +33,7 @@ const CHESS_ONLINE_TABLE_PREFIX = 'chess-2-host';
 
 const SOCKET_CONNECT_TIMEOUT_MS = 6000;
 const SOCKET_REGISTER_TIMEOUT_MS = 6000;
-const MATCHMAKING_REFRESH_MS = 60000;
+const MATCHMAKING_REFRESH_MS = 120000;
 const SEAT_RETRY_BASE_DELAY_MS = 700;
 const MATCHMAKING_RECOVERABLE_ERRORS = new Set([
   'register_required',
@@ -539,7 +539,7 @@ export default function ChessBattleRoyalLobby() {
     setMatchPlayers([]);
     setReadyList([]);
     setSpinningPlayer('');
-    setSearchSecondsLeft(60);
+    setSearchSecondsLeft(MATCHMAKING_REFRESH_MS / 1000);
     if (!skipRefReset) cleanupRef.current = null;
   };
 
@@ -742,7 +742,7 @@ export default function ChessBattleRoyalLobby() {
       if (matchmakingTimeoutRef.current) clearTimeout(matchmakingTimeoutRef.current);
       if (matchmakingCountdownRef.current) clearInterval(matchmakingCountdownRef.current);
       const refreshAt = Date.now() + MATCHMAKING_REFRESH_MS;
-      setSearchSecondsLeft(60);
+      setSearchSecondsLeft(MATCHMAKING_REFRESH_MS / 1000);
       matchmakingCountdownRef.current = window.setInterval(() => {
         setSearchSecondsLeft(Math.max(0, Math.ceil((refreshAt - Date.now()) / 1000)));
       }, 250);
@@ -761,7 +761,7 @@ export default function ChessBattleRoyalLobby() {
           setMatchPlayers([]);
           setReadyList([]);
           setMatchError('');
-          setMatchStatus('Refreshing the queue and looking again…');
+          setMatchStatus('Still searching the ordered queue for the next same-stake opponent…');
           seatAttempts = 0;
           seatPlayer();
           return;
@@ -1097,7 +1097,7 @@ export default function ChessBattleRoyalLobby() {
             </p>
             {onlineQueueMode === 'quick' && (
               <p className="text-center text-xs font-semibold text-cyan-200">
-                Queue refresh in {searchSecondsLeft}s · searching continues automatically
+                120s opponent search window: {searchSecondsLeft}s left
               </p>
             )}
             {tableNumber && (


### PR DESCRIPTION
### Motivation
- Increase the online matchmaking window so a seated player is visible for longer while waiting for the next same-stake opponent. 
- Ensure the client shows a clear countdown and times out the in-game waiting state after the extended window. 
- Keep the existing ordered-queue quick-match behavior (refresh/retry) intact while aligning server-side seat TTL with the client wait time.

### Description
- Increase the quick-match refresh/window from `60s` to `120s` by updating `MATCHMAKING_REFRESH_MS` to `120000` in `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` and adjusting `searchSecondsLeft` handling and UI copy. 
- Add a client-side in-game opponent wait countdown with `CHESS_ONLINE_OPPONENT_WAIT_MS = 120000` plus `onlineWaitSecondsLeft` state and a timer in `webapp/src/pages/Games/ChessBattleRoyal.jsx` that emits `leaveLobby` and sets status to `timeout` when expired. 
- Extend server-side lobby seat TTL to 120 seconds by changing `lobbySeatTtlMs` default in `bot/server.js` so seats remain available long enough for the ordered queue handoff. 
- Update the unit test expectations in `test/chessLobbyHelpers.test.mjs` to reflect the new timing and copy changes.

### Testing
- Ran the focused helper test with Node: `node --test test/chessLobbyHelpers.test.mjs` and all subtests passed. 
- Attempted `npm test` (Jest) which failed to run that ESM test under Jest config (syntax/import handling), so the code-level check was validated via the `node --test` run instead. 
- Linted the changed files with `npx eslint` on the modified paths and it completed without errors for those files. 
- Built the repo with `npm run build` (TypeScript compile) which completed successfully; running the repository-wide `eslint .` reported many pre-existing unrelated errors in generated/dist files and was not treated as a blocker for this focused change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7300ab77488329b120f061ff0d124f)