### PR TITLE
Server-side chess staking & settlement; client lobby/game updates

### DIFF
--- a/bot/routes/matchmaking.js
+++ b/bot/routes/matchmaking.js
@@ -92,4 +92,48 @@ router.post('/release', async (req, res) => {
   finally { await session.endSession(); }
 });
 
+
+router.post('/settle', async (req, res) => {
+  const matchId = String(req.body?.matchId || '');
+  const winnerAccount = String(req.body?.winnerTpcAccountId || req.body?.winnerAccountId || '');
+  const draw = Boolean(req.body?.draw);
+  const feeBps = Math.max(0, Math.min(10_000, Number(process.env.CHESS_HOUSE_FEE_BPS) || 500));
+  const houseAccount = String(process.env.CHESS_HOUSE_ACCOUNT || process.env.HOUSE_TPC_ACCOUNT || '').trim();
+  const session = await mongoose.startSession();
+  try {
+    let result;
+    await session.withTransaction(async () => {
+      const match = await ChessMatch.findOne({ internalMatchId: matchId }).session(session);
+      if (!match) throw new Error('match_not_found');
+      if (['finished', 'draw'].includes(match.status)) { result = { settled: true, status: match.status, winnerTpcAccountId: match.winnerTpcAccountId || null }; return; }
+      if (match.status !== 'playing') throw new Error('match_not_playing');
+      const accounts = [match.player1TpcAccountId, match.player2TpcAccountId];
+      if (draw) {
+        for (const account of accounts) {
+          const transactionId = `chess:${matchId}:draw:${account}`;
+          await User.updateOne({ tpcAccountNumber: account, 'transactions.transactionId': { $ne: transactionId } }, { $inc: { balance: match.stakePerPlayer }, $set: { currentTableId: null }, $push: { transactions: { transactionId, amount: match.stakePerPlayer, type: 'stake_refund', token: 'TPC', status: 'delivered', game: 'chessbattle', players: 2, detail: 'draw' } } }, { session });
+        }
+        match.status = 'draw'; match.result = String(req.body?.reason || 'draw');
+      } else {
+        if (!accounts.includes(winnerAccount)) throw new Error('winner_not_in_match');
+        const gross = Number(match.totalLockedStake || match.stakePerPlayer * 2);
+        const houseFee = Math.floor((gross * feeBps) / 10_000);
+        const payout = gross - houseFee;
+        const payoutTx = `chess:${matchId}:payout:${winnerAccount}`;
+        await User.updateOne({ tpcAccountNumber: winnerAccount, 'transactions.transactionId': { $ne: payoutTx } }, { $inc: { balance: payout }, $set: { currentTableId: null }, $push: { transactions: { transactionId: payoutTx, amount: payout, type: 'stake_payout', token: 'TPC', status: 'delivered', game: 'chessbattle', players: 2, detail: matchId } } }, { session });
+        for (const account of accounts.filter((account) => account !== winnerAccount)) await User.updateOne({ tpcAccountNumber: account }, { $set: { currentTableId: null } }, { session });
+        if (houseFee > 0 && houseAccount) {
+          const feeTx = `chess:${matchId}:house:${houseAccount}`;
+          await User.updateOne({ tpcAccountNumber: houseAccount }, { $inc: { balance: houseFee }, $push: { transactions: { transactionId: feeTx, amount: houseFee, type: 'house_fee', token: 'TPC', status: 'delivered', game: 'chessbattle', players: 2, detail: matchId } } }, { session });
+        }
+        match.status = 'finished'; match.winnerTpcAccountId = winnerAccount; match.result = String(req.body?.reason || 'checkmate');
+      }
+      await match.save({ session });
+      result = { settled: true, status: match.status, winnerTpcAccountId: match.winnerTpcAccountId || null };
+    });
+    res.json(result);
+  } catch (error) { res.status(409).json({ error: error.message || 'settlement_failed' }); }
+  finally { await session.endSession(); }
+});
+
 export default router;

