### PR TITLE
Prevent profile 429 failures: raise server limit and surface 429s to clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
   - `RATE_LIMIT_WINDOW_MS` – (optional) timeframe for rate limits in milliseconds (defaults to 900000)
 
-  - `RATE_LIMIT_MAX` – (optional) max requests per window from one IP (defaults to 100)
+  - `RATE_LIMIT_MAX` – (optional) max API requests per window from one authenticated account or IP (defaults to 1000)
 
   - `ALLOWED_ORIGINS` – list of origins allowed for CORS and socket.io. Multiple
     origins may be comma-separated, e.g.

--- a/bot/server.js
+++ b/bot/server.js
@@ -202,7 +202,11 @@ function resolveCorsOrigin(origin, callback) {
 const rateLimitWindowMs =
   Number(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
 
-const rateLimitMax = Number(process.env.RATE_LIMIT_MAX) || 100;
+// The web app loads several independent account widgets and game services. A
+// 100-request/15-minute global allowance was low enough for normal mobile use
+// to lock the user out of their own profile. Keep this as a broad abuse guard;
+// sensitive write routes apply their own validation and throttling.
+const rateLimitMax = Number(process.env.RATE_LIMIT_MAX) || 1000;
 const app = express();
 const corsOptions = {
   origin: resolveCorsOrigin
@@ -300,6 +304,11 @@ const apiLimiter = rateLimit({
   limit: rateLimitMax,
   standardHeaders: true,
   legacyHeaders: false,
+  handler: (_req, res) => {
+    res.status(429).json({
+      error: 'Too many requests. Please wait a moment and try again.'
+    });
+  },
   keyGenerator: (req) => {
     if (req.auth?.telegramId) return `telegram:${req.auth.telegramId}`;
     if (req.auth?.accountId) return `account:${req.auth.accountId}`;

--- a/test/apiGoogleHeaderFallback.test.js
+++ b/test/apiGoogleHeaderFallback.test.js
@@ -52,4 +52,21 @@ describe('api auth headers google fallback', () => {
     const fetchOptions = global.fetch.mock.calls[0][1];
     expect(fetchOptions.headers['X-Google-Id']).toBe('google-profile-only');
   });
+
+  test('returns a useful error for a long rate-limit response without retrying', async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: { get: () => '900' },
+      text: async () => 'Too many requests'
+    });
+
+    const result = await post('/api/profile/get', { telegramId: 123 });
+
+    expect(result).toEqual({
+      error: 'Too many requests. Please wait a moment and try again.'
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -73,8 +73,20 @@ function normalizeTelegramId(rawId) {
 async function fetchWithRetry(url, options = {}, retries = 3, backoff = 500) {
   try {
     const res = await fetch(url, options);
-    if (res.status === 502 && retries > 0) {
-      await wait(backoff);
+    const retryAfterSeconds = Number(res.headers?.get?.('retry-after'));
+    const hasShortRateLimit =
+      res.status === 429 &&
+      Number.isFinite(retryAfterSeconds) &&
+      retryAfterSeconds <= 5;
+    if ((res.status === 502 || hasShortRateLimit) && retries > 0) {
+      // A global rate-limit window can be several minutes long. Do not freeze
+      // the profile screen for that duration, but do recover automatically
+      // from short throttles and transient gateway failures.
+      const retryDelay =
+        res.status === 429 && Number.isFinite(retryAfterSeconds)
+          ? Math.max(retryAfterSeconds * 1000, backoff)
+          : backoff;
+      await wait(retryDelay);
       return fetchWithRetry(url, options, retries - 1, backoff * 2);
     }
     return res;
@@ -139,10 +151,16 @@ export async function post(path, body, token) {
   try {
     data = text ? JSON.parse(text) : {};
   } catch (err) {
+    if (res.status === 429) {
+      return { error: 'Too many requests. Please wait a moment and try again.' };
+    }
     // Provide a generic error instead of exposing parse details
     return { error: res.ok ? 'The server returned an unreadable response. Please retry.' : `Server error (${res.status}). Please retry.` };
   }
   if (!res.ok) {
+    if (res.status === 429) {
+      return { error: data.error || 'Too many requests. Please wait a moment and try again.' };
+    }
     if (res.status === 502) {
       return { error: 'Server unavailable. Please try again later.' };
     }
@@ -190,9 +208,15 @@ export async function put(path, body, token) {
   try {
     data = text ? JSON.parse(text) : {};
   } catch (err) {
+    if (res.status === 429) {
+      return { error: 'Too many requests. Please wait a moment and try again.' };
+    }
     return { error: res.ok ? 'The server returned an unreadable response. Please retry.' : `Server error (${res.status}). Please retry.` };
   }
   if (!res.ok) {
+    if (res.status === 429) {
+      return { error: data.error || 'Too many requests. Please wait a moment and try again.' };
+    }
     if (res.status === 502) {
       return { error: 'Server unavailable. Please try again later.' };
     }
@@ -222,9 +246,15 @@ export async function get(path, token) {
   try {
     data = text ? JSON.parse(text) : {};
   } catch (err) {
+    if (res.status === 429) {
+      return { error: 'Too many requests. Please wait a moment and try again.' };
+    }
     return { error: res.ok ? 'The server returned an unreadable response. Please retry.' : `Server error (${res.status}). Please retry.` };
   }
   if (!res.ok) {
+    if (res.status === 429) {
+      return { error: data.error || 'Too many requests. Please wait a moment and try again.' };
+    }
     if (res.status === 502) {
       return { error: 'Server unavailable. Please try again later.' };
     }


### PR DESCRIPTION
### Motivation
- Users were getting HTTP 429 (Too Many Requests) errors when opening the profile page due to a low global API limit and non-actionable client behavior. 
- The goal is to avoid legitimate mobile/profile activity hitting a global throttle and to provide a clear, recoverable experience when the server signals throttling.

### Description
- Increase the default global per-window allowance used by the server-side rate limiter from `100` to `1000` in `bot/server.js` to avoid normal mobile/profile activity exhausting the global quota. 
- Add a JSON `429` response handler on the server (`bot/server.js`) that returns `{ error: 'Too many requests. Please wait a moment and try again.' }` so clients can show a friendly message. 
- Improve client-side retry and error handling in `webapp/src/utils/api.js` so short 429s (with small `Retry-After`) are retried automatically while long throttles immediately return a friendly error, and non-JSON 429 replies are handled gracefully. 
- Add a regression test in `test/apiGoogleHeaderFallback.test.js` that verifies long rate-limit (429) responses are not retried and produce the expected error message, and update `README.md` to document the new default limit.

### Testing
- Ran the unit test `test/apiGoogleHeaderFallback.test.js` with `npm test -- --runInBand test/apiGoogleHeaderFallback.test.js` and it passed. 
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully. 
- Performed syntax checks with `node --check bot/server.js` and `node --check webapp/src/utils/api.js`, both of which succeeded. 
- Ran `npx eslint --no-ignore bot/server.js webapp/src/utils/api.js test/apiGoogleHeaderFallback.test.js`, which produced repository-wide style warnings/errors from pre-existing files and did not block the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86ce360b7483298afcf7770a01ce7b)