### PR TITLE
Enforce canonical TPG account for online matchmaking and validate TPG stake/mode

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -1,4 +1,5 @@
 const BASE_SECURITY_CONTROLS = Object.freeze([
+  'tpg_account_number_required',
   'authoritative_lobby_server',
   'socket_identity_binding',
   'seat_request_rate_limit',
@@ -22,6 +23,7 @@ const GAME_ONLINE_POLICY = Object.freeze({
   ludobattleroyal: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   texasholdem: { maxPlayers: [2, 6], allowMatchMeta: ['mode', 'token'] },
   airhockey: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
+  backgammon: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
   murlanroyale: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] }
 });
 
@@ -90,7 +92,7 @@ export function validateSeatTableRequest({
   }
 
   const normalizedStake = Number(stake);
-  if (!Number.isFinite(normalizedStake) || normalizedStake < 0) {
+  if (!Number.isSafeInteger(normalizedStake) || normalizedStake <= 0) {
     return { ok: false, error: 'invalid_stake' };
   }
 
@@ -112,11 +114,25 @@ export function validateSeatTableRequest({
     };
   }
 
+  const token = String(matchMeta.token || '').trim().toUpperCase();
+  if (token !== 'TPG') {
+    return { ok: false, error: 'invalid_stake_token' };
+  }
+
+  const mode = String(matchMeta.mode || '').trim().toLowerCase();
+  if (mode !== 'online') {
+    return { ok: false, error: 'invalid_game_mode' };
+  }
+
   const safeMatchMeta = {};
   for (const key of policy.allowMatchMeta) {
     const value = sanitizeMetaValue(matchMeta[key]);
     if (value != null && value !== '') {
-      safeMatchMeta[key] = value;
+      safeMatchMeta[key] = key === 'token'
+        ? String(value).toUpperCase()
+        : key === 'mode'
+          ? String(value).toLowerCase()
+          : value;
     }
   }
 

--- a/bot/server.js
+++ b/bot/server.js
@@ -2454,6 +2454,7 @@ io.on('connection', (socket) => {
   socket.on('leaveLobby', (payload = {}) => {
     const { tableId } = payload;
     const resolvedAccountId = resolveTpcIdentity(payload);
+    if (hasConflictingIdentities(payload) || !ensureRegistered(socket, resolvedAccountId)) return;
     if (tableId) {
       unseatTableSocket(resolvedAccountId, tableId, socket.id);
     }

--- a/docs/online-contract-checklist.md
+++ b/docs/online-contract-checklist.md
@@ -5,6 +5,8 @@ Use this checklist before enabling any game's **Online** toggle in lobby.
 ## Contract gates (must all be ✅)
 
 - [ ] **Lobby contract**
+  - Resolves the signed-in user's canonical TPG account number before queueing.
+  - Sends `tpcAccountNumber` on register, seat, ready, leave, and reconnect events; legacy IDs are aliases only.
   - Seats through shared `seatTable` flow.
   - Sends `confirmReady` and handles timeout/cancel cleanup.
   - Enforces stake reserve/refund rules.
@@ -16,6 +18,16 @@ Use this checklist before enabling any game's **Online** toggle in lobby.
   - Emits/handles `seatTable`, `lobbyUpdate`, `gameStart`, `leaveLobby`, refund/cancel.
   - Match completion, stake settlement, and win/loss are authoritative.
   - Telemetry emits queued → matched → started → completed/refunded.
+  - Rejects zero/fractional stakes, non-TPG tokens, offline modes, identity conflicts, and unseated ready/leave requests.
+
+## TPG stake contract
+
+Online tables use the platform's server-side TPG ledger as escrow. A lobby may
+only advertise online play when it can reserve the stake before seating, refund
+an unmatched/cancelled player exactly once, and settle the completed match from
+authoritative server state. Wallet addresses and Telegram IDs are authentication
+inputs; neither is a matchmaking key. The canonical TPG account number is the
+only player key stored in a table roster.
 
 ## Release policy
 

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -15,7 +15,7 @@ describe('online game policy', () => {
       maxPlayers: 2,
       matchMeta: {
         variant: '8ball',
-        mode: 'Ranked',
+        mode: 'ONLINE',
         tableSize: '9ft',
         token: 'TPG',
         unexpected: 'ignore-me'
@@ -27,7 +27,7 @@ describe('online game policy', () => {
     expect(result.normalizedMaxPlayers).toBe(2);
     expect(result.safeMatchMeta).toEqual({
       variant: '8ball',
-      mode: 'Ranked',
+      mode: 'online',
       tableSize: '9ft',
       token: 'TPG'
     });
@@ -45,21 +45,31 @@ describe('online game policy', () => {
       gameType: 'chess',
       stake: 100,
       maxPlayers: 2,
-      matchMeta: { preferredSide: 'white', mode: 'online' }
+      matchMeta: { preferredSide: 'white', mode: 'online', token: 'TPG' }
     });
     const checkers = validateSeatTableRequest({
       gameType: 'checkers',
       stake: 100,
       maxPlayers: 2,
-      matchMeta: { preferredSide: 'black', mode: 'online' }
+      matchMeta: { preferredSide: 'black', mode: 'online', token: 'TPG' }
     });
 
     expect(chess.ok).toBe(true);
     expect(chess.normalizedGameType).toBe('chess');
-    expect(chess.safeMatchMeta).toEqual({ preferredSide: 'white', mode: 'online' });
+    expect(chess.safeMatchMeta).toEqual({ preferredSide: 'white', mode: 'online', token: 'TPG' });
     expect(checkers.ok).toBe(true);
     expect(checkers.normalizedGameType).toBe('checkers');
-    expect(checkers.safeMatchMeta).toEqual({ preferredSide: 'black', mode: 'online' });
+    expect(checkers.safeMatchMeta).toEqual({ preferredSide: 'black', mode: 'online', token: 'TPG' });
+
+  });
+
+  test.each([
+    [{ gameType: 'poolroyale', stake: 100, maxPlayers: 2, matchMeta: { mode: 'online', token: 'TON' } }, 'invalid_stake_token'],
+    [{ gameType: 'poolroyale', stake: 100, maxPlayers: 2, matchMeta: { mode: 'ai', token: 'TPG' } }, 'invalid_game_mode'],
+    [{ gameType: 'poolroyale', stake: 0, maxPlayers: 2, matchMeta: { mode: 'online', token: 'TPG' } }, 'invalid_stake'],
+    [{ gameType: 'poolroyale', stake: 1.5, maxPlayers: 2, matchMeta: { mode: 'online', token: 'TPG' } }, 'invalid_stake']
+  ])('rejects a lobby request outside the TPG stake contract %#', (payload, error) => {
+    expect(validateSeatTableRequest(payload)).toEqual({ ok: false, error });
   });
 
   test('accepts and canonicalizes all Domino Royal matchmaking criteria', () => {

--- a/test/simpleOnlineFlow.test.js
+++ b/test/simpleOnlineFlow.test.js
@@ -71,6 +71,15 @@ test('runSimpleOnlineFlow reconnects socket before joining a table', async () =>
 
   assert.equal(result.ok, true);
   assert.equal(mockSocket.seatRequests.length, 1);
+  assert.deepEqual(
+    {
+      tpcAccountNumber: mockSocket.seatRequests[0].payload.tpcAccountNumber,
+      accountId: mockSocket.seatRequests[0].payload.accountId,
+      playerId: mockSocket.seatRequests[0].payload.playerId
+    },
+    { tpcAccountNumber: 'acct-1', accountId: 'acct-1', playerId: 'acct-1' },
+    'all matchmaking events must carry the authoritative TPG account number'
+  );
   assert.equal(state.snapshot.matchError, '');
   assert.equal(transactions.length, 1, 'debit should happen once and no refund should occur');
   result.cleanup();

--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -435,6 +435,7 @@ export default function CheckersBattleRoyalLobby() {
         'seatTable',
         {
           accountId: trackedAccountId || accountId,
+          tpcAccountNumber: seatAccountId,
           tpcAccountId: seatAccountId,
           gameType: 'checkers',
           stake: stake.amount ?? 0,

--- a/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyalLobby.jsx
@@ -184,11 +184,12 @@ export default function LudoBattleRoyalLobby() {
     if (initData) params.set('init', encodeURIComponent(initData));
 
     if (mode === 'online' && accountId) {
-      socket.emit('register', { playerId: accountId });
+      socket.emit('register', { tpcAccountNumber: accountId, accountId, playerId: accountId });
       socket.emit(
         'seatTable',
         {
           accountId,
+          tpcAccountNumber: accountId,
           gameType: 'ludobattleroyal',
           stake: Number(stake.amount) || 0,
           maxPlayers: table.capacity || 2,
@@ -203,7 +204,7 @@ export default function LudoBattleRoyalLobby() {
             return;
           }
           params.set('tableId', res.tableId);
-          socket.emit('confirmReady', { accountId, tableId: res.tableId });
+          socket.emit('confirmReady', { tpcAccountNumber: accountId, accountId, tableId: res.tableId });
           navigate(`/games/ludobattleroyal?${params.toString()}`);
         }
       );

--- a/webapp/src/pages/Games/TavullBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyalLobby.jsx
@@ -221,19 +221,26 @@ export default function TavullBattleRoyalLobby() {
 
     socket.on('gameStart', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
-    socket.emit('register', { playerId: trackedAccountId });
+    socket.emit('register', {
+      tpcAccountNumber: trackedAccountId,
+      accountId: trackedAccountId,
+      playerId: trackedAccountId
+    });
 
     const friendlyName = getTelegramFirstName() || getTelegramUsername() || 'Player';
     socket.emit(
       'seatTable',
       {
         accountId: trackedAccountId || accountId,
+        tpcAccountNumber: trackedAccountId || accountId,
         gameType: 'backgammon',
         stake: stake.amount ?? 0,
         maxPlayers: 2,
         playerName: friendlyName,
         avatar,
-        preferredSide
+        preferredSide,
+        mode: 'online',
+        token: stake.token
       },
       (res) => {
         if (!res?.success || !res.tableId) {
@@ -245,6 +252,7 @@ export default function TavullBattleRoyalLobby() {
         setMatchStatus('Waiting for another player…');
         socket.emit('confirmReady', {
           accountId: trackedAccountId,
+          tpcAccountNumber: trackedAccountId,
           tableId: res.tableId
         });
       }

--- a/webapp/src/pages/Games/snakeOnlineFlow.js
+++ b/webapp/src/pages/Games/snakeOnlineFlow.js
@@ -213,7 +213,7 @@ export async function runSnakeOnlineFlow({
 
   socketInstance.on('lobbyUpdate', handleLobbyUpdate);
   socketInstance.on('gameStart', handleGameStart);
-  socketInstance.emit('register', { playerId: accountId });
+  socketInstance.emit('register', { tpcAccountNumber: accountId, accountId, playerId: accountId });
 
   function startMatchTimeout(tableId) {
     clearTimeoutSafely(matchTimeoutRef);
@@ -229,9 +229,11 @@ export async function runSnakeOnlineFlow({
     'seatTable',
     {
       accountId,
+      tpcAccountNumber: accountId,
       stake: stake.amount,
       token: stake.token,
       gameType: 'snake',
+      mode: 'online',
       maxPlayers: capacity,
       playerName: playerName || getTelegramFirstNameFn?.() || `TPG ${accountId}` || 'Player',
       tableId: table?.id,

--- a/webapp/src/pages/Games/snookerRoyalOnlineFlow.js
+++ b/webapp/src/pages/Games/snookerRoyalOnlineFlow.js
@@ -222,7 +222,7 @@ export async function runSnookerRoyalOnlineFlow({
 
   socketInstance.on('lobbyUpdate', handleLobbyUpdate);
   socketInstance.on('gameStart', handleGameStart);
-  socketInstance.emit('register', { playerId: accountId });
+  socketInstance.emit('register', { tpcAccountNumber: accountId, accountId, playerId: accountId });
 
   function startMatchTimeout(tableId) {
     clearTimeoutSafely(matchTimeoutRef);
@@ -238,6 +238,7 @@ export async function runSnookerRoyalOnlineFlow({
     'seatTable',
     {
       accountId,
+      tpcAccountNumber: accountId,
       stake: stake.amount,
       token: stake.token,
       gameType,

--- a/webapp/src/utils/simpleOnlineFlow.js
+++ b/webapp/src/utils/simpleOnlineFlow.js
@@ -150,7 +150,14 @@ export async function runSimpleOnlineFlow({
 
     socketInstance.on('lobbyUpdate', handleLobbyUpdate);
     socketInstance.on('gameStart', handleGameStart);
-    socketInstance.emit('register', { playerId: accountId });
+    const identity = {
+      tpcAccountNumber: String(accountId),
+      // Kept for one compatibility window. The server always treats the TPG
+      // account number above as the authoritative matchmaking identity.
+      accountId: String(accountId),
+      playerId: String(accountId),
+    };
+    socketInstance.emit('register', identity);
 
     timeoutRef = setTimeout(() => {
       setMatchError('Matchmaking timeout. Stake refunded.');
@@ -158,7 +165,7 @@ export async function runSimpleOnlineFlow({
     }, timeoutMs);
 
     socketInstance.emit('seatTable', {
-      accountId,
+      ...identity,
       gameType,
       stake: Number(stake.amount) || 0,
       maxPlayers,
@@ -175,7 +182,7 @@ export async function runSimpleOnlineFlow({
       }
       pendingTableId = res.tableId;
       setMatchStatus('Waiting for players…');
-      socketInstance.emit('confirmReady', { accountId, tableId: res.tableId });
+      socketInstance.emit('confirmReady', { ...identity, tableId: res.tableId });
     });
 
     setCleanup?.(() => cleanup);


### PR DESCRIPTION
### Motivation
- Ensure every online lobby and matchmaking flow uses the platform TPG account number as the authoritative player identity for seating, matchmaking, refunds and settlement. 
- Prevent mismatched or spoofed identities from affecting other players (leave/confirm flows) and enforce TPG staking rules at the lobby boundary. 
- Close gaps where some games did not carry the canonical TPG id/token/mode and document the required online/escrow contract. 

### Description
- Propagate a canonical `tpcAccountNumber` identity in matchmaking events by emitting `tpcAccountNumber`, `accountId` and `playerId` on `register`, `seatTable` and `confirmReady` flows; updates applied to `webapp/src/utils/simpleOnlineFlow.js` and per-game lobby/flow files (`Checkers`, `Ludo`, `Tavull/Backgammon`, `Snake`, `Snooker`, `Pool`-adjacent flows). 
- Harden server-side identity handling by rejecting conflicting/unregistered identity actions on `leaveLobby` and ensuring `ensureRegistered` checks before unseating (`bot/server.js`).
- Strengthen `validateSeatTableRequest` policy in `bot/config/onlineGamePolicy.js` to require positive whole-number TPG stakes, require `token: 'TPG'` and `mode: 'online'`, canonicalize `mode`/`token` in `safeMatchMeta`, and add a Backgammon/Tavull entry to `GAME_ONLINE_POLICY` and `BASE_SECURITY_CONTROLS` (`tpg_account_number_required`).
- Add/adjust client-side emissions so lobbies send `tpcAccountNumber` and `mode/token` with seat operations (multiple `webapp/src/pages/Games/*Lobby*` changes). 
- Add documentation for the TPG escrow/matchmaking contract in `docs/online-contract-checklist.md` (expected lobby/runtime/backend checks and explicit TPG contract text). 
- Add regression assertions and scenarios in tests: `test/simpleOnlineFlow.test.js` (identity propagation assertion) and `test/onlineGamePolicy.test.js` (token/mode/stake rejection cases and canonicalization expectations). 

### Testing
- Ran targeted matchmaking/lobby suites with `npm test -- --runInBand test/onlineGamePolicy.test.js test/simpleOnlineFlow.test.js test/lobbyUtils.test.js test/dominoRoyalMatchmaking.test.js test/conflictMatchmaking.test.js` and all targeted suites passed (5 suites, 27 tests passed). 
- Built the TypeScript root and production webapp with `npm run build` and `npm --prefix webapp run build`; both completed successfully. 
- Ran file-scoped ESLint checks for changed files; linter reported warnings only (repository ignore settings produced warnings but no new errors). 
- Full test run `npm test -- --runInBand` discovered unrelated, pre-existing failures in `test/inventoryCrossGameConfig.test.js` (inventory/catalog assertions), which are not caused by these matchmaking/identity changes and remain to be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c6d8205548329b30d156ad9738c64)