### PR TITLE
Fix Social Media Control Center developer access and profile rate-limiting

### DIFF
--- a/bot/middleware/auth.js
+++ b/bot/middleware/auth.js
@@ -33,7 +33,9 @@ function attachAuth(req, token, initData) {
     const data = verifyTelegramInitData(initData);
     if (data) {
       req.auth = {
-        telegramId: data.user ? Number(JSON.parse(data.user).id) : undefined
+        telegramId: data.user ? Number(JSON.parse(data.user).id) : undefined,
+        accountId: accountId || undefined,
+        googleId: googleId || undefined
       };
       return true;
     }

--- a/bot/routes/socialAdmin.js
+++ b/bot/routes/socialAdmin.js
@@ -8,11 +8,31 @@ import { ensureDefaultRules } from '../services/socialAutomation.js';
 import { queuePublication } from '../services/socialPublishing.js';
 
 const router = Router();
+
+export function hasSocialDeveloperAccess(auth = {}, env = process.env) {
+  if (auth.apiToken) return true;
+
+  const developerAccountIds = [
+    env.DEV_ACCOUNT_ID,
+    env.DEV_ACCOUNT_ID_1,
+    env.DEV_ACCOUNT_ID_2,
+    env.VITE_DEV_ACCOUNT_ID,
+    env.VITE_DEV_ACCOUNT_ID_1,
+    env.VITE_DEV_ACCOUNT_ID_2
+  ]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean);
+  const accountId = String(auth.accountId || '').trim();
+  if (accountId && developerAccountIds.includes(accountId)) return true;
+
+  const ownerTelegramId = Number(env.OWNER_TELEGRAM_ID);
+  return Number.isFinite(ownerTelegramId) && ownerTelegramId > 0 && auth.telegramId === ownerTelegramId;
+}
+
 router.use((req, res, next) => {
-  const configuredId = process.env.DEV_ACCOUNT_ID;
-  const ownerTelegramId = Number(process.env.OWNER_TELEGRAM_ID);
-  const allowed = req.auth?.apiToken || (configuredId && req.auth?.accountId === configuredId) || (ownerTelegramId && req.auth?.telegramId === ownerTelegramId);
-  if (!allowed) return res.status(403).json({ error: 'Developer access required' });
+  if (!hasSocialDeveloperAccess(req.auth)) {
+    return res.status(403).json({ error: 'Developer access required' });
+  }
   next();
 });
 

--- a/bot/server.js
+++ b/bot/server.js
@@ -302,6 +302,8 @@ const apiLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: (req) => {
     if (req.auth?.telegramId) return `telegram:${req.auth.telegramId}`;
+    if (req.auth?.accountId) return `account:${req.auth.accountId}`;
+    if (req.auth?.googleId) return `google:${req.auth.googleId}`;
     if (req.body?.telegramId) return `telegram:${req.body.telegramId}`;
     if (req.body?.accountId) return `account:${req.body.accountId}`;
     return req.ip;

--- a/bot/tests/socialAdminAccess.test.js
+++ b/bot/tests/socialAdminAccess.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { hasSocialDeveloperAccess } from '../routes/socialAdmin.js';
+
+test('allows every configured developer account environment name', () => {
+  const env = {
+    DEV_ACCOUNT_ID: 'primary',
+    DEV_ACCOUNT_ID_1: 'secondary',
+    VITE_DEV_ACCOUNT_ID_2: 'legacy-client-config'
+  };
+
+  assert.equal(hasSocialDeveloperAccess({ accountId: 'primary' }, env), true);
+  assert.equal(hasSocialDeveloperAccess({ accountId: 'secondary' }, env), true);
+  assert.equal(hasSocialDeveloperAccess({ accountId: 'legacy-client-config' }, env), true);
+});
+
+test('allows the Telegram owner and API token but rejects other users', () => {
+  const env = { OWNER_TELEGRAM_ID: '12345', DEV_ACCOUNT_ID: 'developer' };
+
+  assert.equal(hasSocialDeveloperAccess({ telegramId: 12345 }, env), true);
+  assert.equal(hasSocialDeveloperAccess({ apiToken: true }, env), true);
+  assert.equal(hasSocialDeveloperAccess({ accountId: 'someone-else' }, env), false);
+});

--- a/webapp/src/pages/SocialAdmin.jsx
+++ b/webapp/src/pages/SocialAdmin.jsx
@@ -33,7 +33,6 @@ export default function SocialAdmin() {
   const [busy, setBusy] = useState(false);
   const [connecting, setConnecting] = useState('');
   const refresh = async () => { const [o, p, a] = await Promise.all([socialAdminApi.overview(), socialAdminApi.posts(), socialAdminApi.automations()]); if (!o.error) setOverview(o); if (!p.error) setPosts(p); if (!a.error) setRules(a); };
-  useEffect(() => { refresh(); }, []);
   useEffect(() => { if (tab === 'overview' || tab === 'posts' || tab === 'scheduled') refresh(); }, [tab]);
   const payload = useMemo(() => ({ caption, link, platforms: selected, overrides, media, scheduledAt: mode === 'schedule' ? scheduledAt : null }), [caption, link, selected, overrides, media, mode, scheduledAt]);
   const runValidation = async () => { const result = await socialAdminApi.validate(payload); if (!result.error) setValidation(result); };


### PR DESCRIPTION
### Motivation

- The Social Media Control Center was rejecting valid developer users when Telegram WebApp init data replaced the account identity, and profile API requests were being rate-limited per-IP causing spurious 429s.

### Description

- Preserve account and Google identity when Telegram init data is present by attaching `accountId` and `googleId` in `bot/middleware/auth.js` so developer auth is not lost.  
- Centralize developer authorization in `bot/routes/socialAdmin.js` with `hasSocialDeveloperAccess` to accept API token, any configured developer account env keys, or the OWNER Telegram id.  
- Partition Express rate-limiter keys in `bot/server.js` to use `telegram:<id>`, `account:<id>`, or `google:<id>` when available so authenticated users are rate-limited by identity instead of by shared IP.  
- Remove the duplicate initial dashboard refresh in `webapp/src/pages/SocialAdmin.jsx` to reduce unnecessary API calls, and add `bot/tests/socialAdminAccess.test.js` with node:test assertions for developer-access logic.  

### Testing

- Ran `node --test bot/tests/socialAdminAccess.test.js` and the two new tests passed.  
- Ran `npm --prefix webapp run build` and the webapp production build completed successfully.  
- Ran `git diff --check` (automated check) with no blocking errors.  
- Ran ESLint across modified files: the run reported formatting/lint issues that were noted (they did not block the functional tests or the build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7da0e1d0308329828f09173f18673f)