### PR TITLE
Add 10 home themes (5 free, 5 premium) and wire store unlocks

### DIFF
--- a/webapp/src/components/ThemePicker.jsx
+++ b/webapp/src/components/ThemePicker.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
-import { Check, Palette, X } from 'lucide-react';
+import { Check, LockKeyhole, Palette, ShoppingBag, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 
-import { APP_THEMES, applyAppTheme, getStoredTheme } from '../utils/appTheme.js';
+import { APP_THEMES, applyAppTheme, getOwnedAppThemes, getStoredTheme } from '../utils/appTheme.js';
 
 export default function ThemePicker() {
   const [isOpen, setIsOpen] = useState(false);
   const [theme, setTheme] = useState(getStoredTheme);
+  const [ownedThemes, setOwnedThemes] = useState(getOwnedAppThemes);
   const panelRef = useRef(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     applyAppTheme(theme);
@@ -20,6 +23,12 @@ export default function ThemePicker() {
     document.addEventListener('pointerdown', closeOnOutsideTap);
     return () => document.removeEventListener('pointerdown', closeOnOutsideTap);
   }, [isOpen]);
+
+  useEffect(() => {
+    const syncOwnedThemes = (event) => setOwnedThemes(event.detail?.owned || getOwnedAppThemes());
+    window.addEventListener('appThemeInventoryUpdate', syncOwnedThemes);
+    return () => window.removeEventListener('appThemeInventoryUpdate', syncOwnedThemes);
+  }, []);
 
   return (
     <div ref={panelRef} className="theme-picker">
@@ -40,21 +49,26 @@ export default function ThemePicker() {
               <strong>Choose a style</strong>
               <span>Make TonPlaygram yours</span>
             </div>
-            <span className="theme-picker__count">5 themes</span>
+            <span className="theme-picker__count">5 FREE · 5 STORE</span>
           </div>
           <div className="theme-picker__options" role="radiogroup" aria-label="App theme">
             {APP_THEMES.map((option) => {
               const selected = theme === option.id;
+              const owned = ownedThemes.includes(option.id);
               return (
                 <button
                   type="button"
                   role="radio"
                   aria-checked={selected}
                   key={option.id}
-                  className={`theme-picker__option${selected ? ' is-selected' : ''}`}
+                  className={`theme-picker__option${selected ? ' is-selected' : ''}${owned ? '' : ' is-locked'}`}
                   onClick={() => {
-                    setTheme(option.id);
-                    setIsOpen(false);
+                    if (owned) {
+                      setTheme(option.id);
+                      setIsOpen(false);
+                    } else {
+                      navigate('/store/home');
+                    }
                   }}
                 >
                   <span className="theme-picker__swatches" aria-hidden="true">
@@ -62,12 +76,15 @@ export default function ThemePicker() {
                       <span key={color} style={{ backgroundColor: color }} />
                     ))}
                   </span>
-                  <span>{option.name}</span>
-                  {selected && <Check className="theme-picker__check" size={17} />}
+                  <span className="theme-picker__name">{option.name}<small>{owned ? 'Included' : `${option.price} TPG`}</small></span>
+                  {selected ? <Check className="theme-picker__check" size={17} /> : !owned ? <LockKeyhole className="theme-picker__lock" size={15} /> : null}
                 </button>
               );
             })}
           </div>
+          <button type="button" className="theme-picker__store" onClick={() => navigate('/store/home')}>
+            <ShoppingBag size={15} /> Explore premium themes
+          </button>
         </div>
       )}
     </div>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -19,7 +19,7 @@ body {
 
 /* User-selectable app palettes. These variables recolor the shared utility
    surfaces while preserving the existing layout and game-specific styling. */
-:root[data-app-theme='sunset'] {
+:root[data-app-theme='rose'] {
   --app-bg: #160b24;
   --app-bg-glow: #65254f;
   --app-surface: #2b1237;
@@ -37,7 +37,7 @@ body {
   --app-text: #f4d35e;
 }
 
-:root[data-app-theme='royal'] {
+:root[data-app-theme='lavender'] {
   --app-bg: #0e0821;
   --app-bg-glow: #4c2a82;
   --app-surface: #211342;
@@ -46,14 +46,12 @@ body {
   --app-text: #f9a8d4;
 }
 
-:root[data-app-theme='daylight'] {
-  --app-bg: #e9f5ff;
-  --app-bg-glow: #b7dcff;
-  --app-surface: #ffffff;
-  --app-surface-deep: #dceeff;
-  --app-accent: #1677ff;
-  --app-text: #102a43;
-}
+:root[data-app-theme='aurora'] { --app-bg:#0b0c2f; --app-bg-glow:#603c8f; --app-surface:#17164a; --app-surface-deep:#090a25; --app-accent:#22d3ee; --app-text:#e9d5ff; }
+:root[data-app-theme='ocean'] { --app-bg:#031426; --app-bg-glow:#075985; --app-surface:#082f49; --app-surface-deep:#031426; --app-accent:#38bdf8; --app-text:#f8fafc; }
+:root[data-app-theme='obsidian'] { --app-bg:#030407; --app-bg-glow:#252b36; --app-surface:#111318; --app-surface-deep:#030407; --app-accent:#94a3b8; --app-text:#f8fafc; }
+:root[data-app-theme='gold'] { --app-bg:#1c0e02; --app-bg-glow:#854d0e; --app-surface:#382006; --app-surface-deep:#160b02; --app-accent:#f59e0b; --app-text:#fff1b8; }
+:root[data-app-theme='arctic'] { --app-bg:#03131d; --app-bg-glow:#0e7490; --app-surface:#0b3545; --app-surface-deep:#03131d; --app-accent:#67e8f9; --app-text:#e0f2fe; }
+:root[data-app-theme='crimson'] { --app-bg:#190308; --app-bg-glow:#7f1d1d; --app-surface:#3a0912; --app-surface-deep:#190308; --app-accent:#ef4444; --app-text:#fecdd3; }
 
 :root[data-app-theme]:not([data-app-theme='neon']) body {
   background: radial-gradient(1100px 750px at 70% -10%, var(--app-bg-glow), var(--app-bg) 48%) fixed;
@@ -123,6 +121,7 @@ body {
   backdrop-filter: blur(18px);
   pointer-events: auto;
 }
+.theme-picker__options { max-height: min(56vh, 510px); overflow-y: auto; padding-right: 2px; scrollbar-width: thin; }
 
 .theme-picker__heading {
   display: flex;
@@ -163,6 +162,10 @@ body {
 .theme-picker__swatches { display: flex; }
 .theme-picker__swatches span { width: 23px; height: 27px; margin-right: -6px; border: 2px solid rgba(255,255,255,.8); border-radius: 8px; }
 .theme-picker__option > span:nth-child(2) { font-size: 13px; }
+.theme-picker__name small { display:block; margin-top:3px; color:#94a3b8; font:700 9px/1 sans-serif; letter-spacing:.06em; text-transform:uppercase; }
+.theme-picker__option.is-locked { border-color:rgba(245,158,11,.3); }
+.theme-picker__lock { color:#fbbf24; }
+.theme-picker__store { width:100%; margin-top:10px; min-height:38px; display:flex; align-items:center; justify-content:center; gap:7px; border:1px solid color-mix(in srgb,var(--app-accent,#00f7ff) 55%,transparent); border-radius:11px; color:white; background:color-mix(in srgb,var(--app-accent,#00f7ff) 16%,transparent); font:700 11px/1 sans-serif; }
 .theme-picker__check { color: var(--app-accent, #00f7ff); }
 
 body {

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -157,6 +157,12 @@ import {
 import { DEV_INFO } from '../utils/constants.js';
 import { swatchThumbnail } from '../config/storeThumbnails.js';
 import { getCustomHdriCatalog, saveCustomHdriEntry } from '../utils/customHdriCatalog.js';
+import {
+  APP_THEME_STORE_ITEMS,
+  addAppThemeUnlock,
+  getOwnedAppThemes,
+  isAppThemeOwned
+} from '../utils/appTheme.js';
 
 const UKRAINIAN_DRONE_PREVIEW_STATUS = Object.freeze({
   loading: 'LOADING',
@@ -1243,6 +1249,14 @@ const formatShortDate = (date) =>
   }).format(date);
 
 const storeMeta = {
+  home: {
+    name: 'Home Themes',
+    items: APP_THEME_STORE_ITEMS,
+    defaults: [],
+    labels: { appTheme: Object.fromEntries(APP_THEME_STORE_ITEMS.map((item) => [item.optionId, item.name])) },
+    typeLabels: { appTheme: 'Home Themes' },
+    accountId: POOL_STORE_ACCOUNT_ID
+  },
   poolroyale: {
     name: 'Pool Royale',
     items: POOL_ROYALE_STORE_ITEMS,
@@ -1401,6 +1415,7 @@ export default function Store() {
   const [texasOwned, setTexasOwned] = useState(() =>
     getTexasHoldemInventory(texasHoldemAccountId(accountId))
   );
+  const [appThemesOwned, setAppThemesOwned] = useState(getOwnedAppThemes);
   const [accountBalance, setAccountBalance] = useState(null);
   const [processing, setProcessing] = useState('');
   const [info, setInfo] = useState('');
@@ -1821,6 +1836,11 @@ export default function Store() {
 
   const storeItemsBySlug = useMemo(
     () => ({
+      home: APP_THEME_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'home'
+      })),
       poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({
         ...item,
         key: createItemKey(item.type, item.optionId),
@@ -1898,6 +1918,7 @@ export default function Store() {
 
   const ownedCheckers = useMemo(
     () => ({
+      home: (_type, optionId) => isAppThemeOwned(optionId),
       poolroyale: (type, optionId) =>
         isPoolOptionUnlocked(type, optionId, poolOwned),
       bilardoshqip: (type, optionId) =>
@@ -1939,11 +1960,13 @@ export default function Store() {
       dominoOwned,
       snakeOwned,
       texasOwned,
+      appThemesOwned,
     ]
   );
 
   const labelResolvers = useMemo(
     () => ({
+      home: (item) => item.name,
       poolroyale: (item) =>
         POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       bilardoshqip: (item) =>
@@ -1979,6 +2002,7 @@ export default function Store() {
 
   const typeLabelResolver = useMemo(
     () => ({
+      home: { appTheme: 'Home Themes' },
       poolroyale: TYPE_LABELS,
       bilardoshqip: TYPE_LABELS,
       airhockey: AIR_HOCKEY_TYPE_LABELS,
@@ -2675,6 +2699,8 @@ export default function Store() {
                 resolvedAccountId
               )
             );
+          } else if (slug === 'home') {
+            setAppThemesOwned(addAppThemeUnlock(entry.type, entry.optionId));
           }
         }
       }

--- a/webapp/src/utils/appTheme.js
+++ b/webapp/src/utils/appTheme.js
@@ -1,24 +1,66 @@
 export const APP_THEMES = [
-  { id: 'neon', name: 'Neon Night', colors: ['#071426', '#00f7ff', '#facc15'] },
-  { id: 'sunset', name: 'Sunset', colors: ['#26102f', '#ff6b6b', '#ffd166'] },
-  { id: 'forest', name: 'Emerald', colors: ['#071d18', '#34d399', '#f4d35e'] },
-  { id: 'royal', name: 'Royal', colors: ['#160d31', '#a78bfa', '#f9a8d4'] },
-  { id: 'daylight', name: 'Daylight', colors: ['#e9f5ff', '#1677ff', '#102a43'] }
+  { id: 'neon', name: 'Neon Lights', colors: ['#071426', '#00f7ff', '#f72585'], free: true },
+  { id: 'forest', name: 'Emerald', colors: ['#041712', '#34d399', '#f4d35e'], free: true },
+  { id: 'aurora', name: 'Aurora', colors: ['#11123b', '#22d3ee', '#c084fc'], free: true },
+  { id: 'ocean', name: 'Ocean Blue', colors: ['#061a33', '#38bdf8', '#f8fafc'], free: true },
+  { id: 'rose', name: 'Rose Quartz', colors: ['#351526', '#fb7185', '#fbcfe8'], free: true },
+  { id: 'obsidian', name: 'Obsidian', colors: ['#05060a', '#64748b', '#f8fafc'], price: 450 },
+  { id: 'gold', name: 'Golden Hour', colors: ['#281706', '#f59e0b', '#fff1b8'], price: 500 },
+  { id: 'lavender', name: 'Lavender Dream', colors: ['#1e1239', '#a78bfa', '#f5d0fe'], price: 500 },
+  { id: 'arctic', name: 'Arctic Ice', colors: ['#071d2b', '#67e8f9', '#e0f2fe'], price: 550 },
+  { id: 'crimson', name: 'Crimson Night', colors: ['#25070d', '#ef4444', '#fda4af'], price: 550 }
 ]
 
+export const FREE_APP_THEME_IDS = APP_THEMES.filter(({ free }) => free).map(({ id }) => id)
+export const PREMIUM_APP_THEMES = APP_THEMES.filter(({ free }) => !free)
+export const APP_THEME_STORE_ITEMS = PREMIUM_APP_THEMES.map((theme) => ({
+  id: `home-theme-${theme.id}`,
+  type: 'appTheme',
+  optionId: theme.id,
+  name: theme.name,
+  description: `${theme.name} premium palette for the TonPlaygram home page.`,
+  price: theme.price,
+  swatches: theme.colors
+}))
+
 const STORAGE_KEY = 'tpg-app-theme'
+const OWNED_KEY = 'tpg-owned-app-themes'
+
+export function getOwnedAppThemes () {
+  try {
+    const owned = JSON.parse(localStorage.getItem(OWNED_KEY) || '[]')
+    return [...new Set([...FREE_APP_THEME_IDS, ...(Array.isArray(owned) ? owned : [])])]
+  } catch {
+    return [...FREE_APP_THEME_IDS]
+  }
+}
+
+export function isAppThemeOwned (themeId) {
+  return getOwnedAppThemes().includes(themeId)
+}
+
+export function addAppThemeUnlock (_type, themeId) {
+  const owned = [...new Set([...getOwnedAppThemes(), themeId])]
+  try {
+    localStorage.setItem(OWNED_KEY, JSON.stringify(owned.filter((id) => !FREE_APP_THEME_IDS.includes(id))))
+    window.dispatchEvent(new CustomEvent('appThemeInventoryUpdate', { detail: { owned } }))
+  } catch {
+    // Keep checkout usable when persistent browser storage is unavailable.
+  }
+  return owned
+}
 
 export function getStoredTheme () {
   try {
     const savedTheme = localStorage.getItem(STORAGE_KEY)
-    return APP_THEMES.some(({ id }) => id === savedTheme) ? savedTheme : 'neon'
+    return APP_THEMES.some(({ id }) => id === savedTheme) && isAppThemeOwned(savedTheme) ? savedTheme : 'neon'
   } catch {
     return 'neon'
   }
 }
 
 export function applyAppTheme (theme) {
-  const nextTheme = APP_THEMES.some(({ id }) => id === theme) ? theme : 'neon'
+  const nextTheme = APP_THEMES.some(({ id }) => id === theme) && isAppThemeOwned(theme) ? theme : 'neon'
   document.documentElement.dataset.appTheme = nextTheme
   try {
     localStorage.setItem(STORAGE_KEY, nextTheme)


### PR DESCRIPTION
### Motivation

- Provide users with ten home-page visual themes (preserving Neon and Emerald) while keeping five free and offering five premium palettes through the store. 
- Ensure the UI prevents applying premium themes until purchased and that purchases unlock themes immediately in the UI.

### Description

- Replaced and expanded the theme catalog in `webapp/src/utils/appTheme.js` to define 10 themes with `free`/`price` flags, and added `FREE_APP_THEME_IDS`, `APP_THEME_STORE_ITEMS`, `getOwnedAppThemes`, `isAppThemeOwned`, and `addAppThemeUnlock` to persist and manage ownership. 
- Updated `getStoredTheme` and `applyAppTheme` to respect ownership so only owned themes (free + unlocked) may be applied. 
- Enhanced the theme picker component in `webapp/src/components/ThemePicker.jsx` to show all 10 palettes, display `5 FREE · 5 STORE`, indicate locked themes with a lock icon and price, navigate to the store for premium themes, listen for `appThemeInventoryUpdate` events, and expose a store CTA. 
- Added additional palettes and CSS variables for new themes in `webapp/src/index.css`, and added styling for locked items, store CTA, and a scrollable options panel for portrait/mobile. 
- Integrated a `home` store category in `webapp/src/pages/Store.jsx` that exposes `APP_THEME_STORE_ITEMS`, maps purchases to `addAppThemeUnlock`, and wires the in-app purchase flow to update `appThemesOwned` so purchased themes become immediately available. 

### Testing

- Ran `npm run lint` and the linter completed without errors. 
- Ran `npm run build` and the production build completed successfully (Vite build finished; normal chunk-size warnings noted). 
- Verified repository `git diff --check` / status to ensure files are consistent. 
- Attempted an automated UI preview via Playwright to capture the theme picker on a 390×844 viewport, but the headless browser failed to launch due to a missing system library (`libatk-1.0.so.0`), so an in-container screenshot could not be produced; Playwright browser download step completed but runtime dependencies prevented launch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d81676cc883298abd320d24d2d391)