### PR TITLE
Unify Earn & Social hubs; replace Mining+Tasks nav with Earn, add Social page, update themes and API error messages

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -3,9 +3,9 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
 import Home from './pages/Home.jsx';
-import Mining from './pages/Mining.jsx';
+import Earn from './pages/Earn.jsx';
+import Social from './pages/Social.jsx';
 import Wallet from './pages/Wallet.jsx';
-import Tasks from './pages/Tasks.jsx';
 import Referral from './pages/Referral.jsx';
 import MyAccount from './pages/MyAccount.jsx';
 import Store from './pages/Store.jsx';
@@ -198,7 +198,9 @@ export default function App() {
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/flamingo/*" element={<FlamingoApp />} />
-              <Route path="/mining" element={<Mining />} />
+              <Route path="/earn" element={<Earn />} />
+              <Route path="/social" element={<Social />} />
+              <Route path="/mining" element={<Navigate to="/earn#mining" replace />} />
               <Route
                 path="/mining/transactions"
                 element={<MiningTransactions />}
@@ -440,7 +442,7 @@ export default function App() {
               />
               <Route path="/spin" element={<SpinPage />} />
               <Route path="/admin/influencer" element={<InfluencerAdmin />} />
-              <Route path="/tasks" element={<Tasks />} />
+              <Route path="/tasks" element={<Navigate to="/earn#tasks" replace />} />
               <Route
                 path="/store"
                 element={<Navigate to="/store/all" replace />}

--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -1,11 +1,11 @@
 import {
   AiOutlineHome,
   AiOutlinePlayCircle,
-  AiOutlineCheckSquare,
   AiOutlineUser,
   AiOutlineShop
 } from 'react-icons/ai';
-import { GiMining } from 'react-icons/gi';
+import { GiReceiveMoney } from 'react-icons/gi';
+import { HiOutlineUserGroup } from 'react-icons/hi';
 import NavItem from './NavItem.jsx';
 
 export default function Navbar() {
@@ -13,9 +13,9 @@ export default function Navbar() {
     <nav className="app-bottom-nav fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
       <div className="container mx-auto px-4 pt-3 pb-1 flex items-center justify-between text-base">
         <NavItem to="/" icon={AiOutlineHome} label="Home" />
-        <NavItem to="/mining" icon={GiMining} label="Mining" />
+        <NavItem to="/earn" icon={GiReceiveMoney} label="Earn" />
         <NavItem to="/games" icon={AiOutlinePlayCircle} label="Games" />
-        <NavItem to="/tasks" icon={AiOutlineCheckSquare} label="Tasks" />
+        <NavItem to="/social" icon={HiOutlineUserGroup} label="Social" />
         <NavItem to="/store" icon={AiOutlineShop} label="Store" />
         <NavItem to="/account" icon={AiOutlineUser} label="Profile" />
       </div>

--- a/webapp/src/components/ThemePicker.jsx
+++ b/webapp/src/components/ThemePicker.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Check, LockKeyhole, Palette, ShoppingBag, X } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { Check, Palette, X } from 'lucide-react';
 
 import { APP_THEMES, applyAppTheme, getOwnedAppThemes, getStoredTheme } from '../utils/appTheme.js';
 
@@ -9,7 +8,6 @@ export default function ThemePicker() {
   const [theme, setTheme] = useState(getStoredTheme);
   const [ownedThemes, setOwnedThemes] = useState(getOwnedAppThemes);
   const panelRef = useRef(null);
-  const navigate = useNavigate();
 
   useEffect(() => {
     applyAppTheme(theme);
@@ -49,7 +47,7 @@ export default function ThemePicker() {
               <strong>Choose a style</strong>
               <span>Make TonPlaygram yours</span>
             </div>
-            <span className="theme-picker__count">5 FREE · 5 STORE</span>
+            <span className="theme-picker__count">5 COLOR TONES</span>
           </div>
           <div className="theme-picker__options" role="radiogroup" aria-label="App theme">
             {APP_THEMES.map((option) => {
@@ -67,7 +65,7 @@ export default function ThemePicker() {
                       setTheme(option.id);
                       setIsOpen(false);
                     } else {
-                      navigate('/store/home');
+                      return;
                     }
                   }}
                 >
@@ -76,15 +74,12 @@ export default function ThemePicker() {
                       <span key={color} style={{ backgroundColor: color }} />
                     ))}
                   </span>
-                  <span className="theme-picker__name">{option.name}<small>{owned ? 'Included' : `${option.price} TPG`}</small></span>
-                  {selected ? <Check className="theme-picker__check" size={17} /> : !owned ? <LockKeyhole className="theme-picker__lock" size={15} /> : null}
+                  <span className="theme-picker__name">{option.name}<small>Included</small></span>
+                  {selected ? <Check className="theme-picker__check" size={17} /> : null}
                 </button>
               );
             })}
           </div>
-          <button type="button" className="theme-picker__store" onClick={() => navigate('/store/home')}>
-            <ShoppingBag size={15} /> Explore premium themes
-          </button>
         </div>
       )}
     </div>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -53,6 +53,21 @@ body {
 :root[data-app-theme='arctic'] { --app-bg:#03131d; --app-bg-glow:#0e7490; --app-surface:#0b3545; --app-surface-deep:#03131d; --app-accent:#67e8f9; --app-text:#e0f2fe; }
 :root[data-app-theme='crimson'] { --app-bg:#190308; --app-bg-glow:#7f1d1d; --app-surface:#3a0912; --app-surface-deep:#190308; --app-accent:#ef4444; --app-text:#fecdd3; }
 
+.hub-page { display:grid; gap:16px; padding:12px 12px 28px; }
+.hub-hero { position:relative; overflow:hidden; padding:20px 16px; border:1px solid color-mix(in srgb,var(--app-accent,#22d3ee) 55%,transparent); border-radius:20px; background:radial-gradient(circle at 85% 0,color-mix(in srgb,var(--app-accent,#22d3ee) 30%,transparent),transparent 45%),linear-gradient(145deg,var(--app-surface,#17164a),var(--app-surface-deep,#090a25)); box-shadow:0 14px 35px rgba(0,0,0,.25); }
+.hub-kicker { display:flex; align-items:center; gap:6px; color:var(--app-accent,#22d3ee); font-size:11px; font-weight:800; letter-spacing:.12em; text-transform:uppercase; }
+.hub-hero h1 { margin:6px 0 2px; color:var(--app-text,#fff); font-size:32px; font-weight:900; line-height:1; }
+.hub-hero p { max-width:520px; color:#cbd5e1; font-size:13px; }
+.hub-jump-links { display:grid; grid-template-columns:repeat(3,1fr); gap:7px; margin-top:14px; }
+.earn-page .hub-jump-links { grid-template-columns:repeat(2,1fr); }
+.hub-jump-links a { display:flex; min-height:38px; align-items:center; justify-content:center; gap:6px; border:1px solid color-mix(in srgb,var(--app-accent,#22d3ee) 40%,transparent); border-radius:11px; background:rgba(0,0,0,.2); color:var(--app-text,#fff); font-size:11px; font-weight:800; }
+.hub-section { scroll-margin-top:16px; min-width:0; padding:12px; border:1px solid color-mix(in srgb,var(--app-accent,#22d3ee) 22%,transparent); border-radius:18px; background:color-mix(in srgb,var(--app-surface,#17164a) 75%,transparent); }
+.hub-section-title { display:flex; align-items:center; gap:10px; margin:2px 2px 12px; color:var(--app-accent,#22d3ee); }
+.hub-section-title > svg { width:25px; height:25px; }
+.hub-section-title h2 { color:var(--app-text,#fff); font-size:19px; font-weight:900; }
+.hub-section-title p { color:#94a3b8; font-size:11px; }
+.hub-section .mining-page-content { padding:0; }
+
 :root[data-app-theme]:not([data-app-theme='neon']) body {
   background: radial-gradient(1100px 750px at 70% -10%, var(--app-bg-glow), var(--app-bg) 48%) fixed;
   color: var(--app-text);

--- a/webapp/src/pages/Earn.jsx
+++ b/webapp/src/pages/Earn.jsx
@@ -1,0 +1,27 @@
+import { Coins, ListChecks, Pickaxe } from 'lucide-react';
+import Mining from './Mining.jsx';
+import Tasks from './Tasks.jsx';
+
+export default function Earn() {
+  return (
+    <main className="hub-page earn-page">
+      <header className="hub-hero">
+        <span className="hub-kicker"><Coins size={15} /> Rewards centre</span>
+        <h1>Earn</h1>
+        <p>Mine TPG and complete rewarding tasks from one organised place.</p>
+        <nav className="hub-jump-links" aria-label="Earn sections">
+          <a href="#mining"><Pickaxe size={16} /> Mining</a>
+          <a href="#tasks"><ListChecks size={16} /> Tasks</a>
+        </nav>
+      </header>
+      <section id="mining" className="hub-section">
+        <div className="hub-section-title"><Pickaxe /><div><h2>Mining</h2><p>Start cycles, boost earnings and review rewards.</p></div></div>
+        <Mining />
+      </section>
+      <section id="tasks" className="hub-section">
+        <div className="hub-section-title"><ListChecks /><div><h2>Tasks</h2><p>Check in, complete quests and claim bonuses.</p></div></div>
+        <Tasks />
+      </section>
+    </main>
+  );
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
-import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
 import { getGameThumbnail } from '../config/gameAssets.js';
@@ -82,7 +81,6 @@ export default function Games() {
         })}
       </div>
       <GameTransactionsCard />
-      <LeaderboardCard />
     </div>
   );
 }

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -2,8 +2,6 @@ import { useEffect, useState } from 'react';
 
 import ProjectAchievementsCard from '../components/ProjectAchievementsCard.jsx';
 import PwaDownloadFrame from '../components/PwaDownloadFrame.jsx';
-import HomeSocialHub from '../components/HomeSocialHub.jsx';
-import PlatformStatsCard from '../components/PlatformStatsCard.jsx';
 import ThemePicker from '../components/ThemePicker.jsx';
 
 import { FaArrowUp, FaArrowDown, FaWallet } from 'react-icons/fa';
@@ -316,8 +314,6 @@ export default function Home() {
             </div>
           </div>
 
-          <HomeSocialHub />
-          <PlatformStatsCard />
         </div>
       </div>
 

--- a/webapp/src/pages/Social.jsx
+++ b/webapp/src/pages/Social.jsx
@@ -1,0 +1,24 @@
+import { BarChart3, Trophy, Users } from 'lucide-react';
+import HomeSocialHub from '../components/HomeSocialHub.jsx';
+import PlatformStatsCard from '../components/PlatformStatsCard.jsx';
+import LeaderboardCard from '../components/LeaderboardCard.jsx';
+
+export default function Social() {
+  return (
+    <main className="hub-page social-page">
+      <header className="hub-hero">
+        <span className="hub-kicker"><Users size={15} /> Community centre</span>
+        <h1>Social</h1>
+        <p>Connect with players, follow the rankings and see TonPlaygram grow.</p>
+        <nav className="hub-jump-links" aria-label="Social sections">
+          <a href="#community"><Users size={16} /> Hub</a>
+          <a href="#leaderboard"><Trophy size={16} /> Leaders</a>
+          <a href="#platform-stats"><BarChart3 size={16} /> Stats</a>
+        </nav>
+      </header>
+      <section id="community" className="hub-section"><HomeSocialHub /></section>
+      <section id="leaderboard" className="hub-section"><LeaderboardCard /></section>
+      <section id="platform-stats" className="hub-section"><PlatformStatsCard /></section>
+    </main>
+  );
+}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -74,7 +74,7 @@ async function fetchWithRetry(url, options = {}, retries = 3, backoff = 500) {
 }
 
 function buildHeaders(base = {}) {
-  const headers = { ...base };
+  const headers = { Accept: 'application/json', ...base };
   const initData = window?.Telegram?.WebApp?.initData;
   if (initData) headers['X-Telegram-Init-Data'] = initData;
   const accountId = window?.localStorage?.getItem('accountId');
@@ -119,14 +119,14 @@ export async function post(path, body, token) {
   try {
     text = await res.text();
   } catch {
-    return { error: 'Invalid server response' };
+    return { error: 'The server did not finish its response. Please retry.' };
   }
   let data;
   try {
     data = text ? JSON.parse(text) : {};
   } catch (err) {
     // Provide a generic error instead of exposing parse details
-    return { error: 'Invalid server response' };
+    return { error: res.ok ? 'The server returned an unreadable response. Please retry.' : `Server error (${res.status}). Please retry.` };
   }
   if (!res.ok) {
     if (res.status === 502) {
@@ -156,13 +156,13 @@ export async function put(path, body, token) {
   try {
     text = await res.text();
   } catch {
-    return { error: 'Invalid server response' };
+    return { error: 'The server did not finish its response. Please retry.' };
   }
   let data;
   try {
     data = text ? JSON.parse(text) : {};
   } catch (err) {
-    return { error: 'Invalid server response' };
+    return { error: res.ok ? 'The server returned an unreadable response. Please retry.' : `Server error (${res.status}). Please retry.` };
   }
   if (!res.ok) {
     if (res.status === 502) {
@@ -188,13 +188,13 @@ export async function get(path, token) {
   try {
     text = await res.text();
   } catch {
-    return { error: 'Invalid server response' };
+    return { error: 'The server did not finish its response. Please retry.' };
   }
   let data;
   try {
     data = text ? JSON.parse(text) : {};
   } catch (err) {
-    return { error: 'Invalid server response' };
+    return { error: res.ok ? 'The server returned an unreadable response. Please retry.' : `Server error (${res.status}). Please retry.` };
   }
   if (!res.ok) {
     if (res.status === 502) {

--- a/webapp/src/utils/appTheme.js
+++ b/webapp/src/utils/appTheme.js
@@ -1,14 +1,9 @@
 export const APP_THEMES = [
-  { id: 'neon', name: 'Neon Lights', colors: ['#071426', '#00f7ff', '#f72585'], free: true },
-  { id: 'forest', name: 'Emerald', colors: ['#041712', '#34d399', '#f4d35e'], free: true },
   { id: 'aurora', name: 'Aurora', colors: ['#11123b', '#22d3ee', '#c084fc'], free: true },
-  { id: 'ocean', name: 'Ocean Blue', colors: ['#061a33', '#38bdf8', '#f8fafc'], free: true },
   { id: 'rose', name: 'Rose Quartz', colors: ['#351526', '#fb7185', '#fbcfe8'], free: true },
-  { id: 'obsidian', name: 'Obsidian', colors: ['#05060a', '#64748b', '#f8fafc'], price: 450 },
-  { id: 'gold', name: 'Golden Hour', colors: ['#281706', '#f59e0b', '#fff1b8'], price: 500 },
-  { id: 'lavender', name: 'Lavender Dream', colors: ['#1e1239', '#a78bfa', '#f5d0fe'], price: 500 },
-  { id: 'arctic', name: 'Arctic Ice', colors: ['#071d2b', '#67e8f9', '#e0f2fe'], price: 550 },
-  { id: 'crimson', name: 'Crimson Night', colors: ['#25070d', '#ef4444', '#fda4af'], price: 550 }
+  { id: 'lavender', name: 'Lavender Dream', colors: ['#1e1239', '#a78bfa', '#f5d0fe'], free: true },
+  { id: 'crimson', name: 'Crimson Night', colors: ['#25070d', '#ef4444', '#fda4af'], free: true },
+  { id: 'ocean', name: 'Ocean Blue', colors: ['#061a33', '#38bdf8', '#f8fafc'], free: true }
 ]
 
 export const FREE_APP_THEME_IDS = APP_THEMES.filter(({ free }) => free).map(({ id }) => id)
@@ -53,14 +48,14 @@ export function addAppThemeUnlock (_type, themeId) {
 export function getStoredTheme () {
   try {
     const savedTheme = localStorage.getItem(STORAGE_KEY)
-    return APP_THEMES.some(({ id }) => id === savedTheme) && isAppThemeOwned(savedTheme) ? savedTheme : 'neon'
+    return APP_THEMES.some(({ id }) => id === savedTheme) && isAppThemeOwned(savedTheme) ? savedTheme : 'aurora'
   } catch {
-    return 'neon'
+    return 'aurora'
   }
 }
 
 export function applyAppTheme (theme) {
-  const nextTheme = APP_THEMES.some(({ id }) => id === theme) && isAppThemeOwned(theme) ? theme : 'neon'
+  const nextTheme = APP_THEMES.some(({ id }) => id === theme) && isAppThemeOwned(theme) ? theme : 'aurora'
   document.documentElement.dataset.appTheme = nextTheme
   try {
     localStorage.setItem(STORAGE_KEY, nextTheme)


### PR DESCRIPTION
### Motivation
- Combine the separate Mining and Tasks experiences into a single, well-organised Earn hub for mobile portrait users. 
- Group community features (leaderboard, platform stats, social feed) into a single Social hub with a dedicated navbar icon. 
- Replace the legacy theme set with five new included color tones and make the picker reflect the new catalog. 
- Address repeated "Invalid server response" errors by improving API response handling and messaging.

### Description
- Added two new portrait-oriented hub pages: `webapp/src/pages/Earn.jsx` (contains Mining + Tasks sections) and `webapp/src/pages/Social.jsx` (contains HomeSocialHub, LeaderboardCard and PlatformStatsCard). 
- Replaced Mining + Tasks entries in the bottom navbar with a single `Earn` item and added a `Social` item, and wired routes so `/earn` and `/social` are first-class pages while old `/mining`/`/tasks` URLs redirect into the appropriate `#mining` / `#tasks` anchors. 
- Simplified theme catalog to five included tones (`aurora`, `rose`, `lavender`, `crimson`, `ocean`), made `aurora` the safe default, and adjusted `ThemePicker` UI/logic and `webapp/src/utils/appTheme.js` accordingly. 
- Added hub-focused CSS rules in `webapp/src/index.css` for the new hub layouts and adjusted a few page placements (removed duplicated social/stats/leaderboard cards from Home/Games where applicable). 
- Improved API client behavior in `webapp/src/utils/api.js` by adding `Accept: application/json` header and replacing generic "Invalid server response" messages with clearer, actionable messages for network failures, incomplete responses and non-OK HTTP status cases.

### Testing
- Ran production build with `npm --prefix webapp run build` which completed successfully. 
- Ran linter with `npm --prefix webapp run lint -- --quiet` which returned no errors. 
- Performed repository checks (`git diff --check`) and local static checks which showed no blocking issues. 
- Attempted an automated mobile screenshot via Playwright but the container was missing system libraries (`libatk-1.0.so.0`), so the headless Chromium run failed (environment dependency issue) and could not produce the screenshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d86ae9ee88329bb0ed49d4ada73d2)