### PR TITLE
Fix Chess Battle Royal opponent animations and live media

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -50,6 +50,9 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   const [liveMode, setLiveMode] = useState(false);
   const [anchorElement, setAnchorElement] = useState(null);
   const localVideoRef = useRef(null);
+  const remoteVideoRef = useRef(null);
+  const [opponentElement, setOpponentElement] = useState(null);
+  const [opponentRect, setOpponentRect] = useState(null);
   const [overlayRect, setOverlayRect] = useState({
     top: 96,
     left: 12,
@@ -99,6 +102,14 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     if (!localVideoRef.current) return;
     localVideoRef.current.srcObject = liveChat.localStream || null;
   }, [liveChat.localStream]);
+
+  const remoteStream = liveChat.remotePeers.find((peer) => peer.stream)?.stream || null;
+  useEffect(() => {
+    const video = remoteVideoRef.current;
+    if (!video) return;
+    video.srcObject = remoteStream;
+    if (remoteStream) video.play().catch(() => {});
+  }, [remoteStream]);
 
   useLayoutEffect(() => {
     if (typeof window === 'undefined') return undefined;
@@ -197,6 +208,22 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
         0
       );
       setAnchorElement(node);
+      const opponent = document.querySelector('[data-opponent-player="true"]');
+      if (opponent) {
+        const opponentAvatar = opponent.querySelector('.avatar-timer-avatar, img') || opponent;
+        const opponentBounds = opponentAvatar.getBoundingClientRect();
+        const diameter = Math.max(Math.round(Math.min(opponentBounds.width, opponentBounds.height) * FRAME_SCALE), 32);
+        setOpponentElement(opponentAvatar);
+        setOpponentRect({
+          top: Math.max(Math.round(opponentBounds.top - (diameter - opponentBounds.height) / 2), 0),
+          left: Math.max(Math.round(opponentBounds.left - (diameter - opponentBounds.width) / 2), 0),
+          width: diameter,
+          height: diameter
+        });
+      } else {
+        setOpponentElement(null);
+        setOpponentRect(null);
+      }
       setOverlayRect((prev) => {
         if (
           Math.abs(prev.top - top) <= 1 &&
@@ -314,6 +341,16 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   }, [anchorElement, liveMode]);
 
   useEffect(() => {
+    if (!opponentElement) return undefined;
+    const previousVisibility = opponentElement.style.visibility;
+    if (liveMode && remoteStream) opponentElement.style.visibility = 'hidden';
+    else opponentElement.style.visibility = previousVisibility || '';
+    return () => {
+      opponentElement.style.visibility = previousVisibility || '';
+    };
+  }, [liveMode, opponentElement, remoteStream]);
+
+  useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     const handleStartEvent = (event) => {
       const eventSlug = event?.detail?.gameSlug;
@@ -376,6 +413,20 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
             className="h-full w-full object-cover scale-x-[-1]"
           />
         </button>
+      ) : null}
+      {liveMode && remoteStream && opponentRect ? (
+        <div
+          aria-label="Opponent live video and voice"
+          className="fixed z-[18] overflow-hidden rounded-full border border-sky-300 bg-black/40 shadow-lg pointer-events-none"
+          style={{
+            top: `${opponentRect.top}px`,
+            left: `${opponentRect.left}px`,
+            width: `${opponentRect.width}px`,
+            height: `${opponentRect.height}px`
+          }}
+        >
+          <video ref={remoteVideoRef} autoPlay playsInline className="h-full w-full object-cover" />
+        </div>
       ) : null}
     </>
   );

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -14387,7 +14387,26 @@ function Chess3D({
       if (!fen && !syncedBoard) return;
       try {
         const parsedBoard = parseWireBoard(syncedBoard);
-        board = parsedBoard || parseFEN(String(fen || START_FEN).split(' ')[0]);
+        const authoritativeBoard = parsedBoard || parseFEN(String(fen || START_FEN).split(' ')[0]);
+        // Replay a newly received opponent move through the normal move pipeline.
+        // Repainting the authoritative board immediately skipped every Three.js
+        // piece/capture/weapon animation and made online moves appear to teleport.
+        const from = lastMove?.from;
+        const to = lastMove?.to;
+        const localBoardCanAnimate =
+          onlineRef.current.synced &&
+          from &&
+          to &&
+          board?.[from.r]?.[from.c] &&
+          !authoritativeBoard?.[from.r]?.[from.c] &&
+          authoritativeBoard?.[to.r]?.[to.c] &&
+          uiRef.current.turnWhite !== turnWhite;
+        if (localBoardCanAnimate) {
+          selectAt(from.r, from.c, { force: true });
+          moveSelTo(to.r, to.c, { byAi: true, suppressOnlineEmit: true });
+          return;
+        }
+        board = authoritativeBoard;
         if (Array.isArray(players) && players.length) {
           const me = players.find((p) => String(p.id) === String(accountId));
           const opp = players.find((p) => String(p.id) !== String(accountId));
@@ -14891,7 +14910,7 @@ function Chess3D({
       if (!isPlayerPiece(piece)) return false;
       if (!uiRef.current.turnWhite && piece.w) return false;
       if (uiRef.current.turnWhite && !piece.w) return false;
-      if (onlineRef.current.enabled) {
+      if (onlineRef.current.enabled && !suppressOnlineEmit) {
         if (!onlineRef.current.synced) return false;
         if (
           onlineRef.current.status !== 'started' &&
@@ -14932,7 +14951,7 @@ function Chess3D({
     }
 
     function moveSelTo(rr, cc, options = {}) {
-      const { byAi = false } = options;
+      const { byAi = false, suppressOnlineEmit = false } = options;
       const finalizeAiMove = () => {
         if (byAi) aiMovingRef.current = false;
       };
@@ -14952,7 +14971,7 @@ function Chess3D({
         finalizeAiMove();
         return;
       }
-      if (onlineRef.current.enabled) {
+      if (onlineRef.current.enabled && !suppressOnlineEmit) {
         const myTurnIsWhite = onlineRef.current.side === 'white';
         if (!onlineRef.current.synced) {
           finalizeAiMove();
@@ -15261,7 +15280,7 @@ function Chess3D({
         enqueueChessCommentaryEvent('outro', context, { priority: true });
       }
 
-      if (onlineRef.current.enabled && onlineRef.current.tableId) {
+      if (!suppressOnlineEmit && onlineRef.current.enabled && onlineRef.current.tableId) {
         const movePayload = {
           lastMove: { from: { r: sel.r, c: sel.c }, to: { r: rr, c: cc } },
           fen: boardToFEN(board, nextWhite),
@@ -17426,6 +17445,8 @@ function Chess3D({
                 key={`chess-seat-${player.index}`}
                 className={`absolute ${configOpen ? 'pointer-events-none' : 'pointer-events-auto'} flex flex-col items-center`}
                 data-player-index={player.index}
+                data-self-player={player.index === 0 ? 'true' : undefined}
+                data-opponent-player={player.index === 1 ? 'true' : undefined}
                 style={positionStyle}
               >
                 <AvatarTimer


### PR DESCRIPTION
### Motivation
- Online matches replayed authoritative server state by repainting the board which skipped Three.js piece/capture/weapon animations and made opponent moves appear to teleport. 
- Live avatar video for opponents was not rendered over the opponent avatar, so remote camera/audio were not visible in the portrait UI.

### Description
- Route authoritative remote moves through the local animation pipeline by replaying the received `lastMove` with `selectAt` and `moveSelTo` (using a `suppressOnlineEmit` flag) instead of immediately repainting the board, so captures, weapons and sounds now animate correctly (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Add support for rendering a remote WebRTC `MediaStream` into a dedicated `remoteVideoRef` and position that video over the opponent avatar in portrait mode, hiding the original avatar element while live media plays (`webapp/src/components/GameLiveAvatarOverlay.jsx`).
- Add explicit avatar anchors by setting `data-self-player` and `data-opponent-player` attributes on player seat elements so the overlay reliably finds and attaches to the correct DOM target (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Ensure the local replay path does not re-emit the same authoritative move back to the server by sending moves with `suppressOnlineEmit` when the update is a server-originated replay (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).

### Testing
- Ran production build with `npm --prefix webapp run build` and the build completed successfully. 
- Ran lint with `npm --prefix webapp run lint -- --quiet src/components/GameLiveAvatarOverlay.jsx src/pages/Games/ChessBattleRoyal.jsx` which completed without errors. 
- Ran `git diff --check` with no issues reported. 
- Ran the online move validation test `npm test -- --runInBand test/chessOnlineMoveValidation.test.js` but it failed to run because the test environment could not start the server due to a missing dependency (`compression`); the failure is environmental rather than a logic regression in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dab7797c8832984d4d155b15ca430)