### PR TITLE
Keep chess online players seated in-game while waiting for opponent (show elapsed wait timer)

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -199,7 +199,6 @@ const SNAKE_SHARED_CAPTURE_VEHICLE_MODEL_HOSTS = Object.freeze([
 ]);
 const snakeSharedCaptureVehicleUrls = (fileName) =>
   SNAKE_SHARED_CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${fileName}`);
-const CHESS_ONLINE_OPPONENT_WAIT_MS = 120000;
 
 const CAPTURE_MODEL_URLS = Object.freeze({
   drone: snakeSharedCaptureVehicleUrls('drone.glb'),
@@ -9076,9 +9075,7 @@ function Chess3D({
   const [onlineStatus, setOnlineStatus] = useState(
     onlineRef.current.enabled ? 'connecting' : 'offline'
   );
-  const [onlineWaitSecondsLeft, setOnlineWaitSecondsLeft] = useState(
-    CHESS_ONLINE_OPPONENT_WAIT_MS / 1000
-  );
+  const [onlineWaitSeconds, setOnlineWaitSeconds] = useState(0);
   useEffect(() => {
     if (accountId) {
       setOnlineStatus((prev) => (prev === 'offline' ? 'connecting' : prev));
@@ -9107,25 +9104,17 @@ function Chess3D({
 
   useEffect(() => {
     if (!onlineRef.current.enabled || opponent || onlineStatus === 'in-game') {
-      setOnlineWaitSecondsLeft(CHESS_ONLINE_OPPONENT_WAIT_MS / 1000);
+      setOnlineWaitSeconds(0);
       return undefined;
     }
     if (!['waiting', 'matched', 'connecting', 'starting'].includes(onlineStatus)) {
       return undefined;
     }
-    const expiresAt = Date.now() + CHESS_ONLINE_OPPONENT_WAIT_MS;
-    setOnlineWaitSecondsLeft(CHESS_ONLINE_OPPONENT_WAIT_MS / 1000);
+    const startedAt = Date.now();
+    setOnlineWaitSeconds(0);
     const timer = window.setInterval(() => {
-      const secondsLeft = Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000));
-      setOnlineWaitSecondsLeft(secondsLeft);
-      if (secondsLeft <= 0) {
-        window.clearInterval(timer);
-        if (onlineRef.current.tableId) {
-          socket.emit('leaveLobby', { accountId, tableId: onlineRef.current.tableId });
-        }
-        setOnlineStatus('timeout');
-      }
-    }, 250);
+      setOnlineWaitSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)));
+    }, 1000);
     return () => window.clearInterval(timer);
   }, [accountId, onlineStatus, opponent]);
   const resolvedAccountId = useMemo(() => chessBattleAccountId(accountId), [accountId]);
@@ -16901,10 +16890,8 @@ function Chess3D({
                 {onlineStatus === 'in-game'
                   ? `Synced${opponent ? ` vs ${avatarToName(opponent.avatar) || opponent.name || opponent.id}` : ''}`
                   : onlineStatus === 'waiting'
-                    ? `Waiting for opponent · ${onlineWaitSecondsLeft}s`
-                    : onlineStatus === 'timeout'
-                      ? 'Opponent was not found in 120s'
-                      : `Status: ${onlineStatus}`}
+                    ? `Waiting in game for opponent · ${onlineWaitSeconds}s`
+                    : `Status: ${onlineStatus}`}
               </div>
               {tableId && (
                 <div className="text-[10px] text-emerald-50/70">


### PR DESCRIPTION
### Motivation

- Players who are seated for an online chess match should be taken into the game scene and remain seated waiting for an opponent instead of being removed after a hard 120s timeout.
- The in-game HUD should clearly indicate that the player is waiting inside the game and show an elapsed wait timer for clarity.

### Description

- Replaced the previous timeout-based waiting logic in `webapp/src/pages/Games/ChessBattleRoyal.jsx` by removing the `CHESS_ONLINE_OPPONENT_WAIT_MS` countdown and switching to an elapsed timer stored in `onlineWaitSeconds`.
- Stopped the timeout branch that emitted `leaveLobby` and set `onlineStatus` to `timeout`, so the client no longer automatically leaves the reserved seat when waiting for an opponent.
- Updated the online match HUD text to show `Waiting in game for opponent · {onlineWaitSeconds}s` while the player remains in the game scene.
- Kept the rest of the lobby start/seat flow intact so seats remain reserved and the game will start once the opponent joins and `gameStart` is emitted.

### Testing

- Ran the unit helper tests with `node --test test/chessLobbyHelpers.test.mjs`, and all tests passed (5/5). 
- Performed a production build of the webapp with `npm --prefix webapp run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7304082618832990702249ad08e303)