### PR TITLE
Add theme picker with five selectable app themes

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -25,6 +25,9 @@ import useReferralClaim from './hooks/useReferralClaim.js';
 import useNativePushNotifications from './hooks/useNativePushNotifications.js';
 import { BOT_USERNAME } from './utils/constants.js';
 import { isTelegramWebView } from './utils/telegram.js';
+import { applyAppTheme, getStoredTheme } from './utils/appTheme.js';
+
+applyAppTheme(getStoredTheme());
 
 const SnakeAndLadder = React.lazy(
   () => import('./pages/Games/SnakeAndLadder.jsx')

--- a/webapp/src/components/ThemePicker.jsx
+++ b/webapp/src/components/ThemePicker.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef, useState } from 'react';
+import { Check, Palette, X } from 'lucide-react';
+
+import { APP_THEMES, applyAppTheme, getStoredTheme } from '../utils/appTheme.js';
+
+export default function ThemePicker() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [theme, setTheme] = useState(getStoredTheme);
+  const panelRef = useRef(null);
+
+  useEffect(() => {
+    applyAppTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const closeOnOutsideTap = (event) => {
+      if (!panelRef.current?.contains(event.target)) setIsOpen(false);
+    };
+    document.addEventListener('pointerdown', closeOnOutsideTap);
+    return () => document.removeEventListener('pointerdown', closeOnOutsideTap);
+  }, [isOpen]);
+
+  return (
+    <div ref={panelRef} className="theme-picker">
+      <button
+        type="button"
+        className="theme-picker__trigger"
+        aria-label={isOpen ? 'Close theme picker' : 'Choose app theme'}
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        {isOpen ? <X size={19} /> : <Palette size={20} />}
+      </button>
+
+      {isOpen && (
+        <div className="theme-picker__panel" role="dialog" aria-label="Choose your theme">
+          <div className="theme-picker__heading">
+            <div>
+              <strong>Choose a style</strong>
+              <span>Make TonPlaygram yours</span>
+            </div>
+            <span className="theme-picker__count">5 themes</span>
+          </div>
+          <div className="theme-picker__options" role="radiogroup" aria-label="App theme">
+            {APP_THEMES.map((option) => {
+              const selected = theme === option.id;
+              return (
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  key={option.id}
+                  className={`theme-picker__option${selected ? ' is-selected' : ''}`}
+                  onClick={() => {
+                    setTheme(option.id);
+                    setIsOpen(false);
+                  }}
+                >
+                  <span className="theme-picker__swatches" aria-hidden="true">
+                    {option.colors.map((color) => (
+                      <span key={color} style={{ backgroundColor: color }} />
+                    ))}
+                  </span>
+                  <span>{option.name}</span>
+                  {selected && <Check className="theme-picker__check" size={17} />}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -17,6 +17,154 @@ body {
   text-size-adjust: 100%;
 }
 
+/* User-selectable app palettes. These variables recolor the shared utility
+   surfaces while preserving the existing layout and game-specific styling. */
+:root[data-app-theme='sunset'] {
+  --app-bg: #160b24;
+  --app-bg-glow: #65254f;
+  --app-surface: #2b1237;
+  --app-surface-deep: #160b24;
+  --app-accent: #ff6b6b;
+  --app-text: #ffd166;
+}
+
+:root[data-app-theme='forest'] {
+  --app-bg: #041712;
+  --app-bg-glow: #145c48;
+  --app-surface: #0c2d25;
+  --app-surface-deep: #041712;
+  --app-accent: #34d399;
+  --app-text: #f4d35e;
+}
+
+:root[data-app-theme='royal'] {
+  --app-bg: #0e0821;
+  --app-bg-glow: #4c2a82;
+  --app-surface: #211342;
+  --app-surface-deep: #0e0821;
+  --app-accent: #a78bfa;
+  --app-text: #f9a8d4;
+}
+
+:root[data-app-theme='daylight'] {
+  --app-bg: #e9f5ff;
+  --app-bg-glow: #b7dcff;
+  --app-surface: #ffffff;
+  --app-surface-deep: #dceeff;
+  --app-accent: #1677ff;
+  --app-text: #102a43;
+}
+
+:root[data-app-theme]:not([data-app-theme='neon']) body {
+  background: radial-gradient(1100px 750px at 70% -10%, var(--app-bg-glow), var(--app-bg) 48%) fixed;
+  color: var(--app-text);
+}
+
+:root[data-app-theme]:not([data-app-theme='neon']) .bg-surface {
+  background: radial-gradient(circle at top, var(--app-surface) 0%, var(--app-surface-deep) 88%);
+  box-shadow: inset 0 0 12px color-mix(in srgb, var(--app-accent) 35%, transparent);
+}
+
+:root[data-app-theme]:not([data-app-theme='neon']) .border-border {
+  border-color: var(--app-accent) !important;
+  box-shadow: 0 0 8px color-mix(in srgb, var(--app-accent) 75%, transparent);
+}
+
+:root[data-app-theme]:not([data-app-theme='neon']) .text-primary,
+:root[data-app-theme]:not([data-app-theme='neon']) .text-accent {
+  color: var(--app-accent) !important;
+}
+
+:root[data-app-theme]:not([data-app-theme='neon']) .text-subtext,
+:root[data-app-theme]:not([data-app-theme='neon']) .text-text {
+  color: var(--app-text) !important;
+}
+
+.home-page {
+  position: relative;
+}
+
+.theme-picker {
+  position: sticky;
+  top: max(10px, env(safe-area-inset-top));
+  z-index: 60;
+  height: 0;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+}
+
+.theme-picker__trigger {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--app-accent, #00f7ff) 80%, white);
+  border-radius: 13px;
+  color: white;
+  background: color-mix(in srgb, var(--app-surface, #101a3b) 88%, transparent);
+  box-shadow: 0 5px 22px rgba(0, 0, 0, 0.38), 0 0 12px var(--app-accent, #00f7ff);
+  backdrop-filter: blur(12px);
+  pointer-events: auto;
+}
+
+.theme-picker__panel {
+  position: absolute;
+  top: 48px;
+  right: 0;
+  width: min(292px, calc(100vw - 32px));
+  padding: 14px;
+  color: white;
+  border: 1px solid var(--app-accent, #00f7ff);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--app-surface-deep, #091127) 94%, transparent);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.52), 0 0 18px color-mix(in srgb, var(--app-accent, #00f7ff) 55%, transparent);
+  backdrop-filter: blur(18px);
+  pointer-events: auto;
+}
+
+.theme-picker__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.theme-picker__heading strong,
+.theme-picker__heading span {
+  display: block;
+}
+
+.theme-picker__heading strong { font-size: 16px; }
+.theme-picker__heading div > span { margin-top: 3px; color: #cbd5e1; font: 600 11px/1.2 sans-serif; }
+.theme-picker__heading .theme-picker__count { color: var(--app-accent, #67e8f9); font: 700 10px/1 sans-serif; }
+.theme-picker__options { display: grid; gap: 7px; }
+
+.theme-picker__option {
+  min-height: 46px;
+  display: grid;
+  grid-template-columns: 58px 1fr 20px;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  color: white;
+  text-align: left;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.theme-picker__option.is-selected {
+  border-color: var(--app-accent, #00f7ff);
+  background: color-mix(in srgb, var(--app-accent, #00f7ff) 15%, transparent);
+}
+
+.theme-picker__swatches { display: flex; }
+.theme-picker__swatches span { width: 23px; height: 27px; margin-right: -6px; border: 2px solid rgba(255,255,255,.8); border-radius: 8px; }
+.theme-picker__option > span:nth-child(2) { font-size: 13px; }
+.theme-picker__check { color: var(--app-accent, #00f7ff); }
+
 body {
   font-family: 'Luckiest Guy', 'Comic Sans MS', cursive;
   margin: 0;

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -4,6 +4,7 @@ import ProjectAchievementsCard from '../components/ProjectAchievementsCard.jsx';
 import PwaDownloadFrame from '../components/PwaDownloadFrame.jsx';
 import HomeSocialHub from '../components/HomeSocialHub.jsx';
 import PlatformStatsCard from '../components/PlatformStatsCard.jsx';
+import ThemePicker from '../components/ThemePicker.jsx';
 
 import { FaArrowUp, FaArrowDown, FaWallet } from 'react-icons/fa';
 import { IoLogoTiktok } from 'react-icons/io5';
@@ -156,7 +157,8 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="space-y-4">
+    <div className="home-page space-y-4">
+      <ThemePicker />
       <div className="flex flex-col items-center">
         {photoUrl && (
           <div className="relative">

--- a/webapp/src/utils/appTheme.js
+++ b/webapp/src/utils/appTheme.js
@@ -1,0 +1,29 @@
+export const APP_THEMES = [
+  { id: 'neon', name: 'Neon Night', colors: ['#071426', '#00f7ff', '#facc15'] },
+  { id: 'sunset', name: 'Sunset', colors: ['#26102f', '#ff6b6b', '#ffd166'] },
+  { id: 'forest', name: 'Emerald', colors: ['#071d18', '#34d399', '#f4d35e'] },
+  { id: 'royal', name: 'Royal', colors: ['#160d31', '#a78bfa', '#f9a8d4'] },
+  { id: 'daylight', name: 'Daylight', colors: ['#e9f5ff', '#1677ff', '#102a43'] }
+]
+
+const STORAGE_KEY = 'tpg-app-theme'
+
+export function getStoredTheme () {
+  try {
+    const savedTheme = localStorage.getItem(STORAGE_KEY)
+    return APP_THEMES.some(({ id }) => id === savedTheme) ? savedTheme : 'neon'
+  } catch {
+    return 'neon'
+  }
+}
+
+export function applyAppTheme (theme) {
+  const nextTheme = APP_THEMES.some(({ id }) => id === theme) ? theme : 'neon'
+  document.documentElement.dataset.appTheme = nextTheme
+  try {
+    localStorage.setItem(STORAGE_KEY, nextTheme)
+  } catch {
+    // The visual selection still works when storage is unavailable.
+  }
+  return nextTheme
+}


### PR DESCRIPTION
### Motivation
- Provide users a compact, portrait-friendly control on the home page to switch the app visual style. 
- Ship five curated palettes so users can quickly change the app mood without affecting game layouts.

### Description
- Added a lightweight theme system in `webapp/src/utils/appTheme.js` that defines five palettes (`neon`, `sunset`, `forest`, `royal`, `daylight`) and exposes `getStoredTheme` and `applyAppTheme` for persistence and application.
- Added a floating, accessible theme picker UI component at `webapp/src/components/ThemePicker.jsx` with a compact trigger, a mobile‑sized panel, visual swatches, and radio-like selection behavior that closes on selection or outside tap.
- Applied the stored theme on app startup by calling `applyAppTheme(getStoredTheme())` from `webapp/src/App.jsx` and inserted the `ThemePicker` into the home page wrapper in `webapp/src/pages/Home.jsx`.
- Added CSS variables and styling rules to `webapp/src/index.css` to recolor shared surfaces, borders, accents, and text for non‑neon palettes while preserving existing layout and game-specific styles.

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully and produced the site bundles. 
- Ran code style checks with `eslint` on the modified files, fixed issues, and re-ran linting; linting completed successfully after fixes. 
- Verified the theme picker visually by running the dev server and attempting an automated mobile screenshot with Playwright; this visual check failed because the environment is missing a required system library (`libatk-1.0.so.0`) for the headless Chromium, not due to the code itself. 
- Performed basic smoke checks (style application and local interactions) in the dev build; no runtime errors were observed in the app start-up sequence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d71ad506c8329a284ddacf944fecc)