### PR TITLE
Recover orphaned Chess Battle Royal matches during matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1378,14 +1378,68 @@ async function reserveChessStakeContract(table) {
   try {
     let matchId = '';
     await session.withTransaction(async () => {
-      const active = await ChessMatch.findOne({
+      const activeMatches = await ChessMatch.find({
         status: { $in: ['reserved', 'playing'] },
         $or: [
           { player1TpcAccountId: { $in: accounts } },
           { player2TpcAccountId: { $in: accounts } }
         ]
       }).session(session);
-      if (active) throw new Error('account_already_in_active_match');
+      for (const active of activeMatches) {
+        const activeTable = tableMap.get(String(active.roomId));
+        const hasConnectedPlayer = activeTable?.players?.some((player) => {
+          const liveSocket = io.sockets.sockets.get(String(player.socketId || ''));
+          return liveSocket?.rooms?.has(String(active.roomId));
+        });
+        if (hasConnectedPlayer) {
+          throw new Error('account_already_in_active_match');
+        }
+
+        // A server restart or a closed WebView can leave a persisted chess
+        // contract marked "playing" even though its Socket.IO room no longer
+        // has either phone. Such an orphan used to permanently reject every
+        // later Quick Match for both accounts. Refund the locked stakes inside
+        // this transaction before reserving the replacement match.
+        const orphanAccounts = [
+          active.player1TpcAccountId,
+          active.player2TpcAccountId
+        ].map(String);
+        const releaseIds = [];
+        for (const orphanAccount of orphanAccounts) {
+          const transactionId = `chess:${active.internalMatchId}:orphan-refund:${orphanAccount}`;
+          releaseIds.push(transactionId);
+          await User.updateOne(
+            {
+              $or: [
+                { tpcAccountNumber: orphanAccount },
+                { accountId: orphanAccount }
+              ],
+              'transactions.transactionId': { $ne: transactionId }
+            },
+            {
+              $inc: { balance: Number(active.stakePerPlayer || 0) },
+              $set: { currentTableId: null },
+              $push: {
+                transactions: {
+                  transactionId,
+                  amount: Number(active.stakePerPlayer || 0),
+                  type: 'stake_refund',
+                  token: active.token || 'TPG',
+                  status: 'delivered',
+                  game: 'chessbattle',
+                  players: 2,
+                  detail: 'orphaned_match_recovery'
+                }
+              }
+            },
+            { session }
+          );
+        }
+        active.status = 'refunded';
+        active.result = 'orphaned_match_recovery';
+        active.releaseTransactionIds = releaseIds;
+        await active.save({ session });
+      }
       const users = await User.find({
         $or: [
           { tpcAccountNumber: { $in: accounts } },


### PR DESCRIPTION
### Motivation
- Prevent players from being permanently blocked from quick-match because a previously persisted chess contract is marked active while no connected client remains. 
- Ensure the server only blocks accounts that are truly in an active live game while allowing replacement matches to be created when the original game is orphaned.

### Description
- In `reserveChessStakeContract` the code now queries all persisted chess matches for the two accounts and iterates them instead of failing immediately on any match record. 
- For each persisted match the server now checks the Socket.IO room to see whether any player socket is still connected to that room, and only treats the match as an active game when a connected player exists. 
- If a persisted match is orphaned (no connected socket in the room), the code refunds both players inside the same MongoDB transaction by idempotently inserting refund transactions and crediting their balances, then marks the persisted match as `refunded` and records recovery transaction ids. 
- This preserves protection for genuinely active games while allowing quick-match to recover from server restarts or closed WebViews that left stale "playing" contracts.

### Testing
- Ran `node --check bot/server.js` which completed without syntax errors. 
- Ran `git diff --check` which reported no issues. 
- Attempted to run the chess lobby integration tests via `node --test test/chessLobby*.test.js`, but the test processes were cancelled because the environment lacked a usable native `canvas` binding (`../build/Release/canvas.node`), so the server could not start and the automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c883b4ea08329be8cf3573250d833)