### PR TITLE
Fix Chess Battle Royal online video calls (match-scoped rooms, ICE queueing, WebKit track fallback)

### DIFF
--- a/test/gameLiveVideoRoom.test.js
+++ b/test/gameLiveVideoRoom.test.js
@@ -1,0 +1,20 @@
+import { buildGameLiveChatRoomId } from '../webapp/src/utils/liveVideoRoom.js';
+
+describe('Chess Battle Royal live video room', () => {
+  test('uses the shared online match table rather than a player account', () => {
+    const firstPlayerParams = new URLSearchParams('tableId=chess-table-42&accountId=1001');
+    const secondPlayerParams = new URLSearchParams('tableId=chess-table-42&accountId=2002');
+
+    expect(buildGameLiveChatRoomId('chessbattleroyal', firstPlayerParams)).toBe(
+      buildGameLiveChatRoomId('chessbattleroyal', secondPlayerParams)
+    );
+    expect(buildGameLiveChatRoomId('chessbattleroyal', firstPlayerParams)).toBe(
+      'live-chessbattleroyal-chess-table-42'
+    );
+  });
+
+  test('keeps separate matches in separate video rooms', () => {
+    expect(buildGameLiveChatRoomId('chessbattleroyal', new URLSearchParams('table=alpha')))
+      .not.toBe(buildGameLiveChatRoomId('chessbattleroyal', new URLSearchParams('table=beta')));
+  });
+});

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
+import { buildGameLiveChatRoomId } from '../utils/liveVideoRoom.js';
 
 const AVATAR_ANCHOR_SELECTORS = [
   '[data-self-player="true"] .seat-badge-core',
@@ -74,17 +75,10 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   }, []);
 
   const roomId = useMemo(() => {
-    const accountId =
-      typeof window !== 'undefined'
-        ? window.localStorage.getItem('accountId') || 'guest'
-        : 'guest';
-    const sessionId =
-      params.get('table') ||
-      params.get('tableId') ||
-      params.get('room') ||
-      params.get('roomId') ||
-      'default';
-    return `live-${gameSlug}-${sessionId}-${accountId}`;
+    // A live-chat room belongs to the match, not to an account. Including the
+    // local account ID here put the two online players in different signaling
+    // rooms, so their camera tracks could never be negotiated reliably.
+    return buildGameLiveChatRoomId(gameSlug, params);
   }, [gameSlug, params]);
 
   const liveChat = useLiveVideoChat({

--- a/webapp/src/hooks/useLiveVideoChat.js
+++ b/webapp/src/hooks/useLiveVideoChat.js
@@ -18,6 +18,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled, video =
   const [localStream, setLocalStream] = useState(null);
   const localStreamRef = useRef(null);
   const peersRef = useRef(new Map());
+  const pendingIceCandidatesRef = useRef(new Map());
 
   const safeRoomId = useMemo(() => String(roomId || '').trim(), [roomId]);
 
@@ -41,8 +42,28 @@ export default function useLiveVideoChat({ roomId, displayName, enabled, video =
       peer.close();
       peersRef.current.delete(socketId);
     }
+    pendingIceCandidatesRef.current.delete(socketId);
     removeRemotePeer(socketId);
   }, [removeRemotePeer]);
+
+  const addOrQueueIceCandidate = useCallback(async (socketId, peerConnection, candidate) => {
+    if (peerConnection.remoteDescription) {
+      await peerConnection.addIceCandidate(new RTCIceCandidate(candidate));
+      return;
+    }
+
+    const queued = pendingIceCandidatesRef.current.get(socketId) || [];
+    queued.push(candidate);
+    pendingIceCandidatesRef.current.set(socketId, queued);
+  }, []);
+
+  const flushIceCandidates = useCallback(async (socketId, peerConnection) => {
+    const queued = pendingIceCandidatesRef.current.get(socketId) || [];
+    pendingIceCandidatesRef.current.delete(socketId);
+    for (const candidate of queued) {
+      await peerConnection.addIceCandidate(new RTCIceCandidate(candidate));
+    }
+  }, []);
 
   const emitSignal = useCallback((targetSocketId, data) => {
     if (!safeRoomId || !targetSocketId || !data) return;
@@ -74,8 +95,15 @@ export default function useLiveVideoChat({ roomId, displayName, enabled, video =
     };
 
     peerConnection.ontrack = (event) => {
-      const [stream] = event.streams;
-      if (!stream) return;
+      // WebKit may deliver a track without event.streams. Keep a stable remote
+      // MediaStream in that case so portrait iOS/Telegram clients render it.
+      const currentPeer = peersRef.current.get(socketId);
+      const [receivedStream] = event.streams;
+      const stream = receivedStream || currentPeer?.remoteStream || new MediaStream();
+      if (!receivedStream && !stream.getTracks().includes(event.track)) {
+        stream.addTrack(event.track);
+      }
+      peerConnection.remoteStream = stream;
       upsertRemotePeer(socketId, {
         displayName: participant.displayName || 'Player',
         stream,
@@ -112,6 +140,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled, video =
   const stopLiveChat = useCallback(() => {
     peersRef.current.forEach((peer) => peer.close());
     peersRef.current.clear();
+    pendingIceCandidatesRef.current.clear();
     setRemotePeers([]);
 
     if (localStreamRef.current) {
@@ -212,6 +241,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled, video =
       try {
         if (data.type === 'offer' && data.sdp) {
           await peerConnection.setRemoteDescription(new RTCSessionDescription(data.sdp));
+          await flushIceCandidates(fromSocketId, peerConnection);
           const answer = await peerConnection.createAnswer();
           await peerConnection.setLocalDescription(answer);
           emitSignal(fromSocketId, { type: 'answer', sdp: answer });
@@ -220,11 +250,12 @@ export default function useLiveVideoChat({ roomId, displayName, enabled, video =
 
         if (data.type === 'answer' && data.sdp) {
           await peerConnection.setRemoteDescription(new RTCSessionDescription(data.sdp));
+          await flushIceCandidates(fromSocketId, peerConnection);
           return;
         }
 
         if (data.type === 'ice-candidate' && data.candidate) {
-          await peerConnection.addIceCandidate(new RTCIceCandidate(data.candidate));
+          await addOrQueueIceCandidate(fromSocketId, peerConnection, data.candidate);
         }
       } catch (signalError) {
         console.error('live chat signal handling failed', signalError);
@@ -254,7 +285,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled, video =
       socket.off('liveChat:peer-left', handlePeerLeft);
       socket.off('liveChat:media_state', handleMediaState);
     };
-  }, [closePeer, createOfferForPeer, emitSignal, enabled, ensurePeerConnection, upsertRemotePeer]);
+  }, [addOrQueueIceCandidate, closePeer, createOfferForPeer, emitSignal, enabled, ensurePeerConnection, flushIceCandidates, upsertRemotePeer]);
 
   useEffect(() => () => stopLiveChat(), [stopLiveChat]);
 

--- a/webapp/src/utils/liveVideoRoom.js
+++ b/webapp/src/utils/liveVideoRoom.js
@@ -1,0 +1,9 @@
+export function buildGameLiveChatRoomId(gameSlug, params) {
+  const sessionId =
+    params.get('table') ||
+    params.get('tableId') ||
+    params.get('room') ||
+    params.get('roomId') ||
+    'default';
+  return `live-${gameSlug}-${sessionId}`;
+}


### PR DESCRIPTION
### Motivation

- Players in Chess Battle Royal could not reliably see each other because the live-video signaling room included the local account ID, putting peers in different rooms and preventing track negotiation. 
- Early ICE candidates sometimes arrived before remote session descriptions and were dropped, breaking connectivity on some networks and clients. 
- WebKit-based clients (portrait iOS / Telegram WebView) can deliver `ontrack` events without `event.streams`, causing remote video not to render.

### Description

- Stop including the local account in the live-chat room id by introducing `buildGameLiveChatRoomId` in `webapp/src/utils/liveVideoRoom.js` and using it from `webapp/src/components/GameLiveAvatarOverlay.jsx`. 
- Add a pending-ICE queue in `webapp/src/hooks/useLiveVideoChat.js` with `addOrQueueIceCandidate` and `flushIceCandidates` to buffer candidates until `setRemoteDescription` is applied. 
- Handle `ontrack` cases without `event.streams` by creating/maintaining a stable `MediaStream` and attaching the incoming `track` so WebKit clients can render portrait video. 
- Clear queued candidates when peers close or `stopLiveChat` runs, and wire the new utilities into the existing signaling flow. 
- Add a regression test `test/gameLiveVideoRoom.test.js` that asserts match-scoped room ids are shared across accounts and isolated between matches.

### Testing

- Ran `npx jest test/gameLiveVideoRoom.test.js --runInBand` and the new test suite passed (2 tests). 
- Built the frontend with `npm --prefix webapp run build` and the production build completed successfully (Vite output emitted as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d9fa4778483299d95559a6c40a6c1)