### PR TITLE
Fix Domino Royal online matchmaking flow

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -510,6 +510,7 @@ function createChessTableNumber() {
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
+const dominoRoyalMatchTimeoutMs = Number(process.env.DOMINO_ROYAL_MATCH_TIMEOUT_MS) || 120000;
 const lobbySeatTtlMs = Number(process.env.LOBBY_SEAT_TTL_MS) || 120_000;
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
@@ -690,7 +691,8 @@ function createLobbyTable({
     players: [],
     currentTurn: null,
     ready: new Set(),
-    meta
+    meta,
+    matchTimeout: null
   };
   if (gameType === 'domino-royal' && table.tableNumber) {
     dominoRoyalTableNumbers.add(table.tableNumber);
@@ -1350,6 +1352,21 @@ async function seatTableSocket(
   }
   console.log(`Player ${playerName || accountId} joined table ${tableId}`);
   socket?.join(tableId);
+  if (table.gameType === 'domino-royal' && table.players.length === 1 && !table.matchTimeout) {
+    table.matchTimeout = setTimeout(() => {
+      table.matchTimeout = null;
+      const currentTable = tableMap.get(table.id);
+      if (!currentTable || currentTable.players.length >= currentTable.maxPlayers) return;
+      io.to(table.id).emit('dominoRoyalMatchTimeout', {
+        tableId: table.id,
+        tableNumber: table.tableNumber,
+        timeoutMs: dominoRoyalMatchTimeoutMs
+      });
+      for (const player of [...currentTable.players]) {
+        unseatTableSocket(player.id, table.id, player.socketId);
+      }
+    }, dominoRoyalMatchTimeoutMs);
+  }
   table.ready.delete(String(accountId));
   if (!table.meta) {
     table.meta = normalizeMatchMeta(matchMeta);
@@ -1383,6 +1400,10 @@ function maybeStartGame(table) {
         return;
       }
       console.log(`Table ${table.id} confirmed by all players. Starting game.`);
+      if (table.matchTimeout) {
+        clearTimeout(table.matchTimeout);
+        table.matchTimeout = null;
+      }
       if (table.gameType === 'poolroyale') {
         const randomStarter = table.players[Math.floor(Math.random() * table.players.length)];
         if (randomStarter) table.currentTurn = randomStarter.id;
@@ -1473,6 +1494,10 @@ function unseatTableSocket(accountId, tableId, socketId) {
         checkersMatchSessions.delete(tableId);
       }
       if (table.gameType === 'domino-royal') {
+        if (table.matchTimeout) {
+          clearTimeout(table.matchTimeout);
+          table.matchTimeout = null;
+        }
         dominoRoyalStates.delete(tableId);
         if (table.tableNumber) dominoRoyalTableNumbers.delete(table.tableNumber);
       }

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -28,6 +28,9 @@ let dominoOnlineStateSeq = 0;
 let dominoApplyingRemoteState = false;
 let dominoOnlineHasState = false;
 let dominoOnlineStateHandler = null;
+let dominoOnlineGameStartHandler = null;
+let dominoOnlineMatchTimeoutHandler = null;
+let dominoOnlineWaitingTimer = null;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
 const FRAME_RATE_STORAGE_KEY = 'dominoRoyalFrameRate';
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
@@ -10963,6 +10966,12 @@ function applyDominoOnlineState(remoteState = {}) {
   raceRoundNumber = Number(remoteState.raceRoundNumber) || raceRoundNumber;
   lastHandWinnerIndex = Number.isInteger(remoteState.lastHandWinnerIndex) ? remoteState.lastHandWinnerIndex : null;
   dominoOnlineHasState = true;
+  if (dominoOnlineWaitingTimer) {
+    clearInterval(dominoOnlineWaitingTimer);
+    dominoOnlineWaitingTimer = null;
+  }
+  persistDominoOnlineMatch({ waiting: false, startedAt: Date.now() });
+  setControlEnabled(true);
   refreshSeatAvatars();
   rebuildDominoCharactersForChairs();
   renderBoneyardStack();
@@ -10973,6 +10982,28 @@ function applyDominoOnlineState(remoteState = {}) {
     showWinnerOverlay({ winner: winnerIndex, reason: winnerIndex === human ? 'You won!' : 'Online match finished' });
   }
   dominoApplyingRemoteState = false;
+}
+
+function persistDominoOnlineMatch(update = {}) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage?.setItem(
+      'dominoRoyalOnlineMatch',
+      JSON.stringify({ ...(DOMINO_ONLINE_MATCH || {}), ...update })
+    );
+  } catch {}
+}
+
+function updateDominoOnlineWaitingStatus() {
+  if (!DOMINO_ONLINE_MODE || !DOMINO_ONLINE_MATCH?.waiting) return;
+  const queuedAt = Number(DOMINO_ONLINE_MATCH.queuedAt) || Date.now();
+  const timeoutMs = Number(DOMINO_ONLINE_MATCH.timeoutMs) || 120000;
+  const remaining = Math.max(0, Math.ceil((queuedAt + timeoutMs - Date.now()) / 1000));
+  setStatus(`You are seated. Waiting for opponent… ${remaining}s`);
+  if (remaining <= 0 && dominoOnlineWaitingTimer) {
+    clearInterval(dominoOnlineWaitingTimer);
+    dominoOnlineWaitingTimer = null;
+  }
 }
 
 function connectDominoOnlineTable() {
@@ -10996,6 +11027,40 @@ function connectDominoOnlineTable() {
     applyDominoOnlineState(state);
   };
   DOMINO_ONLINE_SOCKET.on('dominoRoyalState', dominoOnlineStateHandler);
+  if (dominoOnlineGameStartHandler) {
+    DOMINO_ONLINE_SOCKET.off?.('gameStart', dominoOnlineGameStartHandler);
+  }
+  dominoOnlineGameStartHandler = ({ tableId, tableNumber, players: roster = [], meta = {} } = {}) => {
+    if (tableId !== DOMINO_ONLINE_TABLE_ID) return;
+    const onlineSeatIndex = Array.isArray(roster)
+      ? roster.findIndex((player) => String(player?.id || '') === String(DOMINO_ONLINE_ACCOUNT_ID || DOMINO_ONLINE_MATCH?.accountId || ''))
+      : -1;
+    if (onlineSeatIndex >= 0) human = onlineSeatIndex;
+    if (Array.isArray(roster) && roster.length >= 2 && roster.length <= 4) N = roster.length;
+    persistDominoOnlineMatch({ tableId, tableNumber: tableNumber || '', players: roster, meta, waiting: false, startedAt: Date.now() });
+    if (dominoOnlineWaitingTimer) {
+      clearInterval(dominoOnlineWaitingTimer);
+      dominoOnlineWaitingTimer = null;
+    }
+    if (!dominoOnlineHasState && human === 0) {
+      startGame();
+      emitDominoOnlineState('start');
+    }
+    setControlEnabled(true);
+    setStatus('Opponent found. Match started.');
+  };
+  DOMINO_ONLINE_SOCKET.on('gameStart', dominoOnlineGameStartHandler);
+  if (dominoOnlineMatchTimeoutHandler) {
+    DOMINO_ONLINE_SOCKET.off?.('dominoRoyalMatchTimeout', dominoOnlineMatchTimeoutHandler);
+  }
+  dominoOnlineMatchTimeoutHandler = ({ tableId } = {}) => {
+    if (tableId !== DOMINO_ONLINE_TABLE_ID) return;
+    if (dominoOnlineWaitingTimer) clearInterval(dominoOnlineWaitingTimer);
+    dominoOnlineWaitingTimer = null;
+    setControlEnabled(false);
+    setStatus('No opponent found in 120 seconds. Please return to the lobby and start again.');
+  };
+  DOMINO_ONLINE_SOCKET.on('dominoRoyalMatchTimeout', dominoOnlineMatchTimeoutHandler);
   DOMINO_ONLINE_SOCKET.off?.('connect', joinAndSync);
   DOMINO_ONLINE_SOCKET.on('connect', joinAndSync);
   window.__dominoRoyalOnlineReconnectHandler = joinAndSync;
@@ -11006,7 +11071,16 @@ async function bootstrapDominoRoyal() {
     await loadHumanProfileFromApi();
     if (DOMINO_ONLINE_MODE) {
       connectDominoOnlineTable();
-      if (human === 0) {
+      if (DOMINO_ONLINE_MATCH?.waiting) {
+        players = Array.from({ length: N }, (_, i) => ({ id: i, hand: [] }));
+        refreshSeatAvatars();
+        rebuildDominoCharactersForChairs();
+        renderHands();
+        renderChain();
+        updateDominoOnlineWaitingStatus();
+        dominoOnlineWaitingTimer = setInterval(updateDominoOnlineWaitingStatus, 1000);
+        setControlEnabled(false);
+      } else if (human === 0) {
         startGame();
         setControlEnabled(true);
       } else {
@@ -12067,9 +12141,21 @@ function shutdownDominoRoyal(reason = 'unknown') {
   } catch (error) {
     console.warn('Domino Royal shutdown failed', reason, error);
   }
+  if (dominoOnlineWaitingTimer) {
+    clearInterval(dominoOnlineWaitingTimer);
+    dominoOnlineWaitingTimer = null;
+  }
   if (DOMINO_ONLINE_SOCKET && dominoOnlineStateHandler) {
     DOMINO_ONLINE_SOCKET.off?.('dominoRoyalState', dominoOnlineStateHandler);
     dominoOnlineStateHandler = null;
+  }
+  if (DOMINO_ONLINE_SOCKET && dominoOnlineGameStartHandler) {
+    DOMINO_ONLINE_SOCKET.off?.('gameStart', dominoOnlineGameStartHandler);
+    dominoOnlineGameStartHandler = null;
+  }
+  if (DOMINO_ONLINE_SOCKET && dominoOnlineMatchTimeoutHandler) {
+    DOMINO_ONLINE_SOCKET.off?.('dominoRoyalMatchTimeout', dominoOnlineMatchTimeoutHandler);
+    dominoOnlineMatchTimeoutHandler = null;
   }
   if (DOMINO_ONLINE_SOCKET && window.__dominoRoyalOnlineReconnectHandler) {
     DOMINO_ONLINE_SOCKET.off?.('connect', window.__dominoRoyalOnlineReconnectHandler);

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -5,7 +5,7 @@ import { socket } from '../../utils/socket.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-08-03-authoritative-online-v67';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-08-05-online-seat-wait-v68';
 const DOMINO_CHARACTER_PRECONNECT_URLS = Object.freeze([
   'https://threejs.org',
   'https://models.readyplayer.me',

--- a/webapp/src/pages/Games/DominoRoyalLobby.jsx
+++ b/webapp/src/pages/Games/DominoRoyalLobby.jsx
@@ -18,7 +18,7 @@ import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
 import { refreshSocketAuthIdentity, socket } from '../../utils/socket.js';
 import { getOnlineReadiness } from '../../config/onlineContract.js';
-import { joinDominoRoyalLobby } from './dominoRoyalMatchmaking.js';
+import { DOMINO_ROYAL_MATCH_TIMEOUT_MS, joinDominoRoyalLobby } from './dominoRoyalMatchmaking.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -213,7 +213,7 @@ export default function DominoRoyalLobby() {
         criteria: {
           gameType: 'domino-royal',
           stake: Number(stake.amount) || 0,
-          maxPlayers: totalPlayers,
+          maxPlayers: 2,
           playerName: getTelegramUsername() || 'Player',
           avatar,
           mode: 'online',
@@ -237,7 +237,30 @@ export default function DominoRoyalLobby() {
       queuedTableIdRef.current = res.tableId;
       setQueuedTableId(res.tableId);
       const seated = Array.isArray(res.players) ? res.players.length : 1;
-      setQueueStatus(`Table ${res.tableNumber || res.tableId.slice(0, 8)} • ${seated}/${totalPlayers} players ready`);
+      setQueueStatus(`Table ${res.tableNumber || res.tableId.slice(0, 8)} • seat ${seated}/2 ready • waiting up to 120s for opponent`);
+      try {
+        window.sessionStorage?.setItem(
+          'dominoRoyalOnlineMatch',
+          JSON.stringify({
+            tableId: res.tableId,
+            tableNumber: res.tableNumber || '',
+            accountId,
+            players: Array.isArray(res.players) ? res.players : [],
+            meta: res.meta || {},
+            waiting: true,
+            queuedAt: Date.now(),
+            timeoutMs: DOMINO_ROYAL_MATCH_TIMEOUT_MS
+          })
+        );
+      } catch {}
+      launchGame({
+        accountId,
+        tgId,
+        tableId: res.tableId,
+        token: stake.token,
+        amount: stake.amount,
+        flagOverride: flags
+      });
       return;
     }
 
@@ -257,7 +280,7 @@ export default function DominoRoyalLobby() {
     const handleLobbyUpdate = ({ tableId, tableNumber, players: lobbyPlayers = [], ready = [] } = {}) => {
       if (!tableId || tableId !== queuedTableIdRef.current) return;
       setQueueStatus(
-        `Table ${tableNumber || String(tableId).slice(0, 8)} • ${lobbyPlayers.length}/${totalPlayers} players connected • ${ready.length}/${totalPlayers} ready`
+        `Table ${tableNumber || String(tableId).slice(0, 8)} • ${lobbyPlayers.length}/2 players connected • ${ready.length}/2 ready`
       );
     };
 

--- a/webapp/src/pages/Games/dominoRoyalMatchmaking.js
+++ b/webapp/src/pages/Games/dominoRoyalMatchmaking.js
@@ -1,5 +1,6 @@
 const DEFAULT_CONNECT_TIMEOUT_MS = 15000
 const DEFAULT_ACK_TIMEOUT_MS = 6000
+export const DOMINO_ROYAL_MATCH_TIMEOUT_MS = 120000
 
 function waitForSocketConnection (socket, timeoutMs = DEFAULT_CONNECT_TIMEOUT_MS) {
   if (socket?.connected) return Promise.resolve(true)


### PR DESCRIPTION
### Motivation
- Improve the Domino Royal online flow so pressing `Start` immediately opens the game and seats the player instead of leaving them sitting in the lobby UI.
- Ensure a short, server-authoritative opponent match window and clear user feedback when no opponent arrives.
- Make queued/ready seats match 2-player opponent semantics and avoid incorrect multi-player queueing for quick-match.

### Description
- Lobby: limit quick-match criteria to `maxPlayers: 2`, immediately navigate into the game after `seatTable` and persist a waiting context in `sessionStorage` with `waiting`, `queuedAt`, and `timeoutMs` fields (changes in `webapp/src/pages/Games/DominoRoyalLobby.jsx`).
- Timeout constant: export `DOMINO_ROYAL_MATCH_TIMEOUT_MS = 120000` from `dominoRoyalMatchmaking.js` and use it client-side for the waiting UI.
- Server: add `dominoRoyalMatchTimeoutMs`, set a per-table `matchTimeout` when the first Domino Royal seat is taken, emit `dominoRoyalMatchTimeout` on expiry and unseat the waiting player(s), and clear the timeout when a table actually starts or is emptied (changes in `bot/server.js`).
- Game runtime: add in-game waiting support including a countdown/updater, persist/refresh the stored match context, handle `gameStart` to assign the authoritative seat and start/sync host state, listen for `dominoRoyalMatchTimeout` to show a timeout message, and clean up timers/listeners on shutdown (changes in `webapp/public/domino-royal-game.js`).
- Bump the Domino Royal script version so clients load the updated flow (`webapp/src/pages/Games/DominoRoyalArena.jsx`).

### Testing
- Built the repo with `npm run build` and the TypeScript build completed successfully.
- Ran the Domino Royal online unit tests with `npm test -- --runInBand dominoRoyalOnline`, and the suite passed (`5 passed, 0 failed`).
- Verified the updated code path by running the build + tests again after the script version bump, and tests remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73035d9dc48329857485078a68e749)