### PR TITLE
Resolve invite recipient Telegram ID and add browser + Telegram Accept/Reject actions

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -513,6 +513,15 @@ async function getUserSocketIds({ accountId, telegramId } = {}) {
   return socketIds;
 }
 
+async function resolveInviteTelegramId(accountId, telegramId) {
+  if (telegramId !== undefined && telegramId !== null && telegramId !== '') {
+    return telegramId;
+  }
+  if (!accountId) return null;
+  const user = await User.findOne({ accountId: String(accountId) }).select('telegramId').lean();
+  return user?.telegramId ?? null;
+}
+
 const tableWatchers = new Map();
 const liveChatRooms = new Map();
 // Dynamic lobby tables grouped by game type and capacity
@@ -3484,6 +3493,7 @@ io.on('connection', (socket) => {
     if (!fromId || !toId)
       return cb && cb({ success: false, error: 'invalid ids' });
 
+    toTelegramId = await resolveInviteTelegramId(toId, toTelegramId);
     const targets = await getUserSocketIds({ accountId: toId, telegramId: toTelegramId });
     if (targets.size > 0) {
       for (const sid of targets) {
@@ -3544,12 +3554,13 @@ io.on('connection', (socket) => {
       let url = getInviteUrl(roomId, token, amount, game);
       for (let i = 0; i < toIds.length; i++) {
         const toId = toIds[i];
-        const targets = await getUserSocketIds({ accountId: toId, telegramId: telegramIds[i] });
-        if (telegramIds[i]) {
+        const toTelegramId = await resolveInviteTelegramId(toId, telegramIds[i]);
+        const targets = await getUserSocketIds({ accountId: toId, telegramId: toTelegramId });
+        if (toTelegramId) {
           try {
             url = await sendInviteNotification(
               bot,
-              telegramIds[i],
+              toTelegramId,
               fromTelegramId || fromId,
               fromName,
               'group',

--- a/bot/utils/notifications.js
+++ b/bot/utils/notifications.js
@@ -500,10 +500,10 @@ export async function sendInviteNotification(
   const url = getInviteUrl(roomId, token, amount, game);
   const replyMarkup = {
     inline_keyboard: [
-      [{ text: 'Open Game', url }],
       [
+        { text: '✅ Accept', url },
         {
-          text: 'Reject',
+          text: '❌ Reject',
           callback_data: `reject_invite:${roomId}:${toId}`,
         },
       ],

--- a/webapp/src/components/InvitePopup.jsx
+++ b/webapp/src/components/InvitePopup.jsx
@@ -88,13 +88,13 @@ export default function InvitePopup({
             onClick={() => onAccept(game)}
             className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
           >
-            Yes
+            {incoming ? 'Accept' : 'Yes'}
           </button>
           <button
             onClick={onReject}
             className="px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black"
           >
-            No
+            {incoming ? 'Reject' : 'No'}
           </button>
         </div>
       </div>

--- a/webapp/src/components/Layout.jsx
+++ b/webapp/src/components/Layout.jsx
@@ -19,6 +19,35 @@ import useAppUpdate from '../hooks/useAppUpdate.js';
 
 const GAME_ACTIVE_KEY = 'tonplaygram-game-active';
 
+function showGameInviteNotification(invite) {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+  const title = 'New game invite';
+  const gameName = String(invite?.game || 'snake').replace(/[-_]/g, ' ');
+  const stake = Number(invite?.amount) > 0
+    ? ` for ${invite.amount} ${invite.token || 'TPG'}`
+    : '';
+  const options = {
+    body: `${invite?.fromName || 'A TonPlaygram player'} invited you to ${gameName}${stake}. Open TonPlaygram to accept or reject.`,
+    icon: '/assets/icons/file_00000000efd081f78539cff614489f91.png',
+    tag: invite?.roomId ? `game-invite-${invite.roomId}` : 'game-invite',
+  };
+
+  const display = () => {
+    const notification = new Notification(title, options);
+    notification.onclick = () => {
+      window.focus();
+      notification.close();
+    };
+  };
+
+  if (Notification.permission === 'granted') display();
+  else if (Notification.permission === 'default') {
+    Notification.requestPermission()
+      .then((permission) => permission === 'granted' && display())
+      .catch(() => {});
+  }
+}
+
 
 export default function Layout({ children }) {
   const location = useLocation();
@@ -148,7 +177,7 @@ export default function Layout({ children }) {
       opponentNames,
       game
     }) => {
-      setInvite({
+      const nextInvite = {
         fromId,
         fromName,
         roomId,
@@ -157,7 +186,9 @@ export default function Layout({ children }) {
         group,
         opponentNames,
         game
-      });
+      };
+      setInvite(nextInvite);
+      showGameInviteNotification(nextInvite);
       if (inviteSoundRef.current && !isGameMuted()) {
         inviteSoundRef.current.currentTime = 0;
         inviteSoundRef.current.play().catch(() => {});


### PR DESCRIPTION
### Motivation
- Ensure invited players reliably receive notifications when an invite references an account ID only, and present a clear accept/reject UX both in-browser and in Telegram. 
- Match game-invite notification behavior to existing store/receipt notifications (native/browser popup, clear actions). 

### Description
- Add `resolveInviteTelegramId` in `bot/server.js` to look up a user’s `telegramId` from the account record when the invite payload lacks a Telegram ID, and use it for 1v1 and group invites. 
- Use the resolved Telegram ID when calling `sendInviteNotification` and still emit the `gameInvite` socket event to connected clients. 
- Update `bot/utils/notifications.js` to include explicit `✅ Accept` (opens the game URL) and `❌ Reject` callback buttons in Telegram invite messages. 
- Add browser native notification support in `webapp/src/components/Layout.jsx` via `showGameInviteNotification(...)` invoked on the existing `gameInvite` socket event, and change the invite popup buttons in `InvitePopup.jsx` to show `Accept` / `Reject` when the invite is incoming. 

### Testing
- Ran unit tests in `bot` with `npm test` and all tests passed (`11` tests passed). 
- Built the web app with `cd webapp && npm run build` and the production build completed successfully. 
- Performed static checks with `node --check bot/server.js` and `node --check bot/utils/notifications.js` with no syntax errors. 
- Noted `eslint` produced warnings because the repo’s ignore settings excluded the modified webapp files, so those files were not lint-checked by `npx eslint` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a881aba63688329915a2650fde7c3f5)