### PR TITLE
Synchronize Pool Royale online matchmaking with Domino Royal server flow

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1677,7 +1677,7 @@ function maybeStartGame(table) {
         (t) => t.id !== table.id
       );
       if (table.gameType === 'poolroyale') {
-        poolStates.set(table.id, { state: null, hud: null, layout: null, ts: Date.now() });
+        poolStates.set(table.id, { state: null, hud: null, layout: null, ts: Date.now(), revision: 0 });
       } else if (table.gameType === 'domino-royal') {
         dominoRoyalStates.set(table.id, { state: null, action: null, ts: Date.now() });
       } else if (table.gameType === 'murlanroyale') {
@@ -2828,13 +2828,20 @@ io.on('connection', (socket) => {
     cb && cb({ success: true, revision });
   });
 
-  socket.on('joinPoolTable', async ({ tableId, accountId }) => {
+  socket.on('joinPoolTable', async ({ tableId, accountId } = {}, cb) => {
     if (!tableId) return;
-    if (accountId && !ensureRegistered(socket, accountId)) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId });
+    const table = tableMap.get(tableId);
+    if (!ensureRegistered(socket, resolvedAccountId) || !table || table.gameType !== 'poolroyale' ||
+      !table.players.some((player) => String(player.id) === String(resolvedAccountId))) {
+      socket.emit('poolSyncError', { tableId, error: 'seat_required' });
+      cb && cb({ success: false, error: 'seat_required' });
+      return;
+    }
     socket.join(tableId);
-    if (accountId) {
+    if (resolvedAccountId) {
       await registerConnection({
-        userId: String(accountId),
+        userId: String(resolvedAccountId),
         roomId: tableId,
         socketId: socket.id
       });
@@ -2846,13 +2853,22 @@ io.on('connection', (socket) => {
         state: cached.state,
         hud: cached.hud,
         layout: cached.layout,
-        updatedAt: cached.ts
+        updatedAt: cached.ts,
+        revision: cached.revision || 0
       });
     }
+    cb && cb({ success: true, revision: cached?.revision || 0 });
   });
 
-  socket.on('poolSyncRequest', ({ tableId }) => {
+  socket.on('poolSyncRequest', ({ tableId, accountId } = {}) => {
     if (!tableId) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId });
+    const table = tableMap.get(tableId);
+    if (!ensureRegistered(socket, resolvedAccountId) || !socket.rooms.has(tableId) ||
+      !table?.players.some((player) => String(player.id) === String(resolvedAccountId))) {
+      socket.emit('poolSyncError', { tableId, error: 'seat_required' });
+      return;
+    }
     const cached = poolStates.get(tableId);
     if (cached?.state) {
       socket.emit('poolState', {
@@ -2860,47 +2876,72 @@ io.on('connection', (socket) => {
         state: cached.state,
         hud: cached.hud,
         layout: cached.layout,
-        updatedAt: cached.ts
+        updatedAt: cached.ts,
+        revision: cached.revision || 0
       });
     }
   });
 
-  socket.on('poolFrame', ({ tableId, layout, hud, playerId, frameTs }) => {
+  socket.on('poolFrame', ({ tableId, layout, hud, playerId, frameTs, accountId } = {}) => {
     if (!tableId || !Array.isArray(layout)) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId: accountId || playerId || socket.data?.playerId });
+    const table = tableMap.get(tableId);
+    if (!ensureRegistered(socket, resolvedAccountId) || !socket.rooms.has(tableId) ||
+      !table?.players.some((player) => String(player.id) === String(resolvedAccountId))) {
+      socket.emit('poolSyncError', { tableId, error: 'seat_required' });
+      return;
+    }
     const ts = Number.isFinite(frameTs) ? frameTs : Date.now();
     const cached = poolStates.get(tableId) || {};
+    const revision = Number(cached.revision || 0) + 1;
     const payload = {
       tableId,
       layout,
       hud: hud || cached.hud || null,
       updatedAt: ts,
-      playerId: playerId || null
+      playerId: String(resolvedAccountId),
+      revision
     };
     poolStates.set(tableId, {
       state: cached.state || null,
       hud: payload.hud,
       layout,
-      ts
+      ts,
+      revision
     });
     socket.to(tableId).emit('poolFrame', payload);
   });
 
-  socket.on('poolShot', ({ tableId, state, hud, layout }) => {
+  socket.on('poolShot', ({ tableId, state, hud, layout, accountId } = {}, cb) => {
     if (!tableId || !state) return;
+    const resolvedAccountId = resolveTpcIdentity({ accountId: accountId || socket.data?.playerId });
+    const table = tableMap.get(tableId);
+    if (!ensureRegistered(socket, resolvedAccountId) || !socket.rooms.has(tableId) ||
+      !table?.players.some((player) => String(player.id) === String(resolvedAccountId))) {
+      socket.emit('poolSyncError', { tableId, error: 'seat_required' });
+      cb && cb({ success: false, error: 'seat_required' });
+      return;
+    }
+    const cached = poolStates.get(tableId) || {};
+    const revision = Number(cached.revision || 0) + 1;
+    const authoritativeState = { ...state, seq: revision };
     const payload = {
       tableId,
-      state,
+      state: authoritativeState,
       hud: hud || null,
       layout: layout || null,
-      updatedAt: Date.now()
+      updatedAt: Date.now(),
+      revision
     };
     poolStates.set(tableId, {
-      state,
+      state: authoritativeState,
       hud: hud || null,
       layout: layout || null,
-      ts: payload.updatedAt
+      ts: payload.updatedAt,
+      revision
     });
     socket.to(tableId).emit('poolState', payload);
+    cb && cb({ success: true, revision });
   });
 
   socket.on('joinSnookerTable', async ({ tableId, accountId }) => {

--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -171,6 +171,58 @@ test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async
   assert.equal(started[0].tableId, 'tbl-1');
   assert.equal(started[0].matchMeta?.tableSize, '9ft');
   assert.equal(refs.stakeDebitRef.current, null, 'stake cleared after start');
+  assert.equal(
+    mockSocket.leaveRequests.length,
+    0,
+    'starting a match must preserve the authoritative server seat'
+  );
+});
+
+test('runPoolRoyaleOnlineFlow resumes from a persisted gameStart seat response', async () => {
+  const mockSocket = new MockSocket();
+  const refs = createRefs();
+  const state = createState();
+  const started = [];
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPG', amount: 100 },
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: '9ft',
+    deps: {
+      ensureAccountId: () => Promise.resolve('acct-resume'),
+      getAccountBalance: () => Promise.resolve({ balance: 200 }),
+      addTransaction: () => Promise.resolve(),
+      getTelegramId: () => 'tg-resume',
+      getTelegramFirstName: () => 'Resume',
+      socket: mockSocket
+    },
+    state,
+    refs,
+    timeouts: { seat: 100, matchmaking: 200 },
+    onGameStart: (payload) => started.push(payload)
+  });
+
+  mockSocket.seatRequests[0].cb({
+    success: true,
+    tableId: 'tbl-resume',
+    started: true,
+    players: [{ id: 'acct-resume' }, { id: 'acct-opponent' }],
+    gameStart: {
+      tableId: 'tbl-resume',
+      players: [{ id: 'acct-resume' }, { id: 'acct-opponent' }],
+      currentTurn: 'acct-opponent',
+      meta: { variant: 'uk', tableSize: '9ft' }
+    }
+  });
+  await delay(0);
+
+  assert.equal(started.length, 1);
+  assert.equal(started[0].tableId, 'tbl-resume');
+  assert.equal(started[0].currentTurn, 'acct-opponent');
+  assert.equal(mockSocket.leaveRequests.length, 0);
 });
 
 test('runPoolRoyaleOnlineFlow uses profile text while keeping the TPG number private', async () => {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19918,26 +19918,43 @@ const shotPowerRef = useRef(0);
 
   useEffect(() => {
     if (!isOnlineMatch || !tableId) return undefined;
+    let latestRevision = 0;
+    const shouldApplyPayload = (payload = {}) => {
+      const revision = Number(payload.revision ?? payload.state?.seq ?? 0);
+      if (revision > 0 && revision <= latestRevision) return false;
+      if (revision > 0) latestRevision = revision;
+      return true;
+    };
     const handlePoolState = (payload = {}) => {
       if (payload.tableId && payload.tableId !== tableId) return;
+      if (!shouldApplyPayload(payload)) return;
       handleRemotePayload(payload);
       applyRemoteState({ state: payload.state, hud: payload.hud, layout: payload.layout });
     };
     const handlePoolFrame = (payload = {}) => {
       if (payload.tableId && payload.tableId !== tableId) return;
+      if (!shouldApplyPayload(payload)) return;
       handleRemotePayload(payload);
       applyRemoteState({ state: payload.state, hud: payload.hud, layout: payload.layout });
     };
 
-    socket.emit('register', { playerId: accountId });
-    socket.emit('joinPoolTable', { tableId, accountId });
-    socket.emit('poolSyncRequest', { tableId });
+    const joinAndSync = () => {
+      socket.emit('register', { playerId: accountId }, (registered) => {
+        if (!registered?.success) return;
+        socket.emit('joinPoolTable', { tableId, accountId }, (joined) => {
+          if (joined?.success) socket.emit('poolSyncRequest', { tableId, accountId });
+        });
+      });
+    };
     socket.on('poolState', handlePoolState);
     socket.on('poolFrame', handlePoolFrame);
+    socket.on('connect', joinAndSync);
+    joinAndSync();
 
     return () => {
       socket.off('poolState', handlePoolState);
       socket.off('poolFrame', handlePoolFrame);
+      socket.off('connect', joinAndSync);
     };
   }, [accountId, applyRemoteState, handleRemotePayload, isOnlineMatch, tableId]);
 

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -393,13 +393,14 @@ export async function runPoolRoyaleOnlineFlow({
   async function cleanupLobby({
     account = accountIdRef.current,
     skipRefReset,
+    preserveSeat = false,
     refundReason,
     keepError
   } = {}) {
     socketInstance.off('lobbyUpdate', handleLobbyUpdate);
     socketInstance.off('gameStart', handleGameStart);
     socketInstance.off('gameStarted', handleGameStart);
-    if (pendingTableRef.current && account) {
+    if (!preserveSeat && pendingTableRef.current && account) {
       socketInstance.emit('leaveLobby', {
         tpcAccountNumber: account,
         tpcAccountId: account,
@@ -443,7 +444,12 @@ export async function runPoolRoyaleOnlineFlow({
         : matchPlayersRef.current;
     stakeDebitRef.current = null;
     clearTimers();
-    cleanupLobby({ account: accountId, skipRefReset: true, keepError: true });
+    cleanupLobby({
+      account: accountId,
+      skipRefReset: true,
+      preserveSeat: true,
+      keepError: true
+    });
     onGameStart?.({
       tableId: startedId,
       roster,
@@ -563,6 +569,13 @@ export async function runPoolRoyaleOnlineFlow({
         setMatchPlayers(playersList);
         matchPlayersRef.current = playersList;
         setReadyList(res.ready || []);
+        // The server persists the authoritative start payload before replying.
+        // This covers reconnects and explicit-table joins where gameStart was
+        // broadcast before this phone finished attaching its listeners.
+        if (res.started && res.gameStart) {
+          handleGameStart(res.gameStart);
+          return;
+        }
         socketInstance.emit('confirmReady', {
           tpcAccountNumber: accountId,
           tpcAccountId: accountId,


### PR DESCRIPTION
### Motivation

- Align Pool Royale online matchmaking and in-game synchronization with the authoritative structure used by Domino Royal so matches are robust to mobile reconnects and missing broadcasted events.
- Preserve server-authoritative seats during transitions so a started match does not accidentally unseat players and clients can recover from missed `gameStart` broadcasts.

### Description

- Add seat-preservation and resume-on-persisted-start logic to the client flow by introducing `preserveSeat` to `cleanupLobby` and invoking `handleGameStart` when the seat response already includes `started`/`gameStart` in `webapp/src/pages/Games/poolRoyaleOnlineFlow.js`.
- Harden client sync in `webapp/src/pages/Games/PoolRoyale.jsx` by re-registering and rejoining the authoritative table on connect, requesting a snapshot, and dropping stale frames via a monotonic `revision`/`seq` check before applying remote state or frames.
- Make server-side Pool Royale networking authoritative and safe by adding `revision` bookkeeping to `poolStates`, validating `joinPoolTable`/`poolSyncRequest`/`poolFrame`/`poolShot` caller identities, returning cached-state `revision`, and emitting/accepting callback acknowledgements (in `bot/server.js`).
- Add regression tests for seat preservation and resumed seat responses in `test/poolRoyaleOnlineFlow.test.js` to cover the new resume and seat-preserve behaviors.

### Testing

- Ran the updated unit tests `jest --runInBand test/poolRoyaleOnlineFlow.test.js test/poolRoyaleMatchmakingMeta.test.js` and all relevant tests passed (10/10 in the focused suite and matching meta tests executed). 
- Performed static checks with `node --check` on modified JS modules and they reported no syntax errors. 
- Built the webapp with `npm --prefix webapp run build` to exercise client bundling and snapshot writes and the build completed successfully.
- Ran `eslint` which completed but the linter reported warnings due to ignored files in the repository configuration (no blocking errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86b945c7448329afa8ff4e4240e52c)