### PR TITLE
Fix Murlan Royale online socket sync and runtime state relay

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -499,6 +499,7 @@ app.set('tableMap', tableMap);
 const poolStates = new Map();
 const snookerStates = new Map();
 const dominoRoyalStates = new Map();
+const murlanRoyalStates = new Map();
 const dominoRoyalTableNumbers = new Set();
 const chessTableNumbers = new Set();
 
@@ -1455,6 +1456,8 @@ function maybeStartGame(table) {
         poolStates.set(table.id, { state: null, hud: null, layout: null, ts: Date.now() });
       } else if (table.gameType === 'domino-royal') {
         dominoRoyalStates.set(table.id, { state: null, action: null, ts: Date.now() });
+      } else if (table.gameType === 'murlanroyale') {
+        murlanRoyalStates.set(table.id, { state: null, action: null, ts: Date.now(), revision: 0 });
       }
     }, 1000);
   }
@@ -2502,6 +2505,66 @@ io.on('connection', (socket) => {
       revision
     });
     socket.to(tableId).emit('dominoRoyalState', payload);
+    cb && cb({ success: true, revision });
+  });
+
+
+  socket.on('joinMurlanRoyaleTable', async ({ tableId, accountId } = {}) => {
+    if (!tableId) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId });
+    if (!ensureRegistered(socket, resolvedAccountId)) return;
+    const table = tableMap.get(tableId);
+    if (
+      !table ||
+      table.gameType !== 'murlanroyale' ||
+      !table.players.some((player) => String(player.id) === String(resolvedAccountId))
+    ) {
+      socket.emit('murlanRoyaleSyncError', { tableId, error: 'seat_required' });
+      return;
+    }
+    socket.join(tableId);
+    if (resolvedAccountId) {
+      await registerConnection({ userId: String(resolvedAccountId), roomId: tableId, socketId: socket.id });
+    }
+    const cached = murlanRoyalStates.get(tableId);
+    if (cached?.state) {
+      socket.emit('murlanRoyaleState', { tableId, state: cached.state, action: cached.action || null, updatedAt: cached.ts });
+    }
+  });
+
+  socket.on('murlanRoyaleSyncRequest', ({ tableId, accountId } = {}) => {
+    if (!tableId) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId });
+    if (!ensureRegistered(socket, resolvedAccountId)) return;
+    const table = tableMap.get(tableId);
+    if (!table?.players.some((player) => String(player.id) === String(resolvedAccountId))) return;
+    const cached = murlanRoyalStates.get(tableId);
+    if (cached?.state) {
+      socket.emit('murlanRoyaleState', { tableId, state: cached.state, action: cached.action || null, updatedAt: cached.ts });
+    }
+  });
+
+  socket.on('murlanRoyaleState', ({ tableId, accountId, state, action } = {}, cb) => {
+    if (!tableId || !state || typeof state !== 'object') return;
+    if (!socket.rooms.has(tableId)) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId, tpcAccountNumber: action?.accountId });
+    if (!ensureRegistered(socket, resolvedAccountId)) return;
+    const table = tableMap.get(tableId);
+    if (
+      !table ||
+      table.gameType !== 'murlanroyale' ||
+      !table.players.some((player) => String(player.id) === String(resolvedAccountId))
+    ) {
+      cb && cb({ success: false, error: 'seat_required' });
+      socket.emit('murlanRoyaleSyncError', { tableId, error: 'seat_required' });
+      return;
+    }
+    const cached = murlanRoyalStates.get(tableId);
+    const revision = Number(cached?.revision || 0) + 1;
+    const authoritativeState = { ...state, seq: revision };
+    const payload = { tableId, tableNumber: table.tableNumber, state: authoritativeState, action: { ...(action || {}), accountId: String(resolvedAccountId) }, updatedAt: Date.now() };
+    murlanRoyalStates.set(tableId, { state: authoritativeState, action: payload.action, ts: payload.updatedAt, revision });
+    socket.to(tableId).emit('murlanRoyaleState', payload);
     cb && cb({ success: true, revision });
   });
 

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -22,6 +22,7 @@ import { applyTableMaterials, createMurlanStyleTable, TABLE_SHAPE_OPTIONS } from
 import { CARD_THEMES } from '../../utils/cards3d.js';
 import { makeTonplaygramCardBackTexture } from '../../utils/cards3d.js';
 import { createCardGeometry } from '../../utils/cards3d.js';
