### PR TITLE
Move player into board on seat and show in-game waiting state for Checkers online

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -1839,10 +1839,11 @@ export default function CheckersBattleRoyal() {
   const initialSideParam = params.get('side');
   const initialOpponentName = params.get('opponentName') || '';
   const initialOpponentAvatar = params.get('opponentAvatar') || '';
+  const waitingForOpponent = params.get('waitingForOpponent') === '1';
   const [accountId, setAccountId] = useState(initialAccountId);
   const [tableId] = useState(initialTableId);
   const [onlineStatus, setOnlineStatus] = useState(
-    mode === 'online' ? 'connecting' : 'offline'
+    mode === 'online' ? (waitingForOpponent ? 'waiting' : 'connecting') : 'offline'
   );
   const [onlineOpponent, setOnlineOpponent] = useState(
     initialOpponentName || initialOpponentAvatar
@@ -1863,7 +1864,7 @@ export default function CheckersBattleRoyal() {
         ? 'dark'
         : 'light',
     synced: mode !== 'online',
-    status: mode === 'online' ? 'connecting' : 'offline',
+    status: mode === 'online' ? (waitingForOpponent ? 'waiting' : 'connecting') : 'offline',
     opponent: null
   });
   const mountRef = useRef(null);
@@ -1902,7 +1903,11 @@ export default function CheckersBattleRoyal() {
   const proceduralBoardRef = useRef({ lightMat: null, darkMat: null });
 
   const [turn, setTurn] = useState('light');
-  const [status, setStatus] = useState(`Loading arena… ${RULE_SUMMARY}`);
+  const [status, setStatus] = useState(
+    mode === 'online' && waitingForOpponent
+      ? 'Table ready. Waiting for opponent on the board…'
+      : `Loading arena… ${RULE_SUMMARY}`
+  );
   const [configOpen, setConfigOpen] = useState(false);
   const [viewMode, setViewMode] = useState('3d');
   const [graphicsProfileId, setGraphicsProfileId] = useState(() => {
@@ -3416,8 +3421,12 @@ export default function CheckersBattleRoyal() {
     onlineRef.current.tableId = tableId;
     onlineRef.current.accountId = accountId;
     onlineRef.current.synced = false;
-    setOnlineStatus('connecting');
-    setStatus('Connecting to online table…');
+    setOnlineStatus(waitingForOpponent ? 'waiting' : 'connecting');
+    setStatus(
+      waitingForOpponent
+        ? 'Table ready. Waiting for opponent on the board…'
+        : 'Connecting to online table…'
+    );
 
     const handleGameStart = ({ tableId: startedId, players: remotePlayers = [] } = {}) => {
       if (!startedId || startedId !== tableId) return;
@@ -3436,6 +3445,19 @@ export default function CheckersBattleRoyal() {
       );
       setOnlineStatus('in-game');
       setStatus(mySide === 'light' ? 'Your turn. Forced captures are enabled.' : 'Waiting for opponent move…');
+    };
+
+    const handleLobbyUpdate = ({ tableId: eventTableId, players: remotePlayers = [] } = {}) => {
+      if (!eventTableId || eventTableId !== tableId) return;
+      const opp = remotePlayers.find((player) => String(player.id) !== String(accountId));
+      if (opp) {
+        setOnlineOpponent({ name: opp.name || 'Opponent', avatar: opp.avatar || '' });
+        setOnlineStatus('connecting');
+        setStatus('Opponent joined. Starting match…');
+      } else if (!onlineRef.current.synced) {
+        setOnlineStatus('waiting');
+        setStatus('Table ready. Waiting for opponent on the board…');
+      }
     };
 
     const handleCheckersState = ({ tableId: eventTableId, board, turn: remoteTurn } = {}) => {
@@ -3509,6 +3531,7 @@ export default function CheckersBattleRoyal() {
 
     let cancelled = false;
     socket.on('gameStart', handleGameStart);
+    socket.on('lobbyUpdate', handleLobbyUpdate);
     socket.on('checkersState', handleCheckersState);
     socket.on('checkersMoveAccepted', handleMoveAccepted);
     socket.on('checkersMoveRejected', handleMoveRejected);
@@ -3535,6 +3558,7 @@ export default function CheckersBattleRoyal() {
     return () => {
       cancelled = true;
       socket.off('gameStart', handleGameStart);
+      socket.off('lobbyUpdate', handleLobbyUpdate);
       socket.off('checkersState', handleCheckersState);
       socket.off('checkersMoveAccepted', handleMoveAccepted);
       socket.off('checkersMoveRejected', handleMoveRejected);
@@ -3544,7 +3568,7 @@ export default function CheckersBattleRoyal() {
       socket.off('reconnect', handleSocketReconnect);
       socket.emit('leaveLobby', { accountId, tableId });
     };
-  }, [accountId, mode, queueMoveAnimation, renderHighlights, renderPieces, tableId]);
+  }, [accountId, mode, queueMoveAnimation, renderHighlights, renderPieces, tableId, waitingForOpponent]);
 
   useEffect(() => {
     if (onlineRef.current.enabled) return;

--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -498,19 +498,29 @@ export default function CheckersBattleRoyalLobby() {
           pendingTableRef.current = res.tableId;
           setMatchStatus(
             hostedTableId
-              ? `Private table ready (${normalizeHostCode(hostCodeInput)}). Waiting for your invited opponent…`
-              : 'Waiting for another player…'
+              ? `Private table ready (${normalizeHostCode(hostCodeInput)}). Moving you to the board…`
+              : 'Table ready. Moving you to the board…'
           );
           socket.emit('confirmReady', {
             accountId: seatAccountId,
             tpcAccountId: seatAccountId,
             tableId: res.tableId
           });
-          cleanupRef.current = () => {
-            clearTimeout(matchTimeout);
-            matchmakingTimeoutRef.current = null;
-            cleanupLobby({ account: trackedAccountId, skipRefReset: true });
-          };
+
+          clearTimeout(matchTimeout);
+          matchmakingTimeoutRef.current = null;
+          socket.off('gameStart', handleGameStart);
+          socket.off('lobbyUpdate', handleLobbyUpdate);
+          pendingTableRef.current = '';
+          cleanupRef.current = () => {};
+          setMatching(false);
+          navigateToGame({
+            tgId,
+            trackedAccountId,
+            tableId: res.tableId,
+            side: preferredSide === 'black' ? 'dark' : preferredSide === 'white' ? 'light' : 'light',
+            waitingForOpponent: '1'
+          });
         }
       );
     };


### PR DESCRIPTION
### Motivation
- Players who press Start and successfully reserve an online Checkers table were left in the lobby instead of being moved into the game board to wait for the opponent. 
- The goal is to navigate the player to the board immediately after `seatTable` succeeds and keep the board in a clear waiting-for-opponent state while still syncing lobby updates and eventual game start.

### Description
- When `seatTable` returns a table id the lobby now clears matchmaking timeouts/listeners and calls `navigateToGame(...)` with `waitingForOpponent=1` so the client enters the board immediately instead of staying in the lobby (`webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx`).
- The lobby code removes the previous `matchTimeout` and unregisters `gameStart`/`lobbyUpdate` listeners when navigating, and sets `matching` to false before navigation (`pendingTableRef` and cleanup changes).
- The board (`CheckersBattleRoyal.jsx`) reads a new `waitingForOpponent` URL param and initializes `onlineStatus`/`status` accordingly so the UI shows "Table ready. Waiting for opponent on the board…" while waiting.
- The board now listens for a `lobbyUpdate` socket event and updates `onlineOpponent`/`status` when an opponent arrives, and subscribes/unsubscribes `lobbyUpdate` alongside other socket events; the `useEffect` dependency list was updated to include the waiting flag.

Files changed: `webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx`, `webapp/src/pages/Games/CheckersBattleRoyal.jsx`.

### Testing
- Ran lint on the two modified files with `npm --prefix webapp run lint -- src/pages/Games/CheckersBattleRoyal.jsx src/pages/Games/CheckersBattleRoyalLobby.jsx` and it completed with no reported errors.
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a731c4141b083298bae4e731ce63038)