### PR TITLE
Add Social Channels UI, new social tasks and server-side task verification tracking

### DIFF
--- a/bot/models/Task.js
+++ b/bot/models/Task.js
@@ -3,7 +3,9 @@ import mongoose from 'mongoose';
 const taskSchema = new mongoose.Schema({
   telegramId: { type: Number, required: true },
   taskId: { type: String, required: true },
-  completedAt: { type: Date }
+  completedAt: { type: Date },
+  verificationMethod: { type: String, default: 'self_attested' },
+  verificationStatus: { type: String, enum: ['verified', 'attested'], default: 'attested' }
 });
 
 taskSchema.index({ telegramId: 1, taskId: 1 }, { unique: true });

--- a/bot/routes/tasks.js
+++ b/bot/routes/tasks.js
@@ -168,7 +168,14 @@ router.post('/complete', authenticate, async (req, res) => {
   const existing = await Task.findOne({ telegramId, taskId });
   if (existing) return res.json({ message: 'already completed' });
 
-  await Task.create({ telegramId, taskId, completedAt: new Date() });
+  const isServerVerified = taskId.startsWith('react_tg_post') || taskId === 'engage_tweet';
+  await Task.create({
+    telegramId,
+    taskId,
+    completedAt: new Date(),
+    verificationMethod: isServerVerified ? 'platform_api' : (config.verification || 'self_attested'),
+    verificationStatus: isServerVerified ? 'verified' : 'attested'
+  });
   const user = await User.findOneAndUpdate(
     { telegramId },
     { $setOnInsert: { referralCode: telegramId.toString() } },
@@ -184,7 +191,11 @@ router.post('/complete', authenticate, async (req, res) => {
   });
   await user.save();
 
-  res.json({ message: 'completed', reward: config.reward });
+  res.json({
+    message: 'completed',
+    reward: config.reward,
+    verificationStatus: isServerVerified ? 'verified' : 'attested'
+  });
 });
 
 router.post('/verify-telegram-reaction', authenticate, async (req, res) => {

--- a/bot/utils/tasksData.js
+++ b/bot/utils/tasksData.js
@@ -1,4 +1,4 @@
-export const TASKS_VERSION = 6;
+export const TASKS_VERSION = 7;
 
 export const TASKS = [
 
@@ -14,6 +14,46 @@ export const TASKS = [
 
   link: 'https://x.com/TonPlaygram?t=SyGyXA0H8PdLz7z2kfIWQw&s=09'
 
+  },
+
+  {
+    id: 'follow_instagram',
+    description: 'Follow TonPlaygram on Instagram',
+    reward: 450,
+    icon: 'instagram',
+    action: 'follow',
+    verification: 'self_attested',
+    link: 'https://www.instagram.com/tonplaygram'
+  },
+
+  {
+    id: 'follow_youtube',
+    description: 'Subscribe to our YouTube channel',
+    reward: 600,
+    icon: 'youtube',
+    action: 'subscribe',
+    verification: 'self_attested',
+    link: 'https://www.youtube.com/@TonPlaygram'
+  },
+
+  {
+    id: 'follow_facebook',
+    description: 'Follow TonPlaygram on Facebook',
+    reward: 350,
+    icon: 'facebook',
+    action: 'follow',
+    verification: 'self_attested',
+    link: 'https://www.facebook.com/share/1JcMX1CkQr/'
+  },
+
+  {
+    id: 'open_telegram_bot',
+    description: 'Open the official Telegram bot',
+    reward: 250,
+    icon: 'telegram',
+    action: 'open',
+    verification: 'self_attested',
+    link: 'https://t.me/TonPlaygramBot'
   },
 
   {

--- a/webapp/src/components/HomeSocialHub.jsx
+++ b/webapp/src/components/HomeSocialHub.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { FaUserFriends, FaGamepad, FaComments, FaMicrophone, FaMicrophoneSlash, FaPhoneSlash, FaVideo, FaVideoSlash, FaUsers } from 'react-icons/fa';
 import LoginOptions from './LoginOptions.jsx';
+import SocialChannels from './SocialChannels.jsx';
 import { socket } from '../utils/socket.js';
 import { getPlayerId, getTelegramId } from '../utils/telegram.js';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
@@ -137,7 +138,14 @@ export default function HomeSocialHub() {
   try {
     telegramId = getTelegramId();
   } catch (err) {
-    return <LoginOptions />;
+    return (
+      <div className="space-y-4">
+        <SocialChannels />
+        <div className="rounded-xl border border-border bg-surface p-4">
+          <LoginOptions />
+        </div>
+      </div>
+    );
   }
 
   const [friendRequests, setFriendRequests] = useState([]);
@@ -259,6 +267,8 @@ export default function HomeSocialHub() {
           <h3 className="text-lg font-semibold text-white">Messages Hub</h3>
         </div>
       </div>
+
+      <SocialChannels />
 
       <SocialCallStudio displayName={displayName} />
 

--- a/webapp/src/components/SocialChannels.jsx
+++ b/webapp/src/components/SocialChannels.jsx
@@ -1,0 +1,52 @@
+import { FaFacebookF, FaInstagram, FaTelegramPlane, FaTiktok, FaYoutube } from 'react-icons/fa';
+import { FiArrowUpRight } from 'react-icons/fi';
+import { SOCIAL_CHANNELS } from '../config/socialChannels.js';
+
+const ICONS = {
+  facebook: FaFacebookF,
+  instagram: FaInstagram,
+  telegram: FaTelegramPlane,
+  tiktok: FaTiktok,
+  youtube: FaYoutube
+};
+
+export default function SocialChannels() {
+  return (
+    <section aria-labelledby="official-channels-title" className="overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-slate-950/95 via-slate-900/95 to-cyan-950/70 p-4 shadow-[0_18px_50px_rgba(0,0,0,.25)]">
+      <div className="mb-4 flex items-end justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.25em] text-cyan-300">Stay connected</p>
+          <h4 id="official-channels-title" className="mt-1 text-base font-bold text-white">Official TonPlaygram channels</h4>
+          <p className="mt-1 text-xs leading-5 text-slate-300">Follow launches, community news and fresh reward tasks.</p>
+        </div>
+        <span className="shrink-0 rounded-full border border-cyan-300/20 bg-cyan-300/10 px-2.5 py-1 text-[10px] font-semibold text-cyan-100">6 channels</span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {SOCIAL_CHANNELS.map((channel) => {
+          const Icon = ICONS[channel.id];
+          return (
+            <a
+              key={channel.id}
+              href={channel.url}
+              target="_blank"
+              rel="noreferrer noopener"
+              aria-label={`Open TonPlaygram on ${channel.name}`}
+              className="group relative min-w-0 overflow-hidden rounded-xl border border-white/10 bg-white/[0.06] p-3 transition active:scale-[0.98] hover:border-white/25 hover:bg-white/10"
+            >
+              <div className={`absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r ${channel.accent}`} />
+              <div className="flex items-center justify-between gap-2">
+                <span className={`flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br ${channel.accent} text-base font-black text-white shadow-lg`}>
+                  {Icon ? <Icon aria-hidden="true" /> : 'X'}
+                </span>
+                <FiArrowUpRight className="text-slate-500 transition group-hover:text-white" aria-hidden="true" />
+              </div>
+              <p className="mt-2 truncate text-sm font-bold text-white">{channel.name}</p>
+              <p className="truncate text-[10px] text-slate-400">{channel.handle}</p>
+            </a>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/webapp/src/components/TasksCard.jsx
+++ b/webapp/src/components/TasksCard.jsx
@@ -167,8 +167,11 @@ export default function TasksCard() {
       }
     }
 
-    await completeTask(telegramId, task.id);
-
+    const result = await completeTask(telegramId, task.id);
+    if (result.error) {
+      alert(result.error);
+      return;
+    }
     load();
 
   };

--- a/webapp/src/config/socialChannels.js
+++ b/webapp/src/config/socialChannels.js
@@ -1,0 +1,44 @@
+export const SOCIAL_CHANNELS = [
+  {
+    id: 'facebook',
+    name: 'Facebook',
+    handle: 'TonPlaygram',
+    url: 'https://www.facebook.com/share/1JcMX1CkQr/',
+    accent: 'from-blue-600 to-blue-400'
+  },
+  {
+    id: 'instagram',
+    name: 'Instagram',
+    handle: '@tonplaygram',
+    url: 'https://www.instagram.com/tonplaygram',
+    accent: 'from-fuchsia-600 via-pink-500 to-amber-400'
+  },
+  {
+    id: 'telegram',
+    name: 'Telegram',
+    handle: '@TonPlaygramBot',
+    url: 'https://t.me/TonPlaygramBot',
+    accent: 'from-sky-500 to-cyan-300'
+  },
+  {
+    id: 'x',
+    name: 'X',
+    handle: '@TonPlaygram',
+    url: 'https://x.com/TonPlaygram',
+    accent: 'from-slate-700 to-slate-400'
+  },
+  {
+    id: 'tiktok',
+    name: 'TikTok',
+    handle: '@tonplaygram',
+    url: 'https://www.tiktok.com/@tonplaygram',
+    accent: 'from-cyan-400 via-slate-900 to-pink-500'
+  },
+  {
+    id: 'youtube',
+    name: 'YouTube',
+    handle: '@TonPlaygram',
+    url: 'https://www.youtube.com/@TonPlaygram',
+    accent: 'from-red-600 to-red-400'
+  }
+]

--- a/webapp/src/pages/Tasks.jsx
+++ b/webapp/src/pages/Tasks.jsx
@@ -153,7 +153,11 @@ export default function Tasks() {
         return;
       }
     }
-    await completeTask(telegramId, task.id);
+    const result = await completeTask(telegramId, task.id);
+    if (result.error) {
+      alert(result.error);
+      return;
+    }
     load();
   };
 


### PR DESCRIPTION
### Motivation
- Expose TonPlaygram's official social channels (from Linktree) on the home page so users can follow/visit them from the app.
- Provide community tasks for following/visiting those channels with configurable rewards and lightweight verification semantics.
- Track task completion and record verification metadata on the server so completed social tasks can be audited and paid out consistently.

### Description
- Added a channel config at `webapp/src/config/socialChannels.js` and a presentational `SocialChannels` component at `webapp/src/components/SocialChannels.jsx` and wired it into `webapp/src/components/HomeSocialHub.jsx` so the official channels render on the Home view (including the unauthenticated preview path).
- Introduced new social tasks and bumped the tasks version in `bot/utils/tasksData.js` (now `TASKS_VERSION = 7`), adding `follow_instagram`, `follow_youtube`, `follow_facebook`, and `open_telegram_bot` entries with reward/links and `self_attested` verification metadata.
- Updated the task model to record verification metadata by adding `verificationMethod` and `verificationStatus` to `bot/models/Task.js` and adjusted `bot/routes/tasks.js` so task completion persists these fields and returns a `verificationStatus` in the response (server-verified flows like Telegram/X remain marked accordingly).
- Improved client claim flows to surface API errors by updating `webapp/src/components/TasksCard.jsx` and `webapp/src/pages/Tasks.jsx` to handle the result of `completeTask(...)` and show an alert on error.

### Testing
- Built the web app with `npm --prefix webapp run build`; the Vite production build completed successfully (built assets produced, build metadata updated). SUCCESS.
- Ran the dev site and performed a headless browser smoke test using Playwright to load the app at mobile viewport and capture a screenshot; initial runs required installing Playwright browsers/deps but after installing them the smoke check executed and verified the new "Official TonPlaygram channels" section rendered on the Home page. SMOKE TEST: SUCCESS (after installing Playwright browsers/deps).
- No backend unit tests were modified or run in this rollout; server-side changes were exercised via the local dev server during UI smoke checks and manual API call flows (task list/complete) in the dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c5629e834832989d99731f0ea6785)