### PR TITLE
Add Earn and Social hubs, update navbar/routes, expand themes and improve API error handling

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -3,9 +3,9 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
 import Home from './pages/Home.jsx';
-import Mining from './pages/Mining.jsx';
+import Earn from './pages/Earn.jsx';
+import Social from './pages/Social.jsx';
 import Wallet from './pages/Wallet.jsx';
-import Tasks from './pages/Tasks.jsx';
 import Referral from './pages/Referral.jsx';
 import MyAccount from './pages/MyAccount.jsx';
 import Store from './pages/Store.jsx';
@@ -198,7 +198,9 @@ export default function App() {
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/flamingo/*" element={<FlamingoApp />} />
-              <Route path="/mining" element={<Mining />} />
+              <Route path="/earn" element={<Earn />} />
+              <Route path="/social" element={<Social />} />
+              <Route path="/mining" element={<Navigate to="/earn#mining" replace />} />
               <Route
                 path="/mining/transactions"
                 element={<MiningTransactions />}
@@ -440,7 +442,7 @@ export default function App() {
               />
               <Route path="/spin" element={<SpinPage />} />
               <Route path="/admin/influencer" element={<InfluencerAdmin />} />
-              <Route path="/tasks" element={<Tasks />} />
+              <Route path="/tasks" element={<Navigate to="/earn#tasks" replace />} />
               <Route
                 path="/store"
                 element={<Navigate to="/store/all" replace />}

--- a/webapp/src/components/Navbar.jsx
+++ b/webapp/src/components/Navbar.jsx
@@ -1,11 +1,11 @@
 import {
   AiOutlineHome,
   AiOutlinePlayCircle,
-  AiOutlineCheckSquare,
   AiOutlineUser,
   AiOutlineShop
 } from 'react-icons/ai';
-import { GiMining } from 'react-icons/gi';
+import { GiReceiveMoney } from 'react-icons/gi';
+import { HiOutlineUserGroup } from 'react-icons/hi';
 import NavItem from './NavItem.jsx';
 
 export default function Navbar() {
@@ -13,9 +13,9 @@ export default function Navbar() {
     <nav className="app-bottom-nav fixed inset-x-0 bottom-0 z-50 bg-surface text-text shadow border-t border-accent">
       <div className="container mx-auto px-4 pt-3 pb-1 flex items-center justify-between text-base">
         <NavItem to="/" icon={AiOutlineHome} label="Home" />
-        <NavItem to="/mining" icon={GiMining} label="Mining" />
+        <NavItem to="/earn" icon={GiReceiveMoney} label="Earn" />
         <NavItem to="/games" icon={AiOutlinePlayCircle} label="Games" />
-        <NavItem to="/tasks" icon={AiOutlineCheckSquare} label="Tasks" />
+        <NavItem to="/social" icon={HiOutlineUserGroup} label="Social" />
         <NavItem to="/store" icon={AiOutlineShop} label="Store" />
         <NavItem to="/account" icon={AiOutlineUser} label="Profile" />
       </div>

--- a/webapp/src/components/ThemePicker.jsx
+++ b/webapp/src/components/ThemePicker.jsx
@@ -49,7 +49,7 @@ export default function ThemePicker() {
               <strong>Choose a style</strong>
               <span>Make TonPlaygram yours</span>
             </div>
-            <span className="theme-picker__count">5 FREE · 5 STORE</span>
+            <span className="theme-picker__count">5 FREE · 10 STORE</span>
           </div>
           <div className="theme-picker__options" role="radiogroup" aria-label="App theme">
             {APP_THEMES.map((option) => {
@@ -83,7 +83,7 @@ export default function ThemePicker() {
             })}
           </div>
           <button type="button" className="theme-picker__store" onClick={() => navigate('/store/home')}>
-            <ShoppingBag size={15} /> Explore premium themes
+            <ShoppingBag size={15} /> Explore 10 store themes
           </button>
         </div>
       )}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -19,16 +19,7 @@ body {
 
 /* User-selectable app palettes. These variables recolor the shared utility
    surfaces while preserving the existing layout and game-specific styling. */
-:root[data-app-theme='rose'] {
-  --app-bg: #160b24;
-  --app-bg-glow: #65254f;
-  --app-surface: #2b1237;
-  --app-surface-deep: #160b24;
-  --app-accent: #ff6b6b;
-  --app-text: #ffd166;
-}
-
-:root[data-app-theme='forest'] {
+:root[data-app-theme='emerald'] {
   --app-bg: #041712;
   --app-bg-glow: #145c48;
   --app-surface: #0c2d25;
@@ -37,21 +28,34 @@ body {
   --app-text: #f4d35e;
 }
 
-:root[data-app-theme='lavender'] {
-  --app-bg: #0e0821;
-  --app-bg-glow: #4c2a82;
-  --app-surface: #211342;
-  --app-surface-deep: #0e0821;
-  --app-accent: #a78bfa;
-  --app-text: #f9a8d4;
-}
-
-:root[data-app-theme='aurora'] { --app-bg:#0b0c2f; --app-bg-glow:#603c8f; --app-surface:#17164a; --app-surface-deep:#090a25; --app-accent:#22d3ee; --app-text:#e9d5ff; }
-:root[data-app-theme='ocean'] { --app-bg:#031426; --app-bg-glow:#075985; --app-surface:#082f49; --app-surface-deep:#031426; --app-accent:#38bdf8; --app-text:#f8fafc; }
 :root[data-app-theme='obsidian'] { --app-bg:#030407; --app-bg-glow:#252b36; --app-surface:#111318; --app-surface-deep:#030407; --app-accent:#94a3b8; --app-text:#f8fafc; }
-:root[data-app-theme='gold'] { --app-bg:#1c0e02; --app-bg-glow:#854d0e; --app-surface:#382006; --app-surface-deep:#160b02; --app-accent:#f59e0b; --app-text:#fff1b8; }
-:root[data-app-theme='arctic'] { --app-bg:#03131d; --app-bg-glow:#0e7490; --app-surface:#0b3545; --app-surface-deep:#03131d; --app-accent:#67e8f9; --app-text:#e0f2fe; }
-:root[data-app-theme='crimson'] { --app-bg:#190308; --app-bg-glow:#7f1d1d; --app-surface:#3a0912; --app-surface-deep:#190308; --app-accent:#ef4444; --app-text:#fecdd3; }
+:root[data-app-theme='golden-hour'] { --app-bg:#1c0e02; --app-bg-glow:#854d0e; --app-surface:#382006; --app-surface-deep:#160b02; --app-accent:#f59e0b; --app-text:#fff1b8; }
+:root[data-app-theme='arctic-ice'] { --app-bg:#03131d; --app-bg-glow:#0e7490; --app-surface:#0b3545; --app-surface-deep:#03131d; --app-accent:#67e8f9; --app-text:#e0f2fe; }
+:root[data-app-theme='royal-navy'] { --app-bg:#06162d; --app-bg-glow:#123a67; --app-surface:#0b2443; --app-surface-deep:#041020; --app-accent:#f5c84c; --app-text:#fff4c2; }
+:root[data-app-theme='emerald-classic'] { --app-bg:#e9dfc8; --app-bg-glow:#fffaf0; --app-surface:#f7f0df; --app-surface-deep:#ded2b8; --app-accent:#08734a; --app-text:#382a19; }
+:root[data-app-theme='vintage-brown'] { --app-bg:#241006; --app-bg-glow:#6b3514; --app-surface:#3b1d0b; --app-surface-deep:#180a03; --app-accent:#e9b949; --app-text:#ffe7ae; }
+:root[data-app-theme='classic-marble'] { --app-bg:#eee8dc; --app-bg-glow:#ffffff; --app-surface:#faf7f0; --app-surface-deep:#ded8cd; --app-accent:#c9912b; --app-text:#20252b; }
+:root[data-app-theme='midnight-purple'] { --app-bg:#12051f; --app-bg-glow:#51205f; --app-surface:#291034; --app-surface-deep:#0c0315; --app-accent:#e4b635; --app-text:#fff0ad; }
+:root[data-app-theme='ocean-wave'] { --app-bg:#dbe8dc; --app-bg-glow:#8ed0d0; --app-surface:#edf2df; --app-surface-deep:#c9ded2; --app-accent:#16859a; --app-text:#164d54; }
+:root[data-app-theme='golden-age'] { --app-bg:#f5dfaa; --app-bg-glow:#fff4d4; --app-surface:#fff0c8; --app-surface-deep:#e9c77c; --app-accent:#bd7416; --app-text:#5b3308; }
+:root[data-app-theme='steel-blue'] { --app-bg:#08131f; --app-bg-glow:#31516a; --app-surface:#142737; --app-surface-deep:#050d15; --app-accent:#aebbc5; --app-text:#f0f4f7; }
+:root[data-app-theme='sunset-haze'] { --app-bg:#722d39; --app-bg-glow:#e5663d; --app-surface:#a94a3e; --app-surface-deep:#54202b; --app-accent:#ffd08a; --app-text:#fff1d6; }
+:root[data-app-theme='ivory-black'] { --app-bg:#070807; --app-bg-glow:#28241d; --app-surface:#171713; --app-surface-deep:#030403; --app-accent:#e2b33b; --app-text:#fff0bd; }
+
+.hub-page { display:grid; gap:16px; padding:12px 12px 28px; }
+.hub-hero { position:relative; overflow:hidden; padding:20px 16px; border:1px solid color-mix(in srgb,var(--app-accent,#22d3ee) 55%,transparent); border-radius:20px; background:radial-gradient(circle at 85% 0,color-mix(in srgb,var(--app-accent,#22d3ee) 30%,transparent),transparent 45%),linear-gradient(145deg,var(--app-surface,#17164a),var(--app-surface-deep,#090a25)); box-shadow:0 14px 35px rgba(0,0,0,.25); }
+.hub-kicker { display:flex; align-items:center; gap:6px; color:var(--app-accent,#22d3ee); font-size:11px; font-weight:800; letter-spacing:.12em; text-transform:uppercase; }
+.hub-hero h1 { margin:6px 0 2px; color:var(--app-text,#fff); font-size:32px; font-weight:900; line-height:1; }
+.hub-hero p { max-width:520px; color:#cbd5e1; font-size:13px; }
+.hub-jump-links { display:grid; grid-template-columns:repeat(3,1fr); gap:7px; margin-top:14px; }
+.earn-page .hub-jump-links { grid-template-columns:repeat(2,1fr); }
+.hub-jump-links a { display:flex; min-height:38px; align-items:center; justify-content:center; gap:6px; border:1px solid color-mix(in srgb,var(--app-accent,#22d3ee) 40%,transparent); border-radius:11px; background:rgba(0,0,0,.2); color:var(--app-text,#fff); font-size:11px; font-weight:800; }
+.hub-section { scroll-margin-top:16px; min-width:0; padding:12px; border:1px solid color-mix(in srgb,var(--app-accent,#22d3ee) 22%,transparent); border-radius:18px; background:color-mix(in srgb,var(--app-surface,#17164a) 75%,transparent); }
+.hub-section-title { display:flex; align-items:center; gap:10px; margin:2px 2px 12px; color:var(--app-accent,#22d3ee); }
+.hub-section-title > svg { width:25px; height:25px; }
+.hub-section-title h2 { color:var(--app-text,#fff); font-size:19px; font-weight:900; }
+.hub-section-title p { color:#94a3b8; font-size:11px; }
+.hub-section .mining-page-content { padding:0; }
 
 :root[data-app-theme]:not([data-app-theme='neon']) body {
   background: radial-gradient(1100px 750px at 70% -10%, var(--app-bg-glow), var(--app-bg) 48%) fixed;

--- a/webapp/src/pages/Earn.jsx
+++ b/webapp/src/pages/Earn.jsx
@@ -1,0 +1,27 @@
+import { Coins, ListChecks, Pickaxe } from 'lucide-react';
+import Mining from './Mining.jsx';
+import Tasks from './Tasks.jsx';
+
+export default function Earn() {
+  return (
+    <main className="hub-page earn-page">
+      <header className="hub-hero">
+        <span className="hub-kicker"><Coins size={15} /> Rewards centre</span>
+        <h1>Earn</h1>
+        <p>Mine TPG and complete rewarding tasks from one organised place.</p>
+        <nav className="hub-jump-links" aria-label="Earn sections">
+          <a href="#mining"><Pickaxe size={16} /> Mining</a>
+          <a href="#tasks"><ListChecks size={16} /> Tasks</a>
+        </nav>
+      </header>
+      <section id="mining" className="hub-section">
+        <div className="hub-section-title"><Pickaxe /><div><h2>Mining</h2><p>Start cycles, boost earnings and review rewards.</p></div></div>
+        <Mining />
+      </section>
+      <section id="tasks" className="hub-section">
+        <div className="hub-section-title"><ListChecks /><div><h2>Tasks</h2><p>Check in, complete quests and claim bonuses.</p></div></div>
+        <Tasks />
+      </section>
+    </main>
+  );
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
-import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
 import { getGameThumbnail } from '../config/gameAssets.js';
@@ -82,7 +81,6 @@ export default function Games() {
         })}
       </div>
       <GameTransactionsCard />
-      <LeaderboardCard />
     </div>
   );
 }

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -2,8 +2,6 @@ import { useEffect, useState } from 'react';
 
 import ProjectAchievementsCard from '../components/ProjectAchievementsCard.jsx';
 import PwaDownloadFrame from '../components/PwaDownloadFrame.jsx';
-import HomeSocialHub from '../components/HomeSocialHub.jsx';
-import PlatformStatsCard from '../components/PlatformStatsCard.jsx';
 import ThemePicker from '../components/ThemePicker.jsx';
 
 import { FaArrowUp, FaArrowDown, FaWallet } from 'react-icons/fa';
@@ -316,8 +314,6 @@ export default function Home() {
             </div>
           </div>
 
-          <HomeSocialHub />
-          <PlatformStatsCard />
         </div>
       </div>
 

--- a/webapp/src/pages/Social.jsx
+++ b/webapp/src/pages/Social.jsx
@@ -1,0 +1,24 @@
+import { BarChart3, Trophy, Users } from 'lucide-react';
+import HomeSocialHub from '../components/HomeSocialHub.jsx';
+import PlatformStatsCard from '../components/PlatformStatsCard.jsx';
+import LeaderboardCard from '../components/LeaderboardCard.jsx';
+
+export default function Social() {
+  return (
+    <main className="hub-page social-page">
+      <header className="hub-hero">
+        <span className="hub-kicker"><Users size={15} /> Community centre</span>
+        <h1>Social</h1>
+        <p>Connect with players, follow the rankings and see TonPlaygram grow.</p>
+        <nav className="hub-jump-links" aria-label="Social sections">
+          <a href="#community"><Users size={16} /> Hub</a>
+          <a href="#leaderboard"><Trophy size={16} /> Leaders</a>
+          <a href="#platform-stats"><BarChart3 size={16} /> Stats</a>
+        </nav>
+      </header>
+      <section id="community" className="hub-section"><HomeSocialHub /></section>
+      <section id="leaderboard" className="hub-section"><LeaderboardCard /></section>
+      <section id="platform-stats" className="hub-section"><PlatformStatsCard /></section>
+    </main>
+  );
+}

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -74,7 +74,7 @@ async function fetchWithRetry(url, options = {}, retries = 3, backoff = 500) {
 }
 
 function buildHeaders(base = {}) {
-  const headers = { ...base };
+  const headers = { Accept: 'application/json', ...base };
   const initData = window?.Telegram?.WebApp?.initData;
   if (initData) headers['X-Telegram-Init-Data'] = initData;
   const accountId = window?.localStorage?.getItem('accountId');
@@ -119,14 +119,14 @@ export async function post(path, body, token) {
   try {
     text = await res.text();
   } catch {
-    return { error: 'Invalid server response' };
+    return { error: 'The server did not finish its response. Please retry.' };
   }
   let data;
   try {
     data = text ? JSON.parse(text) : {};
   } catch (err) {
     // Provide a generic error instead of exposing parse details
-    return { error: 'Invalid server response' };
+    return { error: res.ok ? 'The server returned an unreadable response. Please retry.' : `Server error (${res.status}). Please retry.` };
   }
   if (!res.ok) {
     if (res.status === 502) {
@@ -156,13 +156,13 @@ export async function put(path, body, token) {
   try {
     text = await res.text();
   } catch {
-    return { error: 'Invalid server response' };
+    return { error: 'The server did not finish its response. Please retry.' };
   }
   let data;
   try {
     data = text ? JSON.parse(text) : {};
   } catch (err) {
-    return { error: 'Invalid server response' };
+    return { error: res.ok ? 'The server returned an unreadable response. Please retry.' : `Server error (${res.status}). Please retry.` };
   }
   if (!res.ok) {
     if (res.status === 502) {
@@ -188,13 +188,13 @@ export async function get(path, token) {
   try {
     text = await res.text();
   } catch {
-    return { error: 'Invalid server response' };
+    return { error: 'The server did not finish its response. Please retry.' };
   }
   let data;
   try {
     data = text ? JSON.parse(text) : {};
   } catch (err) {
-    return { error: 'Invalid server response' };
+    return { error: res.ok ? 'The server returned an unreadable response. Please retry.' : `Server error (${res.status}). Please retry.` };
   }
   if (!res.ok) {
     if (res.status === 502) {

--- a/webapp/src/utils/appTheme.js
+++ b/webapp/src/utils/appTheme.js
@@ -1,14 +1,19 @@
 export const APP_THEMES = [
   { id: 'neon', name: 'Neon Lights', colors: ['#071426', '#00f7ff', '#f72585'], free: true },
-  { id: 'forest', name: 'Emerald', colors: ['#041712', '#34d399', '#f4d35e'], free: true },
-  { id: 'aurora', name: 'Aurora', colors: ['#11123b', '#22d3ee', '#c084fc'], free: true },
-  { id: 'ocean', name: 'Ocean Blue', colors: ['#061a33', '#38bdf8', '#f8fafc'], free: true },
-  { id: 'rose', name: 'Rose Quartz', colors: ['#351526', '#fb7185', '#fbcfe8'], free: true },
-  { id: 'obsidian', name: 'Obsidian', colors: ['#05060a', '#64748b', '#f8fafc'], price: 450 },
-  { id: 'gold', name: 'Golden Hour', colors: ['#281706', '#f59e0b', '#fff1b8'], price: 500 },
-  { id: 'lavender', name: 'Lavender Dream', colors: ['#1e1239', '#a78bfa', '#f5d0fe'], price: 500 },
-  { id: 'arctic', name: 'Arctic Ice', colors: ['#071d2b', '#67e8f9', '#e0f2fe'], price: 550 },
-  { id: 'crimson', name: 'Crimson Night', colors: ['#25070d', '#ef4444', '#fda4af'], price: 550 }
+  { id: 'emerald', name: 'Emerald', colors: ['#041712', '#34d399', '#f4d35e'], free: true },
+  { id: 'obsidian', name: 'Obsidian', colors: ['#05060a', '#64748b', '#f8fafc'], free: true },
+  { id: 'golden-hour', name: 'Golden Hour', colors: ['#281706', '#f59e0b', '#fff1b8'], free: true },
+  { id: 'arctic-ice', name: 'Arctic Ice', colors: ['#071d2b', '#67e8f9', '#e0f2fe'], free: true },
+  { id: 'royal-navy', name: 'Royal Navy', colors: ['#06162d', '#123a67', '#f5c84c'], price: 450 },
+  { id: 'emerald-classic', name: 'Emerald Classic', colors: ['#f4ecd8', '#075c3b', '#d4a72c'], price: 475 },
+  { id: 'vintage-brown', name: 'Vintage Brown', colors: ['#241006', '#6b3514', '#e9b949'], price: 500 },
+  { id: 'classic-marble', name: 'Classic Marble', colors: ['#f7f2e8', '#20252b', '#c9912b'], price: 525 },
+  { id: 'midnight-purple', name: 'Midnight Purple', colors: ['#12051f', '#51205f', '#e4b635'], price: 550 },
+  { id: 'ocean-wave', name: 'Ocean Wave', colors: ['#eaf1df', '#16859a', '#d6a72c'], price: 575 },
+  { id: 'golden-age', name: 'Golden Age', colors: ['#fff3cf', '#bd7416', '#6e3e08'], price: 600 },
+  { id: 'steel-blue', name: 'Steel Blue', colors: ['#08131f', '#31516a', '#c2c8cc'], price: 625 },
+  { id: 'sunset-haze', name: 'Sunset Haze', colors: ['#722d39', '#e5663d', '#f7d7a7'], price: 650 },
+  { id: 'ivory-black', name: 'Ivory Black', colors: ['#070807', '#28241d', '#e2b33b'], price: 675 }
 ]
 
 export const FREE_APP_THEME_IDS = APP_THEMES.filter(({ free }) => free).map(({ id }) => id)


### PR DESCRIPTION
### Motivation
- Consolidate earning features (mining and tasks) into a single `Earn` hub and add a dedicated `Social` hub for community features. 
- Refresh the app theme catalogue with new premium themes and expand styling for hub pages. 
- Update navigation and routes to reflect the new hubs and keep old URLs working via redirects. 
- Make `api` helpers more robust by adding a default `Accept` header and clearer error messages for partial/non-JSON responses.

### Description
- Added new pages `Earn.jsx` and `Social.jsx` and wired them into routing, including redirects from legacy paths (`/mining` -> `/earn#mining`, `/tasks` -> `/earn#tasks`).
- Updated `Navbar.jsx` to replace the Mining/Tasks items with `Earn` and `Social`, and changed icons accordingly. 
- Removed `LeaderboardCard` from `Games.jsx` top-level render and adjusted imports. 
- Reworked theme configuration in `appTheme.js` by renaming/adding many theme IDs, marking several as free, and adding a larger premium theme list; updated `ThemePicker.jsx` UI text to reflect new store counts. 
- Expanded CSS in `index.css` with many new `:root[data-app-theme='...']` palettes and added hub-related layout styles (e.g. `.hub-page`, `.hub-hero`, `.hub-section`).
- Improved `utils/api.js` by adding `Accept: 'application/json'` to `buildHeaders` and returning clearer, friendlier error strings when response reading or JSON parsing fails.

### Testing
- Built the webapp locally with `yarn build` and verified the dev build completed successfully. 
- Ran the existing test suite with `yarn test` and the tests passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d86ae9ee88329bb0ed49d4ada73d2)