### PR TITLE
Domino Royal: open online table immediately and extend opponent wait to 120s

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -511,6 +511,7 @@ const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
 const lobbySeatTtlMs = Number(process.env.LOBBY_SEAT_TTL_MS) || 60_000;
+const dominoRoyalLobbySeatTtlMs = Number(process.env.DOMINO_ROYAL_LOBBY_SEAT_TTL_MS) || 120_000;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
 
@@ -792,7 +793,9 @@ function cleanupSeats() {
   const now = Date.now();
   for (const [tableId, players] of tableSeats) {
     for (const [pid, info] of players) {
-      if (now - info.ts > lobbySeatTtlMs) {
+      const table = tableMap.get(tableId);
+      const ttlMs = table?.gameType === 'domino-royal' ? dominoRoyalLobbySeatTtlMs : lobbySeatTtlMs;
+      if (now - info.ts > ttlMs) {
         // Keep the public table and its authoritative seat map in sync. Merely
         // deleting the seat-map entry leaves a ghost in table.players; the next
         // quick-match player can then be started against that disconnected

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -28,6 +28,38 @@ let dominoOnlineStateSeq = 0;
 let dominoApplyingRemoteState = false;
 let dominoOnlineHasState = false;
 let dominoOnlineStateHandler = null;
+let dominoOnlineLobbyUpdateHandler = null;
+let dominoOnlineGameStartHandler = null;
+let dominoOnlineWaitingTimer = null;
+
+function persistDominoOnlineMatchPatch(patch = {}) {
+  if (typeof window === 'undefined') return null;
+  const next = { ...(DOMINO_ONLINE_MATCH || {}), ...patch };
+  try {
+    window.sessionStorage?.setItem('dominoRoyalOnlineMatch', JSON.stringify(next));
+  } catch {}
+  return next;
+}
+
+function showDominoOnlineWaitingStatus() {
+  if (!DOMINO_ONLINE_MODE || !DOMINO_ONLINE_MATCH?.waitingForOpponent) return;
+  const expiresAt = Number(DOMINO_ONLINE_MATCH.waitingExpiresAt || 0);
+  const update = () => {
+    const remaining = Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000));
+    if (remaining > 0) {
+      setStatus(`Seated at ${DOMINO_ONLINE_MATCH.tableNumber || 'online table'} • waiting for opponent (${remaining}s)`);
+      return;
+    }
+    setStatus('No opponent found in 120 seconds. Return to lobby or keep waiting.');
+    if (dominoOnlineWaitingTimer) {
+      clearInterval(dominoOnlineWaitingTimer);
+      dominoOnlineWaitingTimer = null;
+    }
+  };
+  update();
+  if (!dominoOnlineWaitingTimer) dominoOnlineWaitingTimer = setInterval(update, 1000);
+}
+
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
 const FRAME_RATE_STORAGE_KEY = 'dominoRoyalFrameRate';
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
@@ -10996,9 +11028,42 @@ function connectDominoOnlineTable() {
     applyDominoOnlineState(state);
   };
   DOMINO_ONLINE_SOCKET.on('dominoRoyalState', dominoOnlineStateHandler);
+  if (dominoOnlineLobbyUpdateHandler) DOMINO_ONLINE_SOCKET.off?.('lobbyUpdate', dominoOnlineLobbyUpdateHandler);
+  dominoOnlineLobbyUpdateHandler = ({ tableId, tableNumber, players: lobbyPlayers = [], ready = [] } = {}) => {
+    if (tableId !== DOMINO_ONLINE_TABLE_ID) return;
+    persistDominoOnlineMatchPatch({
+      tableId,
+      tableNumber: tableNumber || DOMINO_ONLINE_MATCH?.tableNumber || '',
+      players: Array.isArray(lobbyPlayers) ? lobbyPlayers : [],
+      ready: Array.isArray(ready) ? ready : [],
+      waitingForOpponent: Array.isArray(lobbyPlayers) && lobbyPlayers.length < N
+    });
+    setStatus(`Seated at ${tableNumber || 'online table'} • ${lobbyPlayers.length}/${N} players connected`);
+  };
+  DOMINO_ONLINE_SOCKET.on('lobbyUpdate', dominoOnlineLobbyUpdateHandler);
+  if (dominoOnlineGameStartHandler) DOMINO_ONLINE_SOCKET.off?.('gameStart', dominoOnlineGameStartHandler);
+  dominoOnlineGameStartHandler = ({ tableId, tableNumber, players: onlinePlayers = [], meta = {} } = {}) => {
+    if (tableId !== DOMINO_ONLINE_TABLE_ID) return;
+    persistDominoOnlineMatchPatch({
+      tableId,
+      tableNumber: tableNumber || DOMINO_ONLINE_MATCH?.tableNumber || '',
+      players: Array.isArray(onlinePlayers) ? onlinePlayers : [],
+      meta,
+      waitingForOpponent: false,
+      startedAt: Date.now()
+    });
+    if (dominoOnlineWaitingTimer) {
+      clearInterval(dominoOnlineWaitingTimer);
+      dominoOnlineWaitingTimer = null;
+    }
+    setStatus('Opponent found • starting online match…');
+    window.location.reload();
+  };
+  DOMINO_ONLINE_SOCKET.on('gameStart', dominoOnlineGameStartHandler);
   DOMINO_ONLINE_SOCKET.off?.('connect', joinAndSync);
   DOMINO_ONLINE_SOCKET.on('connect', joinAndSync);
   window.__dominoRoyalOnlineReconnectHandler = joinAndSync;
+  showDominoOnlineWaitingStatus();
 }
 
 async function bootstrapDominoRoyal() {

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -69,6 +69,7 @@ export default function DominoRoyalLobby() {
   const [queueStatus, setQueueStatus] = useState('');
   const [queueError, setQueueError] = useState('');
   const queuedTableIdRef = useRef('');
+  const launchedOnlineTableRef = useRef(false);
   const onlineStakeDebitedRef = useRef(false);
   const startBet = stake.amount / 100;
   const readiness = getOnlineReadiness('domino-royal');
@@ -237,7 +238,32 @@ export default function DominoRoyalLobby() {
       queuedTableIdRef.current = res.tableId;
       setQueuedTableId(res.tableId);
       const seated = Array.isArray(res.players) ? res.players.length : 1;
-      setQueueStatus(`Table ${res.tableNumber || res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players ready`);
+      setQueueStatus(`Opening table ${res.tableNumber || res.tableId.slice(0, 8)} • waiting up to 120 seconds for an opponent`);
+      try {
+        window.sessionStorage?.setItem(
+          'dominoRoyalOnlineMatch',
+          JSON.stringify({
+            tableId: res.tableId,
+            tableNumber: res.tableNumber || '',
+            accountId: String(accountId),
+            players: Array.isArray(res.players) ? res.players : [],
+            ready: Array.isArray(res.ready) ? res.ready : [],
+            meta: res.meta || {},
+            waitingForOpponent: seated < totalPlayers,
+            waitingStartedAt: Date.now(),
+            waitingExpiresAt: Date.now() + 120000
+          })
+        );
+      } catch {}
+      launchedOnlineTableRef.current = true;
+      launchGame({
+        accountId,
+        tgId,
+        tableId: res.tableId,
+        token: stake.token,
+        amount: stake.amount,
+        flagOverride: flags
+      });
       return;
     }
 
@@ -314,7 +340,7 @@ export default function DominoRoyalLobby() {
     return () => {
       socket.off('lobbyUpdate', handleLobbyUpdate);
       socket.off('gameStart', handleGameStart);
-      if (queuedTableIdRef.current) {
+      if (queuedTableIdRef.current && !launchedOnlineTableRef.current) {
         ensureAccountId()
           .then((accountId) => socket.emit('leaveLobby', { accountId, tableId: queuedTableIdRef.current }))
           .catch(() => {});


### PR DESCRIPTION
### Motivation
- Ensure pressing `START` seats the player and opens the Domino Royal game immediately while preserving their seat and waiting for an opponent up to 120 seconds. 
- Keep matchmaking order and make ready/seated players persist so incoming quick-match players can match against an already-seated waiting player.

### Description
- Client lobby: updated `webapp/src/pages/Games/DominoRoyalLobby.jsx` to immediately persist the online table info to `sessionStorage`, mark the table as launched (`launchedOnlineTableRef`), and navigate into the game right after `seatTable` succeeds so the seated player is opened into the match UI while opponents are searched. 
- Client runtime: enhanced `webapp/public/domino-royal-game.js` to persist lobby updates via `persistDominoOnlineMatchPatch`, display a 120s in-game waiting countdown with `showDominoOnlineWaitingStatus`, listen for `lobbyUpdate` and `gameStart` to update session state, and reload into the final online match once `gameStart` arrives. 
- Server: added a Domino-specific lobby seat TTL `DOMINO_ROYAL_LOBBY_SEAT_TTL_MS` (default 120000 ms) and updated `cleanupSeats()` in `bot/server.js` to use this TTL for `domino-royal` tables so seated players remain available for 120 seconds for matchmaking. 

### Testing
- Verified `node --check` for `webapp/public/domino-royal-game.js`, `webapp/src/pages/Games/dominoRoyalMatchmaking.js`, and `bot/server.js` without syntax errors. 
- Ran unit tests with `npm test -- --runInBand test/dominoRoyalMatchmaking.test.js test/dominoRoyalOnline.test.js bot/tests/dominoRoyalOnline.test.js` and the Domino Royal matchmaking/state suites passed (test suites that matched these patterns passed: 2 suites, 7 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73012da1f88329a94289effcf1a7a9)