### PR TITLE
Prevent global accountId from overwriting per-user scoped IDs (fix Domino Royal matchmaking collisions)

### DIFF
--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -118,14 +118,12 @@ export function getPlayerId() {
     const perTelegramKey = accountIdMapStorageKey(telegramId);
     let telegramScopedId = localStorage.getItem(perTelegramKey);
 
-    if (globalId && (!telegramScopedId || telegramScopedId !== globalId)) {
-      telegramScopedId = globalId;
-      localStorage.setItem(perTelegramKey, telegramScopedId);
-    }
-
     // Backward compatibility:
     // if this Telegram user already had a single legacy accountId stored, bind it
-    // once to the per-user key instead of generating a new id.
+    // once to the first per-user key instead of generating a new id. Never copy
+    // the mutable global alias over a different Telegram user's scoped key: two
+    // accounts sharing a WebView/storage would otherwise occupy the same lobby
+    // seat and could never match each other.
     if (!telegramScopedId && globalId && !hasAnyScopedAccountIds(localStorage)) {
       telegramScopedId = globalId;
       localStorage.setItem(perTelegramKey, telegramScopedId);
@@ -145,10 +143,6 @@ export function getPlayerId() {
   if (googleId) {
     const perGoogleKey = accountIdGoogleStorageKey(googleId);
     let googleScopedId = localStorage.getItem(perGoogleKey);
-    if (globalId && (!googleScopedId || googleScopedId !== globalId)) {
-      googleScopedId = globalId;
-      localStorage.setItem(perGoogleKey, googleScopedId);
-    }
     if (!googleScopedId && globalId && !hasAnyScopedAccountIds(localStorage)) {
       googleScopedId = globalId;
       localStorage.setItem(perGoogleKey, googleScopedId);


### PR DESCRIPTION
### Motivation
- Prevent two different users who share the same browser/WebView storage from being assigned the same lobby identity, which caused Domino Royal matchmaking to treat them as the same player.
- Preserve a safe one-time migration of an existing legacy global `accountId` while ensuring subsequent Telegram/Google users get distinct scoped IDs.
- Ensure online matchmaking queues partition players correctly by per-user identity so seats and ready counts reflect real users.

### Description
- Updated `webapp/src/utils/telegram.js` to stop copying the mutable global `accountId` into a per-Telegram `accountId:tg:<id>` key when that per-user key already exists or when other scoped keys are present.
- Kept the one-time migration behavior that binds a legacy `accountId` to the first Telegram user only when no scoped keys exist, and added explanatory comments about the rationale.
- Applied the same protective behavior for Google-scoped account IDs to avoid cross-user reuse of the global alias.
- No API/behavior changes to matchmaking logic itself; this change only ensures client identities are isolated so server-side lobby matching works as intended.

### Testing
- Ran `npx jest test/telegramAccountIsolation.test.js test/dominoRoyalMatchmaking.test.js test/dominoRoyalOnline.test.js --runInBand`, and all three suites passed (3 suites, 13 tests).
- Verified the Domino Royal matchmaking tests (`test/dominoRoyalMatchmaking.test.js` and `test/dominoRoyalOnline.test.js`) pass after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c93e501ac83299d149712ca6cb791)