### PR TITLE
Murlan Royal: active-seat layout and owner-based hand visibility

### DIFF
--- a/Assets/Scripts/Gameplay/Cards/MurlanRoyalHandVisibility.cs
+++ b/Assets/Scripts/Gameplay/Cards/MurlanRoyalHandVisibility.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+namespace Aiming.Gameplay.Cards
+{
+    /// <summary>
+    /// Prevents network seat order from deciding whether a hand is face-up. Each client
+    /// sees its own cards' fronts; every opponent hand remains face-down.
+    /// </summary>
+    public class MurlanRoyalHandVisibility : MonoBehaviour
+    {
+        [SerializeField] private string ownerUserId;
+        [SerializeField] private GameObject cardFronts;
+        [SerializeField] private GameObject cardBacks;
+
+        public void SetOwner(string userId)
+        {
+            ownerUserId = userId;
+        }
+
+        public void ApplyForLocalPlayer(string localUserId)
+        {
+            bool isLocalHand = !string.IsNullOrEmpty(localUserId) && ownerUserId == localUserId;
+            if (cardFronts != null) cardFronts.SetActive(isLocalHand);
+            if (cardBacks != null) cardBacks.SetActive(!isLocalHand);
+        }
+
+        public void Bind(string ownerId, string localUserId)
+        {
+            SetOwner(ownerId);
+            ApplyForLocalPlayer(localUserId);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
+++ b/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
@@ -3,8 +3,8 @@ using UnityEngine;
 namespace Aiming.Gameplay.Environment
 {
     /// <summary>
-    /// Pushes human characters farther from the table and slightly enlarges chairs.
-    /// Useful for portrait-camera readability tuning in Murlan Royal scenes.
+    /// Keeps the visible seats in sync with the players in a Murlan Royal match.
+    /// In a 1v1 match only the local (bottom) and opponent (top) seats are shown.
     /// </summary>
     public class MurlanRoyalTableSeatingLayout : MonoBehaviour
     {
@@ -13,6 +13,11 @@ namespace Aiming.Gameplay.Environment
         [SerializeField] private Transform[] humanCharacters;
         [SerializeField] private Transform[] chairs;
 
+        [Header("Match Seats")]
+        [SerializeField, Range(2, 4)] private int activePlayerCount = 2;
+        [Tooltip("Seat transforms in portrait-screen order: bottom, top, left, right.")]
+        [SerializeField] private Transform[] seatAnchors;
+
         [Header("Layout Tuning")]
         [SerializeField, Min(0f)] private float humanOutwardOffset = 0.35f;
         [SerializeField, Min(0.1f)] private float chairScaleMultiplier = 1.08f;
@@ -20,6 +25,7 @@ namespace Aiming.Gameplay.Environment
         [SerializeField] private bool humansShouldFaceTableCenter = true;
         [SerializeField] private Vector3 humanFacingEulerOffset = new Vector3(0f, 180f, 0f);
         [SerializeField] private bool runOnAwake = true;
+        private bool chairsScaled;
 
         void Awake()
         {
@@ -33,9 +39,41 @@ namespace Aiming.Gameplay.Environment
         public void ApplyLayout()
         {
             Vector3 center = tableCenter != null ? tableCenter.position : transform.position;
+            ApplyActiveSeats();
             PushHumansOutward(center);
             FixHumanFacing(center);
             ScaleChairs();
+        }
+
+        /// <summary>Called by the online match bootstrap after receiving the roster.</summary>
+        public void ConfigureForPlayers(int playerCount)
+        {
+            activePlayerCount = Mathf.Clamp(playerCount, 2, 4);
+            ApplyLayout();
+        }
+
+        private void ApplyActiveSeats()
+        {
+            int available = humanCharacters == null ? 0 : humanCharacters.Length;
+            int visibleCount = Mathf.Min(activePlayerCount, available);
+            for (int i = 0; i < available; i++)
+            {
+                Transform human = humanCharacters[i];
+                bool active = i < visibleCount;
+                if (human != null)
+                {
+                    human.gameObject.SetActive(active);
+                    if (active && seatAnchors != null && i < seatAnchors.Length && seatAnchors[i] != null)
+                    {
+                        human.SetPositionAndRotation(seatAnchors[i].position, seatAnchors[i].rotation);
+                    }
+                }
+
+                if (chairs != null && i < chairs.Length && chairs[i] != null)
+                {
+                    chairs[i].gameObject.SetActive(active);
+                }
+            }
         }
 
         private void PushHumansOutward(Vector3 center)
@@ -52,6 +90,8 @@ namespace Aiming.Gameplay.Environment
                 {
                     continue;
                 }
+
+                if (!human.gameObject.activeSelf) continue;
 
                 Vector3 horizontalDirection = human.position - center;
                 horizontalDirection.y = 0f;
@@ -80,6 +120,8 @@ namespace Aiming.Gameplay.Environment
                     continue;
                 }
 
+                if (!human.gameObject.activeSelf) continue;
+
                 Vector3 lookDirection = humansShouldFaceTableCenter ? (center - human.position) : (human.position - center);
                 lookDirection.y = 0f;
                 if (lookDirection.sqrMagnitude <= 0.0001f)
@@ -93,7 +135,7 @@ namespace Aiming.Gameplay.Environment
 
         private void ScaleChairs()
         {
-            if (chairs == null)
+            if (chairs == null || chairsScaled)
             {
                 return;
             }
@@ -108,6 +150,7 @@ namespace Aiming.Gameplay.Environment
 
                 chair.localScale *= chairScaleMultiplier;
             }
+            chairsScaled = true;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Keep visible seats synchronized with the actual player roster for Murlan Royal matches and ensure 1v1 layouts show only bottom (local) and top (opponent) seats.
- Prevent network seat order from determining whether a hand is face-up by showing card fronts only to the owning local player.
- Avoid repeated chair scaling and skip layout adjustments for deactivated seat objects to prevent incorrect transforms.

### Description
- Added new `MurlanRoyalHandVisibility` MonoBehaviour that exposes `SetOwner`, `ApplyForLocalPlayer`, and `Bind` to toggle `cardFronts`/`cardBacks` based on `ownerUserId` vs `localUserId`.
- Extended `MurlanRoyalTableSeatingLayout` with `activePlayerCount`, `seatAnchors`, `ApplyActiveSeats`, and `ConfigureForPlayers`, and invoked `ApplyActiveSeats` from `ApplyLayout` to enable runtime seat activation and positioning.
- Updated `PushHumansOutward` and `FixHumanFacing` to skip inactive human characters so only visible seats are moved and rotated.
- Added `chairsScaled` flag to `ScaleChairs` to ensure chairs are scaled only once and avoid repeated multiplicative scaling.

### Testing
- No automated tests were added or executed for these layout and runtime-visibility changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d714431a88329b46794dbec516490)