### PR TITLE
Fix Chess Battle Royal matchmaking endpoint

### DIFF
--- a/webapp/.env
+++ b/webapp/.env
@@ -1,5 +1,5 @@
-VITE_API_BASE_URL=https://api.tonplaygram.com
-VITE_SOCKET_URL=https://api.tonplaygram.com
+VITE_API_BASE_URL=https://tonplaygram-bot.onrender.com
+VITE_SOCKET_URL=https://tonplaygram-bot.onrender.com
 VITE_SOCKET_PATH=/socket.io
 VITE_GOOGLE_CLIENT_ID=1080581969180-2rmpxhzwd67l6hx0n5zti37ya15dyc95.apps.googleusercontent.com
 VITE_DEV_ACCOUNT_ID=5ffe7c43-c0ae-48f6-ab8c-9e065ca95466


### PR DESCRIPTION
### Motivation
- Restore online matchmaking for the Chess Battle Royal lobby by routing production REST and Socket.IO traffic to the currently active TonPlaygram backend instead of the legacy API host.

### Description
- Updated `webapp/.env` to set `VITE_API_BASE_URL` and `VITE_SOCKET_URL` to `https://tonplaygram-bot.onrender.com` so the webapp points at the active bot service for API and Socket.IO connections.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- Ran `npm --prefix webapp run lint -- src/utils/socket.js src/pages/Games/ChessBattleRoyalLobby.jsx` and linting passed for the targeted files.
- Verified the configured host responds with `curl https://tonplaygram-bot.onrender.com/api/ping` returning `{"message":"pong"}` and the Socket.IO polling handshake at `https://tonplaygram-bot.onrender.com/socket.io/?EIO=4&transport=polling` returned a valid session handshake.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c7c6fadb88329a59f96dee9cbb8d7)