### PR TITLE
Fix Chess Battle Royal matchmaking start sync and player privacy

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1570,7 +1570,7 @@ function maybeStartGame(table) {
         ensureCheckersSession(table.id, table);
         io.to(table.id).emit('checkersState', { tableId: table.id, ...initial });
       }
-      io.to(table.id).emit('gameStart', {
+      const gameStartPayload = {
         tableId: table.id,
         tableNumber: table.tableNumber,
         players: table.players,
@@ -1578,7 +1578,13 @@ function maybeStartGame(table) {
         stake: table.stake,
         meta: table.meta,
         matchId: table.matchId || null
-      });
+      };
+      // Older game clients subscribe to `gameStarted`, while current lobbies
+      // subscribe to both names. Broadcasting the compatibility event as part
+      // of the same authoritative transition prevents one phone remaining on
+      // the search screen when accounts use different cached app versions.
+      io.to(table.id).emit('gameStart', gameStartPayload);
+      io.to(table.id).emit('gameStarted', gameStartPayload);
       tableSeats.delete(table.id);
       const key = `${table.gameType}-${table.maxPlayers}`;
       lobbyTables[key] = (lobbyTables[key] || []).filter(

--- a/test/chessLobbyHelpers.test.mjs
+++ b/test/chessLobbyHelpers.test.mjs
@@ -17,6 +17,7 @@ const helperNames = [
   'resolveChessTableMode',
   'resolveInitialOnlineQueue',
   'resolveLobbyStatus',
+  'resolvePlayerName',
   'resolveSeatAccountId',
   'resolveSeatErrorMessage',
   'shouldKeepSearching'
@@ -98,6 +99,20 @@ test('chess lobby status and side helpers match paired players', () => {
     'Both players ready. Starting match…'
   );
   assert.equal(sandbox.resolveChessSide(players, 'black-player'), 'black');
+});
+
+test('chess lobby never substitutes a private account number for a player name', () => {
+  assert.equal(
+    sandbox.resolvePlayerName({ accountId: 'TPG-PRIVATE-123' }),
+    'Player'
+  );
+  assert.equal(
+    sandbox.resolvePlayerName({
+      accountId: 'TPG-PRIVATE-123',
+      username: 'Ada'
+    }),
+    'Ada'
+  );
 });
 
 test('chess lobby builds online game params and seat account fallback', () => {

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -76,8 +76,7 @@ function resolvePlayerName(player) {
       player.username ||
       player.telegramName ||
       player.firstName ||
-      resolveTpcAccountNumber(player) ||
-      ''
+      'Player'
   ).trim();
 }
 
@@ -343,6 +342,7 @@ export default function ChessBattleRoyalLobby() {
   const matchmakingCountdownRef = useRef(null);
   const spinIntervalRef = useRef(null);
   const matchmakingSessionRef = useRef(0);
+  const startedMatchRef = useRef('');
 
   const selectedFlag =
     playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
@@ -457,12 +457,8 @@ export default function ChessBattleRoyalLobby() {
     const candidates = [...onlinePlayers, ...matchPlayers]
       .map((p) => ({
         id: resolveTpcAccountNumber(p),
-        name:
-          p?.username ||
-          p?.name ||
-          p?.telegramName ||
-          p?.telegramId ||
-          resolveTpcAccountNumber(p)
+        name: resolvePlayerName(p),
+        avatar: p?.avatar || p?.photoUrl || p?.photoURL || ''
       }))
       .filter((p) => p.id);
     const deduped = candidates.filter((p, idx, arr) => {
@@ -628,6 +624,7 @@ export default function ChessBattleRoyalLobby() {
 
     setMatchError('');
     setMatching(true);
+    startedMatchRef.current = '';
     setMatchStatus('Connecting to lobby…');
     const matchmakingSession = ++matchmakingSessionRef.current;
     const isCurrentSearch = () =>
@@ -698,6 +695,10 @@ export default function ChessBattleRoyalLobby() {
     } = {}) => {
       if (!startedId || String(startedId) !== String(pendingTableRef.current))
         return;
+      // The server emits both event names for compatibility. Treat the table id
+      // as an idempotency key so each phone enters the game exactly once.
+      if (startedMatchRef.current === String(startedId)) return;
+      startedMatchRef.current = String(startedId);
       const mySide = resolveChessSide(players, seatAccountId);
       const opp = resolveChessOpponent(players, seatAccountId);
       cleanupLobby({ account: trackedAccountId, skipLeave: true });
@@ -1128,8 +1129,8 @@ export default function ChessBattleRoyalLobby() {
               )}
             </div>
             <p className="text-center text-white/60 text-xs">
-              Staking uses your TPG account{accountId ? ` #${accountId}` : ''}{' '}
-              as escrow for every online round.
+              Staking uses your verified TPG account as escrow for every online
+              round. Your account number stays private.
             </p>
           </div>
         )}
@@ -1163,17 +1164,31 @@ export default function ChessBattleRoyalLobby() {
                 {matchPlayers.map((player) => {
                   const playerId = resolveTpcAccountNumber(player);
                   const isReady = readyList.includes(String(playerId));
+                  const playerName = resolvePlayerName(player);
+                  const playerAvatar =
+                    player?.avatar ||
+                    player?.photoUrl ||
+                    player?.photoURL ||
+                    '';
                   return (
                     <div
                       key={playerId || player.name}
                       className="lobby-tile w-full flex items-center justify-between"
                     >
-                      <div>
-                        <p className="text-sm font-semibold">
-                          {player?.name || `TPG ${playerId}`}
-                        </p>
-                        <p className="text-xs text-white/50">
-                          Account #{playerId}
+                      <div className="flex min-w-0 items-center gap-3">
+                        <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full bg-cyan-950 text-sm font-bold text-cyan-200">
+                          {playerAvatar ? (
+                            <img
+                              src={playerAvatar}
+                              alt=""
+                              className="h-full w-full object-cover"
+                            />
+                          ) : (
+                            playerName.slice(0, 1).toUpperCase()
+                          )}
+                        </div>
+                        <p className="truncate text-sm font-semibold">
+                          {playerName}
                         </p>
                       </div>
                       <span


### PR DESCRIPTION
### Motivation

- Prevent phones from desynchronising when a match starts due to different client versions and avoid leaking TPG account numbers as display names in the lobby.

### Description

- Broadcast the authoritative match transition under both Socket.IO event names (`gameStart` and `gameStarted`) so older and newer clients receive the same payload simultaneously (updated `bot/server.js`).
- Make client navigation idempotent by treating the started table id as an idempotency key so a client only enters the game once even if both compatibility events arrive (updated `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx`).
- Stop falling back to TPG account numbers as visible names and instead show `Player` when no username is available, and surface profile avatars (or initials) in matchmaking tiles so account numbers remain private (updated `ChessBattleRoyalLobby.jsx`).
- Update the lobby staking copy to explicitly state that the account number remains private (updated `ChessBattleRoyalLobby.jsx`).
- Add a small regression test that ensures account IDs are never substituted for a display name (`test/chessLobbyHelpers.test.mjs`).

### Testing

- Ran unit helper tests with `node --test test/chessLobbyHelpers.test.mjs`, which passed (all helper assertions including the new privacy regression).
- Exercised the existing matchmaking integration fixture `test/chessLobbyAliasCriteriaMatchmaking.test.js` during development and observed a failing timing/assertion early in the iteration which informed the compatibility/event-idempotency fix; integration timing scenarios remain sensitive to client-server ordering in some tests.
- Built the web frontend with `npm --prefix webapp run build`, which completed successfully, and ran code formatting (`prettier --write`) and lint checks (ESLint reported warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c831ef0808329bece969c57d1517c)