+import { refreshSocketAuthIdentity, socket } from '../../utils/socket.js';
 import { chatBeep, bombSound } from '../../assets/coreSoundData.js';
 import {
   getMurlanInventory,
@@ -3588,7 +3589,8 @@ const START_CARD = { rank: '3', suit: '♠' };
 
 export default function MurlanRoyaleArena({ search }) {
   const mountRef = useRef(null);
-  const players = useMemo(() => buildPlayers(search), [search]);
+  const onlineContext = useMemo(() => resolveMurlanOnlineContext(search), [search]);
+  const players = useMemo(() => buildPlayers(search, onlineContext), [search, onlineContext]);
   const characterRosterSeedRef = useRef(Math.random());
 
   const [murlanInventory, setMurlanInventory] = useState(() => getMurlanInventory(murlanAccountId()));
@@ -4257,6 +4259,7 @@ export default function MurlanRoyaleArena({ search }) {
 
   const gameStateRef = useRef(gameState);
   const selectedRef = useRef(selectedIds);
+  const onlineStateRef = useRef({ suppressNextEmit: false, hydrated: false });
   const humanTurnRef = useRef(false);
 
   const threeStateRef = useRef({
@@ -5523,6 +5526,48 @@ export default function MurlanRoyaleArena({ search }) {
     }
   }, [selectedIds, threeReady, applyStateToScene]);
 
+
+  useEffect(() => {
+    if (!onlineContext.enabled || !onlineContext.tableId || !onlineContext.accountId) return undefined;
+    refreshSocketAuthIdentity({ accountId: onlineContext.accountId }, { reconnect: true });
+    const joinAndSync = () => {
+      socket.emit('register', { playerId: onlineContext.accountId });
+      socket.emit('joinMurlanRoyaleTable', { tableId: onlineContext.tableId, accountId: onlineContext.accountId });
+      socket.emit('murlanRoyaleSyncRequest', { tableId: onlineContext.tableId, accountId: onlineContext.accountId });
+    };
+    const handleRemoteState = ({ tableId, state } = {}) => {
+      if (tableId !== onlineContext.tableId || !state) return;
+      onlineStateRef.current.suppressNextEmit = true;
+      onlineStateRef.current.hydrated = true;
+      setSelectedIds([]);
+      setGameState(state);
+    };
+    socket.on('murlanRoyaleState', handleRemoteState);
+    socket.on('connect', joinAndSync);
+    joinAndSync();
+    return () => {
+      socket.off('murlanRoyaleState', handleRemoteState);
+      socket.off('connect', joinAndSync);
+    };
+  }, [onlineContext]);
+
+  useEffect(() => {
+    if (!onlineContext.enabled || !onlineContext.tableId || !onlineContext.accountId) return;
+    if (onlineStateRef.current.suppressNextEmit) {
+      onlineStateRef.current.suppressNextEmit = false;
+      return;
+    }
+    const hostAccountId = String(onlineContext.players?.[0]?.id || onlineContext.players?.[0]?.tpcAccountNumber || '');
+    const isHost = hostAccountId && hostAccountId === String(onlineContext.accountId);
+    if (!isHost && !onlineStateRef.current.hydrated && !gameState.lastAction) return;
+    socket.emit('murlanRoyaleState', {
+      tableId: onlineContext.tableId,
+      accountId: onlineContext.accountId,
+      state: gameState,
+      action: gameState.lastAction || { type: 'SYNC' }
+    });
+  }, [gameState, onlineContext]);
+
   useEffect(() => {
     if (threeReady) {
       updateSeatAnchors();
@@ -6589,12 +6634,12 @@ export default function MurlanRoyaleArena({ search }) {
     const state = gameState;
     if (state.status !== 'PLAYING') return;
     const active = state.players[state.activePlayer];
-    if (!active || active.isHuman) return;
+    if (!active || active.isHuman || active.isOnlineRemote) return;
     const timer = setTimeout(() => {
       setGameState((prev) => {
         if (prev.status !== 'PLAYING') return prev;
         const current = prev.players[prev.activePlayer];
-        if (!current || current.isHuman) return prev;
+        if (!current || current.isHuman || current.isOnlineRemote) return prev;
         return runAiTurn(prev);
       });
     }, AI_TURN_DELAY);
@@ -7376,7 +7421,21 @@ function cardLabel(card) {
   return `${card.rank}${card.suit || ''}`;
 }
 
-function buildPlayers(search) {
+function resolveMurlanOnlineContext(search) {
+  const params = new URLSearchParams(search);
+  const tableId = params.get('tableId') || '';
+  const accountId = params.get('accountId') || '';
+  const enabled = (params.get('mode') || '').toLowerCase() === 'online' && tableId && accountId;
+  let match = null;
+  if (enabled && typeof window !== 'undefined') {
+    try {
+      match = JSON.parse(window.sessionStorage?.getItem(`murlanRoyaleOnlineMatch:${tableId}`) || 'null');
+    } catch {}
+  }
+  return { enabled, tableId, accountId, players: Array.isArray(match?.players) ? match.players : [] };
+}
+
+function buildPlayers(search, onlineContext = null) {
   const params = new URLSearchParams(search);
   const username = params.get('username') || 'You';
   const avatar = params.get('avatar') || '';
@@ -7384,6 +7443,19 @@ function buildPlayers(search) {
   const totalPlayers = Number.isFinite(requestedPlayers)
     ? Math.min(Math.max(requestedPlayers, 2), 4)
     : 4;
+  if (onlineContext?.enabled && onlineContext.players.length) {
+    return onlineContext.players.slice(0, totalPlayers).map((player, index) => {
+      const isSelf = String(player.id || player.tpcAccountNumber || '') === String(onlineContext.accountId);
+      return {
+        name: player.name || (isSelf ? username : `Player ${index + 1}`),
+        avatar: player.avatar || '',
+        id: player.id || player.tpcAccountNumber || `online-${index}`,
+        isHuman: isSelf,
+        isOnlineRemote: !isSelf,
+        color: PLAYER_COLORS[index % PLAYER_COLORS.length]
+      };
+    });
+  }
   const aiCount = Math.max(totalPlayers - 1, 1);
   const providedFlags = (params.get('flags') || '')
     .split(',')

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -78,7 +78,10 @@ export default function MurlanRoyaleLobby() {
         playerName: getTelegramFirstName() || 'Player',
         state: { setMatching, setMatchStatus, setMatchError },
         deps: { ensureAccountId, getAccountBalance, addTransaction, getTelegramId, socket },
-        onMatched: ({ accountId, tableId }) => {
+        onMatched: ({ accountId, tableId, players }) => {
+          try {
+            window.sessionStorage?.setItem(`murlanRoyaleOnlineMatch:${tableId}`, JSON.stringify({ accountId, tableId, players }));
+          } catch {}
           const params = new URLSearchParams();
           params.set('mode', 'online');
           params.set('tableId', tableId);

--- a/webapp/src/utils/simpleOnlineFlow.js
+++ b/webapp/src/utils/simpleOnlineFlow.js
@@ -1,6 +1,6 @@
 import { ensureAccountId, getTelegramId } from './telegram.js';
 import { getAccountBalance, addTransaction } from './api.js';
-import { socket } from './socket.js';
+import { refreshSocketAuthIdentity, socket } from './socket.js';
 
 const DEFAULT_MATCH_TIMEOUT_MS = 35000;
 const SOCKET_CONNECT_TIMEOUT_MS = 8000;
@@ -140,6 +140,7 @@ export async function runSimpleOnlineFlow({
     });
     stakeDebited = true;
 
+    refreshSocketAuthIdentity({ accountId }, { reconnect: true });
     const socketReady = await ensureSocketReady(socketInstance, socketConnectTimeoutMs);
     if (!socketReady) {
       setMatchError('Socket not connected. Please retry.');


### PR DESCRIPTION
### Motivation
- Resolve "Socket not connected" failures during Murlan Royale matchmaking by ensuring the client socket auth is refreshed with the newly-resolved account identity before connecting.
- Provide a way for the Murlan Royale runtime to receive authoritative online roster and live state so the in-game scene can mark remote seats and sync gameplay between players.

### Description
- Refreshes Socket.IO auth with the resolved account ID prior to socket connect in `webapp/src/utils/simpleOnlineFlow.js` by calling `refreshSocketAuthIdentity` before `ensureSocketReady`.
- Persists the matched roster returned by matchmaking into `sessionStorage` in `webapp/src/pages/Games/MurlanRoyaleLobby.jsx` so the game runtime can reconstruct who is local vs remote when opening the arena.
- Adds client-side online plumbing to `webapp/src/pages/Games/MurlanRoyaleArena.jsx`: introduces `resolveMurlanOnlineContext`, hydrates remote state via `murlanRoyaleState` events, emits `murlanRoyaleState` updates, refreshes socket auth for the arena, and suppresses echoing of inbound state when hydrating.
- Marks online opponents as `isOnlineRemote` in the arena player roster and prevents local AI from taking turns for remote seats, avoiding conflicting local AI behavior.
- Adds server-side state storage and relay for Murlan Royale in `bot/server.js` by adding `murlanRoyalStates` and handling `joinMurlanRoyaleTable`, `murlanRoyaleSyncRequest`, and `murlanRoyaleState` Socket.IO events with seat membership validation and authoritative state broadcasting.

### Testing
- Ran the webapp production build with `npm --prefix webapp run build`, which completed successfully.
- Ran a repository static check via `git diff --check`, which reported no whitespace/error issues.
- Verified the modified client/server paths emit and listen for the new `murlanRoyale*` socket events and that the client hydrates remote state on `murlanRoyaleState` (manual verification during development steps documented in the rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a731be8e0f08329bb8bbf962972e956)