### PR TITLE
Auto-ready same-stake chess quick-matches and assign opposing colours server-side

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1143,37 +1143,10 @@ function assignChessSides(players = []) {
     }));
   }
 
-  const [p1, p2] = players.map((p) => ({
-    ...p,
-    sidePreference: normalizeSidePreference(p.sidePreference)
-  }));
-
-  let whitePlayer = null;
-  let blackPlayer = null;
-
-  if (p1.sidePreference === 'white' && p2.sidePreference === 'black') {
-    whitePlayer = p1;
-    blackPlayer = p2;
-  } else if (p1.sidePreference === 'black' && p2.sidePreference === 'white') {
-    whitePlayer = p2;
-    blackPlayer = p1;
-  } else if (p1.sidePreference === 'white' && p2.sidePreference !== 'white') {
-    whitePlayer = p1;
-    blackPlayer = p2;
-  } else if (p2.sidePreference === 'white' && p1.sidePreference !== 'white') {
-    whitePlayer = p2;
-    blackPlayer = p1;
-  } else if (p1.sidePreference === 'black' && p2.sidePreference !== 'black') {
-    blackPlayer = p1;
-    whitePlayer = p2;
-  } else if (p2.sidePreference === 'black' && p1.sidePreference !== 'black') {
-    blackPlayer = p2;
-    whitePlayer = p1;
-  } else {
-    const p1White = Math.random() < 0.5;
-    whitePlayer = p1White ? p1 : p2;
-    blackPlayer = p1White ? p2 : p1;
-  }
+  // Competitive quick match never lets a client choose its colour. Apart from
+  // being fair, assigning both seats in one authoritative operation guarantees
+  // that two clients can never render themselves with the same pieces.
+  const whitePlayer = players[Math.floor(Math.random() * players.length)];
 
   return players.map((p) => ({
     ...p,

--- a/chess-multiplayer-server/src/ChessLobbyRoom.ts
+++ b/chess-multiplayer-server/src/ChessLobbyRoom.ts
@@ -10,6 +10,13 @@ export const canStartChessMatch = (players: Iterable<LobbyPlayer>) => {
   return seats.length === 2 && seats.every((player) => player.ready && player.connected);
 };
 
+export const assignRandomChessSides = (players: LobbyPlayer[], random = Math.random) => {
+  if (players.length !== 2) return players;
+  const whiteIndex = random() < 0.5 ? 0 : 1;
+  players.forEach((player, index) => { player.side = index === whiteIndex ? 'white' : 'black'; });
+  return players;
+};
+
 export class ChessBattleRoyaleRoom extends Room<{ state: ChessLobbyState }> {
   maxClients = 2;
   private countdown?: ReturnType<typeof setTimeout>;
@@ -53,6 +60,9 @@ export class ChessBattleRoyaleRoom extends Room<{ state: ChessLobbyState }> {
     if (this.state.players.size === this.maxClients) {
       this.lock();
       try { await this.reserveStakes(); } catch (error) { this.state.players.delete(client.sessionId); this.unlock(); throw error; }
+      // Quick Match has no ready-up step: successfully reserving both stakes is
+      // the authoritative confirmation for both connected seats.
+      this.state.players.forEach((seatedPlayer) => { seatedPlayer.ready = true; });
     }
     this.evaluateCountdown();
   }
@@ -110,10 +120,11 @@ export class ChessBattleRoyaleRoom extends Room<{ state: ChessLobbyState }> {
     void this.setMetadata({ visibility: this.state.visibility, invitationCode: this.state.invitationCode, phase: 'countdown' });
     this.lock();
     this.countdown = setTimeout(() => {
+      const players = assignRandomChessSides([...this.state.players.values()]);
       this.state.phase = 'playing';
       this.state.countdownEndsAt = 0;
       void this.setMetadata({ visibility: this.state.visibility, invitationCode: this.state.invitationCode, phase: 'playing' });
-      this.broadcast('match_start', { roomId: this.roomId, matchId: this.state.matchId, tableNumber: this.state.tableNumber, players: [...this.state.players.values()].map((p) => ({ accountId: p.accountId, maskedAccount: p.maskedAccount, name: p.name })) });
+      this.broadcast('match_start', { roomId: this.roomId, matchId: this.state.matchId, tableNumber: this.state.tableNumber, players: players.map((p) => ({ accountId: p.accountId, maskedAccount: p.maskedAccount, name: p.name, side: p.side })) });
     }, 5000);
   }
 

--- a/chess-multiplayer-server/src/matchmaking.test.ts
+++ b/chess-multiplayer-server/src/matchmaking.test.ts
@@ -11,7 +11,7 @@ describe('chess_lobby matchmaking', () => {
   beforeAll(async () => { server = await boot(chessServerConfig as any); });
   afterAll(async () => { await server.shutdown(); });
 
-  it('pairs two clients, starts only when both are ready, and seats a third separately', async () => {
+  it('pairs two clients, reserves both seats, assigns opposite colours, and seats a third separately', async () => {
     const first = await server.sdk.joinOrCreate('chess_lobby', options('first'));
     await waitForPatch();
     expect(first.state.players.size).toBe(1);
@@ -26,17 +26,15 @@ describe('chess_lobby matchmaking', () => {
     expect(third.roomId).not.toBe(first.roomId);
     expect(third.state.players.size).toBe(1);
 
-    first.send('ready', true);
-    await waitForPatch();
-    expect(first.state.phase).toBe('waiting');
     const firstStarted = new Promise<any>((resolve) => first.onMessage('match_start', resolve));
     const secondStarted = new Promise<any>((resolve) => second.onMessage('match_start', resolve));
-    second.send('ready', true);
     await waitForPatch();
     expect(first.state.phase).toBe('countdown');
     const [firstMatch, secondMatch] = await Promise.all([firstStarted, secondStarted]);
     expect(firstMatch.roomId).toBe(first.roomId);
     expect(secondMatch.roomId).toBe(first.roomId);
+    expect(firstMatch.players.map((player: any) => player.side).sort()).toEqual(['black', 'white']);
+    expect(secondMatch.players).toEqual(firstMatch.players);
 
     await Promise.all([first.leave(true), second.leave(true), third.leave(true)]);
   }, 8_000);

--- a/chess-multiplayer-server/src/state.ts
+++ b/chess-multiplayer-server/src/state.ts
@@ -8,6 +8,7 @@ export class LobbyPlayer extends Schema {
   @type('boolean') connected = true;
   @type('number') joinedAt = 0;
   @type('string') maskedAccount = '';
+  @type('string') side: 'white' | 'black' | '' = '';
 }
 
 export class ChessLobbyState extends Schema {


### PR DESCRIPTION
### Motivation
- Quick-match chess games were not reliably starting when two same-stake players joined and clients could end up with the same colour or mismatched lifecycle; the goal is to ensure both seats are escrowed, automatically progressed to start, and assigned opposite colours in an authoritative server-side way so users are charged and winners are paid correctly.

### Description
- Add a `side` property to lobby players and include it in the lobby state so assigned colours are synchronized to clients (`chess-multiplayer-server/src/state.ts`).
- In the Colyseus room (`chess-multiplayer-server/src/ChessLobbyRoom.ts`) mark both players `ready` immediately after successful stake reservation, start the countdown, assign random opposite sides with `assignRandomChessSides`, and include `side` in the `match_start` broadcast.
- In the Socket.IO bot server (`bot/server.js`) replace the client-preference-based colour assignment with a server-authoritative random assignment so two players never receive the same colour in quick matches.
- Update the Colyseus matchmaking test (`chess-multiplayer-server/src/matchmaking.test.ts`) to assert that the match start payload is identical for both clients and that exactly one `white` and one `black` were assigned.

### Testing
- Initial reproduction run with Node tests showed failing/timeouts for chess matchmaking which motivated the fix (these runs surfaced the issue). 
- Ran `npm --prefix chess-multiplayer-server test` (Vitest) after the changes and the chess matchmaking/unit tests passed. 
- Built the chess server with `npm --prefix chess-multiplayer-server run build` which completed successfully. 
- Performed `node --check bot/server.js` and `git diff --check` to validate no syntax or whitespace errors, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c790bdd588329a8daa13bca0e306d)