### PR TITLE
Add ten home themes with in-app theme store and picker integration

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -5,6 +5,7 @@ import { TonConnectUIProvider } from '@tonconnect/ui-react';
 import Home from './pages/Home.jsx';
 import Mining from './pages/Mining.jsx';
 import Wallet from './pages/Wallet.jsx';
+import HomeThemeStore from './pages/HomeThemeStore.jsx';
 import Tasks from './pages/Tasks.jsx';
 import Referral from './pages/Referral.jsx';
 import MyAccount from './pages/MyAccount.jsx';
@@ -445,6 +446,7 @@ export default function App() {
                 path="/store"
                 element={<Navigate to="/store/all" replace />}
               />
+              <Route path="/store/home-themes" element={<HomeThemeStore />} />
               <Route path="/store/:gameSlug" element={<Store />} />
               <Route path="/referral" element={<Referral />} />
               <Route path="/wallet" element={<Wallet />} />

--- a/webapp/src/components/ThemePicker.jsx
+++ b/webapp/src/components/ThemePicker.jsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
-import { Check, Palette, X } from 'lucide-react';
+import { Check, LockKeyhole, Palette, ShoppingBag, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 
-import { APP_THEMES, applyAppTheme, getStoredTheme } from '../utils/appTheme.js';
+import { APP_THEMES, applyAppTheme, getOwnedThemes, getStoredTheme } from '../utils/appTheme.js';
 
 export default function ThemePicker() {
   const [isOpen, setIsOpen] = useState(false);
   const [theme, setTheme] = useState(getStoredTheme);
+  const [owned, setOwned] = useState(getOwnedThemes);
+  const navigate = useNavigate();
   const panelRef = useRef(null);
 
   useEffect(() => {
@@ -20,6 +23,16 @@ export default function ThemePicker() {
     document.addEventListener('pointerdown', closeOnOutsideTap);
     return () => document.removeEventListener('pointerdown', closeOnOutsideTap);
   }, [isOpen]);
+
+  useEffect(() => {
+    const syncOwned = () => setOwned(getOwnedThemes());
+    window.addEventListener('appThemeInventoryUpdated', syncOwned);
+    window.addEventListener('storage', syncOwned);
+    return () => {
+      window.removeEventListener('appThemeInventoryUpdated', syncOwned);
+      window.removeEventListener('storage', syncOwned);
+    };
+  }, []);
 
   return (
     <div ref={panelRef} className="theme-picker">
@@ -40,19 +53,26 @@ export default function ThemePicker() {
               <strong>Choose a style</strong>
               <span>Make TonPlaygram yours</span>
             </div>
-            <span className="theme-picker__count">5 themes</span>
+            <span className="theme-picker__count">5 FREE · 5 STORE</span>
           </div>
           <div className="theme-picker__options" role="radiogroup" aria-label="App theme">
             {APP_THEMES.map((option) => {
               const selected = theme === option.id;
+              const unlocked = owned.has(option.id);
               return (
                 <button
                   type="button"
                   role="radio"
                   aria-checked={selected}
+                  aria-label={`${option.name}${unlocked ? '' : `, locked, ${option.price} TPG`}`}
                   key={option.id}
                   className={`theme-picker__option${selected ? ' is-selected' : ''}`}
                   onClick={() => {
+                    if (!unlocked) {
+                      setIsOpen(false);
+                      navigate('/store/home-themes');
+                      return;
+                    }
                     setTheme(option.id);
                     setIsOpen(false);
                   }}
@@ -63,11 +83,14 @@ export default function ThemePicker() {
                     ))}
                   </span>
                   <span>{option.name}</span>
-                  {selected && <Check className="theme-picker__check" size={17} />}
+                  {selected ? <Check className="theme-picker__check" size={17} /> : !unlocked ? <LockKeyhole className="theme-picker__lock" size={16} /> : null}
                 </button>
               );
             })}
           </div>
+          <button className="theme-picker__store" type="button" onClick={() => { setIsOpen(false); navigate('/store/home-themes'); }}>
+            <ShoppingBag size={15} /> Open theme store
+          </button>
         </div>
       )}
     </div>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -17,66 +17,53 @@ body {
   text-size-adjust: 100%;
 }
 
+.home-theme-store { max-width:720px; margin:0 auto; padding:16px 14px 100px; color:white; }
+.home-theme-store__header { display:grid; grid-template-columns:auto auto 1fr auto; align-items:center; gap:10px; margin-bottom:14px; }
+.home-theme-store__header button { padding:7px 9px; border:1px solid #d6a72e; border-radius:9px; background:#101010; color:#ffe599; font-size:11px; }
+.home-theme-store__header h1 { margin:0; color:#f5cc66; font-size:20px; line-height:1; }.home-theme-store__header p { margin:4px 0 0; color:#cbd5e1; font:10px sans-serif; }.home-theme-store__header strong { color:#f5cc66; font-size:12px; }
+.home-theme-store__message { padding:10px; border:1px solid #b88720; border-radius:10px; background:#211706; color:#ffe599; font:12px sans-serif; }
+.home-theme-store__grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:10px; }
+.home-theme-card { overflow:hidden; border:1px solid #a97d21; border-radius:14px; background:#090b0e; box-shadow:0 7px 20px #0008; }
+.home-theme-card__preview { position:relative; min-height:175px; overflow:hidden; display:flex; flex-direction:column; align-items:center; gap:7px; padding:13px 10px; color:var(--preview-gold); background:radial-gradient(circle at 75% 5%,color-mix(in srgb,var(--preview-accent) 65%,white),transparent 42%),repeating-linear-gradient(135deg,transparent 0 20px,color-mix(in srgb,var(--preview-gold) 16%,transparent) 21px 22px),var(--preview-bg); }
+.home-theme-card__number { position:absolute; top:7px; left:8px; font:bold 12px Georgia; }.home-theme-card__coin { width:44px; height:44px; display:grid; place-items:center; border:3px double var(--preview-gold); border-radius:50%; background:color-mix(in srgb,var(--preview-accent) 70%,black); font:bold 25px Georgia; }.home-theme-card__title { font:bold 18px Georgia; text-shadow:0 2px 2px #000; }.home-theme-card__button { width:88%; padding:5px; border:1px solid var(--preview-gold); border-radius:15px; background:color-mix(in srgb,var(--preview-accent) 80%,black); color:white; text-align:center; font:10px sans-serif; }.home-theme-card__panel { width:90%; height:40px; border:1px solid var(--preview-gold); border-radius:7px; background:color-mix(in srgb,var(--preview-bg) 80%,white); }
+.home-theme-card__details { display:flex; align-items:center; justify-content:space-between; gap:5px; padding:9px; }.home-theme-card__details h2 { margin:0; color:#f4d076; font-size:12px; }.home-theme-card__details span { color:#94a3b8; font:9px sans-serif; }.home-theme-card__details button,.home-theme-card__owned { display:flex; align-items:center; gap:3px; padding:6px 7px; border:1px solid #c89629; border-radius:8px; background:#3a2907; color:#ffe599!important; font:10px sans-serif!important; white-space:nowrap; }
+@media (min-width:600px) { .home-theme-store__grid { grid-template-columns:repeat(3,minmax(0,1fr)); } }
+
 /* User-selectable app palettes. These variables recolor the shared utility
    surfaces while preserving the existing layout and game-specific styling. */
-:root[data-app-theme='sunset'] {
-  --app-bg: #160b24;
-  --app-bg-glow: #65254f;
-  --app-surface: #2b1237;
-  --app-surface-deep: #160b24;
-  --app-accent: #ff6b6b;
-  --app-text: #ffd166;
-}
+:root[data-app-theme='royal-navy'] { --app-bg:#031222; --app-bg-glow:#12395f; --app-surface:#071c32; --app-surface-deep:#020d19; --app-accent:#e7b934; --app-text:#fff1bd; }
+:root[data-app-theme='emerald-classic'] { --app-bg:#e9dfc2; --app-bg-glow:#fffdf4; --app-surface:#f9f0d9; --app-surface-deep:#e9dcb9; --app-accent:#087142; --app-text:#38220d; }
+:root[data-app-theme='vintage-brown'] { --app-bg:#1c0b03; --app-bg-glow:#6f3613; --app-surface:#321606; --app-surface-deep:#160802; --app-accent:#d69b2d; --app-text:#ffe0a0; }
+:root[data-app-theme='classic-marble'] { --app-bg:#ece6dc; --app-bg-glow:#fffef9; --app-surface:#fffaf0; --app-surface-deep:#e4ddd0; --app-accent:#b67b18; --app-text:#20180e; }
+:root[data-app-theme='midnight-purple'] { --app-bg:#0e071a; --app-bg-glow:#5b1268; --app-surface:#21102e; --app-surface-deep:#0b0612; --app-accent:#f0c22b; --app-text:#ffe47a; }
+:root[data-app-theme='ocean-wave'] { --app-bg:#dce8d2; --app-bg-glow:#83c7c5; --app-surface:#eef1dd; --app-surface-deep:#c7ded0; --app-accent:#087d83; --app-text:#153f3d; }
+:root[data-app-theme='golden-age'] { --app-bg:#f1deb0; --app-bg-glow:#fff8df; --app-surface:#fff0c7; --app-surface-deep:#e9c983; --app-accent:#b7740f; --app-text:#55330a; }
+:root[data-app-theme='steel-blue'] { --app-bg:#0c151f; --app-bg-glow:#365a73; --app-surface:#172635; --app-surface-deep:#08111a; --app-accent:#aebec8; --app-text:#ecf2f5; }
+:root[data-app-theme='sunset-haze'] { --app-bg:#7c2827; --app-bg-glow:#fcbd73; --app-surface:#f1b271; --app-surface-deep:#ad4337; --app-accent:#ffd061; --app-text:#fff4d7; }
+:root[data-app-theme='ivory-black'] { --app-bg:#050606; --app-bg-glow:#29251f; --app-surface:#151615; --app-surface-deep:#050505; --app-accent:#d8a92f; --app-text:#fff1bd; }
 
-:root[data-app-theme='forest'] {
-  --app-bg: #041712;
-  --app-bg-glow: #145c48;
-  --app-surface: #0c2d25;
-  --app-surface-deep: #041712;
-  --app-accent: #34d399;
-  --app-text: #f4d35e;
-}
-
-:root[data-app-theme='royal'] {
-  --app-bg: #0e0821;
-  --app-bg-glow: #4c2a82;
-  --app-surface: #211342;
-  --app-surface-deep: #0e0821;
-  --app-accent: #a78bfa;
-  --app-text: #f9a8d4;
-}
-
-:root[data-app-theme='daylight'] {
-  --app-bg: #e9f5ff;
-  --app-bg-glow: #b7dcff;
-  --app-surface: #ffffff;
-  --app-surface-deep: #dceeff;
-  --app-accent: #1677ff;
-  --app-text: #102a43;
-}
-
-:root[data-app-theme]:not([data-app-theme='neon']) body {
-  background: radial-gradient(1100px 750px at 70% -10%, var(--app-bg-glow), var(--app-bg) 48%) fixed;
+:root[data-app-theme] body {
+  background: radial-gradient(1100px 750px at 70% -10%, var(--app-bg-glow), var(--app-bg) 48%), repeating-linear-gradient(135deg, transparent 0 22px, color-mix(in srgb, var(--app-accent) 5%, transparent) 23px 24px) fixed;
   color: var(--app-text);
 }
 
-:root[data-app-theme]:not([data-app-theme='neon']) .bg-surface {
+:root[data-app-theme] .bg-surface {
   background: radial-gradient(circle at top, var(--app-surface) 0%, var(--app-surface-deep) 88%);
   box-shadow: inset 0 0 12px color-mix(in srgb, var(--app-accent) 35%, transparent);
 }
 
-:root[data-app-theme]:not([data-app-theme='neon']) .border-border {
+:root[data-app-theme] .border-border {
   border-color: var(--app-accent) !important;
   box-shadow: 0 0 8px color-mix(in srgb, var(--app-accent) 75%, transparent);
 }
 
-:root[data-app-theme]:not([data-app-theme='neon']) .text-primary,
-:root[data-app-theme]:not([data-app-theme='neon']) .text-accent {
+:root[data-app-theme] .text-primary,
+:root[data-app-theme] .text-accent {
   color: var(--app-accent) !important;
 }
 
-:root[data-app-theme]:not([data-app-theme='neon']) .text-subtext,
-:root[data-app-theme]:not([data-app-theme='neon']) .text-text {
+:root[data-app-theme] .text-subtext,
+:root[data-app-theme] .text-text {
   color: var(--app-text) !important;
 }
 
@@ -139,12 +126,12 @@ body {
 .theme-picker__heading strong { font-size: 16px; }
 .theme-picker__heading div > span { margin-top: 3px; color: #cbd5e1; font: 600 11px/1.2 sans-serif; }
 .theme-picker__heading .theme-picker__count { color: var(--app-accent, #67e8f9); font: 700 10px/1 sans-serif; }
-.theme-picker__options { display: grid; gap: 7px; }
+.theme-picker__options { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; max-height: min(55vh, 410px); overflow-y: auto; }
 
 .theme-picker__option {
   min-height: 46px;
   display: grid;
-  grid-template-columns: 58px 1fr 20px;
+  grid-template-columns: 42px 1fr 16px;
   align-items: center;
   gap: 10px;
   padding: 7px 10px;
@@ -161,9 +148,11 @@ body {
 }
 
 .theme-picker__swatches { display: flex; }
-.theme-picker__swatches span { width: 23px; height: 27px; margin-right: -6px; border: 2px solid rgba(255,255,255,.8); border-radius: 8px; }
+.theme-picker__swatches span { width: 17px; height: 25px; margin-right: -8px; border: 2px solid rgba(255,255,255,.8); border-radius: 7px; }
 .theme-picker__option > span:nth-child(2) { font-size: 13px; }
 .theme-picker__check { color: var(--app-accent, #00f7ff); }
+.theme-picker__lock { color: #f7c948; }
+.theme-picker__store { width:100%; margin-top:10px; padding:9px; display:flex; align-items:center; justify-content:center; gap:7px; border:1px solid var(--app-accent); border-radius:10px; color:white; background:color-mix(in srgb,var(--app-accent) 18%,transparent); font-size:12px; }
 
 body {
   font-family: 'Luckiest Guy', 'Comic Sans MS', cursive;

--- a/webapp/src/pages/HomeThemeStore.jsx
+++ b/webapp/src/pages/HomeThemeStore.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { Check, LockKeyhole, Palette } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { APP_THEMES, getOwnedThemes, unlockAppTheme } from '../utils/appTheme.js';
+import { buyBundle, getAccountBalance } from '../utils/api.js';
+import { poolRoyalAccountId } from '../utils/poolRoyalInventory.js';
+import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
+
+export default function HomeThemeStore() {
+  useTelegramBackButton();
+  const navigate = useNavigate();
+  const accountId = poolRoyalAccountId();
+  const [owned, setOwned] = useState(getOwnedThemes);
+  const [balance, setBalance] = useState(null);
+  const [processing, setProcessing] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (!accountId || accountId === 'guest') return;
+    getAccountBalance(accountId).then((result) => {
+      if (Number.isFinite(Number(result?.balance))) setBalance(Number(result.balance));
+    });
+  }, [accountId]);
+
+  const purchase = async (theme) => {
+    if (!accountId || accountId === 'guest') {
+      setMessage('Link your TPG account before purchasing a premium theme.');
+      return;
+    }
+    if (balance !== null && balance < theme.price) {
+      setMessage(`You need ${theme.price} TPG to unlock ${theme.name}.`);
+      return;
+    }
+    setProcessing(theme.id);
+    setMessage('Confirming TPG payment…');
+    try {
+      const result = await buyBundle(accountId, { items: [{ slug: 'home-themes', type: 'appTheme', optionId: theme.id, price: theme.price }] });
+      if (result?.error) throw new Error(result.error);
+      setOwned(unlockAppTheme(theme.id));
+      setBalance((current) => current === null ? current : Math.max(0, current - theme.price));
+      setMessage(`${theme.name} is unlocked and ready to use.`);
+    } catch (error) {
+      setMessage(error?.message || 'The purchase could not be completed.');
+    } finally { setProcessing(''); }
+  };
+
+  return (
+    <main className="home-theme-store">
+      <header className="home-theme-store__header">
+        <button type="button" onClick={() => navigate(-1)}>Back</button>
+        <Palette size={24} />
+        <div><h1>Home Themes</h1><p>Five included · five premium</p></div>
+        <strong>{balance === null ? '—' : balance.toFixed(2)} TPG</strong>
+      </header>
+      {message && <p className="home-theme-store__message" role="status">{message}</p>}
+      <section className="home-theme-store__grid">
+        {APP_THEMES.map((theme, index) => {
+          const isOwned = owned.has(theme.id);
+          return (
+            <article className="home-theme-card" key={theme.id}>
+              <div className="home-theme-card__preview" style={{ '--preview-bg': theme.colors[0], '--preview-accent': theme.colors[1], '--preview-gold': theme.colors[2] }}>
+                <span className="home-theme-card__number">{index + 1}</span>
+                <div className="home-theme-card__coin">G</div><div className="home-theme-card__title">TonPlayGram</div>
+                <div className="home-theme-card__button">Connect Wallet</div><div className="home-theme-card__panel" />
+              </div>
+              <div className="home-theme-card__details">
+                <div><h2>{theme.name}</h2><span>{theme.free ? 'Included free' : `${theme.price} TPG`}</span></div>
+                {isOwned ? <span className="home-theme-card__owned"><Check size={14} /> Owned</span> : <button disabled={Boolean(processing)} onClick={() => purchase(theme)}>{processing === theme.id ? 'Buying…' : <><LockKeyhole size={13} /> Buy</>}</button>}
+              </div>
+            </article>
+          );
+        })}
+      </section>
+    </main>
+  );
+}

--- a/webapp/src/utils/appTheme.js
+++ b/webapp/src/utils/appTheme.js
@@ -1,29 +1,48 @@
 export const APP_THEMES = [
-  { id: 'neon', name: 'Neon Night', colors: ['#071426', '#00f7ff', '#facc15'] },
-  { id: 'sunset', name: 'Sunset', colors: ['#26102f', '#ff6b6b', '#ffd166'] },
-  { id: 'forest', name: 'Emerald', colors: ['#071d18', '#34d399', '#f4d35e'] },
-  { id: 'royal', name: 'Royal', colors: ['#160d31', '#a78bfa', '#f9a8d4'] },
-  { id: 'daylight', name: 'Daylight', colors: ['#e9f5ff', '#1677ff', '#102a43'] }
+  { id: 'royal-navy', name: 'Royal Navy', colors: ['#06182c', '#12395f', '#e7b934'], free: true },
+  { id: 'emerald-classic', name: 'Emerald Classic', colors: ['#f8f0d9', '#075f3d', '#d7a51f'], free: true },
+  { id: 'vintage-brown', name: 'Vintage Brown', colors: ['#291207', '#6f3613', '#d69b2d'], free: true },
+  { id: 'classic-marble', name: 'Classic Marble', colors: ['#fffaf0', '#171717', '#c78d24'], free: true },
+  { id: 'midnight-purple', name: 'Midnight Purple', colors: ['#140b25', '#5b1268', '#f0c22b'], free: true },
+  { id: 'ocean-wave', name: 'Ocean Wave', colors: ['#e9f2df', '#087d83', '#d59c22'], price: 250 },
+  { id: 'golden-age', name: 'Golden Age', colors: ['#fff4d3', '#d58c1c', '#714008'], price: 250 },
+  { id: 'steel-blue', name: 'Steel Blue', colors: ['#101b27', '#365a73', '#d6d9d8'], price: 250 },
+  { id: 'sunset-haze', name: 'Sunset Haze', colors: ['#fcbd73', '#bb3e34', '#f2cb64'], price: 250 },
+  { id: 'ivory-black', name: 'Ivory Black', colors: ['#090a0a', '#27231d', '#d8a92f'], price: 250 }
 ]
 
 const STORAGE_KEY = 'tpg-app-theme'
+const OWNED_KEY = 'tpg-owned-app-themes'
+
+export function getOwnedThemes () {
+  try {
+    const saved = JSON.parse(localStorage.getItem(OWNED_KEY) || '[]')
+    return new Set([...APP_THEMES.filter((theme) => theme.free).map((theme) => theme.id), ...saved])
+  } catch {
+    return new Set(APP_THEMES.filter((theme) => theme.free).map((theme) => theme.id))
+  }
+}
+
+export function unlockAppTheme (themeId) {
+  const theme = APP_THEMES.find(({ id }) => id === themeId)
+  if (!theme) return getOwnedThemes()
+  const owned = getOwnedThemes()
+  owned.add(themeId)
+  try { localStorage.setItem(OWNED_KEY, JSON.stringify([...owned])) } catch {}
+  window.dispatchEvent(new CustomEvent('appThemeInventoryUpdated', { detail: { themeId } }))
+  return owned
+}
 
 export function getStoredTheme () {
   try {
     const savedTheme = localStorage.getItem(STORAGE_KEY)
-    return APP_THEMES.some(({ id }) => id === savedTheme) ? savedTheme : 'neon'
-  } catch {
-    return 'neon'
-  }
+    return APP_THEMES.some(({ id }) => id === savedTheme) && getOwnedThemes().has(savedTheme) ? savedTheme : 'royal-navy'
+  } catch { return 'royal-navy' }
 }
 
 export function applyAppTheme (theme) {
-  const nextTheme = APP_THEMES.some(({ id }) => id === theme) ? theme : 'neon'
+  const nextTheme = APP_THEMES.some(({ id }) => id === theme) && getOwnedThemes().has(theme) ? theme : 'royal-navy'
   document.documentElement.dataset.appTheme = nextTheme
-  try {
-    localStorage.setItem(STORAGE_KEY, nextTheme)
-  } catch {
-    // The visual selection still works when storage is unavailable.
-  }
+  try { localStorage.setItem(STORAGE_KEY, nextTheme) } catch {}
   return nextTheme
 }


### PR DESCRIPTION
### Motivation

- Provide users with a richer set of home themes (10 total) matching the provided visual references and enable monetization of premium styles. 
- Ensure the UI only lets users apply themes they own while keeping five default themes free and the other five purchasable in-app.

### Description

- Added a new `webapp/src/utils/appTheme.js` which declares the 10 themes, tracks owned themes in `localStorage`, exposes `getOwnedThemes`, `unlockAppTheme`, `getStoredTheme`, and enforces ownership in `applyAppTheme`.
- Updated the theme picker at `webapp/src/components/ThemePicker.jsx` to show a compact 2-column portrait-friendly grid, display free vs locked state, show a lock icon for premium themes, and link locked selections to the new store page.
- Introduced a dedicated portrait-optimized store page `webapp/src/pages/HomeThemeStore.jsx` and registered the route at `GET /store/home-themes` in `webapp/src/App.jsx`, with preview cards, TPG balance display, `buyBundle` integration, and `unlockAppTheme` on purchase success.
- Added theme CSS variables and presentation styles in `webapp/src/index.css` for all ten themes and for the store UI so previews and app surfaces update when a theme is applied.

### Testing

- Ran `npm run build` for the webapp and the production build completed successfully.
- Started the dev server with `npm run dev` and Vite reported ready and reachable, confirming the new route and assets can be served in development.
- Attempted an automated Playwright screenshot of `/store/home-themes`; browser binaries installed successfully but the headless Chromium launch failed at runtime due to a missing system library (`libatk-1.0.so.0`) in this environment, so headless screenshot verification could not run here.
- Ran `git diff --check` and basic repository checks which reported no linting/diff errors for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d77481f8483299814f24d32ef4a09)