### PR TITLE
Remove Flamingo Revolution card from Home page

### DIFF
--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -219,21 +219,6 @@ export default function Home() {
         )}
 
         <div className="w-full mt-2 space-y-4">
-          <Link
-            to="/flamingo"
-            className="group relative block overflow-hidden rounded-2xl border border-rose-400/30 bg-[#111419] p-5 text-left no-underline shadow-[0_18px_45px_rgba(0,0,0,.45)] transition-transform duration-200 active:scale-[.98]"
-          >
-            <div className="absolute -right-10 -top-14 h-36 w-36 rounded-full bg-red-500/15 blur-2xl" />
-            <div className="relative flex items-start gap-4">
-              <span className="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-red-500 text-xl font-black italic text-white">F</span>
-              <div className="min-w-0">
-                <span className="text-[10px] font-bold uppercase tracking-[.18em] text-red-400">Platformë qytetare</span>
-                <h2 className="mt-1 text-xl font-bold text-white">Flamingo Revolution</h2>
-                <p className="mt-2 text-sm leading-relaxed text-slate-300">Organizim, njoftime dhe informacion praktik për protestat paqësore në Shqipëri.</p>
-                <span className="mt-4 inline-flex min-h-11 items-center rounded-xl bg-red-500 px-4 text-sm font-bold text-white">Hap platformën →</span>
-              </div>
-            </div>
-          </Link>
           <div className="relative bg-surface border border-border rounded-xl p-4 flex items-center justify-around overflow-hidden wide-card">
             <img
               src="/assets/icons/snakes_and_ladders.webp"


### PR DESCRIPTION
### Motivation
- The home page contained a prominent “Flamingo Revolution” promotional card that the UI owner asked to remove to declutter the main view.
- The standalone Flamingo feature and its routes remain untouched so the feature itself is preserved.

### Description
- Deleted the Flamingo promotional `<Link to="/flamingo">…</Link>` block from `webapp/src/pages/Home.jsx`, removing the card UI and its contents. 
- The surrounding layout was left intact so the wallet / balances block now appears where the card used to be.
- No other routes, feature modules, or Flamingo internals were modified.

### Testing
- Ran `npx prettier --check src/pages/Home.jsx` and it passed. 
- Ran `npx eslint --no-ignore --no-warn-ignored src/pages/Home.jsx` and it passed. 
- Ran `npm run build` (Vite production build) which completed successfully and produced the `dist` output. 
- Performed a headless mobile check (Playwright) at 390×844 which captured `/tmp/home-mobile.png` and asserted that the exact text "Flamingo Revolution" is no longer present (0 matches).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a787649434c8329a9c1b550624d7eed)