### PR TITLE
Fix Chess Battle Royal quick-match handoff

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -302,7 +302,9 @@ export default function ChessBattleRoyalLobby() {
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matchStatus, setMatchStatus] = useState('');
   const [matchError, setMatchError] = useState('');
-  const [searchSecondsLeft, setSearchSecondsLeft] = useState(60);
+  const [searchSecondsLeft, setSearchSecondsLeft] = useState(
+    MATCHMAKING_REFRESH_MS / 1000
+  );
   const preferredSide = 'auto';
   const pendingTableRef = useRef('');
   const [tableNumber, setTableNumber] = useState('');
@@ -689,6 +691,7 @@ export default function ChessBattleRoyalLobby() {
       if (!pendingTableRef.current) return;
       const message = resolveSeatErrorMessage(error);
       setMatchError(message);
+      setMatchStatus('The match could not start. Cancel and try again.');
     };
 
     cleanupRef.current = () =>
@@ -818,35 +821,26 @@ export default function ChessBattleRoyalLobby() {
             return;
           }
           pendingTableRef.current = res.tableId;
+          armSearchRefresh();
           setTableNumber(String(res.tableNumber || ''));
           setMatchPlayers(Array.isArray(res.players) ? res.players : []);
           setReadyList(
             Array.isArray(res.ready) ? res.ready.map((id) => String(id)) : []
           );
           const playersList = Array.isArray(res.players) ? res.players : [];
-          const mySide = resolveChessSide(playersList, seatAccountId);
           const opp = resolveChessOpponent(playersList, seatAccountId);
           setMatchStatus(
             opp
-              ? 'Match found. Opening the board…'
+              ? 'Match found. Securing both seats…'
               : onlineQueueMode === 'private'
                 ? resolvePrivateMatchStatus(res.tableId, hostCodeInput)
-                : 'Opening the board while we find the same-stake opponent…'
+                : 'Waiting for the next same-stake opponent…'
           );
-          // Keep the server-managed stake contract attached to this table and move immediately into
-          // the game scene. The game screen stays in a waiting state until another
-          // player with the same chess stake/table joins, then both ready signals
-          // start the match. Do not leave the lobby seat during this handoff.
-          cleanupLobby({ account: trackedAccountId, skipLeave: true });
-          navigateToGame({
-            tgId,
-            trackedAccountId,
-            tableId: res.tableId,
-            tableNumber: res.tableNumber,
-            side: mySide,
-            opponentName: resolvePlayerName(opp),
-            opponentAvatar: opp?.avatar
-          });
+          // Stay in the lobby until the authoritative gameStart event. Moving
+          // the first player to the heavy 3D scene here could detach this
+          // listener before the second seat was locked, leaving the two phones
+          // in different lifecycle states. handleGameStart moves both clients
+          // together after stake reservation and side assignment succeed.
         }
       );
     };


### PR DESCRIPTION
### Motivation

- Prevent quick-match clients from entering the heavy 3D game scene before the authoritative server `gameStart` has confirmed both seats, stake reservation and side assignment to avoid mismatched lifecycle states on two phones.
- Make the visible matchmaking countdown reflect the actual refresh interval and improve user-facing status when seating or start failures occur.

### Description

- Initialize the lobby countdown with `MATCHMAKING_REFRESH_MS / 1000` so the displayed seconds match the configured refresh interval.
- When a `seatTable` response succeeds, call `armSearchRefresh()` to start/reset the two-minute same-stake search refresh window and store the `pendingTableRef` (no immediate handoff to the game scene).
- Remove the early `cleanupLobby`/`navigateToGame` handoff and keep the client in the lobby until the server emits the authoritative `gameStart` event, which now performs the joint transition for both players.
- Improve matchmaking feedback by setting a clear `matchStatus` on start failures and updating the intermediary texts shown while securing seats; also remove an unused `resolveChessSide` call in the seat success path.

### Testing

- Ran `npm --prefix webapp run build` and the webapp build completed successfully.
- Ran `npx eslint --no-ignore --no-warn-ignored webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` and lint passed.
- Ran `git diff --check` with no issues reported.
- Ran server-side Jest tests during investigation: an earlier run showed `test/chessLobbyStaleTableIdMatchmaking.test.js` and other socket tests passing while `test/chessLobbyAliasCriteriaMatchmaking.test.js` previously timed out; after the change attempting `jest` on `test/chessLobbyHelpers.test.mjs` failed because Jest in this environment cannot parse the ESM `.mjs` test file (`Cannot use import statement outside a module`), so unit test execution is currently blocked by the test runner configuration rather than the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a786fac36088329869d2e0277e6a56b)