### PR TITLE
Fix Murlan Royal 1v1 seating/cards and harden online session/reconnect

### DIFF
--- a/Assets/Scripts/Gameplay/Cards/MurlanRoyalHandVisibility.cs
+++ b/Assets/Scripts/Gameplay/Cards/MurlanRoyalHandVisibility.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+namespace Aiming.Gameplay.Cards
+{
+    /// <summary>
+    /// Prevents network seat order from deciding whether a hand is face-up. Each client
+    /// sees its own cards' fronts; every opponent hand remains face-down.
+    /// </summary>
+    public class MurlanRoyalHandVisibility : MonoBehaviour
+    {
+        [SerializeField] private string ownerUserId;
+        [SerializeField] private GameObject cardFronts;
+        [SerializeField] private GameObject cardBacks;
+
+        public void SetOwner(string userId)
+        {
+            ownerUserId = userId;
+        }
+
+        public void ApplyForLocalPlayer(string localUserId)
+        {
+            bool isLocalHand = !string.IsNullOrEmpty(localUserId) && ownerUserId == localUserId;
+            if (cardFronts != null) cardFronts.SetActive(isLocalHand);
+            if (cardBacks != null) cardBacks.SetActive(!isLocalHand);
+        }
+
+        public void Bind(string ownerId, string localUserId)
+        {
+            SetOwner(ownerId);
+            ApplyForLocalPlayer(localUserId);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
+++ b/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
@@ -3,8 +3,8 @@ using UnityEngine;
 namespace Aiming.Gameplay.Environment
 {
     /// <summary>
-    /// Pushes human characters farther from the table and slightly enlarges chairs.
-    /// Useful for portrait-camera readability tuning in Murlan Royal scenes.
+    /// Keeps the visible seats in sync with the players in a Murlan Royal match.
+    /// In a 1v1 match only the local (bottom) and opponent (top) seats are shown.
     /// </summary>
     public class MurlanRoyalTableSeatingLayout : MonoBehaviour
     {
@@ -13,6 +13,11 @@ namespace Aiming.Gameplay.Environment
         [SerializeField] private Transform[] humanCharacters;
         [SerializeField] private Transform[] chairs;
 
+        [Header("Match Seats")]
+        [SerializeField, Range(2, 4)] private int activePlayerCount = 2;
+        [Tooltip("Seat transforms in portrait-screen order: bottom, top, left, right.")]
+        [SerializeField] private Transform[] seatAnchors;
+
         [Header("Layout Tuning")]
         [SerializeField, Min(0f)] private float humanOutwardOffset = 0.35f;
         [SerializeField, Min(0.1f)] private float chairScaleMultiplier = 1.08f;
@@ -20,6 +25,7 @@ namespace Aiming.Gameplay.Environment
         [SerializeField] private bool humansShouldFaceTableCenter = true;
         [SerializeField] private Vector3 humanFacingEulerOffset = new Vector3(0f, 180f, 0f);
         [SerializeField] private bool runOnAwake = true;
+        private bool chairsScaled;
 
         void Awake()
         {
@@ -33,9 +39,41 @@ namespace Aiming.Gameplay.Environment
         public void ApplyLayout()
         {
             Vector3 center = tableCenter != null ? tableCenter.position : transform.position;
+            ApplyActiveSeats();
             PushHumansOutward(center);
             FixHumanFacing(center);
             ScaleChairs();
+        }
+
+        /// <summary>Called by the online match bootstrap after receiving the roster.</summary>
+        public void ConfigureForPlayers(int playerCount)
+        {
+            activePlayerCount = Mathf.Clamp(playerCount, 2, 4);
+            ApplyLayout();
+        }
+
+        private void ApplyActiveSeats()
+        {
+            int available = humanCharacters == null ? 0 : humanCharacters.Length;
+            int visibleCount = Mathf.Min(activePlayerCount, available);
+            for (int i = 0; i < available; i++)
+            {
+                Transform human = humanCharacters[i];
+                bool active = i < visibleCount;
+                if (human != null)
+                {
+                    human.gameObject.SetActive(active);
+                    if (active && seatAnchors != null && i < seatAnchors.Length && seatAnchors[i] != null)
+                    {
+                        human.SetPositionAndRotation(seatAnchors[i].position, seatAnchors[i].rotation);
+                    }
+                }
+
+                if (chairs != null && i < chairs.Length && chairs[i] != null)
+                {
+                    chairs[i].gameObject.SetActive(active);
+                }
+            }
         }
 
         private void PushHumansOutward(Vector3 center)
@@ -52,6 +90,8 @@ namespace Aiming.Gameplay.Environment
                 {
                     continue;
                 }
+
+                if (!human.gameObject.activeSelf) continue;
 
                 Vector3 horizontalDirection = human.position - center;
                 horizontalDirection.y = 0f;
@@ -80,6 +120,8 @@ namespace Aiming.Gameplay.Environment
                     continue;
                 }
 
+                if (!human.gameObject.activeSelf) continue;
+
                 Vector3 lookDirection = humansShouldFaceTableCenter ? (center - human.position) : (human.position - center);
                 lookDirection.y = 0f;
                 if (lookDirection.sqrMagnitude <= 0.0001f)
@@ -93,7 +135,7 @@ namespace Aiming.Gameplay.Environment
 
         private void ScaleChairs()
         {
-            if (chairs == null)
+            if (chairs == null || chairsScaled)
             {
                 return;
             }
@@ -108,6 +150,7 @@ namespace Aiming.Gameplay.Environment
 
                 chair.localScale *= chairScaleMultiplier;
             }
+            chairsScaled = true;
         }
     }
 }

--- a/multiplayer-backend/dist/services/gameValidator.js
+++ b/multiplayer-backend/dist/services/gameValidator.js
@@ -9,10 +9,54 @@ export class GameValidator {
         if (!Object.keys(state.scores).includes(actorUserId)) {
             return { valid: false, reason: 'Actor is not in this match' };
         }
-        if (payload.tick < state.tick) {
-            return { valid: false, reason: 'Stale action tick' };
+        if (payload.tick !== state.tick) {
+            return { valid: false, reason: 'Action tick is stale or ahead of the server' };
         }
-        // TODO: Add game-specific anti-cheat rules, cooldown windows, range checks, and deterministic simulations here.
+        if (state.currentTurnUserId !== actorUserId) {
+            return { valid: false, reason: 'Not your turn' };
+        }
+        if (!this.isSafeActionData(payload.actionData)) {
+            return { valid: false, reason: 'Action data exceeds safe limits' };
+        }
         return { valid: true };
+    }
+    validateResult(state, winnerUserId, scores) {
+        if (!state || state.status !== 'ACTIVE')
+            return false;
+        const players = Object.keys(state.scores).sort();
+        if (!players.includes(winnerUserId) || Object.keys(scores).sort().join('|') !== players.join('|'))
+            return false;
+        if (players.some((id) => !Number.isSafeInteger(scores[id]) || scores[id] < 0 || scores[id] !== state.scores[id]))
+            return false;
+        return players.every((id) => scores[winnerUserId] >= scores[id]);
+    }
+    isSafeActionData(value) {
+        let encoded;
+        try {
+            encoded = JSON.stringify(value);
+        }
+        catch {
+            return false;
+        }
+        if (encoded.length > 4096)
+            return false;
+        const safe = (item, depth) => {
+            if (depth > 4)
+                return false;
+            if (typeof item === 'number')
+                return Number.isFinite(item) && Math.abs(item) <= 1_000_000;
+            if (typeof item === 'string')
+                return item.length <= 256;
+            if (typeof item === 'boolean' || item === null)
+                return true;
+            if (Array.isArray(item))
+                return item.length <= 64 && item.every((entry) => safe(entry, depth + 1));
+            if (typeof item === 'object') {
+                const entries = Object.entries(item);
+                return entries.length <= 64 && entries.every(([key, entry]) => key.length <= 64 && safe(entry, depth + 1));
+            }
+            return false;
+        };
+        return safe(value, 0);
     }
 }

--- a/multiplayer-backend/dist/ws/socketGateway.js
+++ b/multiplayer-backend/dist/ws/socketGateway.js
@@ -17,6 +17,8 @@ const roomService = new RoomService();
 const validator = new GameValidator();
 const stateService = new MatchStateService();
 const sessions = new SessionRegistry();
+const RECONNECT_GRACE_MS = 30_000;
+const disconnectTimers = new Map();
 export function createRealtimeServer(app) {
     const httpServer = createServer(app);
     const io = new Server(httpServer, {
@@ -38,12 +40,22 @@ export function createRealtimeServer(app) {
     io.on('connection', async (socket) => {
         const user = socket.data.user;
         sessions.setSocket(user.id, socket.id);
+        const pendingDisconnect = disconnectTimers.get(user.id);
+        if (pendingDisconnect) {
+            clearTimeout(pendingDisconnect);
+            disconnectTimers.delete(user.id);
+        }
         await upsertUser(user.id, user.username);
         await logConnectionEvent({ userId: user.id, socketId: socket.id, event: 'connected' });
         socket.emit('player:connect', { userId: user.id, socketId: socket.id });
         const room = roomService.getRoomByUser(user.id);
         if (room) {
+            socket.join(room.roomCode);
             socket.emit('player:reconnect', { userId: user.id, matchId: room.matchId });
+            const currentState = stateService.getState(room.matchId);
+            if (currentState)
+                socket.emit('match:state_update', currentState);
+            socket.to(room.roomCode).emit('match:connection_status', { userId: user.id, status: 'connected' });
         }
         socket.on('player:queue_join', async (payload) => {
             const parsed = queueJoinSchema.safeParse(payload);
@@ -100,6 +112,8 @@ export function createRealtimeServer(app) {
                 { playerId: playerA.userId, socketId: playerASocketId },
                 { playerId: playerB.userId, socketId: playerBSocketId },
             ].forEach(({ playerId, socketId }) => {
+                const matchedSocket = io.sockets.sockets.get(socketId);
+                matchedSocket?.join(generatedRoom.roomCode);
                 io.to(socketId).emit('match:found', {
                     matchId: dbMatch.id,
                     roomCode: generatedRoom.roomCode,
@@ -156,6 +170,11 @@ export function createRealtimeServer(app) {
                 return;
             }
             const state = stateService.getState(parsed.data.matchId);
+            const actionRoom = roomService.getRoomByUser(user.id);
+            if (!actionRoom || actionRoom.matchId !== parsed.data.matchId) {
+                socket.emit('error', { code: 'ACTION_MATCH_SPOOFED', message: 'You are not in this match' });
+                return;
+            }
             const result = validator.validateAction(parsed.data, state, user.id);
             if (!result.valid) {
                 socket.emit('match:validated_action', { matchId: parsed.data.matchId, tick: parsed.data.tick, accepted: false });
@@ -184,6 +203,11 @@ export function createRealtimeServer(app) {
                 socket.emit('error', { code: 'MATCH_END_SPOOFED', message: 'You are not in this match' });
                 return;
             }
+            const liveState = stateService.getState(parsed.data.matchId);
+            if (!validator.validateResult(liveState, parsed.data.winnerUserId, parsed.data.scoreByUser)) {
+                socket.emit('error', { code: 'MATCH_END_UNVERIFIED', message: 'Result does not match authoritative server state' });
+                return;
+            }
             const endedState = stateService.endMatch(parsed.data.matchId);
             await finishMatch({
                 matchId: parsed.data.matchId,
@@ -207,6 +231,15 @@ export function createRealtimeServer(app) {
             const activeRoom = roomService.getRoomByUser(user.id);
             if (activeRoom) {
                 socket.to(activeRoom.roomCode).emit('player:disconnect', { userId: user.id });
+                const reconnectDeadline = Date.now() + RECONNECT_GRACE_MS;
+                socket.to(activeRoom.roomCode).emit('match:connection_status', {
+                    userId: user.id,
+                    status: 'reconnecting',
+                    reconnectDeadline,
+                });
+                const timer = setTimeout(() => disconnectTimers.delete(user.id), RECONNECT_GRACE_MS);
+                timer.unref();
+                disconnectTimers.set(user.id, timer);
             }
             logger.info({ userId: user.id, socketId: socket.id }, 'Socket disconnected');
         });

--- a/multiplayer-backend/src/services/gameValidator.ts
+++ b/multiplayer-backend/src/services/gameValidator.ts
@@ -14,11 +14,50 @@ export class GameValidator {
       return { valid: false, reason: 'Actor is not in this match' };
     }
 
-    if (payload.tick < state.tick) {
-      return { valid: false, reason: 'Stale action tick' };
+    if (payload.tick !== state.tick) {
+      return { valid: false, reason: 'Action tick is stale or ahead of the server' };
     }
 
-    // TODO: Add game-specific anti-cheat rules, cooldown windows, range checks, and deterministic simulations here.
+    if (state.currentTurnUserId !== actorUserId) {
+      return { valid: false, reason: 'Not your turn' };
+    }
+
+    if (!this.isSafeActionData(payload.actionData)) {
+      return { valid: false, reason: 'Action data exceeds safe limits' };
+    }
+
     return { valid: true };
+  }
+
+  validateResult(state: MatchState | undefined, winnerUserId: string, scores: Record<string, number>) {
+    if (!state || state.status !== 'ACTIVE') return false;
+    const players = Object.keys(state.scores).sort();
+    if (!players.includes(winnerUserId) || Object.keys(scores).sort().join('|') !== players.join('|')) return false;
+    if (players.some((id) => !Number.isSafeInteger(scores[id]) || scores[id] < 0 || scores[id] !== state.scores[id])) return false;
+    return players.every((id) => scores[winnerUserId] >= scores[id]);
+  }
+
+  private isSafeActionData(value: Record<string, unknown>): boolean {
+    let encoded: string;
+    try {
+      encoded = JSON.stringify(value);
+    } catch {
+      return false;
+    }
+    if (encoded.length > 4096) return false;
+
+    const safe = (item: unknown, depth: number): boolean => {
+      if (depth > 4) return false;
+      if (typeof item === 'number') return Number.isFinite(item) && Math.abs(item) <= 1_000_000;
+      if (typeof item === 'string') return item.length <= 256;
+      if (typeof item === 'boolean' || item === null) return true;
+      if (Array.isArray(item)) return item.length <= 64 && item.every((entry) => safe(entry, depth + 1));
+      if (typeof item === 'object') {
+        const entries = Object.entries(item as Record<string, unknown>);
+        return entries.length <= 64 && entries.every(([key, entry]) => key.length <= 64 && safe(entry, depth + 1));
+      }
+      return false;
+    };
+    return safe(value, 0);
   }
 }

--- a/multiplayer-backend/src/types/socket.ts
+++ b/multiplayer-backend/src/types/socket.ts
@@ -9,6 +9,7 @@ export interface ServerToClientEvents {
   'match:end': (payload: MatchResultPayload) => void;
   'player:disconnect': (payload: { userId: string }) => void;
   'player:reconnect': (payload: { userId: string; matchId?: string }) => void;
+  'match:connection_status': (payload: { userId: string; status: 'reconnecting' | 'connected'; reconnectDeadline?: number }) => void;
   error: (payload: RealtimeError) => void;
 }
 

--- a/multiplayer-backend/src/ws/socketGateway.ts
+++ b/multiplayer-backend/src/ws/socketGateway.ts
@@ -21,6 +21,8 @@ const roomService = new RoomService();
 const validator = new GameValidator();
 const stateService = new MatchStateService();
 const sessions = new SessionRegistry();
+const RECONNECT_GRACE_MS = 30_000;
+const disconnectTimers = new Map<string, NodeJS.Timeout>();
 
 export function createRealtimeServer(app: Express) {
   const httpServer = createServer(app);
@@ -45,13 +47,22 @@ export function createRealtimeServer(app: Express) {
   io.on('connection', async (socket) => {
     const user = socket.data.user as { id: string; username: string };
     sessions.setSocket(user.id, socket.id);
+    const pendingDisconnect = disconnectTimers.get(user.id);
+    if (pendingDisconnect) {
+      clearTimeout(pendingDisconnect);
+      disconnectTimers.delete(user.id);
+    }
     await upsertUser(user.id, user.username);
     await logConnectionEvent({ userId: user.id, socketId: socket.id, event: 'connected' });
 
     socket.emit('player:connect', { userId: user.id, socketId: socket.id });
     const room = roomService.getRoomByUser(user.id);
     if (room) {
+      socket.join(room.roomCode);
       socket.emit('player:reconnect', { userId: user.id, matchId: room.matchId });
+      const currentState = stateService.getState(room.matchId);
+      if (currentState) socket.emit('match:state_update', currentState);
+      socket.to(room.roomCode).emit('match:connection_status', { userId: user.id, status: 'connected' });
     }
 
     socket.on('player:queue_join', async (payload) => {
@@ -117,6 +128,8 @@ export function createRealtimeServer(app: Express) {
         { playerId: playerA.userId, socketId: playerASocketId },
         { playerId: playerB.userId, socketId: playerBSocketId },
       ].forEach(({ playerId, socketId }) => {
+        const matchedSocket = io.sockets.sockets.get(socketId);
+        matchedSocket?.join(generatedRoom.roomCode);
         io.to(socketId).emit('match:found', {
           matchId: dbMatch.id,
           roomCode: generatedRoom.roomCode,
@@ -183,6 +196,11 @@ export function createRealtimeServer(app: Express) {
       }
 
       const state = stateService.getState(parsed.data.matchId);
+      const actionRoom = roomService.getRoomByUser(user.id);
+      if (!actionRoom || actionRoom.matchId !== parsed.data.matchId) {
+        socket.emit('error', { code: 'ACTION_MATCH_SPOOFED', message: 'You are not in this match' });
+        return;
+      }
       const result = validator.validateAction(parsed.data, state, user.id);
       if (!result.valid) {
         socket.emit('match:validated_action', { matchId: parsed.data.matchId, tick: parsed.data.tick, accepted: false });
@@ -214,6 +232,12 @@ export function createRealtimeServer(app: Express) {
         return;
       }
 
+      const liveState = stateService.getState(parsed.data.matchId);
+      if (!validator.validateResult(liveState, parsed.data.winnerUserId, parsed.data.scoreByUser)) {
+        socket.emit('error', { code: 'MATCH_END_UNVERIFIED', message: 'Result does not match authoritative server state' });
+        return;
+      }
+
       const endedState = stateService.endMatch(parsed.data.matchId);
       await finishMatch({
         matchId: parsed.data.matchId,
@@ -241,6 +265,15 @@ export function createRealtimeServer(app: Express) {
       const activeRoom = roomService.getRoomByUser(user.id);
       if (activeRoom) {
         socket.to(activeRoom.roomCode).emit('player:disconnect', { userId: user.id });
+        const reconnectDeadline = Date.now() + RECONNECT_GRACE_MS;
+        socket.to(activeRoom.roomCode).emit('match:connection_status', {
+          userId: user.id,
+          status: 'reconnecting',
+          reconnectDeadline,
+        });
+        const timer = setTimeout(() => disconnectTimers.delete(user.id), RECONNECT_GRACE_MS);
+        timer.unref();
+        disconnectTimers.set(user.id, timer);
       }
       logger.info({ userId: user.id, socketId: socket.id }, 'Socket disconnected');
     });

--- a/multiplayer-backend/tests/gameValidator.test.ts
+++ b/multiplayer-backend/tests/gameValidator.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { GameValidator } from '../src/services/gameValidator.js';
+import type { MatchActionPayload, MatchState } from '../src/types/events.js';
+
+const state = (): MatchState => ({
+  matchId: 'm1',
+  tick: 3,
+  currentTurnUserId: 'p1',
+  scores: { p1: 2, p2: 1 },
+  status: 'ACTIVE',
+  updatedAt: Date.now(),
+});
+
+const action = (overrides: Partial<MatchActionPayload> = {}): MatchActionPayload => ({
+  matchId: 'm1',
+  tick: 3,
+  actionType: 'END_TURN',
+  actionData: {},
+  ...overrides,
+});
+
+describe('GameValidator anti-cheat checks', () => {
+  it('accepts only the authoritative tick and current player', () => {
+    const validator = new GameValidator();
+    expect(validator.validateAction(action(), state(), 'p1').valid).toBe(true);
+    expect(validator.validateAction(action({ tick: 2 }), state(), 'p1').valid).toBe(false);
+    expect(validator.validateAction(action(), state(), 'p2').valid).toBe(false);
+  });
+
+  it('rejects non-finite and oversized action data', () => {
+    const validator = new GameValidator();
+    expect(validator.validateAction(action({ actionData: { x: Number.NaN } }), state(), 'p1').valid).toBe(false);
+    expect(validator.validateAction(action({ actionData: { note: 'x'.repeat(300) } }), state(), 'p1').valid).toBe(false);
+  });
+
+  it('accepts only results matching the server score and winner', () => {
+    const validator = new GameValidator();
+    expect(validator.validateResult(state(), 'p1', { p1: 2, p2: 1 })).toBe(true);
+    expect(validator.validateResult(state(), 'p2', { p1: 2, p2: 99 })).toBe(false);
+    expect(validator.validateResult(state(), 'outsider', { p1: 2, p2: 1 })).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure 1v1 Murlan Royal matches render exactly two human characters (local bottom and opponent top) and prevent extra seated humans from appearing. 
- Make card visibility deterministic so each client sees its own card fronts while opponents remain face-down. 
- Improve online match robustness with reconnect recovery and stronger server-side anti-cheat/validation. 

### Description
- UI/scene: Updated `Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs` to support an `activePlayerCount`, map players to portrait seat anchors, hide unused human/ chair objects, and provide `ConfigureForPlayers(int)` to apply roster-driven layouts. 
- Cards: Added `Assets/Scripts/Gameplay/Cards/MurlanRoyalHandVisibility.cs` to bind card ownership and show card fronts only to the local owner while keeping opponent hands face-down. 
- Realtime server: Enhanced `multiplayer-backend/src/ws/socketGateway.ts` to have matched sockets join the gameplay room, rejoin rooms on reconnect, emit authoritative `match:state_update` on reconnect, and broadcast `match:connection_status` (with a 30s reconnect grace window). 
- Anti-cheat/validation: Hardened `multiplayer-backend/src/services/gameValidator.ts` to require exact server tick, enforce current-turn checks, validate action payload size/shape, and verify match results against authoritative state; added `match:action` and `match:end` safeguards in the socket gateway. 
- Tests: Added `multiplayer-backend/tests/gameValidator.test.ts` covering tick/turn enforcement, oversized/non-finite action data rejection, and result verification. 

### Testing
- Ran backend unit tests with `npm test` in `multiplayer-backend`, where all test files passed (3 files, 8 tests). 
- Compiled the backend TypeScript with `npm run build` in `multiplayer-backend` and the build completed successfully. 
- Added and exercised `gameValidator` unit tests which validate the new anti-cheat logic and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d714431a88329b46794dbec516490)