### PR TITLE
Fix rewarded video autoplay on mobile (mute + eager iframe load)

### DIFF
--- a/webapp/src/components/AdModal.tsx
+++ b/webapp/src/components/AdModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 const AD_VIDEO_ID = '7614838290667031816';
-const AD_PLAYER_URL = `https://www.tiktok.com/player/v1/${AD_VIDEO_ID}?autoplay=1&rel=0`;
+// Mobile browsers only permit reliable autoplay when embedded video starts muted.
+const AD_PLAYER_URL = `https://www.tiktok.com/player/v1/${AD_VIDEO_ID}?autoplay=1&muted=1&rel=0`;
 const AD_CANONICAL_URL = `https://www.tiktok.com/@tonplaygram/video/${AD_VIDEO_ID}`;
 const REWARD_DELAY_MS = 15_000;
 
@@ -81,7 +82,7 @@ export default function AdModal({ open, onComplete, onClose }: AdModalProps) {
             className="w-full h-full"
             allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
             allowFullScreen
-            loading="lazy"
+            loading="eager"
             referrerPolicy="strict-origin-when-cross-origin"
           />
         </div>


### PR DESCRIPTION
### Motivation
- Ensure the rewarded TikTok iframe can autoplay reliably on mobile browsers by starting muted and loading immediately.

### Description
- Add `muted=1` to the TikTok player URL and change the iframe `loading` attribute from `lazy` to `eager` in `webapp/src/components/AdModal.tsx` so playback starts when the modal opens.

### Testing
- Ran `npm run lint && npm run build`, which completed successfully, and verified there are no diff errors; a headless Playwright screenshot run to visually confirm autoplay failed due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87fe45c4f08329b4f484b79c32897b)