### PR TITLE
Fix chess online game handoff

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -9427,8 +9427,20 @@ function Chess3D({
         (res) => {
           if (!active) return;
           if (res?.tableId) {
+            const playersList = Array.isArray(res.players) ? res.players : [];
+            const opp = playersList.find(
+              (p) => resolveOnlinePlayerId(p) !== String(accountId)
+            );
+            const meIndex = playersList.findIndex(
+              (p) => resolveOnlinePlayerId(p) === String(accountId)
+            );
+            const mySide =
+              playersList.find((p) => resolveOnlinePlayerId(p) === String(accountId))?.side ||
+              (meIndex === 0 ? 'white' : meIndex === 1 ? 'black' : normalizedInitialSide);
+            onlineRef.current.side = mySide;
+            if (opp) setOpponent(opp);
             joinExistingTable(res.tableId);
-            setOnlineStatus('matched');
+            setOnlineStatus(opp ? 'matched' : 'waiting');
             socket.emit('confirmReady', { accountId, tableId: res.tableId });
           }
         }
@@ -17581,7 +17593,7 @@ export default function ChessBattleRoyal() {
     getTelegramUsername();
   const initialAccountId = params.get('accountId') || '';
   const mode = params.get('mode') || 'ai';
-  const initialTableId = params.get('tableId') || '';
+  const initialTableId = params.get('tableId') || params.get('table') || '';
   const initialTableNumber = params.get('tableNumber') || '';
   const preferredSideParam = params.get('preferredSide');
   const [accountId, setAccountId] = useState(initialAccountId);
@@ -17613,11 +17625,10 @@ export default function ChessBattleRoyal() {
   useEffect(() => {
     let cancelled = false;
     if (mode === 'online' && !initialTableId) {
-      setRedirecting(true);
-      navigate('/games/chessbattleroyal/lobby', { replace: true });
-      return () => {
-        cancelled = true;
-      };
+      // Let the game scene itself claim an online seat when it opens without a
+      // table id. This keeps the player seated at the board while matchmaking
+      // waits for the opponent instead of bouncing them back to the lobby.
+      setRedirecting(false);
     }
     if (mode === 'online' && !initialAccountId) {
       ensureAccountId()


### PR DESCRIPTION
### Motivation
- Keep a player who requests an online Chess Battle Royal match seated in the game scene while the client claims a matchmaking seat, instead of bouncing them back to the lobby.
- Make URL handling more tolerant by accepting `table` as an alias for `tableId` so incoming handoff links work consistently.

### Description
- In `webapp/src/pages/Games/ChessBattleRoyal.jsx` the `seatTable` callback now inspects `res.players`, assigns the player's `side`, stores any already-present opponent, and sets the local online status to `matched` only when an opponent exists or `waiting` otherwise.
- The game now calls `socket.emit('confirmReady', ...)` and `joinExistingTable(...)` as part of the handoff while preserving the waiting state until the opponent joins.
- The route parameter parsing now accepts `params.get('table')` as an alias for `tableId` by changing `initialTableId` to `params.get('tableId') || params.get('table') || ''`.
- The redirect-to-lobby when opening the game in `mode=online` without a `tableId` was removed so the game scene itself can claim the online seat and keep the user visually seated while matchmaking proceeds.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.
- Ran basic diff/checks (`git diff --check`) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73076114fc83299621fe1e0f5d1dd7)