--- a/bot/server.js
+++ b/bot/server.js
@@ -45,6 +45,7 @@ import PostRecord from './models/PostRecord.js';
 import Task from './models/Task.js';
 import WatchRecord from './models/WatchRecord.js';
 import ActiveConnection from './models/ActiveConnection.js';
+import ChessMatch from './models/ChessMatch.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync } from 'fs';
@@ -78,6 +79,8 @@ import { applyAuthoritativeMove, SIDES } from './utils/checkersAuthoritativeEngi
 validateEnv();
 
 const CHESS_START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1';
+const CHESS_HOUSE_FEE_BPS = Math.max(0, Math.min(10_000, Number(process.env.CHESS_HOUSE_FEE_BPS) || 500));
+const CHESS_HOUSE_ACCOUNT = String(process.env.CHESS_HOUSE_ACCOUNT || process.env.HOUSE_TPC_ACCOUNT || '').trim();
 const chessGames = new Map();
 const checkersRealtimeStore = createCheckersRealtimeStore();
 const checkersMatchSessions = new Map();
@@ -1384,6 +1387,141 @@ async function seatTableSocket(
   return table;
 }
 
+
+async function reserveChessStakeContract(table) {
+  if (!table || table.gameType !== 'chess') return { ok: true };
+  if (table.matchId) return { ok: true, matchId: table.matchId };
+  const accounts = table.players.map((player) => String(player.tpcAccountNumber || player.id || '')).filter(Boolean);
+  const stake = Number(table.stake || 0);
+  if (accounts.length !== 2 || new Set(accounts).size !== 2 || !Number.isSafeInteger(stake) || stake <= 0) {
+    return { ok: false, error: 'invalid_chess_stake_contract' };
+  }
+  const session = await mongoose.startSession();
+  try {
+    let matchId = '';
+    await session.withTransaction(async () => {
+      const active = await ChessMatch.findOne({
+        status: { $in: ['reserved', 'playing'] },
+        $or: [
+          { player1TpcAccountId: { $in: accounts } },
+          { player2TpcAccountId: { $in: accounts } }
+        ]
+      }).session(session);
+      if (active) throw new Error('account_already_in_active_match');
+      const users = await User.find({
+        $or: [
+          { tpcAccountNumber: { $in: accounts } },
+          { accountId: { $in: accounts } }
+        ],
+        balance: { $gte: stake },
+        isBanned: { $ne: true }
+      }).session(session);
+      const byAccount = new Map(users.flatMap((user) => [String(user.tpcAccountNumber || ''), String(user.accountId || '')].filter(Boolean).map((id) => [id, user])));
+      if (accounts.some((account) => !byAccount.has(account))) throw new Error('insufficient_balance_or_account_missing');
+      matchId = randomUUID();
+      const transactionIds = accounts.map((account) => `chess:${matchId}:reserve:${account}`);
+      for (const [index, account] of accounts.entries()) {
+        const user = byAccount.get(account);
+        user.balance = Number(user.balance || 0) - stake;
+        user.currentTableId = table.tableNumber || table.id;
+        user.transactions.push({
+          transactionId: transactionIds[index],
+          amount: -stake,
+          type: 'stake_reserve',
+          token: 'TPC',
+          status: 'reserved',
+          game: 'chessbattle',
+          players: 2,
+          detail: matchId
+        });
+        await user.save({ session });
+      }
+      await ChessMatch.create([{
+        tableNumber: table.tableNumber || table.id,
+        internalMatchId: matchId,
+        roomId: table.id,
+        player1TpcAccountId: accounts[0],
+        player2TpcAccountId: accounts[1],
+        stakePerPlayer: stake,
+        totalLockedStake: stake * 2,
+        stakeTransactionIds: transactionIds,
+        status: 'playing',
+        startedAt: new Date()
+      }], { session });
+    });
+    table.matchId = matchId;
+    return { ok: true, matchId };
+  } catch (error) {
+    return { ok: false, error: error.message || 'stake_contract_failed' };
+  } finally {
+    await session.endSession();
+  }
+}
+
+async function settleChessStakeContract(tableId, result = {}) {
+  const winnerSide = result.winner === 'white' || result.winner === 'black' ? result.winner : null;
+  const isDraw = result.draw || !winnerSide;
+  const table = tableMap.get(tableId);
+  const session = await mongoose.startSession();
+  try {
+    let settlement = null;
+    await session.withTransaction(async () => {
+      const match = await ChessMatch.findOne({ roomId: tableId }).session(session);
+      if (!match) throw new Error('match_not_found');
+      if (['finished', 'draw', 'refunded'].includes(match.status)) {
+        settlement = { status: match.status, matchId: match.internalMatchId };
+        return;
+      }
+      if (match.status !== 'playing') throw new Error('match_not_playing');
+      const accounts = [match.player1TpcAccountId, match.player2TpcAccountId];
+      if (isDraw) {
+        for (const account of accounts) {
+          const transactionId = `chess:${match.internalMatchId}:draw:${account}`;
+          await User.updateOne({ $or: [{ tpcAccountNumber: account }, { accountId: account }], 'transactions.transactionId': { $ne: transactionId } }, {
+            $inc: { balance: match.stakePerPlayer },
+            $set: { currentTableId: null },
+            $push: { transactions: { transactionId, amount: match.stakePerPlayer, type: 'stake_refund', token: 'TPC', status: 'delivered', game: 'chessbattle', players: 2, detail: 'draw' } }
+          }, { session });
+        }
+        match.status = 'draw';
+        match.result = String(result.draw || 'draw');
+      } else {
+        const players = Array.isArray(table?.players) ? table.players : [];
+        const winnerPlayer = players.find((player) => player.side === winnerSide);
+        const winnerAccount = String(winnerPlayer?.tpcAccountNumber || winnerPlayer?.id || (winnerSide === 'white' ? accounts[0] : accounts[1]));
+        const gross = Number(match.totalLockedStake || match.stakePerPlayer * 2);
+        const houseFee = Math.floor((gross * CHESS_HOUSE_FEE_BPS) / 10_000);
+        const payout = gross - houseFee;
+        const payoutTx = `chess:${match.internalMatchId}:payout:${winnerAccount}`;
+        await User.updateOne({ $or: [{ tpcAccountNumber: winnerAccount }, { accountId: winnerAccount }], 'transactions.transactionId': { $ne: payoutTx } }, {
+          $inc: { balance: payout },
+          $set: { currentTableId: null },
+          $push: { transactions: { transactionId: payoutTx, amount: payout, type: 'stake_payout', token: 'TPC', status: 'delivered', game: 'chessbattle', players: 2, detail: match.internalMatchId } }
+        }, { session });
+        const loserAccount = accounts.find((account) => account !== winnerAccount);
+        if (loserAccount) await User.updateOne({ $or: [{ tpcAccountNumber: loserAccount }, { accountId: loserAccount }] }, { $set: { currentTableId: null } }, { session });
+        if (houseFee > 0 && CHESS_HOUSE_ACCOUNT) {
+          const feeTx = `chess:${match.internalMatchId}:house:${CHESS_HOUSE_ACCOUNT}`;
+          await User.updateOne({ $or: [{ tpcAccountNumber: CHESS_HOUSE_ACCOUNT }, { accountId: CHESS_HOUSE_ACCOUNT }] }, {
+            $inc: { balance: houseFee },
+            $push: { transactions: { transactionId: feeTx, amount: houseFee, type: 'house_fee', token: 'TPC', status: 'delivered', game: 'chessbattle', players: 2, detail: match.internalMatchId } }
+          }, { session });
+        }
+        match.status = 'finished';
+        match.winnerTpcAccountId = winnerAccount;
+        match.result = `${winnerSide}_checkmate`;
+      }
+      await match.save({ session });
+      settlement = { status: match.status, matchId: match.internalMatchId, winner: match.winnerTpcAccountId || null };
+    });
+    return { ok: true, settlement };
+  } catch (error) {
+    return { ok: false, error: error.message || 'settlement_failed' };
+  } finally {
+    await session.endSession();
+  }
+}
+
 function maybeStartGame(table) {
   if (
     table.players.length === table.maxPlayers &&
@@ -1391,7 +1529,7 @@ function maybeStartGame(table) {
     table.ready.size === table.maxPlayers
   ) {
     if (table.startTimeout) return;
-    table.startTimeout = setTimeout(() => {
+    table.startTimeout = setTimeout(async () => {
       table.startTimeout = null;
       if (
         tableMap.get(table.id) !== table ||
@@ -1402,6 +1540,22 @@ function maybeStartGame(table) {
         return;
       }
       console.log(`Table ${table.id} confirmed by all players. Starting game.`);
+      if (table.gameType === 'chess') {
+        const reservation = await reserveChessStakeContract(table);
+        if (!reservation.ok) {
+          table.ready.clear();
+          io.to(table.id).emit('errorMessage', reservation.error);
+          io.to(table.id).emit('lobbyUpdate', {
+            tableId: table.id,
+            tableNumber: table.tableNumber,
+            players: table.players,
+            currentTurn: table.currentTurn,
+            ready: [],
+            meta: table.meta
+          });
+          return;
+        }
+      }
       if (table.matchTimeout) {
         clearTimeout(table.matchTimeout);
         table.matchTimeout = null;
@@ -1444,7 +1598,8 @@ function maybeStartGame(table) {
         players: table.players,
         currentTurn: table.currentTurn,
         stake: table.stake,
-        meta: table.meta
+        meta: table.meta,
+        matchId: table.matchId || null
       });
       tableSeats.delete(table.id);
       const key = `${table.gameType}-${table.maxPlayers}`;
@@ -2680,6 +2835,13 @@ io.on('connection', (socket) => {
     const payload = { tableId, ...next };
     socket.to(tableId).emit('chessMove', payload);
     cb && cb({ success: true, state: payload });
+    if (next.winner || next.draw) {
+      settleChessStakeContract(tableId, { winner: next.winner, draw: next.draw }).then((settlement) => {
+        io.to(tableId).emit('chessSettlement', { tableId, ...settlement });
+      }).catch((error) => {
+        io.to(tableId).emit('chessSettlement', { tableId, ok: false, error: error.message || 'settlement_failed' });
+      });
+    }
   });
 
   socket.on('checkersMove', async ({ tableId, move }) => {

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -9381,11 +9381,27 @@ function Chess3D({
       setOnlineStatus(opp ? 'matched' : 'waiting');
     };
 
+    const handleChessSettlement = ({ tableId: settledId, ok, settlement, error } = {}) => {
+      if (!settledId || String(settledId) !== String(tableJoin.current)) return;
+      if (ok === false) {
+        setOnlineStatus('settlement-error');
+        setUi((state) => ({ ...state, status: `Settlement pending — ${error || 'retrying'}` }));
+        return;
+      }
+      setOnlineStatus('settled');
+      if (settlement?.status === 'draw') {
+        setUi((state) => ({ ...state, status: 'Draw settled — stakes refunded' }));
+      } else if (settlement?.winner) {
+        setUi((state) => ({ ...state, status: 'Winner paid — house fee kept' }));
+      }
+    };
+
     socket.on('gameStart', handleGameStart);
     socket.on('gameStarted', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
     socket.on('chessState', handleChessState);
     socket.on('chessMove', handleChessState);
+    socket.on('chessSettlement', handleChessSettlement);
 
     cleanups.push(() => {
       socket.off('gameStart', handleGameStart);
@@ -9393,6 +9409,7 @@ function Chess3D({
       socket.off('lobbyUpdate', handleLobbyUpdate);
       socket.off('chessState', handleChessState);
       socket.off('chessMove', handleChessState);
+      socket.off('chessSettlement', handleChessSettlement);
       if (tableJoin.current)
         socket.emit('leaveLobby', { accountId, tableId: tableJoin.current });
     });

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -13,7 +13,6 @@ import {
 } from '../../utils/telegram.js';
 import {
   getAccountBalance,
-  addTransaction,
   getOnlineCount,
   getOnlineUsers
 } from '../../utils/api.js';
@@ -548,19 +547,6 @@ export default function ChessBattleRoyalLobby() {
     if (matching) return;
     let tgId;
     let trackedAccountId;
-    let stakeCharged = false;
-    const refundStakeIfNeeded = async (reason = 'matchmaking_cleanup') => {
-      if (!stakeCharged || !trackedAccountId) return;
-      try {
-        await addTransaction(tgId || getTelegramId(), stake.amount, 'stake_refund', {
-          game: 'chessbattle',
-          players: 2,
-          accountId: trackedAccountId,
-          reason
-        });
-        stakeCharged = false;
-      } catch {}
-    };
     if (isOnline) {
       try {
         trackedAccountId = await ensureAccountId();
@@ -572,12 +558,6 @@ export default function ChessBattleRoyalLobby() {
           return;
         }
         tgId = getTelegramId();
-        await addTransaction(tgId, -stake.amount, 'stake', {
-          game: 'chessbattle',
-          players: 2,
-          accountId: trackedAccountId
-        });
-        stakeCharged = true;
       } catch {}
 
       if (!trackedAccountId) {
@@ -600,7 +580,6 @@ export default function ChessBattleRoyalLobby() {
         ? requestedTableId || buildHostedTableId(hostCodeInput)
         : '';
     if (onlineQueueMode === 'private' && !hostedTableId) {
-      await refundStakeIfNeeded('missing_private_code');
       setMatchError('Enter a private code to create or join a chess table.');
       setMatching(false);
       setMatchStatus('');
@@ -628,7 +607,6 @@ export default function ChessBattleRoyalLobby() {
 
     const socketReady = await ensureSocketConnected();
     if (!socketReady) {
-      await refundStakeIfNeeded('socket_connect_failed');
       setMatchError(
         'Lobby connection failed. Check your network and try again.'
       );
@@ -640,7 +618,6 @@ export default function ChessBattleRoyalLobby() {
     const seatAccountId = resolveSeatAccountId(trackedAccountId, accountId);
     const socketRegistered = await ensureSocketRegistered(seatAccountId);
     if (!socketRegistered) {
-      await refundStakeIfNeeded('socket_register_failed');
       setMatchError('Unable to sync your online session. Please retry.');
       setMatching(false);
       setMatchStatus('');
@@ -668,7 +645,6 @@ export default function ChessBattleRoyalLobby() {
       players = []
     } = {}) => {
       if (!startedId || String(startedId) !== String(pendingTableRef.current)) return;
-      stakeCharged = false;
       const mySide = resolveChessSide(players, seatAccountId);
       const opp = resolveChessOpponent(players, seatAccountId);
       cleanupLobby({ account: trackedAccountId, skipLeave: true });
@@ -767,8 +743,7 @@ export default function ChessBattleRoyalLobby() {
           return;
         }
         cleanupLobby({ account: trackedAccountId });
-        await refundStakeIfNeeded('matchmaking_timeout');
-        setMatchError('No opponent joined in time. Your stake was refunded.');
+        setMatchError('No opponent joined in time. No stake was deducted.');
       }, MATCHMAKING_REFRESH_MS);
     };
     const seatPlayer = (tableIdOverride = '', reconnecting = false) => {
@@ -815,9 +790,8 @@ export default function ChessBattleRoyalLobby() {
                     return;
                   }
                   cleanupLobby({ account: trackedAccountId });
-                  await refundStakeIfNeeded('socket_retry_failed');
                   setMatchError(
-                    'Lobby connection dropped while retrying. Your stake was refunded.'
+                    'Lobby connection dropped while retrying. No stake was deducted.'
                   );
                   setMatchStatus('');
                   return;
@@ -827,9 +801,8 @@ export default function ChessBattleRoyalLobby() {
                     await ensureSocketRegistered(seatAccountId);
                   if (!reRegistered) {
                     cleanupLobby({ account: trackedAccountId });
-                    await refundStakeIfNeeded('socket_reregister_failed');
                     setMatchError(
-                      'Could not restore your online identity. Your stake was refunded.'
+                      'Could not restore your online identity. No stake was deducted.'
                     );
                     setMatchStatus('');
                     return;
@@ -839,7 +812,6 @@ export default function ChessBattleRoyalLobby() {
               }, retryDelay);
               return;
             }
-            await refundStakeIfNeeded('seat_table_failed');
             const errorMessage = resolveSeatErrorMessage(res?.error);
             cleanupLobby({ account: trackedAccountId });
             setMatchError(errorMessage);
@@ -861,11 +833,10 @@ export default function ChessBattleRoyalLobby() {
                 ? resolvePrivateMatchStatus(res.tableId, hostCodeInput)
                 : 'Opening the board while we find the same-stake opponent…'
           );
-          // Keep the reserved stake attached to this table and move immediately into
+          // Keep the server-managed stake contract attached to this table and move immediately into
           // the game scene. The game screen stays in a waiting state until another
           // player with the same chess stake/table joins, then both ready signals
           // start the match. Do not leave the lobby seat during this handoff.
-          stakeCharged = false;
           cleanupLobby({ account: trackedAccountId, skipLeave: true });
           navigateToGame({
             tgId,


### PR DESCRIPTION
### Motivation
- Fix the online lobby/start flow so both seats are managed atomically and the game only begins when both players and their stakes are validated. 
- Ensure stake handling is authoritative on the server: reserve both players' TPC stakes atomically, then pay out winner or refund on draw while keeping a configurable house cut. 
- Remove client-side premature debiting that could leave one player charged while the match fails to start, and provide settlement events to the game UI.

### Description
- Add server-side stake contract and settlement logic: `reserveChessStakeContract` and `settleChessStakeContract` in `bot/server.js`, plus `CHESS_HOUSE_FEE_BPS` and `CHESS_HOUSE_ACCOUNT` configuration support. 
- Call the reservation contract before starting chess matches in `maybeStartGame` and attach `matchId` to `gameStart` metadata so clients know the server-managed match. 
- Emit `chessSettlement` after a match finishes and implement winner payout, draw refunds, and optional house-fee transfer in the settlement logic. 
- Add a service endpoint `POST /api/matchmaking/settle` in `bot/routes/matchmaking.js` to allow settlement via the matchmaking/accounting service. 
- Change the lobby client `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` to stop pre-debiting one player; instead the client only verifies balance and seats the user, relying on the server to atomically reserve stakes. 
- Update the game client `webapp/src/pages/Games/ChessBattleRoyal.jsx` to listen for `chessSettlement` events and reflect settled/draw/settlement-error statuses in the UI.

### Testing
- Ran `node --check bot/server.js` and `node --check bot/routes/matchmaking.js`, both returned no syntax errors. (passed)
- Ran `npm --prefix chess-multiplayer-server test` which executed Colyseus unit tests and all tests passed. (3 files, 9 tests; passed)
- Ran `npm --prefix bot test` which executed the bot test suite and all tests passed. (6 tests; passed)
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a731acf333883298bbf439b635356cf)