### PR TITLE
Make Chess matchmaking start authoritative and prevent duplicate seats

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -702,7 +702,9 @@ function createLobbyTable({
     currentTurn: null,
     ready: new Set(),
     meta,
-    matchTimeout: null
+    matchTimeout: null,
+    started: false,
+    gameStartPayload: null
   };
   if (gameType === 'domino-royal' && table.tableNumber) {
     dominoRoyalTableNumbers.add(table.tableNumber);
@@ -738,6 +740,7 @@ function getAvailableTable(
       const canJoinForced =
         existing.gameType === gameType &&
         Number(existing.stake || 0) === normalizedStake &&
+        (!existing.started || alreadySeated) &&
         (alreadySeated || existing.players.length < existing.maxPlayers) &&
         isMatchMetaCompatible(existing.meta, normalizedMeta, gameType);
       if (canJoinForced) return existing;
@@ -1300,8 +1303,19 @@ async function seatTableSocket(
     map = new Map();
     tableSeats.set(tableId, map);
   }
-  if (!map.has(String(accountId))) {
-    map.set(String(accountId), {
+  // Keep one authoritative roster entry per TPG account. Besides protecting
+  // new joins, this repairs a table created by an older process/client that
+  // managed to append the same account through two transports.
+  const normalizedAccountId = String(accountId);
+  table.players = table.players.filter((player, index, players) => {
+    const playerId = String(player?.tpcAccountNumber || player?.id || '');
+    return playerId !== normalizedAccountId ||
+      players.findIndex((candidate) =>
+        String(candidate?.tpcAccountNumber || candidate?.id || '') === normalizedAccountId
+      ) === index;
+  });
+  if (!map.has(normalizedAccountId)) {
+    map.set(normalizedAccountId, {
       id: accountId,
       tpcAccountNumber: String(accountId),
       name: playerName || String(accountId),
@@ -1329,7 +1343,7 @@ async function seatTableSocket(
     info.ts = Date.now();
     info.socketId = socket?.id;
     info.sidePreference = normalizeSidePreference(preferredSide || info.sidePreference);
-    const p = table.players.find((pl) => pl.id === accountId);
+    const p = table.players.find((pl) => String(pl.id) === normalizedAccountId);
     if (p) {
       p.socketId = socket?.id;
       p.avatar = playerAvatar || p.avatar;
@@ -1353,7 +1367,7 @@ async function seatTableSocket(
       }
     }, dominoRoyalMatchTimeoutMs);
   }
-  table.ready.delete(String(accountId));
+  if (!table.started) table.ready.delete(normalizedAccountId);
   if (!table.meta) {
     table.meta = normalizeMatchMeta(matchMeta);
   }
@@ -1558,6 +1572,7 @@ async function settleChessStakeContract(tableId, result = {}) {
 }
 
 function maybeStartGame(table) {
+  if (table.started) return;
   if (
     table.players.length === table.maxPlayers &&
     table.ready &&
@@ -1636,6 +1651,12 @@ function maybeStartGame(table) {
         meta: table.meta,
         matchId: table.matchId || null
       };
+      // Persist the authoritative transition before broadcasting it. A phone
+      // can reconnect or receive its seat acknowledgement just after the
+      // broadcast; returning this snapshot lets that client enter the exact
+      // same match instead of remaining forever on the lobby screen.
+      table.started = true;
+      table.gameStartPayload = gameStartPayload;
       // Older game clients subscribe to `gameStarted`, while current lobbies
       // subscribe to both names. Broadcasting the compatibility event as part
       // of the same authoritative transition prevents one phone remaining on
@@ -2471,9 +2492,10 @@ io.on('connection', (socket) => {
         // server-authoritative also lets older/mobile clients match when
         // confirmReady is delayed or lost while Telegram's WebView reconnects.
         const shouldReadySeat =
-          validation.normalizedGameType === 'chess' ||
-          validation.normalizedGameType === 'poolroyale' ||
-          readyOnJoin;
+          !table.started &&
+          (validation.normalizedGameType === 'chess' ||
+            validation.normalizedGameType === 'poolroyale' ||
+            readyOnJoin);
         if (shouldReadySeat) {
           table.ready.add(String(resolvedAccountId));
           io.to(table.id).emit('lobbyUpdate', {
@@ -2492,7 +2514,9 @@ io.on('connection', (socket) => {
           players: table.players,
           currentTurn: table.currentTurn,
           ready: Array.from(table.ready),
-          meta: table.meta
+          meta: table.meta,
+          started: Boolean(table.started),
+          gameStart: table.gameStartPayload
         });
         if (shouldReadySeat) maybeStartGame(table);
       } else if (cb) {

--- a/test/chessLobbyAliasCriteriaMatchmaking.test.js
+++ b/test/chessLobbyAliasCriteriaMatchmaking.test.js
@@ -121,6 +121,20 @@ test(
       ]);
       assert.equal(gameStartA.tableId, firstSeat.tableId);
       assert.equal(gameStartB.tableNumber, firstSeat.tableNumber);
+
+      const resumedSeat = await seat(restoredSocket, {
+        accountId: 'chess-alias-b',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        tableId: firstSeat.tableId
+      });
+      assert.equal(resumedSeat.started, true);
+      assert.equal(resumedSeat.gameStart.tableId, firstSeat.tableId);
+      assert.deepEqual(
+        resumedSeat.players.map((player) => player.tpcAccountNumber),
+        ['chess-alias-a', 'chess-alias-b']
+      );
     } finally {
       s1.disconnect();
       s2.disconnect();

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -898,6 +898,14 @@ export default function ChessBattleRoyalLobby() {
             Array.isArray(res.ready) ? res.ready.map((id) => String(id)) : []
           );
           const playersList = Array.isArray(res.players) ? res.players : [];
+          // The server persists the start transition for reconnects and for
+          // the narrow race where Socket.IO delivers gameStart immediately
+          // before this seat acknowledgement. Consume that snapshot through
+          // the same idempotent handler so both phones always open the board.
+          if (res.started && res.gameStart) {
+            handleGameStart(res.gameStart);
+            return;
+          }
           const opp = resolveChessOpponent(playersList, seatAccountId);
           setMatchStatus(
             opp


### PR DESCRIPTION
### Motivation

- Prevent race conditions where one phone misses the server `gameStart` broadcast and remains stuck in the lobby. 
- Avoid duplicate roster entries when the same account reconnects on a new transport and accidentally gets appended twice to the same table. 
- Allow reconnecting clients to recover an already-started match deterministically from the seat acknowledgement. 

### Description

- Persist per-table start state by adding `started` and `gameStartPayload` to lobby tables and only allow non-started forced-joins unless the account is already seated. 
- Deduplicate and canonicalize roster entries by TPG account inside `seatTableSocket`, replace duplicate players created by multiple transports, and update the player's socket id on reconnect. 
- Mark seats ready only when appropriate (skip toggling ready for tables already started) and persist the authoritative start snapshot before broadcasting `gameStart`/`gameStarted`. 
- Surface the persisted start snapshot in the `seatTable` acknowledgement (adds `started` and `gameStart` fields) and make the Chess Battle Royal lobby consume that snapshot via the same idempotent `handleGameStart` path so both phones open the same table exactly once. 
- Add regression coverage to the matchmaking tests to assert resumed seat acknowledgements include the persisted start payload and do not create duplicate roster entries. 

### Testing

- Ran `node --test test/chessLobbyHelpers.test.mjs` and the helper suite passed. 
- Built the web client with `npm --prefix webapp run build` which completed successfully and produced a production `dist`. 
- Performed static checks with `node --check bot/server.js` and `node --check test/chessLobbyAliasCriteriaMatchmaking.test.js` with no syntax errors. 
- Attempted Jest integration runs for the Socket.IO matchmaking tests, but the full Socket.IO integration suite could not start in this container due to a missing optional native binary (`canvas.node`), causing some jest integration runs to time out; unit/helper tests and the webapp build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c9dcc525c8329bc56b379d0d58c65)